### PR TITLE
canDoBackward() in BaseGrahVertex: check for epsilons

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/vertex/BaseGraphVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/vertex/BaseGraphVertex.java
@@ -135,8 +135,8 @@ public abstract class BaseGraphVertex implements GraphVertex {
 
     @Override
     public void clear(){
-        for( int i=0; i<inputs.length; i++ ) inputs[i] = null;
-        for( int i=0; i< epsilons.length; i++ ) epsilons[i] = null;
+        for (int i = 0; i < inputs.length; i++) inputs[i] = null;
+        for (int i = 0; i < epsilons.length; i++) epsilons[i] = null;
     }
 
     @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/vertex/BaseGraphVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/vertex/BaseGraphVertex.java
@@ -148,6 +148,7 @@ public abstract class BaseGraphVertex implements GraphVertex {
     @Override
     public boolean canDoBackward(){
         for (INDArray input : inputs) if (input == null) return false;
+        for (INDArray epsilon : epsilons) if (epsilon == null) return false;
         return true;
     }
 


### PR DESCRIPTION
The default canDoBackward() implementation did not check for the errors to be present. This pull request changes it, as both the inputs and the epsilons are required for the backward pass.