### PR TITLE
Fix null pointer exception from params method when Layer does not have params

### DIFF
--- a/deeplearning4j-core/pom.xml
+++ b/deeplearning4j-core/pom.xml
@@ -61,12 +61,6 @@
             </dependency>
             <dependency>
                 <groupId>org.nd4j</groupId>
-                <artifactId>nd4j-native</artifactId>
-                <version>${nd4j.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.nd4j</groupId>
                 <artifactId>nd4j-jcublas-7.0</artifactId>
                 <version>${nd4j.version}</version>
                 <scope>test</scope>

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -813,10 +813,12 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
 
         List<INDArray> params = new ArrayList<>();
         for (Layer layer: getLayers()){
+            INDArray layerParams;
             if( layer instanceof BasePretrainNetwork && backwardOnly)
-                params.add(((BasePretrainNetwork) layer).paramsBackprop());
+                layerParams = ((BasePretrainNetwork) layer).paramsBackprop();
             else
-                params.add(layer.params());
+                layerParams = layer.params();
+            if(layerParams != null) params.add(layerParams);    //may be null: subsampling etc layers
         }
 
         return Nd4j.toFlattened('f', params);


### PR DESCRIPTION
Additional params method takes into account backwardOnly and was missing adjustment fo Subsampling and other layers that do not have params.

Fix for #1358 