### PR TITLE
Reference updated stack build script.

### DIFF
--- a/buildinglocally.md
+++ b/buildinglocally.md
@@ -243,7 +243,7 @@ copy mkl_rt.dll libblas3.dll
 
 ### Build Script
 
-A community-provided script [build-dl4j-stack.sh](https://gist.github.com/treo/6e243d616ba1ff8ac201444f8e910471) written in bash is available that clones the DL4J stack, builds each repository, and installs them locally to Maven. This script will work on both Linux and OS X platforms.
+A community-provided script [build-dl4j-stack.sh](https://gist.github.com/crockpotveggies/9948a365c2d45adcf96642db336e7df1) written in bash is available that clones the DL4J stack, builds each repository, and installs them locally to Maven. This script will work on both Linux and OS X platforms.
 
 Use the build script as follows for CPU architectures:
 


### PR DESCRIPTION
The build script needed updating, especially since DL4J repo now has a CUDA component that will fail if the user is not using CUDA.