### PR TITLE
Fixed windowsForWordInPosition ignoring windowSize

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Windows.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Windows.java
@@ -163,7 +163,7 @@ public class Windows {
         String window2 = StringUtils.join(onlyTokens);
         int begin = wholeSentence.indexOf(window2);
         int end =   begin + window2.length();
-        return new Window(window,begin,end);
+        return new Window(window, windowSize, begin,end);
 
     }
 


### PR DESCRIPTION
The moving Windows `windowsForWordInPosition` function didn't forward the setted `windowSize` to the created Windows.