### PR TITLE
Huffman Tree sorting fixed, PrefetchingSentenceIterator fixed

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Huffman.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Huffman.java
@@ -18,6 +18,8 @@
 
 package org.deeplearning4j.models.word2vec;
 
+import org.deeplearning4j.models.word2vec.wordstore.VocabularyWord;
+
 import java.util.*;
 
 
@@ -30,6 +32,13 @@ public class Huffman {
 
     public Huffman(Collection<VocabWord> words) {
         this.words = new ArrayList<>(words);
+        Collections.sort(this.words, new Comparator<VocabWord>() {
+            @Override
+            public int compare(VocabWord o1, VocabWord o2) {
+                return Double.compare(o2.getWordFrequency(), o1.getWordFrequency());
+            }
+
+        });
     }
 
     private List<VocabWord> words;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/sentenceiterator/PrefetchingSentenceIteratorTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/sentenceiterator/PrefetchingSentenceIteratorTest.java
@@ -23,6 +23,7 @@ public class PrefetchingSentenceIteratorTest {
         BasicLineIterator iterator = new BasicLineIterator(file);
 
         PrefetchingSentenceIterator fetcher = new PrefetchingSentenceIterator.Builder(iterator)
+                .setFetchSize(1000)
                 .build();
 
         log.info("Phase 1 starting");
@@ -47,5 +48,31 @@ public class PrefetchingSentenceIteratorTest {
         }
 
         assertEquals(97162, cnt);
+    }
+
+    @Test
+    public void testLoadedIterator1() throws Exception {
+        ClassPathResource resource = new ClassPathResource("/big/raw_sentences.txt");
+        File file = resource.getFile();
+        BasicLineIterator iterator = new BasicLineIterator(file);
+
+        PrefetchingSentenceIterator fetcher = new PrefetchingSentenceIterator.Builder(iterator)
+                .setFetchSize(1000)
+                .build();
+
+        log.info("Phase 1 starting");
+
+        int cnt = 0;
+        while (fetcher.hasNext()) {
+            String line = fetcher.nextSentence();
+            // we'll imitate some workload in current thread by using ThreadSleep.
+            // there's no need to keep it enabled forever, just uncomment next line if you're going to test this iterator.
+            // otherwise this test will
+
+           //    Thread.sleep(0, 10);
+
+            cnt++;
+            if (cnt % 10000 == 0) log.info("Line processed: " + cnt);
+        }
     }
 }


### PR DESCRIPTION
Huffman Tree sorting fixed in original dl4j Huffman impl

PrefetchingSentenceIterator fixed and introduced: simple way to offload cpu-intensive iterators or SentencePreProcessor implementations to separate thread. Compatible with all SentenceIterator implementations.