### PR TITLE
remove experimental dsl elements

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/classification/MultiLayerNetworkClassification.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/classification/MultiLayerNetworkClassification.scala
@@ -128,23 +128,6 @@ class NeuralNetworkClassification(override val uid: String)
 }
 
 /**
- * Companion object for running of classification process.
- */
-object NeuralNetworkClassification {
-  def apply(uid: String) = new NeuralNetworkClassification(uid)
-
-  def apply() = new NeuralNetworkClassification()
-
-  def train(dataset: DataFrame): NeuralNetworkClassificationModel = {
-    NeuralNetworkClassification().train(dataset)
-  }
-
-  def train(uid: String, dataset: DataFrame): NeuralNetworkClassificationModel = {
-    NeuralNetworkClassification(uid).train(dataset)
-  }
-}
-
-/**
  * Neural network-based classification model.
  *
  * @author Eron Wright

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/reconstruction/MultiLayerNetworkReconstruction.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/reconstruction/MultiLayerNetworkReconstruction.scala
@@ -123,23 +123,6 @@ class NeuralNetworkReconstruction(override val uid: String)
 }
 
 /**
- * Companion object for reconstruction process.
- */
-object NeuralNetworkReconstruction {
-  def apply(uid: String) = new NeuralNetworkReconstruction(uid)
-
-  def apply() = new NeuralNetworkReconstruction()
-
-  def learn(dataset: DataFrame): NeuralNetworkReconstructionModel = {
-    NeuralNetworkReconstruction().learn(dataset)
-  }
-
-  def learn(uid: String, dataset: DataFrame): NeuralNetworkReconstructionModel = {
-    NeuralNetworkReconstruction(uid).learn(dataset)
-  }
-}
-
-/**
  * Neural network-based reconstruction model.
  *
  * @author Eron Wright


### PR DESCRIPTION
Spark 1.5/1.6 will introduce a standard dsl for pipeline components (SPARK-7434).   Until then I don't want to introduce any such syntax.   