### PR TITLE
Pass num categores in iterator to limit file split

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/impl/LFWDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/impl/LFWDataSetIterator.java
@@ -106,7 +106,7 @@ public class LFWDataSetIterator extends RecordReaderDataSetIterator {
 	 * @param numExamples the overall number of examples
 	 * */
 	public LFWDataSetIterator(int batchSize, int numExamples, int[] imgDim, int numCategories, boolean useSubset, Random rng) {
-		super(new LFWLoader(useSubset).getRecordReader(imgDim[0], imgDim[1], imgDim[2], numExamples, rng), batchSize, imgDim[0] * imgDim[1] * imgDim[2], numCategories);
+		super(new LFWLoader(useSubset).getRecordReader(imgDim[0], imgDim[1], imgDim[2], numExamples, numCategories, rng), batchSize, imgDim[0] * imgDim[1] * imgDim[2], numCategories);
 	}
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/eval/Evaluation.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/eval/Evaluation.java
@@ -265,7 +265,7 @@ public class Evaluation implements Serializable {
     }
 
     public String stats() {
-        return stats(true);
+        return stats(false);
     }
 
     /**


### PR DESCRIPTION
Addresses issue #1225 

Passing through number of categories to limit file split in order to restrict how many categories are loaded