### PR TITLE
2d case handling for activation in GravesLSTM.

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
@@ -349,7 +349,10 @@ public class GravesLSTM extends BaseLayer {
 		this.ifogAs = ifogA;
 		this.memCellActivations = memCellActivations;
 		this.outputActivations = outputActivations;
-
+		if (is2dInput) {
+			int[] shape = outputActivations.shape();
+			outputActivations = outputActivations.reshape(shape[0], shape[1]);
+		}
 		return outputActivations;
 	}
 


### PR DESCRIPTION
Activation should produce same-shaped results in case input is 2-dimessional 