### PR TITLE
#620 - redundant layer conf methods

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -45,7 +45,7 @@ public class AutoEncoder extends BasePretrainNetwork {
     }
 
     @AllArgsConstructor
-    public static class Builder extends BasePretrainNetwork.Builder {
+    public static class Builder extends BasePretrainNetwork.Builder<Builder> {
         private double corruptionLevel = 3e-1f;
         private double sparsity = 0f;
 
@@ -66,51 +66,9 @@ public class AutoEncoder extends BasePretrainNetwork {
         }
 
         @Override
-        public Builder nIn(int nIn) {
-            this.nIn = nIn;
-            return this;
-        }
-
-        @Override
-        public Builder nOut(int nOut) {
-            this.nOut = nOut;
-            return this;
-        }
-
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
-        
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
-        }
-
-        @Override
         @SuppressWarnings("unchecked")
         public AutoEncoder build() {
             return new AutoEncoder(this);
-        }
-        
-        @Override
-        public Builder dist(Distribution dist){
-        	this.dist = dist;
-        	return this;
         }
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
@@ -35,20 +35,20 @@ public abstract class BasePretrainNetwork extends FeedForwardLayer {
         this.customLossFunction = builder.customLossFunction;
     }
 
-    public static abstract class Builder extends FeedForwardLayer.Builder {
+    public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
         protected LossFunctions.LossFunction lossFunction = LossFunctions.LossFunction.RECONSTRUCTION_CROSSENTROPY;
         protected String customLossFunction = null;
 
         public Builder() {}
 
-        public Builder lossFunction(LossFunctions.LossFunction lossFunction) {
+        public T lossFunction(LossFunctions.LossFunction lossFunction) {
             this.lossFunction = lossFunction;
-            return this;
+            return (T) this;
         }
 
-        public Builder customLossFunction(String customLossFunction) {
+        public T customLossFunction(String customLossFunction) {
             this.customLossFunction = customLossFunction;
-            return this;
+            return (T) this;
         }
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -45,7 +45,7 @@ public class ConvolutionLayer extends FeedForwardLayer {
     }
 
     @AllArgsConstructor
-    public static class Builder extends FeedForwardLayer.Builder {
+    public static class Builder extends FeedForwardLayer.Builder<Builder> {
         private Convolution.Type convolutionType = Convolution.Type.VALID;
         private int[] kernelSize = new int[] {5, 5};
         private int[] stride = new int[] {2, 2};
@@ -94,46 +94,6 @@ public class ConvolutionLayer extends FeedForwardLayer {
         public Builder padding(int... padding){
             this.padding = padding;
             return this;
-        }
-
-        @Override
-        public Builder nIn(int nIn) {
-            super.nIn(nIn);
-            return this;
-        }
-
-        @Override
-        public Builder nOut(int nOut) {
-            super.nOut(nOut);
-            return this;
-        }
-
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
-
-        @Override
-        public Builder dist(Distribution dist){
-        	super.dist(dist);
-        	return this;
-        }
-        
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
         }
 
         @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -36,47 +36,8 @@ public class DenseLayer extends FeedForwardLayer {
     }
 
     @AllArgsConstructor
-    public static class Builder extends FeedForwardLayer.Builder {
+    public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
-        @Override
-        public Builder nIn(int nIn) {
-            this.nIn = nIn;
-            return this;
-        }
-        @Override
-        public Builder nOut(int nOut) {
-            this.nOut = nOut;
-            return this;
-        }
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        
-        @Override
-        public Builder dist(Distribution dist){
-        	super.dist(dist);
-        	return this;
-        }
-        
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
-        
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
-        }
-        
         @Override
         @SuppressWarnings("unchecked")
         public DenseLayer build() {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -18,18 +18,18 @@ public abstract class FeedForwardLayer extends Layer {
     	this.nOut = builder.nOut;
     }
 
-    public abstract static class Builder extends Layer.Builder {
+    public abstract static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
         protected int nIn = 0;
         protected int nOut = 0;
 
-        public Builder nIn(int nIn) {
+        public T nIn(int nIn) {
             this.nIn = nIn;
-            return this;
+            return (T) this;
         }
 
-        public Builder nOut(int nOut) {
+        public T nOut(int nOut) {
             this.nOut = nOut;
-            return this;
+            return (T) this;
         }
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
@@ -38,47 +38,8 @@ public class GravesLSTM extends FeedForwardLayer {
     }
 
     @AllArgsConstructor
-    public static class Builder extends FeedForwardLayer.Builder {
+    public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
-        @Override
-        public Builder nIn(int nIn) {
-            this.nIn = nIn;
-            return this;
-        }
-        @Override
-        public Builder nOut(int nOut) {
-            this.nOut = nOut;
-            return this;
-        }
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        
-        @Override
-        public Builder dist(Distribution dist){
-        	super.dist(dist);
-        	return this;
-        }
-        
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
-        
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
-        }
-        
         @Override
         @SuppressWarnings("unchecked")
         public GravesLSTM build() {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
@@ -38,46 +38,7 @@ public class LSTM extends FeedForwardLayer {
     }
 
     @AllArgsConstructor
-    public static class Builder extends FeedForwardLayer.Builder {
-
-        @Override
-        public Builder nIn(int nIn) {
-            this.nIn = nIn;
-            return this;
-        }
-        @Override
-        public Builder nOut(int nOut) {
-            this.nOut = nOut;
-            return this;
-        }
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        
-        @Override
-        public Builder dist(Distribution dist){
-        	super.dist(dist);
-        	return this;
-        }
-        
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
-        
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
-        }
+    public static class Builder extends FeedForwardLayer.Builder<Builder> {
         
         @Override
         @SuppressWarnings("unchecked")

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -77,39 +77,39 @@ public abstract class Layer implements Serializable, Cloneable {
         }
     }
 
-    public abstract static class Builder {
+    public abstract static class Builder<T extends Builder<T>> {
         protected String activationFunction = "sigmoid";
         protected WeightInit weightInit = WeightInit.VI;
         protected Distribution dist = new NormalDistribution(1e-3,1);
         protected double dropOut = 0;
         protected Updater updater = Updater.ADAGRAD;
 
-        public Builder activation(String activationFunction) {
+        public T activation(String activationFunction) {
             this.activationFunction = activationFunction;
-            return this;
+            return (T) this;
         }
 
-        public Builder weightInit(WeightInit weightInit) {
+        public T weightInit(WeightInit weightInit) {
             this.weightInit = weightInit;
-            return this;
+            return (T) this;
         }
         
         /** Distribution to sample initial weights from. Used in conjunction with
          * .weightInit(WeightInit.DISTRIBUTION)
          */
-        public Builder dist(Distribution dist){
+        public T dist(Distribution dist){
         	this.dist = dist;
-        	return this;
+        	return (T) this;
         }
 
-        public Builder dropOut(double dropOut) {
+        public T dropOut(double dropOut) {
             this.dropOut = dropOut;
-            return this;
+            return (T) this;
         }
         
-        public Builder updater(Updater updater){
+        public T updater(Updater updater){
         	this.updater = updater;
-        	return this;
+        	return (T) this;
         }
 
         public abstract <E extends Layer> E build();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
@@ -45,7 +45,7 @@ public class OutputLayer extends FeedForwardLayer {
     }
 
     @AllArgsConstructor
-    public static class Builder extends FeedForwardLayer.Builder {
+    public static class Builder extends FeedForwardLayer.Builder<Builder> {
         private LossFunction lossFunction = LossFunction.RMSE_XENT;
         private String customLossFunction;
 
@@ -63,45 +63,6 @@ public class OutputLayer extends FeedForwardLayer {
         public Builder customLossFunction(String customLossFunction) {
             this.customLossFunction = customLossFunction;
             return this;
-        }
-
-        @Override
-        public Builder nIn(int nIn) {
-            this.nIn = nIn;
-            return this;
-        }
-        @Override
-        public Builder nOut(int nOut) {
-            this.nOut = nOut;
-            return this;
-        }
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        
-        @Override
-        public Builder dist(Distribution dist){
-        	super.dist(dist);
-        	return this;
-        }
-        
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
-        
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
         }
         
         @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RBM.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RBM.java
@@ -73,7 +73,7 @@ public class RBM extends BasePretrainNetwork {
     }
 
     @AllArgsConstructor
-    public static class Builder extends BasePretrainNetwork.Builder {
+    public static class Builder extends BasePretrainNetwork.Builder<Builder> {
         private HiddenUnit hiddenUnit= RBM.HiddenUnit.BINARY;
         private VisibleUnit visibleUnit = RBM.VisibleUnit.BINARY;
         private int k = 1;
@@ -86,38 +86,6 @@ public class RBM extends BasePretrainNetwork {
 
         public Builder() {}
 
-        @Override
-        public Builder nIn(int nIn) {
-            this.nIn = nIn;
-            return this;
-        }
-        @Override
-        public Builder nOut(int nOut) {
-            this.nOut = nOut;
-            return this;
-        }
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        
-        @Override
-        public Builder dist(Distribution dist){
-        	super.dist(dist);
-        	return this;
-        }
-        
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
         @Override
         @SuppressWarnings("unchecked")
         public RBM build() {
@@ -144,12 +112,5 @@ public class RBM extends BasePretrainNetwork {
             this.sparsity = sparsity;
             return this;
         }
-
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
-        }
-
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RecursiveAutoEncoder.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RecursiveAutoEncoder.java
@@ -39,50 +39,12 @@ public class RecursiveAutoEncoder extends FeedForwardLayer {
     	super(builder);
     }
 
-    public static class Builder extends FeedForwardLayer.Builder {
+    public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
-        @Override
-        public Builder nIn(int nIn) {
-            this.nIn = nIn;
-            return this;
-        }
-        @Override
-        public Builder nOut(int nOut) {
-            this.nOut = nOut;
-            return this;
-        }
-        @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        
-        @Override
-        public Builder dist(Distribution dist){
-        	super.dist(dist);
-        	return this;
-        }
-        
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
         @Override
         @SuppressWarnings("unchecked")
         public RecursiveAutoEncoder build() {
             return new RecursiveAutoEncoder(this);
-        }
-        
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
         }
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -53,7 +53,7 @@ public class SubsamplingLayer extends Layer {
     }
 
     @AllArgsConstructor
-    public static class Builder extends Layer.Builder {
+    public static class Builder extends Layer.Builder<Builder> {
         private PoolingType poolingType = PoolingType.MAX;
         private int[] kernelSize = new int[] {2, 2}; // Same as filter size from the last conv layer
         private int[] stride = new int[] {2, 2}; // Default is 2. Down-sample by a factor of 2
@@ -88,26 +88,6 @@ public class SubsamplingLayer extends Layer {
         public Builder() {}
 
         @Override
-        public Builder activation(String activationFunction) {
-            this.activationFunction = activationFunction;
-            return this;
-        }
-        @Override
-        public Builder weightInit(WeightInit weightInit) {
-            this.weightInit = weightInit;
-            return this;
-        }
-        @Override
-        public Builder dist(Distribution dist){
-            this.dist = dist;
-            return this;
-        }
-        @Override
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
-            return this;
-        }
-        @Override
         @SuppressWarnings("unchecked")
         public SubsamplingLayer build() {
             return new SubsamplingLayer(this);
@@ -131,12 +111,6 @@ public class SubsamplingLayer extends Layer {
         public Builder padding(int... padding){
             this.padding = padding;
             return this;
-        }
-
-        @Override
-        public Builder updater(Updater updater){
-        	this.updater = updater;
-        	return this;
         }
     }
 


### PR DESCRIPTION
- remove redundant method declarations by leveraging generics to ensure
a covariant return type on the base method.

No change to the API, just a more sustainable approach to achieving the same fluent syntax.
Closes #620.