### PR TITLE
Fix apply prevMemCellActivation derivative for memory cell error.

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/OutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/OutputLayer.java
@@ -134,7 +134,7 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
         case XENT:
         	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(labelsSubOut.div(output.mul(output.rsub(1)))));
         	return new Pair<>(gradient,labelsSubOut);
-        	
+
         case MSE:
         	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(labelsSubOut.neg()));
             return new Pair<>(gradient,labelsSubOut);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/feedforward/autoencoder/AutoEncoder.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/feedforward/autoencoder/AutoEncoder.java
@@ -126,6 +126,5 @@ public class AutoEncoder extends BasePretrainNetwork  {
         gradient = createGradient(wGradient, vBiasGradient, hBiasGradient);
         setScoreWithZ(z);
 
-
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/feedforward/dense/DenseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/feedforward/dense/DenseLayer.java
@@ -1,8 +1,14 @@
 package org.deeplearning4j.nn.layers.feedforward.dense;
 
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.feedforward.autoencoder.AutoEncoder;
+import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 
 /**
  * @author Adam Gibson

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
@@ -46,11 +46,8 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
  * @author Alex Black
  */
 public class GravesLSTM extends BaseLayer {
-	private static final long serialVersionUID = 2932878786544423542L;
-	private INDArray ifogZs; //memory cell z (linear transformations)
-	private INDArray ifogAs; //memory cell activations (non-linear transformation)
-	private INDArray memCellActivations;
-	private INDArray outputActivations;
+	
+	
 
 	public GravesLSTM(NeuralNetConfiguration conf) {
 		super(conf);
@@ -73,26 +70,33 @@ public class GravesLSTM extends BaseLayer {
 
 	@Override
 	public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon, Gradient gradient, Layer layer) {
+		//First: Do forward pass to get gate activations etc.
+		INDArray[] activations = activateHelper(input(), true);	//Order: {outputActivations,memCellActivations,ifogZs,ifogAs}
+		INDArray outputActivations = activations[0];
+		INDArray memCellActivations = activations[1];
+		INDArray ifogZs = activations[2];
+		INDArray ifogAs = activations[3];
+		
+		INDArray inputWeights = getParam(GravesLSTMParamInitializer.INPUT_WEIGHTS);
 		INDArray recurrentWeights = getParam(GravesLSTMParamInitializer.RECURRENT_WEIGHTS);	//Shape: [hiddenLayerSize,4*hiddenLayerSize+3]; order: [wI,wF,wO,wG,wFF,wOO,wGG]
 
-		INDArray nextWeights = layer.getParam(DefaultParamInitializer.WEIGHT_KEY);		//Weights for next layer
-		INDArray nextDelta = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
 
 		//Expect errors to have shape: [miniBatchSize,n^(L+1),timeSeriesLength]
-		int hiddenLayerSize = recurrentWeights.rows();	//i.e., n^L
-		int prevLayerSize = getParam(GravesLSTMParamInitializer.INPUT_WEIGHTS).shape()[0];
-		int miniBatchSize = nextDelta.size(0);
-		boolean is2dInput = nextDelta.rank() < 3; //Edge case: T=1 may have shape [miniBatchSize,n^(L+1)], equiv. to [miniBatchSize,n^(L+1),1]
-		int timeSeriesLength = (is2dInput? 1 : nextDelta.size(2));
-
-//		int len = nextWeights.length();
-		INDArray wi, wf, wo, wg, prevLayerActivations;
-
+		int hiddenLayerSize = recurrentWeights.size(0);	//i.e., n^L
+		int prevLayerSize = inputWeights.size(0);	//n^(L-1)
+		int miniBatchSize = epsilon.size(0);
+		boolean is2dInput = epsilon.rank() < 3; //Edge case: T=1 may have shape [miniBatchSize,n^(L+1)], equiv. to [miniBatchSize,n^(L+1),1]
+		int timeSeriesLength = (is2dInput? 1: epsilon.size(2));
+		
+		INDArray wi = inputWeights.get(interval(0,prevLayerSize),interval(0,hiddenLayerSize));
 		INDArray wI = recurrentWeights.get(interval(0,hiddenLayerSize),interval(0,hiddenLayerSize));
+		INDArray wf = inputWeights.get(interval(0,prevLayerSize),interval(hiddenLayerSize,2*hiddenLayerSize));
 		INDArray wF = recurrentWeights.get(interval(0,hiddenLayerSize),interval(hiddenLayerSize,2*hiddenLayerSize));
 		INDArray wFF = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize,4*hiddenLayerSize+1));
+		INDArray wo = inputWeights.get(interval(0,prevLayerSize),interval(2*hiddenLayerSize,3*hiddenLayerSize));
 		INDArray wO = recurrentWeights.get(interval(0,hiddenLayerSize),interval(2*hiddenLayerSize,3*hiddenLayerSize));
 		INDArray wOO = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize+1,4*hiddenLayerSize+2));
+		INDArray wg = inputWeights.get(interval(0,prevLayerSize),interval(3*hiddenLayerSize,4*hiddenLayerSize));
 		INDArray wG = recurrentWeights.get(interval(0,hiddenLayerSize),interval(3*hiddenLayerSize,4*hiddenLayerSize));
 		INDArray wGG = recurrentWeights.get(interval(0,hiddenLayerSize),interval(4*hiddenLayerSize+2,4*hiddenLayerSize+3));
 
@@ -101,6 +105,8 @@ public class GravesLSTM extends BaseLayer {
 		INDArray inputWeightGradients = Nd4j.zeros(new int[]{prevLayerSize,4*hiddenLayerSize,timeSeriesLength});
 		INDArray recurrentWeightGradients = Nd4j.zeros(new int[]{hiddenLayerSize,4*hiddenLayerSize+3,timeSeriesLength});	//Order: {I,F,O,G,FF,OO,GG}
 
+		INDArray epsilonNext = Nd4j.zeros(miniBatchSize,prevLayerSize,timeSeriesLength);	//i.e., what would be W^L*(delta^L)^T. Shape: [m,n^(L-1),T]
+		
 		/*Placeholder. To be replaced by masking array for used for variable length time series
 		 *Idea: M[i,j] = 1 if data is present for time j in example i in mini-batch.
 		 *M[i,j] = 0 otherwise
@@ -109,15 +115,13 @@ public class GravesLSTM extends BaseLayer {
 		 */
 //		INDArray timeSeriesMaskArray = Nd4j.ones(miniBatchSize,timeSeriesLength);	//For now: assume that all data in mini-batch is of length 'timeSeriesLength'
 
+		INDArray nablaCellStateNext = Nd4j.zeros(miniBatchSize,hiddenLayerSize);
+		
 		for( int t=timeSeriesLength-1; t>=0; t-- ){
 			INDArray prevMemCellActivations = (t==0 ? Nd4j.zeros(miniBatchSize, hiddenLayerSize) : memCellActivations.slice(t-1, 2) );	//Shape: [m, n^L]
 			INDArray prevHiddenUnitActivation = (t==0 ? Nd4j.zeros(miniBatchSize, hiddenLayerSize) : outputActivations.slice(t-1, 2) );	//Shape: [m, n^L]; i.e., layer output at prev. time step.
+			INDArray currMemCellActivations = (is2dInput ? memCellActivations : memCellActivations.slice(t,2) );
 
-			INDArray nextLayerDeltaSlice = nextDelta;
-			if (!is2dInput) {
-				nextLayerDeltaSlice = nextDelta.slice(t, 2);
-			}
-			//delta^{(L+1)t}
 			//delta_i^{L(t+1)}
 			INDArray deltaiNext = (t==timeSeriesLength-1 ?
 					Nd4j.zeros(miniBatchSize,hiddenLayerSize) :
@@ -135,7 +139,6 @@ public class GravesLSTM extends BaseLayer {
 					Nd4j.zeros(miniBatchSize,hiddenLayerSize) :
 					biasGradients.slice(t+1,2).get(new NDArrayIndex[]{interval(0,miniBatchSize),interval(3*hiddenLayerSize,4*hiddenLayerSize)}));
 
-			//TODO is this still needed?
 			//For variable length mini-batch data: Zero out deltas as necessary, so deltas beyond end of each time series are always 0
 			//Not implemented yet, but left here for when this is implemented
 			/*
@@ -148,7 +151,8 @@ public class GravesLSTM extends BaseLayer {
 			}*/
 
 			//LSTM unit output errors (dL/d(a_out)); not to be confused with \delta=dL/d(z_out)
-			INDArray nablaOut = nextLayerDeltaSlice.mmul(nextWeights.transpose())
+			INDArray epsilonSlice = (is2dInput ? epsilon : epsilon.slice(t, 2));		//(w^{L+1}*(delta^{(L+1)t})^T)^T or equiv.
+			INDArray nablaOut = epsilonSlice.dup()
 					.addi(deltaiNext.mmul(wI.transpose()))
 					.addi(deltafNext.mmul(wF.transpose()))
 					.addi(deltaoNext.mmul(wO.transpose()))
@@ -156,65 +160,58 @@ public class GravesLSTM extends BaseLayer {
 			//Shape: [m,n^L]
 
 			//Output gate deltas:
-			INDArray currMemCellActivations = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), prevMemCellActivations.dup()));//	shape: [m,n^L]
-			INDArray zo = ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize));
-			INDArray deltao = nablaOut.mul(currMemCellActivations)
-					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", zo).derivative()));
-			//Shape: [m,n^L]
+			INDArray sigmahOfS = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), currMemCellActivations.dup()));//	shape: [m,n^L]
+			INDArray zo;
+			if( is2dInput ) zo = ifogZs.get(NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+			else zo = ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+			INDArray sigmaoPrimeOfZo = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", zo).derivative());//			shape: [m,n^L]
+			INDArray deltao = nablaOut.mul(sigmahOfS).muli(sigmaoPrimeOfZo); //Shape: [m,n^L]
 
 			//Memory cell error:
-			INDArray prevMemActivationDerivative = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), prevMemCellActivations.dup()).derivative());//	shape: [m,n^L]
-			INDArray nextForgetGateAs = (t==timeSeriesLength-1 ? Nd4j.zeros(miniBatchSize,hiddenLayerSize) :
-					ifogAs.slice(t,2).get(NDArrayIndex.all(),interval(2 * hiddenLayerSize,3*hiddenLayerSize)) );
-			INDArray nablaCellState = nablaOut.mul(prevHiddenUnitActivation).muli(prevMemActivationDerivative)
-					.addi(nextForgetGateAs.mul(prevMemCellActivations))
+			INDArray sigmahPrimeOfS = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), currMemCellActivations.dup()).derivative());//	shape: [m,n^L]
+			INDArray ao;
+			if( is2dInput ) ao = ifogAs.get(NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+			else ao = ifogAs.slice(t, 2).get(NDArrayIndex.all(),interval(2*hiddenLayerSize,3*hiddenLayerSize));
+			INDArray nextForgetGateAs = (t==timeSeriesLength-1 ? Nd4j.zeros(miniBatchSize,hiddenLayerSize) :	//t==0 should also cover is2dInput case
+					ifogAs.slice(t+1,2).get(NDArrayIndex.all(),interval(2 * hiddenLayerSize,3*hiddenLayerSize)) );
+			INDArray nablaCellState = nablaOut.mul(ao).muli(sigmahPrimeOfS)
+					.addi(nextForgetGateAs.mul(nablaCellStateNext))
 					.addi(deltafNext.mmul(Nd4j.diag(wFF)))
 					.addi(deltaoNext.mmul(Nd4j.diag(wOO)))
 					.addi(deltagNext.mmul(Nd4j.diag(wGG)));
+			nablaCellStateNext = nablaCellState;	//Store for use in next iteration
 
 			//Forget gate delta:
-//			INDArray sActivation = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), prevMemCellActivations.dup()));//	shape: [m,n^L]
-			INDArray zf = ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize));	//z_f^{Lt}	shape: [m,n^L]
+			INDArray zf = (is2dInput ? ifogZs.get(NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize))	//z_f^{Lt}	shape: [m,n^L] 
+					: ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize)) );
 			INDArray deltaf = nablaCellState.mul(prevMemCellActivations)
 					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", zf).derivative()));
 			//Shape: [m,n^L]
 
 			//Input modulation gate delta:
-			INDArray zg = ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4 * hiddenLayerSize));	//z_g^{Lt}	shape: [m,n^L]
-			INDArray ai = ifogAs.slice(t, 2).get(NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize));	//a_i^{Lt}	shape: [m,n^L]
+			INDArray zg = (is2dInput ? ifogZs.get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4 * hiddenLayerSize))	//z_g^{Lt}	shape: [m,n^L] 
+					: ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4 * hiddenLayerSize)) );
+			INDArray ai = (is2dInput ? ifogAs.get(NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize)) 	//a_i^{Lt}	shape: [m,n^L]
+					: ifogAs.slice(t, 2).get(NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize)) );
 			INDArray deltag = nablaCellState.mul(ai)
-					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("tanh", zg).derivative()));
+					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", zg).derivative()));
 			//Shape: [m,n^L]
 
 			//Network input delta:
-			INDArray zi = ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize));	//z_i^{Lt}	shape: [m,n^L]
-			INDArray ag = ifogAs.slice(t, 2).get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4 * hiddenLayerSize));	//a_g^{Lt}	shape: [m,n^L]
+			INDArray zi = (is2dInput ? ifogZs.get(NDArrayIndex.all(),interval(0,hiddenLayerSize))	//z_i^{Lt}	shape: [m,n^L]
+					: ifogZs.slice(t, 2).get(NDArrayIndex.all(),interval(0,hiddenLayerSize)) );
+			INDArray ag = (is2dInput ? ifogAs.get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4 * hiddenLayerSize)) //a_g^{Lt}	shape: [m,n^L]
+					: ifogAs.slice(t, 2).get(NDArrayIndex.all(),interval(3*hiddenLayerSize,4 * hiddenLayerSize)) );	
 			INDArray deltai = nablaCellState.mul(ag)
-					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("tanh", zi).derivative()));
+					.muli(Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf.getActivationFunction(), zi).derivative()));
 			//Shape: [m,n^L]
 
-
-			if (!is2dInput) {
-	//			INDArray prevLayerActivationSlice = epsilon;
-				prevLayerActivations = nextWeights;
-//				wi = nextWeights.get(interval(0,len),interval(0,hiddenLayerSize));
-//				wf = nextWeights.get(interval(0,len),interval(hiddenLayerSize,2 * hiddenLayerSize));
-//				wo = nextWeights.get(interval(0,len),interval(2 * hiddenLayerSize,3 * hiddenLayerSize));
-//				wg = nextWeights.get(interval(0,len),interval(3 * hiddenLayerSize,4*hiddenLayerSize));
-			} else {
-//				wi = nextWeights.get(interval(0,len),interval(0,hiddenLayerSize)).slice(t, 2);
-//				wf = nextWeights.get(interval(0,len),interval(hiddenLayerSize,2 * hiddenLayerSize)).slice(t, 2);
-//				wo = nextWeights.get(interval(0,len),interval(2 * hiddenLayerSize,3 * hiddenLayerSize)).slice(t, 2);
-//				wg = nextWeights.get(interval(0,len),interval(3 * hiddenLayerSize,4*hiddenLayerSize)).slice(t, 2);
-				prevLayerActivations = nextWeights.slice(t,2);
-//				prevLayerActivationSlice = epsilon.slice(t,2);
-			}
-
+			INDArray prevLayerActivationSlice = (is2dInput ? input : input.slice(t, 2));
 			//Indexing here: all columns (==interval(0,n^(L-1)), 3rd dimension based on IFOG order. Sum over mini-batches occurs in delta*prevLayerActivations
-			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(0,hiddenLayerSize)}, deltai.transpose().mmul(prevLayerActivations).transpose());
-			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize)}, deltaf.transpose().mmul(prevLayerActivations).transpose());
-			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(2 * hiddenLayerSize,3 * hiddenLayerSize)}, deltao.transpose().mmul(prevLayerActivations).transpose());
-			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(3 * hiddenLayerSize,4 * hiddenLayerSize)}, deltag.transpose().mmul(prevLayerActivations).transpose());
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(0,hiddenLayerSize)}, deltai.transpose().mmul(prevLayerActivationSlice).transpose());
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(hiddenLayerSize,2 * hiddenLayerSize)}, deltaf.transpose().mmul(prevLayerActivationSlice).transpose());
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(2 * hiddenLayerSize,3 * hiddenLayerSize)}, deltao.transpose().mmul(prevLayerActivationSlice).transpose());
+			inputWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(3 * hiddenLayerSize,4 * hiddenLayerSize)}, deltag.transpose().mmul(prevLayerActivationSlice).transpose());
 
 			if( t > 0 ){
 				//Minor optimization. If t==0, then prevHiddenUnitActivation==zeros(n^L,n^L), so dL/dW for recurrent weights will end up as 0 anyway. (They are initialized as 0)
@@ -223,12 +220,13 @@ public class GravesLSTM extends BaseLayer {
 				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(2 * hiddenLayerSize,3 * hiddenLayerSize)}, deltao.transpose().mmul(prevHiddenUnitActivation).transpose());	//dL/dw_{O}
 				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(3 * hiddenLayerSize,4 * hiddenLayerSize)}, deltag.transpose().mmul(prevHiddenUnitActivation).transpose());	//dL/dw_{O}
 
-				INDArray dLdwFF = deltaf.mul(prevMemCellActivations);	//mul not mmul because these weights are from unit j->j only (whereas other recurrent weights are i->j for all i,j)
+				//Expected shape: [n^L,1]. sum(0) is sum over examples in mini-batch.
+				INDArray dLdwFF = deltaf.mul(prevMemCellActivations).sum(0).transpose();	//mul not mmul because these weights are from unit j->j only (whereas other recurrent weights are i->j for all i,j)
 				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),new NDArrayIndex(4*hiddenLayerSize)}, dLdwFF);	//dL/dw_{FF}
-				INDArray dLdwGG = deltag.mul(prevMemCellActivations);
+				INDArray dLdwGG = deltag.mul(prevMemCellActivations).sum(0).transpose();
 				recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),new NDArrayIndex(4*hiddenLayerSize + 2)}, dLdwGG);	//dL/dw_{GG}
 			}
-			INDArray dLdwOO = deltao.transpose().mul(memCellActivations.slice(t,2)).transpose();
+			INDArray dLdwOO = deltao.mul(currMemCellActivations).sum(0).transpose();	//Expected shape: [n^L,1]. sum(0) is sum over examples in mini-batch.
 			recurrentWeightGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),new NDArrayIndex(4*hiddenLayerSize + 1)}, dLdwOO);	//dL/dw_{OOxy}
 
 			if( miniBatchSize == 1 ){
@@ -243,19 +241,23 @@ public class GravesLSTM extends BaseLayer {
 				biasGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(2*hiddenLayerSize,3 * hiddenLayerSize)}, deltao);
 				biasGradients.slice(t,2).put(new NDArrayIndex[]{NDArrayIndex.all(),interval(3*hiddenLayerSize,4 * hiddenLayerSize)}, deltag);
 			}
+			
+			//Calculate epsilonNext - i.e., equiv. to what would be (w^L*(d^(Lt))^T)^T in a normal network
+			//But here, need to add 4 weights * deltas for the IFOG gates
+			INDArray epsilonNextSlice = wi.mmul(deltai.transpose()).transpose()
+					.addi(wf.mmul(deltaf.transpose()).transpose())
+					.addi(wo.mmul(deltao.transpose()).transpose())
+					.addi(wg.mmul(deltag.transpose()).transpose());
+			epsilonNext.slice(t,2).assign(epsilonNextSlice);
 		}
 
 		//Weight/bias gradients: sum across time dimension. But leave mini-batch dimension for time (in keeping with what BaseLayer.update() expects.
 		Gradient retGradient = new DefaultGradient();
 		retGradient.gradientForVariable().put(GravesLSTMParamInitializer.INPUT_WEIGHTS,inputWeightGradients.sum(2));
 		retGradient.gradientForVariable().put(GravesLSTMParamInitializer.RECURRENT_WEIGHTS,recurrentWeightGradients.sum(2));
-		retGradient.gradientForVariable().put(GravesLSTMParamInitializer.BIAS, biasGradients.sum(2));
+		retGradient.gradientForVariable().put(GravesLSTMParamInitializer.BIAS, biasGradients.sum(2).sum(0));	//Sum on both time and mini-batch
 
-		//TODO: Implement returning of deltas (excluding multiplication by non-linearity) needed by next (lower) layer. This has shape [m,n^L,T],
-		//and is calculated by summing the weights(L-1 to this layer)*deltas for each of the IFOG gates.
-		//See Greff et al. pg11
-
-		return new Pair<>(retGradient,recurrentWeightGradients);
+		return new Pair<>(retGradient,epsilonNext);
 	}
 
 	@Override
@@ -269,7 +271,15 @@ public class GravesLSTM extends BaseLayer {
 	}
 
 	@Override
-	public INDArray activate(INDArray input, boolean training) {
+	public INDArray activate(INDArray input, boolean training){
+		setInput(input,training);
+		return activateHelper(input, training)[0];
+	}
+
+	/**Returns 4 INDArrays: [outputActivations, memCellActivations, ifogZs, ifogAs] in that order.
+	 * Need all 4 to do backward pass, but only care about the first one for forward pass.
+	 */
+	private INDArray[] activateHelper(INDArray input, boolean training){
 		//Mini-batch data format: for mini-batch size m, nIn inputs, and T time series length
 		//Data has shape [m,nIn,T]. Layer activations/output has shape [m,nHiddenUnits,T]
 
@@ -375,16 +385,7 @@ public class GravesLSTM extends BaseLayer {
 			memCellActivations.slice(t,2).assign(currentMemoryCellActivations);
 		}
 
-		//Save output activations, memory cell state, ifog gate Zs and As for use in backward pass:
-		this.ifogZs = ifogZ;
-		this.ifogAs = ifogA;
-		this.memCellActivations = memCellActivations;
-		this.outputActivations = outputActivations;
-		if (is2dInput) {
-			int[] shape = outputActivations.shape();
-			outputActivations = outputActivations.reshape(shape[0], shape[1]);
-		}
-		return outputActivations;
+		return new INDArray[]{outputActivations,memCellActivations,ifogZ,ifogA};
 	}
 
 	@Override
@@ -401,15 +402,4 @@ public class GravesLSTM extends BaseLayer {
 	public Layer transpose(){
 		throw new UnsupportedOperationException("Not yet implemented");
 	}
-
-	@Override
-	public void clear(){
-		super.clear();
-		ifogZs = null;
-		ifogAs = null;
-		memCellActivations = null;
-		outputActivations = null;
-	}
-
-
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
@@ -88,7 +88,7 @@ public class LSTM extends BaseLayer {
      * @param y
      * @return {@link org.deeplearning4j.nn.gradient.Gradient}
      */
-    public Gradient backward(INDArray y) {
+    public Gradient backprop(INDArray y) {
         INDArray decoderWeights = getParam(LSTMParamInitializer.DECODER_WEIGHTS);
         INDArray recurrentWeights = getParam(LSTMParamInitializer.RECURRENT_WEIGHTS);
 
@@ -476,7 +476,7 @@ public class LSTM extends BaseLayer {
     public void computeGradientAndScore() {
         INDArray forward = forward(xi, xs);
         INDArray probas = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("softmax",forward).derivative(),1);
-        gradient = backward(probas);
+        gradient = backprop(probas);
         if (conf.getLossFunction() == LossFunctions.LossFunction.CUSTOM) {
             LossFunction create = Nd4j.getOpFactory().createLossFunction(conf.getCustomLossFunction(), input, forward);
             create.exec();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/models/classifiers/lstm/GravesLSTMTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/models/classifiers/lstm/GravesLSTMTest.java
@@ -88,7 +88,7 @@ public class GravesLSTMTest {
 		GravesLSTM lstm = LayerFactories.getFactory(conf.getLayer()).create(conf);
 		//Set input, do a forward pass:
 		lstm.activate(inputData);
-//		assertNotNull(lstm.input());
+		assertNotNull(lstm.input());
 		
 		//Create pseudo-gradient for input to LSTM layer (i.e., as if created by OutputLayer)
 		//This should have two elements: bias and weight gradients.
@@ -109,12 +109,11 @@ public class GravesLSTMTest {
 		assertNotNull(recurrentWeightGradient);
 
 		assertArrayEquals(biasGradient.shape(),new int[]{1,4*lstmNHiddenUnits});
-//		assertArrayEquals(biasGradient.shape(),new int[]{miniBatchSize,4*lstmNHiddenUnits});
 		assertArrayEquals(inWeightGradient.shape(),new int[]{nIn,4*lstmNHiddenUnits});
 		assertArrayEquals(recurrentWeightGradient.shape(),new int[]{lstmNHiddenUnits,4*lstmNHiddenUnits+3});
 
 		assertNotNull(nextEpsilon);
-//		assertArrayEquals(nextEpsilon.shape(),new int[]{miniBatchSize,nIn,timeSeriesLength});
+		assertArrayEquals(nextEpsilon.shape(),new int[]{miniBatchSize,nIn,timeSeriesLength});
 		
 		//Check update:
 		for( String s : outGradient.gradientForVariable().keySet() ){

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
@@ -8,7 +8,7 @@ import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.override.ClassifierOverride;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.override.ConfOverride;
 import org.deeplearning4j.nn.layers.recurrent.GravesLSTM;
 import org.deeplearning4j.nn.params.GravesLSTMParamInitializer;
@@ -29,8 +29,11 @@ public class MultiLayerTestRNN {
                 .layer(new org.deeplearning4j.nn.conf.layers.GravesLSTM())
                 .nIn(nIn).nOut(nOut)
                 .activationFunction("tanh")
-                .list(2).hiddenLayerSizes(nHiddenUnits)
-                .override(1, new ClassifierOverride())
+                .list(2)
+                .layer(0, new org.deeplearning4j.nn.conf.layers.GravesLSTM.Builder()
+					.nIn(nIn).nOut(nHiddenUnits).weightInit(WeightInit.DISTRIBUTION).build())
+				.layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.SQUARED_LOSS)
+					.nIn(nHiddenUnits).nOut(nOut).weightInit(WeightInit.DISTRIBUTION).build())
                 .build();
         MultiLayerNetwork network = new MultiLayerNetwork(conf);
         network.init();
@@ -63,11 +66,16 @@ public class MultiLayerTestRNN {
         int nOut = 25;
         int[] nHiddenUnits = {17,19,23};
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-                .layer(new org.deeplearning4j.nn.conf.layers.GravesLSTM())
-                .nIn(nIn).nOut(nOut)
                 .activationFunction("tanh")
-                .list(nHiddenUnits.length+1).hiddenLayerSizes(nHiddenUnits)
-                .override(nHiddenUnits.length, new ClassifierOverride())
+                .list(4)
+                .layer(0, new org.deeplearning4j.nn.conf.layers.GravesLSTM.Builder()
+					.nIn(nIn).nOut(17).weightInit(WeightInit.DISTRIBUTION).build())
+				.layer(1, new org.deeplearning4j.nn.conf.layers.GravesLSTM.Builder()
+					.nIn(17).nOut(19).weightInit(WeightInit.DISTRIBUTION).build())
+				.layer(2, new org.deeplearning4j.nn.conf.layers.GravesLSTM.Builder()
+					.nIn(19).nOut(23).weightInit(WeightInit.DISTRIBUTION).build())
+				.layer(3, new OutputLayer.Builder(LossFunctions.LossFunction.SQUARED_LOSS)
+						.nIn(23).nOut(nOut).weightInit(WeightInit.DISTRIBUTION).build())
                 .build();
         MultiLayerNetwork network = new MultiLayerNetwork(conf);
         network.init();
@@ -119,8 +127,6 @@ public class MultiLayerTestRNN {
                 .backprop(true)
                 .pretrain(false)
                 .build();
-
-
     }
 
 


### PR DESCRIPTION
@AlexDBlack - Please take a look

- Found one gap in the calculations compared to notes on getting prevMemCellActivation derivative for the memory cell error
- Also seeking clarity on what prevLayerActivations should be and whether that should be weights for each of the different gates?
- I've fixed some tests to work with new api and added some additional componants to help test when passing in a layer since backprop does depend on a layer. 
- Tests still failing are biasGradient shape and epsilon shape. Probably due to new Output Layer passed in
