### PR TITLE
Introduce support for cuDNN starting with ConvolutionLayer and SubsamplingLayer

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+package org.deeplearning4j.nn.layers.convolution;
+
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * Helper for the convolution layer.
+ *
+ * @author saudet
+ */
+public interface ConvolutionHelper {
+    Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray delta,
+            int[] kernel, int[] strides, int[] pad, INDArray biasGradView, INDArray weightGradView, String afn);
+    INDArray preOutput(INDArray input, INDArray weights, INDArray bias, int[] kernel, int[] strides, int[] pad);
+    INDArray activate(INDArray z, String afn);
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingHelper.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingHelper.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+package org.deeplearning4j.nn.layers.convolution.subsampling;
+
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer.PoolingType;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * Helper for the subsampling layer.
+ *
+ * @author saudet
+ */
+public interface SubsamplingHelper {
+    Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon,
+            int[] kernel, int[] strides, int[] pad, PoolingType poolingType);
+    INDArray activate(INDArray input, boolean training,
+            int[] kernel, int[] strides, int[] pad, PoolingType poolingType);
+}

--- a/deeplearning4j-cuda-7.5/pom.xml
+++ b/deeplearning4j-cuda-7.5/pom.xml
@@ -1,0 +1,67 @@
+<!--
+  ~ /*
+  ~  * Copyright 2016 Skymind,Inc.
+  ~  *
+  ~  *    Licensed under the Apache License, Version 2.0 (the "License");
+  ~  *    you may not use this file except in compliance with the License.
+  ~  *    You may obtain a copy of the License at
+  ~  *
+  ~  *        http://www.apache.org/licenses/LICENSE-2.0
+  ~  *
+  ~  *    Unless required by applicable law or agreed to in writing, software
+  ~  *    distributed under the License is distributed on an "AS IS" BASIS,
+  ~  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  *    See the License for the specific language governing permissions and
+  ~  *    limitations under the License.
+  ~  */
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>deeplearning4j-cuda-7.5</artifactId>
+    <parent>
+        <groupId>org.deeplearning4j</groupId>
+        <artifactId>deeplearning4j-parent</artifactId>
+        <version>0.4-rc3.11-SNAPSHOT</version>
+    </parent>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.nd4j</groupId>
+                <artifactId>nd4j-api</artifactId>
+                <version>${nd4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.nd4j</groupId>
+                <artifactId>nd4j-cuda-7.5</artifactId>
+                <version>${nd4j.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-cuda-7.5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.deeplearning4j</groupId>
+            <artifactId>deeplearning4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco.javacpp-presets</groupId>
+            <artifactId>cuda</artifactId>
+            <version>7.5-1.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/deeplearning4j-cuda-7.5/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
+++ b/deeplearning4j-cuda-7.5/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
@@ -1,0 +1,309 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+package org.deeplearning4j.nn.layers.convolution;
+
+import org.bytedeco.javacpp.FloatPointer;
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.SizeTPointer;
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.BaseLayer;
+import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
+import org.deeplearning4j.util.Dropout;
+import org.nd4j.jita.allocator.Allocator;
+import org.nd4j.jita.allocator.impl.AtomicAllocator;
+import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.convolution.Convolution;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.jcublas.context.CudaContext;
+
+import static org.bytedeco.javacpp.cuda.*;
+import static org.bytedeco.javacpp.cudnn.*;
+
+/**
+ * cuDNN-based helper for the convolution layer.
+ *
+ * @author saudet
+ */
+public class CudnnConvolutionHelper implements ConvolutionHelper {
+
+    static void checkCuda(int error) {
+        if (error != cudaSuccess) {
+            throw new RuntimeException("CUDA error = " + error);
+        }
+    }
+
+    static void checkCudnn(int status) {
+        if (status != CUDNN_STATUS_SUCCESS) {
+            throw new RuntimeException("cuDNN status = " + status);
+        }
+    }
+
+    static class CudnnContext extends cudnnContext {
+
+        static class Deallocator extends CudnnContext implements Pointer.Deallocator {
+            Deallocator(CudnnContext c) { super(c); }
+            @Override public void deallocate() { destroyHandles(); }
+        }
+
+        cudnnTensorStruct srcTensorDesc = new cudnnTensorStruct(),
+                          dstTensorDesc = new cudnnTensorStruct(),
+                          biasTensorDesc = new cudnnTensorStruct(),
+                          deltaTensorDesc = new cudnnTensorStruct();
+        cudnnFilterStruct filterDesc = new cudnnFilterStruct();
+        cudnnConvolutionStruct convDesc = new cudnnConvolutionStruct();
+        cudnnActivationStruct activationDesc = new cudnnActivationStruct();
+
+        CudnnContext() {
+            createHandles();
+            deallocator(new Deallocator(this));
+        }
+
+        CudnnContext(CudnnContext c) {
+            super(c);
+            srcTensorDesc = new cudnnTensorStruct(c.srcTensorDesc);
+            dstTensorDesc = new cudnnTensorStruct(c.dstTensorDesc);
+            biasTensorDesc = new cudnnTensorStruct(c.biasTensorDesc);
+            deltaTensorDesc = new cudnnTensorStruct(c.deltaTensorDesc);
+            filterDesc = new cudnnFilterStruct(c.filterDesc);
+            convDesc = new cudnnConvolutionStruct(c.convDesc);
+            activationDesc = new cudnnActivationStruct(c.activationDesc);
+        }
+
+        void createHandles() {
+            checkCudnn(cudnnCreate(this));
+            checkCudnn(cudnnCreateTensorDescriptor(srcTensorDesc));
+            checkCudnn(cudnnCreateTensorDescriptor(dstTensorDesc));
+            checkCudnn(cudnnCreateTensorDescriptor(biasTensorDesc));
+            checkCudnn(cudnnCreateTensorDescriptor(deltaTensorDesc));
+            checkCudnn(cudnnCreateFilterDescriptor(filterDesc));
+            checkCudnn(cudnnCreateConvolutionDescriptor(convDesc));
+            checkCudnn(cudnnCreateActivationDescriptor(activationDesc));
+        }
+
+        void destroyHandles() {
+            checkCudnn(cudnnDestroyActivationDescriptor(activationDesc));
+            checkCudnn(cudnnDestroyConvolutionDescriptor(convDesc));
+            checkCudnn(cudnnDestroyFilterDescriptor(filterDesc));
+            checkCudnn(cudnnDestroyTensorDescriptor(srcTensorDesc));
+            checkCudnn(cudnnDestroyTensorDescriptor(dstTensorDesc));
+            checkCudnn(cudnnDestroyTensorDescriptor(biasTensorDesc));
+            checkCudnn(cudnnDestroyTensorDescriptor(deltaTensorDesc));
+            checkCudnn(cudnnDestroy(this));
+        }
+    }
+
+    static class WorkSpace extends Pointer {
+
+        static class Deallocator extends WorkSpace implements Pointer.Deallocator {
+            Deallocator(WorkSpace w) { super(w); }
+            @Override public void deallocate() { checkCuda(cudaFree(this)); }
+        }
+
+        WorkSpace() { }
+
+        WorkSpace(long size) {
+            checkCuda(cudaMalloc(this, size));
+            limit = capacity = size;
+            deallocator(new Deallocator(this));
+        }
+
+        WorkSpace(WorkSpace w) {
+            super(w);
+        }
+    }
+
+    CudnnContext cudnnContext = new CudnnContext();
+    WorkSpace workSpace = new WorkSpace();
+    int dataType = Nd4j.dataType() == DataBuffer.Type.DOUBLE ? CUDNN_DATA_DOUBLE : CUDNN_DATA_FLOAT;
+    int tensorFormat = CUDNN_TENSOR_NCHW;
+    FloatPointer alpha = new FloatPointer(1.0f);
+    FloatPointer beta  = new FloatPointer(0.0f);
+    SizeTPointer sizeInBytes = new SizeTPointer(1);
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray delta,
+            int[] kernel, int[] strides, int[] pad, INDArray biasGradView, INDArray weightGradView, String afn) {
+        int miniBatch = input.size(0);
+        int inH = input.size(2);
+        int inW = input.size(3);
+
+        int outDepth = weights.size(0);
+        int inDepth = weights.size(1);
+        int kH = weights.size(2);
+        int kW = weights.size(3);
+
+        int outH = Convolution.outSize(inH, kernel[0], strides[0], pad[0],false);
+        int outW = Convolution.outSize(inW, kernel[1], strides[1], pad[1], false);
+
+        if (!Shape.strideDescendingCAscendingF(delta)) {
+            // apparently not supported by cuDNN
+            delta = delta.dup();
+        }
+
+        int[] srcStride = input.stride();
+        int[] deltaStride = delta.stride();
+        int[] algo = new int[1];
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.srcTensorDesc, dataType, miniBatch, inDepth, inH, inW,
+                srcStride[0], srcStride[1], srcStride[2], srcStride[3]));
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.deltaTensorDesc, dataType, miniBatch, outDepth, outH, outW,
+                deltaStride[0], deltaStride[1], deltaStride[2], deltaStride[3]));
+        checkCudnn(cudnnSetConvolution2dDescriptor(cudnnContext.convDesc, pad[0], pad[1], strides[0], strides[1], 1, 1, CUDNN_CROSS_CORRELATION));
+        checkCudnn(cudnnSetFilter4dDescriptor(cudnnContext.filterDesc, dataType, tensorFormat, outDepth, inDepth, kH, kW));
+        checkCudnn(cudnnGetConvolutionBackwardFilterAlgorithm(cudnnContext, cudnnContext.srcTensorDesc, cudnnContext.deltaTensorDesc,
+                cudnnContext.convDesc, cudnnContext.filterDesc, CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST, 0, algo));
+
+        INDArray epsNext = Nd4j.create(new int[]{miniBatch,inDepth,inH,inW},'c');
+        int[] dstStride = epsNext.stride();
+
+        Allocator allocator = AtomicAllocator.getInstance();
+        CudaContext context = allocator.getFlowController().prepareAction(input, weights, weightGradView, biasGradView, delta, epsNext);
+        Pointer srcData = allocator.getPointer(input, context);
+        Pointer filterData = allocator.getPointer(weights, context);
+        Pointer filterGradData = allocator.getPointer(weightGradView, context);
+        Pointer biasGradData = allocator.getPointer(biasGradView, context);
+        Pointer deltaData = allocator.getPointer(delta, context);
+        Pointer dstData = allocator.getPointer(epsNext, context);
+
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.dstTensorDesc, dataType, miniBatch, inDepth, inH, inW,
+                dstStride[0], dstStride[1], dstStride[2], dstStride[3]));
+        checkCudnn(cudnnGetConvolutionBackwardFilterWorkspaceSize(cudnnContext, cudnnContext.srcTensorDesc,
+                cudnnContext.deltaTensorDesc, cudnnContext.convDesc, cudnnContext.filterDesc, algo[0], sizeInBytes));
+        long sizeInBytes1 = sizeInBytes.get(0);
+        checkCudnn(cudnnGetConvolutionBackwardDataWorkspaceSize(cudnnContext, cudnnContext.filterDesc,
+                cudnnContext.deltaTensorDesc, cudnnContext.convDesc, cudnnContext.dstTensorDesc, algo[0], sizeInBytes));
+        long sizeInBytes2 = sizeInBytes.get(0);
+        if (sizeInBytes1 > workSpace.capacity() || sizeInBytes2 > workSpace.capacity()) {
+            workSpace.deallocate();
+            workSpace = new WorkSpace(Math.max(sizeInBytes1, sizeInBytes2));
+        }
+
+        checkCudnn(cudnnSetTensor4dDescriptor(cudnnContext.biasTensorDesc, tensorFormat, dataType, 1, outDepth, 1, 1));
+        checkCudnn(cudnnConvolutionBackwardBias(cudnnContext, alpha, cudnnContext.deltaTensorDesc, deltaData, beta, cudnnContext.biasTensorDesc, biasGradData));
+        checkCudnn(cudnnConvolutionBackwardFilter(cudnnContext, alpha, cudnnContext.srcTensorDesc, srcData, cudnnContext.deltaTensorDesc, deltaData,
+                cudnnContext.convDesc, algo[0], workSpace, workSpace.capacity(), beta, cudnnContext.filterDesc, filterGradData));
+        checkCudnn(cudnnConvolutionBackwardData(cudnnContext, alpha, cudnnContext.filterDesc, filterData, cudnnContext.deltaTensorDesc, deltaData, cudnnContext.convDesc,
+                algo[0], workSpace, workSpace.capacity(), beta, cudnnContext.dstTensorDesc, dstData));
+
+        allocator.registerAction(context, input, weights, weightGradView, biasGradView, delta, epsNext);
+
+        Gradient retGradient = new DefaultGradient();
+        retGradient.setGradientFor(ConvolutionParamInitializer.BIAS_KEY, biasGradView);
+        retGradient.setGradientFor(ConvolutionParamInitializer.WEIGHT_KEY, weightGradView, 'c');
+
+        return new Pair<>(retGradient,epsNext);
+    }
+
+    @Override
+    public INDArray preOutput(INDArray input, INDArray weights, INDArray bias, int[] kernel, int[] strides, int[] pad) {
+        int miniBatch = input.size(0);
+        int inH = input.size(2);
+        int inW = input.size(3);
+
+        int outDepth = weights.size(0);
+        int inDepth = weights.size(1);
+        int kH = weights.size(2);
+        int kW = weights.size(3);
+
+        int[] srcStride = input.stride();
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.srcTensorDesc, dataType, miniBatch, inDepth, inH, inW,
+                srcStride[0], srcStride[1], srcStride[2], srcStride[3]));
+        checkCudnn(cudnnSetFilter4dDescriptor(cudnnContext.filterDesc, dataType, tensorFormat, outDepth, inDepth, kH, kW));
+        checkCudnn(cudnnSetConvolution2dDescriptor(cudnnContext.convDesc, pad[0], pad[1], strides[0], strides[1], 1, 1, CUDNN_CROSS_CORRELATION));
+
+        // find dimension of convolution output
+        int[] algo = new int[1], n = new int[1], c = new int[1], h = new int[1], w = new int[1];
+        checkCudnn(cudnnGetConvolution2dForwardOutputDim(cudnnContext.convDesc, cudnnContext.srcTensorDesc, cudnnContext.filterDesc, n, c, h, w));
+        INDArray z = Nd4j.createUninitialized(new int[]{n[0],c[0],h[0],w[0]},'c');
+        int[] dstStride = z.stride();
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.dstTensorDesc, dataType, n[0], c[0], h[0], w[0],
+                dstStride[0], dstStride[1], dstStride[2], dstStride[3]));
+        checkCudnn(cudnnGetConvolutionForwardAlgorithm(cudnnContext, cudnnContext.srcTensorDesc, cudnnContext.filterDesc, cudnnContext.convDesc,
+                cudnnContext.dstTensorDesc, CUDNN_CONVOLUTION_FWD_PREFER_FASTEST, 0, algo));
+
+        Allocator allocator = AtomicAllocator.getInstance();
+        CudaContext context = allocator.getFlowController().prepareAction(input, weights, bias, z);
+        Pointer srcData = allocator.getPointer(input, context);
+        Pointer filterData = allocator.getPointer(weights, context);
+        Pointer biasData = allocator.getPointer(bias, context);
+        Pointer dstData = allocator.getPointer(z, context);
+
+        checkCudnn(cudnnGetConvolutionForwardWorkspaceSize(cudnnContext, cudnnContext.srcTensorDesc,
+                cudnnContext.filterDesc, cudnnContext.convDesc, cudnnContext.dstTensorDesc, algo[0], sizeInBytes));
+        if (sizeInBytes.get(0) > workSpace.capacity()) {
+            workSpace.deallocate();
+            workSpace = new WorkSpace(sizeInBytes.get(0));
+        }
+        checkCudnn(cudnnConvolutionForward(cudnnContext, alpha, cudnnContext.srcTensorDesc, srcData,
+                cudnnContext.filterDesc, filterData, cudnnContext.convDesc, algo[0], workSpace, workSpace.capacity(),
+                beta, cudnnContext.dstTensorDesc, dstData));
+
+        checkCudnn(cudnnSetTensor4dDescriptor(cudnnContext.biasTensorDesc, tensorFormat, dataType, 1, c[0], 1, 1));
+        checkCudnn(cudnnAddTensor(cudnnContext, alpha, cudnnContext.biasTensorDesc, biasData, alpha, cudnnContext.dstTensorDesc, dstData));
+
+        allocator.registerAction(context, input, weights, bias, z);
+
+        return z;
+    }
+
+    @Override
+    public INDArray activate(INDArray z, String afn) {
+        INDArray activation = z;
+
+        Allocator allocator = AtomicAllocator.getInstance();
+        CudaContext context = allocator.getFlowController().prepareAction(z);
+        Pointer dstData = allocator.getPointer(z, context);
+
+        switch (afn) {
+            case "identity":
+                break;
+            case "sigmoid":
+                checkCudnn(cudnnSetActivationDescriptor(cudnnContext.activationDesc, CUDNN_ACTIVATION_SIGMOID, CUDNN_PROPAGATE_NAN, 0));
+                checkCudnn(cudnnActivationForward(cudnnContext, cudnnContext.activationDesc, alpha, cudnnContext.dstTensorDesc, dstData, beta, cudnnContext.dstTensorDesc, dstData));
+                break;
+            case "relu":
+                checkCudnn(cudnnSetActivationDescriptor(cudnnContext.activationDesc, CUDNN_ACTIVATION_RELU, CUDNN_PROPAGATE_NAN, 0));
+                checkCudnn(cudnnActivationForward(cudnnContext, cudnnContext.activationDesc, alpha, cudnnContext.dstTensorDesc, dstData, beta, cudnnContext.dstTensorDesc, dstData));
+                break;
+            case "tanh":
+                checkCudnn(cudnnSetActivationDescriptor(cudnnContext.activationDesc, CUDNN_ACTIVATION_TANH, CUDNN_PROPAGATE_NAN, 0));
+                checkCudnn(cudnnActivationForward(cudnnContext, cudnnContext.activationDesc, alpha, cudnnContext.dstTensorDesc, dstData, beta, cudnnContext.dstTensorDesc, dstData));
+                break;
+            case "softmax":
+                checkCudnn(cudnnSoftmaxForward(cudnnContext, CUDNN_SOFTMAX_ACCURATE,
+                        CUDNN_SOFTMAX_MODE_CHANNEL, alpha, cudnnContext.dstTensorDesc, dstData, beta, cudnnContext.dstTensorDesc, dstData));
+                break;
+            case "logsoftmax":
+                checkCudnn(cudnnSoftmaxForward(cudnnContext, CUDNN_SOFTMAX_LOG,
+                        CUDNN_SOFTMAX_MODE_CHANNEL, alpha, cudnnContext.dstTensorDesc, dstData, beta, cudnnContext.dstTensorDesc, dstData));
+                break;
+            default:
+                activation = null;
+        }
+
+        allocator.registerAction(context, z);
+
+        return activation;
+    }
+
+}

--- a/deeplearning4j-cuda-7.5/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/CudnnSubsamplingHelper.java
+++ b/deeplearning4j-cuda-7.5/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/CudnnSubsamplingHelper.java
@@ -1,0 +1,229 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+package org.deeplearning4j.nn.layers.convolution.subsampling;
+
+import org.bytedeco.javacpp.FloatPointer;
+import org.bytedeco.javacpp.Pointer;
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer.PoolingType;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.BaseLayer;
+import org.deeplearning4j.util.Dropout;
+import org.nd4j.jita.allocator.Allocator;
+import org.nd4j.jita.allocator.impl.AtomicAllocator;
+import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.IsMax;
+import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.convolution.Convolution;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.jcublas.context.CudaContext;
+import org.nd4j.linalg.util.ArrayUtil;
+
+import static org.bytedeco.javacpp.cuda.*;
+import static org.bytedeco.javacpp.cudnn.*;
+
+/**
+ * cuDNN-based helper for the subsampling layer.
+ *
+ * @author saudet
+ */
+public class CudnnSubsamplingHelper implements SubsamplingHelper {
+
+    static void checkCuda(int error) {
+        if (error != cudaSuccess) {
+            throw new RuntimeException("CUDA error = " + error);
+        }
+    }
+
+    static void checkCudnn(int status) {
+        if (status != CUDNN_STATUS_SUCCESS) {
+            throw new RuntimeException("cuDNN status = " + status);
+        }
+    }
+
+    static class CudnnContext extends cudnnContext {
+
+        static class Deallocator extends CudnnContext implements Pointer.Deallocator {
+            Deallocator(CudnnContext c) { super(c); }
+            @Override public void deallocate() { destroyHandles(); }
+        }
+
+        cudnnTensorStruct srcTensorDesc = new cudnnTensorStruct(),
+                          dstTensorDesc = new cudnnTensorStruct(),
+                          deltaTensorDesc = new cudnnTensorStruct();
+        cudnnPoolingStruct poolingDesc = new cudnnPoolingStruct();
+
+        CudnnContext() {
+            createHandles();
+            deallocator(new Deallocator(this));
+        }
+
+        CudnnContext(CudnnContext c) {
+            super(c);
+            srcTensorDesc = new cudnnTensorStruct(c.srcTensorDesc);
+            dstTensorDesc = new cudnnTensorStruct(c.dstTensorDesc);
+            deltaTensorDesc = new cudnnTensorStruct(c.deltaTensorDesc);
+            poolingDesc = new cudnnPoolingStruct(c.poolingDesc);
+        }
+
+        void createHandles() {
+            checkCudnn(cudnnCreate(this));
+            checkCudnn(cudnnCreateTensorDescriptor(srcTensorDesc));
+            checkCudnn(cudnnCreateTensorDescriptor(dstTensorDesc));
+            checkCudnn(cudnnCreateTensorDescriptor(deltaTensorDesc));
+            checkCudnn(cudnnCreatePoolingDescriptor(poolingDesc));
+        }
+
+        void destroyHandles() {
+            checkCudnn(cudnnDestroyPoolingDescriptor(poolingDesc));
+            checkCudnn(cudnnDestroyTensorDescriptor(srcTensorDesc));
+            checkCudnn(cudnnDestroyTensorDescriptor(dstTensorDesc));
+            checkCudnn(cudnnDestroyTensorDescriptor(deltaTensorDesc));
+            checkCudnn(cudnnDestroy(this));
+        }
+    }
+
+    CudnnContext cudnnContext = new CudnnContext();
+    int dataType = Nd4j.dataType() == DataBuffer.Type.DOUBLE ? CUDNN_DATA_DOUBLE : CUDNN_DATA_FLOAT;
+    int tensorFormat = CUDNN_TENSOR_NCHW;
+    FloatPointer alpha = new FloatPointer(1.0f);
+    FloatPointer beta  = new FloatPointer(0.0f);
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon,
+            int[] kernel, int[] strides, int[] pad, PoolingType poolingType) {
+        int miniBatch = input.size(0);
+        int depth = input.size(1);
+        int inH = input.size(2);
+        int inW = input.size(3);
+
+        int outH = Convolution.outSize(inH, kernel[0], strides[0], pad[0],false);
+        int outW = Convolution.outSize(inW, kernel[1], strides[1], pad[1], false);
+
+        //subsampling doesn't have weights and thus gradients are not calculated for this layer
+        //only scale and reshape epsilon
+        Gradient retGradient = new DefaultGradient();
+
+        //Epsilons in shape: [miniBatch, depth, outH, outW]
+        //Epsilons out shape: [miniBatch, depth, inH, inW]
+
+        int poolingMode;
+        switch(poolingType) {
+            case AVG:
+                poolingMode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+                break;
+            case MAX:
+                poolingMode = CUDNN_POOLING_MAX;
+                break;
+            case NONE:
+                return new Pair<>(retGradient, epsilon);
+            default:
+                return null;
+        }
+
+        INDArray z = activate(input, true, kernel, strides, pad, poolingType);
+
+        if (!Shape.strideDescendingCAscendingF(epsilon)) {
+            // apparently not supported by cuDNN
+            epsilon = epsilon.dup();
+        }
+
+        int[] srcStride = input.stride();
+        int[] deltaStride = epsilon.stride();
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.srcTensorDesc, dataType, miniBatch, depth, inH, inW,
+                srcStride[0], srcStride[1], srcStride[2], srcStride[3]));
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.deltaTensorDesc, dataType, miniBatch, depth, outH, outW,
+                deltaStride[0], deltaStride[1], deltaStride[2], deltaStride[3]));
+        checkCudnn(cudnnSetPooling2dDescriptor(cudnnContext.poolingDesc, poolingMode, CUDNN_PROPAGATE_NAN,
+                kernel[0], kernel[1], pad[0], pad[1], strides[0], strides[1]));
+
+        INDArray outEpsilon = Nd4j.create(new int[]{miniBatch,depth,inH,inW},'c');
+        int[] dstStride = outEpsilon.stride();
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.dstTensorDesc, dataType, miniBatch, depth, inH, inW,
+                dstStride[0], dstStride[1], dstStride[2], dstStride[3]));
+
+        Allocator allocator = AtomicAllocator.getInstance();
+        CudaContext context = allocator.getFlowController().prepareAction(input, epsilon, z, outEpsilon);
+        Pointer srcData = allocator.getPointer(input, context);
+        Pointer epsData = allocator.getPointer(epsilon, context);
+        Pointer zData = allocator.getPointer(z, context);
+        Pointer dstData = allocator.getPointer(outEpsilon, context);
+
+        checkCudnn(cudnnPoolingBackward(cudnnContext, cudnnContext.poolingDesc, alpha, cudnnContext.deltaTensorDesc, zData,
+                cudnnContext.deltaTensorDesc, epsData, cudnnContext.srcTensorDesc, srcData, beta, cudnnContext.dstTensorDesc, dstData));
+
+        allocator.registerAction(context, input, epsilon, z, outEpsilon);
+
+        return new Pair<>(retGradient,outEpsilon);
+    }
+
+
+    @Override
+    public INDArray activate(INDArray input, boolean training,
+            int[] kernel, int[] strides, int[] pad, PoolingType poolingType) {
+        int miniBatch = input.size(0);
+        int inDepth = input.size(1);
+        int inH = input.size(2);
+        int inW = input.size(3);
+
+        int outH = Convolution.outSize(inH, kernel[0], strides[0], pad[0],false);
+        int outW = Convolution.outSize(inW, kernel[1], strides[1], pad[1], false);
+
+        int poolingMode;
+        switch(poolingType) {
+            case AVG:
+                poolingMode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+                break;
+            case MAX:
+                poolingMode = CUDNN_POOLING_MAX;
+                break;
+            case NONE:
+                return input;
+            default:
+                return null;
+        }
+
+        int[] srcStride = input.stride();
+        checkCudnn(cudnnSetPooling2dDescriptor(cudnnContext.poolingDesc, poolingMode, CUDNN_PROPAGATE_NAN,
+                kernel[0], kernel[1], pad[0], pad[1], strides[0], strides[1]));
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.srcTensorDesc, dataType, miniBatch, inDepth, inH, inW,
+                srcStride[0], srcStride[1], srcStride[2], srcStride[3]));
+
+        INDArray reduced = Nd4j.createUninitialized(new int[]{miniBatch,inDepth,outH,outW},'c');
+        int[] dstStride = reduced.stride();
+        checkCudnn(cudnnSetTensor4dDescriptorEx(cudnnContext.dstTensorDesc, dataType, miniBatch, inDepth, outH, outW,
+                dstStride[0], dstStride[1], dstStride[2], dstStride[3]));
+
+        Allocator allocator = AtomicAllocator.getInstance();
+        CudaContext context = allocator.getFlowController().prepareAction(input, reduced);
+        Pointer srcData = allocator.getPointer(input, context);
+        Pointer dstData = allocator.getPointer(reduced, context);
+
+        checkCudnn(cudnnPoolingForward(cudnnContext, cudnnContext.poolingDesc,
+                alpha, cudnnContext.srcTensorDesc, srcData, beta, cudnnContext.dstTensorDesc, dstData));
+
+        allocator.registerAction(context, input, reduced);
+
+        return reduced;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
         <module>dl4j-test-resources</module>
         <module>dl4j-caffe</module>
         <module>deeplearning4j-ui-parent</module>
+        <module>deeplearning4j-cuda-7.5</module>
     </modules>
 
     <licenses>


### PR DESCRIPTION
This is far from complete, but I'd like some early feedback on if this is going the right way, or if we should do things differently. If it looks alright though, it can be merged.

To use, we only need to add the following dependency in the `pom.xml` file:
```xml
        <dependency>
            <groupId>org.deeplearning4j</groupId>
            <artifactId>deeplearning4j-cuda-7.5</artifactId>
            <version>${dl4j.version}</version>
        </dependency>
```
I've tested with LenetMnistExample only for now, but training time is cut by more than 50% on that sample, so it looks promising.