### PR TITLE
Iris and MNIST DataSetIterator fixes

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/base/IrisUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/base/IrisUtils.java
@@ -36,7 +36,6 @@ public class IrisUtils {
         List<String> lines = IOUtils.readLines(resource.getInputStream());
         List<DataSet> list = new ArrayList<>();
         INDArray ret = Nd4j.ones(Math.abs(to - from), 4);
-        List<String> outcomeTypes = new ArrayList<>();
         double[][] outcomes = new double[lines.size()][3];
         int putCount = 0;
 
@@ -47,15 +46,13 @@ public class IrisUtils {
             addRow(ret,putCount++,split);
 
             String outcome = split[split.length - 1];
-            if(!outcomeTypes.contains(outcome))
-                outcomeTypes.add(outcome);
             double[] rowOutcome = new double[3];
-            rowOutcome[outcomeTypes.indexOf(outcome)] = 1;
+            rowOutcome[Integer.parseInt(outcome)] = 1;
             outcomes[i] = rowOutcome;
         }
 
         for(int i = 0; i < ret.rows(); i++)
-            list.add(new DataSet(ret.getRow(i), Nd4j.create(outcomes[i])));
+            list.add(new DataSet(ret.getRow(i), Nd4j.create(outcomes[from+i])));
 
         return list;
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/MnistDataFetcher.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/MnistDataFetcher.java
@@ -70,8 +70,8 @@ public class MnistDataFetcher extends BaseDataFetcher {
         this.binarize = binarize;
         totalExamples = NUM_EXAMPLES;
         //1 based cursor
-        cursor = 1;
-        man.setCurrent(cursor);
+        cursor = 0;
+        man.setCurrent(cursor+1);
         int[][] image;
         try {
             image = man.readImage();
@@ -109,7 +109,7 @@ public class MnistDataFetcher extends BaseDataFetcher {
                     throw new RuntimeException(e);
                 }
             }
-            man.setCurrent(cursor);
+            man.setCurrent(cursor+1);
             //note data normalization
             try {
                 INDArray in = ArrayUtil.toNDArray(ArrayUtil.flatten(man.readImage()));
@@ -161,7 +161,7 @@ public class MnistDataFetcher extends BaseDataFetcher {
 
     @Override
     public void reset() {
-        cursor = 1;
+        cursor = 0;
         curr = null;
     }
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/DataSetIteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/DataSetIteratorTest.java
@@ -1,0 +1,52 @@
+package org.deeplearning4j.datasets.iterator;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.datasets.iterator.impl.LFWDataSetIterator;
+import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
+import org.junit.Test;
+import org.nd4j.linalg.dataset.DataSet;
+
+public class DataSetIteratorTest {
+	
+	@Test
+	public void testBatchSizeOfOne() throws Exception {
+		//Test for (a) iterators returning correct number of examples, and
+		//(b) Labels are a proper one-hot vector (i.e., sum is 1.0)
+		
+		//Iris:
+		DataSetIterator iris = new IrisDataSetIterator(1, 5);
+		int irisC = 0;
+		while(iris.hasNext()){
+			irisC++;
+			DataSet ds = iris.next();
+			assertTrue(ds.getLabels().sum(Integer.MAX_VALUE).getDouble(0)==1.0);
+		}
+		assertTrue(irisC==5);
+		
+		
+		//MNIST:
+		DataSetIterator mnist = new MnistDataSetIterator(1, 5);
+		int mnistC = 0;
+		while(mnist.hasNext()){
+			mnistC++;
+			DataSet ds = mnist.next();
+			assertTrue(ds.getLabels().sum(Integer.MAX_VALUE).getDouble(0)==1.0);
+		}
+		assertTrue(mnistC==5);
+		
+		//LFW:
+		DataSetIterator lfw = new LFWDataSetIterator(1, 5);
+		int lfwC = 0;
+		while(lfw.hasNext()){
+			lfwC++;
+			DataSet ds = lfw.next();
+			assertTrue(ds.getLabels().sum(Integer.MAX_VALUE).getDouble(0)==1.0);
+		}
+		assertTrue(lfwC==5);
+	}
+
+}


### PR DESCRIPTION
Iris problem: indexing on outcomes array. Also discovered that method of using ArrayList.indexOf() here isn't viable; if only requesting one example, only one outcome is ever observed/put in ArrayList -> is always assigned index of 0.

MNIST: DataFetcher cursor indexing starts at 0, but MnistManager current indexing starts at 1.