### PR TITLE
Add GravesLSTM

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.conf.layers;
+
+/**
+ * LSTM recurrent net, based on Graves: Supervised Sequence Labelling with Recurrent Neural Networks
+ * http://www.cs.toronto.edu/~graves/phd.pdf
+ *
+ */
+public class GravesLSTM extends Layer {
+
+	private static final long serialVersionUID = -6075431033806074674L;
+
+	@Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        return true;
+    }
+
+    public String toString() {
+        return "GravesLSTM{" +
+                '}';
+    }
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/DefaultLayerFactory.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/DefaultLayerFactory.java
@@ -22,12 +22,9 @@ import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.LayerFactory;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.distribution.Distributions;
-import org.deeplearning4j.nn.layers.convolution.ConvolutionLayer;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.rng.distribution.Distribution;
 
 import java.util.*;
 
@@ -77,6 +74,8 @@ public class DefaultLayerFactory implements LayerFactory {
             return new org.deeplearning4j.nn.layers.convolution.ConvolutionDownSampleLayer(conf);
         if(layerConfig instanceof org.deeplearning4j.nn.conf.layers.LSTM)
             return new org.deeplearning4j.nn.layers.recurrent.LSTM(conf);
+        if(layerConfig instanceof org.deeplearning4j.nn.conf.layers.GravesLSTM)
+        	return new org.deeplearning4j.nn.layers.recurrent.GravesLSTM(conf);
         if(layerConfig instanceof org.deeplearning4j.nn.conf.layers.OutputLayer)
             return new org.deeplearning4j.nn.layers.OutputLayer(conf);
         if(layerConfig instanceof org.deeplearning4j.nn.conf.layers.RecursiveAutoEncoder)

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/GravesLSTMLayerFactory.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/GravesLSTMLayerFactory.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.layers.factory;
+
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.params.GravesLSTMParamInitializer;
+
+/**
+ *  LSTM layer initializer.
+ *  For LSTM based on Graves: Supervised Sequence Labelling with Recurrent Neural Networks
+ * http://www.cs.toronto.edu/~graves/phd.pdf
+ */
+public class GravesLSTMLayerFactory extends DefaultLayerFactory {
+
+    public GravesLSTMLayerFactory(Class<? extends Layer> layerConfig) {
+        super(layerConfig);
+    }
+
+    @Override
+    public ParamInitializer initializer() {
+        return new GravesLSTMParamInitializer();
+    }
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/LayerFactories.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/LayerFactories.java
@@ -48,6 +48,8 @@ public class LayerFactories {
             return new ConvolutionLayerFactory(clazz);
         else if(clazz.equals(LSTM.class))
             return new LSTMLayerFactory(LSTM.class);
+        else if(clazz.equals(GravesLSTM.class))
+        	return new GravesLSTMLayerFactory(GravesLSTM.class);
         else if(RecursiveAutoEncoder.class.isAssignableFrom(clazz))
             return new RecursiveAutoEncoderLayerFactory(RecursiveAutoEncoder.class);
         else if(BasePretrainNetwork.class.isAssignableFrom(clazz))
@@ -69,7 +71,7 @@ public class LayerFactories {
         LayerFactory layerFactory = getFactory(conf);
         if(layerFactory instanceof ConvolutionLayerFactory || layerFactory instanceof SubsampleLayerFactory)
             return org.deeplearning4j.nn.api.Layer.Type.CONVOLUTIONAL;
-        else if(layerFactory instanceof LSTMLayerFactory)
+        else if(layerFactory instanceof LSTMLayerFactory || layerFactory instanceof GravesLSTMLayerFactory)
             return org.deeplearning4j.nn.api.Layer.Type.RECURRENT;
         else if(layerFactory instanceof RecursiveAutoEncoderLayerFactory)
             return org.deeplearning4j.nn.api.Layer.Type.RECURSIVE;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
@@ -1,0 +1,373 @@
+/*
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.layers.recurrent;
+
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.BaseLayer;
+import org.deeplearning4j.nn.params.DefaultParamInitializer;
+import org.deeplearning4j.nn.params.GravesLSTMParamInitializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+
+import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
+
+/**LSTM layer implementation.
+ * Based on Graves: Supervised Sequence Labelling with Recurrent Neural Networks
+ * http://www.cs.toronto.edu/~graves/phd.pdf
+ * See also for full/vectorized equations (and a comparison to other LSTM variants):
+ * Greff et al. 2015, "LSTM: A Search Space Odyssey", pg11. This is the "vanilla" variant in said paper
+ * http://arxiv.org/pdf/1503.04069.pdf
+ * @author Alex Black
+ */
+public class GravesLSTM extends BaseLayer {
+	private static final long serialVersionUID = 2932878786544423542L;
+	private INDArray ifogZs;
+	private INDArray ifogAs;
+	private INDArray memCellActivations;
+	private INDArray outputActivations;
+
+	public GravesLSTM(NeuralNetConfiguration conf) {
+		super(conf);
+	}
+
+	@Override
+	public INDArray transform(INDArray data) {
+		return activate(data);
+	}
+
+	@Override
+	public Gradient gradient() {
+		throw new UnsupportedOperationException("Not yet implemented");
+	}
+	
+	@Override
+	public Gradient calcGradient(Gradient layerError, INDArray activation){
+		throw new UnsupportedOperationException("Not yet implemented");
+	}
+	
+	@Override
+    public Gradient backwardGradient(INDArray derivative, Layer nextLayer, Gradient nextGradient, INDArray activation) {
+		INDArray recurrentWeights = getParam(GravesLSTMParamInitializer.RECURRENT_WEIGHTS);	//Shape: [hiddenLayerSize,4*hiddenLayerSize+3]; order: [wI,wF,wO,wG,wFF,wOO,wGG]
+		
+		INDArray nextWeights = nextLayer.getParam(DefaultParamInitializer.WEIGHT_KEY);		//Weights for next layer
+		INDArray nextDelta = nextGradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
+		
+		//Expect errors to have shape: [miniBatchSize,n^(L+1),timeSeriesLength]
+		int[] deltaShape = nextDelta.shape();
+		boolean is2dInput = deltaShape.length < 3;	//Edge case: T=1 may have shape [miniBatchSize,n^(L+1)], equiv. to [miniBatchSize,n^(L+1),1]
+		
+		int hiddenLayerSize = recurrentWeights.rows();	//i.e., n^L
+		int prevLayerSize = getParam(GravesLSTMParamInitializer.INPUT_WEIGHTS).shape()[0];
+		int miniBatchSize = deltaShape[0];
+		int timeSeriesLength = (is2dInput ? 1 : deltaShape[2]);
+		
+		INDArray wI = recurrentWeights.get(interval(0,hiddenLayerSize),interval(0,hiddenLayerSize));
+		INDArray wF = recurrentWeights.get(interval(0,hiddenLayerSize),interval(hiddenLayerSize,2*hiddenLayerSize));
+		INDArray wFF = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize,4*hiddenLayerSize+1));
+		INDArray wO = recurrentWeights.get(interval(0,hiddenLayerSize),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+		INDArray wOO = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize+1,4*hiddenLayerSize+2));
+		INDArray wG = recurrentWeights.get(interval(0,hiddenLayerSize),interval(3*hiddenLayerSize,4*hiddenLayerSize));
+		INDArray wGG = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize+2,4*hiddenLayerSize+3));
+		
+		
+		INDArray biasGradients = Nd4j.zeros(new int[]{miniBatchSize,4*hiddenLayerSize,timeSeriesLength});	//Shape in keeping with what BaseLayer.update() expects for bias
+		INDArray inputWeightGradients = Nd4j.zeros(new int[]{prevLayerSize,4*hiddenLayerSize,timeSeriesLength});
+		INDArray recurrentWeightGradients = Nd4j.zeros(new int[]{hiddenLayerSize,4*hiddenLayerSize+3,timeSeriesLength});	//Order: {I,F,O,G,FF,OO,GG}
+		
+		/*Placeholder. To be replaced by masking array for used for variable length time series
+		 *Idea: M[i,j] = 1 if data is present for time j in example i in mini-batch.
+		 *M[i,j] = 0 otherwise
+		 *Then do a column multiply to set appropriate deltas to 0 if data is beyond end of time series
+		 *for the corresponding example
+		 */
+//		INDArray timeSeriesMaskArray = Nd4j.ones(miniBatchSize,timeSeriesLength);	//For now: assume that all data in mini-batch is of length 'timeSeriesLength'
+		
+		for( int t=timeSeriesLength-1; t>=0; t-- ){
+			INDArray prevMemCellActivations = (t==0 ? Nd4j.zeros(hiddenLayerSize, hiddenLayerSize) : memCellActivations.slice(t-1, 2) );	//Shape: [n^L, n^L]
+			INDArray prevHiddenUnitActivation = (t==0 ? Nd4j.zeros(hiddenLayerSize, hiddenLayerSize) : outputActivations.slice(t-1,2) );	//Shape: [n^L, n^L]; i.e., layer output at prev. time step.
+			
+			INDArray nextLayerDeltaSlice = nextDelta.slice(t, 2);		//delta^{(L+1)t}
+			//delta_i^{L(t+1)}
+			INDArray deltaiNext = (t==timeSeriesLength-1 ?
+					Nd4j.zeros(miniBatchSize,hiddenLayerSize) : 
+					biasGradients.slice(t+1,2).get(new NDArrayIndex[]{interval(0,miniBatchSize),interval(0,hiddenLayerSize)}));
+			//delta_f^{L(t+1)}
+			INDArray deltafNext = (t==timeSeriesLength-1 ?
+					Nd4j.zeros(miniBatchSize,hiddenLayerSize) :
+					biasGradients.slice(t+1,2).get(new NDArrayIndex[]{interval(0,miniBatchSize),interval(hiddenLayerSize,2*hiddenLayerSize)}));
+			//delta_o^{L(t+1)}
+			INDArray deltaoNext = (t==timeSeriesLength-1 ?
+					Nd4j.zeros(miniBatchSize,hiddenLayerSize) :
+					biasGradients.slice(t+1,2).get(new NDArrayIndex[]{interval(0,miniBatchSize),interval(2*hiddenLayerSize,3*hiddenLayerSize)}));
+			//delta_g^{L(t+1)}
+			INDArray deltagNext = (t==timeSeriesLength-1 ?
+					Nd4j.zeros(miniBatchSize,hiddenLayerSize) :
+					biasGradients.slice(t+1,2).get(new NDArrayIndex[]{interval(0,miniBatchSize),interval(3*hiddenLayerSize,4*hiddenLayerSize)}));
+			
+			//For variable length mini-batch data: Zero out deltas as necessary, so deltas beyond end of each time series are always 0
+			//Not implemented yet, but left here for when this is implemented
+			/*
+			if( t < timeSeriesLength-1 ){
+				INDArray maskColumn = timeSeriesMaskArray.getColumn(t);
+				deltaiNext.muliColumnVector(maskColumn);
+				deltafNext.muliColumnVector(maskColumn);
+				deltaoNext.muliColumnVector(maskColumn);
+				deltafNext.muliColumnVector(maskColumn);
+			}*/
+			
+			//LSTM unit output errors (dL/d(a_out)); not to be confused with \delta=dL/d(z_out)
+			INDArray nablaOut = nextLayerDeltaSlice.mmul(nextWeights.transpose())
+					.addi(deltaiNext.mmul(wI.transpose()))
+					.addi(deltafNext.mmul(wF.transpose()))
+					.addi(deltaoNext.mmul(wO.transpose()))
+					.addi(deltagNext.mmul(wG.transpose()));
+				//Shape: [m,n^L]
+			
+			//Output gate deltas:
+			INDArray sigmahOfS = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), prevMemCellActivations.dup()));//	shape: [m,n^L]
+			INDArray zo = ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+			INDArray sigmaoPrimeOfZo = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", zo).derivative());//			shape: [m,n^L]
+			INDArray deltao = nablaOut.mul(sigmahOfS).muli(sigmaoPrimeOfZo);
+				//Shape: [m,n^L]
+			
+			//Memory cell error:
+			INDArray sigmahPrimeOfS = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), prevMemCellActivations.dup()));//	shape: [m,n^L]
+			INDArray nextForgetGateAs = (t==timeSeriesLength-1 ? Nd4j.zeros(miniBatchSize,hiddenLayerSize) :
+				ifogAs.slice(t,2).get(NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize)) );
+			INDArray nablaCellState = nablaOut.mul(prevHiddenUnitActivation).muli(sigmahPrimeOfS)
+					.addi(nextForgetGateAs.mul(prevMemCellActivations))
+					.addi(deltafNext.mmul(Nd4j.diag(wFF)))
+					.addi(deltaoNext.mmul(Nd4j.diag(wOO)))
+					.addi(deltagNext.mmul(Nd4j.diag(wGG)));
+			
+			//Forget gate delta:
+			INDArray zf = ifogZs.slice(t, 0).get(NDArrayIndex.all(),interval(hiddenLayerSize,2*hiddenLayerSize));	//z_f^{Lt}	shape: [m,n^L]
+			INDArray deltaf = nablaCellState.mul(prevMemCellActivations)
+					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", zf).derivative()));
+				//Shape: [m,n^L]
+			
+			//Input modulation gate delta:
+			INDArray zg = ifogZs.slice(t, 0).get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4*hiddenLayerSize));	//z_g^{Lt}	shape: [m,n^L]
+			INDArray ai = ifogAs.slice(t, 0).get(NDArrayIndex.all(),interval(hiddenLayerSize,2*hiddenLayerSize));	//a_i^{Lt}	shape: [m,n^L]
+			INDArray deltag = nablaCellState.mul(ai)
+					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("tanh", zg).derivative()));
+				//Shape: [m,n^L]
+			
+			//Network input delta:
+			INDArray zi = ifogZs.slice(t, 0).get(NDArrayIndex.all(),interval(hiddenLayerSize,2*hiddenLayerSize));	//z_i^{Lt}	shape: [m,n^L]
+			INDArray ag = ifogAs.slice(t, 0).get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4*hiddenLayerSize));	//a_g^{Lt}	shape: [m,n^L]
+			INDArray deltai = nablaCellState.mul(ag)
+					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("tanh", zi).derivative()));
+				//Shape: [m,n^L]
+			
+			INDArray prevLayerActivationSlice = activation.slice(t, 2);
+			//Indexing here: all columns (==interval(0,n^(L-1)), 3rd dimension based on IFOG order. Sum over mini-batches occurs in delta*prevLayerActivations
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(0,hiddenLayerSize)}, deltai.transpose().mmul(prevLayerActivationSlice).transpose());
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(hiddenLayerSize,2*hiddenLayerSize)}, deltaf.transpose().mmul(prevLayerActivationSlice).transpose());
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize)}, deltao.transpose().mmul(prevLayerActivationSlice).transpose());
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(3*hiddenLayerSize,4*hiddenLayerSize)}, deltag.transpose().mmul(prevLayerActivationSlice).transpose());
+			
+			if( t > 0 ){
+				//Minor optimization. If t==0, then prevHiddenUnitActivation==zeros(n^L,n^L), so dL/dW for recurrent weights will end up as 0 anyway. (They are initialized as 0)
+				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(0,hiddenLayerSize)}, deltai.transpose().mmul(prevHiddenUnitActivation).transpose());	//dL/dw_{Ixy} = delta_{ix} * a_{iy}^{L(t-1)}
+				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(hiddenLayerSize,2*hiddenLayerSize)}, deltaf.transpose().mmul(prevHiddenUnitActivation).transpose());	//dL/dw_{Fxy} = delta_{fx} * a_{iy}^{L(t-1)}
+				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize)}, deltao.transpose().mmul(prevHiddenUnitActivation).transpose());	//dL/dw_{O}
+				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(3*hiddenLayerSize,4*hiddenLayerSize)}, deltag.transpose().mmul(prevHiddenUnitActivation).transpose());	//dL/dw_{O}
+				
+				INDArray dLdwFF = deltaf.mul(prevMemCellActivations);	//mul not mmul because these weights are from unit j->j only (whereas other recurrent weights are i->j for all i,j)
+				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),new NDArrayIndex(4*hiddenLayerSize)}, dLdwFF);	//dL/dw_{FF}
+				INDArray dLdwGG = deltag.mul(prevMemCellActivations);
+				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),new NDArrayIndex(4*hiddenLayerSize+2)}, dLdwGG);	//dL/dw_{GG}
+			}
+			INDArray dLdwOO = deltao.transpose().mul(memCellActivations.slice(t,2)).transpose();
+			recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),new NDArrayIndex(4*hiddenLayerSize+1)}, dLdwOO);	//dL/dw_{OOxy}
+			
+			if( miniBatchSize == 1 ){
+				//Mini-batch size = 1 -> nRows = 1 -> special case for indexing...
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{interval(0,hiddenLayerSize)}, deltai);
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{interval(hiddenLayerSize,2*hiddenLayerSize)}, deltaf);
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{interval(2*hiddenLayerSize,3*hiddenLayerSize)}, deltao);
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{interval(3*hiddenLayerSize,4*hiddenLayerSize)}, deltag);
+			} else {
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(0,hiddenLayerSize)}, deltai);
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(hiddenLayerSize,2*hiddenLayerSize)}, deltaf);
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize)}, deltao);
+				biasGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(3*hiddenLayerSize,4*hiddenLayerSize)}, deltag);
+			}
+		}
+
+		//Weight/bias gradients: sum across time dimension. But leave mini-batch dimension for time (in keeping with what BaseLayer.update() expects.
+		Gradient gradient = new DefaultGradient();
+		gradient.gradientForVariable().put(GravesLSTMParamInitializer.INPUT_WEIGHTS,inputWeightGradients.sum(2));
+		gradient.gradientForVariable().put(GravesLSTMParamInitializer.RECURRENT_WEIGHTS,recurrentWeightGradients.sum(2));
+		gradient.gradientForVariable().put(GravesLSTMParamInitializer.BIAS, biasGradients.sum(2));
+		
+		//TODO: Implement returning of deltas (excluding multiplication by non-linearity) needed by next (lower) layer. This has shape [m,n^L,T],
+		//and is calculated by summing the weights(L-1 to this layer)*deltas for each of the IFOG gates.
+		//See Greff et al. pg11
+		
+		return gradient;
+	}
+	
+	@Override
+	public INDArray preOutput(INDArray x){
+		return activate(x);
+	}
+	
+	@Override
+	public INDArray activate(){
+		//Mini-batch data format: for mini-batch size m, nIn inputs, and T time series length
+		//Data has shape [m,nIn,T]. Layer activations/output has shape [m,nHiddenUnits,T]
+		
+		INDArray recurrentWeights = getParam(GravesLSTMParamInitializer.RECURRENT_WEIGHTS);	//Shape: [hiddenLayerSize,4*hiddenLayerSize+3]; order: [wI,wF,wO,wG,wFF,wOO,wGG]
+		INDArray inputWeights = getParam(GravesLSTMParamInitializer.INPUT_WEIGHTS);			//Shape: [n^(L-1),4*hiddenLayerSize]; order: [wi,wf,wo,wg]
+		INDArray biases = getParam(GravesLSTMParamInitializer.BIAS); //by row: IFOG			//Shape: [4,hiddenLayerSize]; order: [bi,bf,bo,bg]^T
+		
+		int[] dataShape = input.shape();
+		boolean is2dInput = dataShape.length < 3;		//Edge case of T=1, may have shape [m,nIn], equiv. to [m,nIn,1]
+		int timeSeriesLength = (is2dInput ? 1 : dataShape[2]);
+		int hiddenLayerSize = recurrentWeights.rows();	//.shape()[0];
+		int miniBatchSize = dataShape[0];
+		int nIn = inputWeights.shape()[0];		//Size of previous layer (or input)
+		
+		
+		//Extract weights and biases:
+		INDArray wi = inputWeights.get(interval(0,nIn),interval(0,hiddenLayerSize));	//i.e., want rows 0..nIn, columns 0..hiddenLayerSize
+		INDArray wI = recurrentWeights.get(interval(0,hiddenLayerSize),interval(0,hiddenLayerSize));
+		INDArray bi = biases.get(interval(0,hiddenLayerSize));
+		
+		INDArray wf = inputWeights.get(interval(0,nIn),interval(hiddenLayerSize,2*hiddenLayerSize));
+		INDArray wF = recurrentWeights.get(interval(0,hiddenLayerSize),interval(hiddenLayerSize,2*hiddenLayerSize));
+		INDArray wFF = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize,4*hiddenLayerSize+1));
+		INDArray bf = biases.get(interval(hiddenLayerSize,2*hiddenLayerSize));
+		
+		INDArray wo = inputWeights.get(interval(0,nIn),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+		INDArray wO = recurrentWeights.get(interval(0,hiddenLayerSize),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+		INDArray wOO = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize+1,4*hiddenLayerSize+2));
+		INDArray bo = biases.get(interval(2*hiddenLayerSize,3*hiddenLayerSize));
+		
+		INDArray wg = inputWeights.get(interval(0,nIn),interval(3*hiddenLayerSize,4*hiddenLayerSize));
+		INDArray wG = recurrentWeights.get(interval(0,hiddenLayerSize),interval(3*hiddenLayerSize,4*hiddenLayerSize));
+		INDArray wGG = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize+2,4*hiddenLayerSize+3));
+		INDArray bg = biases.get(interval(3*hiddenLayerSize,4*hiddenLayerSize));
+		
+		//Allocate arrays for activations:
+		INDArray outputActivations = Nd4j.zeros(new int[]{miniBatchSize,hiddenLayerSize,timeSeriesLength});
+		INDArray ifogZ = Nd4j.zeros(new int[]{miniBatchSize,4*hiddenLayerSize,timeSeriesLength});
+		INDArray ifogA = Nd4j.zeros(new int[]{miniBatchSize,4*hiddenLayerSize,timeSeriesLength});
+		INDArray memCellActivations = Nd4j.zeros(new int[]{miniBatchSize,hiddenLayerSize,timeSeriesLength}); 
+
+		
+		for( int t=0; t<timeSeriesLength; t++ ){
+			INDArray miniBatchData = (is2dInput ? input : input.slice(t, 2));	//[Expected shape: [m,nIn]. Also deals with edge case of T=1, with 'time series' data of shape [m,nIn], equiv. to [m,nIn,1]
+			INDArray prevOutputActivations = (t==0 ? Nd4j.zeros(new int[]{miniBatchSize,hiddenLayerSize}) : outputActivations.slice(t-1,2));	//Shape: [m,nL]
+			INDArray prevMemCellActivations = (t==0 ? Nd4j.zeros(new int[]{miniBatchSize,hiddenLayerSize}) : memCellActivations.slice(t-1,2));	//Shape: [m,nL]
+			
+			//Calculate activations for: network input + forget, output, input modulation gates.
+			INDArray inputActivations = miniBatchData.mmul(wi)
+					.addi(prevOutputActivations.mmul(wI))
+					.addiRowVector(bi);
+			NDArrayIndex[] iIndexes = (miniBatchSize == 1 ?
+					new NDArrayIndex[]{interval(0,hiddenLayerSize)} :		//Indexing: special case for miniBatchSize=nRows=1. can't use "NDArrayIndex.all(),interval(0,hiddenLayerSize)"
+					new NDArrayIndex[]{NDArrayIndex.all(),interval(0,hiddenLayerSize)} );
+			ifogZ.slice(t,2).put(iIndexes, inputActivations);
+			ifogA.slice(t,2).put(iIndexes, Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), inputActivations)));
+			
+
+			INDArray forgetGateActivations = miniBatchData.mmul(wf)
+					.addi(prevOutputActivations.mmul(wF))
+					.addi(prevMemCellActivations.mmul(Nd4j.diag(wFF)))
+					.addiRowVector(bf);
+			NDArrayIndex[] fIndexes = (miniBatchSize == 1 ? new NDArrayIndex[]{interval(hiddenLayerSize,2*hiddenLayerSize)} :
+					new NDArrayIndex[]{NDArrayIndex.all(),interval(hiddenLayerSize,2*hiddenLayerSize)});
+			ifogZ.slice(t,2).put(fIndexes, forgetGateActivations);
+			ifogA.slice(t,2).put(fIndexes, Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", forgetGateActivations)));
+			//Reason for diag above: convert column vector -> diagonal matrix. Cell activations are only connected to the FOG gates in the same unit.
+			//They are not connected to any other unit -> wFF_ij = 0 for i \neq j
+			
+			INDArray inputModGateActivations = miniBatchData.mmul(wg)
+					.addi(prevOutputActivations.mmul(wG))
+					.addi(prevMemCellActivations.mmul(Nd4j.diag(wGG)))
+					.addiRowVector(bg);
+			NDArrayIndex[] gIndexes = (miniBatchSize == 1 ? new NDArrayIndex[]{interval(3*hiddenLayerSize,4*hiddenLayerSize)} :
+					new NDArrayIndex[]{NDArrayIndex.all(),interval(3*hiddenLayerSize,4*hiddenLayerSize)});
+			ifogZ.slice(t,2).put(gIndexes, inputModGateActivations);
+			ifogA.slice(t,2).put(gIndexes,
+					Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", inputModGateActivations)));
+			
+			//Memory cell activations: (s_t then tanh(s_t))
+			INDArray currentMemoryCellActivations = forgetGateActivations.mul(prevMemCellActivations)
+					.addi(inputModGateActivations.mul(inputActivations));
+			currentMemoryCellActivations = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), currentMemoryCellActivations));
+			
+			INDArray outputGateActivations = miniBatchData.mmul(wo)
+					.addi(prevOutputActivations.mmul(wO))
+					.addi(currentMemoryCellActivations.mmul(Nd4j.diag(wOO)))
+					.addiRowVector(bo);
+			NDArrayIndex[] oIndexes = (miniBatchSize == 1 ? new NDArrayIndex[]{interval(2*hiddenLayerSize,3*hiddenLayerSize)} :
+					new NDArrayIndex[]{NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize)});
+			ifogZ.slice(t,2).put(oIndexes, outputGateActivations);
+			ifogA.slice(t,2).put(oIndexes,Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", outputGateActivations)));
+			
+			//LSTM unit outputs:
+			INDArray currHiddenUnitActivations = outputGateActivations.mul(currentMemoryCellActivations);	//Expected shape: [m,hiddenLayerSize]
+			
+			outputActivations.slice(t,2).assign(currHiddenUnitActivations);
+			memCellActivations.slice(t,2).assign(currentMemoryCellActivations);
+		}
+		
+		//Save output activations, memory cell state, ifog gate Zs and As for use in backward pass:
+		this.ifogZs = ifogZ;
+		this.ifogAs = ifogA;
+		this.memCellActivations = memCellActivations;
+		this.outputActivations = outputActivations;
+		
+		return outputActivations;
+	}
+	
+	@Override
+	public INDArray activationMean(){
+		return activate();
+	}
+	
+	@Override
+	public Type type(){
+		return Type.RECURRENT;
+	}
+	
+	@Override
+	public Layer transpose(){
+		throw new UnsupportedOperationException("Not yet implemented");
+	}
+	
+	@Override
+	public void clear(){
+		super.clear();
+		ifogZs = null;
+		ifogAs = null;
+		memCellActivations = null;
+		outputActivations = null;
+	}
+	
+
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -382,7 +382,7 @@ public class MultiLayerNetwork implements Serializable, Classifier {
                     if(type == Layer.Type.FEED_FORWARD || type == Layer.Type.RECURRENT) { 
                         if(i!=(layers.length-1)) {
                             numHiddenLayersSizesUsed++;
-                            conf.setNIn(layerInput.shape()[1]);	//RNN activations may be 3D not 2D (can't just use layerInput.columns())
+                            conf.setNIn(layerInput.size(1));
                             conf.setNOut(hiddenLayerSizes[numHiddenLayersSizesUsed]);
                         } else {
                             conf.setNIn(hiddenLayerSizes[numHiddenLayersSizesUsed]);
@@ -1667,6 +1667,10 @@ public class MultiLayerNetwork implements Serializable, Classifier {
 
     public Layer[] getLayers() {
         return layers;
+    }
+    
+    public Layer getLayer( int i ){
+    	return layers[i];
     }
 
     public void setLayers(Layer[] layers) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -20,7 +20,6 @@ package org.deeplearning4j.nn.multilayer;
 
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.EnumUtils;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.nn.api.*;
@@ -37,7 +36,6 @@ import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.util.MultiLayerUtil;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.LossFunction;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.factory.Nd4j;
@@ -358,7 +356,7 @@ public class MultiLayerNetwork implements Serializable, Classifier {
                     }
                     conf.setNIn(inputSize);
 
-                    if (type == Layer.Type.FEED_FORWARD) {
+                    if (type == Layer.Type.FEED_FORWARD || type == Layer.Type.RECURRENT) {
                         conf.setNOut(hiddenLayerSizes[numHiddenLayersSizesUsed]);
                     }
                 }
@@ -381,10 +379,10 @@ public class MultiLayerNetwork implements Serializable, Classifier {
                      * order in the array without having to create an override
                      * for every layer.
                      */
-                    if(type == Layer.Type.FEED_FORWARD) {
+                    if(type == Layer.Type.FEED_FORWARD || type == Layer.Type.RECURRENT) { 
                         if(i!=(layers.length-1)) {
                             numHiddenLayersSizesUsed++;
-                            conf.setNIn(layerInput.columns());
+                            conf.setNIn(layerInput.shape()[1]);	//RNN activations may be 3D not 2D (can't just use layerInput.columns())
                             conf.setNOut(hiddenLayerSizes[numHiddenLayersSizesUsed]);
                         } else {
                             conf.setNIn(hiddenLayerSizes[numHiddenLayersSizesUsed]);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/GravesLSTMParamInitializer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/params/GravesLSTMParamInitializer.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.params;
+
+import org.canova.api.conf.Configuration;
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.distribution.Distributions;
+import org.deeplearning4j.nn.weights.WeightInitUtil;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.distribution.Distribution;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+
+import java.util.Map;
+
+/**
+ * LSTM Parameters.
+ * Based on Graves: Supervised Sequence Labelling with Recurrent Neural Networks
+ * http://www.cs.toronto.edu/~graves/phd.pdf
+ */
+public class GravesLSTMParamInitializer implements ParamInitializer {
+	/** Weights for previous time step -> current time step connections */
+    public final static String RECURRENT_WEIGHTS = "RW";
+    public final static String BIAS = DefaultParamInitializer.BIAS_KEY;
+    /** Weights for previous layer -> this layer (current time step).
+     * Specifically set to same value af DefaultParamInitializer, as other layers will
+     * want to use these during back-prop. For example, in BaseLayer.backwardGradient(...)
+     * */
+    public final static String INPUT_WEIGHTS = DefaultParamInitializer.WEIGHT_KEY;
+
+    @Override
+    public void init(Map<String, INDArray> params, NeuralNetConfiguration conf) {
+        Distribution dist = Distributions.createDistribution(conf.getDist());
+
+        int nL = conf.getNOut();	//i.e., n neurons in this layer
+        int nLast = conf.getNIn();	//i.e., n neurons in previous layer
+        
+        
+        conf.addVariable(RECURRENT_WEIGHTS);
+        conf.addVariable(INPUT_WEIGHTS);
+        conf.addVariable(BIAS);
+        
+        
+        params.put(RECURRENT_WEIGHTS,WeightInitUtil.initWeights(nL, 4 * nL + 3, conf.getWeightInit(), dist));
+        params.put(INPUT_WEIGHTS,WeightInitUtil.initWeights(nLast, 4 * nL, conf.getWeightInit(), dist));
+        INDArray biases = Nd4j.zeros(1,4*nL);	//Order: input, forget, output, input modulation, i.e., IFOG
+        biases.put(new NDArrayIndex[]{NDArrayIndex.interval(nL, 2*nL),new NDArrayIndex(0)}, Nd4j.ones(1,nL).muli(5));
+        /*The above line initializes the forget gate biases to 5.
+         * See Sutskever PhD thesis, pg19:
+         * "it is important for [the forget gate activations] to be approximately 1 at the early stages of learning,
+         *  which is accomplished by initializing [the forget gate biases] to a large value (such as 5). If it is
+         *  not done, it will be harder to learn long range dependencies because the smaller values of the forget
+         *  gates will create a vanishing gradients problem."
+         *  http://www.cs.utoronto.ca/~ilya/pubs/ilya_sutskever_phd_thesis.pdf
+         */
+        params.put(BIAS, biases);
+
+        params.get(RECURRENT_WEIGHTS).data().persist();
+        params.get(INPUT_WEIGHTS).data().persist();
+        params.get(BIAS).data().persist();
+    }
+
+    @Override
+    public void init(Map<String, INDArray> params, NeuralNetConfiguration conf, Configuration extraConf) {
+        init(params,conf);
+    }
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/models/classifiers/lstm/GravesLSTMTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/models/classifiers/lstm/GravesLSTMTest.java
@@ -1,0 +1,118 @@
+package org.deeplearning4j.models.classifiers.lstm;
+
+import static org.junit.Assert.*;
+
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.distribution.UniformDistribution;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.OutputLayer;
+import org.deeplearning4j.nn.layers.factory.LayerFactories;
+import org.deeplearning4j.nn.layers.recurrent.GravesLSTM;
+import org.deeplearning4j.nn.params.DefaultParamInitializer;
+import org.deeplearning4j.nn.params.GravesLSTMParamInitializer;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+
+public class GravesLSTMTest {
+	
+	@Test
+	public void testLSTMGravesForwardBasic(){
+		//Very basic test of forward prop. of LSTM layer with a time series.
+		//Essentially make sure it doesn't throw any exceptions, and provides output in the correct shape.
+		
+		int nIn = 13;
+		int nHiddenUnits = 17;
+		
+		NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder().activationFunction("tanh")
+                .layer(new org.deeplearning4j.nn.conf.layers.GravesLSTM())
+                .nIn(nIn).nOut(nHiddenUnits).build();
+	
+		GravesLSTM layer = LayerFactories.getFactory(conf.getLayer()).create(conf);
+		
+		//Data: has shape [miniBatchSize,nIn,timeSeriesLength];
+		//Output/activations has shape [miniBatchsize,nHiddenUnits,timeSeriesLength];
+		
+		INDArray dataSingleExampleTimeLength1 = Nd4j.ones(1,nIn,1);
+		INDArray activations1 = layer.activate(dataSingleExampleTimeLength1);
+		assertArrayEquals(activations1.shape(),new int[]{1,nHiddenUnits,1});
+		
+		INDArray dataMultiExampleLength1 = Nd4j.ones(10,nIn,1);
+		INDArray activations2 = layer.activate(dataMultiExampleLength1);
+		assertArrayEquals(activations2.shape(),new int[]{10,nHiddenUnits,1});
+		
+		INDArray dataSingleExampleLength12 = Nd4j.ones(1,nIn,12);
+		INDArray activations3 = layer.activate(dataSingleExampleLength12);
+		assertArrayEquals(activations3.shape(),new int[]{1,nHiddenUnits,12});
+		
+		INDArray dataMultiExampleLength15 = Nd4j.ones(10,nIn,15);
+		INDArray activations4 = layer.activate(dataMultiExampleLength15);
+		assertArrayEquals(activations4.shape(),new int[]{10,nHiddenUnits,15});
+	}
+	
+	@Test
+	public void testLSTMGravesBackwardBasic(){
+		//Very basic test of backprop for mini-batch + time series
+		//Essentially make sure it doesn't throw any exceptions, and provides output in the correct shape. 
+		
+		testGravesBackwardBasicHelper(13,3,17,10,7);
+		testGravesBackwardBasicHelper(13,3,17,1,7);		//Edge case: miniBatchSize = 1
+		testGravesBackwardBasicHelper(13,3,17,10,1);	//Edge case: timeSeriesLength = 1
+		testGravesBackwardBasicHelper(13,3,17,1,1);		//Edge case: both miniBatchSize = 1 and timeSeriesLength = 1
+	}
+	
+	private static void testGravesBackwardBasicHelper(int nIn, int nOut, int lstmNHiddenUnits, int miniBatchSize, int timeSeriesLength ){
+		
+		INDArray inputData = Nd4j.ones(miniBatchSize,nIn,timeSeriesLength);
+		
+		NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder().activationFunction("tanh")
+				.weightInit(WeightInit.DISTRIBUTION).dist(new UniformDistribution(0, 1))
+                .layer(new org.deeplearning4j.nn.conf.layers.GravesLSTM())
+                .nIn(nIn).nOut(lstmNHiddenUnits).build();
+		
+		GravesLSTM lstm = LayerFactories.getFactory(conf.getLayer()).create(conf);
+		//Set input, do a forward pass:
+		lstm.activate(inputData);
+		
+		
+		NeuralNetConfiguration confOut = new NeuralNetConfiguration.Builder().activationFunction("tanh")
+                .layer(new org.deeplearning4j.nn.conf.layers.OutputLayer())
+                .weightInit(WeightInit.DISTRIBUTION).dist(new UniformDistribution(0, 1))
+                .lossFunction(LossFunctions.LossFunction.MCXENT)
+                .nIn(17).nOut(3).build();
+		
+		OutputLayer outLayer = LayerFactories.getFactory(confOut.getLayer()).create(confOut);
+		
+		//Create pseudo-gradient for input to LSTM layer (i.e., as if created by OutputLayer)
+		//This should have two elements: bias and weight gradients.
+		Gradient gradient = new DefaultGradient();
+		INDArray pseudoBiasGradients = Nd4j.ones(miniBatchSize,nOut,timeSeriesLength);
+		gradient.gradientForVariable().put(DefaultParamInitializer.BIAS_KEY,pseudoBiasGradients);
+		INDArray pseudoWeightGradients = Nd4j.ones(miniBatchSize,lstmNHiddenUnits,nOut,timeSeriesLength);
+		gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, pseudoWeightGradients);
+		
+		INDArray sigmaPrimeZLSTM = Nd4j.ones(miniBatchSize,lstmNHiddenUnits,timeSeriesLength);
+		Gradient outGradient = lstm.backwardGradient(sigmaPrimeZLSTM, outLayer, gradient, inputData);
+		
+		INDArray biasGradient = outGradient.getGradientFor(GravesLSTMParamInitializer.BIAS);
+		INDArray inWeightGradient = outGradient.getGradientFor(GravesLSTMParamInitializer.INPUT_WEIGHTS);
+		INDArray recurrentWeightGradient = outGradient.getGradientFor(GravesLSTMParamInitializer.RECURRENT_WEIGHTS);
+		assertNotNull(biasGradient);
+		assertNotNull(inWeightGradient);
+		assertNotNull(recurrentWeightGradient);
+		
+		assertArrayEquals(biasGradient.shape(),new int[]{miniBatchSize,4*lstmNHiddenUnits});
+		assertArrayEquals(inWeightGradient.shape(),new int[]{nIn,4*lstmNHiddenUnits});
+		assertArrayEquals(recurrentWeightGradient.shape(),new int[]{lstmNHiddenUnits,4*lstmNHiddenUnits+3});
+		
+		//Check update:
+		for( String s : outGradient.gradientForVariable().keySet() ){
+			lstm.update(outGradient.getGradientFor(s), s);
+		}
+	}
+
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
@@ -32,7 +32,7 @@ public class MultiLayerTestRNN {
 		network.init();
 		
 		//Ensure that we have the correct number weights and biases, that these have correct shape etc.
-		Layer layer = network.getLayers()[0];
+		Layer layer = network.getLayer(0);
 		assertTrue(layer instanceof GravesLSTM);
 		
 		Map<String,INDArray> paramTable = layer.paramTable();
@@ -70,7 +70,7 @@ public class MultiLayerTestRNN {
 		
 		//Ensure that we have the correct number weights and biases, that these have correct shape etc. for each layer
 		for( int i=0; i<nHiddenUnits.length; i++ ){
-			Layer layer = network.getLayers()[i];
+			Layer layer = network.getLayer(i);
 			assertTrue(layer instanceof GravesLSTM);
 			
 			Map<String,INDArray> paramTable = layer.paramTable();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
@@ -1,0 +1,97 @@
+package org.deeplearning4j.nn.multilayer;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.override.ClassifierOverride;
+import org.deeplearning4j.nn.layers.recurrent.GravesLSTM;
+import org.deeplearning4j.nn.params.GravesLSTMParamInitializer;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+
+public class MultiLayerTestRNN {
+	
+	@Test
+	public void testGravesLSTMInit(){
+		int nIn = 8;
+		int nOut = 25;
+		int nHiddenUnits = 17;
+		MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+        .layer(new org.deeplearning4j.nn.conf.layers.GravesLSTM())
+        .nIn(nIn).nOut(nOut)
+        .activationFunction("tanh")
+        .list(2).hiddenLayerSizes(nHiddenUnits)
+        .override(1, new ClassifierOverride())
+        .build();
+		MultiLayerNetwork network = new MultiLayerNetwork(conf);
+		network.init();
+		
+		//Ensure that we have the correct number weights and biases, that these have correct shape etc.
+		Layer layer = network.getLayers()[0];
+		assertTrue(layer instanceof GravesLSTM);
+		
+		Map<String,INDArray> paramTable = layer.paramTable();
+		assertTrue(paramTable.size() == 3);	//2 sets of weights, 1 set of biases
+		
+		INDArray recurrentWeights = paramTable.get(GravesLSTMParamInitializer.RECURRENT_WEIGHTS);
+		assertArrayEquals(recurrentWeights.shape(),new int[]{nHiddenUnits,4*nHiddenUnits+3});	//Should be shape: [layerSize,4*layerSize+3]
+		INDArray inputWeights = paramTable.get(GravesLSTMParamInitializer.INPUT_WEIGHTS);
+		assertArrayEquals(inputWeights.shape(),new int[]{nIn,4*nHiddenUnits}); //Should be shape: [nIn,4*layerSize]
+		INDArray biases = paramTable.get(GravesLSTMParamInitializer.BIAS);
+		assertArrayEquals(biases.shape(),new int[]{1,4*nHiddenUnits});	//Should be shape: [1,4*layerSize]
+		
+		//Want forget gate biases to be initialized to > 0. See parameter initializer for details
+		INDArray forgetGateBiases = biases.get(new NDArrayIndex[]{NDArrayIndex.interval(nHiddenUnits, 2*nHiddenUnits),new NDArrayIndex(0)});
+		assertTrue(forgetGateBiases.gt(0).sum(0).getDouble(0)==nHiddenUnits);
+		
+		int nParams = recurrentWeights.length() + inputWeights.length() + biases.length();
+		assertTrue(nParams == layer.numParams());
+	}
+	
+	@Test
+	public void testGravesTLSTMInitStacked(){
+		int nIn = 8;
+		int nOut = 25;
+		int[] nHiddenUnits = {17,19,23};
+		MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+        .layer(new org.deeplearning4j.nn.conf.layers.GravesLSTM())
+        .nIn(nIn).nOut(nOut)
+        .activationFunction("tanh")
+        .list(nHiddenUnits.length+1).hiddenLayerSizes(nHiddenUnits)
+        .override(nHiddenUnits.length, new ClassifierOverride())
+        .build();
+		MultiLayerNetwork network = new MultiLayerNetwork(conf);
+		network.init();
+		
+		//Ensure that we have the correct number weights and biases, that these have correct shape etc. for each layer
+		for( int i=0; i<nHiddenUnits.length; i++ ){
+			Layer layer = network.getLayers()[i];
+			assertTrue(layer instanceof GravesLSTM);
+			
+			Map<String,INDArray> paramTable = layer.paramTable();
+			assertTrue(paramTable.size() == 3);	//2 sets of weights, 1 set of biases
+			
+			int layerNIn = (i==0 ? nIn : nHiddenUnits[i-1] );
+			
+			INDArray recurrentWeights = paramTable.get(GravesLSTMParamInitializer.RECURRENT_WEIGHTS);
+			assertArrayEquals(recurrentWeights.shape(),new int[]{nHiddenUnits[i],4*nHiddenUnits[i]+3});	//Should be shape: [layerSize,4*layerSize+3]
+			INDArray inputWeights = paramTable.get(GravesLSTMParamInitializer.INPUT_WEIGHTS);
+			assertArrayEquals(inputWeights.shape(),new int[]{layerNIn,4*nHiddenUnits[i]}); //Should be shape: [nIn,4*layerSize]
+			INDArray biases = paramTable.get(GravesLSTMParamInitializer.BIAS);
+			assertArrayEquals(biases.shape(),new int[]{1,4*nHiddenUnits[i]});	//Should be shape: [1,4*layerSize]
+			
+			//Want forget gate biases to be initialized to > 0. See parameter initializer for details
+			INDArray forgetGateBiases = biases.get(new NDArrayIndex[]{NDArrayIndex.interval(nHiddenUnits[i], 2*nHiddenUnits[i]),new NDArrayIndex(0)});
+			assertTrue(forgetGateBiases.gt(0).sum(0).getDouble(0)==nHiddenUnits[i]);
+			
+			int nParams = recurrentWeights.length() + inputWeights.length() + biases.length();
+			assertTrue(nParams == layer.numParams());
+		}
+	}
+	
+}


### PR DESCRIPTION
Known issues with this LSTM implementation:
gradient() and calcGradient(): Not implemented. I assume this is for unsupervised pretraining, hence is not applicable here?
preOut(x): normally returns z=wx+b. LSTM doesn't really have a z_out due to gating structure -> returns activations instead of z.
activationMean(): as above.
transpose(): not yet implemented. I'm not sure how this would work for LSTM.
Additionally, as previously discussed: this seems to work in isolation (+ MultiLayerNetwork initialization), but it won't work with the current backprop implementation, or with non-RNN layers (such as RBM or OutputLayer).