### PR TITLE
Run specified number of iterations in Spark impl

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/BaseSparkEarlyStoppingTrainer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/earlystopping/BaseSparkEarlyStoppingTrainer.java
@@ -68,10 +68,18 @@ public abstract class BaseSparkEarlyStoppingTrainer<T extends Model> implements 
             throw new IllegalArgumentException("Cannot conduct early stopping without a termination condition (both Iteration "
                 + "and Epoch termination conditions are null/empty)");
         }
+
+        // repartition if size is different
+        if(numPartitions != 0 && numPartitions != train.partitions().size()){
+            log.info("Repartitioning training set to {}", numPartitions);
+            this.train = train.repartition(numPartitions);
+        } else {
+            this.train = train;
+        }
+
         this.sc = sc;
         this.esConfig = esConfig;
         this.net = net;
-        this.train = train;
         this.trainMulti = trainMulti;
         this.examplesPerFit = examplesPerFit;
         this.totalExamples = totalExamples;
@@ -99,14 +107,6 @@ public abstract class BaseSparkEarlyStoppingTrainer<T extends Model> implements 
         if(esConfig.getEpochTerminationConditions() != null){
             for( EpochTerminationCondition c : esConfig.getEpochTerminationConditions()){
                 c.initialize();
-            }
-        }
-
-        // repartition if size is different
-        if(numPartitions != 0){
-            if(numPartitions != train.partitions().size()){
-                log.info("Repartitioning training set to {}", numPartitions);
-                train.repartition(numPartitions);
             }
         }
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/computationgraph/SparkComputationGraph.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/computationgraph/SparkComputationGraph.java
@@ -224,7 +224,9 @@ public class SparkComputationGraph implements Serializable {
                 iterations + "), (num partions = " + rdd.partitions().size() + ")");
         if(!averageEachIteration) {
             //Do multiple iterations and average once at the end
-            runIteration(rdd);
+            for(int i = 0; i < iterations; i++) {
+                runIteration(rdd);
+            }
         } else {
             //Temporarily set numIterations = 1. Control numIterations externally here so we can average between iterations
             for(GraphVertex gv : conf.getVertices().values()) {

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/SparkDl4jMultiLayer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/SparkDl4jMultiLayer.java
@@ -338,7 +338,9 @@ public class SparkDl4jMultiLayer implements Serializable {
                 iterations + "), (num partions = " + rdd.partitions().size() + ")");
         if(!averageEachIteration) {
             //Do multiple iterations and average once at the end
-            runIteration(rdd);
+            for(int i = 0; i < iterations; i++) {
+                runIteration(rdd);
+            }
         } else {
             //Temporarily set numIterations = 1. Control numIterations externall here so we can average between iterations
             for(NeuralNetConfiguration conf : this.conf.getConfs()) {


### PR DESCRIPTION
Both Spark multi-layer and computation graph do not run the specified number of iterations when `AVERAGE_EACH_ITERATION` is set to false. Fix this.