### PR TITLE
activateSelectedLayers

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -489,6 +489,26 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         return ret;
     }
 
+    /**
+     * Calculate activation for few layers at once. Suitable for autoencoder partial activation.
+     *
+     * In example: in 10-layer deep autoencoder, layers 0 - 4 inclusive are used for encoding part, and layers 5-9 inclusive are used for decoding part.
+     *
+     * @param from first layer to be activated, inclusive
+     * @param to last layer to be activated, inclusive
+     * @return the activation from the last layer
+     */
+    public INDArray activateSelectedLayers(int from, int to, INDArray input) {
+        if (input == null) throw new IllegalStateException("Unable to perform activation; no input found");
+        if (from < 0 || from >= layers.length || from >= to) throw new IllegalStateException("Unable to perform activation; FROM is out of layer space");
+        if (to < 1 || to >= layers.length) throw new IllegalStateException("Unable to perform activation; TO is out of layer space");
+
+        INDArray res = input;
+        for (int l = from; l <= to; l++) {
+            res = this.activationFromPrevLayer(l, res, false);
+        }
+        return res;
+    }
 
     /**
      * * Compute input linear transformation (z) of the output layer

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
@@ -31,6 +31,7 @@ import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
 import org.deeplearning4j.nn.conf.distribution.UniformDistribution;
 import org.deeplearning4j.nn.conf.layers.BatchNormalization;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RBM;
 import org.deeplearning4j.nn.layers.BaseOutputLayer;
 import org.deeplearning4j.nn.weights.WeightInit;
@@ -326,6 +327,79 @@ public class MultiLayerTest {
         assertEquals(first.size(), second.size());
     }
 
+    /**
+     *  This test intended only to test activateSelectedLayers method, it does not involves fully-working AutoEncoder.
+     */
+    @Test
+    public void testSelectedActivations() {
+        // Train DeepAutoEncoder on very limited trainset
+        final int numRows = 28;
+        final int numColumns = 28;
+        int seed = 123;
+        int numSamples = 3;
+        int iterations = 1;
+        int listenerFreq = iterations/5;
+
+        log.info("Load data....");
+
+        float[][] trainingData = new float[numSamples][numColumns * numRows];
+        Arrays.fill(trainingData[0],0.95f);
+        Arrays.fill(trainingData[1],0.5f);
+        Arrays.fill(trainingData[2], 0.05f);
+
+
+
+        log.info("Build model....");
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .seed(seed)
+                .iterations(iterations)
+                .optimizationAlgo(OptimizationAlgorithm.LINE_GRADIENT_DESCENT)
+                .list(10)
+                .layer(0, new RBM.Builder().nIn(numRows * numColumns).nOut(1000).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build())
+                .layer(1, new RBM.Builder().nIn(1000).nOut(500).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build())
+                .layer(2, new RBM.Builder().nIn(500).nOut(250).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build())
+                .layer(3, new RBM.Builder().nIn(250).nOut(100).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build())
+                .layer(4, new RBM.Builder().nIn(100).nOut(30).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build()) //encoding stops
+                .layer(5, new RBM.Builder().nIn(30).nOut(100).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build()) //decoding starts
+                .layer(6, new RBM.Builder().nIn(100).nOut(250).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build())
+                .layer(7, new RBM.Builder().nIn(250).nOut(500).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build())
+                .layer(8, new RBM.Builder().nIn(500).nOut(1000).lossFunction(LossFunctions.LossFunction.RMSE_XENT).build())
+                .layer(9, new OutputLayer.Builder(LossFunctions.LossFunction.RMSE_XENT).nIn(1000).nOut(numRows*numColumns).build())
+                .pretrain(true).backprop(true)
+                .build();
+
+        MultiLayerNetwork model = new MultiLayerNetwork(conf);
+        model.init();
+
+        model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
+
+        log.info("Train model....");
+        int cnt = 0;
+        while(cnt < numSamples) {
+            INDArray input = Nd4j.create(trainingData[cnt]);
+            model.fit(new DataSet(input, input));
+            cnt++;
+        }
+        // Make two separate selective calls
+
+        log.info("Testing full cycle...");
+
+        List<INDArray> comparableResult = model.feedForward(Nd4j.create(trainingData[0]));
+
+        INDArray encodeResult = model.activateSelectedLayers(0,4, Nd4j.create(trainingData[0]));
+
+        log.info("Compare feedForward results with selectedActivation");
+
+        assertEquals(comparableResult.get(5), encodeResult);
+
+        INDArray decodeResults = model.activateSelectedLayers(5,9, encodeResult);
+
+
+        log.info("Decode results: " + decodeResults.columns() + " " + decodeResults);
+        log.info("Comparable  results: " + comparableResult.get(10).columns() + " " + comparableResult.get(10));
+
+        assertEquals(comparableResult.get(10), decodeResults);
+    }
 
     private static MultiLayerConfiguration getConf(){
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()


### PR DESCRIPTION
Calculate activation for few layers at once. Suitable for autoencoder partial activation.

As for comments:

Q. What if input is already set?
A. As i can see, activationFromPrevLayer(int curr, INDArray input,boolean training) method, used in activateSelectedLayers fills input, regardless of its previous state, and feedForward(INDArray input) works in the same way. So i dont see problems here - similar functions are declared and work in the same way.

Q. Use slf4j for output.
A. Fixed.

Q. Squash the commit.
A. Done, sorry, i'm still new to git mechanics :)
