### PR TITLE
Fix gradient tests for autoencoder, rbm and remove deprecated code

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/BNGradientCheckTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/BNGradientCheckTest.java
@@ -18,6 +18,9 @@ import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.util.DataTypeUtil;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.DataNormalization;
+import org.nd4j.linalg.dataset.api.preprocessor.NormalizerMinMaxScaler;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 
@@ -43,8 +46,11 @@ public class BNGradientCheckTest {
 
     @Test
     public void testGradient2dSimple(){
-        DataSet ds = new IrisDataSetIterator(150,150).next();
-        ds.normalizeZeroMeanZeroUnitVariance();
+        DataNormalization scaler = new NormalizerMinMaxScaler();
+        DataSetIterator iter = new IrisDataSetIterator(150, 150);
+        scaler.fit(iter);
+        iter.setPreProcessor(scaler);
+        DataSet ds = iter.next();
         INDArray input = ds.getFeatureMatrix();
         INDArray labels = ds.getLabels();
 
@@ -331,8 +337,11 @@ public class BNGradientCheckTest {
 
     @Test
     public void testGradient2dFixedGammaBeta(){
-        DataSet ds = new IrisDataSetIterator(150,150).next();
-        ds.normalizeZeroMeanZeroUnitVariance();
+        DataNormalization scaler = new NormalizerMinMaxScaler();
+        DataSetIterator iter = new IrisDataSetIterator(150, 150);
+        scaler.fit(iter);
+        iter.setPreProcessor(scaler);
+        DataSet ds = iter.next();
         INDArray input = ds.getFeatureMatrix();
         INDArray labels = ds.getLabels();
 


### PR DESCRIPTION
Conflict between loss and activation function combination. Tanh is seeking 0 average in an autoencoder while KLD results in a 0 to 1 range with 0 as inactive and 1 as active. And the final output layer is valuing 0 as a positive result with MSE and tanh. Thus pulled tanh out of activation option under autoencoder test and RBM test. 

Also added in Updater to enable l2 test