### PR TITLE
x86 must be a test dependency

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/pom.xml
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/pom.xml
@@ -123,6 +123,7 @@
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-x86</artifactId>
             <version>${nd4j.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>


### PR DESCRIPTION
Without the test scope, the netlib dependency becomes harder to exclude.   And I don't think we intended to remove the test scope, was just an accidental commit.