### PR TITLE
The negative parameter of Glove has to be Double

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2VecVariables.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/main/java/org/deeplearning4j/spark/models/embeddings/word2vec/Word2VecVariables.java
@@ -30,7 +30,7 @@ public class Word2VecVariables {
     public final static Map<String, Object> defaultVals = new HashMap<String, Object>() {{
         put(VECTOR_LENGTH, 100);
         put(ADAGRAD, false);
-        put(NEGATIVE, 5);
+        put(NEGATIVE, 5.0);
         put(NUM_WORDS, 1);
         // TABLE would be a string of byte of the ndarray used for -ve sampling
         put(WINDOW, 5);


### PR DESCRIPTION
Trying to train the spark implementation of Glove throw me java.lang.ClassCastException which is caused by the default value of the parameter 'negative' which is in an integer while has to be a double (or alternatively we should change the class type to Integer on the assignVar method called in line 124 Glove.java (spark implementation)