### PR TITLE
Add iterator reset where possible

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/canova/RecordReaderDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/canova/RecordReaderDataSetIterator.java
@@ -31,10 +31,7 @@ import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.FeatureUtil;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 
 /**
@@ -247,9 +244,13 @@ public class RecordReaderDataSetIterator implements DataSetIterator {
 
 
     }
+
     @Override
     public void reset() {
-
+        if (recordReader instanceof RecordReader)
+            recordReader.reset();
+        else if (recordReader instanceof SequenceRecordReader)
+            throw new UnsupportedOperationException("Reset not supported for SequenceRecordReader type.");
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/canova/SequenceRecordReaderDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/canova/SequenceRecordReaderDataSetIterator.java
@@ -132,7 +132,7 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
 
     @Override
     public void reset() {
-
+        throw new UnsupportedOperationException("Reset not supported for this iterator");
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIterator.java
@@ -48,12 +48,11 @@ public class MultipleEpochsIterator implements DataSetIterator {
     @Override
     public DataSet next(int num) {
         if(!iter.hasNext()) {
+            log.info("Epoch " + passes + ", number of batches completed " + batch);
             if(passes < numPasses) {
                 passes++;
                 batch = 0;
-                log.info("Epoch " + passes + " batch " + batch);
                 iter.reset();
-
             }
         }
         batch++;
@@ -161,12 +160,11 @@ public class MultipleEpochsIterator implements DataSetIterator {
     @Override
     public DataSet next() {
         if(!iter.hasNext()) {
+            log.info("Epoch " + passes + " batch " + batch);
             if(passes < numPasses) {
                 passes++;
                 batch = 0;
-                log.info("Epoch " + passes + " batch " + batch);
                 iter.reset();
-
             }
         }
         batch++;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIterator.java
@@ -18,6 +18,7 @@
 
 package org.deeplearning4j.datasets.iterator;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.nd4j.linalg.dataset.DataSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,12 +27,13 @@ import org.slf4j.LoggerFactory;
  * A dataset iterator for doing multiple passes over a dataset
  */
 public class MultipleEpochsIterator implements DataSetIterator {
-    private int numPasses;
-    private int batch = 0;
-    private DataSetIterator iter;
-    private int passes = 0;
-    private static final Logger log = LoggerFactory.getLogger(MultipleEpochsIterator.class);
-    private DataSetPreProcessor preProcessor;
+    @VisibleForTesting
+    protected int numPasses;
+    protected int batch = 0;
+    protected DataSetIterator iter;
+    protected int passes = 0;
+    protected static final Logger log = LoggerFactory.getLogger(MultipleEpochsIterator.class);
+    protected DataSetPreProcessor preProcessor;
 
     public MultipleEpochsIterator(int numPasses,DataSetIterator iter) {
         this.numPasses = numPasses;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIteratorTest.java
@@ -1,0 +1,73 @@
+package org.deeplearning4j.datasets.iterator;
+
+import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.impl.FileRecordReader;
+import org.canova.api.split.FileSplit;
+import org.deeplearning4j.datasets.canova.RecordReaderDataSetIterator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by nyghtowl on 11/14/15.
+ */
+public class MultipleEpochsIteratorTest {
+
+    protected File file1, file2, file3, file4, newPath;
+    protected static String localPath = System.getProperty("java.io.tmpdir") + File.separator;
+    protected static String testPath = localPath + "test-folder" + File.separator;
+
+
+    @Before
+    public void doBefore() throws IOException {
+        newPath = new File(testPath);
+
+        newPath.mkdir();
+
+        file1 = File.createTempFile("myfile_1", ".jpg", newPath);
+        file2 = File.createTempFile("myfile_2", ".txt", newPath);
+        file3 = File.createTempFile("myfile_3", ".jpg", newPath);
+        file4 = File.createTempFile("treehouse_4", ".jpg", newPath);
+    }
+
+
+    @Test
+    public void testNextAndReset() throws Exception{
+        int epochs = 2;
+        int batchSize = 2;
+
+        RecordReader recordReader = new FileRecordReader();
+        recordReader.initialize(new FileSplit(new File(testPath)));
+        DataSetIterator iter = new RecordReaderDataSetIterator(recordReader, batchSize);
+        MultipleEpochsIterator multiIter = new MultipleEpochsIterator(epochs, iter);
+
+        assertTrue(multiIter.hasNext());
+        while(multiIter.hasNext()){
+            multiIter.next();
+        }
+        assertEquals(false, multiIter.hasNext());
+        multiIter.reset();
+        assertTrue(multiIter.hasNext());
+        assertEquals(epochs, multiIter.numPasses, 0.0);
+
+    }
+
+
+    @After
+    public void doAfter(){
+        file1.delete();
+        file2.delete();
+        file3.delete();
+        file4.delete();
+        newPath.delete();
+    }
+
+
+
+}


### PR DESCRIPTION
Added test to confirm functionality
Adjuste MultipleEpochIterator so it will work now with reset
Reset does not work on Collections<Writables> thus SequenceRecordReaderDSIterator cannot be used with MultEpochs yet.