### PR TITLE
Run tests from deeplearning4j-core for deeplearning4j-cuda-7.5 as well

### DIFF
--- a/deeplearning4j-cuda-7.5/pom.xml
+++ b/deeplearning4j-cuda-7.5/pom.xml
@@ -63,5 +63,29 @@
             <artifactId>cuda</artifactId>
             <version>7.5-1.2</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
+
+    <build>
+        <testSourceDirectory>../deeplearning4j-core/src/test/java</testSourceDirectory>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.18.1</version>
+                    <configuration>
+                        <additionalClasspathElements>
+                            <additionalClasspathElement>../dl4j-test-resources/src/main/resources</additionalClasspathElement>
+                        </additionalClasspathElements>
+                        <argLine>-Ddtype=double</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/deeplearning4j-cuda-7.5/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnBatchNormalizationHelper.java
+++ b/deeplearning4j-cuda-7.5/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnBatchNormalizationHelper.java
@@ -211,13 +211,13 @@ public class CudnnBatchNormalizationHelper implements BatchNormalizationHelper {
 
         checkCudnn(cudnnSetStream(cudnnContext, new CUstream_st(context.getOldStream())));
         if (training) {
-            if (meanCache.capacity() < mean.data().length()) {
+            if (meanCache.capacity() < mean.data().length() * mean.data().getElementSize()) {
                 meanCache.deallocate();
-                meanCache = new Cache(mean.data().length());
+                meanCache = new Cache(mean.data().length() * mean.data().getElementSize());
             }
-            if (varCache.capacity() < var.data().length()) {
+            if (varCache.capacity() < var.data().length() * mean.data().getElementSize()) {
                 varCache.deallocate();
-                varCache = new Cache(var.data().length());
+                varCache = new Cache(var.data().length() * mean.data().getElementSize());
             }
             checkCudnn(cudnnBatchNormalizationForwardTraining(cudnnContext, batchNormMode, this.alpha, this.beta,
                     cudnnContext.srcTensorDesc, srcData, cudnnContext.dstTensorDesc, dstData,


### PR DESCRIPTION
To run the tests using the CUDA backend along with cuDNN

Without cuDNN, I get
```
Tests run: 391, Failures: 1, Errors: 276, Skipped: 16
```
And with cuDNN I get
```
Tests run: 391, Failures: 1, Errors: 240, Skipped: 16
```
So it looks like cuDNN doesn't break too many things :)