### PR TITLE
New "Building Locally" guide.

### DIFF
--- a/assets/themes/metrico/css/style.css
+++ b/assets/themes/metrico/css/style.css
@@ -495,6 +495,35 @@ iframe {
   font-weight: 700;
 }
 
+.page-content h1, 
+.page-content h2, 
+.page-content h3{
+  margin-top: 30px;
+}
+
+.page-content h4, 
+.page-content h5, 
+.page-content h6 {
+  margin-top: 20px;
+  opacity: 0.8;
+}
+
+.page-content h2 {
+  font-size: 32px;
+}
+
+.page-content h3 {
+  font-size: 27px;
+}
+
+.page-content h4 {
+  font-size: 23px;
+}
+
+.page-content h5 {
+  font-size: 19px;
+}
+
 
 
 /* FUN FACTS / Testimonials Box */

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -32,11 +32,10 @@ CPU options:
 - Intel MKL
 - OpenBLAS
 - ATLAS
-- ND4J-Java (Android)
 
 GPU options:
 
-- Jcublas/CUDA
+- CUDA
 - JOCL (coming soon)
 
 ### Installing Prerequisite Tools
@@ -73,24 +72,15 @@ brew install maven clang-omp
 
 #### Windows
 
-Windows users may need to install [Visual Studio Community 2013 or later](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), which is free. You will need to add its path to your PATH environment variable manually. The path will look something like this: `C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin`
+libnd4j depends on some Unix utilities for compilation. So in order to compile it you will need to install  [Msys2](https://msys2.github.io/).
 
-Type `cl` into your CMD. You may get a message informing you that certain `.dll` files are missing. Make sure that your VS/IDE folder is in the path (see above). If your CMD returns usage info for `cl`, then it's in the right place. 
+After you have setup Msys2 by following [their instructions](https://msys2.github.io/), you will have to install some additional development packages. Start the msys2 shell and setup the dev environment with:
 
-If you use Visual Studio: 
+    pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-extra-cmake-modules make pkg-config grep sed gzip tar mingw64/mingw-w64-x86_64-openblas
 
-1. Set up `PATH` environment variable to point to `\bin\` (for `cl.exe` etc)
-1. Also try running `vcvars32.bat` (also in bin) to set up environment before doing `mvn clean install` on ND4J (it may save you from copying headers around)
-1. `vcvars32` may be temporary, so you might need to run it every time you want to do ND4J `mvn install`.
-1. After installing Visual Studio 2015 and setting the PATH variable, you need to run the `vcvars32.bat` to set up the environment variables (INCLUDE, LIB, LIBPATH) properly so that you don't have to copy header files. But if you run the bat file from Explorer, since the settings are temporary, they're not properly set. So run `vcvars32.bat` from the same CMD window as your `mvn install`, and all the environment variables will be set correctly.
-1. Here is how they should be set: 
+This will install the needed dependencies for use in the msys2 shell.
 
-    INCLUDE = C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include
-    LIB = "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\lib"
-    //so you can link to .lib files^^
-1. In Visual Studio, you also have to click on C++. It is no longer set by default. 
-(*In addition, the include path for [Java CPP](https://github.com/bytedeco/javacpp) doesn't always work on Windows. One workaround is to take the the header files from the include directory of Visual Studio, and put them in the include directory of the Java Run-Time Environment (JRE), where Java is installed. This will affect files such as `standardio.h`.*)
-* For a walkthrough of installing our examples with Git, IntelliJ and Maven, please see our [Quickstart page](http://deeplearning4j.org/quickstart.html#walk)
+You will also need to setup your PATH environment variable to include `C:\msys64\mingw64\bin` (or where ever you have decided to install msys2). If you have IntelliJ (or another IDE) open, you will have to restart it before this change takes effect for applications started through them. If you don't, you probably will see a "Can't find dependent libraries" error.
 
 ### Installing Prerequisite Architectures
 
@@ -143,17 +133,7 @@ brew install homebrew/science/openblas
 
 ##### Windows
 
-[This page](http://avulanov.blogspot.cz/2014/09/howto-to-run-netlib-javabreeze-in.html) describes how to obtain dll for the Windows 64 platform:
-1. Download dll libraries and place them in the Java bin folder (e.g. `C:\prg\Java\jdk1.7.0_45\bin`).
-2. Library `netlib-native_system-win-x86_64.dll` depends on: 
-`libgcc_s_seh-1.dll
-libgfortran-3.dll
-libquadmath-0.dll
-libwinpthread-1.dll
-libblas3.dll
-liblapack3.dll`
-3. (`liblapack3.dll` and `libblas3.dll` are just renamed copies of `libopeblas.dll`)
-4. You can download compiled libs from [here](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Automated%20Builds/), [here](http://www.openblas.net/), or [here](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22netlib-native_system-win-x86_64%22)
+An OpenBLAS package is available for `msys2`. You can install it using the `pacman` command.
 
 #### ATLAS
 
@@ -195,9 +175,9 @@ make time
 make install
 ```
 
-#### Jcublas/CUDA
+#### CUDA
 
-Detailed instructions for installing GPU architectures such as Jcublas can be found [here](http://nd4j.org/gpu_native_backends.html).
+Detailed instructions for installing GPU architectures such as CUDA can be found [here](http://nd4j.org/gpu_native_backends.html).
 
 ## Installing the DL4J Stack
 
@@ -219,8 +199,7 @@ export LIBND4J_HOME=/home/user/directory/libnd4j
 
 You can link with MKL either at build time, or at runtime with binaries initially linked with another BLAS implementation such as OpenBLAS. To build against MKL, simply add the path containing `libmkl_rt.so` (or `mkl_rt.dll` on Windows), say `/path/to/intel64/lib/`, to the `LD_LIBRARY_PATH` environment variable on Linux (or `PATH` on Windows) and build like before. On Linux though, to make sure it uses the correct version of OpenMP, we also might need to set these environment variables:
 
-```
-bash
+```bash
 export MKL_THREADING_LAYER=GNU
 export LD_PRELOAD=/lib64/libgomp.so.1
 ```
@@ -230,14 +209,12 @@ When libnd4j cannot be rebuilt, we can use the MKL libraries after the facts and
 1. Make sure that files such as `/lib64/libopenblas.so.0` and `/lib64/libblas.so.3` are not available (or appear after in the `PATH` on Windows), or they will get loaded by libnd4j by their absolute paths, before anything else.
 2. Inside `/path/to/intel64/lib/`, create a symbolic link or copy of `libmkl_rt.so` (or `mkl_rt.dll` on Windows) to the name that libnd4j expect to load, for example:
 
-```
-bash
+```bash
 ln -s libmkl_rt.so libopenblas.so.0
 ln -s libmkl_rt.so libblas.so.3
 ```
 
-```
-cmd
+```cmd
 copy mkl_rt.dll libopenblas.dll
 copy mkl_rt.dll libblas3.dll
 ```
@@ -248,6 +225,20 @@ copy mkl_rt.dll libblas3.dll
 ### Build Script
 
 A community-provided script [build-dl4j-stack.sh](https://gist.github.com/crockpotveggies/9948a365c2d45adcf96642db336e7df1) written in bash is available that clones the DL4J stack, builds each repository, and installs them locally to Maven. This script will work on both Linux and OS X platforms.
+
+Use the build script as follows:
+
+```
+bash build-dl4j-stack.sh cpu
+```
+
+If you are using a GPU backend:
+
+```
+bash build-dl4j-stack.sh gpu
+```
+
+The build script passes all options and flags to the libnd4j `./buildnativeoperations.sh` script. All flags used for those script can be passed via `build-dl4j-stack.sh`.
 
 ## Using local dependencies
 

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -240,6 +240,47 @@ If you are using a GPU backend:
 
 The build script passes all options and flags to the libnd4j `./buildnativeoperations.sh` script. All flags used for those script can be passed via `build-dl4j-stack.sh`.
 
+### Building Manually
+
+If you prefer, you can build each piece in the DL4J stack by hand. The procedure for each piece of software is essentially:
+
+1. Git clone
+2. Build
+3. Install
+
+The overall procedure looks like the following commands below, with the exception that libnd4j's `./buildnativeoperations.sh` accepts parameters based on the backend you are building for.
+
+```
+# removes any existing repositories to ensure a clean build
+rm -rf libnd4j
+rm -rf nd4j
+rm -rf deeplearning4j
+
+# compile libnd4j
+git clone https://github.com/deeplearning4j/libnd4j.git
+cd libnd4j
+bash buildnativeoperations.sh cpu
+# or when using GPU
+#bash buildnativeoperations.sh -c cuda
+export LIBND4J_HOME=`pwd`
+cd ..
+
+# build and install nd4j to maven locally
+git clone https://github.com/deeplearning4j/nd4j.git
+cd nd4j
+mvn clean install -DskipTests -Dmaven.javadoc.skip=true -pl '!:nd4j-cuda-7.5,!:nd4j-tests'
+# or when using GPU
+#mvn clean install -DskipTests -Dmaven.javadoc.skip=true -pl '!:nd4j-tests'
+cd ..
+
+# build and install deeplearning4j
+git clone https://github.com/deeplearning4j/deeplearning4j.git
+cd deeplearning4j
+mvn clean install -DskipTests -Dmaven.javadoc.skip=true
+cd ..
+```
+
+
 ## Using local dependencies
 
 Once you've installed the DL4J stack to your local maven repository, you can now include it in your build tool's dependencies. Follow the typical [Getting Started](http://deeplearning4j.org/gettingstarted) instructions for Deeplearning4j, and appropriately replace versions with the SNAPSHOT version currently on the [master POM](https://github.com/deeplearning4j/deeplearning4j/blob/master/pom.xml).

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -177,7 +177,26 @@ make install
 
 #### CUDA
 
+##### Linux & OS X
+
 Detailed instructions for installing GPU architectures such as CUDA can be found [here](http://nd4j.org/gpu_native_backends.html).
+
+##### Windows
+
+The CUDA Backend has some additional requirements before it can be built:
+
+* [CUDA SDK](https://developer.nvidia.com/cuda-downloads)
+* [Visual Studio 2012 or 2013](https://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx) (Please note: Visual Studio 2015 is *NOT SUPPORTED* by CUDA 7.5 and below)
+
+In order to build the CUDA backend you will have to setup some more environment variables first, by calling `vcvars64.bat`.
+But first, set the system environment variable `SET_FULL_PATH` to `true`, so all of the variables that `vcvars64.bat` sets up, are passed to the mingw shell.
+
+1. Inside a normal cmd.exe command prompt, run `C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\amd64\vcvars64.bat`
+2. Run `c:\msys64\mingw64_shell.bat` inside that
+3. Change to your libnd4j folder
+4. `./buildnativeoperations.sh -c cuda`
+
+This builds the CUDA nd4j.dll.
 
 ## Installing the DL4J Stack
 
@@ -226,16 +245,16 @@ copy mkl_rt.dll libblas3.dll
 
 A community-provided script [build-dl4j-stack.sh](https://gist.github.com/crockpotveggies/9948a365c2d45adcf96642db336e7df1) written in bash is available that clones the DL4J stack, builds each repository, and installs them locally to Maven. This script will work on both Linux and OS X platforms.
 
-Use the build script as follows:
+Use the build script as follows for CPU architectures:
 
 ```
-./build-dl4j-stack.sh cpu
+./build-dl4j-stack.sh
 ```
 
 If you are using a GPU backend:
 
 ```
-./build-dl4j-stack.sh gpu
+./build-dl4j-stack.sh -c cuda
 ```
 
 The build script passes all options and flags to the libnd4j `./buildnativeoperations.sh` script. All flags used for those script can be passed via `build-dl4j-stack.sh`.
@@ -259,9 +278,9 @@ rm -rf deeplearning4j
 # compile libnd4j
 git clone https://github.com/deeplearning4j/libnd4j.git
 cd libnd4j
-bash buildnativeoperations.sh cpu
+./buildnativeoperations.sh
 # or when using GPU
-#bash buildnativeoperations.sh -c cuda
+#./buildnativeoperations.sh -c cuda
 export LIBND4J_HOME=`pwd`
 cd ..
 

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -1,0 +1,255 @@
+---
+title: Building the DL4J Stack Locally
+layout: default
+---
+
+# Build Locally from Master
+
+For those developers and engineers who prefer to use the most up-to-date version of Deeplearning4j or fork and build their own version, these instructions will walk you through building and installing Deeplearning4j. The preferred installation destination is to your machine's local maven repository. If you are not using the master branch, you can modify these steps as needed (i.e.: switching GIT branches and modifying the `build-dl4j-stack.sh` script).
+
+Building locally requires that you build the entire Deeplearning4j stack which includes:
+
+* [libnd4j](https://github.com/deeplearning4j/libnd4j)
+* [nd4j](https://github.com/deeplearning4j/nd4j)
+* [deeplearning4j](https://github.com/deeplearning4j/deeplearning4j)
+
+Note that Deeplearning4j is designed to work on most platforms (Windows, OS X, and Linux) and is also includes multiple "flavors" depending on the computing architecture you choose to utilize. This includes CPU (OpenBLAS, MKL, ATLAS) and GPU (CUDA).
+
+## Prerequisites
+
+Your local machine will require some essential software and environment variables set *before* you try to build and install the DL4J stack. Depending on your platform and the version of your operating system, the instructions may vary in getting them to work. This software includes:
+
+* git
+* cmake with OpenMP
+* gcc (3.2 or higher)
+* maven (3 or higher)
+
+Architecture-specific software includes:
+
+**CPU options:**
+* Intel MKL
+* OpenBLAS
+* ATLAS
+
+**GPU options:**
+* Jcublas/CUDA
+
+### Installing Prerequisite Tools
+
+#### Linux
+
+**Ubuntu**
+Assuming you are using Ubuntu as your flavor of Linux and you are running as a non-root user, follow these steps to install prerequisite software:
+
+```
+sudo apt-get purge maven maven2 maven3
+sudo add-apt-repository ppa:natecarlson/maven3
+sudo apt-get update
+sudo apt-get install maven build-essentials cmake libgomp1
+
+```
+
+#### OS X
+
+Homebrew is the accepted method of installing prerequisite software. Assuming you have Homebrew installed locally, follow these steps to install your necessary tools.
+
+First, before using Homebrew we need to ensure an up-to-date version of Xcode is installed (it is used as a primary compiler):
+
+```
+xcode-select --install
+```
+
+Finally, install prerequisite tools:
+
+```
+brew update
+brew install maven clang-omp
+```
+
+#### Windows
+
+Windows users may need to install [Visual Studio Community 2013 or later](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), which is free. You will need to add its path to your PATH environment variable manually. The path will look something like this: `C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin`
+
+Type `cl` into your CMD. You may get a message informing you that certain `.dll` files are missing. Make sure that your VS/IDE folder is in the path (see above). If your CMD returns usage info for `cl`, then it's in the right place. 
+
+If you use Visual Studio: 
+
+* Set up `PATH` environment variable to point to `\bin\` (for `cl.exe` etc)
+* Also try running `vcvars32.bat` (also in bin) to set up environment before doing `mvn clean install` on ND4J (it may save you from copying headers around)
+* `vcvars32` may be temporary, so you might need to run it every time you want to do ND4J `mvn install`.
+* After installing Visual Studio 2015 and setting the PATH variable, you need to run the `vcvars32.bat` to set up the environment variables (INCLUDE, LIB, LIBPATH) properly so that you don't have to copy header files. But if you run the bat file from Explorer, since the settings are temporary, they're not properly set. So run `vcvars32.bat` from the same CMD window as your `mvn install`, and all the environment variables will be set correctly.
+* Here is how they should be set: 
+
+    INCLUDE = C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include
+    LIB = "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\lib"
+    //so you can link to .lib files^^
+* In Visual Studio, you also have to click on C++. It is no longer set by default. 
+(*In addition, the include path for [Java CPP](https://github.com/bytedeco/javacpp) doesn't always work on Windows. One workaround is to take the the header files from the include directory of Visual Studio, and put them in the include directory of the Java Run-Time Environment (JRE), where Java is installed. This will affect files such as `standardio.h`.*)
+* For a walkthrough of installing our examples with Git, IntelliJ and Maven, please see our [Quickstart page](http://deeplearning4j.org/quickstart.html#walk)
+
+### Installing Prerequisite Architectures
+
+Once you have installed the prerequisite tools, you can now install the required architectures for your platform.
+
+#### CPU
+
+##### Intel MKL
+
+Of all the existing architectures available for CPU, Intel MKL is currently the fastest. However, it requires some "overhead" before you actually install it.
+
+* Apply for a license at [Intel's site](https://software.intel.com/en-us/intel-mkl)
+* After a few steps through Intel, you will receive a download link
+* Download and install Intel MKL using [the setup guide](https://software.intel.com/sites/default/files/managed/94/bf/Install_Guide_0.pdf)
+
+##### OpenBLAS
+
+###### Linux
+
+**Ubuntu**
+Assuming you are using Ubuntu, you can install OpenBLAS via:
+
+```
+sudo apt-get install libopenblas-dev
+```
+
+You will also need to ensure that `/opt/OpenBLAS/lib` (or any other home directory for OpenBLAS) is on your `PATH`. In order to get OpenBLAS to work with Apache Spark, you will also need to do the following:
+
+```
+sudo cp libopenblas.so liblapack.so.3
+sudo cp libopenblas.so libblas.so.3
+```
+
+**CentOS**
+Enter the following in your terminal (or ssh session) as a root user:
+
+    yum groupinstall 'Development Tools'
+
+After that, you should see a lot of activity and installs on the terminal. To verify that you have, for example, *gcc*, enter this line:
+
+    gcc --version
+
+For more complete instructions, [go here](http://www.cyberciti.biz/faq/centos-linux-install-gcc-c-c-compiler/).
+
+###### OS X
+
+You can install OpenBLAS on OS X with Homebrew Science:
+
+```
+brew install homebrew/science/openblas
+```
+
+###### Windows
+
+[This page](http://avulanov.blogspot.cz/2014/09/howto-to-run-netlib-javabreeze-in.html) describes how to obtain dll for the Windows 64 platform:
+* Download dll libraries and place them in the Java bin folder (e.g. `C:\prg\Java\jdk1.7.0_45\bin`).
+* Library `netlib-native_system-win-x86_64.dll` depends on: 
+`libgcc_s_seh-1.dll
+libgfortran-3.dll
+libquadmath-0.dll
+libwinpthread-1.dll
+libblas3.dll
+liblapack3.dll`
+* (`liblapack3.dll` and `libblas3.dll` are just renamed copies of `libopeblas.dll`)
+* You can download compiled libs from [here](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Automated%20Builds/), [here](http://www.openblas.net/), or [here](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22netlib-native_system-win-x86_64%22)
+
+##### ATLAS
+
+###### Linux
+
+**Ubuntu**
+An apt package is available for ATLAS on Ubuntu:
+
+```
+sudo apt-get install libatlas-base-dev libatlas-dev
+```
+
+**CentOS**
+You can install ATLAS on CentOS using:
+
+```
+sudo yum install atlas-devel
+```
+
+###### OS X
+
+Installing ATLAS on OS X is a somewhat complicated and lengthy process. However, the following commands will work on most machines:
+
+```
+wget http://hivelocity.dl.sourceforge.net/project/math-atlas/Stable/3.10.1/atlas3.10.1.tar.bz2 (Download)
+tar jxf atlas3.10.1.tar.bz2
+mkdir atlas (Creating a directory for ATLAS)
+mv ATLAS atlas/src-3.10.1
+cd atlas/src-3.10.1
+wget http://www.netlib.org/lapack/lapack-3.5.0.tgz (It may be possible that the atlas download already contains this file in which case this command is not needed)
+mkdir intel(Creating a build directory)
+cd intel
+cpufreq-selector -g performance (This command requires root access. It is recommended but not essential)
+../configure --prefix=/path to the directory where you want ATLAS installed/ --shared --with-netlib-lapack-tarfile=../lapack-3.5.0.tgz
+make
+make check
+make ptcheck
+make time
+make install
+```
+
+#### GPU
+
+Detailed instructions for installing GPU architectures such as Jcublas can be found [here](http://nd4j.org/gpu_native_backends.html).
+
+## Downloading and installing
+
+## OS X & Linux
+
+### Checking ENV
+
+Before running the DL4J stack build script, you must ensure certain environment variables are defined before running your build. These are outlined below depending on your architecture.
+
+#### LIBND4J_HOME
+
+You will need to know the exact path of the directory where you are running the DL4J build script (you are encouraged to use a clean empty directory). Otherwise, your build will fail. Once you determine this path, add `/libnd4j` to the end of that path and export it to your local environment. This will look like:
+
+```
+export LIBND4J_HOME=/home/user/directory/libnd4j
+```
+
+#### CPU architecture w/ MKL
+
+You can link with MKL either at build time, or at runtime with binaries initially linked with another BLAS implementation such as OpenBLAS. To build against MKL, simply add the path containing `libmkl_rt.so` (or `mkl_rt.dll` on Windows), say `/path/to/intel64/lib/`, to the `LD_LIBRARY_PATH` environment variable on Linux (or `PATH` on Windows) and build like before. On Linux though, to make sure it uses the correct version of OpenMP, we also might need to set these environment variables:
+
+```bash
+export MKL_THREADING_LAYER=GNU
+export LD_PRELOAD=/lib64/libgomp.so.1
+```
+
+When libnd4j cannot be rebuilt, we can use the MKL libraries after the facts and get them loaded instead of OpenBLAS at runtime, but things are a bit trickier. Please additionally follow the instructions below.
+
+1. Make sure that files such as `/lib64/libopenblas.so.0` and `/lib64/libblas.so.3` are not available (or appear after in the `PATH` on Windows), or they will get loaded by libnd4j by their absolute paths, before anything else.
+
+2. Inside `/path/to/intel64/lib/`, create a symbolic link or copy of `libmkl_rt.so` (or `mkl_rt.dll` on Windows) to the name that libnd4j expect to load, for example:
+
+    ```bash
+    ln -s libmkl_rt.so libopenblas.so.0
+    ln -s libmkl_rt.so libblas.so.3
+    ```
+
+    ```cmd
+    copy mkl_rt.dll libopenblas.dll
+    copy mkl_rt.dll libblas3.dll
+    ```
+
+3. Finally, add `/path/to/intel64/lib/` to the `LD_LIBRARY_PATH` environment variable (or early in the `PATH` on Windows) and run your Java application as usual.
+
+
+### Build Script
+
+A community-provided script [build-dl4j-stack.sh](https://gist.github.com/crockpotveggies/9948a365c2d45adcf96642db336e7df1) written in bash is available that clones the DL4J stack, builds each repository, and installs them locally to Maven. This script will work on both Linux and OS X platforms.
+
+## Using local dependencies
+
+Once you've installed the DL4J stack to your local maven repository, you can now include it in your build tool's dependencies. Follow the typical [Getting Started](http://deeplearning4j.org/gettingstarted) instructions for Deeplearning4j, and appropriately replace versions with the SNAPSHOT version currently on the [master POM](https://github.com/deeplearning4j/deeplearning4j/blob/master/pom.xml).
+
+Note that some build tools such as Gradle and SBT don't properly pull in platform-specific binaries. You can follow instructions [here](http://nd4j.org/dependencies.html) for setting up your favorite build tool.
+
+## Support and Assistance
+
+If you encounter issues while building locally, the Deeplearning4j [Early Adopters Channel](https://gitter.im/deeplearning4j/deeplearning4j/earlyadopters) is a channel dedicated to assisting with build issues and other source problems. Please reach out on Gitter for help.

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -229,13 +229,13 @@ A community-provided script [build-dl4j-stack.sh](https://gist.github.com/crockp
 Use the build script as follows:
 
 ```
-bash build-dl4j-stack.sh cpu
+./build-dl4j-stack.sh cpu
 ```
 
 If you are using a GPU backend:
 
 ```
-bash build-dl4j-stack.sh gpu
+./build-dl4j-stack.sh gpu
 ```
 
 The build script passes all options and flags to the libnd4j `./buildnativeoperations.sh` script. All flags used for those script can be passed via `build-dl4j-stack.sh`.

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -27,12 +27,14 @@ Your local machine will require some essential software and environment variable
 Architecture-specific software includes:
 
 **CPU options:**
+
 - Intel MKL
 - OpenBLAS
 - ATLAS
 - ND4J-Java (Android)
 
 **GPU options:**
+
 - Jcublas/CUDA
 - JOCL (coming soon)
 

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -95,9 +95,7 @@ If you use Visual Studio:
 
 Once you have installed the prerequisite tools, you can now install the required architectures for your platform.
 
-#### CPU
-
-##### Intel MKL
+#### Intel MKL
 
 Of all the existing architectures available for CPU, Intel MKL is currently the fastest. However, it requires some "overhead" before you actually install it.
 
@@ -105,9 +103,9 @@ Of all the existing architectures available for CPU, Intel MKL is currently the 
 2. After a few steps through Intel, you will receive a download link
 3. Download and install Intel MKL using [the setup guide](https://software.intel.com/sites/default/files/managed/94/bf/Install_Guide_0.pdf)
 
-##### OpenBLAS
+#### OpenBLAS
 
-###### Linux
+##### Linux
 
 **Ubuntu**
 Assuming you are using Ubuntu, you can install OpenBLAS via:
@@ -134,7 +132,7 @@ After that, you should see a lot of activity and installs on the terminal. To ve
 
 For more complete instructions, [go here](http://www.cyberciti.biz/faq/centos-linux-install-gcc-c-c-compiler/).
 
-###### OS X
+##### OS X
 
 You can install OpenBLAS on OS X with Homebrew Science:
 
@@ -142,7 +140,7 @@ You can install OpenBLAS on OS X with Homebrew Science:
 brew install homebrew/science/openblas
 ```
 
-###### Windows
+##### Windows
 
 [This page](http://avulanov.blogspot.cz/2014/09/howto-to-run-netlib-javabreeze-in.html) describes how to obtain dll for the Windows 64 platform:
 1. Download dll libraries and place them in the Java bin folder (e.g. `C:\prg\Java\jdk1.7.0_45\bin`).
@@ -156,9 +154,9 @@ liblapack3.dll`
 3. (`liblapack3.dll` and `libblas3.dll` are just renamed copies of `libopeblas.dll`)
 4. You can download compiled libs from [here](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Automated%20Builds/), [here](http://www.openblas.net/), or [here](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22netlib-native_system-win-x86_64%22)
 
-##### ATLAS
+#### ATLAS
 
-###### Linux
+##### Linux
 
 **Ubuntu**
 An apt package is available for ATLAS on Ubuntu:
@@ -174,7 +172,7 @@ You can install ATLAS on CentOS using:
 sudo yum install atlas-devel
 ```
 
-###### OS X
+##### OS X
 
 Installing ATLAS on OS X is a somewhat complicated and lengthy process. However, the following commands will work on most machines:
 
@@ -196,11 +194,11 @@ make time
 make install
 ```
 
-#### GPU
+#### Jcublas/CUDA
 
 Detailed instructions for installing GPU architectures such as Jcublas can be found [here](http://nd4j.org/gpu_native_backends.html).
 
-## Downloading and installing
+## Installing the DL4J Stack
 
 ## OS X & Linux
 
@@ -220,7 +218,8 @@ export LIBND4J_HOME=/home/user/directory/libnd4j
 
 You can link with MKL either at build time, or at runtime with binaries initially linked with another BLAS implementation such as OpenBLAS. To build against MKL, simply add the path containing `libmkl_rt.so` (or `mkl_rt.dll` on Windows), say `/path/to/intel64/lib/`, to the `LD_LIBRARY_PATH` environment variable on Linux (or `PATH` on Windows) and build like before. On Linux though, to make sure it uses the correct version of OpenMP, we also might need to set these environment variables:
 
-```bash
+```
+bash
 export MKL_THREADING_LAYER=GNU
 export LD_PRELOAD=/lib64/libgomp.so.1
 ```
@@ -230,15 +229,18 @@ When libnd4j cannot be rebuilt, we can use the MKL libraries after the facts and
 1. Make sure that files such as `/lib64/libopenblas.so.0` and `/lib64/libblas.so.3` are not available (or appear after in the `PATH` on Windows), or they will get loaded by libnd4j by their absolute paths, before anything else.
 2. Inside `/path/to/intel64/lib/`, create a symbolic link or copy of `libmkl_rt.so` (or `mkl_rt.dll` on Windows) to the name that libnd4j expect to load, for example:
 
-    ```bash
-    ln -s libmkl_rt.so libopenblas.so.0
-    ln -s libmkl_rt.so libblas.so.3
-    ```
+```
+bash
+ln -s libmkl_rt.so libopenblas.so.0
+ln -s libmkl_rt.so libblas.so.3
+```
 
-    ```cmd
-    copy mkl_rt.dll libopenblas.dll
-    copy mkl_rt.dll libblas3.dll
-    ```
+```
+cmd
+copy mkl_rt.dll libopenblas.dll
+copy mkl_rt.dll libblas3.dll
+```
+
 3. Finally, add `/path/to/intel64/lib/` to the `LD_LIBRARY_PATH` environment variable (or early in the `PATH` on Windows) and run your Java application as usual.
 
 

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -13,7 +13,7 @@ Building locally requires that you build the entire Deeplearning4j stack which i
 - [nd4j](https://github.com/deeplearning4j/nd4j)
 - [deeplearning4j](https://github.com/deeplearning4j/deeplearning4j)
 
-Note that Deeplearning4j is designed to work on most platforms (Windows, OS X, and Linux) and is also includes multiple "flavors" depending on the computing architecture you choose to utilize. This includes CPU (OpenBLAS, MKL, ATLAS) and GPU (CUDA).
+Note that Deeplearning4j is designed to work on most platforms (Windows, OS X, and Linux) and is also includes multiple "flavors" depending on the computing architecture you choose to utilize. This includes CPU (OpenBLAS, MKL, ATLAS) and GPU (CUDA). The DL4J stack also supports x86 and PowerPC architectures.
 
 ## Prerequisites
 
@@ -26,14 +26,14 @@ Your local machine will require some essential software and environment variable
 
 Architecture-specific software includes:
 
-**CPU options:**
+CPU options:
 
 - Intel MKL
 - OpenBLAS
 - ATLAS
 - ND4J-Java (Android)
 
-**GPU options:**
+GPU options:
 
 - Jcublas/CUDA
 - JOCL (coming soon)

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -20,9 +20,10 @@ Note that Deeplearning4j is designed to work on most platforms (Windows, OS X, a
 Your local machine will require some essential software and environment variables set *before* you try to build and install the DL4J stack. Depending on your platform and the version of your operating system, the instructions may vary in getting them to work. This software includes:
 
 - git
-- cmake with OpenMP
-- gcc (3.2 or higher)
-- maven (3 or higher)
+- cmake (3.2 or higher)
+- OpenMP
+- gcc (4.9 or higher)
+- maven (3.3 or higher)
 
 Architecture-specific software includes:
 

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -50,7 +50,6 @@ sudo apt-get purge maven maven2 maven3
 sudo add-apt-repository ppa:natecarlson/maven3
 sudo apt-get update
 sudo apt-get install maven build-essentials cmake libgomp1
-
 ```
 
 #### OS X

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -300,7 +300,7 @@ cd ..
 ```
 
 
-## Using local dependencies
+## Using Local Dependencies
 
 Once you've installed the DL4J stack to your local maven repository, you can now include it in your build tool's dependencies. Follow the typical [Getting Started](http://deeplearning4j.org/gettingstarted) instructions for Deeplearning4j, and appropriately replace versions with the SNAPSHOT version currently on the [master POM](https://github.com/deeplearning4j/deeplearning4j/blob/master/pom.xml).
 

--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -9,9 +9,9 @@ For those developers and engineers who prefer to use the most up-to-date version
 
 Building locally requires that you build the entire Deeplearning4j stack which includes:
 
-* [libnd4j](https://github.com/deeplearning4j/libnd4j)
-* [nd4j](https://github.com/deeplearning4j/nd4j)
-* [deeplearning4j](https://github.com/deeplearning4j/deeplearning4j)
+- [libnd4j](https://github.com/deeplearning4j/libnd4j)
+- [nd4j](https://github.com/deeplearning4j/nd4j)
+- [deeplearning4j](https://github.com/deeplearning4j/deeplearning4j)
 
 Note that Deeplearning4j is designed to work on most platforms (Windows, OS X, and Linux) and is also includes multiple "flavors" depending on the computing architecture you choose to utilize. This includes CPU (OpenBLAS, MKL, ATLAS) and GPU (CUDA).
 
@@ -19,20 +19,22 @@ Note that Deeplearning4j is designed to work on most platforms (Windows, OS X, a
 
 Your local machine will require some essential software and environment variables set *before* you try to build and install the DL4J stack. Depending on your platform and the version of your operating system, the instructions may vary in getting them to work. This software includes:
 
-* git
-* cmake with OpenMP
-* gcc (3.2 or higher)
-* maven (3 or higher)
+- git
+- cmake with OpenMP
+- gcc (3.2 or higher)
+- maven (3 or higher)
 
 Architecture-specific software includes:
 
 **CPU options:**
-* Intel MKL
-* OpenBLAS
-* ATLAS
+- Intel MKL
+- OpenBLAS
+- ATLAS
+- ND4J-Java (Android)
 
 **GPU options:**
-* Jcublas/CUDA
+- Jcublas/CUDA
+- JOCL (coming soon)
 
 ### Installing Prerequisite Tools
 
@@ -74,16 +76,16 @@ Type `cl` into your CMD. You may get a message informing you that certain `.dll`
 
 If you use Visual Studio: 
 
-* Set up `PATH` environment variable to point to `\bin\` (for `cl.exe` etc)
-* Also try running `vcvars32.bat` (also in bin) to set up environment before doing `mvn clean install` on ND4J (it may save you from copying headers around)
-* `vcvars32` may be temporary, so you might need to run it every time you want to do ND4J `mvn install`.
-* After installing Visual Studio 2015 and setting the PATH variable, you need to run the `vcvars32.bat` to set up the environment variables (INCLUDE, LIB, LIBPATH) properly so that you don't have to copy header files. But if you run the bat file from Explorer, since the settings are temporary, they're not properly set. So run `vcvars32.bat` from the same CMD window as your `mvn install`, and all the environment variables will be set correctly.
-* Here is how they should be set: 
+1. Set up `PATH` environment variable to point to `\bin\` (for `cl.exe` etc)
+1. Also try running `vcvars32.bat` (also in bin) to set up environment before doing `mvn clean install` on ND4J (it may save you from copying headers around)
+1. `vcvars32` may be temporary, so you might need to run it every time you want to do ND4J `mvn install`.
+1. After installing Visual Studio 2015 and setting the PATH variable, you need to run the `vcvars32.bat` to set up the environment variables (INCLUDE, LIB, LIBPATH) properly so that you don't have to copy header files. But if you run the bat file from Explorer, since the settings are temporary, they're not properly set. So run `vcvars32.bat` from the same CMD window as your `mvn install`, and all the environment variables will be set correctly.
+1. Here is how they should be set: 
 
     INCLUDE = C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include
     LIB = "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\lib"
     //so you can link to .lib files^^
-* In Visual Studio, you also have to click on C++. It is no longer set by default. 
+1. In Visual Studio, you also have to click on C++. It is no longer set by default. 
 (*In addition, the include path for [Java CPP](https://github.com/bytedeco/javacpp) doesn't always work on Windows. One workaround is to take the the header files from the include directory of Visual Studio, and put them in the include directory of the Java Run-Time Environment (JRE), where Java is installed. This will affect files such as `standardio.h`.*)
 * For a walkthrough of installing our examples with Git, IntelliJ and Maven, please see our [Quickstart page](http://deeplearning4j.org/quickstart.html#walk)
 
@@ -97,9 +99,9 @@ Once you have installed the prerequisite tools, you can now install the required
 
 Of all the existing architectures available for CPU, Intel MKL is currently the fastest. However, it requires some "overhead" before you actually install it.
 
-* Apply for a license at [Intel's site](https://software.intel.com/en-us/intel-mkl)
-* After a few steps through Intel, you will receive a download link
-* Download and install Intel MKL using [the setup guide](https://software.intel.com/sites/default/files/managed/94/bf/Install_Guide_0.pdf)
+1. Apply for a license at [Intel's site](https://software.intel.com/en-us/intel-mkl)
+2. After a few steps through Intel, you will receive a download link
+3. Download and install Intel MKL using [the setup guide](https://software.intel.com/sites/default/files/managed/94/bf/Install_Guide_0.pdf)
 
 ##### OpenBLAS
 
@@ -141,16 +143,16 @@ brew install homebrew/science/openblas
 ###### Windows
 
 [This page](http://avulanov.blogspot.cz/2014/09/howto-to-run-netlib-javabreeze-in.html) describes how to obtain dll for the Windows 64 platform:
-* Download dll libraries and place them in the Java bin folder (e.g. `C:\prg\Java\jdk1.7.0_45\bin`).
-* Library `netlib-native_system-win-x86_64.dll` depends on: 
+1. Download dll libraries and place them in the Java bin folder (e.g. `C:\prg\Java\jdk1.7.0_45\bin`).
+2. Library `netlib-native_system-win-x86_64.dll` depends on: 
 `libgcc_s_seh-1.dll
 libgfortran-3.dll
 libquadmath-0.dll
 libwinpthread-1.dll
 libblas3.dll
 liblapack3.dll`
-* (`liblapack3.dll` and `libblas3.dll` are just renamed copies of `libopeblas.dll`)
-* You can download compiled libs from [here](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Automated%20Builds/), [here](http://www.openblas.net/), or [here](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22netlib-native_system-win-x86_64%22)
+3. (`liblapack3.dll` and `libblas3.dll` are just renamed copies of `libopeblas.dll`)
+4. You can download compiled libs from [here](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Automated%20Builds/), [here](http://www.openblas.net/), or [here](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22netlib-native_system-win-x86_64%22)
 
 ##### ATLAS
 
@@ -224,7 +226,6 @@ export LD_PRELOAD=/lib64/libgomp.so.1
 When libnd4j cannot be rebuilt, we can use the MKL libraries after the facts and get them loaded instead of OpenBLAS at runtime, but things are a bit trickier. Please additionally follow the instructions below.
 
 1. Make sure that files such as `/lib64/libopenblas.so.0` and `/lib64/libblas.so.3` are not available (or appear after in the `PATH` on Windows), or they will get loaded by libnd4j by their absolute paths, before anything else.
-
 2. Inside `/path/to/intel64/lib/`, create a symbolic link or copy of `libmkl_rt.so` (or `mkl_rt.dll` on Windows) to the name that libnd4j expect to load, for example:
 
     ```bash
@@ -236,7 +237,6 @@ When libnd4j cannot be rebuilt, we can use the MKL libraries after the facts and
     copy mkl_rt.dll libopenblas.dll
     copy mkl_rt.dll libblas3.dll
     ```
-
 3. Finally, add `/path/to/intel64/lib/` to the `LD_LIBRARY_PATH` environment variable (or early in the `PATH` on Windows) and run your Java application as usual.
 
 

--- a/buildtools.md
+++ b/buildtools.md
@@ -7,7 +7,7 @@ layout: default
 
 While we encourage Deeplearning4j, ND4J and Canova users to employ Maven, it's worthwhile documenting how to configure build files for other tools, like Ivy, Gradle and SBT -- particularly since Google prefers Gradle over Maven for Android projects. 
 
-The instructions below apply to all DL4J and ND4J submodules, such as *deeplearning4j-api, deeplearning4j-scaleout, and ND4J backends. You can find the **latest version** of any project or submodule on [Maven Central](https://search.maven.org/). As of February 2016, the latest version is `rc3.8`.
+The instructions below apply to all DL4J and ND4J submodules, such as *deeplearning4j-api, deeplearning4j-scaleout, and ND4J backends. You can find the **latest version** of any project or submodule on [Maven Central](https://search.maven.org/). As of May 2016, the latest version is `rc3.9`.
 
 ## Maven
 
@@ -17,7 +17,7 @@ You can use Deeplearning4j with Maven by adding the following to your POM.xml:
       <dependency>
           <groupId>org.deeplearning4j</groupId>
           <artifactId>deeplearning4j-core</artifactId>
-          <version>0.4-rc3.8</version>
+          <version>0.4-rc3.9</version>
           <scope>provided</scope>
       </dependency>
     </dependencies>

--- a/devguide.md
+++ b/devguide.md
@@ -5,6 +5,8 @@ layout: default
 
 # Developer Guide
 
+*Note: Developers who are contributing will need to build from source. Follow our [building locally](./buildinglocally.html) guide before getting started.*
+
 ## DeepLearning4J and Related Projects - An Overview
 
 DeepLearning4j is perhaps the more visible project, there are a number of other projects that you should be familiar with - and may consider contributing to. These include:


### PR DESCRIPTION
Early Adopter users who are building from source need a guide to help them navigate a setup from scratch. This piece of documentation is meant to address that.