### PR TITLE
Make sure doc headers use site-wide fonts.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@ layout: all
   </div>
 </section>
 
-<section class="section bg-white" id="content">
+<section class="section bg-white page-content" id="content">
   <div class="container">
     <div class="row">
       <div class="col-sm-12 adjust-img-responsive">

--- a/_layouts/theindex.html
+++ b/_layouts/theindex.html
@@ -9,7 +9,7 @@ layout: all
                 <div class="home-wrapper text-center">
                     <p class="text-muted">Deep Learning for Java</p>
                     <h1>Open-source, distributed, deep-learning library for the JVM</h1>
-                    <a href="/quickstart" class="btn btn-custom">Quickstart</a>
+                    <a href="./quickstart" class="btn btn-custom">Quickstart</a>
                 </div>
             </div>
         </div>

--- a/assets/themes/metrico/css/style.css
+++ b/assets/themes/metrico/css/style.css
@@ -485,6 +485,17 @@ iframe {
 }
 
 
+/* PAGE CONTENT / documentation default wrapper */
+.page-content h1, 
+.page-content h2, 
+.page-content h3, 
+.page-content h4, 
+.page-content h5 {
+  font-family: 'Josefin Sans', sans-serif;
+  font-weight: 700;
+}
+
+
 
 /* FUN FACTS / Testimonials Box */
 .facts-box {


### PR DESCRIPTION
Small fix to ensure the documentation markdown content follows same header styles as rest of the site.