### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterUtils.java
@@ -40,6 +40,9 @@ import org.nd4j.linalg.factory.Nd4j;
  */
 public class ClusterUtils {
 
+	private ClusterUtils() {
+	}
+
 	/** Classify the set of points base on cluster centers. This also adds each point to the ClusterSet */
 	public static ClusterSetInfo classifyPoints(final ClusterSet clusterSet, List<Point> points,
 												ExecutorService executorService) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/DataSets.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/DataSets.java
@@ -26,6 +26,9 @@ import org.nd4j.linalg.dataset.DataSet;
 
 public class DataSets {
 
+	private DataSets() {
+	}
+
 	public static DataSet mnist() {
 		return mnist(60000);
 	}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
@@ -31,6 +31,9 @@ public class GradientCheckUtil {
 
     private static Logger log = LoggerFactory.getLogger(GradientCheckUtil.class);
 
+    private GradientCheckUtil() {
+    }
+
     /**
      * Check backprop gradients for a MultiLayerNetwork.
      * @param mln MultiLayerNetwork to test. This must be initialized.

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/distribution/Distributions.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/distribution/Distributions.java
@@ -25,6 +25,9 @@ import org.nd4j.linalg.factory.Nd4j;
  *
  */
 public class Distributions {
+    private Distributions() {
+    }
+
     public static org.nd4j.linalg.api.rng.distribution.Distribution createDistribution(
             Distribution dist) {
         if (dist == null)

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/util/ComputationGraphUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/graph/util/ComputationGraphUtil.java
@@ -27,6 +27,9 @@ import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
 
 public class ComputationGraphUtil {
 
+    private ComputationGraphUtil() {
+    }
+
     /** Convert a DataSet to the equivalent MultiDataSet */
     public static MultiDataSet toMultiDataSet(DataSet dataSet){
         INDArray f = dataSet.getFeatureMatrix();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/ImageRender.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/plot/ImageRender.java
@@ -32,7 +32,10 @@ import java.io.IOException;
  * @author Adam Gibson
  */
 public class ImageRender {
-    public static void render(INDArray image,String path) throws IOException {
+    private ImageRender() {
+    }
+
+    public static void render(INDArray image, String path) throws IOException {
         BufferedImage imageToRender = null;
         if(image.rank() == 3) {
             ImageLoader loader = new ImageLoader(image.size(-1),image.size(-2),image.size(-3));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ArchiveUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ArchiveUtils.java
@@ -38,6 +38,9 @@ public class ArchiveUtils {
 
     private static final Logger log = LoggerFactory.getLogger(ArchiveUtils.class);
 
+    private ArchiveUtils() {
+    }
+
     /**
      * Extracts files to the specified destination
      * @param file the file to extract to

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ByteUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ByteUtil.java
@@ -22,6 +22,9 @@ import java.io.DataInputStream;
 import java.io.IOException;
 
 public class ByteUtil {
+	private ByteUtil() {
+	}
+
 	/**
 	 *
 	 * 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
@@ -29,6 +29,9 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 public class ConvolutionUtils {
 
 
+    private ConvolutionUtils() {
+    }
+
     /**
      * Get the height and width
      * from the configuration

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/DeepLearningIOUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/DeepLearningIOUtil.java
@@ -26,6 +26,9 @@ import java.io.InputStream;
 
 public class DeepLearningIOUtil {
 
+	private DeepLearningIOUtil() {
+	}
+
 	public static InputStream inputStreamFromPath(String path)  {
 		try {
 			return new BufferedInputStream(new FileInputStream(new File(path)));

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/Dropout.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/Dropout.java
@@ -12,6 +12,9 @@ import org.nd4j.linalg.factory.Nd4j;
  */
 public class Dropout {
 
+    private Dropout() {
+    }
+
     /**
      * Apply drop connect to the given variable
      * @param layer the layer with the variables

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/util/EnumUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/util/EnumUtil.java
@@ -23,7 +23,10 @@ package org.deeplearning4j.util;
  */
 public class EnumUtil {
 
-    public static <E extends Enum> E parse(String value,Class<E> clazz) {
+    private EnumUtil() {
+    }
+
+    public static <E extends Enum> E parse(String value, Class<E> clazz) {
         int i = Integer.parseInt(value);
         Enum[] constants = clazz.getEnumConstants();
         for(Enum constant : constants) {

--- a/deeplearning4j-scaleout/deeplearning4j-aws/src/main/java/org/deeplearning4j/aws/ec2/provision/DistributedDeepLearningTrainer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-aws/src/main/java/org/deeplearning4j/aws/ec2/provision/DistributedDeepLearningTrainer.java
@@ -20,6 +20,9 @@ package org.deeplearning4j.aws.ec2.provision;
 
 public class DistributedDeepLearningTrainer {
 
+	private DistributedDeepLearningTrainer() {
+	}
+
 	/**
 	 * @param args
 	 */

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/data/GraphLoader.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/data/GraphLoader.java
@@ -19,6 +19,9 @@ import java.util.List;
  */
 public class GraphLoader {
 
+    private GraphLoader() {
+    }
+
     /** Simple method for loading an undirected graph, where the graph is represented by a edge list with one edge
      * per line with a delimiter in between<br>
      * This method assumes that all lines in the file are of the form {@code i<delim>j} where i and j are integers

--- a/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/loader/GraphVectorSerializer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-graph/src/main/java/org/deeplearning4j/graph/models/loader/GraphVectorSerializer.java
@@ -22,6 +22,9 @@ public class GraphVectorSerializer {
     private static final Logger log = LoggerFactory.getLogger(GraphVectorSerializer.class);
     private static final String DELIM = "\t";
 
+    private GraphVectorSerializer() {
+    }
+
     public static void writeGraphVectors(DeepWalk deepWalk, String path) throws IOException {
 
         int nVertices = deepWalk.numVertices();


### PR DESCRIPTION
This pull request is focused on resolving the rest of occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

 Please let me know if you have any questions.
Ayman Elkfrawy.