### PR TITLE
Add "flattened convolutional" input type

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/ElementWiseVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/ElementWiseVertex.java
@@ -31,7 +31,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  * Addition may use an arbitrary number of input arrays. Note that in the case of subtraction, only two inputs may be used.
  * @author Alex Black
  */
-@Data @EqualsAndHashCode(callSuper=false)
+@Data
 public class ElementWiseVertex extends GraphVertex {
 
     public ElementWiseVertex(@JsonProperty("op") Op op) {
@@ -88,8 +88,7 @@ public class ElementWiseVertex extends GraphVertex {
         if(vertexInputs.length == 1) return vertexInputs[0];
         InputType first = vertexInputs[0];
         if(first.getType() != InputType.Type.CNN){
-            //FF or RNN data inputs
-            int size = 0;
+            //FF, RNN or flat CNN data inputs
             for( int i=1; i<vertexInputs.length; i++ ){
                 if(vertexInputs[i].getType() != first.getType()){
                     throw new InvalidInputTypeException("Invalid input: ElementWise vertex cannot process activations of different types:"

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
@@ -66,6 +66,8 @@ public class MergeVertex extends GraphVertex {
         if(vertexInputs.length == 1) return vertexInputs[0];
         InputType first = vertexInputs[0];
         if(first.getType() == InputType.Type.CNNFlat){
+            //TODO
+            //Merging flattened CNN format data could be messy?
             throw new InvalidInputTypeException("Invalid input: MergeVertex cannot currently merge CNN data in flattened format. Got: " + vertexInputs);
         } else if(first.getType() != InputType.Type.CNN){
             //FF or RNN data inputs

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
@@ -65,10 +65,12 @@ public class MergeVertex extends GraphVertex {
     public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
         if(vertexInputs.length == 1) return vertexInputs[0];
         InputType first = vertexInputs[0];
-        if(first.getType() != InputType.Type.CNN){
+        if(first.getType() == InputType.Type.CNNFlat){
+            throw new InvalidInputTypeException("Invalid input: MergeVertex cannot currently merge CNN data in flattened format. Got: " + vertexInputs);
+        } else if(first.getType() != InputType.Type.CNN){
             //FF or RNN data inputs
             int size = 0;
-            boolean ff = true;
+            InputType.Type type = null;
             for( int i=0; i<vertexInputs.length; i++ ){
                 if(vertexInputs[i].getType() != first.getType()){
                     throw new InvalidInputTypeException("Invalid input: MergeVertex cannot merge activations of different types:"
@@ -76,10 +78,17 @@ public class MergeVertex extends GraphVertex {
                 }
 
                 int thisSize;
-                if(vertexInputs[i] instanceof InputType.InputTypeFeedForward) thisSize = ((InputType.InputTypeFeedForward)vertexInputs[i]).getSize();
-                else{
-                    thisSize = ((InputType.InputTypeRecurrent)vertexInputs[i]).getSize();
-                    ff = false;
+                switch(vertexInputs[i].getType()){
+                    case FF:
+                        thisSize = ((InputType.InputTypeFeedForward)vertexInputs[i]).getSize();
+                        type = InputType.Type.FF;
+                        break;
+                    case RNN:
+                        thisSize = ((InputType.InputTypeRecurrent)vertexInputs[i]).getSize();
+                        type = InputType.Type.RNN;
+                        break;
+                    default:
+                        throw new IllegalStateException("Unknown input type: " + vertexInputs[i]);  //Should never happen
                 }
                 if(thisSize <= 0){//Size is not defined
                     size = -1;
@@ -90,11 +99,11 @@ public class MergeVertex extends GraphVertex {
 
             if(size > 0){
                 //Size is specified
-                if(ff) return InputType.feedForward(size);
+                if(type == InputType.Type.FF) return InputType.feedForward(size);
                 else return InputType.recurrent(size);
             } else {
                 //size is unknown
-                if(ff) return InputType.feedForward(-1);
+                if(type == InputType.Type.FF) return InputType.feedForward(-1);
                 else return InputType.recurrent(-1);
             }
         } else {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/DuplicateToTimeSeriesVertex.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/DuplicateToTimeSeriesVertex.java
@@ -27,7 +27,8 @@ import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
-/**DuplicateToTimeSeriesVertex is a vertex that goes from 2d activations to a 3d time series activations, by means of
+/**
+ * DuplicateToTimeSeriesVertex is a vertex that goes from 2d activations to a 3d time series activations, by means of
  * duplication. That is, given a 2d input with shape [numExamples,nIn] duplicate each row to give output of
  * [numExamples,nIn,timeSeriesLength], where the activations are the same for all time steps.<br>
  * This method is used for example in sequence to sequence models.<br>
@@ -35,9 +36,10 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  * inputs in the ComputationGraph. That is: Because the length of the time series may differ at runtime, we generally want the number
  * of time steps to match some other input; here, we are specifying the length of the output time series to be the same as
  * one of the input time series<br>
+ *
  * @author Alex Black
  */
-@Data @EqualsAndHashCode(callSuper=false)
+@Data
 public class DuplicateToTimeSeriesVertex extends GraphVertex {
 
     private String inputName;
@@ -46,7 +48,7 @@ public class DuplicateToTimeSeriesVertex extends GraphVertex {
      * @param inputName Name of the input in the ComputationGraph network to use, to determine how long the output time
      *                  series should be. This input should (a) exist, and (b) be a time series input
      */
-    public DuplicateToTimeSeriesVertex(@JsonProperty("inputName") String inputName){
+    public DuplicateToTimeSeriesVertex(@JsonProperty("inputName") String inputName) {
         this.inputName = inputName;
     }
 
@@ -57,9 +59,9 @@ public class DuplicateToTimeSeriesVertex extends GraphVertex {
 
     @Override
     public boolean equals(Object o) {
-        if(!(o instanceof DuplicateToTimeSeriesVertex)) return false;
-        DuplicateToTimeSeriesVertex d = (DuplicateToTimeSeriesVertex)o;
-        if(inputName == null && d.inputName != null || inputName != null && d.inputName == null) return false;
+        if (!(o instanceof DuplicateToTimeSeriesVertex)) return false;
+        DuplicateToTimeSeriesVertex d = (DuplicateToTimeSeriesVertex) o;
+        if (inputName == null && d.inputName != null || inputName != null && d.inputName == null) return false;
         return inputName == null || inputName.equals(d.inputName);
     }
 
@@ -69,23 +71,29 @@ public class DuplicateToTimeSeriesVertex extends GraphVertex {
     }
 
     @Override
-    public int numParams(boolean backprop){
+    public int numParams(boolean backprop) {
         return 0;
     }
 
     @Override
     public org.deeplearning4j.nn.graph.vertex.GraphVertex instantiate(ComputationGraph graph, String name, int idx,
                                                                       INDArray paramsView, boolean initializeParams) {
-        return new org.deeplearning4j.nn.graph.vertex.impl.rnn.DuplicateToTimeSeriesVertex(graph,name,idx,inputName);
+        return new org.deeplearning4j.nn.graph.vertex.impl.rnn.DuplicateToTimeSeriesVertex(graph, name, idx, inputName);
     }
 
     @Override
     public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
-        if(vertexInputs.length != 1) throw new InvalidInputTypeException("Invalid input type: cannot duplicate more than 1 input");
-        if(vertexInputs[0].getType() != InputType.Type.FF){
-            throw new InvalidInputTypeException("Invalid input type: cannot duplicate to time series non feed forward input (got: " + vertexInputs[0] + ")");
+        if (vertexInputs.length != 1)
+            throw new InvalidInputTypeException("Invalid input type: cannot duplicate more than 1 input");
+
+        if (vertexInputs[0].getType() == InputType.Type.FF) {
+            return InputType.recurrent(((InputType.InputTypeFeedForward) vertexInputs[0]).getSize());
+        } else if(vertexInputs[0].getType() != InputType.Type.CNNFlat){
+            return InputType.recurrent(((InputType.InputTypeConvolutionalFlat) vertexInputs[0]).getFlattenedSize());
+        } else {
+            throw new InvalidInputTypeException("Invalid input type: cannot duplicate to time series non feed forward (or CNN flat) input (got: " + vertexInputs[0] + ")");
         }
 
-        return InputType.recurrent(((InputType.InputTypeFeedForward)vertexInputs[0]).getSize());
+
     }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
@@ -33,8 +33,12 @@ import java.io.Serializable;
  */
 public abstract class InputType implements Serializable {
 
-    /** The type of activations in/out of a given GraphVertex. */
-    public enum Type {FF, RNN, CNN}
+    /** The type of activations in/out of a given GraphVertex<br>
+     * FF: Standard feed-foward (2d minibatch, 1d per example) data<br>
+     * RNN: Recurrent neural network (3d minibatch) time series data<br>
+     * CNN: Convolutional neural n
+     */
+    public enum Type {FF, RNN, CNN, CNNFlat}
 
 
     public abstract Type getType();
@@ -57,7 +61,8 @@ public abstract class InputType implements Serializable {
         return new InputTypeRecurrent(size);
     }
 
-    /**Input type for convolutional (CNN) data
+    /**Input type for convolutional (CNN) data, that is 4d with shape [miniBatchSize, depth, height, width].
+     * For CNN data that has been flattened, use {@link #convolationalFlat(int, int, int)}
      * @param height height of the input
      * @param width Width of the input
      * @param depth Depth, or number of channels
@@ -65,6 +70,19 @@ public abstract class InputType implements Serializable {
      */
     public static InputType convolutional(int height, int width, int depth){
         return new InputTypeConvolutional(height,width,depth);
+    }
+
+    /**
+     * Input type for convolutional (CNN) data, where the data is in flattened (row vector) format.
+     * Expect data with shape [miniBatchSize, height * width * depth]. For CNN data in 4d format, use {@link #convolutional(int, int, int)}
+     *
+     * @param height    Height of the (unflattened) data represented by this input type
+     * @param width     Width of the (unflattened) data represented by this input type
+     * @param depth     Depth of the (unflattened) data represented by this input type
+     * @return
+     */
+    public static InputType convolationalFlat(int height, int width, int depth){
+        return new InputTypeConvolutionalFlat(height, width, depth);
     }
 
 
@@ -112,6 +130,27 @@ public abstract class InputType implements Serializable {
         @Override
         public String toString(){
             return "InputTypeConvolutional(h=" + height + ",w=" + width + ",d=" + depth + ")";
+        }
+    }
+
+    @AllArgsConstructor @Data  @EqualsAndHashCode(callSuper=false)
+    public static class InputTypeConvolutionalFlat extends InputType {
+        private int height;
+        private int width;
+        private int depth;
+
+        @Override
+        public Type getType() {
+            return Type.CNN;
+        }
+
+        public int getFlattenedSize(){
+            return height * width * depth;
+        }
+
+        @Override
+        public String toString(){
+            return "InputTypeConvolutionalFlat(h=" + height + ",w=" + width + ",d=" + depth + ")";
         }
     }
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 import java.io.Serializable;
 
 /** The InputType class is used to track and define the types of activations etc used in a ComputationGraph.
- * This is most useful for automatically adding preprocessors between layers.
+ * This is most useful for automatically adding preprocessors between layers, and automatically setting nIn values.
  * See: {@link org.deeplearning4j.nn.conf.ComputationGraphConfiguration.GraphBuilder#setInputTypes(InputType...)} and
  * {@link org.deeplearning4j.nn.conf.ComputationGraphConfiguration#addPreProcessors(InputType...)}
  * @author Alex Black
@@ -146,6 +146,10 @@ public abstract class InputType implements Serializable {
 
         public int getFlattenedSize(){
             return height * width * depth;
+        }
+
+        public InputType getUnflattenedType(){
+            return InputType.convolutional(height, depth, width);
         }
 
         @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
@@ -141,7 +141,7 @@ public abstract class InputType implements Serializable {
 
         @Override
         public Type getType() {
-            return Type.CNN;
+            return Type.CNNFlat;
         }
 
         public int getFlattenedSize(){
@@ -149,7 +149,7 @@ public abstract class InputType implements Serializable {
         }
 
         public InputType getUnflattenedType(){
-            return InputType.convolutional(height, depth, width);
+            return InputType.convolutional(height, width, depth);
         }
 
         @Override

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -39,26 +39,7 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
-        if (inputType == null) {
-            throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): input type is null");
-        }
-
-        switch (inputType.getType()) {
-            case FF:
-            case CNNFlat:
-                //FF -> RNN or CNNFlat -> RNN
-                //In either case, input data format is a row vector per example
-                return new FeedForwardToRnnPreProcessor();
-            case RNN:
-                //RNN -> RNN: No preprocessor necessary
-                return null;
-            case CNN:
-                //CNN -> RNN
-                InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
-                return new CnnToRnnPreProcessor(c.getHeight(),c.getWidth(),c.getDepth());
-            default:
-                throw new RuntimeException("Unknown input type: " + inputType);
-        }
+        return InputTypeUtil.getPreprocessorForInputTypeRnnLayers(inputType, getLayerName());
     }
 
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -45,7 +45,9 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
 
         switch (inputType.getType()) {
             case FF:
-                //FF -> RNN
+            case CNNFlat:
+                //FF -> RNN or CNNFlat -> RNN
+                //In either case, input data format is a row vector per example
                 return new FeedForwardToRnnPreProcessor();
             case RNN:
                 //RNN -> RNN: No preprocessor necessary

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -3,6 +3,7 @@ package org.deeplearning4j.nn.conf.layers;
 import lombok.*;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToCnnPreProcessor;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
@@ -40,8 +41,9 @@ public class BatchNormalization extends FeedForwardLayer {
 
     @Override
     public InputType getOutputType(InputType inputType) {
-        if(inputType == null || inputType.getType() != InputType.Type.CNN){
-            throw new IllegalStateException("Invalid input type: Expected input of type CNN, got " + inputType);
+        if(inputType == null || (inputType.getType() != InputType.Type.CNN && inputType.getType() != InputType.Type.CNNFlat)){
+            //Can handle CNN or flat CNN input formats only
+            throw new IllegalStateException("Invalid input type: Batch norm layer expected input of type CNN, got " + inputType);
         }
         return inputType;
     }
@@ -53,7 +55,10 @@ public class BatchNormalization extends FeedForwardLayer {
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType){
-        //No preprocessor necessory?
+        if(inputType.getType() == InputType.Type.CNNFlat){
+            InputType.InputTypeConvolutionalFlat i = (InputType.InputTypeConvolutionalFlat)inputType;
+            return new FeedForwardToCnnPreProcessor(i.getHeight(), i.getWidth(), i.getDepth());
+        }
 
         return null;
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -29,7 +29,7 @@ public abstract class FeedForwardLayer extends Layer {
 
     @Override
     public InputType getOutputType(InputType inputType) {
-        if (inputType == null || inputType.getType() != InputType.Type.FF) {
+        if (inputType == null || (inputType.getType() != InputType.Type.FF && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
@@ -38,13 +38,18 @@ public abstract class FeedForwardLayer extends Layer {
 
     @Override
     public void setNIn(InputType inputType, boolean override) {
-        if (inputType == null || inputType.getType() != InputType.Type.FF) {
+        if (inputType == null || (inputType.getType() != InputType.Type.FF && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
-            InputType.InputTypeFeedForward f = (InputType.InputTypeFeedForward) inputType;
-            this.nIn = f.getSize();
+            if(inputType.getType() == InputType.Type.FF){
+                InputType.InputTypeFeedForward f = (InputType.InputTypeFeedForward) inputType;
+                this.nIn = f.getSize();
+            } else {
+                InputType.InputTypeConvolutionalFlat f = (InputType.InputTypeConvolutionalFlat) inputType;
+                this.nIn = f.getFlattenedSize();
+            }
         }
     }
 
@@ -56,7 +61,8 @@ public abstract class FeedForwardLayer extends Layer {
 
         switch (inputType.getType()) {
             case FF:
-                //FF -> FF: no preprocessor necessary
+            case CNNFlat:
+                //FF -> FF and CNN (flattened format) -> FF: no preprocessor necessary
                 return null;
             case RNN:
                 //RNN -> FF

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -42,24 +42,7 @@ public class RnnOutputLayer extends BaseOutputLayer {
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
-        if (inputType == null) {
-            throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): input type is null");
-        }
-
-        switch (inputType.getType()) {
-            case FF:
-                //FF -> RNN
-                return new FeedForwardToRnnPreProcessor();
-            case RNN:
-                //RNN -> RNN: No preprocessor necessary
-                return null;
-            case CNN:
-                //CNN -> RNN
-                InputType.InputTypeConvolutional c = (InputType.InputTypeConvolutional)inputType;
-                return new CnnToRnnPreProcessor(c.getHeight(),c.getWidth(),c.getDepth());
-            default:
-                throw new RuntimeException("Unknown input type: " + inputType);
-        }
+        return InputTypeUtil.getPreprocessorForInputTypeRnnLayers(inputType, getLayerName());
     }
 
 

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
@@ -79,7 +79,7 @@ public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
     @Override
     // return 2 dimensions
     public INDArray preProcess(INDArray input, int miniBatchSize) {
-        if(input.rank() == 2) return input; //Should never happen
+        if(input.rank() == 2) return input; //Should usually never happen
 
         //Assume input is standard rank 4 activations out of CNN layer
         //First: we require input to be in c order. But c order (as declared in array order) isn't enough; also need strides to be correct

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToRnnPreProcessor.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/conf/preprocessor/FeedForwardToRnnPreProcessor.java
@@ -7,61 +7,71 @@ import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.Shape;
 
-/**A preprocessor to allow RNN and feed-forward network layers to be used together.<br>
+/**
+ * A preprocessor to allow RNN and feed-forward network layers to be used together.<br>
  * For example, DenseLayer -> GravesLSTM<br>
  * This does two things:<br>
- * (a) Reshapes activations out of FeedFoward layer (which is 2D with shape 
+ * (a) Reshapes activations out of FeedFoward layer (which is 2D with shape
  * [miniBatchSize*timeSeriesLength,layerSize]) into 3d activations (with shape
  * [miniBatchSize,layerSize,timeSeriesLength]) suitable to feed into RNN layers.<br>
  * (b) Reshapes 3d epsilons (weights*deltas from RNN layer, with shape
  * [miniBatchSize,layerSize,timeSeriesLength]) into 2d epsilons (with shape
  * [miniBatchSize*timeSeriesLength,layerSize]) for use in feed forward layer
+ *
  * @author Alex Black
  * @see RnnToFeedForwardPreProcessor for opposite case (i.e., GravesLSTM -> DenseLayer etc)
  */
-@Data @NoArgsConstructor
+@Data
+@NoArgsConstructor
 public class FeedForwardToRnnPreProcessor implements InputPreProcessor {
 
-	@Override
-	public INDArray preProcess(INDArray input, int miniBatchSize) {
-		//Need to reshape FF activations (2d) activations to 3d (for input into RNN layer)
-		if( input.rank() != 2 ) throw new IllegalArgumentException("Invalid input: expect NDArray with rank 2 (i.e., activations for FF layer)");
-		if(input.ordering() == 'c') input = Shape.toOffsetZeroCopy(input,'f');
+    @Override
+    public INDArray preProcess(INDArray input, int miniBatchSize) {
+        //Need to reshape FF activations (2d) activations to 3d (for input into RNN layer)
+        if (input.rank() != 2)
+            throw new IllegalArgumentException("Invalid input: expect NDArray with rank 2 (i.e., activations for FF layer)");
+        if (input.ordering() == 'c') input = Shape.toOffsetZeroCopy(input, 'f');
 
-		int[] shape = input.shape();
-		INDArray reshaped = input.reshape('f',miniBatchSize,shape[0]/miniBatchSize,shape[1]);
-		return reshaped.permute(0,2,1);
-	}
+        int[] shape = input.shape();
+        INDArray reshaped = input.reshape('f', miniBatchSize, shape[0] / miniBatchSize, shape[1]);
+        return reshaped.permute(0, 2, 1);
+    }
 
-	@Override
-	public INDArray backprop(INDArray output, int miniBatchSize) {
-		//Need to reshape RNN epsilons (3d) to 2d (for use in FF layer backprop calculations)
-		if( output.rank() != 3 ) throw new IllegalArgumentException("Invalid input: expect NDArray with rank 3 (i.e., epsilons from RNN layer)");
-		if(output.ordering() != 'f') output = output.dup('f');
-		int[] shape = output.shape();
-		if(shape[0]==1) return output.tensorAlongDimension(0,1,2).permutei(1,0);	//Edge case: miniBatchSize==1
-		if(shape[2]==1) return output.tensorAlongDimension(0,1,0);	//Edge case: timeSeriesLength=1
-		INDArray permuted = output.permute(0,2,1);	//Permute, so we get correct order after reshaping
-		return permuted.reshape('f',shape[0]*shape[2],shape[1]);
-	}
+    @Override
+    public INDArray backprop(INDArray output, int miniBatchSize) {
+        //Need to reshape RNN epsilons (3d) to 2d (for use in FF layer backprop calculations)
+        if (output.rank() != 3)
+            throw new IllegalArgumentException("Invalid input: expect NDArray with rank 3 (i.e., epsilons from RNN layer)");
+        if (output.ordering() != 'f') output = output.dup('f');
+        int[] shape = output.shape();
+        if (shape[0] == 1) return output.tensorAlongDimension(0, 1, 2).permutei(1, 0);    //Edge case: miniBatchSize==1
+        if (shape[2] == 1) return output.tensorAlongDimension(0, 1, 0);    //Edge case: timeSeriesLength=1
+        INDArray permuted = output.permute(0, 2, 1);    //Permute, so we get correct order after reshaping
+        return permuted.reshape('f', shape[0] * shape[2], shape[1]);
+    }
 
-	@Override
-	public FeedForwardToRnnPreProcessor clone() {
-		try {
-			FeedForwardToRnnPreProcessor clone = (FeedForwardToRnnPreProcessor) super.clone();
-			return clone;
-		} catch (CloneNotSupportedException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    @Override
+    public FeedForwardToRnnPreProcessor clone() {
+        try {
+            FeedForwardToRnnPreProcessor clone = (FeedForwardToRnnPreProcessor) super.clone();
+            return clone;
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	@Override
-	public InputType getOutputType(InputType inputType) {
-		if(inputType == null || inputType.getType() != InputType.Type.FF){
-			throw new IllegalStateException("Invalid input: expected input of type FeedForward, got " + inputType);
-		}
+    @Override
+    public InputType getOutputType(InputType inputType) {
+        if (inputType == null || (inputType.getType() != InputType.Type.FF && inputType.getType() != InputType.Type.CNNFlat)) {
+            throw new IllegalStateException("Invalid input: expected input of type FeedForward, got " + inputType);
+        }
 
-        InputType.InputTypeFeedForward ff = (InputType.InputTypeFeedForward)inputType;
-        return InputType.recurrent(ff.getSize());
-	}
+        if (inputType.getType() == InputType.Type.FF) {
+            InputType.InputTypeFeedForward ff = (InputType.InputTypeFeedForward) inputType;
+            return InputType.recurrent(ff.getSize());
+        } else {
+            InputType.InputTypeConvolutionalFlat cf = (InputType.InputTypeConvolutionalFlat) inputType;
+            return InputType.recurrent(cf.getFlattenedSize());
+        }
+    }
 }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -48,7 +48,6 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
     protected static final Logger log = LoggerFactory.getLogger(SubsamplingLayer.class);
 
     SubsamplingHelper helper = null;
-    private INDArray maxIndexes;
 
     public SubsamplingLayer(NeuralNetConfiguration conf) {
         super(conf);
@@ -113,7 +112,6 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         //only scale and reshape epsilon
         int inputHeight = input().size(-2);
         int inputWidth = input().size(-1);
-        INDArray reshapeEpsilon, retE;
         Gradient retGradient = new DefaultGradient();
 
         //Epsilons in shape: [miniBatch, depth, outH, outW]

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -7,11 +7,9 @@ import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.datasets.datavec.RecordReaderMultiDataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
-import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
-import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
-import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.Updater;
+import org.deeplearning4j.nn.conf.*;
 import org.deeplearning4j.nn.conf.distribution.UniformDistribution;
+import org.deeplearning4j.nn.conf.graph.GraphVertex;
 import org.deeplearning4j.nn.conf.graph.LayerVertex;
 import org.deeplearning4j.nn.conf.graph.MergeVertex;
 import org.deeplearning4j.nn.conf.inputs.InputType;
@@ -667,6 +665,81 @@ public class TestComputationGraphNetwork {
         net.update(expectedGradient);
         actualParams = net.params();
         assertEquals(Nd4j.ones(1,43).addi(1), actualParams);
+    }
+
+
+    @Test
+    public void testCnnFlatInputType1(){
+
+        //First: check conv input type. Expect: no preprocessor, nIn set appropriately
+        ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder()
+                .graphBuilder()
+                .addInputs("in")
+                .setInputTypes(InputType.convolutional(10,8,3))
+                .addLayer("layer",new ConvolutionLayer.Builder().kernelSize(2,2).padding(0,0).stride(1,1).build(), "in")
+                .addLayer("out", new OutputLayer.Builder().nOut(10).build(), "layer")
+                .setOutputs("out")
+                .pretrain(false).backprop(true)
+                .build();
+
+        LayerVertex lv = (LayerVertex)conf.getVertices().get("layer");
+        FeedForwardLayer l = ((FeedForwardLayer)(lv).getLayerConf().getLayer());
+        assertEquals(3, l.getNIn());
+        assertNull( lv.getPreProcessor() );
+
+        //Check the equivalent config, but with flat conv data input instead
+        //In this case, the only difference should be the addition of a preprocessor
+        //First: check conv input type. Expect: no preprocessor, nIn set appropriately
+        conf = new NeuralNetConfiguration.Builder()
+                .graphBuilder()
+                .addInputs("in")
+                .setInputTypes(InputType.convolationalFlat(10,8,3))
+                .addLayer("layer",new ConvolutionLayer.Builder().kernelSize(2,2).padding(0,0).stride(1,1).build(), "in")
+                .addLayer("out", new OutputLayer.Builder().nOut(10).build(), "layer")
+                .setOutputs("out")
+                .pretrain(false).backprop(true)
+                .build();
+
+        lv = (LayerVertex)conf.getVertices().get("layer");
+        l = ((FeedForwardLayer)(lv).getLayerConf().getLayer());
+        assertEquals(3, l.getNIn());
+        assertNotNull( lv.getPreProcessor() );
+        InputPreProcessor preProcessor = lv.getPreProcessor();
+        assertTrue(preProcessor instanceof FeedForwardToCnnPreProcessor);
+        FeedForwardToCnnPreProcessor preproc = (FeedForwardToCnnPreProcessor)preProcessor;
+        assertEquals(10,preproc.getInputHeight());
+        assertEquals(8,preproc.getInputWidth());
+        assertEquals(3,preproc.getNumChannels());
+
+
+        //Finally, check configuration with a subsampling layer
+        conf = new NeuralNetConfiguration.Builder()
+                .graphBuilder()
+                .addInputs("in")
+                .setInputTypes(InputType.convolationalFlat(10,8,3))
+                .addLayer("l0", new SubsamplingLayer.Builder().kernelSize(2,2).stride(1,1).padding(0,0).build(), "in")
+                .addLayer("layer",new ConvolutionLayer.Builder().kernelSize(2,2).padding(0,0).stride(1,1).build(), "l0")
+                .addLayer("out", new OutputLayer.Builder().nOut(10).build(), "layer")
+                .setOutputs("out")
+                .pretrain(false).backprop(true)
+                .build();
+
+            //Check subsampling layer:
+        lv = (LayerVertex)conf.getVertices().get("l0");
+        SubsamplingLayer sl = ((SubsamplingLayer) (lv).getLayerConf().getLayer());
+        assertNotNull( lv.getPreProcessor() );
+        preProcessor = lv.getPreProcessor();
+        assertTrue(preProcessor instanceof FeedForwardToCnnPreProcessor);
+        preproc = (FeedForwardToCnnPreProcessor)preProcessor;
+        assertEquals(10,preproc.getInputHeight());
+        assertEquals(8,preproc.getInputWidth());
+        assertEquals(3,preproc.getNumChannels());
+            //Check dense layer
+        lv = (LayerVertex)conf.getVertices().get("layer");
+        l = ((FeedForwardLayer)(lv).getLayerConf().getLayer());
+        assertEquals(3, l.getNIn());
+        assertNull( lv.getPreProcessor() );
+
 
     }
 


### PR DESCRIPTION
PR adds InputType for convolutional data that is in row vector (flattened) format.
This requires different preprocessors etc than the standard CNN data case.

For CNN data with 4d input format (shape ```[miniBatchSize, depth, height, width]```) use InputType.convolutional; for CNN data with 2d flattened format (shape ```[miniBatchSize, depth*height* width]```) use InputType.convolutionalFlat.