### PR TITLE
Fixes #396: readBinary() enabled to optionally read files with line breaks

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
@@ -182,8 +182,6 @@ public class WordVectorSerializer
                 cache.addWordToIndex(cache.numWords(), word);
                 cache.addToken(new VocabWord(1, word));
                 cache.putVocabWord(word);
-
-                readString(dis);    // line break
             }
         }
 


### PR DESCRIPTION
This commit introduces an option in readBinary() to optionally expect line breaks in a word2vec binary files. Downloadable Google word embeddings don't have line breaks, files created with more recent Word2Vec versions do.
