### PR TITLE
Fix: squid:S1155, Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/StringUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/berkeley/StringUtils.java
@@ -651,7 +651,7 @@ public class StringUtils {
 				for (int j = 0; j < max && i + 1 < args.length && args[i + 1].charAt(0) != '-'; i++, j++) {
 					flagArgs.add(args[i + 1]);
 				}
-				if (flagArgs.size() == 0) {
+				if (flagArgs.isEmpty()) {
 					result.setProperty(key, "true");
 				} else {
 					result.setProperty(key, join(flagArgs, " "));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/algorithm/BaseClusteringAlgorithm.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/algorithm/BaseClusteringAlgorithm.java
@@ -125,7 +125,7 @@ public class BaseClusteringAlgorithm implements ClusteringAlgorithm, Serializabl
 
 		//Generate the initial cluster centers, by randomly selecting a point between 0 and max distance
 		//Thus, we are more likely to select (as a new cluster center) a point that is far from an existing cluster
-		while (clusterSet.getClusterCount() < initialClusterCount && points.size() > 0) {
+		while (clusterSet.getClusterCount() < initialClusterCount && !points.isEmpty()) {
 			dxs = ClusterUtils.computeSquareDistancesFromNearestCluster(clusterSet, points, dxs, exec);
 			double r = random.nextFloat() * dxs.maxNumber().doubleValue();
 			for (int i = 0; i < dxs.length(); i++) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/Cluster.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/Cluster.java
@@ -70,7 +70,7 @@ public class Cluster implements Serializable {
 	}
 
 	public boolean isEmpty() {
-		return points == null || points.size() == 0;
+		return points == null || points.isEmpty();
 	}
 
 	public Point getPoint(String id) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterUtils.java
@@ -207,7 +207,7 @@ public class ClusterUtils {
 			info.getPointDistancesFromCenter().put(point.getId(), distance);
 			info.setTotalPointDistanceFromCenter(info.getTotalPointDistanceFromCenter() + distance);
 		}
-		if (cluster.getPoints().size() > 0)
+		if (!cluster.getPoints().isEmpty())
 			info.setAveragePointDistanceFromCenter(info.getTotalPointDistanceFromCenter()/ cluster.getPoints().size());
 		return info;
 	}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/info/ClusterSetInfo.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/info/ClusterSetInfo.java
@@ -73,7 +73,7 @@ public class ClusterSetInfo {
 	}
 
 	public double getAveragePointDistanceFromClusterCenter() {
-		if (clustersInfos == null || clustersInfos.size() == 0)
+		if (clustersInfos == null || clustersInfos.isEmpty())
 			return 0;
 
 		double average = 0;
@@ -83,7 +83,7 @@ public class ClusterSetInfo {
 	}
 	
 	public double getPointDistanceFromClusterVariance() {
-		if (clustersInfos == null || clustersInfos.size() == 0)
+		if (clustersInfos == null || clustersInfos.isEmpty())
 			return 0;
 
 		double average = 0;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/canova/RecordReaderMultiDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/canova/RecordReaderMultiDataSetIterator.java
@@ -488,13 +488,13 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
         /** Create the RecordReaderMultiDataSetIterator */
         public RecordReaderMultiDataSetIterator build(){
             //Validate input:
-            if(recordReaders.size() == 0 && sequenceRecordReaders.size() == 0){
+            if(recordReaders.isEmpty() && sequenceRecordReaders.isEmpty()){
                 throw new IllegalStateException("Cannot construct RecordReaderMultiDataSetIterator with no readers");
             }
 
             if(batchSize <= 0) throw new IllegalStateException("Cannot construct RecordReaderMultiDataSetIterator with batch size <= 0");
 
-            if(inputs.size() == 0 && outputs.size() == 0){
+            if(inputs.isEmpty() && outputs.isEmpty()){
                 throw new IllegalStateException("Cannot construct RecordReaderMultiDataSetIterator with no inputs/outputs");
             }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/iterator/MultipleEpochsIterator.java
@@ -216,7 +216,7 @@ public class MultipleEpochsIterator implements DataSetIterator {
             newEpoch = false;
         }
         if (iter == null)
-            return (epochs < numEpochs) && ((batchedDS.size() != 0 && batchedDS.size() > batch) || batchedDS.size() == 0);
+            return (epochs < numEpochs) && ((!batchedDS.isEmpty() && batchedDS.size() > batch) || batchedDS.isEmpty());
         else
             // either there are still epochs to complete or its the first epoch
             return (epochs < numEpochs) || (iter.hasNext() && (epochs == 0 || epochs == numEpochs));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
@@ -229,7 +229,7 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
         //Check: each layer & node has at least one input
         for (Map.Entry<String, List<String>> e : vertexInputs.entrySet()) {
             String nodeName = e.getKey();
-            if (e.getValue() == null || e.getValue().size() == 0) {
+            if (e.getValue() == null || e.getValue().isEmpty()) {
                 throw new IllegalStateException("Invalid configuration: vertex \"" + nodeName + "\" has no inputs");
             }
             for (String inputName : e.getValue()) {
@@ -299,18 +299,18 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
             inputEdges.put(entry.getKey(), new HashSet<>(entry.getValue()));
         }
 
-        while (noIncomingEdges.size() > 0) {
+        while (!noIncomingEdges.isEmpty()) {
             String next = noIncomingEdges.removeFirst();
             topologicalOrdering.add(next);
 
             //Remove edges next -> vertexOuputsTo[...] from graph;
             List<String> nextEdges = verticesOutputTo.get(next);
 
-            if (nextEdges != null && nextEdges.size() > 0) {
+            if (nextEdges != null && !nextEdges.isEmpty()) {
                 for (String s : nextEdges) {
                     Set<String> set = inputEdges.get(s);
                     set.remove(next);
-                    if (set.size() == 0) {
+                    if (set.isEmpty()) {
                         noIncomingEdges.add(s); //No remaining edges for vertex i -> add to list for processing
                     }
                 }
@@ -321,7 +321,7 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
         for (Map.Entry<String, Set<String>> entry : inputEdges.entrySet()) {
             Set<String> set = entry.getValue();
             if (set == null) continue;
-            if (set.size() > 0)
+            if (!set.isEmpty())
                 throw new IllegalStateException("Invalid configuration: cycle detected in graph. Cannot calculate topological ordering with graph cycle ("
                         + "cycle includes vertex \"" + entry.getKey() + "\")");
         }
@@ -687,7 +687,7 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
             conf.validate();    //throws exception for invalid configuration
 
             //Automatically add preprocessors, set nIns for CNN->dense transitions, etc
-            if (networkInputTypes.size() > 0) {
+            if (!networkInputTypes.isEmpty()) {
                 conf.addPreProcessors(networkInputTypes.toArray(new InputType[networkInputs.size()]));
             }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -193,7 +193,7 @@ public class NeuralNetConfiguration implements Serializable,Cloneable {
          */
         public MultiLayerConfiguration build() {
             List<NeuralNetConfiguration> list = new ArrayList<>();
-            if(layerwise.size() == 0) throw new IllegalStateException("Invalid configuration: no layers defined");
+            if(layerwise.isEmpty()) throw new IllegalStateException("Invalid configuration: no layers defined");
             for(int i = 0; i < layerwise.size(); i++) {
                 if(layerwise.get(i) == null){
                     throw new IllegalStateException("Invalid configuration: layer number " + i + " not specified. Expect layer "

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -383,7 +383,7 @@ public class ComputationGraph implements Serializable, Model {
 
             List<String> thisVertexOutputsTo = verticesOutputTo.get(vertexName);
 
-            if(thisVertexOutputsTo == null || thisVertexOutputsTo.size() == 0 ) continue;   //Output vertex
+            if(thisVertexOutputsTo == null || thisVertexOutputsTo.isEmpty()) continue;   //Output vertex
             VertexIndices[] outputIndices = new VertexIndices[thisVertexOutputsTo.size()];
             int j=0;
             for( String s : thisVertexOutputsTo ){
@@ -753,7 +753,7 @@ public class ComputationGraph implements Serializable, Model {
             int idx = vertexNamesMap2.get(thisVertexName);
             List<String> inputsToThisVertex = configuration.getVertexInputs().get(thisVertexName);
 
-            if(inputsToThisVertex == null || inputsToThisVertex.size() == 0){
+            if(inputsToThisVertex == null || inputsToThisVertex.isEmpty()){
                 inputEdges.put(idx,null);
                 continue;
             }
@@ -780,12 +780,12 @@ public class ComputationGraph implements Serializable, Model {
         LinkedList<Integer> noIncomingEdges = new LinkedList<>();
         for( Map.Entry<Integer,Set<Integer>> entry : inputEdges.entrySet() ) {
             Set<Integer> inputsFrom = entry.getValue();
-            if(inputsFrom == null || inputsFrom.size() == 0) {
+            if(inputsFrom == null || inputsFrom.isEmpty()) {
                 noIncomingEdges.add(entry.getKey());
             }
         }
 
-        while(noIncomingEdges.size() > 0) {
+        while(!noIncomingEdges.isEmpty()) {
             int next = noIncomingEdges.removeFirst();
             out[outCounter++] = next;   //Add to sorted list
 
@@ -796,7 +796,7 @@ public class ComputationGraph implements Serializable, Model {
                 for( Integer v : vertexOutputsTo){
                     Set<Integer> set = inputEdges.get(v);
                     set.remove(next);
-                    if (set.size() == 0) {
+                    if (set.isEmpty()) {
                         noIncomingEdges.add(v); //No remaining edges for vertex i -> add to list for processing
                     }
                 }
@@ -807,7 +807,7 @@ public class ComputationGraph implements Serializable, Model {
         for(Map.Entry<Integer,Set<Integer>> entry : inputEdges.entrySet()){
             Set<Integer> set = entry.getValue();
             if(set == null) continue;
-            if(set.size() > 0) throw new IllegalStateException("Invalid configuration: cycle detected in graph. Cannot calculate topological ordering with graph cycle ("
+            if(!set.isEmpty()) throw new IllegalStateException("Invalid configuration: cycle detected in graph. Cannot calculate topological ordering with graph cycle ("
                     + "cycle includes vertex \"" + vertexNamesMap.get(entry.getKey()) + "\")");
         }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringUtils.java
@@ -279,7 +279,7 @@ public class StringUtils {
      */
     public static String[] getStrings(String str){
         Collection<String> values = getStringCollection(str);
-        if(values.size() == 0) {
+        if(values.isEmpty()) {
             return null;
         }
         return values.toArray(new String[values.size()]);

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTestRNN.java
@@ -244,8 +244,8 @@ public class MultiLayerTestRNN {
 
     	//Check clearing and setting of state:
     	mln.rnnClearPreviousState();
-    	assertTrue(mln.rnnGetPreviousState(0).size()==0);
-    	assertTrue(mln.rnnGetPreviousState(1).size()==0);
+    	assertTrue(mln.rnnGetPreviousState(0).isEmpty());
+    	assertTrue(mln.rnnGetPreviousState(1).isEmpty());
 
     	mln.rnnSetPreviousState(0, currStateL0);
     	assertTrue(mln.rnnGetPreviousState(0).size()==2);

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/graph/Graph.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/graph/Graph.java
@@ -117,7 +117,7 @@ public class Graph<V, E> extends BaseGraph<V,E> {
     @Override
     public Vertex<V> getRandomConnectedVertex(int vertex, Random rng) throws NoEdgesException {
         if(vertex < 0 || vertex >= vertices.size() ) throw new IllegalArgumentException("Invalid vertex index: " + vertex);
-        if(edges[vertex] == null || edges[vertex].size() == 0)
+        if(edges[vertex] == null || edges[vertex].isEmpty())
             throw new NoEdgesException("Cannot generate random connected vertex: vertex " + vertex + " has no outgoing/undirected edges");
         int connectedVertexNum = rng.nextInt(edges[vertex].size());
         Edge<E> edge = edges[vertex].get(connectedVertexNum);

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/iterator/WeightedRandomWalkIterator.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/iterator/WeightedRandomWalkIterator.java
@@ -89,7 +89,7 @@ public class WeightedRandomWalkIterator<V> implements GraphWalkIterator<V> {
             List<? extends Edge<? extends Number>> edgeList = graph.getEdgesOut(currVertexIdx);
 
             //First: check if there are any outgoing edges from this vertex. If not: handle the situation
-            if(edgeList == null || edgeList.size() == 0){
+            if(edgeList == null || edgeList.isEmpty()){
                 switch (mode) {
                     case SELF_LOOP_ON_DISCONNECTED:
                         for (int j = i; j < walkLength; j++) indices[j] = currVertexIdx;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/count/BinaryCoOccurrenceReader.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/count/BinaryCoOccurrenceReader.java
@@ -55,10 +55,10 @@ public class BinaryCoOccurrenceReader<T extends SequenceElement> implements CoOc
     @Override
     public boolean hasMoreObjects() {
 
-        if (buffer.size() > 0) return true;
+        if (!buffer.isEmpty()) return true;
 
         try {
-            return readerThread.hasMoreObjects() || buffer.size() > 0;
+            return readerThread.hasMoreObjects() || !buffer.isEmpty();
         } catch (Exception e) {
             throw new RuntimeException(e);
             //return false;
@@ -67,7 +67,7 @@ public class BinaryCoOccurrenceReader<T extends SequenceElement> implements CoOc
 
     @Override
     public CoOccurrenceWeight<T> nextObject() {
-        if (buffer.size() > 0) {
+        if (!buffer.isEmpty()) {
             return buffer.poll();
         } else {
             // buffer can be starved, or we're already at the end of file.

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
@@ -198,7 +198,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
             }
             log.info("Epoch: [" + currentEpoch+ "]; Words vectorized so far: [" + wordsCounter.get() + "];  Lines vectorized so far: [" + linesCounter.get() + "]; learningRate: [" + minLearningRate + "]");
 
-            if (eventListeners != null && eventListeners.size() > 0) {
+            if (eventListeners != null && !eventListeners.isEmpty()) {
                 for (VectorsListener listener: eventListeners) {
                     if (listener.validateEvent(ListenerEvent.EPOCH, currentEpoch))
                         listener.processEvent(ListenerEvent.EPOCH, this, currentEpoch);
@@ -210,7 +210,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
 
     protected void trainSequence(@NonNull Sequence<T> sequence, AtomicLong nextRandom, double alpha) {
 
-        if (sequence.getElements().size() == 0) return;
+        if (sequence.getElements().isEmpty()) return;
 
         if (trainElementsVectors) {
             // call for ElementsLearningAlgorithm
@@ -827,7 +827,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                         }
 
                         // due to subsampling and null words, new sequence size CAN be 0, so there's no need to insert empty sequence into processing chain
-                        if (newSequence.getElements().size() > 0) buffer.add(newSequence);
+                        if (!newSequence.getElements().isEmpty()) buffer.add(newSequence);
 
                         linesLoaded.incrementAndGet();
                     }
@@ -844,7 +844,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
 
         public boolean hasMoreLines() {
             // statement order does matter here, since there's possible race condition
-            return buffer.size() > 0 || isRunning.get();
+            return !buffer.isEmpty() || isRunning.get();
         }
 
         public Sequence<T> nextSentence() {
@@ -907,7 +907,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                       */
                     double alpha = 0.025;
 
-                    if (sequences.size() == 0) {
+                    if (sequences.isEmpty()) {
                         continue;
                     }
 
@@ -925,7 +925,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                             this.wordsCounter.addAndGet(sequence.getElements().size());
 
                             if (totalLines.get() % 100000 == 0) log.info("Epoch: [" + this.epochNumber+ "]; Words vectorized so far: [" + this.wordsCounter.get() + "];  Lines vectorized so far: [" + this.totalLines.get() + "]; learningRate: [" + alpha + "]");
-                            if (eventListeners != null && eventListeners.size() > 0) {
+                            if (eventListeners != null && !eventListeners.isEmpty()) {
                                 for (VectorsListener listener: eventListeners) {
                                     if (listener.validateEvent(ListenerEvent.LINE, totalLines.get()))
                                         listener.processEvent(ListenerEvent.LINE, SequenceVectors.this, totalLines.get());

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Graph.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/graph/primitives/Graph.java
@@ -159,7 +159,7 @@ public class Graph<V extends SequenceElement, E extends Number> implements IGrap
     @Override
     public Vertex<V> getRandomConnectedVertex(int vertex, Random rng) throws NoEdgesException {
         if(vertex < 0 || vertex >= vertices.size() ) throw new IllegalArgumentException("Invalid vertex index: " + vertex);
-        if(edges[vertex] == null || edges[vertex].size() == 0)
+        if(edges[vertex] == null || edges[vertex].isEmpty())
             throw new NoEdgesException("Cannot generate random connected vertex: vertex " + vertex + " has no outgoing/undirected edges");
         int connectedVertexNum = rng.nextInt(edges[vertex].size());
         Edge<E> edge = edges[vertex].get(connectedVertexNum);

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/inmemory/AbstractCache.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/inmemory/AbstractCache.java
@@ -62,7 +62,7 @@ public class AbstractCache<T extends SequenceElement> implements VocabCache<T> {
      */
     @Override
     public boolean vocabExists() {
-        return vocabulary.size() > 0;
+        return !vocabulary.isEmpty();
     }
 
     /**

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/PrefetchingSentenceIterator.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/PrefetchingSentenceIterator.java
@@ -158,7 +158,7 @@ public class PrefetchingSentenceIterator implements SentenceIterator {
         }
 
         public String nextLine() {
-            if (buffer.size() > 0)
+            if (!buffer.isEmpty())
                 return buffer.poll();
 
             try {
@@ -169,11 +169,11 @@ public class PrefetchingSentenceIterator implements SentenceIterator {
         }
 
         public boolean hasMoreLines() {
-            if (buffer.size() > 0) return true;
+            if (!buffer.isEmpty()) return true;
 
             try {
                 this.lock.readLock().lock();
-                return iterator.hasNext() || buffer.size() > 0;
+                return iterator.hasNext() || !buffer.isEmpty();
             } finally {
                 this.lock.readLock().unlock();
             }

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/StreamLineIterator.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/StreamLineIterator.java
@@ -74,7 +74,7 @@ public class StreamLineIterator implements SentenceIterator {
     @Override
     public boolean hasNext() {
         try {
-            return buffer.size() > 0 || iterator.hasNext() || (currentReader != null && currentReader.ready());
+            return !buffer.isEmpty() || iterator.hasNext() || (currentReader != null && currentReader.ready());
         } catch (IOException e) {
             // this exception is possible only at currentReader.ready(), so it means that it's definitely NOT ready
             return false;

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/DefaultStreamTokenizer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/DefaultStreamTokenizer.java
@@ -70,7 +70,7 @@ public class DefaultStreamTokenizer implements Tokenizer {
     @Override
     public boolean hasMoreTokens() {
         log.info("Tokens size: [" + tokens.size()+"], position: ["+ position.get()+"]");
-        if (tokens.size() > 0) return position.get() < tokens.size();
+        if (!tokens.isEmpty()) return position.get() < tokens.size();
             else return streamHasMoreTokens();
     }
 
@@ -93,7 +93,7 @@ public class DefaultStreamTokenizer implements Tokenizer {
      */
     @Override
     public String nextToken() {
-        if (tokens.size() > 0 && position.get() < tokens.size()) return tokens.get(position.getAndIncrement());
+        if (!tokens.isEmpty() && position.get() < tokens.size()) return tokens.get(position.getAndIncrement());
         return nextTokenFromStream();
     }
 
@@ -137,7 +137,7 @@ public class DefaultStreamTokenizer implements Tokenizer {
     @Override
     public List<String> getTokens() {
         //List<String> tokens = new ArrayList<>();
-        if (tokens.size() > 0) return tokens;
+        if (!tokens.isEmpty()) return tokens;
 
         log.info("Starting prebuffering...");
         while(streamHasMoreTokens()) {

--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/text/functions/TextPipeline.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/text/functions/TextPipeline.java
@@ -148,7 +148,7 @@ public class TextPipeline {
 
     public void filterMinWordAddVocab(Counter<String> wordFreq) {
 
-        if (wordFreq.size() == 0) {
+        if (wordFreq.isEmpty()) {
             throw new IllegalStateException("IllegalStateException: wordFreqCounter has nothing. Check accumulator updating");
         }
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/stats/StatsUtils.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/stats/StatsUtils.java
@@ -136,7 +136,7 @@ public class StatsUtils {
 
             //Also build a histogram...
             Component hist = null;
-            if(minDur != maxDur && list.size() > 0) hist = getHistogram(duration, 20, s, styleChart);
+            if(minDur != maxDur && !list.isEmpty()) hist = getHistogram(duration, 20, s, styleChart);
 
             Component[] temp;
             if (hist != null) {
@@ -149,7 +149,7 @@ public class StatsUtils {
 
 
             //TODO this is really ugly
-            if(list.size() > 0 && (list.get(0) instanceof ExampleCountEventStats || list.get(0) instanceof PartitionCountEventStats)){
+            if(!list.isEmpty() && (list.get(0) instanceof ExampleCountEventStats || list.get(0) instanceof PartitionCountEventStats)){
                 boolean exCount = list.get(0) instanceof ExampleCountEventStats;
 
                 double[] y = new double[list.size()];

--- a/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/storage/HistoryStorage.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/storage/HistoryStorage.java
@@ -51,7 +51,7 @@ public class HistoryStorage {
             if (map.size() == 1) {
                 // if map has only one value, we'll go straight for it
                 return map.values().iterator().next();
-            } else if (map.size() > 0) {
+            } else if (!map.isEmpty()) {
                 List<Object> objects = getSorted(key, SortOutput.DESCENDING);
                 if (version.equals(TargetVersion.OLDEST)) return objects.get(objects.size() - 1);
                     else if (version.equals(TargetVersion.LATEST)) return objects.get(0);

--- a/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/weights/HistogramIterationListener.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/weights/HistogramIterationListener.java
@@ -105,7 +105,7 @@ public class HistogramIterationListener implements IterationListener {
 
 //            log.warn("Starting report building...");
 
-                if (meanMagHistoryParams.size() == 0) {
+                if (meanMagHistoryParams.isEmpty()) {
                     //Initialize:
                     int maxLayerIdx = -1;
                     for (String s : grad.keySet()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155

 Please let me know if you have any questions.
Ayman Elkfrawy.