### PR TITLE
use valid HTML in templates

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,6 @@
       </div>
     </div>
     <div class="container content">
-</body>
 
       {{ content }}
 
@@ -57,6 +56,7 @@
         </p>
       </div>
     </div>       
+  </body>
 </html>
 
 

--- a/_layouts/ja-default.html
+++ b/_layouts/ja-default.html
@@ -29,7 +29,6 @@
       window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var n=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(n?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(a,o);for(var r=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=r(p[c])};
       heap.load("2234280121");
     </script>
-</body>
 
       {{ content }}
 
@@ -41,4 +40,5 @@
         </p>
       </div>
     </div>       
+  </body>
 </html>

--- a/_layouts/kr-default.html
+++ b/_layouts/kr-default.html
@@ -27,7 +27,6 @@
       window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var n=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(n?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(a,o);for(var r=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=r(p[c])};
       heap.load("2234280121");
     </script>
-</body>
 
 
       {{ content }}
@@ -35,4 +34,9 @@
       <div class="footer">
         <p>
           &copy; {{ site.time | date: '%Y' }}。DL4J is distributed under an Apache 2.0 License。<br>
-<a href="https://github.com/deeplearning4j/deeplearning4j">Github</a> // <a href="https://groups.google.com/forum/#!forum/deeplearning4j">Google Groups</a> // <a href="http://deeplearning4j.org/">English Version</a>。</p></br>
+<a href="https://github.com/deeplearning4j/deeplearning4j">Github</a> // <a href="https://groups.google.com/forum/#!forum/deeplearning4j">Google Groups</a> // <a href="http://deeplearning4j.org/">English Version</a>。</p>
+
+      </div>
+    </div>
+  </body>
+</html>

--- a/_layouts/zh-default.html
+++ b/_layouts/zh-default.html
@@ -29,7 +29,6 @@
       window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var n=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(n?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(a,o);for(var r=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=r(p[c])};
       heap.load("2234280121");
     </script>
-</body>
 
 
       {{ content }}
@@ -37,4 +36,9 @@
       <div class="footer">
         <p>
           &copy; {{ site.time | date: '%Y' }}。DL4J是在Apache 2.0许可证下发布。<br>
-<a href="https://github.com/deeplearning4j/deeplearning4j">Github上库</a> // <a href="http://weibo.com/u/5464033927">新浪微博</a> // <a href="https://groups.google.com/forum/#!forum/deeplearning4j">谷歌讨论组</a> // 帮助我们翻译<a href="http://deeplearning4j.org/">English Version</a>。<a href="http://nlp.stanford.edu/projects/chinese-nlp.shtml">Natural-Language Processing Tools at Stanford</a></p></br>
+<a href="https://github.com/deeplearning4j/deeplearning4j">Github上库</a> // <a href="http://weibo.com/u/5464033927">新浪微博</a> // <a href="https://groups.google.com/forum/#!forum/deeplearning4j">谷歌讨论组</a> // 帮助我们翻译<a href="http://deeplearning4j.org/">English Version</a>。<a href="http://nlp.stanford.edu/projects/chinese-nlp.shtml">Natural-Language Processing Tools at Stanford</a></p>
+
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
In the old templates, the content was put after the </body> tag, this fix makes the HTML valid again.