### PR TITLE
Default Scala version in parent POM.

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
@@ -66,6 +66,7 @@
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.1.6</version>
                 <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
                     <recompileMode>incremental</recompileMode>
                     <args>
                         <arg>-deprecation</arg>

--- a/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
@@ -64,10 +64,9 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.1.6</version>
+                <version>3.2.2</version>
                 <configuration>
                     <scalaVersion>${scala.version}</scalaVersion>
-                    <recompileMode>incremental</recompileMode>
                     <args>
                         <arg>-deprecation</arg>
                         <arg>-explaintypes</arg>

--- a/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
@@ -62,19 +62,34 @@
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.1.6</version>
+                <configuration>
+                    <recompileMode>incremental</recompileMode>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-explaintypes</arg>
+                    </args>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
                         <goals>
+                            <goal>add-source</goal>
                             <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
                             <goal>testCompile</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <scalaVersion>${scala.version}</scalaVersion>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark_${scala.binary.version}</artifactId>
+    <artifactId>spark</artifactId>
     <packaging>pom</packaging>
 
     <name>org.deeplearning4j.spark</name>
@@ -38,7 +38,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <hadoop.version>1.0.4</hadoop.version>
         <spark.version>1.5.2</spark.version>
-        <scala.binary.version>2.11</scala.binary.version>
     </properties>
 
 

--- a/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/pom.xml
@@ -44,22 +44,36 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.1.6</version>
+                <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <recompileMode>incremental</recompileMode>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-explaintypes</arg>
+                    </args>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
                         <goals>
+                            <goal>add-source</goal>
                             <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
                             <goal>testCompile</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <scalaVersion>${scala.version}</scalaVersion>
-                </configuration>
             </plugin>
-
-
         </plugins>
     </build>
 

--- a/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/pom.xml
@@ -46,10 +46,9 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.1.6</version>
+                <version>3.2.2</version>
                 <configuration>
                     <scalaVersion>${scala.version}</scalaVersion>
-                    <recompileMode>incremental</recompileMode>
                     <args>
                         <arg>-deprecation</arg>
                         <arg>-explaintypes</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
         <json.version>20131018</json.version>
         <google.protobuf.version>2.6.1</google.protobuf.version>
         <failIfNoTests>false</failIfNoTests>
+        <scala.binary.version>2.11</scala.binary.version>
+        <scala.version>2.11.7</scala.version>
     </properties>
 
 


### PR DESCRIPTION
Leaves the default Scala version as `2.11` for users who just want to build without specifying the Scala version. Also upgrades the scala compiler plugin. In addition, fixes the spark artifact parent for those installing on a fresh Maven repo.

**Note: you will need to build a cross-compatible `canova-spark_2.11` version otherwise it will fail.**