### PR TITLE
Set failIfNoTests=false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
         <canova.version>0.0.0.5-SNAPSHOT</canova.version>
         <nd4j.version>0.0.3.5.5.6-SNAPSHOT</nd4j.version>
         <spring.version>3.2.5.RELEASE</spring.version>
+
+        <failIfNoTests>false</failIfNoTests>
     </properties>
 
 


### PR DESCRIPTION
Due to lack of tests of `dl4j-test-resources`, running test always fails. `failIfNoTests` should be set false as default.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project dl4j-test-resources: No tests were executed!  (Set -DfailIfNoTests=false to ignore this error.) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project dl4j-test-resources: No tests were executed!  (Set -DfailIfNoTests=false to ignore this error.)
```