### PR TITLE
Add NetworkOutputProcessor interface, RnnOutputProcessor class

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/MultiLayerConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/MultiLayerConfiguration.java
@@ -21,11 +21,14 @@
 package org.deeplearning4j.nn.conf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
 import org.deeplearning4j.nn.conf.override.ConfOverride;
+import org.deeplearning4j.nn.conf.preprocessor.output.NetworkOutputProcessor;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.io.IOException;
@@ -49,6 +52,7 @@ public class MultiLayerConfiguration implements Serializable, Cloneable {
     protected double dampingFactor = 100;
     protected Map<Integer,InputPreProcessor> inputPreProcessors = new HashMap<>();
     protected boolean backprop = false;
+    protected NetworkOutputProcessor outputProcessor;
 
     /**
      *
@@ -157,6 +161,7 @@ public class MultiLayerConfiguration implements Serializable, Cloneable {
         protected double dampingFactor = 100;
         protected Map<Integer,InputPreProcessor> inputPreProcessors = new HashMap<>();
         protected boolean backprop = false;
+        protected NetworkOutputProcessor outputProcessor = null;
         @Deprecated
         protected Map<Integer,ConfOverride> confOverrides = new HashMap<>();
 
@@ -207,7 +212,11 @@ public class MultiLayerConfiguration implements Serializable, Cloneable {
         public Builder confs(List<NeuralNetConfiguration> confs) {
             this.confs = confs;
             return this;
+        }
 
+        public Builder outputProcessor(NetworkOutputProcessor processor){
+        	this.outputProcessor = processor;
+        	return this;
         }
 
         public MultiLayerConfiguration build() {
@@ -217,9 +226,9 @@ public class MultiLayerConfiguration implements Serializable, Cloneable {
             conf.dampingFactor = dampingFactor;
             conf.backprop = backprop;
             conf.inputPreProcessors = inputPreProcessors;
+            conf.outputProcessor = outputProcessor;
             Nd4j.getRandom().setSeed(conf.getConf(0).getSeed());
             return conf;
-
         }
 
         @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -160,8 +160,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
                 list.add(layerwise.get(i).build());
             }
             return new MultiLayerConfiguration.Builder().backprop(backprop).inputPreProcessors(inputPreProcessors).
-                    pretrain(pretrain)
-                    .confs(list).build();
+                    pretrain(pretrain).confs(list).outputProcessor(outputProcessor).build();
         }
 
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/output/NetworkOutputProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/output/NetworkOutputProcessor.java
@@ -1,0 +1,31 @@
+package org.deeplearning4j.nn.conf.preprocessor.output;
+
+import java.io.Serializable;
+
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/** NetworkOutputProcessor processes both final network output
+ * (during forward pass) and the labels (during backprop).<br>
+ * Can be used to do things like reshape output and labels, for
+ * example.
+ * @author Alex Black
+ */
+@JsonTypeInfo(use= JsonTypeInfo.Id.NAME, include= JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonSubTypes(value={
+        @JsonSubTypes.Type(value = RnnOutputProcessor.class, name = "rnnOutputProcessor"),
+})
+public interface NetworkOutputProcessor extends Serializable, Cloneable {
+	
+	/** Process the output of the final layer*/
+	INDArray processOutput( INDArray output, MultiLayerNetwork network );
+	
+	/** Process the labels before passing them to the
+	 * output layer during backprop.
+	 */
+	INDArray processLabels( INDArray labels, MultiLayerNetwork network );
+
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/output/RnnOutputProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/output/RnnOutputProcessor.java
@@ -1,0 +1,33 @@
+package org.deeplearning4j.nn.conf.preprocessor.output;
+
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/** RnnOutputProcessor does two things:<br>
+ * (a) reshapes 2d output from OutputLayer to 3d (time series) output,
+ * in the same manner FeedForwardToRnnPreProcessor<br>
+ * (b) reshapes 3d (time series) labels for use with OutputLayer
+ * (similar to what FeedForwardToRnnPreprocessor.backprop() does)
+ * @author Alex Black
+ *
+ */
+public class RnnOutputProcessor implements NetworkOutputProcessor {
+
+	@Override
+	public INDArray processOutput(INDArray output, MultiLayerNetwork network) {
+		//Reshape output from 2d to 3d, as per FeedForwardToRnnPreprocessor.preProcess()
+		int[] shape = output.shape();
+		int miniBatchSize = network.getInputMiniBatchSize();
+		INDArray reshaped = output.reshape(miniBatchSize,shape[0]/miniBatchSize,shape[1]);
+		return reshaped.permute(0,2,1);
+	}
+
+	@Override
+	public INDArray processLabels(INDArray labels, MultiLayerNetwork network) {
+		//Reshape from 3d to 2d, as per FeedForwardToRnnPreprocessor.backprop()
+		int[] shape = labels.shape();
+		if(shape[0]==1) return labels.tensorAlongDimension(0,1,2); //Edge case: miniBatchsize=1
+		INDArray permuted = labels.permute(0,2,1);	//Permute, so we get correct order after reshaping
+		return permuted.reshape(shape[0]*shape[2],shape[1]);
+	}
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
@@ -15,6 +15,7 @@ import org.deeplearning4j.nn.conf.layers.GRU;
 import org.deeplearning4j.nn.conf.layers.GravesLSTM;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.preprocessor.RnnToFeedForwardPreProcessor;
+import org.deeplearning4j.nn.conf.preprocessor.output.RnnOutputProcessor;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.junit.Test;
@@ -232,6 +233,7 @@ public class GradientCheckTests {
 	        		.nOut(nOut).weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1.0))
 	        		.updater(Updater.NONE).build())
 	        .inputPreProcessor(2, new RnnToFeedForwardPreProcessor())
+	        .outputProcessor(new RnnOutputProcessor())
 	        .pretrain(false).backprop(true)
 	        .build();
     	
@@ -247,10 +249,12 @@ public class GradientCheckTests {
     			}
     		}
     	}
-    	INDArray labels = Nd4j.zeros(miniBatchSize*timeSeriesLength,nOut);	//Would be this shape after reshaping 3d -> 2d for output layer
-    	for( int i=0; i<labels.size(0); i++){
-    		int idx = r.nextInt(nOut);
-    		labels.putScalar(new int[]{i,idx}, 1.0f);
+    	INDArray labels = Nd4j.zeros(miniBatchSize,nOut,timeSeriesLength);
+    	for( int i=0; i<miniBatchSize; i++ ){
+    		for( int j=0; j<timeSeriesLength; j++ ){
+	    		int idx = r.nextInt(nOut);
+	    		labels.putScalar(new int[]{i,idx,j}, 1.0f);
+    		}
     	}
     	
     	if( PRINT_RESULTS ){
@@ -286,10 +290,12 @@ public class GradientCheckTests {
     			}
     		}
     	}
-    	INDArray labels = Nd4j.zeros(miniBatchSize*timeSeriesLength,nOut);	//Would be this shape after reshaping 3d -> 2d for output layer
-    	for( int i=0; i<labels.size(0); i++){
-    		int idx = r.nextInt(nOut);
-    		labels.putScalar(new int[]{i,idx}, 1.0f);
+    	INDArray labels = Nd4j.zeros(miniBatchSize,nOut,timeSeriesLength);
+    	for( int i=0; i<miniBatchSize; i++ ){
+    		for( int j=0; j<timeSeriesLength; j++ ){
+	    		int idx = r.nextInt(nOut);
+	    		labels.putScalar(new int[]{i,idx,j}, 1.0f);
+    		}
     	}
         
         double[] l2vals = {0.0, 0.4, 0.0};
@@ -315,6 +321,7 @@ public class GradientCheckTests {
 			                		.weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1))
 			                		.updater(Updater.NONE).build())
 			                .inputPreProcessor(1, new RnnToFeedForwardPreProcessor())
+			                .outputProcessor(new RnnOutputProcessor())
 			                .pretrain(false).backprop(true)
 			                .build();
 			
@@ -360,10 +367,12 @@ public class GradientCheckTests {
         		}
         	}
         	
-        	INDArray labels = Nd4j.zeros(miniBatchSize[i]*timeSeriesLength[i],nOut);	//Would be this shape after reshaping 3d -> 2d for output layer
-        	for( int m=0; m<labels.size(0); m++){
-        		int idx = r.nextInt(nOut);
-        		labels.putScalar(new int[]{m,idx}, 1.0f);
+        	INDArray labels = Nd4j.zeros(miniBatchSize[i],nOut,timeSeriesLength[i]);
+        	for( int m=0; m<miniBatchSize[i]; m++ ){
+        		for( int j=0; j<timeSeriesLength[i]; j++ ){
+    	    		int idx = r.nextInt(nOut);
+    	    		labels.putScalar(new int[]{m,idx,j}, 1.0f);
+        		}
         	}
     		
     		MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
@@ -375,6 +384,7 @@ public class GradientCheckTests {
 	            .layer(1, new OutputLayer.Builder(LossFunction.MCXENT).activation("softmax").nIn(layerSize).nOut(nOut)
 	            		.weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1)).updater(Updater.NONE).build())
 	            .inputPreProcessor(1, new RnnToFeedForwardPreProcessor())
+	            .outputProcessor(new RnnOutputProcessor())
 	            .pretrain(false).backprop(true)
 	            .build();
     		MultiLayerNetwork mln = new MultiLayerNetwork(conf);
@@ -410,6 +420,7 @@ public class GradientCheckTests {
 	        .layer(2, new OutputLayer.Builder(LossFunction.MCXENT).activation("softmax").nIn(layerSize).nOut(nOut)
 	        		.weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1.0)).updater(Updater.NONE).build())
 	        .inputPreProcessor(2, new RnnToFeedForwardPreProcessor())
+	        .outputProcessor(new RnnOutputProcessor())
 	        .pretrain(false).backprop(true)
 	        .build();
     	
@@ -425,10 +436,12 @@ public class GradientCheckTests {
     			}
     		}
     	}
-    	INDArray labels = Nd4j.zeros(miniBatchSize*timeSeriesLength,nOut);	//Would be this shape after reshaping 3d -> 2d for output layer
-    	for( int i=0; i<labels.size(0); i++){
-    		int idx = r.nextInt(nOut);
-    		labels.putScalar(new int[]{i,idx}, 1.0f);
+    	INDArray labels = Nd4j.zeros(miniBatchSize,nOut,timeSeriesLength);
+    	for( int i=0; i<miniBatchSize; i++ ){
+    		for( int j=0; j<timeSeriesLength; j++ ){
+	    		int idx = r.nextInt(nOut);
+	    		labels.putScalar(new int[]{i,idx,j}, 1.0f);
+    		}
     	}
     	
     	if( PRINT_RESULTS ){
@@ -453,7 +466,7 @@ public class GradientCheckTests {
     	int nIn = 7;
     	int layerSize = 9;
     	int nOut = 4;
-    	int miniBatchSize = 6;
+    	int miniBatchSize = 5;
     	
     	Random r = new Random(12345L);
     	INDArray input = Nd4j.zeros(miniBatchSize,nIn,timeSeriesLength);
@@ -464,10 +477,12 @@ public class GradientCheckTests {
     			}
     		}
     	}
-    	INDArray labels = Nd4j.zeros(miniBatchSize*timeSeriesLength,nOut);	//Would be this shape after reshaping 3d -> 2d for output layer
-    	for( int i=0; i<labels.size(0); i++){
-    		int idx = r.nextInt(nOut);
-    		labels.putScalar(new int[]{i,idx}, 1.0f);
+    	INDArray labels = Nd4j.zeros(miniBatchSize,nOut,timeSeriesLength);
+    	for( int i=0; i<miniBatchSize; i++ ){
+    		for( int j=0; j<timeSeriesLength; j++ ){
+	    		int idx = r.nextInt(nOut);
+	    		labels.putScalar(new int[]{i,idx,j}, 1.0f);
+    		}
     	}
         
         double[] l2vals = {0.0, 0.4, 0.0};
@@ -493,6 +508,7 @@ public class GradientCheckTests {
 			                		.weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1))
 			                		.updater(Updater.NONE).build())
 			                .inputPreProcessor(1, new RnnToFeedForwardPreProcessor())
+			                .outputProcessor(new RnnOutputProcessor())
 			                .pretrain(false).backprop(true)
 			                .build();
 			
@@ -537,11 +553,12 @@ public class GradientCheckTests {
         			}
         		}
         	}
-        	
-        	INDArray labels = Nd4j.zeros(miniBatchSize[i]*timeSeriesLength[i],nOut);	//Would be this shape after reshaping 3d -> 2d for output layer
-        	for( int m=0; m<labels.size(0); m++){
-        		int idx = r.nextInt(nOut);
-        		labels.putScalar(new int[]{m,idx}, 1.0f);
+        	INDArray labels = Nd4j.zeros(miniBatchSize[i],nOut,timeSeriesLength[i]);
+        	for( int m=0; m<miniBatchSize[i]; m++ ){
+        		for( int j=0; j<timeSeriesLength[i]; j++ ){
+    	    		int idx = r.nextInt(nOut);
+    	    		labels.putScalar(new int[]{m,idx,j}, 1.0f);
+        		}
         	}
     		
     		MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
@@ -553,6 +570,7 @@ public class GradientCheckTests {
 	            .layer(1, new OutputLayer.Builder(LossFunction.MCXENT).activation("softmax").nIn(layerSize).nOut(nOut)
 	            		.weightInit(WeightInit.DISTRIBUTION).dist(new NormalDistribution(0,1)).updater(Updater.NONE).build())
 	            .inputPreProcessor(1, new RnnToFeedForwardPreProcessor())
+	            .outputProcessor(new RnnOutputProcessor())
 	            .pretrain(false).backprop(true)
 	            .build();
     		MultiLayerNetwork mln = new MultiLayerNetwork(conf);

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/preprocessor/output/TestRnnOutputProcessor.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/preprocessor/output/TestRnnOutputProcessor.java
@@ -1,0 +1,62 @@
+package org.deeplearning4j.nn.conf.preprocessor.output;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.GravesLSTM;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.preprocessor.RnnToFeedForwardPreProcessor;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
+
+public class TestRnnOutputProcessor {
+	
+	@Test
+	public void testRnnOutputProcessor(){
+		Nd4j.getRandom().setSeed(12345);
+		
+		int timeSeriesLength = 10;
+		int nIn = 9;
+		int lstmLayerSize = 12;
+		int nOut = 7;
+		int miniBatchSize = 13;
+		
+		MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+			.list(2)
+			.layer(0,new GravesLSTM.Builder().nIn(nIn).nOut(lstmLayerSize).build())
+			.layer(1,new OutputLayer.Builder(LossFunction.MCXENT).nIn(lstmLayerSize).nOut(nOut).build())
+			.inputPreProcessor(1, new RnnToFeedForwardPreProcessor())
+			.outputProcessor(new RnnOutputProcessor())
+			.pretrain(false).backprop(true)
+			.build();
+		
+		MultiLayerNetwork mln = new MultiLayerNetwork(conf);
+		mln.init();
+		
+		assertNotNull(mln.getLayerWiseConfigurations().getOutputProcessor());
+		assertTrue(mln.getLayerWiseConfigurations().getOutputProcessor() instanceof RnnOutputProcessor);
+		
+		INDArray input3d = Nd4j.rand(new int[]{miniBatchSize,nIn,timeSeriesLength});
+		mln.setInput(input3d);
+		
+		INDArray labels3d = Nd4j.rand(new int[]{miniBatchSize,nOut,timeSeriesLength});
+		
+		RnnOutputProcessor proc = new RnnOutputProcessor();
+		INDArray labels2d = proc.processLabels(labels3d,mln);
+		assertArrayEquals(labels2d.shape(),new int[]{miniBatchSize*timeSeriesLength,nOut});
+		INDArray labels3dv2 = proc.processOutput(labels2d,mln);
+		assertTrue(labels3d.equals(labels3dv2));
+		
+		List<INDArray> activations = mln.feedForward(input3d);
+		INDArray out = activations.get(2);
+		assertArrayEquals(out.shape(),new int[]{miniBatchSize,nOut,timeSeriesLength});
+		
+		mln.fit(input3d, labels3d);	//Ok as long as it doesn't throw an exception (due to shapes etc)
+	}
+}


### PR DESCRIPTION
Added a NetworkOutputProcessor
Basic need:
When using RNNs + OutputLayer, we previously needed to manually do two things:
(a) reshape labels 3d->2d (normally 3 dimensions: [miniBatchSize,outputSize,timeSeriesLength] to 2 dimensions)
(b) reshape outputs 2d->3d
Problem: we had no way of doing this automatically. We have preprocessors but these work before each layer, not after.
Now we can simply add a .outputProcessor(new RnnOutputProcessor()) to the configuration, and the reshaping of labels (3d->2d) and output (2d->3d) with OutputLayer is handled automatically.