### PR TITLE
Optimization of wordsNearest

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
@@ -374,32 +374,33 @@ public class WordVectorsImpl implements WordVectors {
 
     /**
      * Words nearest based on positive and negative words
+     *
      * @param positive the positive words
      * @param negative the negative words
      * @param top the top n words
      * @return the words nearest the mean of the words
      */
-    public Collection<String> wordsNearest(List<String> positive,List<String> negative,int top) {
-        for(String p : SetUtils.union(new HashSet<>(positive),new HashSet<>(negative))) {
-            if(!vocab().containsWord(p)) {
+    @Override
+    public Collection<String> wordsNearest(List<String> positive, List<String> negative, int top) {
+        for (String p : SetUtils.union(new HashSet<>(positive), new HashSet<>(negative))) {
+            if (!vocab().containsWord(p)) {
                 return new ArrayList<>();
             }
         }
 
-
         INDArray words = Nd4j.create(positive.size() + negative.size(), lookupTable().layerSize());
         int row = 0;
-        Set<String> union = SetUtils.union(new HashSet<>(positive),new HashSet<>(negative));
-        for(String s : positive) {
-            words.putRow(row++,lookupTable().vector(s));
+        Set<String> union = SetUtils.union(new HashSet<>(positive), new HashSet<>(negative));
+        for (String s : positive) {
+            words.putRow(row++, lookupTable().vector(s));
         }
 
-        for(String s : negative) {
+        for (String s : negative) {
             words.putRow(row++, lookupTable().vector(s).mul(-1));
         }
 
         INDArray mean = words.isMatrix() ? words.mean(0) : words;
-        if(lookupTable() instanceof  InMemoryLookupTable) {
+        if (lookupTable() instanceof InMemoryLookupTable) {
             InMemoryLookupTable l = (InMemoryLookupTable) lookupTable();
 
             INDArray syn0 = l.getSyn0();
@@ -409,51 +410,79 @@ public class WordVectorsImpl implements WordVectors {
             // We assume that syn0 is normalized.
             // Hence, the following division is not needed anymore.
             // distances.diviRowVector(distances.norm2(1));
-            INDArray[] sorted = Nd4j.sortWithIndices(distances,0,false);
+            //INDArray[] sorted = Nd4j.sortWithIndices(distances,0,false);
+            INDArray[] sorted = getTopN(distances.vectorAlongDimension(0, 0), top + union.size());
             INDArray sort = sorted[0];
             List<String> ret = new ArrayList<>();
-            if(top > sort.length())
-                top = sort.length();
-            //there will be a redundant word
-            int end = top;
-            for(int i = 0; i < end; i++) {
+
+            for (int i = 0; i < sort.length(); i++) {
                 String word = vocab().wordAtIndex(sort.getInt(i));
-                if(union.contains(word)) {
-                    end++;
-                    if(end >= sort.length())
+                if (word != null && !word.equals("UNK") && !word.equals("STOP") && !union.contains(word)) {
+                    ret.add(word);
+                    if (ret.size() >= top) {
                         break;
-                    continue;
+                    }
                 }
-
-                String add = vocab().wordAtIndex(sort.getInt(i));
-                if(add == null || add.equals("UNK") || add.equals("STOP")) {
-                    end++;
-                    if(end >= sort.length())
-                        break;
-                    continue;
-                }
-
-
-                ret.add(vocab().wordAtIndex(sort.getInt(i)));
             }
-
 
             return ret;
         }
 
         Counter<String> distances = new Counter<>();
 
-        for(String s : vocab().words()) {
+        for (String s : vocab().words()) {
             INDArray otherVec = getWordVectorMatrix(s);
-            double sim = Transforms.cosineSim(mean,otherVec);
+            double sim = Transforms.cosineSim(mean, otherVec);
             distances.incrementCount(s, sim);
         }
-
 
         distances.keepTopNKeys(top);
         return distances.keySet();
 
+    }
 
+    /**
+     * Get top N elements
+     *
+     * @param vec the vec to extract the top elements from
+     * @param N the number of elements to extract
+     * @return the indices and the sorted top N elements
+     */
+    private static INDArray[] getTopN(INDArray vec, int N) {
+        Comparator comparator = new Comparator<Double[]>() {
+            @Override
+            public int compare(Double[] o1, Double[] o2) {
+                return Double.compare(o1[0], o2[0]);
+            }
+        };
+
+        PriorityQueue<Double[]> queue = new PriorityQueue(comparator);
+
+        for (int j = 0; j < vec.length(); j++) {
+            final Double[] pair = new Double[]{vec.getDouble(j), (double) j};
+            if (queue.size() < N) {
+                queue.add(pair);
+            } else {
+                Double[] head = queue.peek();
+                if (comparator.compare(pair, head) > 0) {
+                    queue.poll();
+                    queue.add(pair);
+                }
+            }
+        }
+
+        vec = Nd4j.create(queue.size());
+        INDArray indexVector = Nd4j.create(queue.size());
+
+        int index = queue.size();
+
+        while (!queue.isEmpty()) {
+            Double[] pair = queue.poll();
+            vec.putScalar(--index, pair[0]);
+            indexVector.putScalar(index, pair[1]);
+        }
+
+        return new INDArray[]{indexVector, vec};
     }
 
 


### PR DESCRIPTION
After performing the multiplication, sorting the whole matrix and then extracting the top N words is expensive. I switched the implementation to a priority queue. The result is a boost in the performance. For the word `France` in the `GoogleNews` corpus, the original implementation takes `2908 ms` in sorting. The new implementation takes only `102 ms` to perform the extraction.