### PR TITLE
LearningRate and BiasLearningRate

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -721,7 +721,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
 
             if(layer != null ) {
                 if (Double.isNaN(layer.getLearningRate())) layer.setLearningRate(learningRate);
-                if (Double.isNaN(layer.getBiasLearningRate())) layer.setBiasLearningRate(learningRate);
+                if (Double.isNaN(layer.getBiasLearningRate())) layer.setBiasLearningRate(layer.getLearningRate());
                 if (layer.getLearningRateSchedule() == null) layer.setLearningRateSchedule(learningRateSchedule);
                 if (Double.isNaN(layer.getL1())) layer.setL1(l1);
                 if (Double.isNaN(layer.getL2())) layer.setL2(l2);


### PR DESCRIPTION
The default behavior of Learning and BiasLearningRate is error-prone if you intend to change the learning rate of one specific layer.
In the current case, if you do, you most likely want to specify the same rate for the bias learning rate. Here unless otherwise specified it will apply the global learningRate instead of applying the learningRate of that specific layer.