### PR TITLE
Use JavaDoubleRDD instead of JavaRDD<Double> to make computing sum, mean more efficient

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/graph/SparkComputationGraph.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/graph/SparkComputationGraph.java
@@ -274,24 +274,15 @@ public class SparkComputationGraph implements Serializable {
     }
 
     public double calculateScore(JavaRDD<DataSet> data, boolean average) {
-        long n = data.count();
-        JavaRDD<Double> scores = data.mapPartitions(new ScoreFlatMapFunctionCGDataSet(conf.toJson(), sc.broadcast(network.params(false))));
-        List<Double> scoresList = scores.collect();
-        double sum = 0.0;
-        for (Double d : scoresList)
-            sum += d;
-        if (average) return sum / n;
-        return sum;
+        JavaDoubleRDD scores = data.mapPartitionsToDouble(new ScoreFlatMapFunctionCGDataSet(conf.toJson(), sc.broadcast(network.params(false))));
+        if (average) return scores.mean();
+        return scores.sum();
     }
 
     public double calculateScoreMultiDataSet(JavaRDD<MultiDataSet> data, boolean average) {
-        long n = data.count();
-        JavaRDD<Double> scores = data.mapPartitions(new ScoreFlatMapFunctionCGMultiDataSet(conf.toJson(), sc.broadcast(network.params(false))));
-        List<Double> scoresList = scores.collect();
-        double sum = 0.0;
-        for (Double d : scoresList) sum += d;
-        if (average) return sum / n;
-        return sum;
+        JavaDoubleRDD scores = data.mapPartitionsToDouble(new ScoreFlatMapFunctionCGMultiDataSet(conf.toJson(), sc.broadcast(network.params(false))));
+        if (average) return scores.mean();
+        return scores.sum();
     }
 
     /**

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/graph/scoring/ScoreFlatMapFunctionCGDataSet.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/graph/scoring/ScoreFlatMapFunctionCGDataSet.java
@@ -18,7 +18,7 @@
 
 package org.deeplearning4j.spark.impl.graph.scoring;
 
-import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.DoubleFlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
@@ -33,7 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /** Function used to score a DataSet using a ComputationGraph */
-public class ScoreFlatMapFunctionCGDataSet implements FlatMapFunction<Iterator<DataSet>, Double> {
+public class ScoreFlatMapFunctionCGDataSet implements DoubleFlatMapFunction<Iterator<DataSet>> {
 
     private String json;
     private Broadcast<INDArray> params;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/graph/scoring/ScoreFlatMapFunctionCGMultiDataSet.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/graph/scoring/ScoreFlatMapFunctionCGMultiDataSet.java
@@ -18,7 +18,7 @@
 
 package org.deeplearning4j.spark.impl.graph.scoring;
 
-import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.DoubleFlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
@@ -33,7 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /** Function used to score a MultiDataSet using a given ComputationGraph */
-public class ScoreFlatMapFunctionCGMultiDataSet implements FlatMapFunction<Iterator<MultiDataSet>, Double> {
+public class ScoreFlatMapFunctionCGMultiDataSet implements DoubleFlatMapFunction<Iterator<MultiDataSet>> {
 
     private String json;
     private Broadcast<INDArray> params;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/SparkDl4jMultiLayer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/SparkDl4jMultiLayer.java
@@ -305,13 +305,9 @@ public class SparkDl4jMultiLayer implements Serializable {
      * @param average Whether to sum the scores, or averag them
      */
     public double calculateScore(JavaRDD<DataSet> data, boolean average) {
-        long n = data.count();
-        JavaRDD<Double> scores = data.mapPartitions(new ScoreFlatMapFunction(conf.toJson(), sc.broadcast(network.params(false))));
-        List<Double> scoresList = scores.collect();
-        double sum = 0.0;
-        for (Double d : scoresList) sum += d;
-        if (average) return sum / n;
-        return sum;
+        JavaDoubleRDD scores = data.mapPartitionsToDouble(new ScoreFlatMapFunction(conf.toJson(), sc.broadcast(network.params(false))));
+        if (average) return scores.mean();
+        return scores.sum();
     }
 
     /**

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/scoring/ScoreFlatMapFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/multilayer/scoring/ScoreFlatMapFunction.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.spark.impl.multilayer.scoring;
 
-import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.DoubleFlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-public class ScoreFlatMapFunction implements FlatMapFunction<Iterator<DataSet>, Double> {
+public class ScoreFlatMapFunction implements DoubleFlatMapFunction<Iterator<DataSet>> {
 
     private String json;
     private Broadcast<INDArray> params;


### PR DESCRIPTION
A tiny change for your consideration. For computing a mean or sum over an RDD of doubles, it's not necessary to pull the whole RDD back to the driver, and also count it, and compute manually. It can be computed directly in the cluster.