### PR TITLE
Fix for issue 487 with method BarnesHutTsne.plot

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
@@ -506,7 +506,7 @@ public class BarnesHutTsne extends Tsne implements Model {
      */
     public void plot(INDArray matrix,int nDims,List<String> labels,String path) throws IOException {
 
-        fit(matrix);
+        fit(matrix, nDims);
 
         BufferedWriter write = new BufferedWriter(new FileWriter(new File(path)));
 
@@ -600,6 +600,12 @@ public class BarnesHutTsne extends Tsne implements Model {
     @Override
     public void fit(INDArray data) {
         this.x  = data;
+        fit();
+    }
+    
+    public void fit(INDArray data, int nDims) {
+        this.x = data;
+        this.numDimensions = nDims;
         fit();
     }
 


### PR DESCRIPTION
See the issue I've opened [here](https://github.com/deeplearning4j/deeplearning4j/issues/487).

Added the overloaded method fit(INDArray data, int nDims) to BarnesHutTsne.
Changed the method BarnesHutTsne.plot so that it now calls this new fit method instead of fit(INDArray data). 
-> The parameter nDims of the method plot is no longer unused.
-> non-2D tSNE is now possible.