### PR TITLE
InMemoryLookupCache should not load UNK

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
@@ -120,7 +120,7 @@ public class WordVectorSerializer
         int layerSize = Integer.parseInt(initial[1]);
         syn0 = Nd4j.create(words, layerSize);
 
-        cache = new InMemoryLookupCache();
+        cache = new InMemoryLookupCache(false);
 
         int currLine = 0;
         while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
Made `readTextModel` consistent with `readBinaryModel`