### PR TITLE
fix ignored fields in BarnesHutTsne builder

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
@@ -61,7 +61,6 @@ import static org.nd4j.linalg.factory.Nd4j.zeros;
  */
 public class BarnesHutTsne extends Tsne implements Model {
     private int N;
-    private double perplexity;
     private double theta;
     private INDArray rows;
     private INDArray cols;
@@ -98,6 +97,37 @@ public class BarnesHutTsne extends Tsne implements Model {
         this.switchMomentumIteration = momentumSwitchIteration;
     }
 
+    public BarnesHutTsne(INDArray x,
+                         INDArray y,
+                         int numDimensions,
+                         String simiarlityFunction,
+                         double theta,
+                         boolean invert,
+                         int maxIter,
+                         double realMin,
+                         double initialMomentum,
+                         double finalMomentum,
+                         double momentum,
+                         int switchMomentumIteration,
+                         boolean normalize,
+                         boolean usePca,
+                         int stopLyingIteration,
+                         double tolerance,
+                         double learningRate,
+                         boolean useAdaGrad,
+                         double perplexity,
+                         double minGain) {
+        super(maxIter, realMin,initialMomentum,finalMomentum,momentum,switchMomentumIteration,normalize,
+                usePca,stopLyingIteration,tolerance,learningRate,useAdaGrad,perplexity,minGain);
+        this.y = y;
+        this.x = x;
+        this.numDimensions = numDimensions;
+        this.simiarlityFunction = simiarlityFunction;
+        this.theta = theta;
+        this.invert = invert;
+    }
+
+
     public String getSimiarlityFunction() {
         return simiarlityFunction;
     }
@@ -112,6 +142,14 @@ public class BarnesHutTsne extends Tsne implements Model {
 
     public void setInvert(boolean invert) {
         this.invert = invert;
+    }
+
+    public double getTheta(){
+        return theta;
+    }
+
+    public double getPerplexity(){
+        return perplexity;
     }
 
     /**
@@ -725,10 +763,9 @@ public class BarnesHutTsne extends Tsne implements Model {
 
         @Override
         public BarnesHutTsne build() {
-            BarnesHutTsne t = new BarnesHutTsne(null,null,2,perplexity,theta,maxIter,this.stopLyingIteration,this.switchMomentumIteration,this.momentum,this.finalMomentum,this.learningRate);
-            t.useAdaGrad = useAdaGrad;
-            t.usePca = usePca;
-            return t;
+            return new BarnesHutTsne(null, null, 2, similarityFunction,theta,invert,
+                    maxIter,realMin,initialMomentum,finalMomentum,momentum,switchMomentumIteration,normalize,
+                    usePca,stopLyingIteration,tolerance,learningRate,useAdaGrad,perplexity,minGain);
         }
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/plot/BarnesHutTsneTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/plot/BarnesHutTsneTest.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.plot;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
+import static org.junit.Assert.*;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
@@ -55,5 +56,50 @@ public class BarnesHutTsneTest {
         b.fit(data);
     }
 
+    @Test
+    public void testBuilderFields() throws Exception {
+        final double theta = 0;
+        final boolean invert = false;
+        final String similarityFunctions = "eucidean";
+        final int maxIter = 1;
+        final double realMin = 1.0;
+        final double initialMomentum = 2.0;
+        final double finalMomentum = 3.0;
+        final double momentum = 4.0;
+        final int switchMomentumIteration = 1;
+        final boolean normalize = false;
+        final boolean usePca = true;
+        final int stopLyingIteration = 100;
+        final double tolerance = 1e-1;
+        final double learningRate = 100;
+        final boolean useAdaGrad = false;
+        final double perplexity = 1.0;
+        final double minGain = 1.0;
 
+        BarnesHutTsne b = new BarnesHutTsne.Builder().theta(theta).invertDistanceMetric(invert).similarityFunction(similarityFunctions)
+                .setMaxIter(maxIter).setRealMin(realMin).setInitialMomentum(initialMomentum).setFinalMomentum(finalMomentum)
+                .setMomentum(momentum).setSwitchMomentumIteration(switchMomentumIteration).normalize(normalize)
+                .usePca(usePca).stopLyingIteration(stopLyingIteration).tolerance(tolerance).learningRate(learningRate)
+                .perplexity(perplexity).minGain(minGain).build();
+
+        final double DELTA = 1e-15;
+
+        assertEquals(theta,b.getTheta(),DELTA);
+        assertEquals("invert", invert, b.isInvert());
+        assertEquals("similarityFunctions",similarityFunctions,b.getSimiarlityFunction());
+        assertEquals("maxIter", maxIter, b.maxIter);
+        assertEquals(realMin,b.realMin,DELTA);
+        assertEquals(initialMomentum,b.initialMomentum,DELTA);
+        assertEquals(finalMomentum, b.finalMomentum,DELTA);
+        assertEquals(momentum,b.momentum,DELTA);
+        assertEquals("switchMomentumnIteration", switchMomentumIteration, b.switchMomentumIteration);
+        assertEquals("normalize", normalize,b.normalize);
+        assertEquals("usePca", usePca,b.usePca);
+        assertEquals("stopLyingIteration", stopLyingIteration,b.stopLyingIteration);
+        assertEquals(tolerance,b.tolerance,DELTA);
+        assertEquals(learningRate,b.learningRate,DELTA);
+        assertEquals("useAdaGrad", useAdaGrad, b.useAdaGrad);
+        assertEquals(perplexity,b.getPerplexity(),DELTA);
+        assertEquals(minGain,b.minGain,DELTA);
+    }
 }


### PR DESCRIPTION
This fixes the bug that BarnesHutTsne.Builder ignores following fields.

Declared at BarnesHutTsne
* boolean invert
* double perplexity (due to unexpected hiding variable)

Inherited from Tsne
* double realMin
* double initialMomentum
* boolean normalize
* double tolerance
* double minGain

This also adds additional constructor to BarnesHutTsne to afford above variables and some getter methods of them, with keeping public API consistently.