### PR TITLE
Refactor ComputationGraphConfiguration preprocessor and InputType functionality

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/api/Layer.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.nn.api;
 
 
 import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -261,4 +262,5 @@ public interface Layer extends Serializable,Cloneable,Model {
     int getInputMiniBatchSize();
 
     void setMaskArray(INDArray maskArray);
+
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
@@ -364,9 +364,6 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
                             //CNN -> CNN: no preprocessor required
                             //UNLESS: network input -> CNN layer. Input is in 2d format, not 4d format...
                             InputType.InputTypeConvolutional conv = (InputType.InputTypeConvolutional) layerInput;
-                            if(networkInputs.contains(vertexInputs.get(s).get(0))){
-                                lv.setPreProcessor(new FeedForwardToCnnPreProcessor(conv.getHeight(), conv.getWidth(), conv.getDepth()));
-                            }
                             //Also: should set the nIns: i.e., depth, for CNN layers only. Not necessary to set for subsampling layers
                             if(l instanceof ConvolutionLayer){
                                 ConvolutionLayer cl = (ConvolutionLayer)l;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/InputPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/InputPreProcessor.java
@@ -21,6 +21,7 @@ package org.deeplearning4j.nn.conf;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.preprocessor.*;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
@@ -68,4 +69,12 @@ public interface InputPreProcessor extends Serializable, Cloneable {
     INDArray backprop(INDArray output, int miniBatchSize);
 
     InputPreProcessor clone();
+
+    /**
+     * For a given type of input to this preprocessor, what is the type of the output?
+     *
+     * @param inputType    Type of input for the preprocessor
+     * @return             Type of input after applying the preprocessor
+     */
+    InputType getOutputType(InputType inputType);
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
@@ -98,7 +98,6 @@ public class LayerVertex extends GraphVertex {
         }
 
         //Assume any necessary preprocessors have already been added
-
         InputType afterPreprocessor;
         if(preProcessor == null) afterPreprocessor = vertexInputs[0];
         else afterPreprocessor = preProcessor.getOutputType(vertexInputs[0]);

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
@@ -98,63 +98,11 @@ public class LayerVertex extends GraphVertex {
         }
 
         //Assume any necessary preprocessors have already been added
-        Layer layer = layerConf.getLayer();
-        if (layer instanceof ConvolutionLayer || layer instanceof SubsamplingLayer) {
-            InputType.InputTypeConvolutional afterPreProcessor;
-            if (preProcessor != null) {
-                if (preProcessor instanceof FeedForwardToCnnPreProcessor) {
-                    FeedForwardToCnnPreProcessor ffcnn = (FeedForwardToCnnPreProcessor) preProcessor;
-                    afterPreProcessor = (InputType.InputTypeConvolutional) InputType.convolutional(ffcnn.getInputHeight(), ffcnn.getInputWidth(), ffcnn.getNumChannels());
-                } else if (preProcessor instanceof RnnToCnnPreProcessor) {
-                    RnnToCnnPreProcessor rnncnn = (RnnToCnnPreProcessor) preProcessor;
-                    afterPreProcessor = (InputType.InputTypeConvolutional) InputType.convolutional(rnncnn.getInputHeight(), rnncnn.getInputWidth(), rnncnn.getNumChannels());
-                } else {
-                    //Assume no change to type of input...
-                    //TODO checks for non convolutional input...
-                    afterPreProcessor = (InputType.InputTypeConvolutional) vertexInputs[0];
-                }
-            } else {
-                if(!(vertexInputs[0] instanceof InputType.InputTypeConvolutional)){
-                    String layerName = layerConf.getLayer().getLayerName();
-                    throw new IllegalStateException("Layer \"" + layerName + "\" of type " + layer.getClass() + " receiving input of type " + Arrays.toString(vertexInputs) + " with no preprocessor");
-                }
-                afterPreProcessor = (InputType.InputTypeConvolutional) vertexInputs[0];
-            }
 
-            int channelsOut;
-            int[] kernel;
-            int[] stride;
-            int[] padding;
-            if (layer instanceof ConvolutionLayer) {
-                channelsOut = ((ConvolutionLayer) layer).getNOut();
-                kernel = ((ConvolutionLayer) layer).getKernelSize();
-                stride = ((ConvolutionLayer) layer).getStride();
-                padding = ((ConvolutionLayer) layer).getPadding();
-            } else {
-                channelsOut = afterPreProcessor.getDepth();
-                kernel = ((SubsamplingLayer) layer).getKernelSize();
-                stride = ((SubsamplingLayer) layer).getStride();
-                padding = ((SubsamplingLayer) layer).getPadding();
-            }
+        InputType afterPreprocessor;
+        if(preProcessor == null) afterPreprocessor = vertexInputs[0];
+        else afterPreprocessor = preProcessor.getOutputType(vertexInputs[0]);
 
-            //First: check that the kernel size/stride/padding is valid
-            int inHeight = afterPreProcessor.getHeight();
-            int inWidth = afterPreProcessor.getWidth();
-            KernelValidationUtil.validateShapes(inHeight, inWidth,
-                    kernel[0], kernel[1], stride[0], stride[1],padding[0], padding[1]);
-
-            int outWidth = (inWidth - kernel[1] + 2 * padding[1]) / stride[1] + 1;
-            int outHeight = (inHeight - kernel[0] + 2 * padding[0]) / stride[0] + 1;
-
-            return InputType.convolutional(outHeight,outWidth,channelsOut);
-        } else if (layer instanceof BaseRecurrentLayer) {
-            return InputType.recurrent(((BaseRecurrentLayer) layer).getNOut());
-        } else if (layer instanceof FeedForwardLayer) {
-            //Dense, autoencoder, etc
-            return InputType.feedForward(((FeedForwardLayer) layer).getNOut());
-        } else {
-            //Unknown... probably same as input??
-            return vertexInputs[0];
-        }
+        return layerConf.getLayer().getOutputType(afterPreprocessor);
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 
 /**
  */
@@ -18,6 +19,12 @@ public class ActivationLayer extends FeedForwardLayer {
     public ActivationLayer clone() {
         ActivationLayer clone = (ActivationLayer) super.clone();
         return clone;
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null) throw new IllegalStateException("Invalid input type: null");
+        return inputType;
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 
 /**
  *  Autoencoder.

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -1,18 +1,30 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 
-@Data @NoArgsConstructor
+@Data
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class BaseRecurrentLayer extends FeedForwardLayer {
-	
-	protected BaseRecurrentLayer(Builder builder){
-		super(builder);
-	}
-	
-	@AllArgsConstructor
+public abstract class BaseRecurrentLayer extends FeedForwardLayer {
+
+    protected BaseRecurrentLayer(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if (inputType == null || inputType.getType() != InputType.Type.RNN || ((InputType.InputTypeRecurrent) inputType).getSize() <= 0) {
+            throw new IllegalStateException("Invalid input for RNN layer: expect RNN input type with size > 0. Got: " + inputType);
+        }
+
+        return InputType.recurrent(nOut);
+    }
+
+    @AllArgsConstructor
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<Builder<T>> {
 
     }
+
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -15,12 +15,26 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
 
     @Override
     public InputType getOutputType(InputType inputType) {
-        if (inputType == null || inputType.getType() != InputType.Type.RNN || ((InputType.InputTypeRecurrent) inputType).getSize() <= 0) {
-            throw new IllegalStateException("Invalid input for RNN layer: expect RNN input type with size > 0. Got: " + inputType);
+        if (inputType == null || inputType.getType() != InputType.Type.RNN ) {
+            throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: " + inputType);
         }
 
         return InputType.recurrent(nOut);
     }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override){
+        if (inputType == null || inputType.getType() != InputType.Type.RNN ) {
+            throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: " + inputType);
+        }
+
+        if(nIn <= 0 || override){
+            InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent)inputType;
+            this.nIn = r.getSize();
+        }
+    }
+
+
 
     @AllArgsConstructor
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<Builder<T>> {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -1,7 +1,10 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.preprocessor.CnnToRnnPreProcessor;
+import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToRnnPreProcessor;
 
 @Data
 @NoArgsConstructor
@@ -15,7 +18,7 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
 
     @Override
     public InputType getOutputType(InputType inputType) {
-        if (inputType == null || inputType.getType() != InputType.Type.RNN ) {
+        if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: " + inputType);
         }
 
@@ -23,17 +26,38 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
     }
 
     @Override
-    public void setNIn(InputType inputType, boolean override){
-        if (inputType == null || inputType.getType() != InputType.Type.RNN ) {
+    public void setNIn(InputType inputType, boolean override) {
+        if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: " + inputType);
         }
 
-        if(nIn <= 0 || override){
-            InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent)inputType;
+        if (nIn <= 0 || override) {
+            InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent) inputType;
             this.nIn = r.getSize();
         }
     }
 
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        if (inputType == null) {
+            throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): input type is null");
+        }
+
+        switch (inputType.getType()) {
+            case FF:
+                //FF -> RNN
+                return new FeedForwardToRnnPreProcessor();
+            case RNN:
+                //RNN -> RNN: No preprocessor necessary
+                return null;
+            case CNN:
+                //CNN -> RNN
+                InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
+                return new CnnToRnnPreProcessor(c.getHeight(),c.getWidth(),c.getDepth());
+            default:
+                throw new RuntimeException("Unknown input type: " + inputType);
+        }
+    }
 
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
@@ -33,6 +34,15 @@ public class BatchNormalization extends FeedForwardLayer {
     public BatchNormalization clone() {
         BatchNormalization clone = (BatchNormalization) super.clone();
         return clone;
+    }
+
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+            throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
+        }
+        return inputType;
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -43,6 +44,18 @@ public class BatchNormalization extends FeedForwardLayer {
             throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
         }
         return inputType;
+    }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override){
+        //No op
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType){
+        //No preprocessor necessory?
+
+        return null;
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -49,10 +49,22 @@ public class ConvolutionLayer extends FeedForwardLayer {
     @Override
     public InputType getOutputType(InputType inputType) {
         if(inputType == null || inputType.getType() != InputType.Type.CNN){
-            throw new IllegalStateException("Invalid input for Convolution layer: Expected CNN input, got " + inputType);
+            throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName() + "\"): Expected CNN input, got " + inputType);
         }
 
         return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, nOut, getLayerName());
+    }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override){
+        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+            throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName() + "\"): Expected CNN input, got " + inputType);
+        }
+
+        if(nIn <= 0 || override){
+            InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
+            this.nIn = c.getDepth();
+        }
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -52,7 +52,7 @@ public class ConvolutionLayer extends FeedForwardLayer {
             throw new IllegalStateException("Invalid input for Convolution layer: Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding);
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, nOut, getLayerName());
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.convolution.Convolution;
 
 /**
@@ -43,6 +44,15 @@ public class ConvolutionLayer extends FeedForwardLayer {
         if(clone.stride != null) clone.stride = clone.stride.clone();
         if(clone.padding != null) clone.padding = clone.padding.clone();
         return clone;
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+            throw new IllegalStateException("Invalid input for Convolution layer: Expected CNN input, got " + inputType);
+        }
+
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding);
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.convolution.Convolution;
 
@@ -65,6 +66,15 @@ public class ConvolutionLayer extends FeedForwardLayer {
             InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
             this.nIn = c.getDepth();
         }
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        if(inputType == null ){
+            throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName() + "\"): input is null");
+        }
+
+        return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -9,27 +9,40 @@ import org.deeplearning4j.nn.conf.inputs.InputType;
 /**
  * Created by jeffreytang on 7/21/15.
  */
-@Data @NoArgsConstructor
+@Data
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class FeedForwardLayer extends Layer {
     protected int nIn;
     protected int nOut;
-    
+
     public FeedForwardLayer(Builder builder) {
-    	super(builder);
-    	this.nIn = builder.nIn;
-    	this.nOut = builder.nOut;
+        super(builder);
+        this.nIn = builder.nIn;
+        this.nOut = builder.nOut;
     }
 
 
     @Override
     public InputType getOutputType(InputType inputType) {
-        if(inputType == null || inputType.getType() != InputType.Type.FF){
-            throw new IllegalStateException("Invalid input type: expected FeedForward input type. Got: " + inputType);
+        if (inputType == null || inputType.getType() != InputType.Type.FF) {
+            throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         return InputType.feedForward(nOut);
+    }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override) {
+        if (inputType == null || inputType.getType() != InputType.Type.FF) {
+            throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
+        }
+
+        if (nIn <= 0 || override) {
+            InputType.InputTypeFeedForward f = (InputType.InputTypeFeedForward) inputType;
+            this.nIn = f.getSize();
+        }
     }
 
     public abstract static class Builder<T extends Builder<T>> extends Layer.Builder<T> {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 
 /**
  * Created by jeffreytang on 7/21/15.
@@ -19,6 +20,16 @@ public abstract class FeedForwardLayer extends Layer {
     	super(builder);
     	this.nIn = builder.nIn;
     	this.nOut = builder.nOut;
+    }
+
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.FF){
+            throw new IllegalStateException("Invalid input type: expected FeedForward input type. Got: " + inputType);
+        }
+
+        return InputType.feedForward(nOut);
     }
 
     public abstract static class Builder<T extends Builder<T>> extends Layer.Builder<T> {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -4,7 +4,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.preprocessor.CnnToFeedForwardPreProcessor;
+import org.deeplearning4j.nn.conf.preprocessor.RnnToFeedForwardPreProcessor;
 
 /**
  * Created by jeffreytang on 7/21/15.
@@ -42,6 +45,28 @@ public abstract class FeedForwardLayer extends Layer {
         if (nIn <= 0 || override) {
             InputType.InputTypeFeedForward f = (InputType.InputTypeFeedForward) inputType;
             this.nIn = f.getSize();
+        }
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        if (inputType == null) {
+            throw new IllegalStateException("Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
+        }
+
+        switch (inputType.getType()) {
+            case FF:
+                //FF -> FF: no preprocessor necessary
+                return null;
+            case RNN:
+                //RNN -> FF
+                return new RnnToFeedForwardPreProcessor();
+            case CNN:
+                //CNN -> FF
+                InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
+                return new CnnToFeedForwardPreProcessor(c.getHeight(),c.getWidth(),c.getDepth());
+            default:
+                throw new RuntimeException("Unknown input type: " + inputType);
         }
     }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
@@ -1,0 +1,41 @@
+package org.deeplearning4j.nn.conf.layers;
+
+import org.deeplearning4j.nn.conf.inputs.InputType;
+
+/**
+ * Utilities for calculating input types
+ *
+ * @author Alex Black
+ */
+public class InputTypeUtil {
+
+
+    public static InputType getOutputTypeCnnLayers(InputType inputType, int[] kernelSize, int[] stride, int[] padding) {
+
+        InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional)inputType;
+        int inHeight = i.getHeight();
+        int inWidth = i.getWidth();
+        int padH = padding[0];
+        int padW = padding[1];
+        int kH = kernelSize[0];
+        int kW = kernelSize[1];
+        int sH = stride[0];
+        int sW = stride[1];
+
+        if((inHeight-kH+2*padH)%sH != 0){
+            throw new IllegalStateException("Invalid input configuration for height: inHeight=" + inHeight + ", kernelH="
+                    + kH + ", strideH=" + sH + ", padH=" + padH + "; (" +inHeight + "-" + kH + "+2*" + padH + ")/" + sH
+                    + " is not an integer");
+        }
+        if((inWidth-kW+2*padW)%sW != 0){
+            throw new IllegalStateException("Invalid input configuration for width: inWidth=" + inWidth + ", kernelW="
+                    + kW + ", strideW=" + sW + ", padW=" + padW + "; (" +inWidth + "-" + kW + "+2*" + padW + ")/" + sW
+                    + " is not an integer");
+        }
+
+        int hOut = (inHeight-kH+2*padH)/sH+1;
+        int wOut = (inWidth-kW+2*padW)/sH+1;
+        return InputType.convolutional(hOut,wOut,((InputType.InputTypeConvolutional) inputType).getDepth());
+    }
+
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
@@ -10,9 +10,10 @@ import org.deeplearning4j.nn.conf.inputs.InputType;
 public class InputTypeUtil {
 
 
-    public static InputType getOutputTypeCnnLayers(InputType inputType, int[] kernelSize, int[] stride, int[] padding) {
+    public static InputType getOutputTypeCnnLayers(InputType inputType, int[] kernelSize, int[] stride, int[] padding,
+                                                   int outputDepth, String layerName) {
 
-        InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional)inputType;
+        InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional) inputType;
         int inHeight = i.getHeight();
         int inWidth = i.getWidth();
         int padH = padding[0];
@@ -22,20 +23,20 @@ public class InputTypeUtil {
         int sH = stride[0];
         int sW = stride[1];
 
-        if((inHeight-kH+2*padH)%sH != 0){
-            throw new IllegalStateException("Invalid input configuration for height: inHeight=" + inHeight + ", kernelH="
-                    + kH + ", strideH=" + sH + ", padH=" + padH + "; (" +inHeight + "-" + kH + "+2*" + padH + ")/" + sH
+        if ((inHeight - kH + 2 * padH) % sH != 0) {
+            throw new IllegalStateException("Invalid input configuration (layer name = \"" + layerName + "\") for height: inHeight=" + inHeight + ", kernelH="
+                    + kH + ", padH=" + padH + ", strideH=" + sH + "; (" + inHeight + "-" + kH + "+2*" + padH + ")/" + sH
                     + " is not an integer");
         }
-        if((inWidth-kW+2*padW)%sW != 0){
-            throw new IllegalStateException("Invalid input configuration for width: inWidth=" + inWidth + ", kernelW="
-                    + kW + ", strideW=" + sW + ", padW=" + padW + "; (" +inWidth + "-" + kW + "+2*" + padW + ")/" + sW
+        if ((inWidth - kW + 2 * padW) % sW != 0) {
+            throw new IllegalStateException("Invalid input configuration (layer name = \"" + layerName + "\") for width: inWidth=" + inWidth + ", kernelW="
+                    + kW + ", padW=" + padW + ", strideW=" + sW + "; (" + inWidth + "-" + kW + "+2*" + padW + ")/" + sW
                     + " is not an integer");
         }
 
-        int hOut = (inHeight-kH+2*padH)/sH+1;
-        int wOut = (inWidth-kW+2*padW)/sH+1;
-        return InputType.convolutional(hOut,wOut,((InputType.InputTypeConvolutional) inputType).getDepth());
+        int hOut = (inHeight - kH + 2 * padH) / sH + 1;
+        int wOut = (inWidth - kW + 2 * padW) / sH + 1;
+        return InputType.convolutional(hOut, wOut, outputDepth);
     }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
@@ -1,12 +1,17 @@
 package org.deeplearning4j.nn.conf.layers;
 
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToCnnPreProcessor;
+import org.deeplearning4j.nn.conf.preprocessor.RnnToCnnPreProcessor;
 
 /**
  * Utilities for calculating input types
  *
  * @author Alex Black
  */
+@Slf4j
 public class InputTypeUtil {
 
 
@@ -37,6 +42,38 @@ public class InputTypeUtil {
         int hOut = (inHeight - kH + 2 * padH) / sH + 1;
         int wOut = (inWidth - kW + 2 * padW) / sH + 1;
         return InputType.convolutional(hOut, wOut, outputDepth);
+    }
+
+    /**
+     * Utility method for determining the appropriate preprocessor for CNN layers, such as {@link ConvolutionLayer} and
+     * {@link SubsamplingLayer}
+     *
+     * @param inputType     Input type to get the preprocessor for
+     * @return              Null if no preprocessor is required; otherwise the appropriate preprocessor for the given input type
+     */
+    public static InputPreProcessor getPreProcessorForInputTypeCnnLayers(InputType inputType, String layerName){
+
+        //To add x-to-CNN preprocessor: need to know image depth/width/height after reshaping
+        //But this can't be inferred from the FF/RNN activations directly (could be anything)
+
+        switch (inputType.getType()){
+            case FF:
+                //FF -> CNN
+//                return new FeedForwardToCnnPreProcessor(inputSize[0], inputSize[1], inputDepth);
+                log.info("Automatic addition of FF -> CNN preprocessors: not yet implemented (layer name: \"" + layerName + "\")");
+                return null;
+            case RNN:
+                //RNN -> CNN
+//                return new RnnToCnnPreProcessor(inputSize[0], inputSize[1], inputDepth);
+                log.warn("Automatic addition of RNN -> CNN preprocessors: not yet implemented (layer name: \"" + layerName + "\")");
+                return null;
+            case CNN:
+                //CNN -> CNN: no preprocessor required
+                return null;
+            default:
+                throw new RuntimeException("Unknown input type: " + inputType);
+        }
+
     }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -28,6 +28,7 @@ import org.deeplearning4j.nn.conf.GradientNormalization;
 import org.deeplearning4j.nn.conf.LearningRatePolicy;
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.weights.WeightInit;
 
 import java.io.Serializable;
@@ -119,6 +120,14 @@ public abstract class Layer implements Serializable, Cloneable {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * For a given type of input to this layer, what is the type of the output?
+     *
+     * @param inputType    Type of input for the layer
+     * @return             Type of output from the layer
+     */
+    public abstract InputType getOutputType(InputType inputType);
 
     @SuppressWarnings("unchecked")
     public abstract static class Builder<T extends Builder<T>> {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -129,6 +129,15 @@ public abstract class Layer implements Serializable, Cloneable {
      */
     public abstract InputType getOutputType(InputType inputType);
 
+    /**
+     * Set the nIn value (number of inputs, or input depth for CNNs) based on the given input type
+     *
+     * @param inputType    Input type for this layer
+     * @param override     If false: only set the nIn value if it's not already set. If true: set it regardless of whether it's
+     *                     already set or not.
+     */
+    public abstract void setNIn(InputType inputType, boolean override);
+
     @SuppressWarnings("unchecked")
     public abstract static class Builder<T extends Builder<T>> {
         protected String layerName = null;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 
 /**
  * Created by nyghtowl on 10/29/15.
@@ -27,6 +28,15 @@ public class LocalResponseNormalization extends Layer{
     public LocalResponseNormalization clone() {
         LocalResponseNormalization clone = (LocalResponseNormalization) super.clone();
         return clone;
+    }
+
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+            throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
+        }
+        return inputType;
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -6,10 +6,11 @@ import org.deeplearning4j.nn.conf.inputs.InputType;
 /**
  * Created by nyghtowl on 10/29/15.
  */
-@Data @NoArgsConstructor
+@Data
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class LocalResponseNormalization extends Layer{
+public class LocalResponseNormalization extends Layer {
     // hyper-parameters defined using a validation set
     protected double n; // # adjacent kernal maps
     protected double k; // constant (e.g. scale)
@@ -33,19 +34,24 @@ public class LocalResponseNormalization extends Layer{
 
     @Override
     public InputType getOutputType(InputType inputType) {
-        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+        if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
         }
         return inputType;
     }
 
+    @Override
+    public void setNIn(InputType inputType, boolean override) {
+        //No op
+    }
+
     @AllArgsConstructor
     public static class Builder extends Layer.Builder<Builder> {
         // defaults based on AlexNet model
-        private double k=2;
-        private double n=5;
-        private double alpha=1e-4;
-        private double beta=0.75;
+        private double k = 2;
+        private double n = 5;
+        private double alpha = 1e-4;
+        private double beta = 0.75;
 
         public Builder(double k, double alpha, double beta) {
             this.k = k;
@@ -53,24 +59,25 @@ public class LocalResponseNormalization extends Layer{
             this.beta = beta;
         }
 
-        public Builder() {}
+        public Builder() {
+        }
 
-        public Builder k(double k){
+        public Builder k(double k) {
             this.k = k;
             return this;
         }
 
-        public Builder n(double n){
+        public Builder n(double n) {
             this.n = n;
             return this;
         }
 
-        public Builder alpha(double alpha){
+        public Builder alpha(double alpha) {
             this.alpha = alpha;
             return this;
         }
 
-        public Builder beta(double beta){
+        public Builder beta(double beta) {
             this.beta = beta;
             return this;
         }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 
 /**
@@ -35,7 +36,7 @@ public class LocalResponseNormalization extends Layer {
     @Override
     public InputType getOutputType(InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
-            throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
+            throw new IllegalStateException("Invalid input type for LRN layer (layer name = \"" + getLayerName() + "\"): Expected input of type CNN, got " + inputType);
         }
         return inputType;
     }
@@ -43,6 +44,15 @@ public class LocalResponseNormalization extends Layer {
     @Override
     public void setNIn(InputType inputType, boolean override) {
         //No op
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        if (inputType == null ) {
+            throw new IllegalStateException("Invalid input type for LRN layer (layer name = \"" + getLayerName() + "\"): null");
+        }
+
+        return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -4,7 +4,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.preprocessor.CnnToRnnPreProcessor;
+import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToRnnPreProcessor;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 
 @Data
@@ -36,6 +39,29 @@ public class RnnOutputLayer extends BaseOutputLayer {
             this.nIn = r.getSize();
         }
     }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        if (inputType == null) {
+            throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): input type is null");
+        }
+
+        switch (inputType.getType()) {
+            case FF:
+                //FF -> RNN
+                return new FeedForwardToRnnPreProcessor();
+            case RNN:
+                //RNN -> RNN: No preprocessor necessary
+                return null;
+            case CNN:
+                //CNN -> RNN
+                InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
+                return new CnnToRnnPreProcessor(c.getHeight(),c.getWidth(),c.getDepth());
+            default:
+                throw new RuntimeException("Unknown input type: " + inputType);
+        }
+    }
+
 
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -7,33 +7,46 @@ import lombok.ToString;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 
-@Data @NoArgsConstructor
+@Data
+@NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class RnnOutputLayer extends BaseOutputLayer {
 
-	private RnnOutputLayer(Builder builder){
-		super(builder);
-	}
+    private RnnOutputLayer(Builder builder) {
+        super(builder);
+    }
 
     @Override
     public InputType getOutputType(InputType inputType) {
-        if(inputType == null || inputType.getType() != InputType.Type.RNN){
-            throw new IllegalStateException("Invalid input type: Expected RNN input, got " + inputType);
+        if (inputType == null || inputType.getType() != InputType.Type.RNN) {
+            throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
         }
         return InputType.recurrent(nOut);
     }
 
+    @Override
+    public void setNIn(InputType inputType, boolean override) {
+        if (inputType == null || inputType.getType() != InputType.Type.RNN) {
+            throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
+        }
+
+        if (nIn <= 0 || override) {
+            InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent) inputType;
+            this.nIn = r.getSize();
+        }
+    }
+
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
-        public Builder(){
+        public Builder() {
             this.lossFunction = LossFunction.MCXENT;
         }
 
-    	public Builder(LossFunction lossFunction) {
+        public Builder(LossFunction lossFunction) {
             this.lossFunction = lossFunction;
         }
-        
+
         @Override
         @SuppressWarnings("unchecked")
         public RnnOutputLayer build() {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 
 @Data @NoArgsConstructor
@@ -14,6 +15,14 @@ public class RnnOutputLayer extends BaseOutputLayer {
 	private RnnOutputLayer(Builder builder){
 		super(builder);
 	}
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.RNN){
+            throw new IllegalStateException("Invalid input type: Expected RNN input, got " + inputType);
+        }
+        return InputType.recurrent(nOut);
+    }
 
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -58,6 +58,11 @@ public class SubsamplingLayer extends Layer {
         return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, ((InputType.InputTypeConvolutional) inputType).getDepth(), getLayerName());
     }
 
+    @Override
+    public void setNIn(InputType inputType, boolean override){
+        //No op: subsampling layer doesn't have nIn value
+    }
+
     @AllArgsConstructor
     public static class Builder extends Layer.Builder<Builder> {
         private PoolingType poolingType = PoolingType.MAX;

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 
 /**
@@ -61,6 +62,15 @@ public class SubsamplingLayer extends Layer {
     @Override
     public void setNIn(InputType inputType, boolean override){
         //No op: subsampling layer doesn't have nIn value
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        if(inputType == null ){
+            throw new IllegalStateException("Invalid input for Subsampling layer (layer name=\"" + getLayerName() + "\"): input is null");
+        }
+
+        return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -52,10 +52,10 @@ public class SubsamplingLayer extends Layer {
     @Override
     public InputType getOutputType(InputType inputType) {
         if(inputType == null || inputType.getType() != InputType.Type.CNN){
-            throw new IllegalStateException("Invalid input for Subsampling layer: Expected CNN input, got " + inputType);
+            throw new IllegalStateException("Invalid input for Subsampling layer (layer name=\"" + getLayerName() + "\"): Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding);
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, ((InputType.InputTypeConvolutional) inputType).getDepth(), getLayerName());
     }
 
     @AllArgsConstructor

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 
 /**
  * Subsampling layer also referred to as pooling in convolution neural nets
@@ -46,6 +47,15 @@ public class SubsamplingLayer extends Layer {
         if(clone.stride != null) clone.stride = clone.stride.clone();
         if(clone.padding != null) clone.padding = clone.padding.clone();
         return clone;
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+            throw new IllegalStateException("Invalid input for Subsampling layer: Expected CNN input, got " + inputType);
+        }
+
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding);
     }
 
     @AllArgsConstructor
@@ -98,17 +108,35 @@ public class SubsamplingLayer extends Layer {
             return this;
         }
 
+        /**
+         * Kernel size
+         *
+         * @param kernelSize    kernel size in height and width dimensions
+         */
         public Builder kernelSize(int... kernelSize){
+            if(kernelSize.length != 2) throw new IllegalArgumentException("Invalid input: must be length 2");
             this.kernelSize = kernelSize;
             return this;
         }
 
+        /**
+         * Stride
+         *
+         * @param stride    stride in height and width dimensions
+         */
         public Builder stride(int... stride){
+            if(stride.length != 2) throw new IllegalArgumentException("Invalid input: must be length 2");
             this.stride = stride;
             return this;
         }
 
+        /**
+         * Padding
+         *
+         * @param padding    padding in the height and width dimensions
+         */
         public Builder padding(int... padding){
+            if(padding.length != 2) throw new IllegalArgumentException("Invalid input: must be length 2");
             this.padding = padding;
             return this;
         }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/BinomialSamplingPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/BinomialSamplingPreProcessor.java
@@ -21,6 +21,7 @@ package org.deeplearning4j.nn.conf.preprocessor;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -40,5 +41,11 @@ public class BinomialSamplingPreProcessor extends BaseInputPreProcessor {
     @Override
     public INDArray backprop(INDArray output, int miniBatchSize) {
         return output;	//No op?
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null) throw new IllegalStateException("Invalid input type: cannot be null");
+        return inputType;
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.util.ArrayUtil;
@@ -112,5 +113,16 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+            throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
+        }
+
+        InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
+        int outSize = c.getDepth() * c.getHeight() * c.getWidth();
+        return InputType.feedForward(outSize);
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToRnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToRnnPreProcessor.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.util.ArrayUtil;
 
@@ -90,5 +91,16 @@ public class CnnToRnnPreProcessor implements InputPreProcessor {
     @Override
     public CnnToRnnPreProcessor clone() {
         return new CnnToRnnPreProcessor(inputHeight,inputWidth,numChannels);
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.CNN){
+            throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
+        }
+
+        InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
+        int outSize = c.getDepth() * c.getHeight() * c.getWidth();
+        return InputType.recurrent(outSize);
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ComposableInputPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ComposableInputPreProcessor.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
@@ -66,5 +67,13 @@ public class ComposableInputPreProcessor extends BaseInputPreProcessor {
             clone.inputPreProcessors = processors;
         }
         return clone;
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        for(InputPreProcessor p : inputPreProcessors){
+            inputType = p.getOutputType(inputType);
+        }
+        return inputType;
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToCnnPreProcessor.java
@@ -25,6 +25,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.util.ArrayUtil;
@@ -117,5 +118,20 @@ public class FeedForwardToCnnPreProcessor implements InputPreProcessor {
         }
     }
 
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.FF){
+            throw new IllegalStateException("Invalid input type: Expected input of type FeedForward, got " + inputType);
+        }
+
+        InputType.InputTypeFeedForward c = (InputType.InputTypeFeedForward)inputType;
+        int expSize = inputHeight * inputWidth * numChannels;
+        if(c.getSize() != expSize){
+            throw new IllegalStateException("Invalid input: expected FeedForward input of size " + expSize + " = (d=" + numChannels +
+            " * w=" + inputWidth + " * h=" + inputHeight + "), got " + inputType);
+        }
+
+        return InputType.convolutional(inputHeight, inputWidth, numChannels);
+    }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToRnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToRnnPreProcessor.java
@@ -3,6 +3,7 @@ package org.deeplearning4j.nn.conf.preprocessor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.Shape;
 
@@ -52,5 +53,15 @@ public class FeedForwardToRnnPreProcessor implements InputPreProcessor {
 		} catch (CloneNotSupportedException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@Override
+	public InputType getOutputType(InputType inputType) {
+		if(inputType == null || inputType.getType() != InputType.Type.FF){
+			throw new IllegalStateException("Invalid input: expected input of type FeedForward, got " + inputType);
+		}
+
+        InputType.InputTypeFeedForward ff = (InputType.InputTypeFeedForward)inputType;
+        return InputType.recurrent(ff.getSize());
 	}
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ReshapePreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ReshapePreProcessor.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.util.ArrayUtil;
 
@@ -33,6 +34,7 @@ import org.nd4j.linalg.util.ArrayUtil;
  * @author Adam Gibson
  */
 @Data @EqualsAndHashCode(callSuper=false)
+@Deprecated
 public class ReshapePreProcessor extends BaseInputPreProcessor {
     private int[] fromShape;	//Epsilons: To this shape in backward pass
     private int[] toShape;		//Activations: To this shape in forward pass
@@ -83,5 +85,18 @@ public class ReshapePreProcessor extends BaseInputPreProcessor {
         if(clone.fromShape != null) clone.fromShape = clone.fromShape.clone();
         if(clone.toShape != null) clone.toShape = clone.toShape.clone();
         return clone;
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        switch (toShape.length){
+            case 2:
+            case 3:
+                return InputType.feedForward(toShape[1]);
+            case 4:
+                return InputType.convolutional(toShape[3],toShape[2],toShape[1]);
+            default:
+                throw new IllegalStateException();
+        }
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToCnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToCnnPreProcessor.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.util.ArrayUtil;
 
@@ -81,5 +82,21 @@ public class RnnToCnnPreProcessor implements InputPreProcessor {
     @Override
     public RnnToCnnPreProcessor clone() {
         return new RnnToCnnPreProcessor(inputHeight, inputWidth, numChannels);
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.RNN){
+            throw new IllegalStateException("Invalid input type: Expected input of type RNN, got " + inputType);
+        }
+
+        InputType.InputTypeRecurrent c = (InputType.InputTypeRecurrent)inputType;
+        int expSize = inputHeight * inputWidth * numChannels;
+        if(c.getSize() != expSize){
+            throw new IllegalStateException("Invalid input: expected RNN input of size " + expSize + " = (d=" + numChannels +
+                    " * w=" + inputWidth + " * h=" + inputHeight + "), got " + inputType);
+        }
+
+        return InputType.convolutional(inputHeight, inputWidth, numChannels);
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
@@ -2,6 +2,7 @@ package org.deeplearning4j.nn.conf.preprocessor;
 
 import lombok.Data;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.Shape;
 
@@ -59,5 +60,15 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null || inputType.getType() != InputType.Type.RNN){
+            throw new IllegalStateException("Invalid input: expected input of type RNN, got " + inputType);
+        }
+
+        InputType.InputTypeRecurrent rnn = (InputType.InputTypeRecurrent)inputType;
+        return InputType.feedForward(rnn.getSize());
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/UnitVarianceProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/UnitVarianceProcessor.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.conf.preprocessor;
 
 import lombok.*;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -52,5 +53,11 @@ public class UnitVarianceProcessor extends BaseInputPreProcessor {
         UnitVarianceProcessor clone = (UnitVarianceProcessor) super.clone();
         if(clone.columnStds != null) clone.columnStds = clone.columnStds.dup();
         return clone;
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null) throw new IllegalStateException("Invalid input type: cannot be null");
+        return inputType;
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanAndUnitVariancePreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanAndUnitVariancePreProcessor.java
@@ -21,6 +21,7 @@ package org.deeplearning4j.nn.conf.preprocessor;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -48,5 +49,10 @@ public class ZeroMeanAndUnitVariancePreProcessor extends BaseInputPreProcessor {
         return output;	//no-op
     }
 
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null) throw new IllegalStateException("Invalid input type: cannot be null");
+        return inputType;
+    }
 
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanPrePreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/ZeroMeanPrePreProcessor.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.nn.conf.preprocessor;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
@@ -40,5 +41,11 @@ public class ZeroMeanPrePreProcessor extends BaseInputPreProcessor {
     @Override
     public INDArray backprop(INDArray output, int miniBatchSize) {
         return output;
+    }
+
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if(inputType == null) throw new IllegalStateException("Invalid input type: cannot be null");
+        return inputType;
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -354,11 +354,8 @@ public class TestComputationGraphNetwork {
                 .build();
             //Check preprocessors:
         lv1 = (LayerVertex) conf3.getVertices().get("cnn");
-        assertNotNull(lv1.getPreProcessor());
-        FeedForwardToCnnPreProcessor ffcnn = (FeedForwardToCnnPreProcessor)lv1.getPreProcessor();
-        assertEquals(1, ffcnn.getNumChannels());
-        assertEquals(28, ffcnn.getInputHeight());
-        assertEquals(28, ffcnn.getInputWidth());
+        assertNull(lv1.getPreProcessor());      //Shouldn't be adding preprocessor here
+
         lv2 = (LayerVertex) conf3.getVertices().get("pool");
         assertNull(lv2.getPreProcessor());
         LayerVertex lv3 = (LayerVertex) conf3.getVertices().get("dense");
@@ -388,11 +385,8 @@ public class TestComputationGraphNetwork {
 
         //Check preprocessors:
         lv1 = (LayerVertex) conf4.getVertices().get("cnn");
-        assertNotNull(lv1.getPreProcessor());
-        ffcnn = (FeedForwardToCnnPreProcessor)lv1.getPreProcessor();
-        assertEquals(1, ffcnn.getNumChannels());
-        assertEquals(28, ffcnn.getInputHeight());
-        assertEquals(28, ffcnn.getInputWidth());
+        assertNull(lv1.getPreProcessor());  //Expect no preprocessor: cnn data -> cnn layer
+
         lv2 = (LayerVertex) conf4.getVertices().get("pool");
         assertNull(lv2.getPreProcessor());
         lv3 = (LayerVertex) conf4.getVertices().get("dense");
@@ -426,18 +420,10 @@ public class TestComputationGraphNetwork {
                 .pretrain(false).backprop(true)
                 .build();
         lv1 = (LayerVertex) conf5.getVertices().get("cnn_1");
-        assertTrue(lv1.getPreProcessor() instanceof FeedForwardToCnnPreProcessor);
-        ffcnn = (FeedForwardToCnnPreProcessor)lv1.getPreProcessor();
-        assertEquals(1, ffcnn.getNumChannels());
-        assertEquals(28, ffcnn.getInputWidth());
-        assertEquals(28, ffcnn.getInputHeight());
+        assertNull(lv1.getPreProcessor());  //Expect no preprocessor: cnn data -> cnn layer
 
         lv2 = (LayerVertex) conf5.getVertices().get("cnn_2");
-        assertTrue(lv2.getPreProcessor() instanceof FeedForwardToCnnPreProcessor);
-        FeedForwardToCnnPreProcessor ffcnn2 = (FeedForwardToCnnPreProcessor)lv2.getPreProcessor();
-        assertEquals(1, ffcnn2.getNumChannels());
-        assertEquals(28, ffcnn2.getInputWidth());
-        assertEquals(28, ffcnn2.getInputHeight());
+        assertNull(lv2.getPreProcessor());  //Expect no preprocessor: cnn data -> cnn layer
 
         assertNull(((LayerVertex) conf5.getVertices().get("max_1")).getPreProcessor());
 


### PR DESCRIPTION
Addresses issues listed in: https://github.com/deeplearning4j/deeplearning4j/issues/1947

Setting nIns, determining appropriate preprocessors and determining the type of output of a layer (given some input) made properly object oriented + less brittle.

Also improves input/configuration validation and messages on invalid configuration.