### PR TITLE
Obtain NominalAttribute property

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/classification/MultiLayerNetworkClassification.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/classification/MultiLayerNetworkClassification.scala
@@ -88,7 +88,7 @@ class NeuralNetworkClassification(override val uid: String)
     val outputLayer = c.getConf(c.getConfs.size() - 1)
     val numClasses = outputLayer.getNOut match {
       case 0 => {
-        Attribute.fromStructField(dataset.schema($(labelCol))) match {
+        NominalAttribute.fromStructField(dataset.schema($(labelCol))) match {
           case (attr: NominalAttribute) => attr.getNumValues match {
             case Some(value: Int) => value
             case _ => throw new UnsupportedOperationException("expected numValues on nominal attribute")

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/sql/sources/iris/IrisRelation.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/sql/sources/iris/IrisRelation.scala
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.input.{CombineFileInputFormat, CombineFileRecordReader, CombineFileSplit}
 import org.apache.spark.Logging
+import org.apache.spark.ml.attribute.{NominalAttribute, Attribute}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
@@ -41,8 +42,11 @@ case class IrisRelation(location: String)(@transient val sqlContext: SQLContext)
   extends BaseRelation
   with PrunedScan with Logging {
 
+  private val labelMetadata = new MetadataBuilder().putMetadata("ml_attr",
+    new MetadataBuilder().putLong("num_vals", 3).build()).build()
+
   override def schema: StructType = StructType(
-    StructField("label", DoubleType, nullable = false) ::
+    StructField("label", DoubleType, nullable = false, metadata = labelMetadata) ::
       StructField("features", VectorUDT(), nullable = false) :: Nil)
 
   override def buildScan(requiredColumns: Array[String]): RDD[Row] = {


### PR DESCRIPTION
In case of using reconstruction  `NominalAttribute` from DataFrame, `fromStructField` must be called from `NominalAttribute` to get `NominalAttribute` property.
And fix corresponding iris unit test to set Metadata for label numbers.