### PR TITLE
Fix deprecated SetupLayer to assume flat input for cnn

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/setup/ConvolutionLayerSetup.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/setup/ConvolutionLayerSetup.java
@@ -27,6 +27,6 @@ public class ConvolutionLayerSetup {
      */
     @Deprecated
     public ConvolutionLayerSetup(MultiLayerConfiguration.Builder builder, int height, int width, int channels) {
-        builder.setInputType(InputType.convolutional(height, width, channels));
+        builder.setInputType(InputType.convolutionalFlat(height, width, channels));
     }
 }


### PR DESCRIPTION
Previous setup assumed all input was flat and needed preprocess for input to cnn. Switching setuplayer back to that until it is fully removed