### PR TITLE
Make layout more narrow - docs friendly.

### DIFF
--- a/_layouts/theindex.html
+++ b/_layouts/theindex.html
@@ -5,7 +5,7 @@ layout: all
     <div class="bg-overlay-gradient bg-overlay"></div>
     <div class="container">
         <div class="row">
-            <div class="col-md-8 col-md-offset-2">
+            <div class="col-md-10 col-md-offset-1">
                 <div class="home-wrapper text-center">
                     <p class="text-muted">Deep Learning for Java</p>
                     <h1>Open-source, distributed, deep-learning library for the JVM</h1>

--- a/assets/themes/metrico/css/style.css
+++ b/assets/themes/metrico/css/style.css
@@ -30,6 +30,11 @@ p {
   line-height: 1.75em;
   font-size: 15px;
 }
+
+/* narrow the bootstrap container */
+.container {
+  max-width: 1000px;
+}
     
 /* BUTTONS */
 


### PR DESCRIPTION
Adjusts the max-width of the DL4J website to be slightly narrower to make reading of text a little more user-friendly.

Based on feedback from @treo.