### PR TITLE
Further CNN & Subsampling Fixes - Backprop version is running

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Layer.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 public interface Layer extends Serializable,Cloneable,Model {
 
     enum Type {
-       FEED_FORWARD,RECURRENT,CONVOLUTIONAL,RECURSIVE,MULTILAYER
+       FEED_FORWARD,RECURRENT,CONVOLUTIONAL,SUBSAMPLING,RECURSIVE,MULTILAYER
     }
 
     /**Calculate the l2 regularization term<br>

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
@@ -73,20 +73,16 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
     // return 2 dimensions
     public INDArray preProcess(INDArray input) {
         int[] otherOutputs = null;
+        this.inputHeight = input.size(-2);
+        this.inputWidth = input.size(-1);
 
         if(input.shape().length == 2) {
-            this.inputHeight = input.shape()[0];
-            this.inputWidth = input.shape()[1];
             return input;
         } else if(input.shape().length == 4) {
-            this.inputHeight = input.shape()[2];
-            this.inputWidth = input.shape()[3];
-            this.numChannels = input.shape()[1];
+            this.numChannels = input.size(-3);
             otherOutputs = new int[3];
         }
         else if(input.shape().length == 3) {
-            this.inputHeight = input.shape()[1];
-            this.inputWidth = input.shape()[2];
             otherOutputs = new int[2];
         }
         System.arraycopy(input.shape(), 1, otherOutputs, 0, otherOutputs.length);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -95,19 +95,17 @@ public class ConvolutionLayer extends BaseLayer {
 
         Gradient retGradient = new DefaultGradient();
 
-        // TODO chainer adds bias to existing biasGradient for layer. Do we want to do this?
-        //gb += gy[0].sum(axis=(0, 2, 3))
+        //gb = gy[0].sum(axis=(0, 2, 3))
         retGradient.setGradientFor(ConvolutionParamInitializer.BIAS_KEY, delta.sum(0, 2, 3));
 
-        // TODO Note chainer adds weightGradient to existing weightGradient for layer. Do we want to do this?
-        // gW += np.tensordot(gy[0], col, ([0, 2, 3], [0, 4, 5]))
+        // gW = np.tensordot(gy[0], col, ([0, 2, 3], [0, 4, 5]))
         INDArray weightGradient = Nd4j.tensorMmul(delta, col, new int[][] {{0, 2, 3},{0, 4, 5}});
         retGradient.setGradientFor(ConvolutionParamInitializer.WEIGHT_KEY, weightGradient);
 
         //gcol = tensorMmul(W, gy[0], (0, 1))
-        INDArray nextEpsilon = Nd4j.tensorMmul(weights, delta, new int[][]{{0, 1},new int[] {1,0}});
+        INDArray nextEpsilon = Nd4j.tensorMmul(weights, delta, new int[][] {{0}, {1}});
 
-        nextEpsilon = Nd4j.rollAxis(nextEpsilon, 3).reshape(Ints.concat(new int[]{1, 1}, nextEpsilon.shape()));
+        nextEpsilon = Nd4j.rollAxis(nextEpsilon, 3);
         nextEpsilon = Convolution.col2im(nextEpsilon, conf.getStride(), conf.getPadding(), inputHeight, inputWidth);
         return new Pair<>(retGradient,nextEpsilon);
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -110,7 +110,6 @@ public class SubsamplingLayer extends BaseLayer {
                         , NDArrayIndex.all()
                         , NDArrayIndex.newAxis()
                         , NDArrayIndex.newAxis());
-//                retE = retE.reshape(1,2,1,1,2,2); TODO remove - this is just used to check shapes till get is fixed
                 reshapeEpsilon = Nd4j.tile(retE,1,1,conf.getKernelSize()[0],conf.getKernelSize()[1],1,1);
                 reshapeEpsilon = Convolution.col2im(reshapeEpsilon, conf.getStride(), conf.getPadding(), inputHeight, inputWidth);
                 reshapeEpsilon.divi(ArrayUtil.prod(conf.getKernelSize()));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -69,7 +69,7 @@ public class SubsamplingLayer extends BaseLayer {
 
     @Override
     public Type type() {
-        return Type.CONVOLUTIONAL;
+        return Type.SUBSAMPLING;
     }
 
 
@@ -170,7 +170,7 @@ public class SubsamplingLayer extends BaseLayer {
 
     @Override
     public INDArray activationMean() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -184,13 +184,17 @@ public class SubsamplingLayer extends BaseLayer {
     }
 
     @Override
-    public void fit() {}
+    public void fit() {
+
+    }
 
     @Override
     public void fit(INDArray input) {}
 
     @Override
-    public void computeGradientAndScore() {}
+    public void computeGradientAndScore() {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public double score() {
@@ -203,17 +207,19 @@ public class SubsamplingLayer extends BaseLayer {
 
     @Override
     public void update(INDArray gradient, String paramType) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray params() { return Nd4j.create(0);}
+    public INDArray params() { throw new UnsupportedOperationException();}
 
     @Override
     public INDArray getParam(String param) {
-        return Nd4j.create(0);
+        throw new UnsupportedOperationException();
     }
     @Override
     public void setParams(INDArray params) {
+        throw new UnsupportedOperationException();
     }
 
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -28,6 +28,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.OutputLayer;
+import org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer;
 import org.deeplearning4j.nn.layers.factory.LayerFactories;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.nn.weights.WeightInit;
@@ -791,11 +792,13 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
      */
     @Override
     public INDArray params() {
-        List<INDArray> params = new ArrayList<>();
-        for (int i = 0; i < getnLayers(); i++)
-            params.add(layers[i].params());
 
-        return Nd4j.toFlattened(params);
+        List<INDArray> params = new ArrayList<>();
+        for (Layer layer: getLayers())
+            if(!(layer instanceof SubsamplingLayer)) {
+                params.add(layer.params());
+            }
+            return Nd4j.toFlattened(params);
     }
 
     /**
@@ -1509,13 +1512,14 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         int idx = 0;
         for (int i = 0; i < getLayers().length; i++) {
             Layer layer = getLayer(i);
-
-            int range = layer.numParams();
-            INDArray get = params.get(NDArrayIndex.point(0),NDArrayIndex.interval(idx, range + idx));
-            if (get.length() < 1)
-                throw new IllegalStateException("Unable to retrieve layer. No params found (length was 0");
-            layer.setParams(get);
-            idx += range;
+            if(!(layer instanceof SubsamplingLayer)) {
+                int range = layer.numParams();
+                INDArray get = params.get(NDArrayIndex.point(0),NDArrayIndex.interval(idx, range + idx));
+                if (get.length() < 1)
+                    throw new IllegalStateException("Unable to retrieve layer. No params found (length was 0");
+                layer.setParams(get);
+                idx += range;
+            }
         }
     }
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
@@ -305,9 +305,9 @@ public class ConvolutionLayerTest {
         final int numColumns = 28;
         int nChannels = 1;
         int outputNum = 10;
-        int numSamples = 1;
-        int batchSize = 1;
-        int iterations = 1;
+        int numSamples = 10;
+        int batchSize = 10;
+        int iterations = 10;
         int seed = 123;
         int listenerFreq = iterations/5;
 
@@ -321,9 +321,9 @@ public class ConvolutionLayerTest {
                 .activationFunction("relu")
                 .optimizationAlgo(OptimizationAlgorithm.LINE_GRADIENT_DESCENT)
                 .list(3)
-                .layer(0, new ConvolutionLayer.Builder(new int[]{9, 9})
+                .layer(0, new ConvolutionLayer.Builder(new int[]{10, 10})
                         .nIn(nChannels)
-                        .nOut(8)
+                        .nOut(6)
                         .build())
                 .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX, new int[] {2,2})
                         .build())

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
@@ -245,7 +245,9 @@ public class ConvolutionLayerTest {
         int nChannelsIn = 1;
         int depth = 2;
 
-        INDArray W = Nd4j.create(new double[] {0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5}, new int[]{2,1,2,2});
+        INDArray W = Nd4j.create(new double[] {
+                0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5
+        }, new int[]{2,1,2,2});
         INDArray b = Nd4j.create(new double[] {1,1});
         Layer layer = getCNNConfig(nChannelsIn, depth, kernelSize, stride, padding);
         layer.setParam("W", W);
@@ -326,7 +328,7 @@ public class ConvolutionLayerTest {
                 .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX, new int[] {2,2})
                         .build())
                 .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
-                        .nIn(20)
+                        .nIn(150)
                         .nOut(outputNum)
                         .activation("softmax")
                         .build())


### PR DESCRIPTION
- Fixed nextEpsilon tensormul. No more of this concat static numbers that are causing an error when new values are passed in regarding number of examples and input channel.
- Updated so subsampling does not need params
