### PR TITLE
Fix: squid:S2095, Resources should be closed

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/mnist/draw/LoadAndDraw.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/mnist/draw/LoadAndDraw.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.datasets.mnist.draw;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
@@ -40,8 +41,11 @@ public class LoadAndDraw {
 		ObjectInputStream ois = new ObjectInputStream(new FileInputStream(args[0]));
 		
 		BasePretrainNetwork network = (BasePretrainNetwork) ois.readObject();
-		
-		
+		try {
+			ois.close();
+		} catch (IOException e) {
+		}
+
 		DataSet test = null;
 		while(iter.hasNext()) {
 			test = iter.next();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/SerializationUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/SerializationUtils.java
@@ -18,13 +18,8 @@
 
 package org.deeplearning4j.util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
+import java.io.*;
+
 import org.apache.commons.io.FileUtils;
 
 /**
@@ -36,11 +31,19 @@ public class SerializationUtils {
 
 	@SuppressWarnings("unchecked")
 	public static <T> T readObject(File file) {
+		ObjectInputStream ois = null;
 		try {
-			ObjectInputStream ois = new ObjectInputStream(FileUtils.openInputStream(file));
+			ois = new ObjectInputStream(FileUtils.openInputStream(file));
 			return (T) ois.readObject();
 		} catch (Exception e) {
 			throw new RuntimeException(e);
+		} finally {
+			if (ois != null)
+				try {
+					ois.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
 		}
 		
 	}

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/sentiwordnet/SWN3.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/sentiwordnet/SWN3.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.text.corpora.sentiwordnet;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -67,9 +68,9 @@ public class SWN3 implements Serializable {
 		HashMap<String, Vector<Double>> _temp = new HashMap<String, Vector<Double>>();
 
 		ClassPathResource resource = new ClassPathResource(sentiWordNetPath);
-
+		BufferedReader csv = null;
 		try{
-			BufferedReader csv =  new BufferedReader(new InputStreamReader(resource.getInputStream()));
+			csv =  new BufferedReader(new InputStreamReader(resource.getInputStream()));
 			String line = "";           
 			while((line = csv.readLine()) != null) {
 				if(line.isEmpty())
@@ -122,7 +123,15 @@ public class SWN3 implements Serializable {
 		}
 		catch(Exception e) {
 			throw new RuntimeException(e);
-		}        
+		} finally {
+			if (csv != null) {
+				try {
+					csv.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
 	}
 
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2095 - “Resources should be closed”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2095

 Please let me know if you have any questions.
Ayman Elkfrawy.