### PR TITLE
Make predict work for a vector

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1026,8 +1026,11 @@ public class MultiLayerNetwork implements Serializable, Classifier {
     public int[] predict(INDArray d) {
         INDArray output = output(d);
         int[] ret = new int[d.slices()];
-        for (int i = 0; i < ret.length; i++)
-            ret[i] = Nd4j.getBlasWrapper().iamax(output.getRow(i));
+        if (d.isRowVector()) ret[0] = Nd4j.getBlasWrapper().iamax(output);
+        else {
+            for (int i = 0; i < ret.length; i++)
+                ret[i] = Nd4j.getBlasWrapper().iamax(output.getRow(i));
+        }
         return ret;
     }
 


### PR DESCRIPTION
Predict was not working for matrix with one row, because getRow method works only for 2-dimensional matrix.