### PR TITLE
Gradient fixes and numerical gradient tests

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Layer.java
@@ -40,17 +40,19 @@ public interface Layer extends Serializable,Cloneable,Model {
        FEED_FORWARD,RECURRENT,CONVOLUTIONAL,RECURSIVE,MULTILAYER
     }
 
-    /**
-     * The l2 magnitude for the weights
-     * @return the l2 magnitude for the weights
+    /**Calculate the l2 regularization term<br>
+     * 0.0 if regularization is not used. Or 0.5 * l2Coeff * l2Magnitude otherwise.<br>
+     * Note that this does not divide by mini-batch size
+     * @return the l2 regularization term for this layer.
      */
-    double l2Magnitude();
+    double calcL2();
 
-    /**
-     * The l1 magnitude for the weights
-     * @return the l1 magnitude for the weights
+    /**Calculate the l1 regularization term<br>
+     * 0.0 if regularization is not used. Or l1Coeff * l1Magnitude otherwise.<br>
+     * Note that this does not divide by mini-batch size
+     * @return the l1 regularization term for this layer.
      */
-    double l1Magnitude();
+    double calcL1();
 
     /**
      * Returns the layer type

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -177,8 +177,8 @@ public abstract class BaseLayer implements Layer {
 
         else {
             score = LossCalculation.builder()
-                    .l1(conf.getL1()).l2(conf.getL2())
-                    .l1Magnitude(l1Magnitude()).l2Magnitude(l2Magnitude())
+                    .l1(1.0).l2(1.0)	//TODO: Temporary until Nd4J LossCalculation refactor
+                    .l1Magnitude(calcL1()).l2Magnitude(calcL2())
                     .labels(input).z(z).lossFunction(conf.getLossFunction())
                     .useRegularization(conf.isUseRegularization()).build().score();
 
@@ -378,13 +378,15 @@ public abstract class BaseLayer implements Layer {
     }
 
     @Override
-    public double l2Magnitude() {
-        return Transforms.pow(getParam(DefaultParamInitializer.WEIGHT_KEY),2).sum(Integer.MAX_VALUE).getDouble(0);
+    public double calcL2() {
+    	if(!conf.isUseRegularization() || conf.getL2() <= 0.0 ) return 0.0;
+        return 0.5 * conf.getL2() * Transforms.pow(getParam(DefaultParamInitializer.WEIGHT_KEY),2).sum(Integer.MAX_VALUE).getDouble(0);
     }
 
     @Override
-    public double l1Magnitude() {
-        return Transforms.abs(getParam(DefaultParamInitializer.WEIGHT_KEY)).sum(Integer.MAX_VALUE).getDouble(0);
+    public double calcL1() {
+    	if(!conf.isUseRegularization() || conf.getL1() <= 0.0 ) return 0.0;
+        return conf.getL1() * Transforms.abs(getParam(DefaultParamInitializer.WEIGHT_KEY)).sum(Integer.MAX_VALUE).getDouble(0);
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/OutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/OutputLayer.java
@@ -59,6 +59,9 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
     private INDArray labels;
     
     private transient Solver solver;
+    
+    private double fullNetworkL1;
+    private double fullNetworkL2;
 
     public OutputLayer(NeuralNetConfiguration conf) {
         super(conf);
@@ -70,9 +73,11 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
     
     /** Compute score after labels and input have been set.
      */
-    public double computeScore(){
+    public double computeScore( double fullNetworkL1, double fullNetworkL2 ){
     	if( input == null || labels == null )
     		throw new IllegalStateException("Cannot calculate score without input and labels");
+    	this.fullNetworkL1 = fullNetworkL1;
+    	this.fullNetworkL2 = fullNetworkL2;
     	setScoreWithZ(output(input));
     	return score;
     }
@@ -98,8 +103,8 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
 
         else {
             score = LossCalculation.builder()
-                    .l1(conf.getL1()).l2(conf.getL2())
-                    .l1Magnitude(l1Magnitude()).l2Magnitude(l2Magnitude())
+                    .l1(1.0).l2(1.0)	//TODO: Temporary until Nd4J LossCalculation refactor
+                    .l1Magnitude(fullNetworkL1).l2Magnitude(fullNetworkL2)
                     .labels(labels).z(z).lossFunction(conf.getLossFunction())
                     .miniBatch(true)
                     .useRegularization(conf.isUseRegularization()).build().score();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/OutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/OutputLayer.java
@@ -20,8 +20,8 @@ package org.deeplearning4j.nn.layers;
 
 import java.io.*;
 
-
 import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.berkeley.Triple;
 import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.nn.api.Classifier;
 import org.deeplearning4j.nn.api.Layer;
@@ -82,11 +82,10 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
         if(input == null || labels == null)
             return;
 
-        INDArray output = output(input);
-        Pair<Gradient,INDArray> pair = getGradientsAndDelta(output);
-        this.gradient = pair.getFirst();
-        setScoreWithZ(output);
-
+        INDArray z = preOutput(input);
+        Triple<Gradient,INDArray,INDArray> triple = getGradientsAndDelta(z);
+        this.gradient = triple.getFirst();
+        setScoreWithZ(triple.getThird());
     }
 
     @Override
@@ -114,11 +113,11 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
 
     @Override
     public Pair<Gradient,INDArray> backpropGradient(INDArray epsilon, Gradient nextGradient, Layer layer) {
-	Pair<Gradient,INDArray> pair = getGradientsAndDelta(output(input));	//Returns Gradient and delta^(this), not Gradient and epsilon^(this-1)
-    	INDArray delta = pair.getSecond();
+    	Triple<Gradient,INDArray,INDArray> triple = getGradientsAndDelta(preOutput(input));	//Returns Gradient and delta^(this), not Gradient and epsilon^(this-1)
+    	INDArray delta = triple.getSecond();
 
         INDArray epsilonNext = params.get(DefaultParamInitializer.WEIGHT_KEY).mmul(delta.transpose()).transpose();
-        return new Pair<>(pair.getFirst(),epsilonNext);
+        return new Pair<>(triple.getFirst(),epsilonNext);
     }
 
     /**
@@ -132,7 +131,9 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
 
     }
     
-    private Pair<Gradient,INDArray> getGradientsAndDelta(INDArray output){
+    /** Returns tuple: {Gradient,Delta,Output} given preOut */
+    private Triple<Gradient,INDArray,INDArray> getGradientsAndDelta(INDArray preOut){
+    	INDArray output = Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform(conf().getActivationFunction(), preOut.dup()));
     	INDArray outSubLabels = output.sub(labels);
     	Gradient gradient = new DefaultGradient();
     	gradient.gradientForVariable().put(DefaultParamInitializer.BIAS_KEY, outSubLabels.sum(0));
@@ -140,32 +141,34 @@ public class OutputLayer extends BaseLayer implements Serializable,Classifier {
     	switch (conf.getLossFunction()) {
     	case MCXENT:	//cross-entropy (multi-class, with one-hot encoding)
     		gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(outSubLabels));
-    		return new Pair<>(gradient,outSubLabels);
+    		return new Triple<>(gradient,outSubLabels,output);
         case XENT: // cross-entropy (single binary output variable)
         	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(outSubLabels.div(output.mul(output.rsub(1)))));
-        	return new Pair<>(gradient,outSubLabels);
+        	return new Triple<>(gradient,outSubLabels,output);
 
         case MSE: // mean squared error
-        	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(outSubLabels.neg()));
-            return new Pair<>(gradient,outSubLabels);
+        	INDArray delta = outSubLabels.mul(derivativeActivation(preOut));
+        	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(delta));
+        	gradient.gradientForVariable().put(DefaultParamInitializer.BIAS_KEY, delta.sum(0));
+            return new Triple<>(gradient,delta,output);
         	
         case EXPLL: // exponential logarithmic
         	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(labels.rsub(1).divi(output)));
-            return new Pair<>(gradient,outSubLabels);
+            return new Triple<>(gradient,outSubLabels,output);
             
         case RMSE_XENT: // root mean squared error cross entropy
         	INDArray squaredrmseXentDiff = pow(outSubLabels, 2.0);
         	INDArray sqrt = sqrt(squaredrmseXentDiff);
         	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(sqrt));
-            return new Pair<>(gradient,outSubLabels);
+            return new Triple<>(gradient,outSubLabels,output);
         	
         case SQUARED_LOSS:
         	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(input.transpose().mmul(pow(outSubLabels,2))));
-            return new Pair<>(gradient,outSubLabels);
+            return new Triple<>(gradient,outSubLabels,output);
             
-        case NEGATIVELOGLIKELIHOOD: // mulit-class cross-entropy
+        case NEGATIVELOGLIKELIHOOD: // multi-class cross-entropy
         	gradient.gradientForVariable().put(DefaultParamInitializer.WEIGHT_KEY, input.transpose().mmul(outSubLabels));
-            return new Pair<>(gradient,outSubLabels);
+            return new Triple<>(gradient,outSubLabels,output);
         default:
         	throw new IllegalStateException("Invalid loss function: " + conf.getLossFunction());
     	}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.layers.convolution;
 
 import com.google.common.primitives.Ints;
+
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -57,13 +58,15 @@ public class ConvolutionLayer extends BaseLayer {
     public void setCol(INDArray col) {this.col = col;}
 
     @Override
-    public double l2Magnitude() {
-        return Transforms.pow(getParam(ConvolutionParamInitializer.WEIGHT_KEY), 2).sum(Integer.MAX_VALUE).getDouble(0);
+    public double calcL2() {
+    	if(!conf.isUseRegularization() || conf.getL2() <= 0.0 ) return 0.0;
+        return 0.5 * conf.getL2() * Transforms.pow(getParam(ConvolutionParamInitializer.WEIGHT_KEY), 2).sum(Integer.MAX_VALUE).getDouble(0);
     }
 
     @Override
-    public double l1Magnitude() {
-        return Transforms.abs(getParam(ConvolutionParamInitializer.WEIGHT_KEY)).sum(Integer.MAX_VALUE).getDouble(0);
+    public double calcL1() {
+    	if(!conf.isUseRegularization() || conf.getL1() <= 0.0 ) return 0.0;
+        return conf.getL1() * Transforms.abs(getParam(ConvolutionParamInitializer.WEIGHT_KEY)).sum(Integer.MAX_VALUE).getDouble(0);
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -60,12 +60,12 @@ public class SubsamplingLayer extends BaseLayer {
 
 
     @Override
-    public double l2Magnitude() {
+    public double calcL2() {
         return 0;
     }
 
     @Override
-    public double l1Magnitude() {
+    public double calcL1() {
         return 0;
     }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
@@ -30,6 +30,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.ops.transforms.Transforms;
 
 import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
 
@@ -406,4 +407,20 @@ public class GravesLSTM extends BaseLayer {
 	public Layer transpose(){
 		throw new UnsupportedOperationException("Not yet implemented");
 	}
+	
+	@Override
+    public double calcL2() {
+    	if(!conf.isUseRegularization() || conf.getL2() <= 0.0 ) return 0.0;
+    	double l2 = Transforms.pow(getParam(GravesLSTMParamInitializer.RECURRENT_WEIGHTS), 2).sum(Integer.MAX_VALUE).getDouble(0)
+    			+ Transforms.pow(getParam(GravesLSTMParamInitializer.INPUT_WEIGHTS), 2).sum(Integer.MAX_VALUE).getDouble(0);
+    	return 0.5 * conf.getL2() * l2;
+    }
+
+    @Override
+    public double calcL1() {
+    	if(!conf.isUseRegularization() || conf.getL1() <= 0.0 ) return 0.0;
+        double l1 = Transforms.abs(getParam(GravesLSTMParamInitializer.RECURRENT_WEIGHTS)).sum(Integer.MAX_VALUE).getDouble(0)
+        		+ Transforms.abs(getParam(GravesLSTMParamInitializer.INPUT_WEIGHTS)).sum(Integer.MAX_VALUE).getDouble(0);
+        return conf.getL1() * l1;
+    }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
@@ -473,13 +473,19 @@ public class LSTM extends BaseLayer {
 
 
     @Override
-    public double l2Magnitude() {
-        return Transforms.pow(getParam(LSTMParamInitializer.RECURRENT_WEIGHTS), 2).sum(Integer.MAX_VALUE).getDouble(0);
+    public double calcL2() {
+    	if(!conf.isUseRegularization() || conf.getL2() <= 0.0 ) return 0.0;
+    	double l2 = Transforms.pow(getParam(LSTMParamInitializer.RECURRENT_WEIGHTS), 2).sum(Integer.MAX_VALUE).getDouble(0)
+    			+ Transforms.pow(getParam(LSTMParamInitializer.DECODER_WEIGHTS), 2).sum(Integer.MAX_VALUE).getDouble(0);
+    	return 0.5 * conf.getL2() * l2;
     }
 
     @Override
-    public double l1Magnitude() {
-        return Transforms.abs(getParam(LSTMParamInitializer.RECURRENT_WEIGHTS)).sum(Integer.MAX_VALUE).getDouble(0);
+    public double calcL1() {
+    	if(!conf.isUseRegularization() || conf.getL1() <= 0.0 ) return 0.0;
+        double l1 = Transforms.abs(getParam(LSTMParamInitializer.RECURRENT_WEIGHTS)).sum(Integer.MAX_VALUE).getDouble(0)
+        		+ Transforms.abs(getParam(LSTMParamInitializer.DECODER_WEIGHTS)).sum(Integer.MAX_VALUE).getDouble(0);
+        return conf.getL1() * l1;
     }
 
 
@@ -496,8 +502,8 @@ public class LSTM extends BaseLayer {
 
         else {
             score = LossCalculation.builder()
-                    .l1(conf.getL1()).l2(conf.getL2())
-                    .l1Magnitude(l1Magnitude()).l2Magnitude(l2Magnitude())
+                    .l1(1.0).l2(1.0)	//TODO: Temporary until Nd4J LossCalculation refactor
+                    .l1Magnitude(calcL1()).l2Magnitude(calcL2())
                     .labels(xs).z(probas).lossFunction(conf.getLossFunction())
                     .useRegularization(conf.isUseRegularization()).build().score();
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1369,7 +1369,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         if( getOutputLayer() instanceof OutputLayer ){
         	OutputLayer ol = (OutputLayer)getOutputLayer();
         	ol.setLabels(data.getLabels());
-        	ol.computeScore();
+        	ol.computeScore(calcL1(),calcL2());
         	this.score = ol.score();
         } else {
         	log.warn("Cannot calculate score wrt labels without an OutputLayer");
@@ -1404,7 +1404,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         backprop();
         // Updating activations based on new gradients
         feedForward();
-        score = ((OutputLayer)getOutputLayer()).computeScore();
+        score = ((OutputLayer)getOutputLayer()).computeScore(calcL1(),calcL2());
     }
 
     @Override
@@ -1706,13 +1706,21 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
     }
 
     @Override
-    public double l2Magnitude() {
-        throw new UnsupportedOperationException();
+    public double calcL2() {
+    	double l2 = 0.0;
+    	for( int i=0; i<layers.length; i++ ){
+			l2 += layers[i].calcL2();
+    	}
+        return l2;
     }
 
     @Override
-    public double l1Magnitude() {
-        throw new UnsupportedOperationException();
+    public double calcL1() {
+    	double l1 = 0.0;
+    	for( int i=0; i<layers.length; i++ ){
+			l1 += layers[i].calcL1();
+    	}
+        return l1;
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -43,7 +43,7 @@ public abstract class BaseUpdater implements Updater {
         if(conf.isUseRegularization() && conf.getL1() > 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
         	gradient.addi(Transforms.sign(params).muli(conf.getL1()/layer.input().size(0)));
         if(conf.isMiniBatch())
-            gradient.divi((double) layer.input().size(0) / conf.getTimeSeriesLength());
+            gradient.divi(((double) layer.input().size(0)) / conf.getTimeSeriesLength());
 
         if(conf.isConstrainGradientToUnitNorm())
             gradient.divi(gradient.norm2(Integer.MAX_VALUE));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -39,12 +39,11 @@ public abstract class BaseUpdater implements Updater {
         NeuralNetConfiguration conf = layer.conf();
         INDArray params = layer.getParam(param);
         if(conf.isUseRegularization() && conf.getL2() > 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
-            gradient.subi(params.mul(conf.getL2()));
-        if(conf.isUseRegularization() && conf.getL1() < 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
-            gradient.subi(Transforms.sign(params).muli(conf.getL1()));
-
+        	gradient.addi(params.mul(conf.getL2()/layer.input().size(0)));	//dC/dw = dC0/dw + lambda/n * w where C0 is pre-l2 cost function 
+        if(conf.isUseRegularization() && conf.getL1() > 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
+        	gradient.addi(Transforms.sign(params).muli(conf.getL1()/layer.input().size(0)));
         if(conf.isMiniBatch())
-            gradient.divi((double) layer.input().size(0) * conf.getTimeSeriesLength());
+            gradient.divi((double) layer.input().size(0) / conf.getTimeSeriesLength());
 
         if(conf.isConstrainGradientToUnitNorm())
             gradient.divi(gradient.norm2(Integer.MAX_VALUE));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
@@ -135,10 +135,10 @@ public abstract class BaseOptimizer implements ConvexOptimizer {
         Pair<Gradient,Double> pair = gradientAndScore();
         score = pair.getSecond();
         if(searchState.isEmpty()){
-        	searchState.put(GRADIENT_KEY, pair.getFirst().gradient(conf.getVariables()));
+        	searchState.put(GRADIENT_KEY, pair.getFirst().gradient());
         	setupSearchState(pair);		//Only do this once
         } else {
-        	searchState.put(GRADIENT_KEY, pair.getFirst().gradient(conf.getVariables()));
+        	searchState.put(GRADIENT_KEY, pair.getFirst().gradient());
         }
 
         //pre existing termination conditions
@@ -181,7 +181,7 @@ public abstract class BaseOptimizer implements ConvexOptimizer {
             pair = gradientAndScore();
 
             //updates searchDirection
-            postStep(pair.getFirst().gradient(conf.getVariables()));
+            postStep(pair.getFirst().gradient());
             score = pair.getSecond();
 
             //invoke listeners for debugging

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MathUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MathUtils.java
@@ -28,6 +28,7 @@ import org.apache.commons.math3.linear.CholeskyDecomposition;
 import org.apache.commons.math3.linear.NonSquareMatrixException;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.random.RandomGenerator;
+import org.apache.commons.math3.util.FastMath;
 import org.deeplearning4j.berkeley.Counter;
 
 
@@ -161,7 +162,7 @@ public class MathUtils  {
      * @return
      */
     public static double sigmoid(double x) {
-        return 1.0 / (1.0 + Math.pow(Math.E, -x));
+        return 1.0 / (1.0 + FastMath.exp(-x));
     }
 
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
@@ -8,7 +8,6 @@ import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
-import org.deeplearning4j.nn.conf.distribution.UniformDistribution;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
@@ -125,7 +124,7 @@ public class GradientCheckTests {
         INDArray labels = ds.getLabels();
         
         double[] l2vals = {0.4, 0.0, 0.4};
-        double[] l1vals = {0.0, 0.5, 0.5};
+        double[] l1vals = {0.0, 0.5, 0.5};	//i.e., use l2vals[i] with l1vals[i]
     	
     	for( String afn : activFns ){
     		for( boolean doLearningFirst : characteristic ){

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
@@ -3,6 +3,7 @@ package org.deeplearning4j.gradientcheck;
 import static org.junit.Assert.*;
 
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.Updater;
@@ -20,6 +21,8 @@ import org.nd4j.linalg.factory.NDArrayFactory;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 
+/**@author Alex Black 14 Aug 2015
+ */
 public class GradientCheckTests {
 
     private static final boolean PRINT_RESULTS = true;
@@ -35,67 +38,113 @@ public class GradientCheckTests {
 
     @Test
     public void testGradientMLP2LayerIrisSimple(){
-        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-                .activationFunction("tanh")
-                .weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1))
-                .regularization(false)
-                .seed(12345L)
-                .list(2)
-                .layer(0, new DenseLayer.Builder().nIn(4).nOut(3).build())
-                .layer(1, new OutputLayer.Builder(LossFunction.MCXENT).activation("softmax").nIn(3).nOut(3).build())
-                .build();
-
-        MultiLayerNetwork mln = new MultiLayerNetwork(conf);
-        mln.init();
-
-        for( int i=0; i<mln.getnLayers(); i++ ){
-            System.out.println("Layer " + i + " # params: " + mln.getLayer(i).numParams());
-        }
-
-        DataSet ds = new IrisDataSetIterator(150,150).next();
+    	//Parameterized test, testing combinations of:
+    	// (a) activation function
+    	// (b) Whether to test at random initialization, or after some learning (i.e., 'characteristic mode of operation')
+    	// (c) Loss function (with specified output activations)
+    	String[] activFns = {"sigmoid","tanh","relu","hardtanh"};
+    	boolean[] characteristic = {false,true};	//If true: run some backprop steps first
+    	
+    	LossFunction[] lossFunctions = {LossFunction.MCXENT, LossFunction.MSE};
+    	String[] outputActivations = {"softmax","tanh"};	//i.e., lossFunctions[i] used with outputActivations[i] here
+    	
+    	DataSet ds = new IrisDataSetIterator(150,150).next();
         ds.normalizeZeroMeanZeroUnitVariance();
         INDArray input = ds.getFeatureMatrix();
         INDArray labels = ds.getLabels();
-
-        boolean gradOK = GradientCheckUtil.checkGradients(mln, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
-                PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, false);
-
-        assertTrue(gradOK);
+    	
+    	for( String afn : activFns ){
+    		for( boolean doLearningFirst : characteristic ){
+    			for( int i=0; i<lossFunctions.length; i++ ){
+    				LossFunction lf = lossFunctions[i];
+    				String outputActivation = outputActivations[i];
+    				
+			        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+			                .activationFunction(afn)
+			                .weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1))
+			                .regularization(false)
+			                .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
+			                .updater(Updater.SGD).learningRate(0.1)
+			                .seed(12345L)
+			                .list(2)
+			                .layer(0, new DenseLayer.Builder().nIn(4).nOut(3).build())
+			                .layer(1, new OutputLayer.Builder(lf).activation(outputActivation).nIn(3).nOut(3).build())
+			                .pretrain(false).backprop(true)
+			                .build();
+			
+			        MultiLayerNetwork mln = new MultiLayerNetwork(conf);
+			        mln.init();
+			        
+			        if(doLearningFirst){
+			        	//Run a number of iterations of learning
+				        mln.setInput(ds.getFeatures());
+				        mln.setLabels(ds.getLabels());
+				        mln.computeGradientAndScore();
+				        double scoreBefore = mln.score();
+				        for( int j=0; j<10; j++ ) mln.fit(ds);
+				        mln.computeGradientAndScore();
+				        double scoreAfter = mln.score();
+				        //Can't test in 'characteristic mode of operation' if not learning
+				        String msg = "testGradMLP2LayerIrisSimple() - score did not (sufficiently) decrease during learning - activationFn="
+				        		+afn+", lossFn="+lf+", outputActivation="+outputActivation+", doLearningFirst="+doLearningFirst
+				        		+" (before="+scoreBefore +", scoreAfter="+scoreAfter+")";
+				        assertTrue(msg,scoreAfter < 0.8 *scoreBefore);
+			        }
+			
+			        if( PRINT_RESULTS ){
+			        	System.out.println("testGradientMLP2LayerIrisSimpleRandom() - activationFn="+afn+", lossFn="+lf+", outputActivation="+outputActivation
+			        		+", doLearningFirst="+doLearningFirst );
+			        	for( int j=0; j<mln.getnLayers(); j++ ) System.out.println("Layer " + j + " # params: " + mln.getLayer(j).numParams());
+			        }
+			
+			        boolean gradOK = GradientCheckUtil.checkGradients(mln, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
+			                PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, false);
+			
+			        String msg = "testGradMLP2LayerIrisSimple() - activationFn="+afn+", lossFn="+lf+", outputActivation="+outputActivation
+			        		+", doLearningFirst="+doLearningFirst;
+			        assertTrue(msg,gradOK);
+    			}
+    		}
+    	}
     }
-
+    
     @Test
-    public void testGradientMLP2LayerIrisL2(){
-        //As above, but with L2 regularization
+    public void testGradientMLP2LayerIrisL1L2Simple(){
+        //As above (testGradientMLP2LayerIrisSimple()) but with L2, L1, and both L2/L1 applied
         //Need to run gradient through updater, so that L2 can be applied
 
-        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-                .activationFunction("tanh")
-                .weightInit(WeightInit.XAVIER).dist(new UniformDistribution(0,1))
-                .regularization(true)
-                .l2(0.3).l1(0.0).dropOut(0.0)
-                .updater(Updater.NONE)
-                .seed(12345L)
-                .list(2)
-                .layer(0, new DenseLayer.Builder().nIn(4).nOut(10).build())
-                .layer(1, new OutputLayer.Builder(LossFunction.MCXENT).activation("softmax").nIn(10).nOut(3).build())
-                .build();
-
-        MultiLayerNetwork mln = new MultiLayerNetwork(conf);
-        mln.init();
-
-        for( int i=0; i< mln.getnLayers(); i++ ){
-            System.out.println("Layer " + i + " # params: " + mln.getLayer(i).numParams());
-        }
-
-        DataSet ds = new IrisDataSetIterator(150,150).next();
-        ds.normalizeZeroMeanZeroUnitVariance();
-        INDArray input = ds.getFeatureMatrix();
-        INDArray labels = ds.getLabels();
-
-        boolean gradOK = GradientCheckUtil.checkGradients(mln, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
-                PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, true);
-
-        assertTrue(gradOK);
+    	String[] activFns = {"sigmoid","tanh","relu","hardtanh"};
+    	for( String afn : activFns ){
+	        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+	                .activationFunction(afn)
+	                .weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1))
+	                .regularization(true)
+	                .l2(0.3).l1(0.0).dropOut(0.0)
+	                .updater(Updater.NONE)	//Checking raw gradient here
+	                .seed(12345L)
+	                .list(2)
+	                .layer(0, new DenseLayer.Builder().nIn(4).nOut(3).build())
+	                .layer(1, new OutputLayer.Builder(LossFunction.MCXENT).activation("softmax").nIn(3).nOut(3).build())
+	                .build();
+	
+	        MultiLayerNetwork mln = new MultiLayerNetwork(conf);
+	        mln.init();
+	
+	        if( PRINT_RESULTS ){
+	        	System.out.println("testGradientMLP2LayerIrisL2Random() - " + afn );
+	        	for( int i=0; i<mln.getnLayers(); i++ ) System.out.println("Layer " + i + " # params: " + mln.getLayer(i).numParams());
+	        }
+	
+	        DataSet ds = new IrisDataSetIterator(150,150).next();
+	        ds.normalizeZeroMeanZeroUnitVariance();
+	        INDArray input = ds.getFeatureMatrix();
+	        INDArray labels = ds.getLabels();
+	
+	        boolean gradOK = GradientCheckUtil.checkGradients(mln, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
+	                PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, false);
+	
+	        assertTrue(gradOK);
+    	}
     }
 
     @Test

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
@@ -63,8 +63,7 @@ public class GradientCheckUtil {
             updater.update(mln, gradAndScore.getFirst(), 0);
         }
 
-//      INDArray gradientToCheck = gradAndScore.getFirst().gradient();
-        INDArray gradientToCheck = gradAndScore.getFirst().gradient(mln.conf().variables());
+      INDArray gradientToCheck = gradAndScore.getFirst().gradient();
         INDArray originalParams = mln.params();
 
         int nParams = mln.numParams();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
@@ -63,7 +63,7 @@ public class GradientCheckUtil {
             updater.update(mln, gradAndScore.getFirst(), 0);
         }
 
-      INDArray gradientToCheck = gradAndScore.getFirst().gradient();
+        INDArray gradientToCheck = gradAndScore.getFirst().gradient();
         INDArray originalParams = mln.params();
 
         int nParams = mln.numParams();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/BackPropMLPTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/BackPropMLPTest.java
@@ -3,7 +3,6 @@ package org.deeplearning4j.nn.multilayer;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.deeplearning4j.datasets.iterator.DataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/BackPropMLPTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/BackPropMLPTest.java
@@ -183,7 +183,7 @@ public class BackPropMLPTest {
             }
 
 
-            float eps = 0.01f;
+            float eps = 1e-4f;
             assertArrayEquals(l1WeightsFloatAfter,expectedL1WeightsAfter,eps);
             assertArrayEquals(l2WeightsFloatAfter,expectedL2WeightsAfter,eps);
             assertEquals(l1BiasFloatAfter,expectedL1BiasAfter,eps);

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
@@ -729,12 +729,12 @@ public class TestOptimizers {
         }
 
         @Override
-        public double l2Magnitude() {
+        public double calcL2() {
             return 0;
         }
 
         @Override
-        public double l1Magnitude() {
+        public double calcL1() {
             return 0;
         }
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/rntn/RNTN.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/rntn/RNTN.java
@@ -1130,12 +1130,12 @@ public class RNTN implements Layer {
     }
 
     @Override
-    public double l2Magnitude() {
+    public double calcL2() {
         return 0;
     }
 
     @Override
-    public double l1Magnitude() {
+    public double calcL1() {
         return 0;
     }
 


### PR DESCRIPTION
Can be merged as is if OK, though see todo/notes at end.

Change log:
- Changed order gradients are placed into Gradient maps. Now Gradient.gradient() does same thing (same flattening order) as Gradient.gradient(conf.getVariables()) for backprop
- Added/improved MLP gradient tests; now reasonably thorough. Tests multiple activation functions, random params vs. after some learning, l1/l2/both/neither; though only testing MCXENT and MSE so far (easy to add others). All tests passing at present.
- Fixed MSE gradient calculation in OutputLayer (was incorrect)
- Refactor l1/l2 calculation: Changed Layer.l2Magnitude() to calcL2(). Similar for L1. Difference: former did sum w^2. Latter does 0.5 * l2 * sum w^2. Reason being: can add the latter terms, but can't add the former (due to potentially different l1/l2 coeffs for each layer). Also necessary for l1/l2 calculations for MLN-in-a-MLN usage in the future.
- L1/L2 only calculated if regularization is enabled and coeff > 0 (previously: always calculated)
- Full network L1/L2 is now used in scoring, not just output layer L1/L2
- Fixed L1/L2 gradient in BaseUpdater.postApply()
- LSTM/GravesLSTM now do L1/L2 calc on both types of weights (recurrent + non-recurrent)


TODO / additional notes:
- TODO: Change ND4J LossCalculation scoring to match l1/l2 changes (i.e., don't pass l1/l2 coefficients and magnitude; instead pass in output of MultiLayerNetwork.calcL2() etc). Then fix up my temp workaround in various scoring methods (that call LossCalculation.score())
- I'm still unclear on gradient division and mini-batch, in conjunction with NeuralNetConfiguration.minibatch. So if minibatch==true, this is normal training, right? And minibatch==false is distributed? If so, then shouldn't minibatch be true by default? (Suggest reviewing BaseUpdater.postApply() and MultiLayerNetwork.backprop() re division by mini-batch size; also OutputLayer.setScoreWithZ() passing miniBatch(true) (hardcoded) to LossCalculation)