### PR TITLE
Resolve dl4j-caffe dependencies

### DIFF
--- a/dl4j-caffe/pom.xml
+++ b/dl4j-caffe/pom.xml
@@ -33,6 +33,12 @@
             <version>${google.protobuf.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Resolve build failure because of junit dependencies.