### PR TITLE
Moved a warning switch from constructor to the stats() function

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/eval/Evaluation.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/eval/Evaluation.java
@@ -48,25 +48,15 @@ public class Evaluation<T extends Comparable<? super T>> implements Serializable
     protected static Logger log = LoggerFactory.getLogger(Evaluation.class);
     //What to output from the precision/recall function when we encounter an edge case
     protected static final double DEFAULT_EDGE_VALUE = 0.0;
-    protected boolean warnNotClassified = false;
 
     // Empty constructor
     public Evaluation() {}
-
-    public Evaluation(boolean warnNotClassified) {
-        this.warnNotClassified = warnNotClassified;
-    }
 
     // Constructor that takes number of output classes
     public Evaluation(int numClasses) {
         for(int i = 0; i < numClasses; i++)
             labelsList.add(i);
         confusion = new ConfusionMatrix<>(labelsList);
-    }
-
-    public Evaluation(List<String> labels, boolean warnNotClassified) {
-        this(labels);
-        this.warnNotClassified = warnNotClassified;
     }
 
     public Evaluation(List<String> labels) {
@@ -273,11 +263,17 @@ public class Evaluation<T extends Comparable<? super T>> implements Serializable
         }
     }
 
+    public String stats() {
+        return stats(true);
+    }
+
     /**
-     * Method to obtain the classification report, as a String
+     * Method to obtain the classification report as a String
+     *
+     * @param suppressWarnings whether or not to output warnings related to the evaluation results
      * @return A (multi-line) String with accuracy, precision, recall, f1 score etc
      */
-    public String stats() {
+    public String stats(boolean suppressWarnings) {
         String actual, expected;
         StringBuilder builder = new StringBuilder().append("\n");
         StringBuilder warnings = new StringBuilder();
@@ -294,7 +290,7 @@ public class Evaluation<T extends Comparable<? super T>> implements Serializable
             }
 
             //Output possible warnings regarding precision/recall calculation
-            if (warnNotClassified && truePositives.getCount(clazz) == 0) {
+            if (!suppressWarnings && truePositives.getCount(clazz) == 0) {
                 if (falsePositives.getCount(clazz) == 0) {
                     warnings.append(String.format("Warning: class %s was never predicted by the model. This class was excluded from the average precision\n", actual));
                 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/SparkDl4jMultiLayer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/SparkDl4jMultiLayer.java
@@ -416,27 +416,16 @@ public class SparkDl4jMultiLayer implements Serializable {
     }
 
     public Evaluation evaluate(JavaRDD<DataSet> data) {
-        return evaluate(data, null, false);
+        return evaluate(data, null);
     }
-
-    public Evaluation evaluate(JavaRDD<DataSet> data, boolean warnNotClassified) {
-        return evaluate(data, null, warnNotClassified);
-    }
-
 
     /**Evaluate the network (classification performance) in a distributed manner.
      * @param data Data to evaluate on
      * @param labelsList List of labels used for evaluation
-     * @param warnNotClassified true enables printing what classes were not identified in evaluation
      * @return Evaluation object; results of evaluation on all examples in the data set
      */
-
-    public Evaluation evaluate(JavaRDD<DataSet> data, List<String> labelsList, boolean warnNotClassified){
-
-        JavaRDD<Evaluation> evaluations = data.map(new EvaluateMapFunction(network, labelsList, warnNotClassified));
-        Evaluation evaluation = evaluations.reduce(new EvaluationReduceFunction());
-        return evaluation;
-
+    public Evaluation evaluate(JavaRDD<DataSet> data, List<String> labelsList){
+        JavaRDD<Evaluation> evaluations = data.map(new EvaluateMapFunction(network, labelsList));
+        return evaluations.reduce(new EvaluationReduceFunction());
     }
-
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/evaluation/EvaluateMapFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/evaluation/EvaluateMapFunction.java
@@ -11,7 +11,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-/**Function to evaluate data (classification), in a distributed manner
+/**
+ * Function to evaluate data (classification), in a distributed manner
  * @author Alex Black
  */
 
@@ -21,17 +22,15 @@ public class EvaluateMapFunction implements Function<DataSet, Evaluation> {
 
     protected MultiLayerNetwork network;
     protected List<String> labels = new ArrayList<>();
-    boolean warnNotClassified = false;
 
-    public EvaluateMapFunction(MultiLayerNetwork network, List<String> labels, boolean warnNotClassified){
+    public EvaluateMapFunction(MultiLayerNetwork network, List<String> labels) {
         this.network = network;
         this.labels = labels;
-        this.warnNotClassified = warnNotClassified;
     }
 
     @Override
     public Evaluation call(DataSet data) throws Exception {
-        Evaluation evaluation = new Evaluation<>(labels, warnNotClassified);
+        Evaluation evaluation = new Evaluation(labels);
 
         INDArray out;
         if(data.hasMaskArrays()) {
@@ -52,7 +51,4 @@ public class EvaluateMapFunction implements Function<DataSet, Evaluation> {
         return evaluation;
 
     }
-
-
-
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/evaluation/EvaluationReduceFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/evaluation/EvaluationReduceFunction.java
@@ -18,6 +18,5 @@ public class EvaluationReduceFunction implements Function2<Evaluation, Evaluatio
     public Evaluation call(Evaluation eval1, Evaluation eval2) throws Exception {
         eval1.merge(eval2);
         return eval1;
-
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/multilayer/TestSparkMultiLayer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/multilayer/TestSparkMultiLayer.java
@@ -286,7 +286,7 @@ public class TestSparkMultiLayer extends BaseSparkTest {
 
         Evaluation evalExpected = new Evaluation();
         INDArray outLocal = netCopy.output(input, Layer.TrainingMode.TEST);
-        evalExpected.eval(labels,outLocal);
+        evalExpected.eval(labels, outLocal);
 
         Evaluation evalActual = sparkNet.evaluate(sparkData);
 


### PR DESCRIPTION
A small change in the `Evaluation` class to avoid carrying this switch in every constructor. Considered making a setter, but it is actually not a responsibility of this class to care about such switches.