### PR TITLE
Fixed endless wait.

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BaseTextVectorizer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BaseTextVectorizer.java
@@ -196,8 +196,13 @@ public abstract class BaseTextVectorizer implements TextVectorizer {
 
         long diff = Long.MAX_VALUE;
 
-        while(latch.get() < queued.get() && diff > 5) {
-            diff = Math.abs(latch.get() - queued.get());
+        while(latch.get() < queued.get()) {
+            long newDiff = Math.abs(latch.get() - queued.get());
+            if (diff == newDiff) {
+                break;
+            }
+            diff = newDiff;
+
             try {
                 Thread.sleep(10000);
                 log.info("latch count " + latch.get() + " with queued " + queued.get());


### PR DESCRIPTION
For large texts the text vectorizer endlessly waits for the actors to finish, because the allowed diff between processed and total work units is too low. Now the vectorizer stops, if there is no progress for 10 seconds.