### PR TITLE
Add epsilon INDArray as a member of MultiLayerNetwork

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -81,6 +81,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
     protected NeuralNetConfiguration defaultConfiguration;
     protected MultiLayerConfiguration layerWiseConfigurations;
     protected Gradient gradient;
+    protected INDArray epsilon;
     protected double score;
     private INDArray params;
     /*
@@ -719,6 +720,10 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
         return gradient;
     }
 
+    public INDArray epsilon() {
+        return epsilon;
+    }
+
     @Override
     public Pair<Gradient, Double> gradientAndScore() {
         return new Pair<>(gradient(), score());
@@ -1176,6 +1181,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
     protected void backprop() {
         Pair<Gradient,INDArray> pair = calcBackpropGradients(null, true);
         this.gradient = (pair == null ? null : pair.getFirst());
+        this.epsilon = (pair == null ? null : pair.getSecond());
     }
 
     /** Calculate gradients and errors. Used in two places:


### PR DESCRIPTION
This will be updated after calls to backprop(), which previously uses
the first projection of the output from calcBackpropGradients() to
update the top-level gradient, but does not use the second projection
(the epsilons) for anything.

A getter for epsilon is also implemented.

This closes #1201; my initial requirement was to obtain the
backpropagated errors at the neural network's input.