### PR TITLE
Fix NeuralNetworkReconstructionTest failure.

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/scala/org/deeplearning4j/spark/ml/reconstruction/NeuralNetworkReconstructionTest.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/scala/org/deeplearning4j/spark/ml/reconstruction/NeuralNetworkReconstructionTest.scala
@@ -3,7 +3,6 @@ package org.deeplearning4j.spark.ml.reconstruction
 import org.apache.spark.Logging
 import org.deeplearning4j.nn.api.OptimizationAlgorithm
 import org.deeplearning4j.nn.conf.{Updater, MultiLayerConfiguration, NeuralNetConfiguration}
-import org.deeplearning4j.nn.conf.`override`.ConfOverride
 import org.deeplearning4j.nn.conf.layers.{OutputLayer, RBM}
 import org.deeplearning4j.nn.weights.WeightInit
 import org.deeplearning4j.spark.sql.sources.iris.DefaultSource

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/scala/org/deeplearning4j/spark/ml/reconstruction/NeuralNetworkReconstructionTest.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/scala/org/deeplearning4j/spark/ml/reconstruction/NeuralNetworkReconstructionTest.scala
@@ -1,9 +1,11 @@
 package org.deeplearning4j.spark.ml.reconstruction
 
 import org.apache.spark.Logging
-import org.deeplearning4j.nn.conf.NeuralNetConfiguration
+import org.deeplearning4j.nn.api.OptimizationAlgorithm
+import org.deeplearning4j.nn.conf.{Updater, MultiLayerConfiguration, NeuralNetConfiguration}
 import org.deeplearning4j.nn.conf.`override`.ConfOverride
 import org.deeplearning4j.nn.conf.layers.{OutputLayer, RBM}
+import org.deeplearning4j.nn.weights.WeightInit
 import org.deeplearning4j.spark.sql.sources.iris.DefaultSource
 import org.deeplearning4j.spark.util.TestSparkContext
 import org.junit.runner.RunWith
@@ -19,26 +21,31 @@ import org.springframework.core.io.ClassPathResource
 class NeuralNetworkReconstructionTest
   extends FunSuite with TestSparkContext with Logging with Matchers {
 
-  test("iris") {
-    val conf = new NeuralNetConfiguration.Builder()
+  private def getConfiguration(): MultiLayerConfiguration = {
+    new NeuralNetConfiguration.Builder()
       .seed(11L)
+      .iterations(100)
+      .weightInit(WeightInit.XAVIER)
+      .activationFunction("relu")
+      .k(1)
       .lossFunction(LossFunctions.LossFunction.RMSE_XENT)
-      .nIn(4).nOut(3)
-      .layer(new RBM)
-      .visibleUnit(RBM.VisibleUnit.GAUSSIAN)
-      .hiddenUnit(RBM.HiddenUnit.RECTIFIED)
-      .activationFunction("tanh")
+      .learningRate(1e-3f)
+      .optimizationAlgo(OptimizationAlgorithm.LINE_GRADIENT_DESCENT)
+      .momentum(0.9)
+      .updater(Updater.ADAGRAD)
+      .constrainGradientToUnitNorm(true)
+      .dropOut(0.5)
+      .useDropConnect(true)
       .list(2)
-      .hiddenLayerSizes(3)
-      .`override`(1, new ConfOverride() {
-      def overrideLayer(i: Int, builder: NeuralNetConfiguration.Builder) {
-        if (i == 1) {
-          builder.activationFunction("softmax")
-          builder.layer(new OutputLayer)
-          builder.lossFunction(LossFunctions.LossFunction.MCXENT)
-        }
-      }
-    }).build
+      .layer(0, new RBM.Builder(RBM.HiddenUnit.RECTIFIED, RBM.VisibleUnit.GAUSSIAN)
+        .nIn(4).nOut(3).build())
+      .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+        .nIn(3).nOut(3).activation("softmax").build())
+      .build();
+  }
+
+  test("iris") {
+    val conf = getConfiguration()
 
     val path = new ClassPathResource("data/irisSvmLight.txt").getFile.toURI.toString
     val dataFrame = sqlContext.read.format(classOf[DefaultSource].getName).load(path)


### PR DESCRIPTION
Update the configuration used in NeuralNetworkReconstructionTest. This update fix below test failure.

```
15/08/16 17:58:51 ERROR Executor: Exception in task 0.0 in stage 2.0 (TID 4)
java.lang.IllegalStateException: Unable to retrieve layer. No params found (length was 0
        at org.deeplearning4j.nn.multilayer.MultiLayerNetwork.setParameters(MultiLayerNetwork.java:1525)
        at org.deeplearning4j.nn.multilayer.MultiLayerNetwork.setParams(MultiLayerNetwork.java:811)
        at org.deeplearning4j.spark.ml.nn.ParameterAveragingTrainingStrategy$$anonfun$train$1$$anonfun$apply$mcVI$sp$1.apply(TrainingStrategy.scala:87)
        at org.deeplearning4j.spark.ml.nn.ParameterAveragingTrainingStrategy$$anonfun$train$1$$anonfun$apply$mcVI$sp$1.apply(TrainingStrategy.scala:81)
        at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$29.apply(RDD.scala:878)
        at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$29.apply(RDD.scala:878)
        at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:1765)
        at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:1765)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:63)
        at org.apache.spark.scheduler.Task.run(Task.scala:70)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:213)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
```