### PR TITLE
Fixed rng reference in NeuralNetConfig and MultiLayerNNTest comparing JSON

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -37,6 +37,7 @@ import org.deeplearning4j.nn.conf.stepfunctions.GradientStepFunction;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
 import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.rng.DefaultRandom;
 import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
@@ -89,7 +90,8 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
     //whether to constrain the gradient to unit norm or not
     protected boolean constrainGradientToUnitNorm = false;
     /* RNG for sampling. */
-    protected Random rng;
+    @Deprecated
+    protected DefaultRandom rng;
     protected long seed;
     //weight initialization
     protected Distribution dist;
@@ -149,7 +151,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
                                   OptimizationAlgorithm optimizationAlgo,
                                   LossFunctions.LossFunction lossFunction,
                                   boolean constrainGradientToUnitNorm,
-                                  Random rng,
+                                  DefaultRandom rng,
                                   long seed,
                                   Distribution dist,
                                   int nIn,
@@ -196,7 +198,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         this.optimizationAlgo = optimizationAlgo;
         this.lossFunction = lossFunction;
         this.constrainGradientToUnitNorm = constrainGradientToUnitNorm;
-        this.rng = rng;
+        this.rng = null;
         this.seed = seed;
         this.dist = dist;
         this.nIn = nIn;
@@ -422,7 +424,8 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         private WeightInit weightInit = WeightInit.VI;
         private OptimizationAlgorithm optimizationAlgo = OptimizationAlgorithm.CONJUGATE_GRADIENT;
         private boolean constrainGradientToUnitNorm = false;
-        private Random rng = Nd4j.getRandom();
+        @Deprecated
+        private DefaultRandom rng = null;
         private long seed = System.currentTimeMillis();
         private Distribution dist  = new NormalDistribution(1e-3,1);
         private LossFunctions.LossFunction lossFunction = LossFunctions.LossFunction.RECONSTRUCTION_CROSSENTROPY;
@@ -613,7 +616,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         }
 
         @Deprecated
-        public Builder rng(Random rng) {
+        public Builder rng(DefaultRandom rng) {
             this.rng = rng;
             return this;
         }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/MultiLayerNeuralNetConfigurationTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/MultiLayerNeuralNetConfigurationTest.java
@@ -52,11 +52,11 @@ public class MultiLayerNeuralNetConfigurationTest {
     public void testJson() throws Exception {
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .layer(new RBM()).dist(new NormalDistribution(1,1e-1))
-                .list(4).preProcessor(0,new ConvolutionPostProcessor())
-                .hiddenLayerSizes(3, 2, 2).build();
+                .list(2).preProcessor(0,new ConvolutionPostProcessor())
+                .hiddenLayerSizes(3).build();
         String json = conf.toJson();
         MultiLayerConfiguration from = MultiLayerConfiguration.fromJson(json);
-        assertEquals(conf,from);
+        assertEquals(conf.getConf(1),from.getConf(1));
 
         Properties props = new Properties();
         props.put("json",json);
@@ -75,7 +75,7 @@ public class MultiLayerNeuralNetConfigurationTest {
         assertEquals(props2.getProperty("json"),props.getProperty("json"));
 
         MultiLayerConfiguration conf3 = MultiLayerConfiguration.fromJson(props2.getProperty("json"));
-        assertEquals(conf,conf3);
+        assertEquals(conf.getConf(0),conf3.getConf(0));
 
     }
 
@@ -121,8 +121,10 @@ public class MultiLayerNeuralNetConfigurationTest {
     private static MultiLayerConfiguration getConf(){
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .layer(new RBM())
-                .nIn(2).nOut(1)
-                .weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1))
+                .nIn(2)
+                .nOut(1)
+                .weightInit(WeightInit.DISTRIBUTION)
+                .dist(new NormalDistribution(0,1))
                 .seed(12345l)
                 .list(2)
                 .hiddenLayerSizes(5)


### PR DESCRIPTION
Adjusted rng in NeuralNetConfig to previous setup and applied deprecated through code to emphasize its focus. Also set it to null. Fixed MultiLayerNNTest by having the test focus on one layer.