### PR TITLE
fix poor IterativeGradientDescent results

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/IterationGradientDescent.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/IterationGradientDescent.java
@@ -46,13 +46,11 @@ public class IterationGradientDescent extends BaseOptimizer {
     @Override
     public boolean optimize() {
         for(int i = 0; i < conf.getNumIterations(); i++) {
-            model.setScore();
             Pair<Gradient,Double> score = gradientAndScore();
-            updateGradientAccordingToParams(score.getFirst(), model, batchSize());
-            model.update(score.getFirst());
+            // model.update(score.getFirst()); // this line causing very bad optimization results
             for(IterationListener listener : conf.getListeners())
                 listener.iterationDone(model,i);
-
+            log.info("Error at iteration " + i + " was " + model.score());
         }
         return true;
     }


### PR DESCRIPTION
1) the parent ```gradientAndScore()``` already does the same thing, no need to repeat in the subclass.

2) I think the ```IterativeGradientDescent``` is broken somehow since change set 6c0b09526e3. The fix here works for me. However, I do not know the exact reason why it was broken, feel free to fix this in some other way.

Before my fix here, the results look like
```
F1: 0.09406057573452803 precision: 0.06347404131060248. recall: 0.1815402088837313. accuracy: 0.2982842058952926
  CLASS[0]: precision: 0.25404732254047324 recall: 0.403960396039604
  CLASS[1]: precision: 0.0 recall: 0.0
  CLASS[2]: precision: 0.06332288401253919 recall: 0.5037406483790524
  CLASS[3]: precision: 0.0 recall: 0.0
  CLASS[4]: precision: 0.0 recall: 0.0
```
after my fix, the same data set and MultiLayerNetwork configuration yield
```
F1: 0.20373523732056809 precision: 0.20166805181125774. recall: 0.20584524083973058. accuracy: 0.42921556925933296
  CLASS[0]: precision: 0.25894378194207834 recall: 0.10033003300330033
  CLASS[1]: precision: 0.3351286654697786 recall: 0.3123257110987172
  CLASS[2]: precision: 0.06302521008403361 recall: 0.03740648379052369
  CLASS[3]: precision: 0.16517857142857142 recall: 0.08268156424581005
  CLASS[4]: precision: 0.18606403013182674 recall: 0.4964824120603015
```
For reference, my network config is
```
    val hiddenLayerSizes = array(500, 200, 10) // 500, 100, 10
    val gen = MersenneTwister(123)

    val iteration = 5
    val layerFactory = LayerFactories.getFactory(javaClass<RBM>())
    val listBuilder = NeuralNetConfiguration.Builder()
            .iterations(iteration)!!
            .weightInit(WeightInit.DISTRIBUTION)!!
            .dist(Distributions.normal(gen, 1e-2))!!
            .activationFunction("tanh")!!
            .hiddenUnit(RBM.HiddenUnit.BINARY)!!
            .visibleUnit(RBM.VisibleUnit.BINARY)!!
            .layerFactory(layerFactory)!!
            .constrainGradientToUnitNorm(true )!!
            .optimizationAlgo(OptimizationAlgorithm.ITERATION_GRADIENT_DESCENT)!!
            .rng(gen)!!
            .learningRate(5e-2.toDouble())!!
            .nIn(trainingSet.numInputs())!!
            .nOut(trainingSet.numOutcomes())!!
            .list(hiddenLayerSizes.size() + 1)!!
            .hiddenLayerSizes(*hiddenLayerSizes.toIntArray())

    listBuilder.override({ i, builder ->
                if (i >= hiddenLayerSizes.size() ) { // 0 based, last one is output
                    builder.layerFactory(DefaultLayerFactory(javaClass<OutputLayer>()))
                    builder.activationFunction("softmax")
                    builder.lossFunction(LossFunctions.LossFunction.MSE)
                    builder.iterations(iteration)
                }
            })
    val conf = listBuilder.build()!!
    val nn = MultiLayerNetwork(conf)
     nn.fit(trainingSet)
```
