### PR TITLE
Fix: squid:S2293, The operator ("<>") should be used.

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Counter.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Counter.java
@@ -307,7 +307,7 @@ public class Counter<E> implements Serializable {
 
 	public List<E> getSortedKeys() {
 		PriorityQueue<E> pq = this.asPriorityQueue();
-		List<E> keys = new ArrayList<E>();
+		List<E> keys = new ArrayList<>();
 		while (pq.hasNext()) {
 			keys.add(pq.next());
 		}
@@ -370,7 +370,7 @@ public class Counter<E> implements Serializable {
 		NumberFormat f = NumberFormat.getInstance();
 		f.setMaximumFractionDigits(5);
 		int numKeysPrinted = 0;
-		for (E element : new TreeSet<E>(keySet())) {
+		for (E element : new TreeSet<>(keySet())) {
 
 			sb.append(element.toString());
 			sb.append(" : ");
@@ -411,7 +411,7 @@ public class Counter<E> implements Serializable {
 	 * whose priorities are those elements' counts in the counter.
 	 */
 	public PriorityQueue<E> asPriorityQueue() {
-		PriorityQueue<E> pq = new PriorityQueue<E>(entries.size());
+		PriorityQueue<E> pq = new PriorityQueue<>(entries.size());
 		for (Map.Entry<E, Double> entry : entries.entrySet()) {
 			pq.add(entry.getKey(), entry.getValue());
 		}
@@ -425,7 +425,7 @@ public class Counter<E> implements Serializable {
 	 * @return
 	 */
 	public PriorityQueue<E> asMinPriorityQueue() {
-		PriorityQueue<E> pq = new PriorityQueue<E>(entries.size());
+		PriorityQueue<E> pq = new PriorityQueue<>(entries.size());
 		for (Map.Entry<E, Double> entry : entries.entrySet()) {
 			pq.add(entry.getKey(), -entry.getValue());
 		}
@@ -448,7 +448,7 @@ public class Counter<E> implements Serializable {
 
 	public Counter(Map<? extends E, Double> mapCounts) {
 		this(false);
-		this.entries = new HashMap<E, Double>();
+		this.entries = new HashMap<>();
 		for (Entry<? extends E, Double> entry : mapCounts.entrySet()) {
 			incrementCount(entry.getKey(), entry.getValue());
 		}
@@ -490,7 +490,7 @@ public class Counter<E> implements Serializable {
 	}
 
 	public static void main(String[] args) {
-		Counter<String> counter = new Counter<String>();
+		Counter<String> counter = new Counter<>();
 		System.out.println(counter);
 		counter.incrementCount("planets", 7);
 		System.out.println(counter);
@@ -518,7 +518,7 @@ public class Counter<E> implements Serializable {
 	}
 
 	private void keepKeysHelper(int keepN, boolean top) {
-		Counter<E> tmp = new Counter<E>();
+		Counter<E> tmp = new Counter<>();
 
 		int n = 0;
 		for (E e : Iterators.able(top ? asPriorityQueue() : asMinPriorityQueue())) {
@@ -565,7 +565,7 @@ public class Counter<E> implements Serializable {
 	}
 
 	public Counter<E> scaledClone(double c) {
-		Counter<E> newCounter = new Counter<E>();
+		Counter<E> newCounter = new Counter<>();
 
 		for (Map.Entry<E, Double> entry : getEntrySet()) {
 			newCounter.setCount(entry.getKey(), entry.getValue() * c);
@@ -575,7 +575,7 @@ public class Counter<E> implements Serializable {
 	}
 
 	public Counter<E> difference(Counter<E> counter) {
-		Counter<E> clone = new Counter<E>(this);
+		Counter<E> clone = new Counter<>(this);
 		for (E key : counter.keySet()) {
 			double count = counter.getCount(key);
 			clone.incrementCount(key, -1 * count);
@@ -584,7 +584,7 @@ public class Counter<E> implements Serializable {
 	}
 
 	public Counter<E> toLogSpace() {
-		Counter<E> newCounter = new Counter<E>(this);
+		Counter<E> newCounter = new Counter<>(this);
 		for (E key : newCounter.keySet()) {
 			newCounter.setCount(key, Math.log(getCount(key)));
 		}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/CounterMap.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/CounterMap.java
@@ -162,7 +162,7 @@ public class CounterMap<K, V> implements java.io.Serializable {
      */
     protected Counter<V> buildCounter(MapFactory<V, Double> mf)
     {
-        return new Counter<V>(mf);
+        return new Counter<>(mf);
     }
 
     /**
@@ -294,7 +294,7 @@ public class CounterMap<K, V> implements java.io.Serializable {
             Counter<V> counter = entry.getValue();
             V localMax = counter.argMax();
             if (counter.getCount(localMax) > maxCount || maxKey == null) {
-                maxKey = new Pair<K, V>(entry.getKey(), localMax);
+                maxKey = new Pair<>(entry.getKey(), localMax);
                 maxCount = counter.getCount(localMax);
             }
         }
@@ -376,7 +376,7 @@ public class CounterMap<K, V> implements java.io.Serializable {
     }
 
     public static void main(String[] args) {
-        CounterMap<String, String> bigramCounterMap = new CounterMap<String, String>();
+        CounterMap<String, String> bigramCounterMap = new CounterMap<>();
         bigramCounterMap.incrementCount("people", "run", 1);
         bigramCounterMap.incrementCount("cats", "growl", 2);
         bigramCounterMap.incrementCount("cats", "scamper", 3);
@@ -414,7 +414,7 @@ public class CounterMap<K, V> implements java.io.Serializable {
      * @return
      */
     public CounterMap<V,K> invert() {
-        CounterMap<V,K> invertCounterMap = new CounterMap<V, K>();
+        CounterMap<V,K> invertCounterMap = new CounterMap<>();
         for (K key: this.keySet()) {
             Counter<V> keyCounts = this.getCounter(key);
             for (V val: keyCounts.keySet()) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Iterators.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Iterators.java
@@ -36,7 +36,7 @@ public class Iterators {
 	}
 
 	public static <T> List<T> fillList(Iterator<? extends T> it) {
-		List<T> lst = new ArrayList<T>();
+		List<T> lst = new ArrayList<>();
 		fillList(it, lst);
 		return lst;
 	}
@@ -115,7 +115,7 @@ public class Iterators {
 	 */
 	public static <T> Iterator<T> thread(final Iterator<T> base) {
 		return new Iterator<T>() {
-			ArrayBlockingQueue<T> els = new ArrayBlockingQueue<T>(2);
+			ArrayBlockingQueue<T> els = new ArrayBlockingQueue<>(2);
 			private boolean finishedLoading = false;
 			private boolean running = false;
 
@@ -307,7 +307,7 @@ public class Iterators {
 	}
 
 	public static <T> Iterator<T> filter(Iterator<T> iterator, Filter<T> filter) {
-		return new FilteredIterator<T>(filter, iterator);
+		return new FilteredIterator<>(filter, iterator);
 	}
 
 	public static <T> Iterator<T> concat(Iterable<Iterator<? extends T>> args) {
@@ -318,7 +318,7 @@ public class Iterators {
 			}
 
 		};
-		return new IteratorIterator<T>(Arrays.asList(args).iterator(), factory);
+		return new IteratorIterator<>(Arrays.asList(args).iterator(), factory);
 	}
 
 	public static <T> Iterator<T> concat(Iterator<? extends T>... args) {
@@ -329,7 +329,7 @@ public class Iterators {
 			}
 
 		};
-		return new IteratorIterator<T>(Arrays.asList(args).iterator(), factory);
+		return new IteratorIterator<>(Arrays.asList(args).iterator(), factory);
 	}
 
 	public static <U> Iterator<U> oneItemIterator(final U item) {
@@ -374,7 +374,7 @@ public class Iterators {
 	}
 
 	public static <T> List<T> nextList(List<Iterator<T>> iterators) {
-		List<T> items = new ArrayList<T>(iterators.size());
+		List<T> items = new ArrayList<>(iterators.size());
 		for (Iterator<T> iter : iterators) {
 			items.add(iter.next());
 		}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/MapFactory.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/MapFactory.java
@@ -36,7 +36,7 @@ public abstract class MapFactory<K, V> implements Serializable {
 		private static final long serialVersionUID = 1L;
 
 		public Map<K, V> buildMap() {
-			return new HashMap<K, V>();
+			return new HashMap<>();
 		}
 	}
 
@@ -44,7 +44,7 @@ public abstract class MapFactory<K, V> implements Serializable {
 		private static final long serialVersionUID = 1L;
 
 		public Map<K, V> buildMap() {
-			return new IdentityHashMap<K, V>();
+			return new IdentityHashMap<>();
 		}
 	}
 
@@ -52,7 +52,7 @@ public abstract class MapFactory<K, V> implements Serializable {
 		private static final long serialVersionUID = 1L;
 
 		public Map<K, V> buildMap() {
-			return new TreeMap<K, V>();
+			return new TreeMap<>();
 		}
 	}
 
@@ -60,7 +60,7 @@ public abstract class MapFactory<K, V> implements Serializable {
 		private static final long serialVersionUID = 1L;
 
 		public Map<K, V> buildMap() {
-			return new WeakHashMap<K, V>();
+			return new WeakHashMap<>();
 		}
 	}
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Pair.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Pair.java
@@ -49,7 +49,7 @@ public class Pair<F, S> implements Serializable,Comparable<Pair<F,S>> {
 	}
 
 	public Pair<S, F> reverse() {
-		return new Pair<S, F>(second, first);
+		return new Pair<>(second, first);
 	}
 
 	public boolean equals(Object o) {
@@ -154,12 +154,12 @@ public class Pair<F, S> implements Serializable,Comparable<Pair<F,S>> {
 	}
 
 	public static <S, T> Pair<S, T> newPair(S first, T second) {
-		return new Pair<S, T>(first, second);
+		return new Pair<>(first, second);
 	}
 	// Duplicate method to faccilitate backwards compatibility
 	// - aria42
 	public static <S, T> Pair<S, T> makePair(S first, T second) {
-		return new Pair<S, T>(first, second);
+		return new Pair<>(first, second);
 	}
 
 	public static class LexicographicPairComparator<F,S>  implements Comparator<Pair<F,S>> {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/PriorityQueue.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/PriorityQueue.java
@@ -41,7 +41,7 @@ public class PriorityQueue<E> implements Iterator<E>, Serializable, Cloneable, P
 	double[] priorities;
 
 	protected void grow(int newCapacity) {
-		List<E> newElements = new ArrayList<E>(newCapacity);
+		List<E> newElements = new ArrayList<>(newCapacity);
 		double[] newPriorities = new double[newCapacity];
 		if (size > 0) {
 			newElements.addAll(elements);
@@ -228,7 +228,7 @@ public class PriorityQueue<E> implements Iterator<E>, Serializable, Cloneable, P
 	 */
 	public Counter<E> asCounter() {
 		PriorityQueue<E> pq = clone();
-		Counter<E> counter = new Counter<E>();
+		Counter<E> counter = new Counter<>();
 		while (pq.hasNext()) {
 			double priority = pq.getPriority();
 			E element = pq.next();
@@ -243,10 +243,10 @@ public class PriorityQueue<E> implements Iterator<E>, Serializable, Cloneable, P
 	 */
 	@Override
 	public PriorityQueue<E> clone() {
-		PriorityQueue<E> clonePQ = new PriorityQueue<E>();
+		PriorityQueue<E> clonePQ = new PriorityQueue<>();
 		clonePQ.size = size;
 		clonePQ.capacity = capacity;
-		clonePQ.elements = new ArrayList<E>(capacity);
+		clonePQ.elements = new ArrayList<>(capacity);
 		clonePQ.priorities = new double[capacity];
 		if (size() > 0) {
 			clonePQ.elements.addAll(elements);
@@ -268,7 +268,7 @@ public class PriorityQueue<E> implements Iterator<E>, Serializable, Cloneable, P
 	}
 
 	public static void main(String[] args) {
-		PriorityQueue<String> pq = new PriorityQueue<String>();
+		PriorityQueue<String> pq = new PriorityQueue<>();
 		System.out.println(pq);
 		pq.put("one", 1);
 		System.out.println(pq);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/StringUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/StringUtils.java
@@ -590,15 +590,15 @@ public class StringUtils {
 	 */
 	public static Map<String, String[]> argsToMap(String[] args,
 			Map<String, Integer> flagsToNumArgs) {
-		Map<String, String[]> result = new HashMap<String, String[]>();
-		List<String> remainingArgs = new ArrayList<String>();
+		Map<String, String[]> result = new HashMap<>();
+		List<String> remainingArgs = new ArrayList<>();
 		String key;
 		for (int i = 0; i < args.length; i++) {
 			key = args[i];
 			if (key.charAt(0) == '-') { // found a flag
 				Integer maxFlagArgs = flagsToNumArgs.get(key);
 				int max = maxFlagArgs == null ? 0 : maxFlagArgs.intValue();
-				List<String> flagArgs = new ArrayList<String>();
+				List<String> flagArgs = new ArrayList<>();
 				for (int j = 0; j < max && i + 1 < args.length && args[i + 1].charAt(0) != '-'; i++, j++) {
 					flagArgs.add(args[i + 1]);
 				}
@@ -638,7 +638,7 @@ public class StringUtils {
 	 */
 	public static Properties argsToProperties(String[] args, Map flagsToNumArgs) {
 		Properties result = new Properties();
-		List<String> remainingArgs = new ArrayList<String>();
+		List<String> remainingArgs = new ArrayList<>();
 		String key;
 		for (int i = 0; i < args.length; i++) {
 			key = args[i];
@@ -647,7 +647,7 @@ public class StringUtils {
 
 				Integer maxFlagArgs = (Integer) flagsToNumArgs.get(key);
 				int max = maxFlagArgs == null ? 1 : maxFlagArgs.intValue();
-				List<String> flagArgs = new ArrayList<String>();
+				List<String> flagArgs = new ArrayList<>();
 				for (int j = 0; j < max && i + 1 < args.length && args[i + 1].charAt(0) != '-'; i++, j++) {
 					flagArgs.add(args[i + 1]);
 				}
@@ -758,7 +758,7 @@ public class StringUtils {
 	 * @return A Map from keys to possible values (String or null)
 	 */
 	public static Map parseCommandLineArguments(String[] args) {
-		Map<String, String> result = new HashMap<String, String>();
+		Map<String, String> result = new HashMap<>();
 		String key, value;
 		for (int i = 0; i < args.length; i++) {
 			key = args[i];
@@ -831,7 +831,7 @@ public class StringUtils {
 	 */
 	public static String[] splitOnCharWithQuoting(String s, char splitChar, char quoteChar,
 			char escapeChar) {
-		List<String> result = new ArrayList<String>();
+		List<String> result = new ArrayList<>();
 		int i = 0;
 		int length = s.length();
 		StringBuilder b = new StringBuilder();
@@ -1030,7 +1030,7 @@ public class StringUtils {
 
   public static List<Matcher> allMatches(String str, String regex) {
     Pattern p = Pattern.compile(regex);
-    List<Matcher> matches = new ArrayList<Matcher>();
+    List<Matcher> matches = new ArrayList<>();
     while (true) {
       Matcher m = p.matcher(str);
       if (!m.find()) break;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Triple.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/Triple.java
@@ -110,7 +110,7 @@ public class Triple<S,T,U>  implements Serializable {
 
 	public static <S,T,U> Triple<S,T,U> makeTriple(S s, T t, U u) {
 		// TODO Auto-generated method stub
-		return new Triple<S, T, U>(s,t,u);
+		return new Triple<>(s, t, u);
 	}
 	
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/algorithm/iteration/IterationHistory.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/algorithm/iteration/IterationHistory.java
@@ -25,7 +25,7 @@ import org.deeplearning4j.clustering.cluster.info.ClusterSetInfo;
 
 public class IterationHistory {
 
-	private Map<Integer, IterationInfo> iterationsInfos = new HashMap<Integer, IterationInfo>();
+	private Map<Integer, IterationInfo> iterationsInfos = new HashMap<>();
 	
 	public ClusterSetInfo getMostRecentClusterSetInfo() {
 		IterationInfo iterationInfo = getMostRecentIterationInfo();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterSet.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterSet.java
@@ -106,7 +106,7 @@ public class ClusterSet implements Serializable {
 			}
 		}
 
-		return new Pair<Cluster, Double>(nearestCluster, minDistance);
+		return new Pair<>(nearestCluster, minDistance);
 
 	}
 
@@ -145,7 +145,7 @@ public class ClusterSet implements Serializable {
 	}
 
 	public List<Cluster> getMostPopulatedClusters(int count) {
-		List<Cluster> mostPopulated = new ArrayList<Cluster>(clusters);
+		List<Cluster> mostPopulated = new ArrayList<>(clusters);
 		Collections.sort(mostPopulated, new Comparator<Cluster>() {
 			public int compare(Cluster o1, Cluster o2) {
 				return new Integer(o1.getPoints().size()).compareTo(new Integer(o2.getPoints().size()));
@@ -155,7 +155,7 @@ public class ClusterSet implements Serializable {
 	}
 
 	public List<Cluster> removeEmptyClusters() {
-		List<Cluster> emptyClusters = new ArrayList<Cluster>();
+		List<Cluster> emptyClusters = new ArrayList<>();
 		for (Cluster cluster : clusters)
 			if (cluster.isEmpty())
 				emptyClusters.add(cluster);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/trainer/BaseEarlyStoppingTrainer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/earlystopping/trainer/BaseEarlyStoppingTrainer.java
@@ -123,7 +123,7 @@ public abstract class BaseEarlyStoppingTrainer<T extends Model> implements IEarl
                     } catch (IOException e2) {
                         throw new RuntimeException(e2);
                     }
-                    return new EarlyStoppingResult<T>(
+                    return new EarlyStoppingResult<>(
                             EarlyStoppingResult.TerminationReason.Error,
                             e.toString(),
                             scoreVsEpoch,

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MathUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MathUtils.java
@@ -206,8 +206,8 @@ public class MathUtils  {
     public static double stringSimilarity(String...strings) {
         if(strings==null)
             return 0;
-        Counter<String> counter = new Counter<String>();
-        Counter<String> counter2 = new Counter<String>();
+        Counter<String> counter = new Counter<>();
+        Counter<String> counter2 = new Counter<>();
 
         for(int i = 0; i < strings[0].length(); i++)
             counter.incrementCount(String.valueOf(strings[0].charAt(i)), 1.0);
@@ -563,7 +563,7 @@ public class MathUtils  {
     public static List<double[]> coordSplit(double[] vector) {
 
         if(vector==null) return null;
-        List<double[]> ret = new ArrayList<double[]>();
+        List<double[]> ret = new ArrayList<>();
 		/* x coordinates */
         double[] xVals = new double[vector.length/2];
 		/* y coordinates */

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MultiDimensionalSet.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MultiDimensionalSet.java
@@ -36,19 +36,19 @@ public class MultiDimensionalSet<K,V> implements Set<Pair<K,V>> {
     }
 
     public static <K,V> MultiDimensionalSet<K,V> hashSet() {
-        return new MultiDimensionalSet<K,V>(new HashSet<Pair<K,V>>());
+        return new MultiDimensionalSet<>(new HashSet<Pair<K, V>>());
     }
 
 
     public static <K,V> MultiDimensionalSet<K,V> treeSet() {
-        return new MultiDimensionalSet<K,V>(new TreeSet<Pair<K,V>>());
+        return new MultiDimensionalSet<>(new TreeSet<Pair<K, V>>());
     }
 
 
 
 
     public static <K,V> MultiDimensionalSet<K,V> concurrentSkipListSet() {
-        return new MultiDimensionalSet<K,V>(new ConcurrentSkipListSet<Pair<K,V>>());
+        return new MultiDimensionalSet<>(new ConcurrentSkipListSet<Pair<K, V>>());
     }
 
     /**

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/SetUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/SetUtils.java
@@ -30,7 +30,7 @@ public class SetUtils
 
 	public static <T> Set<T> intersection(Collection<T> parentCollection, Collection<T> removeFromCollection)
 	{
-		Set<T> results = new HashSet<T>(parentCollection) ;
+		Set<T> results = new HashSet<>(parentCollection) ;
 		results.retainAll(removeFromCollection) ;
 		return results ;
 	}
@@ -47,7 +47,7 @@ public class SetUtils
 
 	public static <T> Set<T> union(Set<? extends T> s1, Set<? extends T> s2)
 	{
-		Set<T> s3 = new HashSet<T>(s1) ;
+		Set<T> s3 = new HashSet<>(s1) ;
 		s3.addAll(s2) ;
 		return s3 ;
 	}
@@ -56,7 +56,7 @@ public class SetUtils
 
 	public static <T> Set<T> difference(Collection<? extends T> s1, Collection<? extends T> s2)
 	{
-		Set<T> s3 = new HashSet<T>(s1) ;
+		Set<T> s3 = new HashSet<>(s1) ;
 		s3.removeAll(s2) ;
 		return s3 ;
 	}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringGrid.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringGrid.java
@@ -218,7 +218,7 @@ public class StringGrid extends ArrayList<List<String>> {
     }
 
     public void sortColumnsByWordLikelihoodIncluded(final int column) {
-        final Counter<String> counter = new Counter<String>();
+        final Counter<String> counter = new Counter<>();
         List<String> col = getColumn(column);
 
 
@@ -237,7 +237,7 @@ public class StringGrid extends ArrayList<List<String>> {
 
         //laplace smoothing
         counter.incrementAll(counter.keySet(), 1.0);
-        Set<String> remove = new HashSet<String>();
+        Set<String> remove = new HashSet<>();
         for(String key : counter.keySet())
             if(key.length() < 2 || key.matches("[a-z]+"))
                 remove.add(key);
@@ -299,7 +299,7 @@ public class StringGrid extends ArrayList<List<String>> {
             }
         }
         FingerPrintKeyer keyer = new FingerPrintKeyer();
-        Set<Integer> alreadyDeDupped = new HashSet<Integer>();
+        Set<Integer> alreadyDeDupped = new HashSet<>();
         for(int i = 0; i< size(); i++) {
             String key = keyer.key(get(i).get(column));
             Map<String,Integer> map = cluster.get(key);
@@ -327,7 +327,7 @@ public class StringGrid extends ArrayList<List<String>> {
 
         for(String key : cluster.keySet()) {
             StringTokenizer val = new StringTokenizer(key);
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             boolean allLower = true;
 
             outer: while(val.hasMoreTokens()) {
@@ -368,7 +368,7 @@ public class StringGrid extends ArrayList<List<String>> {
             //getFromOrigin the max value of the cluster
             String max2 = maximalValue(cluster);
             StringTokenizer val = new StringTokenizer(max2);
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             while(val.hasMoreTokens()) {
                 String token = val.nextToken();
                 //weird capitalization
@@ -406,7 +406,7 @@ public class StringGrid extends ArrayList<List<String>> {
     }
 
     private String maximalValue(Map<String,Integer> map) {
-        Counter<String> counter = new Counter<String>();
+        Counter<String> counter = new Counter<>();
         for(String s : map.keySet()) {
             counter.incrementCount(s,map.get(s));
         }
@@ -421,7 +421,7 @@ public class StringGrid extends ArrayList<List<String>> {
 
 
     public List<Integer> filterRowsByColumn(int column,Collection<String> values) {
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         for(int i = 0; i< size(); i++) {
             if(values.contains(get(i).get(column)))
                 list.add(i);
@@ -443,7 +443,7 @@ public class StringGrid extends ArrayList<List<String>> {
     }
 
     public List<String> toLines() {
-        List<String> lines = new ArrayList<String>();
+        List<String> lines = new ArrayList<>();
         for(List<String> list : this) {
             StringBuilder sb = new StringBuilder();
             for(String s : list) {
@@ -522,7 +522,7 @@ public class StringGrid extends ArrayList<List<String>> {
     public void split(int column,String sepBy) {
         List<String> col = getColumn(column);
         int validate = -1;
-        Set<String> remove = new HashSet<String>();
+        Set<String> remove = new HashSet<>();
         for(int i = 0; i< col.size(); i++) {
             String s = col.get(i);
             String[] split2 = StringUtils.splitOnCharWithQuoting(s, sepBy.charAt(0), '"', '\\');
@@ -605,7 +605,7 @@ public class StringGrid extends ArrayList<List<String>> {
      */
     public void combineColumns(int templateColumn,Integer[] paramColumns) {
         for(List<String> list : this) {
-            List<String> format = new ArrayList<String>();
+            List<String> format = new ArrayList<>();
             for(int j : paramColumns)
                 format.add(list.get(j));
 
@@ -690,7 +690,7 @@ public class StringGrid extends ArrayList<List<String>> {
         checkInvalidColumn(column);
         StringGrid grid = new StringGrid(sep,numColumns);
         List<String> columns = getColumn(column);
-        Counter<String> counter = new Counter<String>();
+        Counter<String> counter = new Counter<>();
         for(String val : columns)
             counter.incrementCount(val,1.0);
         counter.pruneKeysBelowThreshold(2.0);
@@ -708,11 +708,11 @@ public class StringGrid extends ArrayList<List<String>> {
         checkInvalidColumn(column);
         StringGrid grid = new StringGrid(sep,numColumns);
         List<String> columns = getColumn(column);
-        Counter<String> counter = new Counter<String>();
+        Counter<String> counter = new Counter<>();
         for(String val : columns)
             counter.incrementCount(val,1.0);
 
-        Set<String> keys = new HashSet<String>(counter.keySet());
+        Set<String> keys = new HashSet<>(counter.keySet());
         for(String key : keys) {
             if(counter.getCount(key) > 1) {
                 counter.removeKey(key);

--- a/deeplearning4j-scaleout/deeplearning4j-aws/src/main/java/org/deeplearning4j/aws/ec2/Ec2BoxCreator.java
+++ b/deeplearning4j-scaleout/deeplearning4j-aws/src/main/java/org/deeplearning4j/aws/ec2/Ec2BoxCreator.java
@@ -91,7 +91,7 @@ public class Ec2BoxCreator extends BaseS3 {
 		launchSpecification.setInstanceType("t1.micro");
 
 		// Add the security group to the request.
-		List<String> securityGroups = new ArrayList<String>();
+		List<String> securityGroups = new ArrayList<>();
 		securityGroups.add("GettingStartedGroup");
 		launchSpecification.setSecurityGroups(securityGroups);
 

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/iterator/parallel/RandomWalkGraphIteratorProvider.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/iterator/parallel/RandomWalkGraphIteratorProvider.java
@@ -49,7 +49,7 @@ public class RandomWalkGraphIteratorProvider<V> implements GraphWalkIteratorProv
             int to = Math.min(nVertices,from+verticesPerIter);
             if(i == numIterators - 1) to = nVertices;
 
-            GraphWalkIterator<V> iter = new RandomWalkIterator<V>(graph,walkLength,rng.nextLong(),mode,from,to);
+            GraphWalkIterator<V> iter = new RandomWalkIterator<>(graph, walkLength, rng.nextLong(), mode, from, to);
             list.add(iter);
             last = to;
         }

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/iterator/parallel/WeightedRandomWalkGraphIteratorProvider.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/iterator/parallel/WeightedRandomWalkGraphIteratorProvider.java
@@ -52,7 +52,7 @@ public class WeightedRandomWalkGraphIteratorProvider<V> implements GraphWalkIter
             int to = Math.min(nVertices,from+verticesPerIter);
             if(i == numIterators - 1) to = nVertices;
 
-            GraphWalkIterator<V> iter = new WeightedRandomWalkIterator<V>(graph,walkLength,rng.nextLong(),mode,from,to);
+            GraphWalkIterator<V> iter = new WeightedRandomWalkIterator<>(graph, walkLength, rng.nextLong(), mode, from, to);
             list.add(iter);
             last = to;
         }

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/deepwalk/DeepWalk.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/deepwalk/DeepWalk.java
@@ -100,7 +100,7 @@ public class DeepWalk<V,E> extends GraphVectorsImpl<V,E> {
         if(!initCalled) initialize(graph);
         //First: create iterators, one for each thread
 
-        GraphWalkIteratorProvider<V> iteratorProvider = new RandomWalkGraphIteratorProvider<V>(graph,walkLength,seed,
+        GraphWalkIteratorProvider<V> iteratorProvider = new RandomWalkGraphIteratorProvider<>(graph, walkLength, seed,
                 NoEdgeHandling.SELF_LOOP_ON_DISCONNECTED);
 
         fit(iteratorProvider);

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/embeddings/GraphVectorsImpl.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/embeddings/GraphVectorsImpl.java
@@ -57,7 +57,7 @@ public class GraphVectorsImpl<V,E> implements GraphVectors<V,E> {
         double norm2 = vec.norm2Number().doubleValue();
 
 
-        PriorityQueue<Pair<Double,Integer>> pq = new PriorityQueue<Pair<Double,Integer>>(lookupTable.getNumVertices(),new PairComparator());
+        PriorityQueue<Pair<Double,Integer>> pq = new PriorityQueue<>(lookupTable.getNumVertices(), new PairComparator());
 
         Level1 l1 = Nd4j.getBlasWrapper().level1();
         for( int i=0; i<numVertices(); i++ ){

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/loader/GraphVectorSerializer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/loader/GraphVectorSerializer.java
@@ -76,7 +76,7 @@ public class GraphVectorSerializer {
         InMemoryGraphLookupTable table = new InMemoryGraphLookupTable(nVertices,vecSize,null,0.01);
         table.setVertexVectors(vectors);
 
-        return new GraphVectorsImpl<Object,Object>(null,table);
+        return new GraphVectorsImpl<>(null, table);
     }
 
 }

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/test/java/org/deeplearning4j/graph/graph/TestGraph.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/test/java/org/deeplearning4j/graph/graph/TestGraph.java
@@ -91,7 +91,7 @@ public class TestGraph {
         }
 
         int walkLength = 4;
-        RandomWalkIterator<String> iter = new RandomWalkIterator<String>(graph, walkLength, 1235, NoEdgeHandling.EXCEPTION_ON_DISCONNECTED);
+        RandomWalkIterator<String> iter = new RandomWalkIterator<>(graph, walkLength, 1235, NoEdgeHandling.EXCEPTION_ON_DISCONNECTED);
 
         int count = 0;
         Set<Integer> startIdxSet = new HashSet<>();
@@ -164,7 +164,7 @@ public class TestGraph {
         }
 
         int walkLength = 5;
-        WeightedRandomWalkIterator<String> iterator = new WeightedRandomWalkIterator<String>(graph, walkLength, 12345);
+        WeightedRandomWalkIterator<String> iterator = new WeightedRandomWalkIterator<>(graph, walkLength, 12345);
 
         int walkCount = 0;
         Set<Integer> set = new HashSet<>();

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/test/java/org/deeplearning4j/graph/models/deepwalk/TestDeepWalk.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/test/java/org/deeplearning4j/graph/models/deepwalk/TestDeepWalk.java
@@ -93,7 +93,7 @@ public class TestDeepWalk {
 
         Random r = new Random(12345);
 
-        Graph<String,String> graph = new Graph<String, String>(nVertices,new StringVertexFactory());
+        Graph<String,String> graph = new Graph<>(nVertices, new StringVertexFactory());
         for( int i=0; i<nVertices; i++ ){
             for( int j=0; j<nEdgesPerVertex; j++ ){
                 int to = r.nextInt(nVertices);
@@ -250,7 +250,7 @@ public class TestDeepWalk {
         //Create GraphWalkIteratorProvider. The GraphWalkIteratorProvider is used to create multiple GraphWalkIterator objects.
         //Here, it is used to create a GraphWalkIterator, one for each thread
         int walkLength = 5;
-        GraphWalkIteratorProvider<String> iteratorProvider = new WeightedRandomWalkGraphIteratorProvider<String>(graph,walkLength);
+        GraphWalkIteratorProvider<String> iteratorProvider = new WeightedRandomWalkGraphIteratorProvider<>(graph, walkLength);
 
         //Fit in parallel
         deepWalk.fit(iteratorProvider);

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/GloVe.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/GloVe.java
@@ -387,7 +387,7 @@ public  class GloVe<T extends SequenceElement> implements ElementsLearningAlgori
         }
 
         public GloVe<T> build() {
-            GloVe<T> ret = new GloVe<T>();
+            GloVe<T> ret = new GloVe<>();
             ret.symmetric = this.symmetric;
             ret.shuffle = this.shuffle;
             ret.xMax = this.xMax;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
@@ -712,7 +712,7 @@ public class WordVectorSerializer {
 
 
 
-        List<VocabWord> words = new ArrayList<VocabWord>(vocabCache.vocabWords());
+        List<VocabWord> words = new ArrayList<>(vocabCache.vocabWords());
         for (SequenceElement word: words) {
             VocabularyWord vw = new VocabularyWord(word.getLabel());
             vw.setCount(vocabCache.wordFrequency(word.getLabel()));

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
@@ -241,7 +241,7 @@ public class WordVectorsImpl<T extends SequenceElement> implements WordVectors {
 
     public void setLookupTable(@NonNull WeightLookupTable lookupTable) {
         this.lookupTable = lookupTable;
-        if (modelUtils == null) this.modelUtils = new BasicModelUtils<T>();
+        if (modelUtils == null) this.modelUtils = new BasicModelUtils<>();
 
         this.modelUtils.init(lookupTable);
     }

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/AbstractCoOccurrences.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/AbstractCoOccurrences.java
@@ -109,7 +109,7 @@ public class AbstractCoOccurrences<T extends SequenceElement> implements Seriali
 
         List<CoOccurrencesCalculatorThread> threads = new ArrayList<>();
         for (int x = 0; x < workers; x++) {
-            threads.add(x, new CoOccurrencesCalculatorThread(x, new FilteredSequenceIterator<T>(new SynchronizedSequenceIterator<T>(sequenceIterator), vocabCache), processedSequences));
+            threads.add(x, new CoOccurrencesCalculatorThread(x, new FilteredSequenceIterator<>(new SynchronizedSequenceIterator<>(sequenceIterator), vocabCache), processedSequences));
             threads.get(x).start();
         }
 
@@ -163,7 +163,7 @@ public class AbstractCoOccurrences<T extends SequenceElement> implements Seriali
                 T element2 = vocabCache.elementAtIndex(Integer.valueOf(strings[1]));
                 Double weight = Double.valueOf(strings[2]);
 
-                return new Pair<>(new Pair<T, T>(element1, element2), weight);
+                return new Pair<>(new Pair<>(element1, element2), weight);
             }
 
             @Override
@@ -203,7 +203,7 @@ public class AbstractCoOccurrences<T extends SequenceElement> implements Seriali
         }
 
         public Builder<T> iterate(@NonNull SequenceIterator<T> iterator) {
-            this.sequenceIterator = new SynchronizedSequenceIterator<T>(iterator);
+            this.sequenceIterator = new SynchronizedSequenceIterator<>(iterator);
             return this;
         }
 
@@ -475,7 +475,7 @@ public class AbstractCoOccurrences<T extends SequenceElement> implements Seriali
                  localMap = coOccurrenceCounts;
 
                 // set new CountMap, and release write lock
-                coOccurrenceCounts = new CountMap<T>();
+                coOccurrenceCounts = new CountMap<>();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             } finally {

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/Glove.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/Glove.java
@@ -366,7 +366,7 @@ public class Glove extends SequenceVectors<VocabWord> {
                         .iterator(sentenceIterator)
                         .tokenizerFactory(tokenFactory)
                         .build();
-                this.iterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer).build();
+                this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
             }
 
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/GloveWeightLookupTable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/GloveWeightLookupTable.java
@@ -329,7 +329,7 @@ public class GloveWeightLookupTable<T extends SequenceElement> extends InMemoryL
         }
 
         public GloveWeightLookupTable<T> build() {
-            return new GloveWeightLookupTable<T>(vocabCache,vectorLength,useAdaGrad,lr,gen,negative,xMax,maxCount);
+            return new GloveWeightLookupTable<>(vocabCache, vectorLength, useAdaGrad, lr, gen, negative, xMax, maxCount);
         }
     }
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/count/BinaryCoOccurrenceReader.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/count/BinaryCoOccurrenceReader.java
@@ -40,7 +40,7 @@ public class BinaryCoOccurrenceReader<T extends SequenceElement> implements CoOc
         this.vocabCache = vocabCache;
         this.file = file;
         this.countMap = map;
-        buffer = new ArrayBlockingQueue<CoOccurrenceWeight<T>>(200000);
+        buffer = new ArrayBlockingQueue<>(200000);
 
         try {
             inputStream = new BufferedInputStream(new FileInputStream(this.file), 100 * 1024 * 1024);
@@ -200,7 +200,7 @@ public class BinaryCoOccurrenceReader<T extends SequenceElement> implements CoOc
                 double eW = bB.getDouble( position + 8);
 
 
-                CoOccurrenceWeight<T> object = new CoOccurrenceWeight<T>();
+                CoOccurrenceWeight<T> object = new CoOccurrenceWeight<>();
                 object.setElement1(vocabCache.elementAtIndex(e1idx));
                 object.setElement2(vocabCache.elementAtIndex(e2idx));
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
@@ -122,10 +122,10 @@ public class ParagraphVectors extends Word2Vec {
      */
     public INDArray inferVector(List<VocabWord> document, double learningRate, double minLearningRate, int iterations) {
         if (sequenceLearningAlgorithm == null) {
-            sequenceLearningAlgorithm = new DBOW<VocabWord>();
+            sequenceLearningAlgorithm = new DBOW<>();
             sequenceLearningAlgorithm.configure(vocab, lookupTable, configuration);
         }
-        Sequence<VocabWord> sequence = new Sequence<VocabWord>();
+        Sequence<VocabWord> sequence = new Sequence<>();
         sequence.addElements(document);
         sequence.setSequenceLabel(new VocabWord(1.0, String.valueOf(new Random().nextInt())));
 
@@ -570,7 +570,7 @@ public class ParagraphVectors extends Word2Vec {
                         .iterator(labelAwareIterator)
                         .tokenizerFactory(tokenizerFactory)
                         .build();
-                this.iterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer).build();
+                this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
             }
 
             ret.numEpochs = this.numEpochs;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
@@ -265,8 +265,8 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
         protected String STOP = configuration.getSTOP();
 
         // defaults values for learning algorithms are set here
-        protected ElementsLearningAlgorithm<T> elementsLearningAlgorithm = new SkipGram<T>();
-        protected SequenceLearningAlgorithm<T> sequenceLearningAlgorithm = new DBOW<T>();
+        protected ElementsLearningAlgorithm<T> elementsLearningAlgorithm = new SkipGram<>();
+        protected SequenceLearningAlgorithm<T> sequenceLearningAlgorithm = new DBOW<>();
 
         protected Set<VectorsListener<T>> vectorsListeners = new HashSet<>();
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Graph.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Graph.java
@@ -44,14 +44,14 @@ public class Graph<V extends SequenceElement, E extends Number> implements IGrap
 
     @SuppressWarnings("unchecked")
     public Graph(List<Vertex<V>> vertices, boolean allowMultipleEdges){
-        this.vertices = new ArrayList<Vertex<V>>(vertices);
+        this.vertices = new ArrayList<>(vertices);
         this.allowMultipleEdges = allowMultipleEdges;
         edges = (List<Edge<E>>[]) Array.newInstance(List.class,vertices.size());
     }
 
     @SuppressWarnings("unchecked")
     public Graph(Collection<V> elements, boolean allowMultipleEdges) {
-        this.vertices = new ArrayList<Vertex<V>>();
+        this.vertices = new ArrayList<>();
         this.allowMultipleEdges = allowMultipleEdges;
         int idx = 0;
         for (V element: elements) {
@@ -141,7 +141,7 @@ public class Graph<V extends SequenceElement, E extends Number> implements IGrap
      */
     @Override
     public void addEdge(int from, int to, E value, boolean directed) {
-        addEdge(new Edge<E>(from, to, value, directed));
+        addEdge(new Edge<>(from, to, value, directed));
     }
 
     @Override

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/PopularityWalker.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/PopularityWalker.java
@@ -88,7 +88,7 @@ public class PopularityWalker<T extends SequenceElement> extends RandomWalker<T>
                 case FORWARD_UNIQUE:
                 case FORWARD_PREFERRED: {
                         // we get  popularity of each node connected to the current node.
-                        PriorityQueue<Node<T>> queue = new PriorityQueue<Node<T>>();
+                        PriorityQueue<Node<T>> queue = new PriorityQueue<>();
 
                         // ArrayUtils.removeElements(sourceGraph.getConnectedVertexIndices(order[currentPosition]), visitedHops);
                         int[] connections = ArrayUtils.removeElements(sourceGraph.getConnectedVertexIndices(vertex.vertexID()), visitedHops);
@@ -126,7 +126,7 @@ public class PopularityWalker<T extends SequenceElement> extends RandomWalker<T>
                             //logger.info("Queue: " + queue);
                             //logger.info("Queue size: " + queue.size());
 
-                            List<Node<T>> list = new ArrayList<Node<T>>();
+                            List<Node<T>> list = new ArrayList<>();
                             double[] weights = new double[cSpread];
 
                             int fcnt = 0;
@@ -320,7 +320,7 @@ public class PopularityWalker<T extends SequenceElement> extends RandomWalker<T>
          */
         @Override
         public PopularityWalker<T> build() {
-            PopularityWalker<T> walker = new PopularityWalker<T>();
+            PopularityWalker<T> walker = new PopularityWalker<>();
             walker.noEdgeHandling = this.noEdgeHandling;
             walker.sourceGraph = this.sourceGraph;
             walker.walkLength = this.walkLength;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/RandomWalker.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/RandomWalker.java
@@ -66,7 +66,7 @@ public class RandomWalker<T extends SequenceElement> implements GraphWalker<T> {
         int[] visitedHops = new int[walkLength];
         Arrays.fill(visitedHops, -1);
 
-        Sequence<T> sequence = new Sequence<T>();
+        Sequence<T> sequence = new Sequence<>();
 
         int startPosition = position.getAndIncrement();
         int lastId = -1;
@@ -309,7 +309,7 @@ public class RandomWalker<T extends SequenceElement> implements GraphWalker<T> {
          * @return
          */
         public RandomWalker<T> build() {
-            RandomWalker<T> walker = new RandomWalker<T>();
+            RandomWalker<T> walker = new RandomWalker<>();
             walker.noEdgeHandling = this.noEdgeHandling;
             walker.sourceGraph = this.sourceGraph;
             walker.walkLength = this.walkLength;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/iterators/AbstractSequenceIterator.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/iterators/AbstractSequenceIterator.java
@@ -73,7 +73,7 @@ public class AbstractSequenceIterator<T extends SequenceElement> implements Sequ
          * @return
          */
         public AbstractSequenceIterator<T> build() {
-            AbstractSequenceIterator<T> iterator = new AbstractSequenceIterator<T>(underlyingIterable);
+            AbstractSequenceIterator<T> iterator = new AbstractSequenceIterator<>(underlyingIterable);
 
             return iterator;
         }

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/listeners/SerializingListener.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/listeners/SerializingListener.java
@@ -139,7 +139,7 @@ public class SerializingListener<T extends SequenceElement> implements VectorsLi
          * @return
          */
         public SerializingListener<T> build() {
-            SerializingListener<T> listener = new SerializingListener<T>();
+            SerializingListener<T> listener = new SerializingListener<>();
             listener.modelPrefix = this.modelPrefix;
             listener.targetFolder = this.targetFolder;
             listener.useBinarySerialization = this.useBinarySerialization;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/GraphTransformer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/GraphTransformer.java
@@ -140,7 +140,7 @@ public class GraphTransformer<T extends SequenceElement> implements Iterable<Seq
         }
 
         public GraphTransformer<T> build() {
-            GraphTransformer<T> transformer = new GraphTransformer<T>();
+            GraphTransformer<T> transformer = new GraphTransformer<>();
             transformer.sourceGraph = this.sourceGraph;
             transformer.labelsProvider = this.labelsProvider;
             transformer.shuffle = this.shuffle;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
@@ -47,7 +47,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
                     .iterator(sentenceIter)
                     .tokenizerFactory(this.tokenizerFactory)
                     .build();
-            this.iterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer).build();
+            this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
         }
     }
 
@@ -64,7 +64,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
                     .iterator(iterator)
                     .tokenizerFactory(tokenizerFactory)
                     .build();
-            this.iterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer).build();
+            this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
         }
     }
 
@@ -447,7 +447,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
                         .iterator(sentenceIterator)
                         .tokenizerFactory(tokenizerFactory)
                         .build();
-                this.iterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer).build();
+                this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
             }
 
             ret.numEpochs = this.numEpochs;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/iterator/Word2VecDataFetcher.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/iterator/Word2VecDataFetcher.java
@@ -52,9 +52,9 @@ public class Word2VecDataFetcher implements DataSetFetcher {
 	private Word2Vec vec;
 	private static Pattern begin = Pattern.compile("<[A-Z]+>");
 	private static Pattern end = Pattern.compile("</[A-Z]+>");
-	private List<String> labels = new ArrayList<String>();
+	private List<String> labels = new ArrayList<>();
 	private int batch;
-	private List<Window> cache = new ArrayList<Window>();
+	private List<Window> cache = new ArrayList<>();
 	private static final Logger log = LoggerFactory.getLogger(Word2VecDataFetcher.class);
 	private int totalExamples;
 	private String path;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
@@ -398,7 +398,7 @@ public class VocabConstructor<T extends SequenceElement> {
         }
 
         public VocabConstructor<T> build() {
-            VocabConstructor<T> constructor = new VocabConstructor<T>();
+            VocabConstructor<T> constructor = new VocabConstructor<>();
             constructor.sources = this.sources;
             constructor.cache = this.cache;
             constructor.stopWords = this.stopWords;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/annotator/PoStagger.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/annotator/PoStagger.java
@@ -156,9 +156,9 @@ public class PoStagger extends CasAnnotator_ImplBase {
 
 	    for (AnnotationIteratorPair annotationIteratorPair : comboIterator) {
 	      
-	      final List<AnnotationFS> sentenceTokenAnnotationList = new LinkedList<AnnotationFS>();
+	      final List<AnnotationFS> sentenceTokenAnnotationList = new LinkedList<>();
 
-	      final List<String> sentenceTokenList = new LinkedList<String>();
+	      final List<String> sentenceTokenList = new LinkedList<>();
 
 	      for (AnnotationFS tokenAnnotation : annotationIteratorPair.getSubIterator()) {
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/sentiwordnet/SWN3.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/sentiwordnet/SWN3.java
@@ -59,8 +59,8 @@ public class SWN3 implements Serializable {
 	
 	public SWN3(String sentiWordNetPath) {
 
-		_dict = new HashMap<String, Double>();
-		HashMap<String, List<Double>> _temp = new HashMap<String, List<Double>>();
+		_dict = new HashMap<>();
+		HashMap<String, List<Double>> _temp = new HashMap<>();
 
 		ClassPathResource resource = new ClassPathResource(sentiWordNetPath);
 		BufferedReader csv = null;
@@ -92,7 +92,7 @@ public class SWN3 implements Serializable {
 						_temp.put(w_n[0], l);
 					}
 					else {
-						List<Double> l = new ArrayList<Double>();
+						List<Double> l = new ArrayList<>();
 						for(int i = 0;i<index; i++)
 							l.add(0.0);
 						l.add(index, score);
@@ -179,7 +179,7 @@ public class SWN3 implements Serializable {
 
 	public double scoreTokens(List<Token> tokens) {
 		double totalScore = 0.0;
-		Set<String> negativeWords = new HashSet<String>();
+		Set<String> negativeWords = new HashSet<>();
 		double scoreForSentence = 0.0;
 		for(Token token : tokens) {
 			scoreForSentence += extract(token.getCoveredText().toLowerCase());

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/BinarizeTreeTransformer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/BinarizeTreeTransformer.java
@@ -46,7 +46,7 @@ public class BinarizeTreeTransformer implements TreeTransformer {
     public Tree transform(Tree t) {
         if (t == null)
             return null;
-        Deque<Pair<Tree,String>> stack = new ArrayDeque<Pair<Tree,String>>();
+        Deque<Pair<Tree,String>> stack = new ArrayDeque<>();
         stack.add(new Pair<>(t,t.label()));
         String originalLabel = t.label();
         while (!stack.isEmpty()) {

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelsSource.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelsSource.java
@@ -97,7 +97,7 @@ public class LabelsSource implements Serializable {
      * @param label
      */
     public synchronized void storeLabel(String label) {
-        if (labels == null) labels = new ArrayList<String>();
+        if (labels == null) labels = new ArrayList<>();
 
         if (!labels.contains(label)) labels.add(label);
     }

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/invertedindex/LuceneInvertedIndex.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/invertedindex/LuceneInvertedIndex.java
@@ -891,10 +891,10 @@ public class LuceneInvertedIndex<T extends SequenceElement> implements InvertedI
         public InvertedIndex<T> build() {
             LuceneInvertedIndex<T> ret;
             if(indexDir != null) {
-                ret = new LuceneInvertedIndex<T>(vocabCache,cache,indexDir.getAbsolutePath());
+                ret = new LuceneInvertedIndex<>(vocabCache, cache, indexDir.getAbsolutePath());
             }
             else
-                ret = new LuceneInvertedIndex<T>(vocabCache);
+                ret = new LuceneInvertedIndex<>(vocabCache);
             try {
                 ret.batchSize = batchSize;
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Windows.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Windows.java
@@ -81,7 +81,7 @@ public class Windows {
      */
     public static List<Window> windows(String words,int windowSize) {
         StringTokenizer tokenizer = new StringTokenizer(words);
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         while(tokenizer.hasMoreTokens())
             list.add(tokenizer.nextToken());
         return windows(list,windowSize);
@@ -116,7 +116,7 @@ public class Windows {
      */
     public static List<Window> windows(String words) {
         StringTokenizer tokenizer = new StringTokenizer(words);
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         while(tokenizer.hasMoreTokens())
             list.add(tokenizer.nextToken());
         return windows(list,5);

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/NGramTokenizer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/NGramTokenizer.java
@@ -41,7 +41,7 @@ public class NGramTokenizer implements Tokenizer {
         }
         if (maxN != 1) {
             this.originalTokens = this.tokens;
-            this.tokens = new ArrayList<String>();
+            this.tokens = new ArrayList<>();
             Integer nOriginalTokens = this.originalTokens.size();
             Integer min = Math.min(maxN + 1, nOriginalTokens + 1);
             for (int i = minN; i < min; i++) {

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/PosUimaTokenizer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/PosUimaTokenizer.java
@@ -59,7 +59,7 @@ public class PosUimaTokenizer  implements Tokenizer {
         if(PosUimaTokenizer.engine == null)
             PosUimaTokenizer.engine = engine;
         this.allowedPosTags = allowedPosTags;
-        this.tokens = new ArrayList<String>();
+        this.tokens = new ArrayList<>();
         this.stripNones = stripNones;
         try {
             if(cas == null)
@@ -122,7 +122,7 @@ public class PosUimaTokenizer  implements Tokenizer {
 
     @Override
     public List<String> getTokens() {
-        List<String> tokens = new ArrayList<String>();
+        List<String> tokens = new ArrayList<>();
         while(hasMoreTokens()) {
             String nextT = nextToken();
             if (stripNones && nextT.equals("NONE"))

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/embeddings/inmemory/InMemoryLookupTableTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/embeddings/inmemory/InMemoryLookupTableTest.java
@@ -45,7 +45,7 @@ public class InMemoryLookupTableTest {
                 .tokenizerFactory(t)
                 .build();
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> vocabConstructor = new VocabConstructor.Builder<VocabWord>()
@@ -100,7 +100,7 @@ public class InMemoryLookupTableTest {
                 .tokenizerFactory(t)
                 .build();
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> vocabConstructor = new VocabConstructor.Builder<VocabWord>()
@@ -135,7 +135,7 @@ public class InMemoryLookupTableTest {
                 .tokenizerFactory(t)
                 .build();
 
-        sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> vocabTransfer = new VocabConstructor.Builder<VocabWord>()

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/glove/AbstractCoOccurrencesTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/glove/AbstractCoOccurrencesTest.java
@@ -51,7 +51,7 @@ public class AbstractCoOccurrencesTest {
                 .tokenizerFactory(t)
                 .build();
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> constructor = new VocabConstructor.Builder<VocabWord>()

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/glove/count/BinaryCoOccurrenceReaderTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/glove/count/BinaryCoOccurrenceReaderTest.java
@@ -48,14 +48,14 @@ public class BinaryCoOccurrenceReaderTest {
 
         BinaryCoOccurrenceWriter<VocabWord> writer = new BinaryCoOccurrenceWriter<>(tempFile);
 
-        CoOccurrenceWeight<VocabWord> object1 = new CoOccurrenceWeight<VocabWord>();
+        CoOccurrenceWeight<VocabWord> object1 = new CoOccurrenceWeight<>();
         object1.setElement1(word1);
         object1.setElement2(word2);
         object1.setWeight(3.14159265);
 
         writer.writeObject(object1);
 
-        CoOccurrenceWeight<VocabWord> object2 = new CoOccurrenceWeight<VocabWord>();
+        CoOccurrenceWeight<VocabWord> object2 = new CoOccurrenceWeight<>();
         object2.setElement1(word2);
         object2.setElement2(word3);
         object2.setWeight(0.197);
@@ -99,21 +99,21 @@ public class BinaryCoOccurrenceReaderTest {
 
         BinaryCoOccurrenceWriter<VocabWord> writer = new BinaryCoOccurrenceWriter<>(tempFile);
 
-        CoOccurrenceWeight<VocabWord> object1 = new CoOccurrenceWeight<VocabWord>();
+        CoOccurrenceWeight<VocabWord> object1 = new CoOccurrenceWeight<>();
         object1.setElement1(word1);
         object1.setElement2(word2);
         object1.setWeight(3.14159265);
 
         writer.writeObject(object1);
 
-        CoOccurrenceWeight<VocabWord> object2 = new CoOccurrenceWeight<VocabWord>();
+        CoOccurrenceWeight<VocabWord> object2 = new CoOccurrenceWeight<>();
         object2.setElement1(word2);
         object2.setElement2(word3);
         object2.setWeight(0.197);
 
         writer.writeObject(object2);
 
-        CoOccurrenceWeight<VocabWord> object3 = new CoOccurrenceWeight<VocabWord>();
+        CoOccurrenceWeight<VocabWord> object3 = new CoOccurrenceWeight<>();
         object3.setElement1(word1);
         object3.setElement2(word3);
         object3.setWeight(0.001);

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/SequenceVectorsTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/SequenceVectorsTest.java
@@ -90,7 +90,7 @@ public class SequenceVectorsTest {
         /*
             And we pack that transformer into AbstractSequenceIterator
          */
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
 
@@ -203,7 +203,7 @@ public class SequenceVectorsTest {
                 .tokenizerFactory(t)
                 .build();
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         SequenceVectors<VocabWord> vectors = new SequenceVectors.Builder<VocabWord>(new VectorsConfiguration())
@@ -268,7 +268,7 @@ public class SequenceVectorsTest {
                 .tokenizerFactory(t)
                 .build();
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VectorsConfiguration configuration = new VectorsConfiguration();
@@ -351,7 +351,7 @@ public class SequenceVectorsTest {
                 .build();
 */
 
-        GraphTransformer<Blogger> graphTransformer = new GraphTransformer.Builder<Blogger>(graph)
+        GraphTransformer<Blogger> graphTransformer = new GraphTransformer.Builder<>(graph)
                 .setGraphWalker(walker)
                 .shuffleOnReset(true)
                 .setVocabCache(vocabCache)
@@ -363,7 +363,7 @@ public class SequenceVectorsTest {
         logger.info("Blogger: " + blogger);
 
 
-        AbstractSequenceIterator<Blogger> sequenceIterator = new AbstractSequenceIterator.Builder<Blogger>(graphTransformer)
+        AbstractSequenceIterator<Blogger> sequenceIterator = new AbstractSequenceIterator.Builder<>(graphTransformer)
                 .build();
 
         WeightLookupTable<Blogger> lookupTable = new InMemoryLookupTable.Builder<Blogger>()
@@ -473,7 +473,7 @@ public class SequenceVectorsTest {
 
         reader.close();
 
-        Graph<Blogger, Double> graph = new Graph<Blogger, Double>(bloggers, true);
+        Graph<Blogger, Double> graph = new Graph<>(bloggers, true);
 
         // load edges
         File edges = new File("/ext/Temp/BlogCatalog/edges.csv");

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/PopularityWalkerTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/PopularityWalkerTest.java
@@ -26,7 +26,7 @@ public class PopularityWalkerTest {
     @Before
     public void setUp() {
         if (graph == null) {
-            graph = new Graph<VocabWord, Double>(10, false, new AbstractVertexFactory<VocabWord>());
+            graph = new Graph<>(10, false, new AbstractVertexFactory<VocabWord>());
 
             for (int i = 0; i < 10; i++) {
                 graph.getVertex(i).setValue(new VocabWord(i, String.valueOf(i)));
@@ -48,7 +48,7 @@ public class PopularityWalkerTest {
 
     @Test
     public void testPopularityWalkerCreation() throws Exception {
-        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<VocabWord>(graph)
+        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<>(graph)
                 .setWalkDirection(WalkDirection.FORWARD_ONLY)
                 .setWalkLength(10)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)
@@ -59,7 +59,7 @@ public class PopularityWalkerTest {
 
     @Test
     public void testPopularityWalker1() throws Exception {
-        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<VocabWord>(graph)
+        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<>(graph)
                 .setWalkDirection(WalkDirection.FORWARD_ONLY)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)
                 .setWalkLength(10)
@@ -81,7 +81,7 @@ public class PopularityWalkerTest {
 
     @Test
     public void testPopularityWalker2() throws Exception {
-        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<VocabWord>(graph)
+        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<>(graph)
                 .setWalkDirection(WalkDirection.FORWARD_ONLY)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)
                 .setWalkLength(10)
@@ -102,7 +102,7 @@ public class PopularityWalkerTest {
 
     @Test
     public void testPopularityWalker3() throws Exception {
-        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<VocabWord>(graph)
+        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<>(graph)
                 .setWalkDirection(WalkDirection.FORWARD_ONLY)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)
                 .setWalkLength(10)
@@ -139,7 +139,7 @@ public class PopularityWalkerTest {
 
     @Test
     public void testPopularityWalker4() throws Exception {
-        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<VocabWord>(graph)
+        GraphWalker<VocabWord> walker = new PopularityWalker.Builder<>(graph)
                 .setWalkDirection(WalkDirection.FORWARD_ONLY)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)
                 .setWalkLength(10)

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/RandomWalkerTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/graph/walkers/impl/RandomWalkerTest.java
@@ -31,7 +31,7 @@ public class RandomWalkerTest {
     @Before
     public void setUp() throws Exception {
         if (graph == null) {
-            graph = new Graph<VocabWord, Double>(10, false, new AbstractVertexFactory<VocabWord>());
+            graph = new Graph<>(10, false, new AbstractVertexFactory<VocabWord>());
 
             for (int i = 0; i < 10; i++) {
                 graph.getVertex(i).setValue(new VocabWord(i, String.valueOf(i)));
@@ -41,7 +41,7 @@ public class RandomWalkerTest {
                 graph.addEdge(i, x, 1.0, false);
             }
 
-            graphDirected = new Graph<VocabWord, Double>(10, false, new AbstractVertexFactory<VocabWord>());
+            graphDirected = new Graph<>(10, false, new AbstractVertexFactory<VocabWord>());
 
             for (int i = 0; i < 10; i++) {
                 graphDirected.getVertex(i).setValue(new VocabWord(i, String.valueOf(i)));
@@ -51,7 +51,7 @@ public class RandomWalkerTest {
                 graphDirected.addEdge(i, x, 1.0, true);
             }
 
-            graphBig = new Graph<VocabWord, Double>(1000, false, new AbstractVertexFactory<VocabWord>());
+            graphBig = new Graph<>(1000, false, new AbstractVertexFactory<VocabWord>());
 
             for (int i = 0; i < 1000; i++) {
                 graphBig.getVertex(i).setValue(new VocabWord(i, String.valueOf(i)));
@@ -65,7 +65,7 @@ public class RandomWalkerTest {
 
     @Test
     public void testGraphCreation() throws Exception {
-        Graph<VocabWord, Double> graph = new Graph<VocabWord, Double>(10, false, new AbstractVertexFactory<VocabWord>());
+        Graph<VocabWord, Double> graph = new Graph<>(10, false, new AbstractVertexFactory<VocabWord>());
 
         // we have 10 elements
         assertEquals(10,graph.numVertices());
@@ -80,7 +80,7 @@ public class RandomWalkerTest {
 
     @Test
     public void testGraphTraverseRandom1() throws Exception {
-        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<VocabWord>(graph)
+        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<>(graph)
                 .setNoEdgeHandling(NoEdgeHandling.SELF_LOOP_ON_DISCONNECTED)
                 .setWalkLength(3)
                 .build();
@@ -104,7 +104,7 @@ public class RandomWalkerTest {
 
     @Test
     public void testGraphTraverseRandom2() throws Exception {
-        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<VocabWord>(graph)
+        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<>(graph)
                 .setNoEdgeHandling(NoEdgeHandling.EXCEPTION_ON_DISCONNECTED)
                 .setWalkLength(20)
                 .setWalkDirection(WalkDirection.FORWARD_UNIQUE)
@@ -130,7 +130,7 @@ public class RandomWalkerTest {
 
     @Test
     public void testGraphTraverseRandom3() throws Exception {
-        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<VocabWord>(graph)
+        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<>(graph)
                 .setNoEdgeHandling(NoEdgeHandling.EXCEPTION_ON_DISCONNECTED)
                 .setWalkLength(20)
                 .setWalkDirection(WalkDirection.FORWARD_UNIQUE)
@@ -154,7 +154,7 @@ public class RandomWalkerTest {
 
     @Test
     public void testGraphTraverseRandom4() throws Exception {
-        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<VocabWord>(graphBig)
+        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<>(graphBig)
                 .setNoEdgeHandling(NoEdgeHandling.EXCEPTION_ON_DISCONNECTED)
                 .setWalkLength(20)
                 .setWalkDirection(WalkDirection.FORWARD_UNIQUE)
@@ -172,7 +172,7 @@ public class RandomWalkerTest {
 
     @Test
     public void testGraphTraverseRandom5() throws Exception {
-        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<VocabWord>(graphBig)
+        RandomWalker<VocabWord> walker = (RandomWalker<VocabWord>) new RandomWalker.Builder<>(graphBig)
                 .setWalkLength(20)
                 .setWalkDirection(WalkDirection.FORWARD_UNIQUE)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)
@@ -189,7 +189,7 @@ public class RandomWalkerTest {
 
     @Test
     public void testGraphTraverseRandom6() throws Exception {
-        GraphWalker<VocabWord> walker =  new RandomWalker.Builder<VocabWord>(graphDirected)
+        GraphWalker<VocabWord> walker = new RandomWalker.Builder<>(graphDirected)
                 .setWalkLength(20)
                 .setWalkDirection(WalkDirection.FORWARD_UNIQUE)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/GraphTransformerTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/GraphTransformerTest.java
@@ -29,7 +29,7 @@ public class GraphTransformerTest {
     @Before
     public void setUp() throws Exception {
         if (graph == null) {
-            graph = new Graph<VocabWord, Double>(10, false, new AbstractVertexFactory<VocabWord>());
+            graph = new Graph<>(10, false, new AbstractVertexFactory<VocabWord>());
 
             for (int i = 0; i < 10; i++) {
                 graph.getVertex(i).setValue(new VocabWord(i, String.valueOf(i)));
@@ -43,11 +43,11 @@ public class GraphTransformerTest {
 
     @Test
     public void testGraphTransformer1() throws Exception {
-        GraphWalker<VocabWord> walker = new RandomWalker.Builder<VocabWord>(graph)
+        GraphWalker<VocabWord> walker = new RandomWalker.Builder<>(graph)
                 .setNoEdgeHandling(NoEdgeHandling.CUTOFF_ON_DISCONNECTED)
                 .build();
 
-        GraphTransformer<VocabWord> transformer = new GraphTransformer.Builder<VocabWord>(graph)
+        GraphTransformer<VocabWord> transformer = new GraphTransformer.Builder<>(graph)
                 .setGraphWalker(walker)
                 .build();
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructorTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructorTest.java
@@ -82,7 +82,7 @@ public class VocabConstructorTest {
         /*
             And we pack that transformer into AbstractSequenceIterator
          */
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> constructor = new VocabConstructor.Builder<VocabWord>()
@@ -113,7 +113,7 @@ public class VocabConstructorTest {
                 .build();
 
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> constructor = new VocabConstructor.Builder<VocabWord>()
@@ -259,7 +259,7 @@ public class VocabConstructorTest {
                 .tokenizerFactory(t)
                 .build();
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> vocabConstructor = new VocabConstructor.Builder<VocabWord>()
@@ -301,7 +301,7 @@ public class VocabConstructorTest {
                 .tokenizerFactory(t)
                 .build();
 
-        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        AbstractSequenceIterator<VocabWord> sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> vocabConstructor = new VocabConstructor.Builder<VocabWord>()
@@ -323,7 +323,7 @@ public class VocabConstructorTest {
                 .tokenizerFactory(t)
                 .build();
 
-        sequenceIterator = new AbstractSequenceIterator.Builder<VocabWord>(transformer)
+        sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer)
                 .build();
 
         VocabConstructor<VocabWord> vocabTransfer = new VocabConstructor.Builder<VocabWord>()

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/core/ClusterListener.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/core/ClusterListener.java
@@ -39,7 +39,7 @@ public class ClusterListener extends UntypedActor {
 	Cluster cluster = Cluster.get(getContext().system());
 	protected ActorRef mediator = DistributedPubSubExtension.get(getContext().system()).mediator();
 	public final static String TOPICS = "topics";
-	private List<String> topics = new ArrayList<String>();
+	private List<String> topics = new ArrayList<>();
 	private Cancellable topicTask;
 	//subscribe to cluster changes
 	@Override

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/util/ActorRefUtils.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/util/ActorRefUtils.java
@@ -133,7 +133,7 @@ public class ActorRefUtils implements DeepLearningConfigurable {
 	 */
 	public static String absPath(ActorRef self,ActorSystem system) {
 		String address = Cluster.get(system).selfAddress().toString();
-		List<String> path2 = new ArrayList<String>();
+		List<String> path2 = new ArrayList<>();
 		scala.collection.immutable.Iterable<String> elements = self.path().elements();
 		scala.collection.Iterator<String> iter = elements.iterator();
 		while(iter.hasNext())

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-zookeeper/src/main/java/org/deeplearning4j/scaleout/zookeeper/ZookeeperPathBuilder.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-zookeeper/src/main/java/org/deeplearning4j/scaleout/zookeeper/ZookeeperPathBuilder.java
@@ -29,7 +29,7 @@ public class ZookeeperPathBuilder {
 	private List<String> paths;
 
 	public ZookeeperPathBuilder() {
-		paths = new ArrayList<String>();
+		paths = new ArrayList<>();
 	}
 
 	public ZookeeperPathBuilder setPort(int port) {

--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2Vec.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2Vec.java
@@ -240,7 +240,7 @@ public class Word2Vec extends WordVectorsImpl<VocabWord> implements Serializable
 
 
         vocab = vocabCache;
-        InMemoryLookupTable<VocabWord> inMemoryLookupTable = new InMemoryLookupTable<VocabWord>();
+        InMemoryLookupTable<VocabWord> inMemoryLookupTable = new InMemoryLookupTable<>();
         Environment env = EnvironmentUtils.buildEnvironment();
         env.setNumCores(maxRep);
         env.setAvailableMemory(totals);

--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/text/functions/TextPipeline.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/text/functions/TextPipeline.java
@@ -59,7 +59,7 @@ public class TextPipeline {
     private Broadcast<List<String>> stopWordBroadCast;
     // Return values
     private JavaRDD<Pair<List<String>, AtomicLong>> sentenceWordsCountRDD;
-    private VocabCache<VocabWord> vocabCache = new AbstractCache<VocabWord>();
+    private VocabCache<VocabWord> vocabCache = new AbstractCache<>();
     private Broadcast<VocabCache<VocabWord>> vocabCacheBroadcast;
     private JavaRDD<List<VocabWord>> vocabWordListRDD;
     private JavaRDD<AtomicLong> sentenceCountRDD;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2293 - “The diamond operator ("<>") should be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2293

 Please let me know if you have any questions.
Ayman Elkfrawy.