### PR TITLE
Add gradient clipping, rework gradient normalization

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/GradientNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/GradientNormalization.java
@@ -1,0 +1,59 @@
+package org.deeplearning4j.nn.conf;
+
+/**Gradient normalization strategies. These are applied on raw gradients, before the gradients are passed to the
+ * updater (SGD, RMSProp, Momentum, etc)<br>
+ * <p><b>None</b> = no gradient normalization (default)<br></p>
+ *
+ * <p><b>RenormalizeL2PerLayer</b> = rescale gradients by dividing by the L2 norm of all gradients for the layer.<br></p>
+ *
+ * <p><b>RenormalizeL2PerParamType</b> = rescale gradients by dividing by the L2 norm of the gradients, separately for
+ * each type of parameter within the layer.<br>
+ * This differs from RenormalizeL2PerLayer in that here, each parameter type (weight, bias etc) is normalized separately.<br>
+ * For example, in a MLP/FeedForward network (where G is the gradient vector), the output is as follows:
+ * <ul style="list-style-type:none">
+ *     <li>GOut_weight = G_weight / l2(G_weight)</li>
+ *     <li>GOut_bias = G_bias / l2(G_bias)</li>
+ * </ul>
+ * </p>
+ *
+ * <p><b>ClipElementWiseAbsoluteValue</b> = clip the gradients on a per-element basis.<br>
+ * For each gradient g, set g <- sign(g)*max(maxAllowedValue,|g|).<br>
+ * i.e., if a parameter gradient has absolute value greater than the threshold, truncate it.<br>
+ * For example, if threshold = 5, then values in range -5&lt;g&lt;5 are unmodified; values &lt;-5 are set
+ * to -5; values &gt;5 are set to 5.<br>
+ * This was proposed by Mikolov (2012), <i>Statistical Language Models Based on Neural Networks</i> (thesis),
+ * <a href="http://www.fit.vutbr.cz/~imikolov/rnnlm/thesis.pdf">http://www.fit.vutbr.cz/~imikolov/rnnlm/thesis.pdf</a>
+ * in the context of learning recurrent neural networks.<br>
+ * Threshold for clipping can be set in Layer configuration, using gradientNormalizationThreshold(double threshold)
+ * </p>
+ *
+ * <p><b>ClipL2PerLayer</b> = conditional renormalization. Somewhat similar to RenormalizeL2PerLayer, this strategy
+ * scales the gradients <i>if and only if</i> the L2 norm of the gradients (for entire layer) exceeds a specified
+ * threshold. Specifically, if G is gradient vector for the layer, then:
+ * <ul style="list-style-type:none">
+ *     <li>GOut = G &nbsp;&nbsp;&nbsp; if l2Norm(G) < threshold (i.e., no change) </li>
+ *     <li>GOut = threshold * G / l2Norm(G) &nbsp;&nbsp;&nbsp; otherwise </li>
+ * </ul>
+ * Thus, the l2 norm of the scaled gradients will not exceed the specified threshold, though may be smaller than it<br>
+ * See: Pascanu, Mikolov, Bengio (2012), <i>On the difficulty of training Recurrent Neural Networks</i>,
+ * <a href="http://arxiv.org/abs/1211.5063">http://arxiv.org/abs/1211.5063</a><br>
+ * Threshold for clipping can be set in Layer configuration, using gradientNormalizationThreshold(double threshold)
+ * </p>
+ *
+ * <p><b>ClipL2PerParamType</b> = conditional renormalization. Very similar to ClipL2PerLayer, however instead of clipping
+ * per layer, do clipping on each parameter type separately.<br>
+ * For example in a recurrent neural network, input weight gradients, recurrent weight gradients and bias gradient are all
+ * clipped separately. Thus if one set of gradients are very large, these may be clipped while leaving the other gradients
+ * unmodified.<br>
+ * Threshold for clipping can be set in Layer configuration, using gradientNormalizationThreshold(double threshold)</p>
+ *
+ * @author Alex Black
+ */
+public enum GradientNormalization {
+    None,
+    RenormalizeL2PerLayer,
+    RenormalizeL2PerParamType,
+    ClipElementWiseAbsoluteValue,
+    ClipL2PerLayer,
+    ClipL2PerParamType
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -1,11 +1,19 @@
 package org.deeplearning4j.nn.updater;
 
+import com.google.common.base.Function;
+import org.apache.commons.math3.util.FastMath;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.Updater;
+import org.deeplearning4j.nn.conf.GradientNormalization;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.accum.Norm2;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.BooleanIndexing;
+import org.nd4j.linalg.indexing.conditions.AbsValueGreaterThan;
+import org.nd4j.linalg.indexing.conditions.Condition;
 import org.nd4j.linalg.learning.GradientUpdater;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
@@ -16,37 +24,109 @@ import java.util.Map;
  * @author Adam Gibson
  */
 public abstract class BaseUpdater implements Updater {
-    protected Map<String,GradientUpdater> updaterForVariable = new HashMap<>();
+    protected Map<String, GradientUpdater> updaterForVariable = new HashMap<>();
 
 
     @Override
-    public void update(Layer layer, Gradient gradient,int iteration) {
-        for(Map.Entry<String,INDArray> gradientPair : gradient.gradientForVariable().entrySet()) {
-            GradientUpdater updater = init(gradientPair.getKey(),gradientPair.getValue(),layer);
+    public void update(Layer layer, Gradient gradient, int iteration) {
+        preApply(layer, gradient, iteration);
+        for (Map.Entry<String, INDArray> gradientPair : gradient.gradientForVariable().entrySet()) {
+            GradientUpdater updater = init(gradientPair.getKey(), gradientPair.getValue(), layer);
             INDArray gradient2 = updater.getGradient(gradientPair.getValue(), iteration);
-            postApply(layer,gradient2,gradientPair.getKey());
-            gradient.setGradientFor(gradientPair.getKey(),gradient2);
+            postApply(layer, gradient2, gradientPair.getKey());
+            gradient.setGradientFor(gradientPair.getKey(), gradient2);
         }
     }
 
     /**
      * Apply the regularization
+     *
      * @param layer
      * @param gradient
      * @param param
      */
-    public void postApply(Layer layer,INDArray gradient,String param) {
+    public void postApply(Layer layer, INDArray gradient, String param) {
         NeuralNetConfiguration conf = layer.conf();
         INDArray params = layer.getParam(param);
-        if(conf.isUseRegularization() && conf.getLayer().getL2() > 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
-        	gradient.addi(params.mul(conf.getLayer().getL2()));	//dC/dw = dC0/dw + lambda/n * w where C0 is pre-l2 cost function
-        if(conf.isUseRegularization() && conf.getLayer().getL1() > 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
-        	gradient.addi(Transforms.sign(params).muli(conf.getLayer().getL1()));
-        if(conf.isMiniBatch())
+        if (conf.isUseRegularization() && conf.getLayer().getL2() > 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
+            gradient.addi(params.mul(conf.getLayer().getL2()));    //dC/dw = dC0/dw + lambda/n * w where C0 is pre-l2 cost function
+        if (conf.isUseRegularization() && conf.getLayer().getL1() > 0 && !(param.equals(DefaultParamInitializer.BIAS_KEY)))
+            gradient.addi(Transforms.sign(params).muli(conf.getLayer().getL1()));
+        if (conf.isMiniBatch())
             gradient.divi(layer.getInputMiniBatchSize());
-        if(conf.isConstrainGradientToUnitNorm())
+        if (conf.isConstrainGradientToUnitNorm())
             gradient.divi(gradient.norm2(Integer.MAX_VALUE));
 
+    }
+
+    /**
+     * Apply gradient normalization: scale based on L2, clipping etc.
+     */
+    public void preApply(Layer layer, Gradient gradient, int iteration) {
+        GradientNormalization normalization = layer.conf().getLayer().getGradientNormalization();
+        if (normalization == null || normalization == GradientNormalization.None ) return;  //no op
+
+        final double threshold = layer.conf().getLayer().getGradientNormalizationThreshold();
+
+        switch (normalization) {
+            case RenormalizeL2PerLayer:
+                double sumSquares = 0.0;
+                for (INDArray g : gradient.gradientForVariable().values()) {
+                    double l2 = g.norm2Number().doubleValue();
+                    //l2 norm: sqrt(sum_i g_i^2)
+                    sumSquares += l2*l2;
+                }
+                double layerL2 = FastMath.sqrt(sumSquares);
+                for (INDArray g : gradient.gradientForVariable().values()) {
+                    g.divi(layerL2);
+                }
+                break;
+            case RenormalizeL2PerParamType:
+                for (INDArray g : gradient.gradientForVariable().values()) {
+                    double l2 = Nd4j.getExecutioner().execAndReturn(new Norm2(g)).getFinalResult().doubleValue();
+                    g.divi(l2);
+                }
+                break;
+            case ClipElementWiseAbsoluteValue:
+                Condition absValueCondition = new AbsValueGreaterThan(threshold);
+                Function<Number,Number> clipFn = new Function<Number, Number>() {
+                    @Override
+                    public Number apply(Number number) {
+                        return (number.doubleValue() > threshold ? threshold : -threshold);
+                    }
+                };
+
+                for( INDArray g : gradient.gradientForVariable().values()){
+                    BooleanIndexing.applyWhere(g, absValueCondition, clipFn);
+                }
+                break;
+            case ClipL2PerLayer:
+                double sumSquares2 = 0.0;
+                for (INDArray g : gradient.gradientForVariable().values()) {
+                    double l2 = Nd4j.getExecutioner().execAndReturn(new Norm2(g)).getFinalResult().doubleValue();
+                    //l2 norm: sqrt(sum_i g_i^2)
+                    sumSquares2 += l2*l2;
+                }
+                double layerL22 = FastMath.sqrt(sumSquares2);
+                if(layerL22 > threshold ){
+                    double scalingFactor = threshold / layerL22;    // g = g / l2 * threshold ->
+                    for(INDArray g : gradient.gradientForVariable().values()){
+                        g.muli(scalingFactor);
+                    }
+                }
+                break;
+            case ClipL2PerParamType:
+                for (INDArray g : gradient.gradientForVariable().values()) {
+                    double l2 = g.norm2Number().doubleValue();
+                    if(l2 > threshold){
+                        double scalingFactor = l2 / threshold;
+                        g.divi(scalingFactor);
+                    }
+                }
+                break;
+            default:
+                throw new RuntimeException("Unknown (or not implemented) gradient normalization strategy: " + normalization);
+        }
     }
 
     public abstract void init();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/layers/LayerBuilderTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/layers/LayerBuilderTest.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.nn.conf.layers;
 
+import org.deeplearning4j.nn.conf.GradientNormalization;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -42,11 +43,15 @@ public class LayerBuilderTest {
     Distribution dist = new NormalDistribution(1.0, 0.1);
     double dropOut = 0.1;
     Updater updater = Updater.ADAGRAD;
+    GradientNormalization gradNorm = GradientNormalization.ClipL2PerParamType;
+    double gradNormThreshold = 8;
 
     @Test
     public void testLayer() throws Exception {
         RecursiveAutoEncoder layer = new RecursiveAutoEncoder.Builder()
-            .activation(act).weightInit(weight).dist(dist).dropOut(dropOut).updater(updater).build();
+            .activation(act).weightInit(weight).dist(dist).dropOut(dropOut).updater(updater)
+            .gradientNormalization(gradNorm).gradientNormalizationThreshold(gradNormThreshold)
+            .build();
 
         checkSerialization(layer);
 
@@ -55,6 +60,8 @@ public class LayerBuilderTest {
         assertEquals(dist, layer.getDist());
         assertEquals(dropOut, layer.getDropOut(), DELTA);
         assertEquals(updater, layer.getUpdater());
+        assertEquals(gradNorm, layer.getGradientNormalization());
+        assertEquals(gradNormThreshold, layer.getGradientNormalizationThreshold(), 0.0);
     }
 
     @Test

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestGradientNormalization.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestGradientNormalization.java
@@ -1,0 +1,225 @@
+package org.deeplearning4j.nn.updater;
+
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.Updater;
+import org.deeplearning4j.nn.conf.GradientNormalization;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.factory.LayerFactories;
+import org.deeplearning4j.nn.params.DefaultParamInitializer;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestGradientNormalization {
+
+    @Test
+    public void testRenormalizatonPerLayer(){
+        Nd4j.getRandom().setSeed(12345);
+
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new DenseLayer.Builder().nIn(10).nOut(20)
+                        .updater(org.deeplearning4j.nn.conf.Updater.NONE)
+                .gradientNormalization(GradientNormalization.RenormalizeL2PerLayer)
+                .build()).build();
+
+        Layer layer = LayerFactories.getFactory(conf.getLayer()).create(conf);
+        Updater updater = UpdaterCreator.getUpdater(layer);
+        INDArray weightGrad = Nd4j.rand(10, 20);
+        INDArray biasGrad = Nd4j.rand(1, 10);
+        INDArray weightGradCopy = weightGrad.dup();
+        INDArray biasGradCopy = biasGrad.dup();
+        Gradient gradient = new DefaultGradient();
+        gradient.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGrad);
+        gradient.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGrad);
+
+        updater.update(layer, gradient, 0);
+
+        assertNotEquals(weightGradCopy, weightGrad);
+        assertNotEquals(biasGradCopy, biasGrad);
+
+        double sumSquaresWeight = weightGradCopy.mul(weightGradCopy).sumNumber().doubleValue();
+        double sumSquaresBias = biasGradCopy.mul(biasGradCopy).sumNumber().doubleValue();
+        double sumSquares = sumSquaresWeight + sumSquaresBias;
+        double l2Layer = Math.sqrt(sumSquares);
+
+        INDArray normWeightsExpected = weightGradCopy.div(l2Layer);
+        INDArray normBiasExpected = biasGradCopy.div(l2Layer);
+
+        double l2Weight = gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY).norm2Number().doubleValue();
+        double l2Bias = gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY).norm2Number().doubleValue();
+        assertTrue(!Double.isNaN(l2Weight) && l2Weight > 0.0 );
+        assertTrue(!Double.isNaN(l2Bias) && l2Bias > 0.0 );
+        assertEquals(normWeightsExpected, gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY));
+        assertEquals(normBiasExpected, gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY));
+    }
+
+    @Test
+    public void testRenormalizationPerParamType(){
+        Nd4j.getRandom().setSeed(12345);
+
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new DenseLayer.Builder().nIn(10).nOut(20)
+                        .updater(org.deeplearning4j.nn.conf.Updater.NONE)
+                        .gradientNormalization(GradientNormalization.RenormalizeL2PerParamType)
+                        .build()).build();
+
+        Layer layer = LayerFactories.getFactory(conf.getLayer()).create(conf);
+        Updater updater = UpdaterCreator.getUpdater(layer);
+        INDArray weightGrad = Nd4j.rand(10, 20);
+        INDArray biasGrad = Nd4j.rand(1, 10);
+        INDArray weightGradCopy = weightGrad.dup();
+        INDArray biasGradCopy = biasGrad.dup();
+        Gradient gradient = new DefaultGradient();
+        gradient.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGrad);
+        gradient.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGrad);
+
+        updater.update(layer, gradient, 0);
+
+        INDArray normWeightsExpected = weightGradCopy.div(weightGradCopy.norm2Number());
+        INDArray normBiasExpected = biasGradCopy.div(biasGradCopy.norm2Number());
+
+        assertEquals(normWeightsExpected, gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY));
+        assertEquals(normBiasExpected, gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY));
+    }
+
+    @Test
+    public void testAbsValueClippingPerElement(){
+        Nd4j.getRandom().setSeed(12345);
+        double threshold = 3;
+
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new DenseLayer.Builder().nIn(10).nOut(20)
+                        .updater(org.deeplearning4j.nn.conf.Updater.NONE)
+                        .gradientNormalization(GradientNormalization.ClipElementWiseAbsoluteValue)
+                        .gradientNormalizationThreshold(threshold)
+                        .build()).build();
+
+        Layer layer = LayerFactories.getFactory(conf.getLayer()).create(conf);
+        Updater updater = UpdaterCreator.getUpdater(layer);
+        INDArray weightGrad = Nd4j.rand(10, 20).muli(10).subi(5);
+        INDArray biasGrad = Nd4j.rand(1, 10).muli(10).subi(5);
+        INDArray weightGradCopy = weightGrad.dup();
+        INDArray biasGradCopy = biasGrad.dup();
+        Gradient gradient = new DefaultGradient();
+        gradient.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGrad);
+        gradient.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGrad);
+
+        updater.update(layer, gradient, 0);
+
+        assertNotEquals(weightGradCopy, weightGrad);
+        assertNotEquals(biasGradCopy, biasGrad);
+
+        INDArray expectedWeightGrad = weightGradCopy.dup();
+        for( int i=0; i<expectedWeightGrad.length(); i++ ){
+            double d = expectedWeightGrad.getDouble(i);
+            if(d>threshold) expectedWeightGrad.putScalar(i,threshold);
+            else if(d<-threshold) expectedWeightGrad.putScalar(i,-threshold);
+        }
+        INDArray expectedBiasGrad = biasGradCopy.dup();
+        for( int i=0; i<expectedBiasGrad.length(); i++ ){
+            double d = expectedBiasGrad.getDouble(i);
+            if(d>threshold) expectedBiasGrad.putScalar(i,threshold);
+            else if(d<-threshold) expectedBiasGrad.putScalar(i,-threshold);
+        }
+
+        assertEquals(expectedWeightGrad,gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY));
+        assertEquals(expectedBiasGrad,gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY));
+    }
+
+    @Test
+    public void testL2ClippingPerLayer(){
+        Nd4j.getRandom().setSeed(12345);
+        double threshold = 3;
+
+        for( int t=0; t<2; t++ ) {
+            //t=0: small -> no clipping
+            //t=1: large -> clipping
+
+            NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .layer(new DenseLayer.Builder().nIn(10).nOut(20)
+                            .updater(org.deeplearning4j.nn.conf.Updater.NONE)
+                            .gradientNormalization(GradientNormalization.ClipL2PerLayer)
+                            .gradientNormalizationThreshold(threshold)
+                            .build()).build();
+
+            Layer layer = LayerFactories.getFactory(conf.getLayer()).create(conf);
+            Updater updater = UpdaterCreator.getUpdater(layer);
+            INDArray weightGrad = Nd4j.rand(10, 20).muli((t==0 ? 0.05 : 10));
+            INDArray biasGrad = Nd4j.rand(1, 10).muli((t==0 ? 0.05 : 10));
+            INDArray weightGradCopy = weightGrad.dup();
+            INDArray biasGradCopy = biasGrad.dup();
+            Gradient gradient = new DefaultGradient();
+            gradient.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGrad);
+            gradient.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGrad);
+
+            double layerGradL2 = gradient.gradient().norm2Number().doubleValue();
+            if(t==0) assertTrue(layerGradL2 < threshold);
+            else assertTrue(layerGradL2 > threshold);
+
+            updater.update(layer, gradient, 0);
+
+            if(t==0) {
+                //norm2 < threshold -> no change
+                assertEquals(weightGradCopy, weightGrad);
+                assertEquals(biasGradCopy, biasGrad);
+                continue;
+            } else {
+                //norm2 > threshold -> rescale
+                assertNotEquals(weightGradCopy, weightGrad);
+                assertNotEquals(biasGradCopy, biasGrad);
+            }
+
+            //for above threshold only...
+            double scalingFactor = threshold / layerGradL2;
+            INDArray expectedWeightGrad = weightGradCopy.mul(scalingFactor);
+            INDArray expectedBiasGrad = biasGradCopy.mul(scalingFactor);
+            assertEquals(expectedWeightGrad, gradient.getGradientFor(DefaultParamInitializer.WEIGHT_KEY));
+            assertEquals(expectedBiasGrad, gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY));
+        }
+    }
+
+    @Test
+    public void testL2ClippingPerParamType(){
+        Nd4j.getRandom().setSeed(12345);
+        double threshold = 3;
+
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .layer(new DenseLayer.Builder().nIn(10).nOut(20)
+                        .updater(org.deeplearning4j.nn.conf.Updater.NONE)
+                        .gradientNormalization(GradientNormalization.ClipL2PerParamType)
+                        .gradientNormalizationThreshold(threshold)
+                        .build()).build();
+
+        Layer layer = LayerFactories.getFactory(conf.getLayer()).create(conf);
+        Updater updater = UpdaterCreator.getUpdater(layer);
+        INDArray weightGrad = Nd4j.rand(10, 20).muli(0.05);
+        INDArray biasGrad = Nd4j.rand(1, 10).muli(10);
+        INDArray weightGradCopy = weightGrad.dup();
+        INDArray biasGradCopy = biasGrad.dup();
+        Gradient gradient = new DefaultGradient();
+        gradient.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGrad);
+        gradient.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGrad);
+
+        double weightL2 = weightGrad.norm2Number().doubleValue();
+        double biasL2 = biasGrad.norm2Number().doubleValue();
+        assertTrue(weightL2 < threshold);
+        assertTrue(biasL2 > threshold);
+
+        updater.update(layer, gradient, 0);
+
+        assertEquals(weightGradCopy, weightGrad);   //weight norm2 < threshold -> no change
+        assertNotEquals(biasGradCopy, biasGrad);    //bias norm2 > threshold -> rescale
+
+
+        double biasScalingFactor = threshold / biasL2;
+        INDArray expectedBiasGrad = biasGradCopy.mul(biasScalingFactor);
+        assertEquals(expectedBiasGrad, gradient.getGradientFor(DefaultParamInitializer.BIAS_KEY));
+    }
+}


### PR DESCRIPTION
Rework gradient normalization and add gradient clipping
- Deprecate constrainGradientToUnitNorm option (still works as before if used; essentially replaced by RenormalizeL2PerParamType, except for difference in order)
- Add .gradientNormalization(GradientNormalization) configuration option and .gradientNormalizationThreshold(double) (see image below for details)
- Gradient normalization is applied before gradient updating (unlike old constrainGradientToUnitNorm), as this makes more sense (and seems to be the approach taken for gradient clipping in the literature)
  - Applying before gradient updating (SGD, adagrad, etc) is preferable: consider effect of using SGD + constrainGradient, where normalization occurs after SGD: in this case normalization/scaling applies after learning rate is applied, hence we no longer have control over step size (i.e., effect of multiplying by learning rate is essentially removed due to renormalization)
- Reason for having two versions for each of Renormalize and Clip (i.e., per layer vs. per parameter type): it's unclear if one is always preferable.
  - Per layer seems more common (and preferable for things like MLP/FF networks), though (a) the old constrainGradientToUnitNorm used to do it on a per parameter type basis, and (b) in some situations this makes some sense (i.e., in a RNN: why penalize my bias gradients just because my recurrent weight gradients are blowing up?)
  - I'm certainly open to removing the per-parameter option. Thoughts?


![image](https://cloud.githubusercontent.com/assets/2360237/10714789/7141db12-7b52-11e5-948a-6d4f8c2cc4c6.png)
