### PR TITLE
Fix: squid:S2864, "entrySet()" should be iterated when both the key a…

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -477,8 +477,9 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
             Constructor c = getClass().getConstructor(NeuralNetConfiguration.class);
             layer = (Layer) c.newInstance(conf);
             Map<String,INDArray> linkedTable = new LinkedHashMap<>();
-            for(String s: params.keySet())
-                linkedTable.put(s,params.get(s).dup());
+            for (Map.Entry<String, INDArray> entry : params.entrySet()) {
+                linkedTable.put(entry.getKey(),entry.getValue().dup());
+            }
             layer.setParamTable(linkedTable);
         } catch (Exception e) {
             e.printStackTrace();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -234,8 +234,8 @@ public abstract class BaseUpdater implements Updater {
 
         protected Updater setUpdaterState(BaseUpdater updater){
             updater.updaterForVariable = new LinkedHashMap<>();
-            for(String s : this.aggregatorMap.keySet() ){
-                updater.updaterForVariable.put(s,this.aggregatorMap.get(s).getUpdater());
+            for (Map.Entry<String, GradientUpdaterAggregator> entry : aggregatorMap.entrySet()) {
+                updater.updaterForVariable.put(entry.getKey(), entry.getValue().getUpdater());
             }
             return updater;
         }
@@ -257,8 +257,8 @@ public abstract class BaseUpdater implements Updater {
     @Override
     public Updater clone(){
         Map<String,GradientUpdater> newMap = new HashMap<>();
-        for( String s : updaterForVariable.keySet()){
-            newMap.put(s, updaterForVariable.get(s).getAggregator(true).getUpdater());
+        for (Map.Entry<String, GradientUpdater> entry : updaterForVariable.entrySet()) {
+            newMap.put(entry.getKey(), entry.getValue().getAggregator(true).getUpdater());
         }
 
         BaseUpdater updater;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/listeners/ParamAndGradientIterationListener.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/optimize/listeners/ParamAndGradientIterationListener.java
@@ -169,9 +169,9 @@ public class ParamAndGradientIterationListener implements IterationListener {
 
 
         //Calculate actual values for parameters and gradients
-        for (String s : params.keySet()) {
-            INDArray currParams = params.get(s);
-            INDArray currGrad = grads.get(s);
+        for (Map.Entry<String, INDArray> entry : params.entrySet()) {
+            INDArray currParams = entry.getValue();
+            INDArray currGrad = grads.get(entry.getKey());
 
             //Parameters:
             if (printMean) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringGrid.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/StringGrid.java
@@ -324,8 +324,9 @@ public class StringGrid extends ArrayList<List<String>> {
     private void modifyRows(Set<Integer> alreadyDeDupped,Integer column,List<Integer> rows,Map<String,Integer> cluster) {
         String chosenKey = null;
         Integer max = null;
-
-        for(String key : cluster.keySet()) {
+        for (Map.Entry<String, Integer> entry : cluster.entrySet()) {
+            String key = entry.getKey();
+            int value = entry.getValue();
             StringTokenizer val = new StringTokenizer(key);
             List<String> list = new ArrayList<>();
             boolean allLower = true;
@@ -353,12 +354,12 @@ public class StringGrid extends ArrayList<List<String>> {
             }
             //first selection that's valid
             if(max == null) {
-                max = cluster.get(key);
+                max = value;
                 chosenKey = key;
             }
             //count is higher
-            else if(!allLower && cluster.get(key) > max) {
-                max = cluster.get(key);
+            else if(!allLower && value > max) {
+                max = value;
                 chosenKey = key;
             }
         }
@@ -407,8 +408,8 @@ public class StringGrid extends ArrayList<List<String>> {
 
     private String maximalValue(Map<String,Integer> map) {
         Counter<String> counter = new Counter<>();
-        for(String s : map.keySet()) {
-            counter.incrementCount(s,map.get(s));
+        for (Map.Entry<String, Integer> entry : map.entrySet()) {
+            counter.incrementCount(entry.getKey(), map.get(entry.getValue()));
         }
         return counter.argMax();
     }
@@ -559,8 +560,9 @@ public class StringGrid extends ArrayList<List<String>> {
         }
 
         //prevent concurrent modification
-        for(Integer i : replace.keySet())
-            set(i,replace.get(i));
+        for (Map.Entry<Integer, List<String>> entry : replace.entrySet()) {
+            set(entry.getKey(), entry.getValue());
+        }
     }
 
     public void filterBySimilarity(double threshold,int firstColumn,int secondColumn) {

--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/GloveWeightLookupTable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/glove/GloveWeightLookupTable.java
@@ -217,8 +217,10 @@ public class GloveWeightLookupTable<T extends SequenceElement> extends InMemoryL
 
     private static INDArray weights(GloveWeightLookupTable glove,Map<String,float[]> data,VocabCache vocab) {
         INDArray ret = Nd4j.create(data.size(),glove.layerSize());
-        for(String key : data.keySet()) {
-            INDArray row = Nd4j.create(Nd4j.createBuffer(data.get(key)));
+
+        for (Map.Entry<String, float[]> entry : data.entrySet()) {
+            String key = entry.getKey();
+            INDArray row = Nd4j.create(Nd4j.createBuffer(entry.getValue()));
             if(row.length() != glove.layerSize())
                 continue;
             if(vocab.indexOf(key) >= data.size())

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/core/actor/MasterActor.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka/src/main/java/org/deeplearning4j/scaleout/actor/core/actor/MasterActor.java
@@ -149,19 +149,16 @@ public class MasterActor extends  UntypedActor implements DeepLearningConfigurab
                         try {
                             long now = System.currentTimeMillis();
                             Map<String,Long> heartbeats = MasterActor.this.stateTracker.getHeartBeats();
-                            for(String key : heartbeats.keySet()) {
-                                long lastChecked = heartbeats.get(key);
+                            for (Map.Entry<String, Long> entry : heartbeats.entrySet()) {
+                                String key = entry.getKey();
+                                long lastChecked = entry.getValue();
                                 long diff = now - lastChecked;
                                 long seconds = TimeUnit.MILLISECONDS.toSeconds(diff);
                                 if(seconds >= 120) {
                                     log.info("Removing stale worker " + key);
                                     MasterActor.this.stateTracker.removeWorker(key);
                                 }
-
                             }
-
-
-
                         }catch(Exception e) {
                             throw new RuntimeException(e);
                         }

--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2VecChange.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2VecChange.java
@@ -58,10 +58,9 @@ public class Word2VecChange implements Serializable {
      *              to apply the changes to
      */
     public void apply(InMemoryLookupTable table) {
-
-        for(Integer i : changes.keySet()) {
-            Set<INDArray> changes = this.changes.get(i);
-            INDArray toChange = table.getSyn0().slice(i);
+        for (Map.Entry<Integer, Set<INDArray>> entry : changes.entrySet()) {
+            Set<INDArray> changes = entry.getValue();
+            INDArray toChange = table.getSyn0().slice(entry.getKey());
             for(INDArray syn1 : changes)
                 Nd4j.getBlasWrapper().level1().axpy(toChange.length(), 1, syn1, toChange);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2864 - “entrySet()" should be iterated when both the key and value are needed ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2864

 Please let me know if you have any questions.
Ayman Elkfrawy.