### PR TITLE
Fix scala multi-build.

### DIFF
--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -1,4 +1,3 @@
-#! /bin/sh
-for v in 2.10 2.11 ; do
-  mvn -Dscala.binary.version=$v $*
-done
+#! /bin/bash
+mvn -Dscala.binary.version=2.10 -Dscala.version=2.10.6 "$@"
+mvn -Dscala.binary.version=2.11 -Dscala.version=2.11.7 "$@"

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/pom.xml
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/pom.xml
@@ -24,13 +24,12 @@
 		<artifactId>deeplearning4j-scaleout</artifactId>
 		<version>0.4-rc3.10-SNAPSHOT</version>
 	</parent>
-	<artifactId>deeplearning4j-scaleout-akka</artifactId>
+	<artifactId>deeplearning4j-scaleout-akka_${scala.binary.version}</artifactId>
 	<name>deeplearning4j-scaleout-akka</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<akka.version>2.3.4-spark</akka.version>
 		<hazelcast.version>3.4.2</hazelcast.version>
-		<scala.binary.version>2.10</scala.binary.version>
 		<akka.group>org.spark-project.akka</akka.group>
 	</properties>
 	<dependencyManagement>

--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/pom.xml
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>dl4j-spark-nlp</artifactId>
+    <artifactId>dl4j-spark-nlp_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
 
     <name>dl4j-spark-nlp</name>
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
-            <artifactId>dl4j-spark</artifactId>
+            <artifactId>dl4j-spark_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>dl4j-spark</artifactId>
+    <artifactId>dl4j-spark_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
 
     <name>dl4j-spark</name>
@@ -34,7 +34,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <hadoop.version>1.0.4</hadoop.version>
-        <scala.version>2.11.6</scala.version>
         <spark.version>1.4.0</spark.version>
     </properties>
 

--- a/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark</artifactId>
+    <artifactId>spark_${scala.binary.version}</artifactId>
     <packaging>pom</packaging>
 
     <name>org.deeplearning4j.spark</name>
@@ -37,7 +37,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <hadoop.version>1.0.4</hadoop.version>
-        <scala.version>2.11.6</scala.version>
         <spark.version>1.3.0</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
     </properties>


### PR DESCRIPTION
This fixes the Scala multi-build so that the scala suffix is appropriately appended to the artifact in the maven repository. It also addresses some issues where the multi-build was not properly overriding scala binary versions when pulling in Spark. Additionally, the suffix for `scaleout-akka` had a repeated underscore.

A maven repository should now look like this:
![screen shot 2016-05-20 at 10 18 42 am](https://cloud.githubusercontent.com/assets/1445295/15436226/a62b69da-1e75-11e6-94d7-ff1b3e1ec268.png)
