### PR TITLE
Add additional constructors for SparkEarlyStoppingGraphTrainer

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/BaseSparkEarlyStoppingTrainer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/BaseSparkEarlyStoppingTrainer.java
@@ -102,6 +102,14 @@ public abstract class BaseSparkEarlyStoppingTrainer<T extends Model> implements 
             }
         }
 
+        // repartition if size is different
+        if(numPartitions != 0){
+            if(numPartitions != train.partitions().size()){
+                log.info("Repartitioning training set to {}", numPartitions);
+                train.repartition(numPartitions);
+            }
+        }
+
         if(listener != null)
             listener.onStart(esConfig,net);
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/SparkEarlyStoppingGraphTrainer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/SparkEarlyStoppingGraphTrainer.java
@@ -38,8 +38,20 @@ public class SparkEarlyStoppingGraphTrainer extends BaseSparkEarlyStoppingTraine
     private SparkComputationGraph sparkNet;
 
     public SparkEarlyStoppingGraphTrainer(SparkContext sc, EarlyStoppingConfiguration<ComputationGraph> esConfig, ComputationGraph net,
+                                          JavaRDD<MultiDataSet> train, int examplesPerFit, int totalExamples) {
+        this(sc,esConfig,net,train,examplesPerFit,totalExamples,0,null);
+    }
+
+    public SparkEarlyStoppingGraphTrainer(SparkContext sc, EarlyStoppingConfiguration<ComputationGraph> esConfig, ComputationGraph net,
                                           JavaRDD<MultiDataSet> train, int examplesPerFit, int totalExamples, int numPartitions) {
         this(sc,esConfig,net,train,examplesPerFit,totalExamples,numPartitions,null);
+    }
+
+    public SparkEarlyStoppingGraphTrainer(SparkContext sc, EarlyStoppingConfiguration<ComputationGraph> esConfig, ComputationGraph net,
+                                          JavaRDD<MultiDataSet> train, int examplesPerFit, int totalExamples, 
+                                          EarlyStoppingListener<ComputationGraph> listener) {
+        super(sc, esConfig, net, null, train, examplesPerFit, totalExamples, 0, listener);
+        this.sparkNet = new SparkComputationGraph(sc,net);
     }
 
     public SparkEarlyStoppingGraphTrainer(SparkContext sc, EarlyStoppingConfiguration<ComputationGraph> esConfig, ComputationGraph net,

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/SparkEarlyStoppingTrainer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/SparkEarlyStoppingTrainer.java
@@ -51,6 +51,17 @@ public class SparkEarlyStoppingTrainer extends BaseSparkEarlyStoppingTrainer<Mul
     private SparkDl4jMultiLayer sparkNet;
 
     public SparkEarlyStoppingTrainer(SparkContext sc, EarlyStoppingConfiguration<MultiLayerNetwork> esConfig, MultiLayerNetwork net,
+                                     JavaRDD<DataSet> train, int examplesPerFit, int totalExamples) {
+        this(sc, esConfig, net, train, examplesPerFit, totalExamples, 0, null);
+    }
+
+    public SparkEarlyStoppingTrainer(SparkContext sc, EarlyStoppingConfiguration<MultiLayerNetwork> esConfig, MultiLayerNetwork net,
+                                     JavaRDD<DataSet> train, int examplesPerFit, int totalExamples, EarlyStoppingListener<MultiLayerNetwork> listener) {
+        super(sc, esConfig, net, train, null, examplesPerFit, totalExamples, 0, listener);
+        sparkNet = new SparkDl4jMultiLayer(sc, net);
+    }
+
+    public SparkEarlyStoppingTrainer(SparkContext sc, EarlyStoppingConfiguration<MultiLayerNetwork> esConfig, MultiLayerNetwork net,
                                      JavaRDD<DataSet> train, int examplesPerFit, int totalExamples, int numPartitions) {
         this(sc, esConfig, net, train, examplesPerFit, totalExamples, numPartitions, null);
     }


### PR DESCRIPTION
If the user doesn't want to change the numPartitions already in Spark, then it's wise that we provide a constructor to leave it out.