### PR TITLE
ScoreImprovementEpochTerminationCondition can now with minImprovement

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/termination/ScoreImprovementEpochTerminationCondition.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/termination/ScoreImprovementEpochTerminationCondition.java
@@ -18,15 +18,26 @@
 
 package org.deeplearning4j.earlystopping.termination;
 
-/** Terminate training if best model score does not improve for N epochs*/
-public class ScoreImprovementEpochTerminationCondition implements EpochTerminationCondition {
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Terminate training if best model score does not improve for N epochs
+ */
+public class ScoreImprovementEpochTerminationCondition implements EpochTerminationCondition {
+    private static Logger log = LoggerFactory.getLogger(ScoreImprovementEpochTerminationCondition.class);
     private int maxEpochsWithNoImprovement;
     private int bestEpoch = -1;
     private double bestScore;
+    private double minImprovement = 0.0;
 
     public ScoreImprovementEpochTerminationCondition(int maxEpochsWithNoImprovement) {
         this.maxEpochsWithNoImprovement = maxEpochsWithNoImprovement;
+    }
+
+    public ScoreImprovementEpochTerminationCondition(int maxEpochsWithNoImprovement, double minImprovement) {
+        this.maxEpochsWithNoImprovement = maxEpochsWithNoImprovement;
+        this.minImprovement = minImprovement;
     }
 
     @Override
@@ -36,12 +47,16 @@ public class ScoreImprovementEpochTerminationCondition implements EpochTerminati
 
     @Override
     public boolean terminate(int epochNum, double score) {
-        if(bestEpoch == -1){
+        if (bestEpoch == -1) {
             bestEpoch = epochNum;
             bestScore = score;
             return false;
         } else {
-            if(score < bestScore){
+            double improvement = bestScore - score;
+            if (improvement > minImprovement) {
+                if (minImprovement > 0){
+                    log.info("Epoch with score greater than threshold * * *");
+                }
                 bestScore = score;
                 bestEpoch = epochNum;
                 return false;
@@ -52,7 +67,7 @@ public class ScoreImprovementEpochTerminationCondition implements EpochTerminati
     }
 
     @Override
-    public String toString(){
-        return "ScoreImprovementEpochTerminationCondition(maxEpochsWithNoImprovement="+maxEpochsWithNoImprovement+")";
+    public String toString() {
+        return "ScoreImprovementEpochTerminationCondition(maxEpochsWithNoImprovement=" + maxEpochsWithNoImprovement + ", minImprovement="+minImprovement+")";
     }
 }


### PR DESCRIPTION
ScoreImprovementEpochTerminationCondition can now with the minImprovement factor. The idea was inspired from a similar implementation in the python theanets library that I am using, and though it would be nice for dl4j as well. 
The minImprovement is considered along with the maxEpochsWithImprovement. Each time the improvement achieved is greater than the bestScore + minImprovement, the event is logged if the minImprovement is greater than 0.   
This is to really enable a good early exit, if the model is not improving significantly the training will end much faster. A reasonable value of around 0.001 or 0.005 as minImprovement has yielded good results in my experience. 

Added a new testcase (testMinImprovementNEpochsTermination) to ensure its working correctly