### PR TITLE
Mw spark runiteration

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -25,6 +25,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
+import org.deeplearning4j.nn.params.PretrainParamInitializer;
 import org.deeplearning4j.optimize.Solver;
 import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.IterationListener;
@@ -470,7 +471,16 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
 
     @Override
     public int numParams(boolean backwards) {
-        return numParams();
+        if(backwards==true){
+            int ret = 0;
+            for(Map.Entry<String,INDArray> entry : params.entrySet()){
+                if(this instanceof BasePretrainNetwork && PretrainParamInitializer.VISIBLE_BIAS_KEY.equals(entry.getKey())) continue;
+                ret += entry.getValue().length();
+            }
+            return ret;
+        }
+        else
+            return numParams();
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -19,7 +19,6 @@
 package org.deeplearning4j.nn.multilayer;
 
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.nn.api.*;
@@ -963,17 +962,16 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
      */
     @Override
     public int numParams() {
-        int length = 0;
-        for (int i = 0; i < layers.length; i++)
-            length += layers[i].numParams();
-
-        return length;
-
+        return numParams(false);
     }
 
     @Override
     public int numParams(boolean backwards) {
-        return numParams();
+        int length = 0;
+        for (int i = 0; i < layers.length; i++)
+            length += layers[i].numParams(backwards);
+
+        return length;
     }
 
     /**
@@ -1145,6 +1143,8 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
 
         }
         if (layerWiseConfigurations.isBackprop()) {
+            if(layerWiseConfigurations.isPretrain())
+                iter.reset();
             while (iter.hasNext()) {
                 DataSet next = iter.next();
                 if (next.getFeatureMatrix() == null || next.getLabels() == null)
@@ -1752,6 +1752,11 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
     @Override
     public double score() {
         return score;
+    }
+
+
+    public void setScore(double score) {
+        this.score = score;
     }
 
     @Override

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/INDArrayFromTupleFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/INDArrayFromTupleFunction.java
@@ -2,14 +2,12 @@ package org.deeplearning4j.spark.impl.common.misc;
 
 import org.apache.spark.api.java.function.Function;
 import org.deeplearning4j.nn.api.Updater;
-import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import scala.Tuple2;
 import scala.Tuple3;
 
-public class INDArrayFromTupleFunction implements Function<Tuple2<MultiLayerNetwork,Double>,INDArray> {
+public class INDArrayFromTupleFunction implements Function<Tuple3<INDArray,Updater,Double>,INDArray> {
     @Override
-    public INDArray call(Tuple2<MultiLayerNetwork, Double> indArrayTuple2) throws Exception {
-        return indArrayTuple2._1().params();
+    public INDArray call(Tuple3<INDArray, Updater, Double> indArrayTuple2) throws Exception {
+        return indArrayTuple2._1();
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/INDArrayFromTupleFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/INDArrayFromTupleFunction.java
@@ -2,13 +2,14 @@ package org.deeplearning4j.spark.impl.common.misc;
 
 import org.apache.spark.api.java.function.Function;
 import org.deeplearning4j.nn.api.Updater;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import scala.Tuple2;
 import scala.Tuple3;
 
-public class INDArrayFromTupleFunction implements Function<Tuple3<INDArray,Updater,Double>,INDArray> {
+public class INDArrayFromTupleFunction implements Function<Tuple2<MultiLayerNetwork,Double>,INDArray> {
     @Override
-    public INDArray call(Tuple3<INDArray, Updater, Double> indArrayTuple2) throws Exception {
-        return indArrayTuple2._1();
+    public INDArray call(Tuple2<MultiLayerNetwork, Double> indArrayTuple2) throws Exception {
+        return indArrayTuple2._1().params();
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/UpdaterFromTupleFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/UpdaterFromTupleFunction.java
@@ -2,14 +2,13 @@ package org.deeplearning4j.spark.impl.common.misc;
 
 import org.apache.spark.api.java.function.Function;
 import org.deeplearning4j.nn.api.Updater;
-import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import scala.Tuple2;
 import scala.Tuple3;
 
-public class UpdaterFromTupleFunction implements Function<Tuple2<MultiLayerNetwork, Double>,Updater> {
+
+public class UpdaterFromTupleFunction implements Function<Tuple3<INDArray,Updater,Double>,Updater> {
     @Override
-    public Updater call(Tuple2<MultiLayerNetwork, Double> t2) throws Exception {
-        return t2._1().getUpdater();
+    public Updater call(Tuple3<INDArray, Updater, Double> indArrayTuple2) throws Exception {
+        return indArrayTuple2._2();
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/UpdaterFromTupleFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/misc/UpdaterFromTupleFunction.java
@@ -2,12 +2,14 @@ package org.deeplearning4j.spark.impl.common.misc;
 
 import org.apache.spark.api.java.function.Function;
 import org.deeplearning4j.nn.api.Updater;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import scala.Tuple2;
 import scala.Tuple3;
 
-public class UpdaterFromTupleFunction implements Function<Tuple3<INDArray,Updater,Double>,Updater> {
+public class UpdaterFromTupleFunction implements Function<Tuple2<MultiLayerNetwork, Double>,Updater> {
     @Override
-    public Updater call(Tuple3<INDArray, Updater, Double> indArrayTuple2) throws Exception {
-        return indArrayTuple2._2();
+    public Updater call(Tuple2<MultiLayerNetwork, Double> t2) throws Exception {
+        return t2._1().getUpdater();
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/IterativeReduceFlatMap.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/IterativeReduceFlatMap.java
@@ -19,9 +19,7 @@
 package org.deeplearning4j.spark.impl.multilayer;
 
 import org.apache.spark.Accumulator;
-import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.Function;
 import org.apache.spark.broadcast.Broadcast;
 import org.deeplearning4j.nn.api.Updater;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
@@ -33,7 +31,6 @@ import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Tuple2;
 import scala.Tuple3;
 
 import java.util.ArrayList;
@@ -47,45 +44,61 @@ import java.util.List;
  *
  * @author Adam Gibson
  */
-public class IterativeReduceFlatMap implements Function<DataSet, Tuple2<MultiLayerNetwork,Double>> {
 
-    protected SparkContext sc;
-    protected MultiLayerNetwork network;
-//    protected Broadcast<INDArray> params;
-//    protected Broadcast<Updater> updater;
+
+public class IterativeReduceFlatMap implements FlatMapFunction<Iterator<DataSet>,Tuple3<INDArray,Updater,Double>> {
     protected static Logger log = LoggerFactory.getLogger(IterativeReduceFlatMap.class);
 
-    protected final Accumulator<Double> best_score_acc;
+    private String json;
+    private Broadcast<INDArray> params;
+    private Broadcast<Updater> updater;
+
+    private final Accumulator<Double> best_score_acc;
 
     /**
      * Pass in json configuration and baseline parameters
-     * @param json json configuration for the network
-     * @param params the parameters to use for the network
+     *
+     * @param json         json configuration for the network
+     * @param params       the parameters to use for the network
      * @param bestScoreAcc accumulator which tracks best score seen
      */
-//    public IterativeReduceFlatMap(String json, Broadcast<INDArray> params, Broadcast<Updater> updater,
-//                                  Accumulator<Double> bestScoreAcc) {
-//        this.json = json;
-//        this.params = params;
-//        this.updater = updater;
-//        if(updater.getValue() == null)
-//            throw new IllegalArgumentException("Updater shouldn't be null");
-//        this.best_score_acc = bestScoreAcc;
-//    }
-
-
-    public IterativeReduceFlatMap(MultiLayerNetwork network, Accumulator<Double> bestScoreAcc) {
-        this.network = network;
+    public IterativeReduceFlatMap(String json, Broadcast<INDArray> params, Broadcast<Updater> updater,
+                                  Accumulator<Double> bestScoreAcc) {
+        this.json = json;
+        this.params = params;
+        this.updater = updater;
+        if (updater.getValue() == null)
+            throw new IllegalArgumentException("Updater shouldn't be null");
         this.best_score_acc = bestScoreAcc;
     }
 
+
     @Override
-    public Tuple2<MultiLayerNetwork, Double> call(DataSet dataSet) throws Exception {
+    public Iterable<Tuple3<INDArray, Updater, Double>> call(Iterator<DataSet> dataSetIterator) throws Exception {
+        if (!dataSetIterator.hasNext()) {
+            return Collections.singletonList(new Tuple3<INDArray, Updater, Double>(Nd4j.zeros(params.value().shape()), null, 0.0));
+        }
+        List<DataSet> collect = new ArrayList<>();
+        while (dataSetIterator.hasNext()) {
+            collect.add(dataSetIterator.next());
+        }
 
+        DataSet data = DataSet.merge(collect, false);
+        if (log.isDebugEnabled()) {
+            log.debug("Training on {} examples with data {}", data.numExamples(), data.labelCounts());
+        }
+        MultiLayerNetwork network = new MultiLayerNetwork(MultiLayerConfiguration.fromJson(json));
+        network.init();
         network.setListeners(new ScoreIterationListener(1), new BestScoreIterationListener(best_score_acc));
-        network.fit(dataSet);
+        INDArray val = params.value();
+        Updater upd = updater.getValue();
+        if (val.length() != network.numParams(false))
+            throw new IllegalStateException("Network did not have same number of parameters as the broadcasted set parameters");
+        network.setParameters(val);
+        network.setUpdater(upd);
+        network.fit(data);
 
-        return new Tuple2<>(network, network.score());
+        return Collections.singletonList(new Tuple3<>(network.params(false), network.getUpdater(), network.score()));
 
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/IterativeReduceFlatMap.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/IterativeReduceFlatMap.java
@@ -19,7 +19,9 @@
 package org.deeplearning4j.spark.impl.multilayer;
 
 import org.apache.spark.Accumulator;
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
 import org.apache.spark.broadcast.Broadcast;
 import org.deeplearning4j.nn.api.Updater;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
@@ -45,14 +47,15 @@ import java.util.List;
  *
  * @author Adam Gibson
  */
-public class IterativeReduceFlatMap implements FlatMapFunction<Iterator<DataSet>,Tuple3<INDArray,Updater,Double>> {
+public class IterativeReduceFlatMap implements Function<DataSet, Tuple2<MultiLayerNetwork,Double>> {
 
-    private String json;
-    private Broadcast<INDArray> params;
-    private Broadcast<Updater> updater;
-    private static Logger log = LoggerFactory.getLogger(IterativeReduceFlatMap.class);
+    protected SparkContext sc;
+    protected MultiLayerNetwork network;
+//    protected Broadcast<INDArray> params;
+//    protected Broadcast<Updater> updater;
+    protected static Logger log = LoggerFactory.getLogger(IterativeReduceFlatMap.class);
 
-    private final Accumulator<Double> best_score_acc;
+    protected final Accumulator<Double> best_score_acc;
 
     /**
      * Pass in json configuration and baseline parameters
@@ -60,44 +63,29 @@ public class IterativeReduceFlatMap implements FlatMapFunction<Iterator<DataSet>
      * @param params the parameters to use for the network
      * @param bestScoreAcc accumulator which tracks best score seen
      */
-    public IterativeReduceFlatMap(String json, Broadcast<INDArray> params, Broadcast<Updater> updater,
-                                  Accumulator<Double> bestScoreAcc) {
-        this.json = json;
-        this.params = params;
-        this.updater = updater;
-        if(updater.getValue() == null)
-            throw new IllegalArgumentException("Updater shouldn't be null");
+//    public IterativeReduceFlatMap(String json, Broadcast<INDArray> params, Broadcast<Updater> updater,
+//                                  Accumulator<Double> bestScoreAcc) {
+//        this.json = json;
+//        this.params = params;
+//        this.updater = updater;
+//        if(updater.getValue() == null)
+//            throw new IllegalArgumentException("Updater shouldn't be null");
+//        this.best_score_acc = bestScoreAcc;
+//    }
+
+
+    public IterativeReduceFlatMap(MultiLayerNetwork network, Accumulator<Double> bestScoreAcc) {
+        this.network = network;
         this.best_score_acc = bestScoreAcc;
     }
 
-
-
     @Override
-    public Iterable<Tuple3<INDArray,Updater,Double>> call(Iterator<DataSet> dataSetIterator) throws Exception {
-        if(!dataSetIterator.hasNext()) {
-            return Collections.singletonList(new Tuple3<INDArray,Updater,Double>(Nd4j.zeros(params.value().shape()),null,0.0));
-        }
-        List<DataSet> collect = new ArrayList<>();
-        while(dataSetIterator.hasNext()) {
-            collect.add(dataSetIterator.next());
-        }
+    public Tuple2<MultiLayerNetwork, Double> call(DataSet dataSet) throws Exception {
 
-        DataSet data = DataSet.merge(collect,false);
-        if(log.isDebugEnabled()) {
-            log.debug("Training on {} examples with data {}",data.numExamples(), data.labelCounts());
-        }
-        MultiLayerNetwork network = new MultiLayerNetwork(MultiLayerConfiguration.fromJson(json));
-        network.init();
         network.setListeners(new ScoreIterationListener(1), new BestScoreIterationListener(best_score_acc));
-        INDArray val = params.value();
-        Updater upd = updater.getValue();
-        if(val.length() != network.numParams(false))
-            throw new IllegalStateException("Network did not have same number of parameters as the broadcasted set parameters");
-        network.setParameters(val);
-        network.setUpdater(upd);
-        network.fit(data);
+        network.fit(dataSet);
 
-        return Collections.singletonList(new Tuple3<>(network.params(false),network.getUpdater(),network.score()));
+        return new Tuple2<>(network, network.score());
 
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/BaseSparkTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/BaseSparkTest.java
@@ -19,12 +19,23 @@
 package org.deeplearning4j.spark;
 
 import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.spark.impl.multilayer.SparkDl4jMultiLayer;
 import org.junit.After;
 import org.junit.Before;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 
 /**
@@ -33,11 +44,33 @@ import java.io.Serializable;
 public abstract class BaseSparkTest  implements Serializable
 {
     protected transient JavaSparkContext sc;
+    protected transient INDArray labels;
+    protected transient INDArray input;
+    protected transient INDArray rowSums;
+    protected transient int nRows = 200;
+    protected transient int nIn = 4;
+    protected transient int nOut = 3;
+    protected transient DataSet data;
+    protected transient JavaRDD<DataSet> sparkData;
 
     @Before
     public void before() {
+
         sc = getContext();
+        Random r = new Random(12345);
+        labels = Nd4j.create(nRows, nOut);
+        input = Nd4j.rand(nRows,nIn);
+        rowSums = input.sum(1);
+        input.diviColumnVector(rowSums);
+
+        for( int i=0; i<nRows; i++ ){
+            int x1 = r.nextInt(nOut);
+            labels.putScalar(new int[]{i, x1}, 1.0);
+        }
+
+        sparkData = getBasicSparkDataSet(nRows, input, labels);
     }
+
     @After
     public void after() {
         sc.close();
@@ -61,7 +94,48 @@ public abstract class BaseSparkTest  implements Serializable
         sc = new JavaSparkContext(sparkConf);
 
         return sc;
-
     }
+
+    protected JavaRDD<DataSet> getBasicSparkDataSet(int nRows, INDArray input, INDArray labels){
+        List<DataSet> list = new ArrayList<>();
+        for( int i=0; i<nRows; i++ ){
+            INDArray inRow = input.getRow(i).dup();
+            INDArray outRow = labels.getRow(i).dup();
+
+            DataSet ds = new DataSet(inRow,outRow);
+            list.add(ds);
+        }
+        list.iterator();
+
+        data = new DataSet().merge(list);
+        return sc.parallelize(list);
+    }
+
+
+    protected SparkDl4jMultiLayer getBasicNetwork(){
+        return new SparkDl4jMultiLayer(sc,getBasicConf());
+    }
+
+    protected MultiLayerConfiguration getBasicConf(){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .seed(123)
+                .updater(Updater.NESTEROVS)
+                .learningRate(0.1)
+                .momentum(0.9)
+                .list(2)
+                .layer(0, new org.deeplearning4j.nn.conf.layers.DenseLayer.Builder()
+                        .nIn(nIn).nOut(3)
+                        .activation("tanh").build())
+                .layer(1, new org.deeplearning4j.nn.conf.layers.OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .nIn(3).nOut(nOut)
+                        .activation("softmax")
+                        .build())
+                .backprop(true)
+                .pretrain(false)
+                .build();
+
+        return conf;
+    }
+
 
 }


### PR DESCRIPTION
Attempted simplifying spark train like eval improvements and rolled back when found to be not impactful and data lost from rdd. Fixed a few bugs in MLN in how many params are counted and reseting iterator in forward when pretrain is present. Expanded spark tests.