### PR TITLE
legacyAveraging as default for ParallelWrapper due to AWS

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/ParallelWrapper.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/ParallelWrapper.java
@@ -206,7 +206,7 @@ public class ParallelWrapper {
         private int averagingFrequency = 1;
         private boolean reportScore = false;
         private boolean averageUpdaters = true;
-        private boolean legacyAveraging = false;
+        private boolean legacyAveraging = true;
 
         /**
          * Build ParallelWrapper for MultiLayerNetwork


### PR DESCRIPTION
legacyAveraging as default for ParallelWrapper due to AWS