### PR TITLE
Fix rng and seed in weighutil and neuralnetconfiguration to ensure consistency

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -37,14 +37,18 @@ import org.deeplearning4j.nn.conf.stepfunctions.GradientStepFunction;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
 import org.deeplearning4j.nn.conf.layers.Layer;
-import org.deeplearning4j.nn.conf.rng.DefaultRandom;
-import org.deeplearning4j.nn.conf.rng.Random;
+import org.nd4j.linalg.api.rng.Random;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 
 /**
  * A Serializable configuration
@@ -85,7 +89,8 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
     //whether to constrain the gradient to unit norm or not
     protected boolean constrainGradientToUnitNorm = false;
     /* RNG for sampling. */
-    protected  Random rng;
+    protected Random rng;
+    protected long seed;
     //weight initialization
     protected Distribution dist;
     protected StepFunction stepFunction = new GradientStepFunction();
@@ -127,7 +132,6 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
     protected ConvolutionLayer.ConvolutionType convolutionType = ConvolutionLayer.ConvolutionType.MAX;
 
 
-
     public NeuralNetConfiguration(double sparsity,
                                   boolean useAdaGrad,
                                   double lr,
@@ -146,6 +150,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
                                   LossFunctions.LossFunction lossFunction,
                                   boolean constrainGradientToUnitNorm,
                                   Random rng,
+                                  long seed,
                                   Distribution dist,
                                   int nIn,
                                   int nOut,
@@ -192,6 +197,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         this.lossFunction = lossFunction;
         this.constrainGradientToUnitNorm = constrainGradientToUnitNorm;
         this.rng = rng;
+        this.seed = seed;
         this.dist = dist;
         this.nIn = nIn;
         this.nOut = nOut;
@@ -221,7 +227,6 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
                 e.printStackTrace();
             }
         }
-
 
         if(dist == null)
             this.dist = new NormalDistribution(0.01,1);
@@ -379,8 +384,6 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         }
     }
 
-
-
     /**
      * Object mapper for serialization of configurations
      * @return
@@ -419,7 +422,8 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         private WeightInit weightInit = WeightInit.VI;
         private OptimizationAlgorithm optimizationAlgo = OptimizationAlgorithm.CONJUGATE_GRADIENT;
         private boolean constrainGradientToUnitNorm = false;
-        private Random rng = new DefaultRandom();
+        private Random rng = Nd4j.getRandom();
+        private long seed = System.currentTimeMillis();
         private Distribution dist  = new NormalDistribution(1e-3,1);
         private LossFunctions.LossFunction lossFunction = LossFunctions.LossFunction.RECONSTRUCTION_CROSSENTROPY;
         private int nIn;
@@ -608,11 +612,21 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             return this;
         }
 
-
-
-
+        @Deprecated
         public Builder rng(Random rng) {
             this.rng = rng;
+            return this;
+        }
+
+        public Builder seed(int seed) {
+            this.seed = (long) seed;
+            Nd4j.getRandom().setSeed(seed);
+            return this;
+        }
+
+        public Builder seed(long seed) {
+            this.seed = seed;
+            Nd4j.getRandom().setSeed(seed);
             return this;
         }
 
@@ -625,7 +639,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             NeuralNetConfiguration ret = new NeuralNetConfiguration( sparsity,  useAdaGrad,  lr,  k,
                     corruptionLevel,  numIterations,  momentum,  l2,  useRegularization, momentumAfter,
                     resetAdaGradIterations,  dropOut,  applySparsity,  weightInit,  optimizationAlgo, lossFunction,
-                    constrainGradientToUnitNorm,  rng,
+                    constrainGradientToUnitNorm,  rng, seed,
                     dist,  nIn,  nOut,  activationFunction, visibleUnit,hiddenUnit,weightShape,filterSize,stride,featureMapSize,kernel
                     ,batchSize,numLineSearchIterations,minimize,layer,convolutionType,l1,customLossFunction);
             ret.useAdaGrad = this.useAdaGrad;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/DefaultLayerFactory.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/DefaultLayerFactory.java
@@ -59,10 +59,9 @@ public class DefaultLayerFactory implements LayerFactory {
 
     @Override
     public <E extends Layer> E create(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners) {
-        Distribution dist = Distributions.createDistribution(conf.getDist());
         Layer ret = getInstance(conf);
         ret.setIterationListeners(iterationListeners);
-        Map<String,INDArray> params = getParams(conf, dist);
+        Map<String,INDArray> params = getParams(conf);
         ret.setParamTable(params);
         ret.setConf(conf);
         return (E) ret;
@@ -90,7 +89,7 @@ public class DefaultLayerFactory implements LayerFactory {
     }
 
 
-    protected Map<String,INDArray> getParams(NeuralNetConfiguration conf, Distribution dist) {
+    protected Map<String,INDArray> getParams(NeuralNetConfiguration conf) {
         ParamInitializer init = initializer();
         Map<String,INDArray> params = Collections.synchronizedMap(new LinkedHashMap<String,INDArray>());
         init.init(params,conf);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/ConvolutionParamInitializer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/ConvolutionParamInitializer.java
@@ -25,6 +25,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.distribution.Distributions;
 import org.deeplearning4j.nn.weights.WeightInitUtil;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 import org.nd4j.linalg.factory.Nd4j;
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/DefaultParamInitializer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/DefaultParamInitializer.java
@@ -24,6 +24,7 @@ import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.distribution.Distributions;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 import org.nd4j.linalg.factory.Nd4j;
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/LSTMParamInitializer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/LSTMParamInitializer.java
@@ -24,6 +24,7 @@ import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.distribution.Distributions;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -51,7 +52,7 @@ public class LSTMParamInitializer implements ParamInitializer {
         conf.addVariable(DECODER_WEIGHTS);
         conf.addVariable(DECODER_BIAS);
         params.put(RECURRENT_WEIGHTS,WeightInitUtil.initWeights(inputSize + hiddenSize + 1, 4 * hiddenSize, conf.getWeightInit(), dist));
-        params.put(DECODER_WEIGHTS,WeightInitUtil.initWeights(hiddenSize,outputSize,conf.getWeightInit(),dist));
+        params.put(DECODER_WEIGHTS,WeightInitUtil.initWeights(hiddenSize,outputSize,conf.getWeightInit(), dist));
         params.put(DECODER_BIAS, Nd4j.zeros(outputSize));
         params.get(RECURRENT_WEIGHTS).data().persist();
         params.get(DECODER_BIAS).data().persist();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/RecursiveParamInitializer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/RecursiveParamInitializer.java
@@ -22,6 +22,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.distribution.Distributions;
 import org.deeplearning4j.nn.weights.WeightInitUtil;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 
 import java.util.Map;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/weights/WeightInitUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/weights/WeightInitUtil.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.nn.weights;
 
 
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -74,16 +75,16 @@ public class WeightInitUtil {
   public static INDArray initWeights(int[] shape, WeightInit initScheme,
                                      Distribution dist) {
     INDArray ret;
+    Nd4j.getRandom().setSeed(Nd4j.getRandom().getSeed());
     switch (initScheme) {
       case NORMALIZED:
-        ret = Nd4j.rand(shape);
+        ret = Nd4j.rand(shape, Nd4j.getRandom());
         return ret.subi(0.5).divi(shape[0]);
       case UNIFORM:
         double a = 1 / (double) shape[0];
         return Nd4j.rand(shape, -a, a, Nd4j.getRandom());
-
       case VI:
-        ret = Nd4j.rand(shape);
+        ret = Nd4j.rand(shape, Nd4j.getRandom());
         int len = 0;
         for (int aShape : shape) {
           len += aShape;
@@ -91,7 +92,6 @@ public class WeightInitUtil {
         double r = Math.sqrt(6) / Math.sqrt(len + 1);
         ret.muli(2).muli(r).subi(r);
         return ret;
-
       case DISTRIBUTION:
         ret = dist.sample(shape);
         return ret;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/MultiLayerNeuralNetConfigurationTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/MultiLayerNeuralNetConfigurationTest.java
@@ -123,7 +123,7 @@ public class MultiLayerNeuralNetConfigurationTest {
                 .layer(new RBM())
                 .nIn(2).nOut(1)
                 .weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1))
-                .rng(new DefaultRandom(12345L)) //RNG with specified seed
+                .seed(12345l)
                 .list(2)
                 .hiddenLayerSizes(5)
                 .override(1, new ClassifierOverride())

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/NeuralNetConfigurationTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/NeuralNetConfigurationTest.java
@@ -21,6 +21,7 @@ package org.deeplearning4j.nn.conf;
 import static org.junit.Assert.*;
 
 import org.deeplearning4j.nn.conf.rng.DefaultRandom;
+import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.factory.Nd4j;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
@@ -98,15 +99,13 @@ public class NeuralNetConfigurationTest {
 
     @Test
     public void testRNG() {
-//        Nd4j.getRandom().setSeed (123);
-
         NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
                 .layer(new RBM())
                 .nIn(trainingSet.numInputs())
                 .nOut(trainingSet.numOutcomes())
-                .weightInit(WeightInit.SIZE)
+                .weightInit(WeightInit.NORMALIZED)
                 .constrainGradientToUnitNorm(true)
-                .rng(new DefaultRandom(123))
+                .seed(123)
                 .iterations(3)
                 .activationFunction("tanh")
                 .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
@@ -115,29 +114,23 @@ public class NeuralNetConfigurationTest {
                 .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
                 .build();
         Layer model = LayerFactories.getFactory(conf).create(conf);
-
         INDArray modelWeights = model.getParam(DefaultParamInitializer.WEIGHT_KEY);
 
-        float[][] weights = new float[][]{
-                {1.5115644931793213f, -1.294399261474609f}
-                ,{0.28141850233078003f, 0.6243384480476379f}
-                ,{0.9196174144744873f, -0.7969362735748291f}
-        };
+        Layer model2 = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights2 = model2.getParam(DefaultParamInitializer.WEIGHT_KEY);
 
-        INDArray exceptedWeights = Nd4j.create(weights);
-        assertEquals(modelWeights, exceptedWeights);
+        assertEquals(modelWeights, modelWeights2);
     }
 
     @Test
-    public void testSetSeed() {
-        Nd4j.getRandom().setSeed (123);
+    public void testSetSeedNormalized() {
+        Nd4j.getRandom().setSeed(123);
         NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
                 .layer(new RBM())
                 .nIn(trainingSet.numInputs())
                 .nOut(trainingSet.numOutcomes())
-                .weightInit(WeightInit.SIZE)
+                .weightInit(WeightInit.NORMALIZED)
                 .constrainGradientToUnitNorm(true)
-                .rng(new DefaultRandom(123))
                 .iterations(3)
                 .activationFunction("tanh")
                 .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
@@ -146,17 +139,110 @@ public class NeuralNetConfigurationTest {
                 .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
                 .build();
         Layer model = LayerFactories.getFactory(conf).create(conf);
-
         INDArray modelWeights = model.getParam(DefaultParamInitializer.WEIGHT_KEY);
 
-        float[][] weights = new float[][]{
-                {0.5940669775009155f, 0.3747984766960144f}
-                ,{-0.6466538906097412f, -1.1622607707977295f}
-                ,{-0.8259235620498657f, -0.5524767637252808f}
-        };
+        Layer model2 = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights2 = model2.getParam(DefaultParamInitializer.WEIGHT_KEY);
 
-        INDArray exceptedWeights = Nd4j.create(weights);
-        assertEquals(modelWeights, exceptedWeights);
+        assertEquals(modelWeights, modelWeights2);
+    }
+
+    @Test
+    public void testSetSeedUniform() {
+        Nd4j.getRandom().setSeed(123);
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new RBM())
+                .nIn(trainingSet.numInputs())
+                .nOut(trainingSet.numOutcomes())
+                .weightInit(WeightInit.UNIFORM)
+                .iterations(3)
+                .activationFunction("tanh")
+                .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
+                .hiddenUnit(RBM.HiddenUnit.RECTIFIED)
+                .lossFunction(LossFunctions.LossFunction.RMSE_XENT)
+                .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
+                .build();
+        Layer model = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights = model.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        Layer model2 = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights2 = model2.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        assertEquals(modelWeights, modelWeights2);
+    }
+
+    @Test
+    public void testSetSeedVI() {
+        Nd4j.getRandom().setSeed(123);
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new RBM())
+                .nIn(trainingSet.numInputs())
+                .nOut(trainingSet.numOutcomes())
+                .weightInit(WeightInit.VI)
+                .iterations(3)
+                .activationFunction("tanh")
+                .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
+                .hiddenUnit(RBM.HiddenUnit.RECTIFIED)
+                .lossFunction(LossFunctions.LossFunction.RMSE_XENT)
+                .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
+                .build();
+        Layer model = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights = model.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        Layer model2 = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights2 = model2.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        assertEquals(modelWeights, modelWeights2);
+    }
+
+    @Test
+    public void testSetSeedDistribution() {
+        Nd4j.getRandom().setSeed(123);
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new RBM())
+                .nIn(trainingSet.numInputs())
+                .nOut(trainingSet.numOutcomes())
+                .weightInit(WeightInit.DISTRIBUTION)
+                .iterations(3)
+                .activationFunction("tanh")
+                .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
+                .hiddenUnit(RBM.HiddenUnit.RECTIFIED)
+                .lossFunction(LossFunctions.LossFunction.RMSE_XENT)
+                .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
+                .build();
+        Layer model = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights = model.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        Layer model2 = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights2 = model2.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        assertEquals(modelWeights, modelWeights2);
+    }
+
+    @Test
+    public void testSetSeedSize() {
+        Nd4j.getRandom().setSeed(123);
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new RBM())
+                .nIn(trainingSet.numInputs())
+                .nOut(trainingSet.numOutcomes())
+                .weightInit(WeightInit.SIZE)
+                .iterations(3)
+                .activationFunction("tanh")
+                .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
+                .hiddenUnit(RBM.HiddenUnit.RECTIFIED)
+                .lossFunction(LossFunctions.LossFunction.RMSE_XENT)
+                .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
+                .build();
+        Layer model = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights = model.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        Layer model2 = LayerFactories.getFactory(conf).create(conf);
+        INDArray modelWeights2 = model2.getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        assertEquals(modelWeights, modelWeights2);
+
+
 
     }
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/learning/WeightInitTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/learning/WeightInitTests.java
@@ -22,6 +22,7 @@ package org.deeplearning4j.nn.learning;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.nn.weights.WeightInitUtil;
 import org.junit.Test;
+import org.nd4j.linalg.api.rng.DefaultRandom;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
@@ -31,7 +32,7 @@ public class WeightInitTests {
 
     @Test
     public void testSi() {
-        WeightInitUtil.initWeights(1,2, WeightInit.VI, Nd4j.getDistributions().createNormal(0,1));
+        WeightInitUtil.initWeights(1,2, WeightInit.VI, Nd4j.getDistributions().createNormal(0, 1));
     }
 
 }


### PR DESCRIPTION
Key change was added seed parameter to NeuralNetConfiguration, allow entry and set of seed against Nd4j and deprecated setting rng. Emphasize, changed rng and seed so that they function off nd4j and no longer leverage dl4j's defaultrandom or random. Fixed locking in weight initialization when setting seed by adding call against nd4j prior in WeightInitUtil. Also pulled out redudant call in layer creation to initalize distribution.