### PR TITLE
Fix not found companion object

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/classification/MultiLayerNetworkClassification.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/classification/MultiLayerNetworkClassification.scala
@@ -128,6 +128,23 @@ class NeuralNetworkClassification(override val uid: String)
 }
 
 /**
+ * Companion object for running of classification process.
+ */
+object NeuralNetworkClassification {
+  def apply(uid: String) = new NeuralNetworkClassification(uid)
+
+  def apply() = new NeuralNetworkClassification()
+
+  def train(dataset: DataFrame): NeuralNetworkClassificationModel = {
+    NeuralNetworkClassification().train(dataset)
+  }
+
+  def train(uid: String, dataset: DataFrame): NeuralNetworkClassificationModel = {
+    NeuralNetworkClassification(uid).train(dataset)
+  }
+}
+
+/**
  * Neural network-based classification model.
  *
  * @author Eron Wright

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/reconstruction/MultiLayerNetworkReconstruction.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/reconstruction/MultiLayerNetworkReconstruction.scala
@@ -123,6 +123,23 @@ class NeuralNetworkReconstruction(override val uid: String)
 }
 
 /**
+ * Companion object for reconstruction process.
+ */
+object NeuralNetworkReconstruction {
+  def apply(uid: String) = new NeuralNetworkReconstruction(uid)
+
+  def apply() = new NeuralNetworkReconstruction()
+
+  def learn(dataset: DataFrame): NeuralNetworkReconstructionModel = {
+    NeuralNetworkReconstruction().learn(dataset)
+  }
+
+  def learn(uid: String, dataset: DataFrame): NeuralNetworkReconstructionModel = {
+    NeuralNetworkReconstruction(uid).learn(dataset)
+  }
+}
+
+/**
  * Neural network-based reconstruction model.
  *
  * @author Eron Wright


### PR DESCRIPTION
When we use NeuralNetwork* classes from spark ml (such as spark-shell), they cannot be found due to missing companion object. Companion object should retain constructor and training API at least.
```scala
scala> org.deeplearning4j.spark.ml.classification.NeuralNetworkClassification
<console>:20: error: object NeuralNetworkClassification is not a member of package org.deeplearning4j.spark.ml.classification
Note: class NeuralNetworkClassification exists, but it has no companion object.
              org.deeplearning4j.spark.ml.classification.NeuralNetworkClassification
                                                         ^
```