### PR TITLE
Revised cnn processors to ensure adjusting shapes and added tests.

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
@@ -42,28 +42,28 @@ import java.util.Arrays;
 */
 @Data
 public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
-     private int inputWidth;
      private int inputHeight;
+     private int inputWidth;
      private int numChannels;
 
      /**
-      * @param inputWidth the rows
       * @param inputHeight the columns
+      * @param inputWidth the rows
       * @param numChannels the channels
       */
 
      @JsonCreator
-    public CnnToFeedForwardPreProcessor(@JsonProperty("inputWidth") int inputWidth,
-                                        @JsonProperty("inputHeight") int inputHeight,
+    public CnnToFeedForwardPreProcessor(@JsonProperty("inputHeight") int inputHeight,
+                                        @JsonProperty("inputWidth") int inputWidth,
                                         @JsonProperty("numChannels") int numChannels) {
-        this.inputWidth = inputWidth;
-        this.inputHeight = inputHeight;
-        this.numChannels = numChannels;
+         this.inputHeight = inputHeight;
+         this.inputWidth = inputWidth;
+         this.numChannels = numChannels;
     }
 
-    public CnnToFeedForwardPreProcessor(int inputWidth, int inputHeight) {
-        this.inputWidth = inputWidth;
+    public CnnToFeedForwardPreProcessor(int inputHeight, int inputWidth) {
         this.inputHeight = inputHeight;
+        this.inputWidth = inputWidth;
         this.numChannels = 1;
     }
 
@@ -75,11 +75,18 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
         int[] otherOutputs = null;
 
         if(input.shape().length == 2) {
+            this.inputHeight = input.shape()[0];
+            this.inputWidth = input.shape()[1];
             return input;
         } else if(input.shape().length == 4) {
+            this.inputHeight = input.shape()[2];
+            this.inputWidth = input.shape()[3];
+            this.numChannels = input.shape()[1];
             otherOutputs = new int[3];
         }
         else if(input.shape().length == 3) {
+            this.inputHeight = input.shape()[1];
+            this.inputWidth = input.shape()[2];
             otherOutputs = new int[2];
         }
         System.arraycopy(input.shape(), 1, otherOutputs, 0, otherOutputs.length);
@@ -91,9 +98,9 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
     public INDArray backprop(INDArray output){
         if (output.shape().length == 4)
             return output;
-        if (output.columns() != inputWidth * inputHeight)
-            throw new IllegalArgumentException("Invalid input: expect output columns must be equal to rows " + inputWidth + " x columns " + inputHeight + " but was instead " + Arrays.toString(output.shape()));
-        return output.reshape(output.size(0), numChannels, inputWidth, inputHeight);
+        if (output.columns() != inputWidth * inputHeight * numChannels)
+            throw new IllegalArgumentException("Invalid input: expect output columns must be equal to rows " + inputHeight + " x columns " + inputWidth + " x depth " + numChannels +" but was instead " + Arrays.toString(output.shape()));
+        return output.reshape(output.size(0), numChannels, inputHeight, inputWidth);
     }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
@@ -70,6 +70,7 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
     public CnnToFeedForwardPreProcessor(){}
 
     @Override
+    // return 2 dimensions
     public INDArray preProcess(INDArray input) {
         int[] otherOutputs = null;
 
@@ -81,6 +82,7 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
         else if(input.shape().length == 3) {
             otherOutputs = new int[2];
         }
+        System.arraycopy(input.shape(), 1, otherOutputs, 0, otherOutputs.length);
         int[] shape = new int[] {input.shape()[0], ArrayUtil.prod(otherOutputs)};
         return input.reshape(shape);
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
@@ -45,8 +45,8 @@ import java.util.Arrays;
  */
 @Data
 public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
-    private int inputWidth;
     private int inputHeight;
+    private int inputWidth;
     private int numChannels;
 
     @Getter(AccessLevel.NONE)
@@ -55,22 +55,22 @@ public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
 
     /**
      * Reshape to a channels x rows x columns tensor
-     * @param inputWidth the rows
      * @param inputHeight the columns
+     * @param inputWidth the rows
      * @param numChannels the channels
      */
     @JsonCreator
-    public FeedForwardToCnnPreProcessor(@JsonProperty("inputWidth") int inputWidth,
-                                        @JsonProperty("inputHeight") int inputHeight,
+    public FeedForwardToCnnPreProcessor(@JsonProperty("inputHeight") int inputHeight,
+                                        @JsonProperty("inputWidth") int inputWidth,
                                         @JsonProperty("numChannels") int numChannels) {
-        this.inputWidth = inputWidth;
         this.inputHeight = inputHeight;
+        this.inputWidth = inputWidth;
         this.numChannels = numChannels;
     }
 
     public FeedForwardToCnnPreProcessor(int inputWidth, int inputHeight) {
-        this.inputWidth = inputWidth;
         this.inputHeight = inputHeight;
+        this.inputWidth = inputWidth;
         this.numChannels = 1;
     }
 
@@ -80,8 +80,8 @@ public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
         if(input.shape().length == 4)
             return input;
         if(input.columns() != inputWidth * inputHeight)
-            throw new IllegalArgumentException("Invalid input: expect output columns must be equal to rows " + inputWidth + " x columns " + inputHeight + " but was instead " + Arrays.toString(input.shape()));
-        return input.reshape(input.size(0),numChannels,inputWidth,inputHeight);
+            throw new IllegalArgumentException("Invalid input: expect output columns must be equal to rows " + inputHeight + " x columns " + inputWidth  + " but was instead " + Arrays.toString(input.shape()));
+        return input.reshape(input.size(0),numChannels,inputHeight,inputWidth);
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
@@ -85,6 +85,7 @@ public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
     }
 
     @Override
+    // return 4 dimensions
     public INDArray backprop(INDArray output){
         if(shape == null || ArrayUtil.prod(shape) != output.length()) {
             int[] otherOutputs = null;
@@ -96,6 +97,7 @@ public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
             else if(output.shape().length == 3) {
                 otherOutputs = new int[2];
             }
+            System.arraycopy(output.shape(), 1, otherOutputs, 0, otherOutputs.length);
             shape = new int[] {output.shape()[0], ArrayUtil.prod(otherOutputs)};
         }
         return output.reshape(shape);

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/preprocessor/CNNProcessorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/preprocessor/CNNProcessorTest.java
@@ -37,10 +37,12 @@ public class CNNProcessorTest {
         INDArray check2to4 = convProcessor.preProcess(in2D);
         int val2to4 = check2to4.shape().length;
         assertTrue(val2to4 == 4);
+        assertEquals(Nd4j.create(1, 1, 28, 28), check2to4);
 
-        INDArray result2 = convProcessor.preProcess(in4D);
-        int val4to4 = result2.shape().length;
+        INDArray check4to4 = convProcessor.preProcess(in4D);
+        int val4to4 = check4to4.shape().length;
         assertTrue(val4to4 == 4);
+        assertEquals(Nd4j.create(20, 1, 28, 28), check4to4);
 
     }
 
@@ -48,19 +50,23 @@ public class CNNProcessorTest {
     @Test
     public void testFeeForwardToCnnPreProcessorBackprop() {
         FeedForwardToCnnPreProcessor convProcessor = new FeedForwardToCnnPreProcessor(rows, cols, 1);
+        convProcessor.preProcess(in2D);
 
         INDArray check2to2 = convProcessor.backprop(in2D);
         int val2to2 = check2to2.shape().length;
         assertTrue(val2to2 == 2);
+        assertEquals(Nd4j.create(1, 784), check2to2);
 
         INDArray check3to2 = convProcessor.backprop(in3D);
         int val3to2 = check3to2.shape().length;
         assertTrue(val3to2 == 2);
+        assertEquals(Nd4j.create(20, 5488), check3to2);
 
 
         INDArray check4to2 = convProcessor.backprop(in4D);
         int val4to2 = check4to2.shape().length;
         assertTrue(val4to2 == 2);
+        assertEquals(Nd4j.create(20, 784), check4to2);
 
     }
 
@@ -71,30 +77,37 @@ public class CNNProcessorTest {
         INDArray check2to4 = convProcessor.backprop(in2D);
         int val2to4 = check2to4.shape().length;
         assertTrue(val2to4 == 4);
+        assertEquals(Nd4j.create(1, 1, 28, 28), check2to4);
 
-        INDArray result2 = convProcessor.backprop(in4D);
-        int val4to4 = result2.shape().length;
+        INDArray check4to4 = convProcessor.backprop(in4D);
+        int val4to4 = check4to4.shape().length;
         assertTrue(val4to4 == 4);
+        assertEquals(Nd4j.create(20, 1, 28, 28), check4to4);
 
     }
 
     @Test
     public void testCnnToFeeForwardPreProcessorBackprop() {
         CnnToFeedForwardPreProcessor convProcessor = new CnnToFeedForwardPreProcessor(rows, cols, 1);
+        convProcessor.preProcess(in4D);
 
         INDArray check2to2 = convProcessor.preProcess(in2D);
         int val2to2 = check2to2.shape().length;
         assertTrue(val2to2 == 2);
+        assertEquals(Nd4j.create(1, 784), check2to2);
 
         INDArray check3to2 = convProcessor.preProcess(in3D);
         int val3to2 = check3to2.shape().length;
         assertTrue(val3to2 == 2);
+        assertEquals(Nd4j.create(20, 5488), check3to2);
 
         INDArray check4to2 = convProcessor.preProcess(in4D);
         int val4to2 = check4to2.shape().length;
         assertTrue(val4to2 == 2);
+        assertEquals(Nd4j.create(20, 784), check4to2);
 
     }
+
     @Test
     public void testCNNInputPreProcessorMnist() throws Exception {
         int numSamples = 1;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
@@ -297,8 +297,6 @@ public class ConvolutionLayerTest {
 
     @Test
     public void testCNNMLN() throws Exception {
-        Nd4j.MAX_SLICES_TO_PRINT = -1;
-        Nd4j.MAX_ELEMENTS_PER_SLICE = -1;
         Nd4j.ENFORCE_NUMERICAL_STABILITY = true;
 
         final int numRows = 28;
@@ -334,6 +332,7 @@ public class ConvolutionLayerTest {
                         .build())
                 .inputPreProcessor(0, new FeedForwardToCnnPreProcessor(numRows, numColumns, 1))
                 .inputPreProcessor(2, new CnnToFeedForwardPreProcessor())
+                .backprop(true).pretrain(false)
                 .build();
         MultiLayerNetwork model = new MultiLayerNetwork(conf);
         model.init();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
@@ -326,7 +326,7 @@ public class ConvolutionLayerTest {
                 .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX, new int[] {2,2})
                         .build())
                 .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
-                        .nIn(8)
+                        .nIn(20)
                         .nOut(outputNum)
                         .activation("softmax")
                         .build())


### PR DESCRIPTION
- Fixed how shapes are captured and applied for cnns wiht example MLN
- Aligned cnn preprocessors with height, width ordering
- Identified calculation needed to determine nIn when transitioning from CNN to FF (last layers's shape dimensions > 0 multiplied) so if shape is 8,8,5,5 the FF layer's nIn is 200. This ensures correct weight setup.