### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/deeplearning4j-cli/deeplearning4j-cli-api/src/main/java/org/deeplearning4j/cli/api/schemes/Schemes.java
+++ b/deeplearning4j-cli/deeplearning4j-cli-api/src/main/java/org/deeplearning4j/cli/api/schemes/Schemes.java
@@ -25,6 +25,9 @@ import org.deeplearning4j.cli.files.FileScheme;
  * @author sonali
  */
 public class Schemes {
+    private Schemes() {
+    }
+
     /**
      * Selects appropriate Scheme for reading/writing data
      * @param scheme

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/base/IrisUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/base/IrisUtils.java
@@ -30,7 +30,10 @@ import org.nd4j.linalg.io.ClassPathResource;
 
 public class IrisUtils {
 
-    public static List<DataSet> loadIris(int from,int to) throws IOException {
+    private IrisUtils() {
+    }
+
+    public static List<DataSet> loadIris(int from, int to) throws IOException {
         ClassPathResource resource = new ClassPathResource("/iris.dat");
         @SuppressWarnings("unchecked")
         List<String> lines = IOUtils.readLines(resource.getInputStream());

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/SloppyMath.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/SloppyMath.java
@@ -35,7 +35,10 @@ import java.util.Map;
  */
 public final class SloppyMath {
 
-	  public static double abs(double x) {
+    private SloppyMath() {
+    }
+
+    public static double abs(double x) {
 		    if (x > 0)
 		      return x;
 		    return -1.0 * x;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/creator/MnistDataSetCreator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/creator/MnistDataSetCreator.java
@@ -26,6 +26,9 @@ import org.deeplearning4j.util.SerializationUtils;
 
 public class MnistDataSetCreator {
 
+	private MnistDataSetCreator() {
+	}
+
 	/**
 	 * @param args
 	 */

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/mnist/draw/LoadAndDraw.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/mnist/draw/LoadAndDraw.java
@@ -32,6 +32,9 @@ import org.deeplearning4j.nn.layers.BasePretrainNetwork;
 
 public class LoadAndDraw {
 
+	private LoadAndDraw() {
+	}
+
 	/**
 	 * @param args
 	 */

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
@@ -126,7 +126,7 @@ public class LayerVertex extends GraphVertex {
             //First: check that the kernel size/stride/padding is valid
             int inHeight = afterPreProcessor.getHeight();
             int inWidth = afterPreProcessor.getWidth();
-            new KernelValidationUtil().validateShapes(inHeight, inWidth,
+            KernelValidationUtil.validateShapes(inHeight, inWidth,
                     kernel[0], kernel[1], stride[0], stride[1],padding[0], padding[1]);
 
             int outWidth = (inWidth - kernel[1] + 2 * padding[1]) / stride[1] + 1;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/setup/ConvolutionLayerSetup.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/setup/ConvolutionLayerSetup.java
@@ -405,7 +405,7 @@ public class ConvolutionLayerSetup {
 
     private void getConvolutionOutputSize(int[] input, int[] kernel, int[] padding, int[] stride) {
         int[] ret = new int[input.length];
-        new KernelValidationUtil().validateShapes(input[0], input[1],
+        KernelValidationUtil.validateShapes(input[0], input[1],
                 kernel[0], kernel[1], stride[0], stride[1],padding[0], padding[1]);
 
         for(int i = 0; i < ret.length; i++) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/KernelValidationUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/KernelValidationUtil.java
@@ -8,8 +8,11 @@ import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
  */
 public class KernelValidationUtil {
 
+    private KernelValidationUtil() {
+    }
+
     public static void validateShapes(int inHeight, int inWidth, int kernelHeight, int kernelWidth, int strideHeight,
-                               int strideWidth, int padHeight, int padWidth) {
+                                      int strideWidth, int padHeight, int padWidth) {
 
         // Check filter > size + padding
         if (kernelHeight > (inHeight + 2*padHeight))

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/LayerFactories.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/factory/LayerFactories.java
@@ -28,6 +28,9 @@ import org.deeplearning4j.nn.conf.layers.*;
  * @author Adam Gibson
  */
 public class LayerFactories {
+    private LayerFactories() {
+    }
+
     /**
      * Get the factory based on the passed in class
      * @param conf the clazz to get the layer factory for

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelpers.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelpers.java
@@ -43,6 +43,9 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.point;
  */
 public class LSTMHelpers {
 
+    private LSTMHelpers() {
+    }
+
     /**
      * Returns FwdPassReturn object with activations/INDArrays. Allows activateHelper to be used for forward pass, backward pass
      * and rnnTimeStep whilst being reasonably efficient for all

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/UpdaterCreator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/UpdaterCreator.java
@@ -12,6 +12,9 @@ import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
  */
 public class UpdaterCreator {
 
+    private UpdaterCreator() {
+    }
+
     /**
      * Create an updater based on the configuration
      * @param conf the configuration to get the updater for

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/weights/WeightInitUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/weights/WeightInitUtil.java
@@ -37,6 +37,9 @@ public class WeightInitUtil {
      */
     public static final char DEFAULT_WEIGHT_INIT_ORDER = 'f';
 
+    private WeightInitUtil() {
+    }
+
 //    /**
 //     * Normalized weight init
 //     *

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/stepfunctions/StepFunctions.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/stepfunctions/StepFunctions.java
@@ -26,7 +26,10 @@ public class StepFunctions {
     private static final GradientStepFunction GRADIENT_STEP_FUNCTION_INSTANCE = new GradientStepFunction();
     private static final NegativeDefaultStepFunction NEGATIVE_DEFAULT_STEP_FUNCTION_INSTANCE = new NegativeDefaultStepFunction();
     private static final NegativeGradientStepFunction NEGATIVE_GRADIENT_STEP_FUNCTION_INSTANCE = new NegativeGradientStepFunction();
-    
+
+    private StepFunctions() {
+    }
+
     public static StepFunction createStepFunction(org.deeplearning4j.nn.conf.stepfunctions.StepFunction stepFunction) {
     	if(stepFunction == null ) return null;
         if(stepFunction instanceof org.deeplearning4j.nn.conf.stepfunctions.DefaultStepFunction)

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/InputSplit.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/InputSplit.java
@@ -28,7 +28,10 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 
 public class InputSplit {
 
-	public static void splitInputs(INDArray inputs,INDArray outcomes,List<Pair<INDArray,INDArray>> train,List<Pair<INDArray,INDArray>> test,double split) {
+	private InputSplit() {
+	}
+
+	public static void splitInputs(INDArray inputs, INDArray outcomes, List<Pair<INDArray,INDArray>> train, List<Pair<INDArray,INDArray>> test, double split) {
 		List<Pair<INDArray,INDArray>> list = new ArrayList<>();
 		for(int i = 0; i < inputs.rows(); i++) {
 			list.add(new Pair<>(inputs.getRow(i),outcomes.getRow(i)));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ModelSerializer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ModelSerializer.java
@@ -27,6 +27,9 @@ import java.util.zip.ZipOutputStream;
  */
 public class ModelSerializer {
 
+    private ModelSerializer() {
+    }
+
     /**
      * Write a model to a file
      * @param model the model to write

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MultiLayerUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MultiLayerUtil.java
@@ -30,6 +30,9 @@ import java.util.List;
  * @author Adam Gibson
  */
 public class MultiLayerUtil {
+    private MultiLayerUtil() {
+    }
+
     /**
      * Return the weight matrices for a multi layer network
      * @param network the network to get the weights for

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MultiThreadUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/MultiThreadUtils.java
@@ -29,7 +29,10 @@ public class MultiThreadUtils {
 	private static Logger log = LoggerFactory.getLogger(MultiThreadUtils.class);
 
 	private static ExecutorService instance;
-	
+
+	private MultiThreadUtils() {
+	}
+
 	public static synchronized ExecutorService newExecutorService() {
 		int nThreads = Runtime.getRuntime().availableProcessors();
 		return new ThreadPoolExecutor(nThreads, nThreads, 60L, TimeUnit.SECONDS,

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ReflectionUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ReflectionUtils.java
@@ -44,6 +44,9 @@ public class ReflectionUtils {
     private static final Map<Class<?>, Constructor<?>> CONSTRUCTOR_CACHE =
             new ConcurrentHashMap<>();
 
+    private ReflectionUtils() {
+    }
+
 
     /**
      * This code is to support backward compatibility and break the compile

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/SerializationUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/SerializationUtils.java
@@ -29,6 +29,9 @@ import org.apache.commons.io.FileUtils;
  */
 public class SerializationUtils {
 
+	private SerializationUtils() {
+	}
+
 	@SuppressWarnings("unchecked")
 	public static <T> T readObject(File file) {
 		ObjectInputStream ois = null;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringUtils.java
@@ -42,6 +42,9 @@ public class StringUtils {
         decimalFormat.applyPattern("#.##");
     }
 
+    private StringUtils() {
+    }
+
     /**
      * Make a string representation of the exception.
      * @param e The exception to stringify

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
@@ -30,6 +30,9 @@ import org.nd4j.linalg.indexing.NDArrayIndex;
 public class TimeSeriesUtils {
 
 
+    private TimeSeriesUtils() {
+    }
+
     /**
      * Calculate a moving average given the length
      * @param toAvg the array to average

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
@@ -80,6 +80,9 @@ public class WordVectorSerializer {
     private static final String whitespaceReplacement = "_Az92_";
     private static final Logger log = LoggerFactory.getLogger(WordVectorSerializer.class);
 
+    private WordVectorSerializer() {
+    }
+
     /**
      * Loads the google model
      *

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/TreeFactory.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/corpora/treeparser/TreeFactory.java
@@ -44,6 +44,8 @@ import java.util.List;
 public class TreeFactory {
 
 
+    private TreeFactory() {
+    }
 
     /**
      * Builds a tree recursively

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Util.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Util.java
@@ -31,9 +31,8 @@ import org.deeplearning4j.berkeley.MapFactory;
 public class Util {
 
 
-
-
-
+    private Util() {
+    }
 
     /**
      * Returns a thread safe counter map

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/WindowConverter.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/WindowConverter.java
@@ -36,8 +36,8 @@ import java.util.List;
 public class WindowConverter {
 
 
-
-
+    private WindowConverter() {
+    }
 
     /**
      * Converts a window (each word in the window)

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Windows.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/movingwindow/Windows.java
@@ -36,6 +36,9 @@ import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
 public class Windows {
 
 
+    private Windows() {
+    }
+
     /**
      * Constructs a list of window of size windowSize.
      * Note that padding for each window is created as well.

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/stopwords/StopWords.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/stopwords/StopWords.java
@@ -33,6 +33,9 @@ public class StopWords {
 
 	private static List<String> stopWords;
 
+	private StopWords() {
+	}
+
 	@SuppressWarnings("unchecked")
 	public static List<String> getStopWords() {
 

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/preprocessor/StringCleaning.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/preprocessor/StringCleaning.java
@@ -28,6 +28,9 @@ public class StringCleaning {
 
     private static final Pattern punctPattern = Pattern.compile("[\\d\\.:,\"\'\\(\\)\\[\\]|/?!;]+");
 
+    private StringCleaning() {
+    }
+
     /**
      * Strip punctuation
      * @param base the base string

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/parallel/Parallelization.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/parallel/Parallelization.java
@@ -38,6 +38,9 @@ public class Parallelization {
 
     private static final Logger log = LoggerFactory.getLogger(Parallelization.class);
 
+    private Parallelization() {
+    }
+
     public interface RunnableWithParams<E> {
         void run(E currentItem,Object[] args);
     }

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/util/PortTaken.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/util/PortTaken.java
@@ -22,6 +22,9 @@ import java.net.ServerSocket;
 
 public class PortTaken {
 
+	private PortTaken() {
+	}
+
 	public static boolean portTaken(int port) {
 		try {
 			ServerSocket s = new ServerSocket(port);

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-zookeeper/src/main/java/org/deeplearning4j/scaleout/zookeeper/utils/ZkUtils.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-zookeeper/src/main/java/org/deeplearning4j/scaleout/zookeeper/utils/ZkUtils.java
@@ -26,6 +26,9 @@ import java.io.Serializable;
 
 public class ZkUtils {
 
+	private ZkUtils() {
+	}
+
 	public static byte[] toBytes(Serializable ser) throws Exception {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		ObjectOutputStream ois = new ObjectOutputStream(bos);

--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2VecVariables.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2VecVariables.java
@@ -44,6 +44,9 @@ public class Word2VecVariables {
         put(SEED, 42L);
     }};
 
+    private Word2VecVariables() {
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> T getDefault(String variableName) {
         return (T) defaultVals.get(variableName);

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/stats/StatsUtils.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/stats/StatsUtils.java
@@ -32,6 +32,9 @@ public class StatsUtils {
 
     public static final long DEFAULT_MAX_TIMELINE_SIZE_MS = 20 * 60 * 1000;  //20 minutes
 
+    private StatsUtils() {
+    }
+
     public static void exportStats(List<EventStats> list, String outputDirectory, String filename, String delimiter, SparkContext sc) throws IOException {
         String path = FilenameUtils.concat(outputDirectory, filename);
         exportStats(list, path, delimiter, sc);

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/time/TimeSourceProvider.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/time/TimeSourceProvider.java
@@ -21,6 +21,9 @@ public class TimeSourceProvider {
      */
     public static final String TIMESOURCE_CLASSNAME_PROPERTY = "org.deeplearning4j.spark.time.TimeSource";
 
+    private TimeSourceProvider() {
+    }
+
     /**
      * Get a TimeSource
      * the default TimeSource instance (default: {@link NTPTimeSource}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
@@ -53,6 +53,9 @@ import java.util.List;
 public class MLLibUtil {
 
 
+    private MLLibUtil() {
+    }
+
     /**
      * This is for the edge case where
      * you have a single output layer

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SerializationTester.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SerializationTester.java
@@ -14,6 +14,9 @@ import akka.serialization.Serializer;
 public class SerializationTester {
 
 
+    private SerializationTester() {
+    }
+
     /**
      * Testing akka serialization
      * @param system the system to test on

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -17,6 +17,9 @@ import java.util.List;
  */
 public class SparkUtils {
 
+    private SparkUtils() {
+    }
+
     /**
      * Write a String to a file (on HDFS or local) in UTF-8 format
      *

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/UIDProvider.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/UIDProvider.java
@@ -79,6 +79,8 @@ public class UIDProvider {
         }
     }
 
+    private UIDProvider() {
+    }
 
 
     public static String getJVMUID(){

--- a/deeplearning4j-ui-parent/deeplearning4j-ui-components/src/main/java/org/deeplearning4j/ui/api/Utils.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui-components/src/main/java/org/deeplearning4j/ui/api/Utils.java
@@ -4,6 +4,9 @@ import java.awt.*;
 
 public class Utils {
 
+    private Utils() {
+    }
+
     /** Convert an AWT color to a hex color string, such as #000000 */
     public static String colorToHex(Color color){
         return String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());

--- a/deeplearning4j-ui-parent/deeplearning4j-ui-components/src/main/java/org/deeplearning4j/ui/standalone/StaticPageUtil.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui-components/src/main/java/org/deeplearning4j/ui/standalone/StaticPageUtil.java
@@ -28,6 +28,9 @@ import java.util.*;
  */
 public class StaticPageUtil {
 
+    private StaticPageUtil() {
+    }
+
     public static String renderHTML(Collection<Component> components) throws Exception {
         return renderHTML(components.toArray(new Component[components.size()]));
     }

--- a/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/UiUtils.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/UiUtils.java
@@ -7,6 +7,9 @@ import org.slf4j.Logger;
 
 public class UiUtils {
 
+    private UiUtils() {
+    }
+
     public static void tryOpenBrowser(String path, Logger log){
         try{
             UiUtils.openBrowser(new URI(path));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

 Please let me know if you have any questions.
Ayman Elkfrawy.