### PR TITLE
Fix CifarDataSetIterator and renable tests using it and CifarLoader

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/DataSetIteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/DataSetIteratorTest.java
@@ -164,7 +164,6 @@ public class DataSetIteratorTest {
 	}
 
 	@Test
-	@Ignore	//Until CifarDataSetIterator / CifarLoader is fixed
 	public void testCifarIterator() throws Exception {
 		int numExamples = 10;
 		int row = 28;
@@ -179,7 +178,6 @@ public class DataSetIteratorTest {
 
 
 	@Test
-	@Ignore	//Until CifarDataSetIterator / CifarLoader is fixed
 	public void testCifarModel() throws Exception{
 		final int height = 32;
 		final int width = 32;


### PR DESCRIPTION
For https://github.com/deeplearning4j/Canova/issues/156

Also, CifarLoader doesn't support image scaling, so test using the data's native size (32x32x3).