### PR TITLE
Adjust learning rate based on score improvement

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -51,6 +51,7 @@ import java.util.Map;
 public class NeuralNetConfiguration implements Serializable,Cloneable {
 
     private double lr = 1e-1;
+    private double lrScoreDecay;
     protected int numIterations = 5;
     /* momentum for learning */
     protected double momentum = 0.5;
@@ -278,6 +279,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
     public static class Builder implements Cloneable {
         private double rmsDecay = 0.95;
         private double lr = 1e-1f;
+        private double lrScoreDecay;
         private double momentum = 0.5f;
         private double l2 = 0f;
         private boolean useRegularization = false;
@@ -406,6 +408,11 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             return this;
         }
 
+        public Builder learningRateScoreDecay(double lrScoreDecay) {
+            this.lrScoreDecay = lrScoreDecay;
+            return this;
+        }
+
         public Builder momentum(double momentum) {
             this.momentum = momentum;
             return this;
@@ -476,6 +483,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             conf.batchSize = batchSize;
             conf.layer = layer;
             conf.lr = (!Double.isNaN(layer.getLr()) ? layer.getLr() : lr);
+            conf.lrScoreDecay = lrScoreDecay;
             conf.numIterations = numIterations;
             conf.momentum = momentum;
             conf.l2 = (!Double.isNaN(layer.getL2()) ? layer.getL2() : l2);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -52,7 +52,7 @@ import java.util.Map;
 public class NeuralNetConfiguration implements Serializable,Cloneable {
 
     private double lr = 1e-1;
-    private double lrScoreDecay;
+    private double lrScoreBasedDecay;
     protected int numIterations = 5;
     /* momentum for learning */
     protected double momentum = 0.5;
@@ -281,7 +281,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
     public static class Builder implements Cloneable {
         private double rmsDecay = 0.95;
         private double lr = 1e-1f;
-        private double lrScoreDecay;
+        private double lrScoreBasedDecay;
         private double momentum = 0.5f;
         private double l2 = 0f;
         private boolean useRegularization = false;
@@ -410,8 +410,8 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             return this;
         }
 
-        public Builder learningRateScoreDecay(double lrScoreDecay) {
-            this.lrScoreDecay = lrScoreDecay;
+        public Builder learningRateScoreBasedDecayRate(double lrScoreBasedDecay) {
+            this.lrScoreBasedDecay = lrScoreBasedDecay;
             return this;
         }
 
@@ -485,7 +485,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             conf.batchSize = batchSize;
             conf.layer = layer;
             conf.lr = (!Double.isNaN(layer.getLr()) ? layer.getLr() : lr);
-            conf.lrScoreDecay = lrScoreDecay;
+            conf.lrScoreBasedDecay = lrScoreBasedDecay;
             conf.numIterations = numIterations;
             conf.momentum = momentum;
             conf.l2 = (!Double.isNaN(layer.getL2()) ? layer.getL2() : l2);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1780,6 +1780,9 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
 
     }
 
+    public NeuralNetConfiguration getDefaultConfiguration() {
+        return defaultConfiguration;
+    }
 
     public INDArray getLabels() {
         return labels;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -44,7 +44,6 @@ public abstract class BaseUpdater implements Updater {
         	gradient.addi(Transforms.sign(params).muli(conf.getL1()));
         if(conf.isMiniBatch())
             gradient.divi(layer.getInputMiniBatchSize());
-
         if(conf.isConstrainGradientToUnitNorm())
             gradient.divi(gradient.norm2(Integer.MAX_VALUE));
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/api/ConvexOptimizer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/api/ConvexOptimizer.java
@@ -21,6 +21,7 @@ package org.deeplearning4j.optimize.api;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.api.Model;
 import org.deeplearning4j.nn.api.Updater;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.learning.AdaGrad;
@@ -41,6 +42,8 @@ public interface ConvexOptimizer extends Serializable {
     double score();
 
     Updater getUpdater();
+
+    NeuralNetConfiguration getConf();
 
     /**
      * The gradient and score for this optimizer
@@ -86,11 +89,6 @@ public interface ConvexOptimizer extends Serializable {
      */
     void setupSearchState(Pair<Gradient, Double> pair);
 
-
-
-
-
-
     /**
      * Update the gradient according to the configuration such as adagrad, momentum, and sparsity
      * @param gradient the gradient to modify
@@ -100,5 +98,11 @@ public interface ConvexOptimizer extends Serializable {
      */
     void updateGradientAccordingToParams(Gradient gradient, Model model, int batchSize);
 
-
+    /**
+     * Check termination conditions
+     * setup a search state
+     * @param gradient layer gradients
+     * @param iteration what iteration the optimizer is on
+     */
+    boolean checkTerminalConditions(INDArray gradient, double oldScore, double score, int iteration);
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
@@ -36,6 +36,7 @@ import org.deeplearning4j.optimize.stepfunctions.NegativeGradientStepFunction;
 import org.deeplearning4j.optimize.terminations.EpsTermination;
 import org.deeplearning4j.optimize.terminations.ZeroDirection;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +59,7 @@ public abstract class BaseOptimizer implements ConvexOptimizer {
     protected BackTrackLineSearch lineMaximizer;
     protected Updater updater;
     protected double step;
-    private int batchSize = 10;
+    private int batchSize;
     protected double score,oldScore;
     protected double stepMax = Double.MAX_VALUE;
     public final static String GRADIENT_KEY = "g";
@@ -191,7 +192,9 @@ public abstract class BaseOptimizer implements ConvexOptimizer {
             //check for termination conditions based on absolute change in score
             for(TerminationCondition condition : terminationConditions){
                 if(condition.terminate(score,oldScore,new Object[]{pair.getFirst().gradient()})){
-                    log.debug("Hit termination condition on iteration {}: score={}, oldScore={}, condition={}",i,score,oldScore,condition);
+                    log.debug("Hit termination condition on iteration {}: score={}, oldScore={}, condition={}", i, score, oldScore, condition);
+                    if(condition.equals(EpsTermination.class) && !Double.isNaN(conf.getLrScoreDecay()))
+                        conf.setLr(conf.getLr()/(conf.getLrScoreDecay() + Nd4j.EPS_THRESHOLD));
                     return true;
                 }
             }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
@@ -12,6 +12,7 @@ import org.deeplearning4j.nn.api.Updater;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.factory.LayerFactories;
@@ -29,9 +30,12 @@ public class TestUpdaters {
 
 	int nIn = 3;
 	int nOut = 2;
+    double epsilon = 1e-8;
 	INDArray weightGradient = Nd4j.ones(nIn,nOut);
 	INDArray biasGradient = Nd4j.ones(1,nOut);
 	Gradient gradient = new DefaultGradient();
+    INDArray val, gradExpected;
+    String key;
 
 	@Before
 	public void beforeDo(){
@@ -41,7 +45,11 @@ public class TestUpdaters {
 
 	@Test
 	public void testAdaDeltaUpdate(){
-		double lr = 1e-2;
+        INDArray dxSquared;
+        Map<String, INDArray> msg = new HashMap<>();
+        Map<String, INDArray> msdx = new HashMap<>();
+
+        double lr = 1e-2;
 		double rho = 0.85;
 
 		NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
@@ -53,69 +61,43 @@ public class TestUpdaters {
 		Layer layer = LayerFactories.getFactory(conf).create(conf, null, 0);
 		Updater updater = UpdaterCreator.getUpdater(layer);
 
-		updater.update(layer, gradient, -1);
+        for (int i = 0; i < 2; i++) {
+            updater.update(layer, gradient, i);
 
-		// calculations for one iteration / update
-		INDArray msgW, msdxW, dxSquaredW, weightGradExpected, weightGradExpected2,
-				msgB, msdxB, dxSquaredB,biasGradExpected, biasGradExpected2;
+            Gradient gradientDup = new DefaultGradient();
+            gradientDup.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+            gradientDup.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
 
-		msgW = Nd4j.zeros(weightGradient.shape());
-		msdxW = Nd4j.zeros(weightGradient.shape());
-		msgW.muli(rho);
-		msgW.addi(1-rho).muli(weightGradient.mul(weightGradient));
+            // calculations for one iteration / update
 
-		weightGradExpected = Transforms.sqrt(msdxW.add(Nd4j.EPS_THRESHOLD))
-				.divi(Transforms.sqrt(msgW.add(Nd4j.EPS_THRESHOLD))).muli(weightGradient);
+            for (Map.Entry<String, INDArray> entry : gradientDup.gradientForVariable().entrySet()) {
+                key = entry.getKey();
+                val = entry.getValue();
+				INDArray msgTmp = msg.get(key);
+				INDArray msdxTmp = msdx.get(key);
 
-		msgB = Nd4j.zeros(biasGradient.shape());
-		msdxB = Nd4j.zeros(biasGradient.shape());
-		msgB.muli(rho);
-		msgB.addi(1-rho).muli(biasGradient.mul(biasGradient));
+                if(msgTmp == null) {
+                    msgTmp = Nd4j.zeros(val.shape());
+                    msdxTmp = Nd4j.zeros(val.shape());
+                }
 
-		biasGradExpected = Transforms.sqrt(msdxB.add(Nd4j.EPS_THRESHOLD))
-				.divi(Transforms.sqrt(msgB.add(Nd4j.EPS_THRESHOLD))).muli(weightGradient);
+                msgTmp.muli(rho);
+                msgTmp.addi(1 - rho).muli(val.mul(val));
 
+                gradExpected = Transforms.sqrt(msdxTmp.add(Nd4j.EPS_THRESHOLD))
+						.divi(Transforms.sqrt(msgTmp.add(Nd4j.EPS_THRESHOLD))).muli(val);
 
-		INDArray weightGradActual = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
+                assertEquals(gradExpected, gradient.getGradientFor(entry.getKey()));
 
-		assertEquals(weightGradExpected, weightGradActual);
-		assertEquals(biasGradExpected, biasGradActual);
-		assertEquals(rho, layer.conf().getRho(), 1e-4);
+                msdxTmp.muli(rho);
+                dxSquared = gradExpected.mul(gradExpected);
+                msdxTmp.addi(dxSquared.muli(1 - rho));
 
-
-		// calculations for two iterations / updates
-		Gradient gradient2 = new DefaultGradient();
-		gradient2.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradExpected);
-		gradient2.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradExpected);
-
-		updater.update(layer, gradient2, -1);
-
-		msdxW.muli(rho);
-		dxSquaredW = weightGradExpected.mul(weightGradExpected);
-		msdxW.addi(dxSquaredW.muli(1 - rho));
-
-		msgW.muli(rho);
-		msgW.addi(1-rho).muli(weightGradExpected.mul(weightGradExpected));
-
-		weightGradExpected2 = Transforms.sqrt(msdxW.add(Nd4j.EPS_THRESHOLD))
-				.divi(Transforms.sqrt(msgW.add(Nd4j.EPS_THRESHOLD))).muli(weightGradExpected);
-
-		msdxB.muli(rho);
-		dxSquaredB = biasGradExpected.mul(biasGradExpected);
-		msdxB.addi(dxSquaredB.muli(1 - rho));
-
-		msgB.muli(rho);
-		msgB.addi(1-rho).muli(biasGradExpected.mul(biasGradExpected));
-		biasGradExpected2 = Transforms.sqrt(msdxB.add(Nd4j.EPS_THRESHOLD))
-				.divi(Transforms.sqrt(msgB.add(Nd4j.EPS_THRESHOLD))).muli(biasGradExpected);
-
-		INDArray weightGradActual2 = gradient2.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual2 = gradient2.getGradientFor(DefaultParamInitializer.BIAS_KEY);
-
-		assertEquals(weightGradExpected2, weightGradActual2);
-		assertEquals(biasGradExpected2, biasGradActual2);
-		assertEquals(rho, layer.conf().getRho(), 1e-4);
+				msg.put(key, msgTmp);
+				msdx.put(key, msdxTmp);
+            }
+            assertEquals(rho, layer.conf().getRho(), 1e-4);
+        }
 
 	}
 
@@ -134,24 +116,23 @@ public class TestUpdaters {
 
 		updater.update(layer, gradient, -1);
 
-		// calculations
-		INDArray weightGradExpected = Transforms.sqrt(weightGradient.mul(weightGradient)
-				.add(1e-8)).rdiv(lr).mul(weightGradient);
+        Gradient gradientDup = new DefaultGradient();
+        gradientDup.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientDup.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
 
-		INDArray biasGradExpected = Transforms.sqrt(biasGradient.mul(biasGradient)
-				.add(1e-8)).rdiv(lr).mul(biasGradient);
-
-		INDArray weightGradActual = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
-
-		assertEquals(weightGradExpected, weightGradActual);
-		assertEquals(biasGradExpected, biasGradActual);
+        for (Map.Entry<String, INDArray> entry : gradientDup.gradientForVariable().entrySet()) {
+            val = entry.getValue();
+            gradExpected = Transforms.sqrt(val.mul(val).add(epsilon)).rdiv(lr).mul(val);
+            assertEquals(gradExpected, gradient.getGradientFor(entry.getKey()));
+        }
 		assertEquals(lr, layer.conf().getLr(), 1e-4);
 	}
 
+
 	@Test
 	public void testAdamUpdater(){
-		double lr = 0.01;
+        INDArray m, v;
+        double lr = 0.01;
 		int iteration = 0;
 		double beta1 = 0.9; // TODO allow passing in betas and update test
 		double beta2 = 0.999;
@@ -167,33 +148,28 @@ public class TestUpdaters {
 
 		updater.update(layer, gradient, iteration);
 
-		// calculations
-		INDArray mW, vW, weightGradExpected, mB, vB, biasGradExpected;
-
 		double beta1t = FastMath.pow(beta1, iteration);
 		double beta2t = FastMath.pow(beta2, iteration);
 		double alphat = lr * FastMath.sqrt(((1-beta2t)/(1-beta1t)));
 
-		mW = Nd4j.zeros(weightGradient.shape());
-		vW = Nd4j.zeros(weightGradient.shape());
+        Gradient gradientDup = new DefaultGradient();
+        gradientDup.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientDup.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
 
-		mW.muli(beta1).addi(weightGradient.mul(1.0-beta1));
-		vW.muli(beta2).addi(weightGradient.mul(weightGradient).mul(1.0 - beta2));
-		weightGradExpected = mW.mul(alphat).divi(Transforms.sqrt(vW).addi(1e-8));
+        for (Map.Entry<String, INDArray> entry : gradientDup.gradientForVariable().entrySet()) {
+            val = entry.getValue();
+            m = Nd4j.zeros(val.shape());
+            v = Nd4j.zeros(val.shape());
 
-		mB = Nd4j.zeros(biasGradient.shape());
-		vB = Nd4j.zeros(biasGradient.shape());
+            m.muli(beta1).addi(val.mul(1.0-beta1));
+            v.muli(beta2).addi(val.mul(val).mul(1.0-beta2));
+            gradExpected = m.mul(alphat).divi(Transforms.sqrt(v).addi(epsilon));
 
-		mB.muli(beta1).addi(biasGradient.mul(1.0-beta1));
-		vB.muli(beta2).addi(biasGradient.mul(biasGradient).mul(1.0-beta2));
-		biasGradExpected = mB.mul(alphat).divi(Transforms.sqrt(vB).addi(1e-8));
+            assertEquals(gradExpected, gradient.getGradientFor(entry.getKey()));
+        }
 
-		INDArray weightGradActual = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
-
-		assertEquals(weightGradExpected, weightGradActual);
-		assertEquals(biasGradExpected, biasGradActual);
-		assertEquals(lr, layer.conf().getLr(), 1e-4);
+        assertEquals(beta1, layer.conf().getMeanDecay(), 1e-4);
+        assertEquals(beta2, layer.conf().getVarDecay(), 1e-4);
 
 	}
 
@@ -201,6 +177,7 @@ public class TestUpdaters {
 	public void testNestorovsUpdater(){
 		double lr = 1e-2;
 		double mu = 0.6;
+        INDArray v, vPrev;
 
 		NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
 				.learningRate(lr).momentum(mu)
@@ -213,23 +190,20 @@ public class TestUpdaters {
 
 		updater.update(layer, gradient, -1);
 
-		// calculations
-		INDArray vW, vPrevW, weightGradExpected, vB, vPrevB, biasGradExpected;
-		vW = Nd4j.zeros(weightGradient.shape());
-		vPrevW = vW;
-		vW = vPrevW.mul(mu).subi(weightGradient.mul(lr));
-		weightGradExpected = vPrevW.muli(mu).addi(vW.mul(-mu - 1));
+        Gradient gradientDup = new DefaultGradient();
+        gradientDup.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientDup.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
 
-		vB = Nd4j.zeros(biasGradient.shape());
-		vPrevB = vB;
-		vB = vPrevB.mul(mu).subi(biasGradient.mul(lr));
-		biasGradExpected = vPrevB.muli(mu).addi(vB.mul(-mu - 1));
+        for (Map.Entry<String, INDArray> entry : gradientDup.gradientForVariable().entrySet()) {
+            val = entry.getValue();
+            v = Nd4j.zeros(val.shape());
+            vPrev = v;
+            v = vPrev.mul(mu).subi(val.mul(lr));
+            gradExpected = vPrev.muli(mu).addi(v.mul(-mu - 1));
 
-		INDArray weightGradActual = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
+            assertEquals(gradExpected, gradient.getGradientFor(entry.getKey()));
+        }
 
-		assertEquals(weightGradExpected, weightGradActual);
-		assertEquals(biasGradExpected, biasGradActual);
 		assertEquals(mu, layer.conf().getMomentum(), 1e-4);
 	}
 
@@ -240,8 +214,11 @@ public class TestUpdaters {
 		Map<Integer,Double> momentumAfter = new HashMap<>();
 		momentumAfter.put(1, 0.2);
 		int iterations = 2;
+		Map<String, INDArray> v = new HashMap<>();
 
-		NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+		INDArray vPrev;
+
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
 				.learningRate(lr).momentum(mu).momentumAfter(momentumAfter).iterations(iterations)
 				.layer(new DenseLayer.Builder()
 						.nIn(nIn).nOut(nOut).updater(org.deeplearning4j.nn.conf.Updater.NESTEROVS).build())
@@ -250,35 +227,34 @@ public class TestUpdaters {
 		Layer layer = LayerFactories.getFactory(conf).create(conf, null, 0);
 		Updater updater = UpdaterCreator.getUpdater(layer);
 
-		updater.update(layer, gradient, 0);
-		updater.update(layer, gradient, 1);
+        Gradient gradientDup = new DefaultGradient();
+        gradientDup.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientDup.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
 
-		// calculations
-		INDArray vW, vPrevW, weightGradExpected, vB, vPrevB, biasGradExpected;
-		vW = Nd4j.zeros(weightGradient.shape());
-		vPrevW = vW;
-		vW = vPrevW.mul(mu).subi(weightGradient.mul(lr));
-		weightGradient = vPrevW.muli(mu).addi(vW.mul(-mu - 1));
+        for (int i = 0; i < 2; i++) {
+            updater.update(layer, gradient, i);
 
-		vPrevW = vW;
-		vW = vPrevW.mul(momentumAfter.get(1)).subi(weightGradient.mul(lr));
-		weightGradExpected = vPrevW.muli(momentumAfter.get(1)).addi(vW.mul(-momentumAfter.get(1) - 1));
+            for (Map.Entry<String, INDArray> entry : gradientDup.gradientForVariable().entrySet()) {
+				key = entry.getKey();
+				val = entry.getValue();
+				INDArray vTmp = v.get(key);
 
-		vB = Nd4j.zeros(biasGradient.shape());
-		vPrevB = vB;
-		vB = vPrevB.mul(mu).subi(biasGradient.mul(lr));
-		biasGradient = vPrevB.muli(mu).addi(vB.mul(-mu - 1));
+				if(v == null)
+                    vTmp = Nd4j.zeros(val.shape());
+                vPrev = vTmp;
+                vTmp = vPrev.mul(mu).subi(val.mul(lr));
+                gradExpected = vPrev.muli(mu).addi(vTmp.mul(-mu - 1));
+                gradientDup.setGradientFor(key, gradExpected);
 
-		vPrevB = vB;
-		vB = vPrevB.mul(momentumAfter.get(1)).subi(biasGradient.mul(lr));
-		biasGradExpected = vPrevB.muli(momentumAfter.get(1)).addi(vB.mul(-momentumAfter.get(1) - 1));
+                assertEquals(gradExpected, gradient.getGradientFor(entry.getKey()));
+				v.put(key, vTmp);
+            }
 
-		INDArray weightGradActual = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
+            assertEquals(momentumAfter, layer.conf().getMomentumAfter());
+        }
 
-		assertEquals(weightGradExpected, weightGradActual);
-		assertEquals(biasGradExpected, biasGradActual);
-	}
+
+    }
 
 
 	@Test
@@ -298,30 +274,24 @@ public class TestUpdaters {
 
 		updater.update(layer, gradient, -1);
 
-		// calculations
-		INDArray lastGW, lastGB;
+        Gradient gradientDup = new DefaultGradient();
+        gradientDup.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientDup.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
 
-		lastGW = Nd4j.zeros(weightGradient.shape());
-		lastGB = Nd4j.zeros(biasGradient.shape());
+        for (Map.Entry<String, INDArray> entry : gradientDup.gradientForVariable().entrySet()) {
+            val = entry.getValue();
+            INDArray lastG = Nd4j.zeros(val.shape());
+            lastG.muli(rmsDecay).addi(weightGradient.mul(weightGradient).muli(1 - rmsDecay));
+            gradExpected = val.mul(lr).div(Transforms.sqrt(lastG.add(Nd4j.EPS_THRESHOLD)));
 
-		lastGW.muli(rmsDecay).addi(weightGradient.mul(weightGradient).muli(1 - rmsDecay));
-		INDArray weightGradExpected = weightGradient.mul(lr).div(Transforms.sqrt(lastGW.add(Nd4j.EPS_THRESHOLD)));
-
-		lastGB.muli(rmsDecay).addi(biasGradient.mul(biasGradient).muli(1 - rmsDecay));
-		INDArray biasGradExpected = biasGradient.mul(lr).div(Transforms.sqrt(lastGB.add(Nd4j.EPS_THRESHOLD)));
-
-		INDArray weightGradActual = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
-
-		assertEquals(weightGradExpected, weightGradActual);
-		assertEquals(biasGradExpected, biasGradActual);
+            assertEquals(gradExpected, gradient.getGradientFor(entry.getKey()));
+        }
 		assertEquals(rmsDecay, layer.conf().getRmsDecay(), 1e-4);
-
 	}
 
 	@Test
 	public void testSGDUpdater(){
-		double lr = 0.01;
+		double lr = 0.05;
 		
 		NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
 				.learningRate(lr)
@@ -334,19 +304,22 @@ public class TestUpdaters {
 
 		updater.update(layer, gradient, -1);
 
-		// calculations
-		INDArray weightGradExpected = weightGradient.mul(lr);
-		INDArray biasGradExpected = biasGradient.mul(lr);
-		
-		INDArray weightGradActual = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY);
-		INDArray biasGradActual = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY);
-		
-		assertEquals(weightGradExpected, weightGradActual);
-		assertEquals(biasGradExpected, biasGradActual);
-		assertEquals(lr, layer.conf().getLr(), 1e-4);
+        Gradient gradientDup = new DefaultGradient();
+        gradientDup.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientDup.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
+
+        for (Map.Entry<String, INDArray> entry : gradientDup.gradientForVariable().entrySet()) {
+            val = entry.getValue();
+            gradExpected = val.mul(lr);
+            assertEquals(gradExpected, gradient.getGradientFor(entry.getKey()));
+        }
+
+        assertEquals(lr, layer.conf().getLr(), 1e-4);
+
 
 	}
-	
+
+
 	@Test
 	public void testNoOpUpdater(){
 		Random r = new Random(12345L);
@@ -372,8 +345,38 @@ public class TestUpdaters {
 		assertEquals(biasGradient, biasGradActual);
 
 	}
-	
-	@Test
+
+    @Test
+    public void testLrScoreDecay(){
+        double lr = 0.1;
+        double lrScoreDecay = 10;
+        int nLayers = 2;
+        int iterations = 1;
+        int[] nIns = {2,3};
+        int[] nOuts = {3,4};
+        INDArray input = Nd4j.ones(nIns[0],nOuts[0]);
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .learningRate(lr).learningRateScoreDecay(lrScoreDecay).iterations(iterations)
+                .list(nLayers)
+                .layer(0, new DenseLayer.Builder().nIn(nIns[0]).nOut(nOuts[0]).updater(org.deeplearning4j.nn.conf.Updater.SGD).build())
+                .layer(1, new OutputLayer.Builder().nIn(nIns[1]).nOut(nOuts[1]).updater(org.deeplearning4j.nn.conf.Updater.SGD).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+        net.setInput(input);
+
+        // TODO test changing lr - need to isolate baseOptimize
+//        ConvexOptimizer opt = new StochasticGradientDescent(net.getDefaultConfiguration(), new NegativeDefaultStepFunction(), null, net);
+//        boolean v = opt.optimize();
+
+        assertEquals(lrScoreDecay, net.getLayer(0).conf().getLrScoreDecay(), 1e-4);
+//        assertEquals(lr, net.conf().getLr(), 1e-4);
+
+    }
+
+    @Test
 	public void testMultiLayerUpdater() throws Exception {
 		Nd4j.getRandom().setSeed(12345L);
 		int nLayers = 4;


### PR DESCRIPTION
- Added functionality to adjust learning rate baed on score improvements or lack thereof
- Located under optimizer in and focused on termination conditions
- Only occurs when there is a score change in optimize
- Functionality limited to division by a double
- Tests added under updaters
- Split out termination condition check into a separate method from optimize
- Expanded ConvexOptimizer api to get NeuralNetConf and call termination condition check
- Finished condensing the updater tests

Latest version of master is merged in as of this PR submission and currently compiles. All updater tests run successfully