### PR TITLE
#565 - JSON serialization for InputPreProcessor

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/InputPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/InputPreProcessor.java
@@ -19,6 +19,9 @@
 package org.deeplearning4j.nn.conf;
 
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.deeplearning4j.nn.conf.preprocessor.*;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.io.Serializable;
@@ -30,6 +33,19 @@ import java.io.Serializable;
  *
  * @author Adam Gibson
  */
+@JsonTypeInfo(use= JsonTypeInfo.Id.NAME, include= JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonSubTypes(value={
+        @JsonSubTypes.Type(value = CnnToFeedForwardPreProcessor.class, name = "cnnToFeedForward"),
+        @JsonSubTypes.Type(value = ComposableInputPreProcessor.class, name = "composableInput"),
+        @JsonSubTypes.Type(value = FeedForwardToCnnPreProcessor.class, name = "feedForwardToCnn"),
+        @JsonSubTypes.Type(value = FeedForwardToRnnPreProcessor.class, name = "feedForwardToRnn"),
+        @JsonSubTypes.Type(value = RnnToFeedForwardPreProcessor.class, name = "rnnToFeedForward"),
+        @JsonSubTypes.Type(value = BinomialSamplingPreProcessor.class, name = "binomialSampling"),
+        @JsonSubTypes.Type(value = ReshapePreProcessor.class, name = "reshape"),
+        @JsonSubTypes.Type(value = UnitVarianceProcessor.class, name = "unitVariance"),
+        @JsonSubTypes.Type(value = ZeroMeanAndUnitVariancePreProcessor.class, name = "zeroMeanAndUnitVariance"),
+        @JsonSubTypes.Type(value = ZeroMeanPrePreProcessor.class, name = "zeroMean"),
+})
 public interface InputPreProcessor extends Serializable {
 
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/BaseInputPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/BaseInputPreProcessor.java
@@ -7,10 +7,4 @@ import org.deeplearning4j.nn.conf.InputPreProcessor;
  */
 
 public abstract class BaseInputPreProcessor implements InputPreProcessor {
-
-
-    @Override
-    public boolean equals(Object obj) {
-        return getClass().toString().equals(obj.getClass().toString());
-    }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/BinomialSamplingPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/BinomialSamplingPreProcessor.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.conf.preprocessor;
 
 
+import lombok.Data;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -26,6 +27,7 @@ import org.nd4j.linalg.factory.Nd4j;
  * Binomial sampling pre processor
  * @author Adam Gibson
  */
+@Data
 public class BinomialSamplingPreProcessor extends BaseInputPreProcessor {
 
 	@Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
@@ -18,7 +18,9 @@
 
 package org.deeplearning4j.nn.conf.preprocessor;
 
-import lombok.EqualsAndHashCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.util.ArrayUtil;
@@ -38,12 +40,11 @@ import java.util.Arrays;
  * @author Adam Gibson
  * @see FeedForwardToCnnPreProcessor for opposite case (i.e., DenseLayer -> CNNetc)
 */
- @EqualsAndHashCode
+@Data
 public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
      private int inputWidth;
      private int inputHeight;
      private int numChannels;
-     private int[] shape;
 
      /**
       * @param inputWidth the rows
@@ -51,7 +52,10 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
       * @param numChannels the channels
       */
 
-    public CnnToFeedForwardPreProcessor(int inputWidth, int inputHeight, int numChannels) {
+     @JsonCreator
+    public CnnToFeedForwardPreProcessor(@JsonProperty("inputWidth") int inputWidth,
+                                        @JsonProperty("inputHeight") int inputHeight,
+                                        @JsonProperty("numChannels") int numChannels) {
         this.inputWidth = inputWidth;
         this.inputHeight = inputHeight;
         this.numChannels = numChannels;
@@ -77,7 +81,7 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
         else if(input.shape().length == 3) {
             otherOutputs = new int[2];
         }
-        shape = new int[] {input.shape()[0], ArrayUtil.prod(otherOutputs)};
+        int[] shape = new int[] {input.shape()[0], ArrayUtil.prod(otherOutputs)};
         return input.reshape(shape);
     }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ComposableInputPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ComposableInputPreProcessor.java
@@ -18,6 +18,9 @@
 
 package org.deeplearning4j.nn.conf.preprocessor;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.gradient.Gradient;
@@ -27,10 +30,12 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  * Composable input pre processor
  * @author Adam Gibson
  */
+@Data
 public class ComposableInputPreProcessor extends BaseInputPreProcessor {
 	private InputPreProcessor[] inputPreProcessors;
 
-    public ComposableInputPreProcessor(InputPreProcessor[] inputPreProcessors) {
+    @JsonCreator
+    public ComposableInputPreProcessor(@JsonProperty("inputPreProcessors") InputPreProcessor[] inputPreProcessors) {
         this.inputPreProcessors = inputPreProcessors;
     }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
@@ -18,7 +18,9 @@
 
 package org.deeplearning4j.nn.conf.preprocessor;
 
-import lombok.EqualsAndHashCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.gradient.Gradient;
@@ -41,11 +43,14 @@ import java.util.Arrays;
  * @see CnnToFeedForwardPreProcessor for opposite case (i.e., CNN -> DenseLayer etc)
 
  */
-@EqualsAndHashCode
+@Data
 public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
     private int inputWidth;
     private int inputHeight;
     private int numChannels;
+
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
     private int[] shape;
 
     /**
@@ -54,7 +59,10 @@ public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
      * @param inputHeight the columns
      * @param numChannels the channels
      */
-    public FeedForwardToCnnPreProcessor(int inputWidth, int inputHeight, int numChannels) {
+    @JsonCreator
+    public FeedForwardToCnnPreProcessor(@JsonProperty("inputWidth") int inputWidth,
+                                        @JsonProperty("inputHeight") int inputHeight,
+                                        @JsonProperty("numChannels") int numChannels) {
         this.inputWidth = inputWidth;
         this.inputHeight = inputHeight;
         this.numChannels = numChannels;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToRnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToRnnPreProcessor.java
@@ -1,5 +1,8 @@
 package org.deeplearning4j.nn.conf.preprocessor;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import org.deeplearning4j.nn.conf.InputPreProcessor;
@@ -17,14 +20,15 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  * @author Alex Black
  * @see RnnToFeedForwardPreProcessor for opposite case (i.e., GravesLSTM -> DenseLayer etc)
  */
-@EqualsAndHashCode
+@Data
 public class FeedForwardToRnnPreProcessor implements InputPreProcessor {
 	private static final long serialVersionUID = -6900959538072178994L;
 	private final int timeSeriesLength;
 	
 	/**@param timeSeriesLength Length of time series training data
 	 */
-	public FeedForwardToRnnPreProcessor(int timeSeriesLength ){
+	@JsonCreator
+	public FeedForwardToRnnPreProcessor(@JsonProperty("timeSeriesLength") int timeSeriesLength ){
 		this.timeSeriesLength = timeSeriesLength;
 	}
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ReshapePreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ReshapePreProcessor.java
@@ -18,6 +18,10 @@
 
 package org.deeplearning4j.nn.conf.preprocessor;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**Reshape post processor.<br>
@@ -27,6 +31,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  *
  * @author Adam Gibson
  */
+@Data
 public class ReshapePreProcessor extends BaseInputPreProcessor {
     private int[] fromShape;	//Epsilons: To this shape in backward pass
     private int[] toShape;		//Activations: To this shape in forward pass
@@ -39,9 +44,12 @@ public class ReshapePreProcessor extends BaseInputPreProcessor {
      * Otherwise fromShape is the shape that epsilons (weights*deltas or equiv.)
 	 *  are reshaped to by backprop(...)
 	 */
-    public ReshapePreProcessor(int[] fromShape, int[] toShape, boolean dynamic){
+    @JsonCreator
+    public ReshapePreProcessor(@JsonProperty("fromShape") int[] fromShape,
+                               @JsonProperty("toShape") int[] toShape,
+                               @JsonProperty("dynamic") boolean dynamic){
         this.fromShape = fromShape;
-	this.toShape = toShape;
+	    this.toShape = toShape;
         this.dynamic = dynamic;
     }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
@@ -1,5 +1,8 @@
 package org.deeplearning4j.nn.conf.preprocessor;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import org.deeplearning4j.nn.conf.InputPreProcessor;
@@ -17,14 +20,15 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  * @author Alex Black
  * @see FeedForwardToRnnPreProcessor for opposite case (i.e., DenseLayer -> GravesLSTM etc)
  */
-@EqualsAndHashCode
+@Data
 public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
 	private static final long serialVersionUID = -2334789406636365730L;
 	private final int timeSeriesLength;
 	
 	/**@param timeSeriesLength Length of time series training data
 	 */
-	public RnnToFeedForwardPreProcessor(int timeSeriesLength ) {
+	@JsonCreator
+	public RnnToFeedForwardPreProcessor(@JsonProperty("timeSeriesLength") int timeSeriesLength ) {
 		this.timeSeriesLength = timeSeriesLength;
 	}
 	

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/UnitVarianceProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/UnitVarianceProcessor.java
@@ -18,6 +18,10 @@
 
 package org.deeplearning4j.nn.conf.preprocessor;
 
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -28,8 +32,11 @@ import org.nd4j.linalg.factory.Nd4j;
  *
  * @author Adma Gibson
  */
+@Data
 public class UnitVarianceProcessor extends BaseInputPreProcessor {
 
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
 	INDArray columnStds;
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanAndUnitVariancePreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanAndUnitVariancePreProcessor.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.conf.preprocessor;
 
 
+import lombok.Data;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -29,6 +30,7 @@ import org.nd4j.linalg.factory.Nd4j;
  *
  * @author Adam Gibson
  */
+@Data
 public class ZeroMeanAndUnitVariancePreProcessor extends BaseInputPreProcessor {
 
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanPrePreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanPrePreProcessor.java
@@ -18,6 +18,7 @@
 
 package org.deeplearning4j.nn.conf.preprocessor;
 
+import lombok.Data;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -27,6 +28,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  *
  * @author Adam Gibson
  */
+@Data
 public class ZeroMeanPrePreProcessor extends BaseInputPreProcessor {
 
 	@Override


### PR DESCRIPTION
Added Data annotation to the known input preprocessors, annotated the
constructors, and added the JsonSubTypes annotation to the interface.

With that, the preprocessors are handled much as other polymorphic conf
elements are.  Sample JSON output:

```
"inputPreProcessors" : {
    "0" : {
      "feedForwardToCnn" : {
        "inputWidth" : 28,
        "inputHeight" : 28,
        "numChannels" : 1
      }
    },
    "2" : {
      "cnnToFeedForward" : {
        "inputWidth" : 28,
        "inputHeight" : 28,
        "numChannels" : 1
      }
    }
```

Closes #565.