### PR TITLE
Scala binary classifier missing for some artifacts

### DIFF
--- a/deeplearning4j-cli/deeplearning4j-cli-spark/pom.xml
+++ b/deeplearning4j-cli/deeplearning4j-cli-spark/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
-            <artifactId>dl4j-spark-nlp</artifactId>
+            <artifactId>dl4j-spark-nlp_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/deeplearning4j-scaleout/deeplearning4j-aws/pom.xml
+++ b/deeplearning4j-scaleout/deeplearning4j-aws/pom.xml
@@ -38,7 +38,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.deeplearning4j</groupId>
-			<artifactId>deeplearning4j-scaleout-akka</artifactId>
+			<artifactId>deeplearning4j-scaleout-akka_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
`${scala.binary.version}` suffix wasn't added to some of the scala-related artifacts, making maven pull in whatever it found -- which could be the wrong version, and possibly forcing the wrong scala version! 