### PR TITLE
Ensure that layer API is serializable

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -18,9 +18,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -33,6 +31,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
  *
  */
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class AutoEncoder extends BasePretrainNetwork {
     protected double corruptionLevel;
     protected double sparsity;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
@@ -18,10 +18,11 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public abstract class BasePretrainNetwork extends FeedForwardLayer {
 
     public BasePretrainNetwork(FeedForwardLayer.Builder builder){

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -1,8 +1,6 @@
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -12,8 +10,9 @@ import org.nd4j.linalg.convolution.Convolution;
 /**
  * @author Adam Gibson
  */
-@Data
-@NoArgsConstructor
+@Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class ConvolutionLayer extends FeedForwardLayer {
     protected Convolution.Type convolutionType;
     protected int[] kernelSize; // Square filter
@@ -57,6 +56,11 @@ public class ConvolutionLayer extends FeedForwardLayer {
 
         public Builder() {}
 
+        public Builder convolutionType(Convolution.Type convolutionType) {
+            this.convolutionType = convolutionType;
+            return this;
+        }
+
         @Override
         public Builder nIn(int nIn) {
             super.nIn(nIn);
@@ -84,7 +88,7 @@ public class ConvolutionLayer extends FeedForwardLayer {
             this.dropOut = dropOut;
             return this;
         }
-        
+
         @Override
         public Builder dist(Distribution dist){
         	super.dist(dist);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -18,9 +18,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -29,6 +27,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
 /**Dense layer: fully connected feed forward layer trainable by backprop.
  */
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class DenseLayer extends FeedForwardLayer {
 
     private DenseLayer(Builder builder) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -1,13 +1,13 @@
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * Created by jeffreytang on 7/21/15.
  */
-@Data
-@NoArgsConstructor
+@Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public abstract class FeedForwardLayer extends Layer {
     protected int nIn;
     protected int nOut;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
@@ -18,9 +18,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -31,6 +29,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
  * http://www.cs.toronto.edu/~graves/phd.pdf
  */
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class GravesLSTM extends FeedForwardLayer {
 
     private GravesLSTM(Builder builder) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
@@ -18,9 +18,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -31,6 +29,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
  * Based on karpathy et. al's work on generation of image descriptions.
  */
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class LSTM extends FeedForwardLayer {
     
     private LSTM(Builder builder) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -39,12 +39,14 @@ import org.deeplearning4j.nn.weights.WeightInit;
 @JsonSubTypes(value={
         @JsonSubTypes.Type(value = AutoEncoder.class, name = "autoEncoder"),
         @JsonSubTypes.Type(value = ConvolutionDownSampleLayer.class, name = "convolutionDownSample"),
+        @JsonSubTypes.Type(value = ConvolutionLayer.class, name = "convolution"),
         @JsonSubTypes.Type(value = LSTM.class, name = "LSTM"),
         @JsonSubTypes.Type(value = GravesLSTM.class, name = "gravesLSTM"),
         @JsonSubTypes.Type(value = OutputLayer.class, name = "output"),
         @JsonSubTypes.Type(value = RBM.class, name = "RBM"),
-        @JsonSubTypes.Type(value = DenseLayer.class, name = "denseLayer"),
+        @JsonSubTypes.Type(value = DenseLayer.class, name = "dense"),
         @JsonSubTypes.Type(value = RecursiveAutoEncoder.class, name = "recursiveAutoEncoder"),
+        @JsonSubTypes.Type(value = SubsamplingLayer.class, name = "subsampling"),
         })
 @Data
 @NoArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
@@ -18,9 +18,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -34,6 +32,8 @@ import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
  *
  */
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class OutputLayer extends FeedForwardLayer {
     private LossFunction lossFunction;
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RBM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RBM.java
@@ -18,9 +18,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -51,6 +49,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
  */
 
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class RBM extends BasePretrainNetwork {
     protected HiddenUnit hiddenUnit;
     protected VisibleUnit visibleUnit;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RecursiveAutoEncoder.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RecursiveAutoEncoder.java
@@ -18,8 +18,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -32,6 +31,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
 *
 */
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class RecursiveAutoEncoder extends FeedForwardLayer {
 
     private RecursiveAutoEncoder(Builder builder) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -1,8 +1,6 @@
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -19,6 +17,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
  */
 
 @Data @NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class SubsamplingLayer extends Layer {
 
     protected PoolingType poolingType;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/LayerBuilderTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/LayerBuilderTest.java
@@ -1,5 +1,9 @@
 package org.deeplearning4j.nn.layers;
 
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.Updater;
+import org.deeplearning4j.nn.conf.distribution.Distribution;
+import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
 import org.deeplearning4j.nn.conf.layers.*;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RBM.*;
@@ -11,10 +15,14 @@ import static org.junit.Assert.*;
 import org.nd4j.linalg.convolution.Convolution;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 
+import java.io.*;
+
 /**
  * @author Jeffrey Tang.
  */
 public class LayerBuilderTest {
+    final double DELTA = 1e-15;
+
     int numIn = 10;
     int numOut = 5;
     double drop = 0.3;
@@ -22,40 +30,132 @@ public class LayerBuilderTest {
     PoolingType poolType = PoolingType.MAX;
     int[] kernelSize = new int[]{2, 2};
     int[] stride = new int[]{2, 2};
+    int[] padding = new int[]{1,1};
     HiddenUnit hidden = HiddenUnit.RECTIFIED;
     VisibleUnit visible = VisibleUnit.GAUSSIAN;
     int k  = 1;
-    Convolution.Type convType = Convolution.Type.FULL;
+    Convolution.Type convType = Convolution.Type.VALID;
     LossFunction loss = LossFunction.MCXENT;
     WeightInit weight = WeightInit.XAVIER;
     double corrupt = 0.4;
     double sparsity = 0.3;
+    double corruptionLevel = 0.5;
+    Distribution dist = new NormalDistribution(1.0, 0.1);
+    double dropOut = 0.1;
+    Updater updater = Updater.ADAGRAD;
 
     @Test
-    public void testLayerBuilderAPI() {
-        // Make new Convolutional layer
-        ConvolutionLayer conv = new ConvolutionLayer.Builder(kernelSize,new int[]{1,1}).activation(act).build();
-        // Make new Subsampling layer
-        SubsamplingLayer sample = new SubsamplingLayer.Builder(poolType, stride).build();
-        // Make new RBM layer
-        RBM rbm = new RBM.Builder(hidden, visible, k).nIn(numIn).nOut(numOut).build();
-        // Make new Output layer
-        OutputLayer out = new OutputLayer.Builder(loss).nIn(numIn).nOut(numOut).activation(act).dropOut(drop).build();
+    public void testLayer() throws Exception {
+        RecursiveAutoEncoder layer = new RecursiveAutoEncoder.Builder()
+            .activation(act).weightInit(weight).dist(dist).dropOut(dropOut).updater(updater).build();
 
-        // Test Output layer API
-        assertTrue(out.getNIn() == numIn);
-        assertTrue(out.getNOut() == numOut);
-        assertTrue(out.getDropOut() == drop);
-        assertTrue(out.getActivationFunction().equals(act));
-        // Test Convolution layer API
-        assertTrue(conv.getConvolutionType() == convType);
-         // Test Subsampling layer API
-        assertTrue(sample.getPoolingType() == poolType);
-        assertTrue(sample.getStride() == stride);
-        // Test RBM layer API
-        assertTrue(rbm.getNIn() == numIn);
-        assertTrue(rbm.getNOut() == numOut);
-        assertTrue(rbm.getHiddenUnit() == hidden);
-        assertTrue(rbm.getVisibleUnit() == visible);
+        checkSerialization(layer);
+
+        assertEquals(act, layer.getActivationFunction());
+        assertEquals(weight, layer.getWeightInit());
+        assertEquals(dist, layer.getDist());
+        assertEquals(dropOut, layer.getDropOut(), DELTA);
+        assertEquals(updater, layer.getUpdater());
+    }
+
+    @Test
+    public void testFeedForwardLayer() throws Exception {
+        RecursiveAutoEncoder ff = new RecursiveAutoEncoder.Builder().nIn(numIn).nOut(numOut).build();
+
+        checkSerialization(ff);
+
+        assertEquals(numIn, ff.getNIn());
+        assertEquals(numOut, ff.getNOut());
+    }
+    @Test
+    public void testConvolutionLayer() throws Exception {
+        ConvolutionLayer conv = new ConvolutionLayer.Builder(kernelSize, stride, padding)
+                .convolutionType(convType).build();
+
+        checkSerialization(conv);
+
+        assertEquals(convType, conv.getConvolutionType());
+        assertArrayEquals(kernelSize, conv.getKernelSize());
+        assertArrayEquals(stride, conv.getStride());
+        assertArrayEquals(padding, conv.getPadding());
+    }
+
+    @Test
+    public void testRBM() throws Exception {
+        RBM rbm = new RBM.Builder(hidden, visible, k).build();
+
+        checkSerialization(rbm);
+
+        assertEquals(hidden, rbm.getHiddenUnit());
+        assertEquals(visible, rbm.getVisibleUnit());
+        assertEquals(k, rbm.getK());
+    }
+
+    @Test
+    public void testSubsamplingLayer() throws Exception {
+        SubsamplingLayer sample = new SubsamplingLayer.Builder(poolType, stride)
+                .kernelSize(kernelSize)
+                .padding(padding)
+                .build();
+
+        checkSerialization(sample);
+
+        assertArrayEquals(padding, sample.getPadding());
+        assertArrayEquals(kernelSize, sample.getKernelSize());
+        assertEquals(poolType, sample.getPoolingType());
+        assertArrayEquals(stride, sample.getStride());
+    }
+
+    @Test
+    public void testOutputLayer() throws Exception {
+        OutputLayer out = new OutputLayer.Builder(loss).build();
+
+        checkSerialization(out);
+
+        assertEquals(loss, out.getLossFunction());
+    }
+
+    @Test
+    public void testAutoEncoder() throws Exception {
+        AutoEncoder enc = new AutoEncoder.Builder(corruptionLevel).sparsity(sparsity).build();
+
+        checkSerialization(enc);
+
+        assertEquals(corruptionLevel, enc.getCorruptionLevel(), DELTA);
+        assertEquals(sparsity, enc.getSparsity(), DELTA);
+    }
+
+    private void checkSerialization(Layer layer) throws Exception {
+        NeuralNetConfiguration confExpected = new NeuralNetConfiguration.Builder()
+                .layer(layer)
+                .build();
+        NeuralNetConfiguration confActual;
+
+        // check Java serialization
+        byte[] data;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             ObjectOutput out = new ObjectOutputStream(bos)) {
+            out.writeObject(confExpected);
+            data = bos.toByteArray();
+        }
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(data);
+             ObjectInput in = new ObjectInputStream(bis)) {
+            confActual = (NeuralNetConfiguration) in.readObject();
+        }
+        assertEquals("unequal Java serialization", confExpected.getLayer(), confActual.getLayer());
+
+        // check JSON
+        String json = confExpected.toJson();
+        confActual = NeuralNetConfiguration.fromJson(json);
+        assertEquals("unequal JSON serialization", confExpected.getLayer(), confActual.getLayer());
+
+        // check YAML
+        String yaml = confExpected.toYaml();
+        confActual = NeuralNetConfiguration.fromYaml(yaml);
+        assertEquals("unequal YAML serialization", confExpected.getLayer(), confActual.getLayer());
+
+        // check the layer's use of callSuper on equals method
+        confActual.getLayer().setDropOut(new java.util.Random().nextDouble());
+        assertNotEquals("broken equals method (missing callSuper?)", confExpected.getLayer(), confActual.getLayer());
     }
 }


### PR DESCRIPTION
- Added subsampling & convolution layer to known subtypes.
- Use deep equality check.
- Rewrote unit test to cover serialization (java/json/yaml) and to
check all properties for correctness.
- Changed json output from ‘denseLayer’ to ‘dense’ for consistency.

Closes #584.