### PR TITLE
BackTrackLineSearch fixes and optimizations

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/GradientAscent.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/GradientAscent.java
@@ -18,7 +18,6 @@
 
 package org.deeplearning4j.optimize.solvers;
 
-
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.api.Model;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -27,10 +26,8 @@ import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.api.StepFunction;
 import org.deeplearning4j.optimize.api.TerminationCondition;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * Vectorized Stochastic Gradient Ascent
@@ -38,9 +35,9 @@ import java.util.LinkedList;
  *
  */
 public class GradientAscent extends BaseOptimizer {
+	private static final long serialVersionUID = 6336124657542062284L;
 
-
-    public GradientAscent(NeuralNetConfiguration conf, StepFunction stepFunction, Collection<IterationListener> iterationListeners, Model model) {
+	public GradientAscent(NeuralNetConfiguration conf, StepFunction stepFunction, Collection<IterationListener> iterationListeners, Model model) {
         super(conf, stepFunction, iterationListeners, model);
     }
 
@@ -55,7 +52,7 @@ public class GradientAscent extends BaseOptimizer {
         double norm2 = line.norm2(Integer.MAX_VALUE).getDouble(0);
         if(norm2 > stpMax)
             line.muli(stpMax / norm2);
-
+        
     }
 
     @Override
@@ -65,13 +62,8 @@ public class GradientAscent extends BaseOptimizer {
 
     @Override
     public void setupSearchState(Pair<Gradient, Double> pair) {
-
         super.setupSearchState(pair);
         INDArray gradient = (INDArray) searchState.get(GRADIENT_KEY);
-        INDArray searchDirection = gradient.dup();
-        searchState.put("searchDirection",searchDirection);
-
+        searchState.put("searchDirection",gradient);
     }
-
-
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/stepfunctions/DefaultStepFunction.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/stepfunctions/DefaultStepFunction.java
@@ -18,9 +18,7 @@
 
 package org.deeplearning4j.optimize.stepfunctions;
 
-import org.deeplearning4j.optimize.GradientAdjustment;
 import org.deeplearning4j.optimize.api.StepFunction;
-import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -29,14 +27,14 @@ import org.nd4j.linalg.factory.Nd4j;
  * @author Adam Gibson
  */
 public class DefaultStepFunction implements StepFunction {
+	private static final long serialVersionUID = -4707790524365648985L;
+
+	/**Does x = x + stepSize * line
+	 * @param params Expects params[0] to be step size.
+	 */
     @Override
     public void step(INDArray x, INDArray line, Object[] params) {
-        double alam = (double) params[0];
-        double oldAlam = (double) params[1];
-        double scalar = alam - oldAlam;
-        Nd4j.getBlasWrapper().level1().axpy(line.length(),scalar, line, x);
-
-
+        Nd4j.getBlasWrapper().level1().axpy(line.length(),(double)params[0], line, x);
     }
 
     @Override
@@ -47,6 +45,5 @@ public class DefaultStepFunction implements StepFunction {
     @Override
     public void step() {
         throw new UnsupportedOperationException();
-
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
@@ -1,0 +1,69 @@
+package org.deeplearning4j.optimize.solver;
+
+import org.deeplearning4j.datasets.iterator.DataSetIterator;
+import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.RBM;
+import org.deeplearning4j.nn.conf.override.ConfOverride;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.Test;
+import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
+
+public class TestOptimizers {
+	
+	@Test
+	public void testOptimizersBasicMLPBackprop(){
+		//Basic tests of the 'does it throw an exception' variety.
+		
+		DataSetIterator iter = new IrisDataSetIterator(5,50);
+		
+		for( OptimizationAlgorithm oa : OptimizationAlgorithm.values() ){
+			MultiLayerNetwork network = new MultiLayerNetwork(getMLPConfigIris(oa));
+			network.init();
+			
+			iter.reset();
+			network.fit(iter);
+		}
+	}
+	
+	private static MultiLayerConfiguration getMLPConfigIris( OptimizationAlgorithm oa ){
+		MultiLayerConfiguration c = new NeuralNetConfiguration.Builder()
+		.nIn(4).nOut(3)
+		.weightInit(WeightInit.DISTRIBUTION)
+		.dist(new NormalDistribution(0, 0.1))
+
+		.activationFunction("sigmoid")
+		.lossFunction(LossFunction.MCXENT)
+		.optimizationAlgo(oa)
+		.iterations(1)
+		.batchSize(5)
+		.constrainGradientToUnitNorm(false)
+		.corruptionLevel(0.0)
+		.layer(new RBM())
+		.learningRate(0.1).useAdaGrad(false)
+		.regularization(true)
+		.l2(0.01)
+		.applySparsity(false).sparsity(0.0)
+		.seed(12345L)
+		.list(4).hiddenLayerSizes(8,10,5)
+		.backward(true).pretrain(false)
+		.useDropConnect(false)
+
+		.override(3, new ConfOverride() {
+			@Override
+			public void overrideLayer(int i, NeuralNetConfiguration.Builder builder) {
+				builder.activationFunction("softmax");
+				builder.layer(new OutputLayer());
+				builder.weightInit(WeightInit.DISTRIBUTION);
+				builder.dist(new NormalDistribution(0, 0.1));
+			}
+		}).build();
+
+		return c;
+	}
+}


### PR DESCRIPTION
- Reorder slope calculation to after potential scaling of search direction (as per NR code)
- Switched back NegativeDefaultStepFunction -> DefaultStepFunction if stepFunction is null. Default step function is more in keeping with NR code, but happy to discuss which is a better default.
- Changed "if(f >= fold + ALF * alam * slope){" to <=, (this is actually the Wolfe/Armijo condition btw) as we are trying to minimize the loss/cost function. In line with NR code, which is also doing minimization.
- Some slight changes to logging for performance reasons. See http://www.slf4j.org/faq.html#logging_performance, also https://logging.apache.org/log4j/2.x/performance.html