### PR TITLE
Use Buffered Streams when (De-)Serializing Models

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/saver/LocalFileGraphSaver.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/saver/LocalFileGraphSaver.java
@@ -21,11 +21,8 @@ package org.deeplearning4j.earlystopping.saver;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.deeplearning4j.earlystopping.EarlyStoppingModelSaver;
-import org.deeplearning4j.nn.api.Updater;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
-import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
-import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.updater.graph.ComputationGraphUpdater;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
@@ -99,11 +96,11 @@ public class LocalFileGraphSaver implements EarlyStoppingModelSaver<ComputationG
         ComputationGraphUpdater updater = net.getUpdater();
 
         FileUtils.writeStringToFile(new File(confOut), confJSON, encoding);
-        try(DataOutputStream dos = new DataOutputStream(Files.newOutputStream(Paths.get(paramOut)))){
+        try(DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(Paths.get(paramOut))))){
             Nd4j.write(params, dos);
         }
 
-        try(ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(new File(updaterOut)))){
+        try(ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(new File(updaterOut))))){
             oos.writeObject(updater);
         }
     }
@@ -128,10 +125,10 @@ public class LocalFileGraphSaver implements EarlyStoppingModelSaver<ComputationG
         String confJSON = FileUtils.readFileToString(new File(confOut), encoding);
         INDArray params;
         ComputationGraphUpdater updater;
-        try(DataInputStream dis = new DataInputStream(Files.newInputStream(Paths.get(paramOut)))){
+        try(DataInputStream dis = new DataInputStream(new BufferedInputStream(Files.newInputStream(Paths.get(paramOut))))){
             params = Nd4j.read(dis);
         }
-        try(ObjectInputStream ois = new ObjectInputStream(new FileInputStream(new File(updaterOut)))){
+        try(ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(new FileInputStream(new File(updaterOut))))){
             updater = (ComputationGraphUpdater)ois.readObject();
         }catch(ClassNotFoundException e){
             throw new RuntimeException(e);  //Should never happen

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/saver/LocalFileModelSaver.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/saver/LocalFileModelSaver.java
@@ -78,11 +78,11 @@ public class LocalFileModelSaver implements EarlyStoppingModelSaver<MultiLayerNe
         Updater updater = net.getUpdater();
 
         FileUtils.writeStringToFile(new File(confOut), confJSON, encoding);
-        try(DataOutputStream dos = new DataOutputStream(Files.newOutputStream(Paths.get(paramOut)))){
+        try(DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(Paths.get(paramOut))))){
             Nd4j.write(params, dos);
         }
 
-        try(ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(new File(updaterOut)))){
+        try(ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(new File(updaterOut))))){
             oos.writeObject(updater);
         }
     }
@@ -107,10 +107,10 @@ public class LocalFileModelSaver implements EarlyStoppingModelSaver<MultiLayerNe
         String confJSON = FileUtils.readFileToString(new File(confOut), encoding);
         INDArray params;
         Updater updater;
-        try(DataInputStream dis = new DataInputStream(Files.newInputStream(Paths.get(paramOut)))){
+        try(DataInputStream dis = new DataInputStream(new BufferedInputStream(Files.newInputStream(Paths.get(paramOut))))){
             params = Nd4j.read(dis);
         }
-        try(ObjectInputStream ois = new ObjectInputStream(new FileInputStream(new File(updaterOut)))){
+        try(ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(new FileInputStream(new File(updaterOut))))){
             updater = (Updater)ois.readObject();
         }catch(ClassNotFoundException e){
             throw new RuntimeException(e);  //Should never happen

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ModelSerializer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ModelSerializer.java
@@ -1,7 +1,6 @@
 package org.deeplearning4j.util;
 
 import lombok.NonNull;
-import org.apache.commons.io.FileUtils;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.Model;
 import org.deeplearning4j.nn.api.Updater;
@@ -18,7 +17,6 @@ import org.nd4j.linalg.heartbeat.reports.Task;
 import java.io.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 /**
@@ -29,11 +27,15 @@ import java.util.zip.ZipOutputStream;
 public class ModelSerializer {
 
     public static void writeModel(@NonNull Model model, @NonNull File file, boolean saveUpdater) throws IOException {
-        writeModel(model, new FileOutputStream(file), saveUpdater);
+        try(BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(file))){
+            writeModel(model, stream, saveUpdater);
+        }
     }
 
     public static void writeModel(@NonNull Model model, @NonNull String path, boolean saveUpdater) throws IOException {
-        writeModel(model, new FileOutputStream(path), saveUpdater);
+        try(BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(path))){
+            writeModel(model, stream, saveUpdater);
+        }
     }
 
     public static void writeModel(@NonNull Model model, @NonNull OutputStream stream, boolean saveUpdater) throws IOException {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/NetSaverLoaderUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/NetSaverLoaderUtils.java
@@ -34,11 +34,9 @@ public class NetSaverLoaderUtils {
         log.info("Saving model and parameters to {} and {} ...",  confPath, paramPath);
 
         // save parameters
-        try {
-            DataOutputStream dos = new DataOutputStream(new FileOutputStream(paramPath));
+        try(DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(paramPath)))) {
             Nd4j.write(net.params(), dos);
             dos.flush();
-            dos.close();
 
             // save model configuration
             FileUtils.write(new File(confPath), net.conf().toJson());
@@ -81,11 +79,9 @@ public class NetSaverLoaderUtils {
         // save parameters for each layer
         log.info("Saving parameters to {} ...", paramPath);
 
-        try {
-            DataOutputStream dos = new DataOutputStream(new FileOutputStream(paramPath));
+        try (DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(paramPath)))){
             Nd4j.write(param, dos);
             dos.flush();
-            dos.close();
         } catch(IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This speeds up the model saving time by about 30x on my system for larger models.