### PR TITLE
Fix: squid:S1149, Synchronized classes Vector, Stack and StringBuffer…

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/StringUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/StringUtils.java
@@ -133,7 +133,7 @@ public class StringUtils {
 	 */
 	public static String slurpReader(Reader reader) {
 		BufferedReader r = new BufferedReader(reader);
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		try {
 			char[] chars = new char[SLURPBUFFSIZE];
 			while (true) {
@@ -239,7 +239,7 @@ public class StringUtils {
 		}
 		BufferedReader br = new BufferedReader(new InputStreamReader(is, encoding));
 		String temp;
-		StringBuffer buff = new StringBuffer(16000); // make biggish
+		StringBuilder buff = new StringBuilder(16000); // make biggish
 		while ((temp = br.readLine()) != null) {
 			buff.append(temp);
 			buff.append(lineSeparator);
@@ -257,7 +257,7 @@ public class StringUtils {
 		InputStream is = uc.getInputStream();
 		BufferedReader br = new BufferedReader(new InputStreamReader(is));
 		String temp;
-		StringBuffer buff = new StringBuffer(16000); // make biggish
+		StringBuilder buff = new StringBuilder(16000); // make biggish
 		while ((temp = br.readLine()) != null) {
 			buff.append(temp);
 			buff.append(lineSeparator);
@@ -305,7 +305,7 @@ public class StringUtils {
 	 * <tt>join(numbers, ", ")</tt>.
 	 */
 	public static String join(Iterable l, String glue) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		boolean first = true;
 		for (Object o : l) {
 			if (!first) {
@@ -324,7 +324,7 @@ public class StringUtils {
 	 * <tt>join(numbers, ", ")</tt>.
 	 */
 	public static String join(List<?> l, String glue) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < l.size(); i++) {
 			if (i > 0) {
 				sb.append(glue);
@@ -389,7 +389,7 @@ public class StringUtils {
 		if (str == null)
 			str = "null";
 		int slen = str.length();
-		StringBuffer sb = new StringBuffer(str);
+		StringBuilder sb = new StringBuilder(str);
 		for (int i = 0; i < totalChars - slen; i++) {
 			sb.append(" ");
 		}
@@ -414,7 +414,7 @@ public class StringUtils {
 			str = "null";
 		int leng = str.length();
 		if (leng < num) {
-			StringBuffer sb = new StringBuffer(str);
+			StringBuilder sb = new StringBuilder(str);
 			for (int i = 0; i < num - leng; i++) {
 				sb.append(" ");
 			}
@@ -440,7 +440,7 @@ public class StringUtils {
 	public static String padLeft(String str, int totalChars) {
 		if (str == null)
 			str = "null";
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < totalChars - str.length(); i++) {
 			sb.append(" ");
 		}
@@ -480,7 +480,7 @@ public class StringUtils {
 	 */
 	public static String fileNameClean(String s) {
 		char[] chars = s.toCharArray();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < chars.length; i++) {
 			char c = chars[i];
 			if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
@@ -780,7 +780,7 @@ public class StringUtils {
 	}
 
 	public static String stripNonAlphaNumerics(String orig) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		char c;
 		for (int i = 0; i < orig.length(); i++) {
 			c = orig.charAt(i);
@@ -799,7 +799,7 @@ public class StringUtils {
 	}
 
 	public static String escapeString(String s, char[] charsToEscape, char escapeChar) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < s.length(); i++) {
 			char c = s.charAt(i);
 			if (c == escapeChar) {
@@ -834,14 +834,14 @@ public class StringUtils {
 		List<String> result = new ArrayList<String>();
 		int i = 0;
 		int length = s.length();
-		StringBuffer b = new StringBuffer();
+		StringBuilder b = new StringBuilder();
 		while (i < length) {
 			char curr = s.charAt(i);
 			if (curr == splitChar) {
 				// add last buffer
 				if (b.length() > 0) {
 					result.add(b.toString());
-					b = new StringBuffer();
+					b = new StringBuilder();
 				}
 				i++;
 			} else if (curr == quoteChar) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/rearrange/LocalUnstructuredDataFormatter.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/rearrange/LocalUnstructuredDataFormatter.java
@@ -127,7 +127,7 @@ public class LocalUnstructuredDataFormatter {
         int startOfFormat = path.lastIndexOf('.');
         if(startOfFormat < 0)
             throw new IllegalStateException("Illegal path; no format found");
-        StringBuffer label = new StringBuffer();
+        StringBuilder label = new StringBuilder();
         while(path.charAt(startOfFormat) != '-') {
             label.append(path.charAt(startOfFormat));
             startOfFormat--;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/BarnesHutTsne.java
@@ -527,7 +527,7 @@ public class BarnesHutTsne extends Tsne implements Model {
             String word = labels.get(i);
             if(word == null)
                 continue;
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             INDArray wordVector = Y.getRow(i);
             for(int j = 0; j < wordVector.length(); j++) {
                 sb.append(wordVector.getDouble(j));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/LegacyTsne.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/LegacyTsne.java
@@ -399,7 +399,7 @@ public class LegacyTsne implements Serializable {
             String word = labels.get(i);
             if(word == null)
                 continue;
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             INDArray wordVector = y.getRow(i);
             for(int j = 0; j < wordVector.length(); j++) {
                 sb.append(wordVector.getDouble(j));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/Tsne.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/Tsne.java
@@ -189,7 +189,7 @@ public class Tsne {
             String word = labels.get(i);
             if(word == null)
                 continue;
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             INDArray wordVector = Y.getRow(i);
             for(int j = 0; j < wordVector.length(); j++) {
                 sb.append(wordVector.getDouble(j));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringGrid.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringGrid.java
@@ -445,7 +445,7 @@ public class StringGrid extends ArrayList<List<String>> {
     public List<String> toLines() {
         List<String> lines = new ArrayList<String>();
         for(List<String> list : this) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for(String s : list) {
                 sb.append(s.replaceAll(sep," "));
                 sb.append(sep);
@@ -472,7 +472,7 @@ public class StringGrid extends ArrayList<List<String>> {
 
         if(column1 != column2)
             for(List<String> list : this) {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append(list.get(column1));
                 sb.append(list.get(column2));
                 list.set(Math.min(column1,column2),sb.toString().replaceAll("\"","").replace(sep," "));

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/sentiwordnet/SWN3.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/sentiwordnet/SWN3.java
@@ -21,12 +21,7 @@ package org.deeplearning4j.text.corpora.sentiwordnet;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.cas.CAS;
@@ -64,7 +59,7 @@ public class SWN3 implements Serializable {
 	public SWN3(String sentiWordNetPath) {
 
 		_dict = new HashMap<String, Double>();
-		HashMap<String, Vector<Double>> _temp = new HashMap<String, Vector<Double>>();
+		HashMap<String, List<Double>> _temp = new HashMap<String, List<Double>>();
 
 		ClassPathResource resource = new ClassPathResource(sentiWordNetPath);
 
@@ -88,19 +83,19 @@ public class SWN3 implements Serializable {
 					w_n[0] += "#"+data[0];
 					int index = Integer.parseInt(w_n[1])-1;
 					if(_temp.containsKey(w_n[0])) {
-						Vector<Double> v = _temp.get(w_n[0]);
-						if(index>v.size())
-							for(int i = v.size();i<index; i++)
-								v.add(0.0);
-						v.add(index, score);
-						_temp.put(w_n[0], v);
+						List<Double> l = _temp.get(w_n[0]);
+						if(index>l.size())
+							for(int i = l.size();i<index; i++)
+								l.add(0.0);
+						l.add(index, score);
+						_temp.put(w_n[0], l);
 					}
 					else {
-						Vector<Double> v = new Vector<Double>();
+						List<Double> l = new ArrayList<Double>();
 						for(int i = 0;i<index; i++)
-							v.add(0.0);
-						v.add(index, score);
-						_temp.put(w_n[0], v);
+							l.add(0.0);
+						l.add(index, score);
+						_temp.put(w_n[0], l);
 					}
 				}
 			}
@@ -109,12 +104,12 @@ public class SWN3 implements Serializable {
 			Set<String> temp = _temp.keySet();
 			for (Iterator<String> iterator = temp.iterator(); iterator.hasNext(); ) {
 				String word = iterator.next();
-				Vector<Double> v = _temp.get(word);
+				List<Double> l = _temp.get(word);
 				double score = 0.0;
 				double sum = 0.0;
-				for(int i = 0; i < v.size(); i++)
-					score += ((double)1/(double)(i+1))*v.get(i);
-				for(int i = 1; i<=v.size(); i++)
+				for(int i = 0; i < l.size(); i++)
+					score += ((double)1/(double)(i+1))*l.get(i);
+				for(int i = 1; i<=l.size(); i++)
 					sum += (double)1/(double)i;
 				score /= sum;
 				_dict.put(word, score);

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/BinarizeTreeTransformer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/BinarizeTreeTransformer.java
@@ -46,7 +46,7 @@ public class BinarizeTreeTransformer implements TreeTransformer {
     public Tree transform(Tree t) {
         if (t == null)
             return null;
-        Stack<Pair<Tree,String>> stack = new Stack<>();
+        Deque<Pair<Tree,String>> stack = new ArrayDeque<Pair<Tree,String>>();
         stack.add(new Pair<>(t,t.label()));
         String originalLabel = t.label();
         while (!stack.isEmpty()) {

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/HeadWordFinder.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/HeadWordFinder.java
@@ -235,7 +235,7 @@ public class HeadWordFinder  {
     }
 
     int findHead3(String lhs, List<String> rhss) {
-        StringBuffer keyBuffer = new StringBuffer(lhs + " ->");
+        StringBuilder keyBuffer = new StringBuilder(lhs + " ->");
         for (String rhs : rhss)
             keyBuffer.append(" " + rhs);
         String key = keyBuffer.toString();

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/inputsanitation/InputHomogenization.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/inputsanitation/InputHomogenization.java
@@ -68,7 +68,7 @@ public class InputHomogenization {
 	 * @return the normalized text passed in via constructor
 	 */
 	public String transform() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for(int i = 0; i < input.length(); i++) {
 			if(ignoreCharactersContaining != null && ignoreCharactersContaining.contains(String.valueOf(input.charAt(i))))
 				sb.append(input.charAt(i));

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/ContextLabelRetriever.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/ContextLabelRetriever.java
@@ -106,7 +106,7 @@ public class ContextLabelRetriever {
         }
 
         //now join the output
-        StringBuffer strippedSentence = new StringBuffer();
+        StringBuilder strippedSentence = new StringBuilder();
         for(Pair<String,List<String>> tokensWithLabel : tokensWithSameLabel) {
             String joinedSentence = StringUtils.join(tokensWithLabel.getSecond()," ");
             //spaces between separate parts of the sentence

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/DefaultStreamTokenizer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/DefaultStreamTokenizer.java
@@ -103,7 +103,7 @@ public class DefaultStreamTokenizer implements Tokenizer {
      * @return
      */
     private String nextTokenFromStream() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
 
         if(streamTokenizer.ttype == StreamTokenizer.TT_WORD) {

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-zookeeper/src/main/java/org/deeplearning4j/scaleout/zookeeper/ZookeeperPathBuilder.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-zookeeper/src/main/java/org/deeplearning4j/scaleout/zookeeper/ZookeeperPathBuilder.java
@@ -60,7 +60,7 @@ public class ZookeeperPathBuilder {
 	}
 
 	public String build() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("/" + host + ":" + port);
 		for(String s : paths) {
 			sb.append("/" + s);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149

 Please let me know if you have any questions.
Ayman Elkfrawy.