### PR TITLE
Applied learningRate schedule and fixed learningRate decay when score doesn't change

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Model.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Model.java
@@ -87,6 +87,12 @@ public interface Model {
      */
     void setParams(INDArray params);
 
+    /**
+     * Update learningRate using for this model.
+     * Use the learningRateScoreBasedDecay to adapt the score
+     * if the Eps termination condition is met
+     */
+    void applyLearningRateScoreDecay();
 
 
     /**

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -71,6 +71,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
     protected StepFunction stepFunction;
     protected boolean useRegularization = false;
     protected boolean useDropConnect = false;
+    protected boolean useSchedules = false;
     //minimize or maximize objective
     protected boolean minimize = true;
     // Graves LSTM & RNN
@@ -271,13 +272,14 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         protected double biasInit = 0.0;
         protected Distribution dist = new NormalDistribution(1e-3,1);
         private double learningRate = 1e-1;
+        private Map<Integer, Double> learningRateAfter = new HashMap<>();
         private double lrScoreBasedDecay;
         private double momentum = 0.5;
         private Map<Integer, Double> momentumAfter = new HashMap<>();
         private double l1 = 0.0;
         private double l2 = 0.0;
         protected double dropOut = 0;
-        protected Updater updater = Updater.NONE;
+        protected Updater updater = Updater.SGD;
         private double rho;
         private double rmsDecay = 0.95;
         private double adamMeanDecay = 0.9;
@@ -289,6 +291,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         private int maxNumLineSearchIterations = 5;
         private long seed = System.currentTimeMillis();
         private boolean useRegularization = false;
+        private boolean useSchedules = false;
         private OptimizationAlgorithm optimizationAlgo = OptimizationAlgorithm.CONJUGATE_GRADIENT;
         @Deprecated
         private boolean constrainGradientToUnitNorm = false;
@@ -299,6 +302,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         private int timeSeriesLength = 1;
         private GradientNormalization gradientNormalization = GradientNormalization.None;
         private double gradientNormalizationThreshold = 1.0;
+
 
 
         /**Deprecated.
@@ -417,6 +421,12 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             return this;
         }
 
+        /** Whether to use schedules, learningRateAfter and momentumAfter*/
+        public Builder schedules(boolean schedules) {
+            this.useSchedules = schedules;
+            return this;
+        }
+
         @Override
         public Builder clone() {
             try {
@@ -465,6 +475,12 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
         /** Learning rate. Defaults to 1e-1*/
         public Builder learningRate(double learningRate) {
             this.learningRate = learningRate;
+            return this;
+        }
+
+        /** Learning rate schedule. Map of the iteration to the learning rate to apply at that iteration. */
+        public Builder learningRateAfter(Map<Integer, Double> learningRateAfter) {
+            this.learningRateAfter = learningRateAfter;
             return this;
         }
 
@@ -578,6 +594,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
             conf.layer = layer;
             conf.numIterations = numIterations;
             conf.useRegularization = useRegularization;
+            conf.useSchedules = useSchedules;
             conf.optimizationAlgo = optimizationAlgo;
             conf.constrainGradientToUnitNorm = constrainGradientToUnitNorm;
             conf.seed = seed;
@@ -588,6 +605,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
 
 
             if(Double.isNaN(layer.getLearningRate())) layer.setLearningRate(learningRate);
+            if(layer.getLearningRateAfter() == null) layer.setLearningRateAfter(learningRateAfter);
             if(Double.isNaN(layer.getLrScoreBasedDecay())) layer.setLrScoreBasedDecay(lrScoreBasedDecay);
             if(Double.isNaN(layer.getL1())) layer.setL1(l1);
             if(Double.isNaN(layer.getL2())) layer.setL2(l2);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -60,6 +60,8 @@ public abstract class Layer implements Serializable, Cloneable {
     protected double biasInit;
     protected Distribution dist;
     protected double learningRate;
+    //learning rate after n iterations
+    protected Map<Integer,Double> learningRateAfter;
     protected double lrScoreBasedDecay;
     protected double momentum;
     //momentum after n iterations
@@ -82,6 +84,7 @@ public abstract class Layer implements Serializable, Cloneable {
         this.biasInit = builder.biasInit;
     	this.dist = builder.dist;
         this.learningRate = builder.learningRate;
+        this.learningRateAfter = builder.learningRateAfter;
         this.lrScoreBasedDecay = builder.lrScoreBasedDecay;
         this.momentum = builder.momentum;
         this.momentumAfter = builder.momentumAfter;
@@ -116,6 +119,7 @@ public abstract class Layer implements Serializable, Cloneable {
         protected double biasInit = Double.NaN;
         protected Distribution dist = null;
         protected double learningRate = Double.NaN;
+        protected Map<Integer,Double> learningRateAfter = null;
         protected double lrScoreBasedDecay = Double.NaN;
         protected double momentum = Double.NaN;
         protected Map<Integer,Double> momentumAfter = null;
@@ -165,6 +169,12 @@ public abstract class Layer implements Serializable, Cloneable {
         public T learningRate(double learningRate){
             this.learningRate = learningRate;
             return (T)this;
+        }
+
+        /** Learning rate schedule. Map of the iteration to the learning rate to apply at that iteration. */
+        public T learningRateAfter(Map<Integer, Double> learningRateAfter) {
+            this.learningRateAfter = learningRateAfter;
+            return (T) this;
         }
 
         /** Rate to decrease learningRate by when the score stops improving.

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -561,4 +561,10 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
     public int getInputMiniBatchSize(){
     	return inputMiniBatchSize;
     }
+
+    @Override
+    public void applyLearningRateScoreDecay() {
+        conf.getLayer().setLearningRate(conf.getLayer().getLearningRate() / (conf.getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
+    }
+
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -564,7 +564,7 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
 
     @Override
     public void applyLearningRateScoreDecay() {
-        conf.getLayer().setLearningRate(conf.getLayer().getLearningRate() / (conf.getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
+        conf.getLayer().setLearningRate(conf.getLayer().getLearningRate() * (conf.getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
     }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
@@ -23,6 +23,7 @@ import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer;
 import org.deeplearning4j.nn.params.PretrainParamInitializer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.LossFunction;
@@ -100,6 +101,11 @@ public abstract class BasePretrainNetwork<LayerConfT extends org.deeplearning4j.
                     .miniBatch(conf.isMiniBatch()).miniBatchSize(getInputMiniBatchSize())
                     .useRegularization(conf.isUseRegularization()).build().score();
         }
+    }
+
+    @Override
+    public void applyLearningRateScoreDecay() {
+        conf.getLayer().setLearningRate(conf.getLayer().getLearningRate() / (conf.getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
     }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
@@ -103,9 +103,5 @@ public abstract class BasePretrainNetwork<LayerConfT extends org.deeplearning4j.
         }
     }
 
-    @Override
-    public void applyLearningRateScoreDecay() {
-        conf.getLayer().setLearningRate(conf.getLayer().getLearningRate() / (conf.getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
-    }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/feedforward/autoencoder/AutoEncoder.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/feedforward/autoencoder/AutoEncoder.java
@@ -134,4 +134,6 @@ public class AutoEncoder extends BasePretrainNetwork<org.deeplearning4j.nn.conf.
         setScoreWithZ(z);
 
     }
+
+
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -3,8 +3,10 @@ package org.deeplearning4j.nn.layers.normalization;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.BaseLayer;
 import org.deeplearning4j.nn.params.BatchNormalizationParamInitializer;
 import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.IterationListener;
@@ -20,7 +22,7 @@ import java.util.*;
  *
  * @author Adam Gibson
  */
-public class BatchNormalization implements Layer {
+public class BatchNormalization extends BaseLayer<ConvolutionLayer> {
     private INDArray std;
     private NeuralNetConfiguration conf;
     private int index = 0;
@@ -31,7 +33,7 @@ public class BatchNormalization implements Layer {
     private INDArray xHat;
 
     public BatchNormalization(NeuralNetConfiguration conf) {
-        this.conf = conf;
+        super(conf);
     }
 
     @Override
@@ -365,10 +367,6 @@ public class BatchNormalization implements Layer {
             throw new IllegalArgumentException("Illegal input for batch size");
         return new int[] {leadDim,cDim,rdim};
 
-    }
-    @Override
-    public void applyLearningRateScoreDecay() {
-        conf.getLayer().setLearningRate(conf.getLayer().getLearningRate() / (conf.getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
     }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -366,5 +366,9 @@ public class BatchNormalization implements Layer {
         return new int[] {leadDim,cDim,rdim};
 
     }
+    @Override
+    public void applyLearningRateScoreDecay() {
+        conf.getLayer().setLearningRate(conf.getLayer().getLearningRate() / (conf.getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
+    }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1712,7 +1712,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         for (Layer layer: layers) {
             if(!(layer instanceof SubsamplingLayer)) {
                 layer.conf().getLayer().setLearningRate(
-                        layer.conf().getLayer().getLearningRate() / (layer.conf().getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
+                        layer.conf().getLayer().getLearningRate() * (layer.conf().getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
             }
         }
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1708,6 +1708,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         }
     }
 
+
     public void applyLearningRateScoreDecay() {
         for (Layer layer: layers) {
             if(!(layer instanceof SubsamplingLayer)) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1708,6 +1708,16 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         }
     }
 
+    public void applyLearningRateScoreDecay() {
+        for (Layer layer: layers) {
+            if(!(layer instanceof SubsamplingLayer)) {
+                layer.conf().getLayer().setLearningRate(
+                        layer.conf().getLayer().getLearningRate() / (layer.conf().getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
+            }
+        }
+    }
+
+
 
     /**
      * Feed forward with the r operator

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -68,11 +68,13 @@ public abstract class BaseUpdater implements Updater {
 
         if (conf.getLayer().getLearningRateAfter().containsKey(iteration)) {
             conf.getLayer().setLearningRate(conf.getLayer().getLearningRateAfter().get(iteration));
-            updaterForVariable.remove(param);
+            if(updaterForVariable.get(param) != null)
+                updaterForVariable.get(param).setLearningRate(conf.getLayer().getLearningRateAfter().get(iteration));
         }
         if (conf.getLayer().getMomentumAfter().containsKey(iteration)) {
             conf.getLayer().setMomentum(conf.getLayer().getMomentumAfter().get(iteration));
-            updaterForVariable.remove(param);
+            if(updaterForVariable.get(param) != null)
+                updaterForVariable.get(param).setMomentum(conf.getLayer().getMomentumAfter().get(iteration));
         }
 
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -29,14 +29,22 @@ public abstract class BaseUpdater implements Updater {
 
     @Override
     public void update(Layer layer, Gradient gradient, int iteration) {
+        String paramName;
+        INDArray paramVal, gradient2;
+        GradientUpdater updater;
+
         preApply(layer, gradient, iteration);
         for (Map.Entry<String, INDArray> gradientPair : gradient.gradientForVariable().entrySet()) {
+            paramName = gradientPair.getKey();
+            paramVal = gradientPair.getValue();
+
             if(layer.conf().isUseSchedules())
-                checkSchedules(layer, iteration, gradientPair.getKey());
-            GradientUpdater updater = init(gradientPair.getKey(), gradientPair.getValue(), layer);
-            INDArray gradient2 = updater.getGradient(gradientPair.getValue(), iteration);
-            postApply(layer, gradient2, gradientPair.getKey());
-            gradient.setGradientFor(gradientPair.getKey(), gradient2);
+                checkSchedules(layer, iteration, paramName);
+
+            updater = init(paramName, paramVal, layer);
+            gradient2 = updater.getGradient(paramVal, iteration);
+            postApply(layer, gradient2, paramName);
+            gradient.setGradientFor(paramName, gradient2);
         }
     }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -89,6 +89,11 @@ public abstract class BaseUpdater implements Updater {
 
     /**
      *  Apply gradient normalization: scale based on L2, clipping etc.
+     *  RenormalizeL2PerLayer: divide all layer gradients by L2 to rescale
+     *  RenormalizeL2PerParamType: divide each parameter type gradient in a layer by L2 to rescale
+     *  ClipElementWiseAbsoluteValue: clip gradients per-element
+     *  ClipL2PerLayer: same as RenormalizeL2PerLayer but limited by gradient L2 norm for the layer meeting a threshold
+     *  ClipL2PerParamType: same as RenormalizeL2PerParamType but limited by gradient L2 norm for each parameter type in a layer meeting a threshold
      */
     public void preApply(Layer layer, Gradient gradient, int iteration) {
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -77,12 +77,12 @@ public abstract class BaseUpdater implements Updater {
         if (conf.getLayer().getLearningRateAfter().containsKey(iteration)) {
             conf.getLayer().setLearningRate(conf.getLayer().getLearningRateAfter().get(iteration));
             if(updaterForVariable.get(param) != null)
-                updaterForVariable.get(param).setLearningRate(conf.getLayer().getLearningRateAfter().get(iteration));
+                updaterForVariable.get(param).update(conf.getLayer().getLearningRateAfter().get(iteration));
         }
         if (conf.getLayer().getMomentumAfter().containsKey(iteration)) {
             conf.getLayer().setMomentum(conf.getLayer().getMomentumAfter().get(iteration));
             if(updaterForVariable.get(param) != null)
-                updaterForVariable.get(param).setMomentum(conf.getLayer().getMomentumAfter().get(iteration));
+                updaterForVariable.get(param).update(null,conf.getLayer().getMomentumAfter().get(iteration));
         }
 
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -82,7 +82,7 @@ public abstract class BaseUpdater implements Updater {
         if (conf.getLayer().getMomentumAfter().containsKey(iteration)) {
             conf.getLayer().setMomentum(conf.getLayer().getMomentumAfter().get(iteration));
             if(updaterForVariable.get(param) != null)
-                updaterForVariable.get(param).update(null,conf.getLayer().getMomentumAfter().get(iteration));
+                updaterForVariable.get(param).update(conf.getLayer().getLearningRate(), conf.getLayer().getMomentumAfter().get(iteration));
         }
 
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/NesterovsUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/NesterovsUpdater.java
@@ -21,8 +21,7 @@ public class NesterovsUpdater extends BaseUpdater {
     public GradientUpdater init(String variable, INDArray gradient, Layer layer) {
         Nesterovs nesterovs = (Nesterovs) updaterForVariable.get(variable);
         if(nesterovs == null) {
-            nesterovs = new Nesterovs(layer.conf().getLayer().getMomentum(), layer.conf().getLayer().getMomentumAfter(),
-                    layer.conf().getLayer().getLearningRate());
+            nesterovs = new Nesterovs(layer.conf().getLayer().getMomentum(), layer.conf().getLayer().getLearningRate());
             updaterForVariable.put(variable,nesterovs);
         }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/NoOpUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/NoOpUpdater.java
@@ -27,5 +27,16 @@ public class NoOpUpdater extends BaseUpdater {
 		public INDArray getGradient(INDArray gradient, int iteration) {
 			return gradient;
 		}
+
+		@Override
+		public void setLearningRate(double learningRate) {
+			//no op
+		}
+
+		@Override
+		public void setMomentum(double momentum) {
+			//no op
+		}
+
 	}
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/NoOpUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/NoOpUpdater.java
@@ -24,18 +24,13 @@ public class NoOpUpdater extends BaseUpdater {
 
 	private static class NoOpGradientUpdater implements GradientUpdater {
 		@Override
+		public void update(Object... args) {
+
+		}
+
+		@Override
 		public INDArray getGradient(INDArray gradient, int iteration) {
 			return gradient;
-		}
-
-		@Override
-		public void setLearningRate(double learningRate) {
-			//no op
-		}
-
-		@Override
-		public void setMomentum(double momentum) {
-			//no op
 		}
 
 	}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/RmsPropUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/RmsPropUpdater.java
@@ -17,9 +17,9 @@ public class RmsPropUpdater extends BaseUpdater {
 
     @Override
     public GradientUpdater init(String variable, INDArray gradient, Layer layer) {
-        org.nd4j.linalg.learning.RmsPropUpdater rmsprop = (org.nd4j.linalg.learning.RmsPropUpdater) updaterForVariable.get(variable);
+        org.nd4j.linalg.learning.RmsProp rmsprop = (org.nd4j.linalg.learning.RmsProp) updaterForVariable.get(variable);
         if(rmsprop == null) {
-            rmsprop = new org.nd4j.linalg.learning.RmsPropUpdater(layer.conf().getLayer().getLearningRate(), layer.conf().getLayer().getRmsDecay());
+            rmsprop = new org.nd4j.linalg.learning.RmsProp(layer.conf().getLayer().getLearningRate(), layer.conf().getLayer().getRmsDecay());
             updaterForVariable.put(variable,rmsprop);
         }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/SgdUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/SgdUpdater.java
@@ -17,9 +17,9 @@ public class SgdUpdater extends BaseUpdater {
 
     @Override
     public GradientUpdater init(String variable, INDArray gradient, Layer layer) {
-        org.nd4j.linalg.learning.SgdUpdater updater = (org.nd4j.linalg.learning.SgdUpdater) updaterForVariable.get(variable);
+        org.nd4j.linalg.learning.Sgd updater = (org.nd4j.linalg.learning.Sgd) updaterForVariable.get(variable);
         if(updater == null) {
-            updater = new org.nd4j.linalg.learning.SgdUpdater(layer.conf().getLayer().getLearningRate());
+            updater = new org.nd4j.linalg.learning.Sgd(layer.conf().getLayer().getLearningRate());
             updaterForVariable.put(variable,updater);
         }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/listeners/ScoreIterationListener.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/listeners/ScoreIterationListener.java
@@ -52,7 +52,8 @@ public class ScoreIterationListener implements IterationListener {
             printIterations = 1;
         if(iteration % printIterations == 0) {
             invoke();
-            log.info("Score at iteration " + iteration + " is " + model.score());
+            double result = model.score();
+            log.info("Score at iteration " + iteration + " is " + result);
 
         }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
@@ -213,8 +213,9 @@ public abstract class BaseOptimizer implements ConvexOptimizer {
             if(condition.terminate(score,oldScore,new Object[]{gradient})){
                 log.debug("Hit termination condition on iteration {}: score={}, oldScore={}, condition={}", i, score, oldScore, condition);
                 if(condition instanceof EpsTermination && !Double.isNaN(conf.getLayer().getLrScoreBasedDecay())) {
-                    model.conf().getLayer().setLearningRate(model.conf().getLayer().getLearningRate() /
-                            (model.conf().getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD));
+//                    double newLr = model.conf().getLayer().getLearningRate() / (model.conf().getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD);
+//                    model.conf().getLayer().setLearningRate(newLr);
+                    model.applyLearningRateScoreDecay();
                 }
                 return true;
             }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/BaseOptimizer.java
@@ -184,13 +184,10 @@ public abstract class BaseOptimizer implements ConvexOptimizer {
                 log.debug("Step size returned by line search is 0.0.");
             }
 
-            //record old score for deltas and other termination conditions
-//            oldScore = score;
             pair = gradientAndScore();
 
             //updates searchDirection
             postStep(pair.getFirst().gradient());
-//            score = pair.getSecond();
 
             //invoke listeners for debugging
             for(IterationListener listener : iterationListeners)
@@ -213,8 +210,6 @@ public abstract class BaseOptimizer implements ConvexOptimizer {
             if(condition.terminate(score,oldScore,new Object[]{gradient})){
                 log.debug("Hit termination condition on iteration {}: score={}, oldScore={}, condition={}", i, score, oldScore, condition);
                 if(condition instanceof EpsTermination && !Double.isNaN(conf.getLayer().getLrScoreBasedDecay())) {
-//                    double newLr = model.conf().getLayer().getLearningRate() / (model.conf().getLayer().getLrScoreBasedDecay() + Nd4j.EPS_THRESHOLD);
-//                    model.conf().getLayer().setLearningRate(newLr);
                     model.applyLearningRateScoreDecay();
                 }
                 return true;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/StochasticGradientDescent.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/StochasticGradientDescent.java
@@ -64,6 +64,8 @@ public class StochasticGradientDescent extends BaseOptimizer {
                 listener.iterationDone(model, i);
 
             checkTerminalConditions(pair.getFirst().gradient(), oldScore, score, i);
+
+
         }
         return true;
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/StochasticGradientDescent.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/solvers/StochasticGradientDescent.java
@@ -62,6 +62,8 @@ public class StochasticGradientDescent extends BaseOptimizer {
 
             for(IterationListener listener : iterationListeners)
                 listener.iterationDone(model, i);
+
+            checkTerminalConditions(pair.getFirst().gradient(), oldScore, score, i);
         }
         return true;
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
@@ -593,6 +593,11 @@ public class BarnesHutTsne extends Tsne implements Model {
     }
 
     @Override
+    public void applyLearningRateScoreDecay() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
     public void fit(INDArray data) {
         this.x  = data;
         fit();
@@ -768,5 +773,8 @@ public class BarnesHutTsne extends Tsne implements Model {
                     maxIter,realMin,initialMomentum,finalMomentum,momentum,switchMomentumIteration,normalize,
                     usePca,stopLyingIteration,tolerance,learningRate,useAdaGrad,perplexity,minGain);
         }
+
+
     }
+
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestSchedules.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestSchedules.java
@@ -1,0 +1,360 @@
+package org.deeplearning4j.nn.updater;
+
+import org.apache.commons.math3.util.FastMath;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.Updater;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.factory.LayerFactories;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.params.DefaultParamInitializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.ops.transforms.Transforms;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by nyghtowl on 10/27/15.
+ */
+public class TestSchedules {
+    int nIn = 3;
+    int nOut = 2;
+    double epsilon = 1e-8;
+    INDArray weightGradient = Nd4j.ones(nIn,nOut);
+    INDArray biasGradient = Nd4j.ones(1,nOut);
+    Gradient gradientSingle = new DefaultGradient();
+    Gradient gradientMLN = new DefaultGradient();
+    INDArray val, gradExpected, vPrev;
+    String key;
+    Map<String, INDArray> tmpStorage, tmpStorage2, tmpStorage3, tmpStorage4 = new HashMap<>();
+    org.deeplearning4j.nn.conf.Updater[] updaters = {
+            org.deeplearning4j.nn.conf.Updater.SGD,
+            org.deeplearning4j.nn.conf.Updater.ADAGRAD,
+            org.deeplearning4j.nn.conf.Updater.ADAM,
+            org.deeplearning4j.nn.conf.Updater.RMSPROP,
+    };
+
+    @Before
+    public void beforeDo(){
+        int nLayers = 2;
+        String wKey, bKey;
+
+        gradientSingle.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientSingle.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
+
+        for (int j=0; j < nLayers; j++){
+            wKey = String.valueOf(j) + "_" + DefaultParamInitializer.WEIGHT_KEY;
+            gradientMLN.setGradientFor(wKey, weightGradient);
+            bKey = String.valueOf(j) + "_" + DefaultParamInitializer.BIAS_KEY ;
+            gradientMLN.setGradientFor(bKey, biasGradient);
+        }
+
+        val = null;
+        gradExpected = null;
+        vPrev = null;
+        tmpStorage = new HashMap<>();
+        tmpStorage2 = new HashMap<>();
+        tmpStorage3 = new HashMap<>();
+        tmpStorage4 = new HashMap<>();
+
+    }
+
+    @Test
+    public void testLearningRateAfterSingleLayer() {
+        Map<Integer, Double> learningRateAfter = new HashMap<>();
+        learningRateAfter.put(1, 0.2);
+        int iterations = 2;
+
+        for (org.deeplearning4j.nn.conf.Updater updaterFunc : updaters) {
+            double lr = 1e-2;
+            NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .learningRate(lr).learningRateAfter(learningRateAfter).schedules(true).iterations(iterations)
+                    .layer(new DenseLayer.Builder()
+                            .nIn(nIn).nOut(nOut).updater(updaterFunc).build())
+                    .build();
+
+            Layer layer = LayerFactories.getFactory(conf).create(conf, null, 0);
+            Updater updater = UpdaterCreator.getUpdater(layer);
+
+            Gradient gradientActual = new DefaultGradient();
+            gradientActual.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+            gradientActual.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
+
+            Gradient gradientExpected = new DefaultGradient();
+            gradientExpected.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+            gradientExpected.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
+
+            for (int i = 0; i < 2; i++) {
+                updater.update(layer, gradientActual, i);
+
+                if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.SGD))
+                    lr = testSGDComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+                else if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.ADAGRAD))
+                    lr = testAdaGradComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+                else if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.ADAM))
+                    lr = testAdamComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+                else if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.RMSPROP))
+                    lr = testRMSPropComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+                assertEquals(lr, layer.conf().getLayer().getLearningRate(), 1e-4);
+            }
+        }
+    }
+
+
+    @Test
+    public void testLearningRateAfterMLN(){
+        Map<Integer,Double> learningRateAfter = new HashMap<>();
+        learningRateAfter.put(1, 0.2);
+        int iterations = 2;
+        int nLayers = 2;
+        int[] nIns = {4,2};
+        int[] nOuts = {2,3};
+
+        for (org.deeplearning4j.nn.conf.Updater updaterFunc : updaters) {
+            double lr = 1e-2;
+
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .learningRate(lr).learningRateAfter(learningRateAfter).schedules(true).iterations(iterations)
+                    .updater(updaterFunc)
+                    .list(nLayers)
+                    .layer(0, new DenseLayer.Builder().nIn(nIns[0]).nOut(nOuts[0]).build())
+                    .layer(1, new OutputLayer.Builder().nIn(nIns[1]).nOut(nOuts[1]).build())
+                    .backprop(true).pretrain(false)
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+
+            Updater updater = UpdaterCreator.getUpdater(net);
+            String wKey, bKey;
+            Gradient gradientActual = new DefaultGradient();
+            for (int k = 0; k < nLayers; k++) {
+                wKey = String.valueOf(k) + "_" + DefaultParamInitializer.WEIGHT_KEY;
+                gradientActual.setGradientFor(wKey, weightGradient);
+                bKey = String.valueOf(k) + "_" + DefaultParamInitializer.BIAS_KEY;
+                gradientActual.setGradientFor(bKey, biasGradient);
+            }
+
+
+            Gradient gradientExpected = new DefaultGradient();
+            for (int k = 0; k < nLayers; k++) {
+                wKey = String.valueOf(k) + "_" + DefaultParamInitializer.WEIGHT_KEY;
+                gradientExpected.setGradientFor(wKey, weightGradient);
+                bKey = String.valueOf(k) + "_" + DefaultParamInitializer.BIAS_KEY;
+                gradientExpected.setGradientFor(bKey, biasGradient);
+            }
+
+
+            for (int i = 0; i < 2; i++) {
+                updater.update(net, gradientActual, i);
+                if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.SGD))
+                    lr = testSGDComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+                else if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.ADAGRAD))
+                    lr = testAdaGradComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+                else if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.ADAM))
+                    lr = testAdamComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+                else if(updaterFunc.equals(org.deeplearning4j.nn.conf.Updater.RMSPROP))
+                    lr = testRMSPropComputation(gradientActual, gradientExpected, lr, learningRateAfter, i);
+
+                assertEquals(lr, net.getLayer(1).conf().getLayer().getLearningRate(), 1e-4);
+            }
+        }
+    }
+
+
+    @Test
+    public void testmomentumAfterUpdaterSingleLayer(){
+        double lr = 1e-2;
+        double mu = 0.6;
+        Map<Integer,Double> momentumAfter = new HashMap<>();
+        momentumAfter.put(1, 0.2);
+        int iterations = 2;
+
+        NeuralNetConfiguration conf = new NeuralNetConfiguration.Builder()
+                .learningRate(lr).momentum(mu).momentumAfter(momentumAfter).schedules(true).iterations(iterations)
+                .layer(new DenseLayer.Builder()
+                        .nIn(nIn).nOut(nOut).updater(org.deeplearning4j.nn.conf.Updater.NESTEROVS).build())
+                .build();
+
+        Layer layer = LayerFactories.getFactory(conf).create(conf, null, 0);
+        Updater updater = UpdaterCreator.getUpdater(layer);
+
+        Gradient gradientExpected = new DefaultGradient();
+        gradientExpected.setGradientFor(DefaultParamInitializer.WEIGHT_KEY, weightGradient);
+        gradientExpected.setGradientFor(DefaultParamInitializer.BIAS_KEY, biasGradient);
+
+        for (int i = 0; i < 2; i++) {
+            updater.update(layer, gradientSingle, i);
+            mu = testNesterovsComputation(gradientSingle, gradientExpected, lr, mu, momentumAfter, i);
+            assertEquals(mu, layer.conf().getLayer().getMomentum(), 1e-4);
+        }
+    }
+
+    @Test
+    public void testMomentumAfterMLN(){
+        double lr = 1e-2;
+        double mu = 0.6;
+        Map<Integer,Double> momentumAfter = new HashMap<>();
+        momentumAfter.put(1, 0.2);
+        int iterations = 2;
+        int nLayers = 2;
+        int[] nIns = {4,2};
+        int[] nOuts = {2,3};
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .learningRate(lr).momentum(mu).momentumAfter(momentumAfter).schedules(true).iterations(iterations)
+                .list(nLayers)
+                .layer(0, new DenseLayer.Builder().nIn(nIns[0]).nOut(nOuts[0]).updater(org.deeplearning4j.nn.conf.Updater.NESTEROVS).build())
+                .layer(1, new OutputLayer.Builder().nIn(nIns[1]).nOut(nOuts[1]).updater(org.deeplearning4j.nn.conf.Updater.NESTEROVS).build())
+                .backprop(true).pretrain(false)
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        Updater updater = UpdaterCreator.getUpdater(net);
+
+        String wKey, bKey;
+
+        Gradient gradientExpected = new DefaultGradient();
+        for (int k=0; k < nLayers; k++){
+            wKey = String.valueOf(k) + "_" + DefaultParamInitializer.WEIGHT_KEY;
+            gradientExpected.setGradientFor(wKey, weightGradient);
+            bKey = String.valueOf(k) + "_" + DefaultParamInitializer.BIAS_KEY ;
+            gradientExpected.setGradientFor(bKey, biasGradient);
+        }
+
+        for (int i = 0; i < 2; i++) {
+            updater.update(net, gradientMLN, i);
+            mu = testNesterovsComputation(gradientMLN, gradientExpected, lr, mu, momentumAfter, i);
+            assertEquals(mu, net.getLayer(1).conf().getLayer().getMomentum(), 1e-4);
+        }
+    }
+
+///// Updater Calculations
+
+    public double testSGDComputation(Gradient gradientActual, Gradient gradientExpected, double lr, Map<Integer, Double> learningRateAfter, int i){
+        for (Map.Entry<String, INDArray> entry : gradientExpected.gradientForVariable().entrySet()) {
+            if (learningRateAfter != null)
+                lr = (learningRateAfter.containsKey(i)) ? learningRateAfter.get(i) : lr;
+            key = entry.getKey();
+            val = entry.getValue();
+            gradExpected = val.mul(lr);
+            gradientExpected.setGradientFor(key, gradExpected);
+            assertEquals(gradExpected, gradientActual.getGradientFor(key));
+        }
+        return lr;
+    }
+
+    public double testNesterovsComputation(Gradient gradientActual, Gradient gradientExpected, double lr, double mu, Map<Integer, Double> momentumAfter, int i) {
+
+        for (Map.Entry<String, INDArray> entry : gradientExpected.gradientForVariable().entrySet()) {
+            if(momentumAfter !=null)
+                mu = (momentumAfter.containsKey(i)) ? momentumAfter.get(i) : mu;
+            key = entry.getKey();
+            val = entry.getValue();
+            INDArray vTmp = tmpStorage.get(key);
+
+            if(vTmp == null)
+                vTmp = Nd4j.zeros(val.shape());
+            vPrev = vTmp;
+            vTmp = vPrev.mul(mu).subi(val.mul(lr));
+            gradExpected = vPrev.muli(mu).addi(vTmp.mul(-mu - 1));
+            gradientExpected.setGradientFor(key, gradExpected);
+
+            assertEquals(gradExpected, gradientActual.getGradientFor(entry.getKey()));
+            tmpStorage.put(key, vTmp);
+        }
+        return mu;
+    }
+
+
+    public double testAdaGradComputation(Gradient gradientActual, Gradient gradientExpected, double lr, Map<Integer, Double> learningRateAfter, int i) {
+
+        for (Map.Entry<String, INDArray> entry : gradientExpected.gradientForVariable().entrySet()) {
+            if (learningRateAfter != null)
+                lr = (learningRateAfter.containsKey(i)) ? learningRateAfter.get(i) : lr;
+            key = entry.getKey();
+            val = entry.getValue();
+            INDArray historicalGradient = tmpStorage.get(key);
+
+            if(historicalGradient == null) historicalGradient = val.mul(val);
+            else historicalGradient.addi(val.mul(val));
+
+            gradExpected = Transforms.sqrt(historicalGradient.add(epsilon)).rdiv(lr).mul(val);
+            assertEquals(gradExpected, gradientActual.getGradientFor(key));
+            gradientExpected.setGradientFor(key, gradExpected);
+            tmpStorage.put(key, historicalGradient);
+        }
+
+        return lr;
+    }
+
+    public double testAdamComputation(Gradient gradientActual, Gradient gradientExpected, double lr, Map<Integer, Double> learningRateAfter, int i) {
+        double beta1 = 0.9;
+        double beta2 = 0.999;
+
+        for (Map.Entry<String, INDArray> entry : gradientExpected.gradientForVariable().entrySet()) {
+            if (learningRateAfter != null)
+                lr = (learningRateAfter.containsKey(i)) ? learningRateAfter.get(i) : lr;
+            key = entry.getKey();
+            val = entry.getValue();
+
+            INDArray mTmp = tmpStorage2.get(key);
+            INDArray vTmp = tmpStorage3.get(key);
+
+            if(mTmp == null) mTmp = Nd4j.zeros(val.shape());
+            if(vTmp == null) vTmp = Nd4j.zeros(val.shape());
+
+            mTmp.muli(beta1).addi(val.mul(1.0-beta1));
+            vTmp.muli(beta2).addi(val.mul(val).mul(1.0-beta2));
+
+            double beta1t = FastMath.pow(beta1, i);
+            double beta2t = FastMath.pow(beta2, i);
+            double alphat = lr * FastMath.sqrt(1-beta2t)/(1-beta1t);
+
+            gradExpected = mTmp.mul(alphat).divi(Transforms.sqrt(vTmp).addi(epsilon));
+            gradientExpected.setGradientFor(key, gradExpected);
+            assertEquals(gradExpected, gradientActual.getGradientFor(key));
+
+            tmpStorage2.put(key, mTmp);
+            tmpStorage3.put(key, vTmp);
+        }
+        return lr;
+    }
+
+    public double testRMSPropComputation(Gradient gradientActual, Gradient gradientExpected, double lr, Map<Integer, Double> learningRateAfter, int i) {
+        double rmsDecay = 0.95;
+
+        for (Map.Entry<String, INDArray> entry : gradientExpected.gradientForVariable().entrySet()) {
+            if (learningRateAfter != null)
+                lr = (learningRateAfter.containsKey(i)) ? learningRateAfter.get(i) : lr;
+            key = entry.getKey();
+            val = entry.getValue();
+            INDArray lastGTmp = tmpStorage4.get(key);
+
+            if(lastGTmp==null)
+                lastGTmp = Nd4j.zeros(val.shape());
+
+            lastGTmp.muli(rmsDecay).addi(val.mul(val).muli(1 - rmsDecay));
+            gradExpected = val.mul(lr).div(Transforms.sqrt(lastGTmp.add(Nd4j.EPS_THRESHOLD)));
+            gradientExpected.setGradientFor(key, gradExpected);
+
+            assertEquals(gradExpected, gradientActual.getGradientFor(key));
+            tmpStorage4.put(key, lastGTmp);
+        }
+
+        return lr;
+    }
+}
+

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
@@ -329,7 +329,6 @@ public class TestUpdaters {
 				assertEquals(gradExpected, g.getGradientFor(entry.getKey()));
 				v.put(key, vTmp);
 			}
-			v =  new HashMap<>();
 			assertEquals(lr, net.getLayer(1).conf().getLayer().getLearningRate(), 1e-4);
 		}
 	}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
@@ -365,8 +365,8 @@ public class TestUpdaters {
         int[] nOuts = {2,3};
 		int oldScore = 1;
 		int newScore = 1;
-		int iteration = 1;
-        INDArray gradient = Nd4j.ones(nIns[0],nOuts[0]);
+		int iteration = 3;
+        INDArray gradientW = Nd4j.ones(nIns[0],nOuts[0]);
 
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .learningRate(lr).learningRateScoreBasedDecayRate(lrScoreDecay)
@@ -380,9 +380,10 @@ public class TestUpdaters {
         net.init();
 
 		ConvexOptimizer opt = new StochasticGradientDescent(net.getDefaultConfiguration(), new NegativeDefaultStepFunction(), null, net);
-        opt.checkTerminalConditions(gradient, oldScore, newScore, iteration);
+        opt.checkTerminalConditions(gradientW, oldScore, newScore, iteration);
 		assertEquals(lrScoreDecay, net.getLayer(0).conf().getLayer().getLrScoreBasedDecay(), 1e-4);
-		assertEquals(lr/(lrScoreDecay + Nd4j.EPS_THRESHOLD), opt.getConf().getLayer().getLearningRate(), 1e-4);
+		assertEquals(lr/(lrScoreDecay + Nd4j.EPS_THRESHOLD), net.getLayer(0).conf().getLayer().getLearningRate(), 1e-4);
+
 	}
 
     @Test

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/updater/TestUpdaters.java
@@ -359,7 +359,7 @@ public class TestUpdaters {
     @Test
     public void testLrScoreDecay(){
         double lr = 0.01;
-        double lrScoreDecay = 10;
+        double lrScoreDecay = 0.10;
         int nLayers = 2;
         int[] nIns = {4,2};
         int[] nOuts = {2,3};
@@ -382,7 +382,7 @@ public class TestUpdaters {
 		ConvexOptimizer opt = new StochasticGradientDescent(net.getDefaultConfiguration(), new NegativeDefaultStepFunction(), null, net);
         opt.checkTerminalConditions(gradientW, oldScore, newScore, iteration);
 		assertEquals(lrScoreDecay, net.getLayer(0).conf().getLayer().getLrScoreBasedDecay(), 1e-4);
-		assertEquals(lr/(lrScoreDecay + Nd4j.EPS_THRESHOLD), net.getLayer(0).conf().getLayer().getLearningRate(), 1e-4);
+		assertEquals(lr*(lrScoreDecay + Nd4j.EPS_THRESHOLD), net.getLayer(0).conf().getLayer().getLearningRate(), 1e-4);
 
 	}
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
@@ -352,6 +352,11 @@ public class TestOptimizers {
         }
 
         @Override
+        public void applyLearningRateScoreDecay() {
+
+        }
+
+        @Override
         public void setListeners(IterationListener... listeners) {
 
         }
@@ -495,6 +500,10 @@ public class TestOptimizers {
             this.score =  costFn;
         }
 
+        @Override
+        public void applyLearningRateScoreDecay() {
+
+        }
 
 
         @Override
@@ -651,7 +660,10 @@ public class TestOptimizers {
 
         }
 
+        @Override
+        public void applyLearningRateScoreDecay() {
 
+        }
 
 
         @Override

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/rntn/RNTN.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/rntn/RNTN.java
@@ -917,6 +917,11 @@ public class RNTN implements Layer {
         computeGradientAndScore();
     }
 
+    @Override
+    public void applyLearningRateScoreDecay() {
+
+    }
+
     public int getNumParameters() {
         if(numParameters < 0) {
             int totalSize = 0;


### PR DESCRIPTION
- Fixed learning rate adjustment for score termination condition (no longer changes) met
- Applied learningRateSchedule and moved momentumSchedule inside BaseUpdater
- If learningRate or momentum changes then it will update the existing layer config and create a new updater instance
- Expanded documentation on neuralnetconfig and layer
- Added tests for the updaters

