### PR TITLE
Fix the title of the page & some errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ highlighter: rouge
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.
 #
-title : Deeplearning4j - Open-source, distributed deep learning for the JVM 
+title : "Deeplearning4j: Open-source, distributed deep learning for the JVM"
 tagline: Deep Learning for Java
 author :
   name : Skymind Inc.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,9 +9,9 @@
 
   <title>
     {% if page.title == "Home" %}
-      {{ site.title }}{{ site.tagline }}
+      {{ site.title }}
     {% else %}
-      {{ page.title }}{{ site.title }}
+      {{ page.title }} - {{ site.title }}
     {% endif %}
   </title>
 

--- a/canova.md
+++ b/canova.md
@@ -1,5 +1,5 @@
 ---
-title: Canova: A Vectorization Lib for Machine Learning
+title: "Canova: A Vectorization Lib for Machine Learning"
 layout: default
 ---
 

--- a/compare-dl4j-torch7-pylearn.md
+++ b/compare-dl4j-torch7-pylearn.md
@@ -1,5 +1,5 @@
 ---
-title: Deep Learning Comp Sheet: Deeplearning4j vs. Torch vs. Theano vs. Caffe vs. TensorFlow
+title: "Deep Learning Comp Sheet: Deeplearning4j vs. Torch vs. Theano vs. Caffe vs. TensorFlow"
 layout: default
 ---
 

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Home
 ---
 
 # What is Deeplearning4j?

--- a/recurrentnetwork.md
+++ b/recurrentnetwork.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorial: Recurrent Networks and LSTMs in Java
+title: "Tutorial: Recurrent Networks and LSTMs in Java"
 layout: default
 ---
 

--- a/word2vec.md
+++ b/word2vec.md
@@ -1,5 +1,5 @@
 ---
-title: Word2vec: Neural Word Embeddings in Java
+title: "Word2vec: Neural Word Embeddings in Java"
 layout: default
 ---
 


### PR DESCRIPTION
This fixes the problem with words glued together in the title of the page.  Other changes the incorrect title of some pages - the special characters, like ':' should be put into the quotes.