### PR TITLE
Add overload of MLLibUtil.fromBinary that takes RDD of tuples

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
@@ -132,8 +132,7 @@ public class MLLibUtil {
      * in to something usable for machine learning
      * @param binaryFiles the binary files to convert
      * @param reader the reader to use
-     * @return the labeled points based on
-     * the given rdd
+     * @return the labeled points based on the given rdd
      */
     public static JavaRDD<LabeledPoint> fromBinary(JavaPairRDD<String, PortableDataStream> binaryFiles,final RecordReader reader) {
         JavaRDD<Collection<Writable>> records = binaryFiles.map(new Function<Tuple2<String, PortableDataStream>, Collection<Writable>>() {
@@ -151,6 +150,17 @@ public class MLLibUtil {
             }
         });
         return ret;
+    }
+
+    /**
+     * Convert a traditional sc.binaryFiles
+     * in to something usable for machine learning
+     * @param binaryFiles the binary files to convert
+     * @param reader the reader to use
+     * @return the labeled points based on the given rdd
+     */
+    public static JavaRDD<LabeledPoint> fromBinary(JavaRDD<Tuple2<String, PortableDataStream>> binaryFiles, final RecordReader reader) {
+        return fromBinary(JavaPairRDD.fromJavaRDD(binaryFiles), reader);
     }
 
 


### PR DESCRIPTION
It should be more convenient to use from Scala code than version that takes `JavaPairRDD`.