### PR TITLE
Try forcing Jekyll to use GFM

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ permalink: /:categories/:year/:month/:day/:title
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 highlighter: rouge
+kramdown:
+   input: GFM
 
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.


### PR DESCRIPTION
GFM is Github Flavored Markdown. It allows to use syntax highlighting and should force the generated pages to at least look a bit like their preview.