### PR TITLE
Fix: squid:S1206, "equals(Object obj)" and "hashCode()" should be ove…

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/eval/ConfusionMatrix.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/eval/ConfusionMatrix.java
@@ -243,6 +243,14 @@ public class ConfusionMatrix<T extends Comparable<? super T>> implements Seriali
         return matrix.equals(c.matrix) && classes.equals(c.classes);
     }
 
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + (matrix == null? 0 : matrix.hashCode());
+        result = 31 * result + (classes == null? 0 : classes.hashCode());
+        return result;
+    }
+
     public static void main(String[] args) {
         ConfusionMatrix<String> confusionMatrix = new ConfusionMatrix<>(Arrays.asList("a", "b", "c"));
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -248,6 +248,13 @@ public abstract class BaseUpdater implements Updater {
     }
 
     @Override
+    public int hashCode() {
+        int result = 19;
+        result = 31 * result + (updaterForVariable == null? 0 : updaterForVariable.hashCode());
+        return result;
+    }
+
+    @Override
     public Updater clone(){
         Map<String,GradientUpdater> newMap = new HashMap<>();
         for( String s : updaterForVariable.keySet()){

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/api/Edge.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/api/Edge.java
@@ -45,4 +45,14 @@ public class Edge<T> {
         if((value != null && e.value == null) || (value == null && e.value != null)) return false;
         return value == null || value.equals(e.value);
     }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + (directed? 1 : 0);
+        result = 31 * result + from;
+        result = 31 * result + to;
+        result = 31 * result + (value==null? 0 : value.hashCode());
+        return result;
+    }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/api/Vertex.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/api/Vertex.java
@@ -33,4 +33,12 @@ public class Vertex<T> {
         if ((value == null && v.value != null) || (value != null && v.value == null)) return false;
         return value == null || value.equals(v.value);
     }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + idx;
+        result = 31 * result + (value==null? 0 : value.hashCode());
+        return result;
+    }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/graph/Graph.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/graph/Graph.java
@@ -5,10 +5,7 @@ import org.deeplearning4j.graph.exception.NoEdgesException;
 import org.deeplearning4j.graph.vertexfactory.VertexFactory;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 /** Graph, where all edges and vertices are stored in-memory.<br>
  * Internally, this is a directed graph with adjacency list representation; however, if undirected edges
@@ -217,5 +214,14 @@ public class Graph<V, E> extends BaseGraph<V,E> {
             if(!edges[i].equals(g.edges[i])) return false;
         }
         return vertices.equals(g.vertices);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 23;
+        result = 31 * result + (allowMultipleEdges? 1 : 0);
+        result = 31 * result + Arrays.hashCode(edges);
+        result = 31 * result + vertices.hashCode();
+        return result;
     }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Edge.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Edge.java
@@ -45,4 +45,14 @@ public class Edge<T extends Number> {
         if((value != null && e.value == null) || (value == null && e.value != null)) return false;
         return value == null || value.equals(e.value);
     }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + (directed? 1 : 0);
+        result = 31 * result + from;
+        result = 31 * result + to;
+        result = 31 * result + (value==null? 0 : value.hashCode());
+        return result;
+    }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Graph.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Graph.java
@@ -257,4 +257,13 @@ public class Graph<V extends SequenceElement, E extends Number> implements IGrap
         }
         return vertices.equals(g.vertices);
     }
+
+    @Override
+    public int hashCode() {
+        int result = 23;
+        result = 31 * result + (allowMultipleEdges? 1 : 0);
+        result = 31 * result + Arrays.hashCode(edges);
+        result = 31 * result + vertices.hashCode();
+        return result;
+    }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Vertex.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Vertex.java
@@ -33,4 +33,12 @@ public class Vertex<T extends SequenceElement> {
         if ((value == null && v.value != null) || (value != null && v.value == null)) return false;
         return value == null || value.equals(v.value);
     }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + idx;
+        result = 31 * result + (value==null? 0 : value.hashCode());
+        return result;
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1206 - “ "equals(Object obj)" and "hashCode()" should be overridden in pairs ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1206

 Please let me know if you have any questions.
Ayman Elkfrawy.