### PR TITLE
Avoid NPE in UpdaterAggregatorImpl.merge when one aggregator has a value for a key and other does not

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/updater/BaseUpdater.java
@@ -225,9 +225,15 @@ public abstract class BaseUpdater implements Updater {
             } else {
                 if(ag.aggregatorMap == null) return;
                 for(String s : ag.aggregatorMap.keySet() ) {
-                    GradientUpdaterAggregator first = aggregatorMap.get(s);
                     GradientUpdaterAggregator second = ag.aggregatorMap.get(s);
-                    first.combine(second);
+                    if (second != null) {
+                        GradientUpdaterAggregator first = aggregatorMap.get(s);
+                        if (first == null) {
+                            aggregatorMap.put(s, second);
+                        } else {
+                            first.combine(second);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
I'm seeing this error intermittently but frequently with 0.4.0:

```
Caused by: java.lang.NullPointerException
	at org.deeplearning4j.nn.updater.BaseUpdater$UpdaterAggregatorImpl.merge(BaseUpdater.java:230)
	at org.deeplearning4j.nn.updater.MultiLayerUpdater$MultiLayerUpdaterAggregator.merge(MultiLayerUpdater.java:101)
	at org.deeplearning4j.spark.impl.paramavg.aggregator.ParameterAveragingElementCombineFunction.call(ParameterAveragingElementCombineFunction.java:32)
	at org.deeplearning4j.spark.impl.paramavg.aggregator.ParameterAveragingElementCombineFunction.call(ParameterAveragingElementCombineFunction.java:14)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$toScalaFunction2$1.apply(JavaPairRDD.scala:1012)
	at org.apache.spark.rdd.RDD$$anonfun$aggregate$1$$anonfun$22.apply(RDD.scala:1113)
	at org.apache.spark.rdd.RDD$$anonfun$aggregate$1$$anonfun$22.apply(RDD.scala:1113)
...
```

It looks like `first` is `null` in the line `first.combine(second)`. I took a reasonable guess that this just needs to handle the case where one map has a value for a key but the other doesn't in `merge`? or does this not make sense that this happens at all here?

It seems fairly safe to take care of `null`; the overhead is trivial.