### PR TITLE
Implement best score tracking during spark optimisation

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/BestScoreAccumulator.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/BestScoreAccumulator.java
@@ -1,0 +1,33 @@
+package org.deeplearning4j.spark.impl.common;
+
+import org.apache.spark.Accumulator;
+import org.apache.spark.AccumulatorParam;
+import org.apache.spark.SparkContext;
+
+/**
+ * Accumulator which tracks best score seen.
+ *
+ * Created by mlapan on 27/10/15.
+ */
+public class BestScoreAccumulator implements AccumulatorParam<Double> {
+    public static final String NAME = "Best score";
+
+    @Override
+    public Double addAccumulator(Double v1, Double v2) {
+        return Math.min(v1, v2);
+    }
+
+    @Override
+    public Double addInPlace(Double v1, Double v2) {
+        return Math.min(v1, v2);
+    }
+
+    @Override
+    public Double zero(Double init) {
+        return Double.POSITIVE_INFINITY;
+    }
+    
+    public static Accumulator<Double> create(SparkContext sc) {
+        return sc.accumulator(Double.POSITIVE_INFINITY, NAME, new BestScoreAccumulator());
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/BestScoreIterationListener.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/BestScoreIterationListener.java
@@ -1,0 +1,33 @@
+package org.deeplearning4j.spark.impl.common;
+
+import org.apache.spark.Accumulator;
+import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.optimize.api.IterationListener;
+
+/**
+ * Iteration listener which sends score to BestScoreAcumulator
+ *
+ * Created by mlapan on 27/10/15.
+ */
+public class BestScoreIterationListener implements IterationListener {
+    private Accumulator<Double> best_score_acc = null;
+
+    public BestScoreIterationListener(Accumulator<Double> best_score_acc) {
+        this.best_score_acc = best_score_acc;
+    }
+
+    @Override
+    public boolean invoked() {
+        return false;
+    }
+
+    @Override
+    public void invoke() {
+    }
+
+    @Override
+    public void iterationDone(Model model, int iteration) {
+        if (best_score_acc != null)
+            best_score_acc.add(model.score());
+    }
+}


### PR DESCRIPTION
I find it convenient to track best score during optimisation of large models. With this patch, spark shows best score for every iteration in task's UI.