### PR TITLE
fixed the issue: org.deeplearning4j.earlystopping.saver.getLatestModel() loading the best mode instead of the latest model #1651

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/saver/LocalFileModelSaver.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/saver/LocalFileModelSaver.java
@@ -97,9 +97,9 @@ public class LocalFileModelSaver implements EarlyStoppingModelSaver<MultiLayerNe
 
     @Override
     public MultiLayerNetwork getLatestModel() throws IOException {
-        String confOut = FilenameUtils.concat(directory,bestFileNameConf);
-        String paramOut = FilenameUtils.concat(directory,bestFileNameParam);
-        String updaterOut = FilenameUtils.concat(directory,bestFileNameUpdater);
+        String confOut = FilenameUtils.concat(directory,latestFileNameConf);
+        String paramOut = FilenameUtils.concat(directory,latestFileNameParam);
+        String updaterOut = FilenameUtils.concat(directory,latestFileNameUpdater);
         return load(confOut,paramOut,updaterOut);
     }
 


### PR DESCRIPTION
In org.deeplearning4j.earlystopping.saver.getLatestModel(), it was loading the best model.
