### PR TITLE
BestScoreEpochTerminationCondition

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/termination/BestScoreEpochTerminationCondition.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/termination/BestScoreEpochTerminationCondition.java
@@ -1,0 +1,41 @@
+package org.deeplearning4j.earlystopping.termination;
+
+/**
+ * Created by Sadat Anwar on 3/26/16.
+ *
+ * Stop the training once we achieved an expected score. Normally this will stop if the current score is lower than
+ * the initialized score. If you want to stop the training once the score increases the defined score set the
+ * lesserBetter flag to false (feel free to give the flag a better name)
+ */
+public class BestScoreEpochTerminationCondition  implements EpochTerminationCondition{
+    private final double bestExpectedScore;
+    private boolean lesserBetter = true;
+
+    public BestScoreEpochTerminationCondition(double bestExpectedScore){
+        this.bestExpectedScore = bestExpectedScore;
+    }
+
+    public BestScoreEpochTerminationCondition(double bestExpectedScore, boolean lesserBetter){
+        this(bestExpectedScore);
+        this.lesserBetter = lesserBetter;
+    }
+
+    @Override
+    public void initialize() {
+        /* No OP */
+    }
+
+    @Override
+    public boolean terminate(int epochNum, double score) {
+        if (lesserBetter) {
+            return score < bestExpectedScore;
+        } else{
+            return bestExpectedScore < score;
+        }
+    }
+
+    @Override
+    public String toString(){
+        return "BestScoreEpochTerminationCondition("+bestExpectedScore+")";
+    }
+}


### PR DESCRIPTION
Stop the training once we achieved an expected score. 
Normally this will stop if the current score is lower than the initialized score. 
If you want to stop the training once the score increases the defined score set the lesserBetter flag to false (feel free to give the flag a better name). 
Useful specially in debugging cases when you dont want to finish the training. Also can be used in cases where you are okay with a certain level of error. 
