### PR TITLE
Deprecate `GradientPlotterIterationListener` and NeuralNetPlotterIterationListener

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/NeuralNetPlotter.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/NeuralNetPlotter.java
@@ -45,7 +45,10 @@ import org.springframework.core.io.ClassPathResource;
  * for visualizations
  * @author Adam Gibson
  *
+ * @deprecated take a look at deeplearning4j-ui as new visualisation means
+ *
  */
+@Deprecated
 public class NeuralNetPlotter implements Serializable {
 
     private static 	ClassPathResource script = new ClassPathResource("scripts" + File.separator + "plot.py");

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/AccuracyPlotterIterationListener.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/AccuracyPlotterIterationListener.java
@@ -13,8 +13,11 @@ import java.util.ArrayList;
 /**
  *
  * Reference: https://cs231n.github.io/neural-networks-3/
+ *
+ * @deprecated try to use deeplearning4j-ui instead
  */
 
+@Deprecated
 public class AccuracyPlotterIterationListener implements IterationListener {
     private int epochs = 1; // number times the model saw all the data
     private INDArray input;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/GradientPlotterIterationListener.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/GradientPlotterIterationListener.java
@@ -7,7 +7,10 @@ import org.deeplearning4j.plot.NeuralNetPlotter;
 
 /**
  * Plots weight distributions and activation probabilities
+ *
+ * @deprecated use {@link org.deeplearning4j.ui.weights.HistogramIterationListener} from deeplearning4j-ui instead
  */
+@Deprecated
 public class GradientPlotterIterationListener implements IterationListener {
     private int iterations = 10;
     private NeuralNetPlotter plotter = new NeuralNetPlotter();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/LossPlotterIterationListener.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/LossPlotterIterationListener.java
@@ -22,8 +22,11 @@ import java.util.UUID;
 
 /**
  * Reference: https://cs231n.github.io/neural-networks-3/
+ *
+ * @deprecated try to use deeplearning4j-ui instead
  */
 
+@Deprecated
 public class LossPlotterIterationListener implements IterationListener {
     private int iterations = 1;
     private NeuralNetPlotter plotter = new NeuralNetPlotter();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/NeuralNetPlotterIterationListener.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/NeuralNetPlotterIterationListener.java
@@ -26,7 +26,10 @@ import org.deeplearning4j.plot.NeuralNetPlotter;
 /**
  * Renders network activations every n iterations
  * @author Adam Gibson
+ *
+ * @deprecated use {@link org.deeplearning4j.ui.weights.HistogramIterationListener} from deeplearning4j-ui instead
  */
+@Deprecated
 public class NeuralNetPlotterIterationListener implements IterationListener {
     private int iterations = 10;
     private NeuralNetPlotter plotter = new NeuralNetPlotter();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/RenderFilterIterationListener.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/iterationlistener/RenderFilterIterationListener.java
@@ -5,7 +5,10 @@ import org.deeplearning4j.nn.api.Model;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.plot.NeuralNetPlotter;
 
-
+/**
+ * @deprecated try to use deeplearning4j-ui instead
+ */
+@Deprecated
 public class RenderFilterIterationListener implements IterationListener {
     private int iterations = 10;
     private NeuralNetPlotter plotter = new NeuralNetPlotter();


### PR DESCRIPTION
According to the #958, they are not supported anymore.