### PR TITLE
Add check for zero-length sequences to prevent null pointer exceptions

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/SequenceRecordReaderDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/SequenceRecordReaderDataSetIterator.java
@@ -9,6 +9,7 @@ import org.datavec.api.records.reader.SequenceRecordReader;
 import org.datavec.api.records.reader.SequenceRecordReaderMeta;
 import org.datavec.api.writable.Writable;
 import org.datavec.common.data.NDArrayWritable;
+import org.deeplearning4j.datasets.datavec.exception.ZeroLengthSequenceException;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
@@ -155,6 +156,8 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
             } else {
                 sequence = recordReader.sequenceRecord();
             }
+            assertNonZeroLengthSequence(sequence, "combined features and labels");
+
             INDArray[] fl = getFeaturesLabelsSingleReader(sequence);
             if (i == 0) {
                 minLength = fl[0].size(0);
@@ -232,6 +235,8 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
                 featureSequence = recordReader.sequenceRecord();
                 labelSequence = labelsReader.sequenceRecord();
             }
+            assertNonZeroLengthSequence(featureSequence, "features");
+            assertNonZeroLengthSequence(labelSequence, "labels");
 
             INDArray features = getFeatures(featureSequence);
             INDArray labels = getLabels(labelSequence); //2d time series, with shape [timeSeriesLength,vectorSize]
@@ -241,6 +246,12 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
         }
 
         return nextMultipleSequenceReaders(featureList, labelList, meta);
+    }
+
+    private void assertNonZeroLengthSequence(List<?> sequence, String type) {
+        if (sequence.size() == 0) {
+            throw new ZeroLengthSequenceException(type);
+        }
     }
 
     private DataSet nextMultipleSequenceReaders(List<INDArray> featureList, List<INDArray> labelList, List<RecordMetaData> meta ){

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/exception/ZeroLengthSequenceException.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/exception/ZeroLengthSequenceException.java
@@ -1,0 +1,14 @@
+package org.deeplearning4j.datasets.datavec.exception;
+
+/**
+ * Unchecked exception, thrown to signify that a zero-length sequence data set was encountered.
+ */
+public class ZeroLengthSequenceException extends RuntimeException {
+    public ZeroLengthSequenceException() {
+        this("");
+    }
+
+    public ZeroLengthSequenceException(String type) {
+        super(String.format("Encountered zero-length %ssequence", type.equals("") ? "" : type + " "));
+    }
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetiteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetiteratorTest.java
@@ -20,7 +20,6 @@ package org.deeplearning4j.datasets.datavec;
 
 import org.apache.commons.io.FilenameUtils;
 import org.datavec.api.records.Record;
-import org.datavec.api.records.SequenceRecord;
 import org.datavec.api.records.metadata.RecordMetaData;
 import org.datavec.api.records.reader.RecordReader;
 import org.datavec.api.records.reader.RecordReaderMeta;
@@ -34,22 +33,13 @@ import org.datavec.api.split.NumberedFileInputSplit;
 import org.datavec.api.writable.IntWritable;
 import org.datavec.api.writable.Writable;
 import org.datavec.common.data.NDArrayWritable;
-import org.deeplearning4j.eval.Evaluation;
-import org.deeplearning4j.eval.meta.Prediction;
-import org.deeplearning4j.nn.api.OptimizationAlgorithm;
-import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
-import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.Updater;
-import org.deeplearning4j.nn.conf.layers.OutputLayer;
-import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.datasets.datavec.exception.ZeroLengthSequenceException;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
-import org.nd4j.linalg.dataset.api.preprocessor.NormalizerStandardize;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.io.ClassPathResource;
-import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -680,6 +670,36 @@ public class RecordReaderDataSetiteratorTest {
         }
         assertEquals(3,countF);
         assertEquals(1,iteratorRegression.totalOutcomes());
+    }
+
+    @Test(expected = ZeroLengthSequenceException.class)
+    public void testSequenceRecordReaderSingleReaderWithEmptySequenceThrows() throws Exception {
+        SequenceRecordReader reader = new CSVSequenceRecordReader(1, ",");
+        reader.initialize(new FileSplit(new ClassPathResource("empty.txt").getTempFileFromArchive()));
+
+        new SequenceRecordReaderDataSetIterator(reader, 1, -1, 1, true).next();
+    }
+
+    @Test(expected = ZeroLengthSequenceException.class)
+    public void testSequenceRecordReaderTwoReadersWithEmptyFeatureSequenceThrows() throws Exception {
+        SequenceRecordReader featureReader = new CSVSequenceRecordReader(1, ",");
+        SequenceRecordReader labelReader = new CSVSequenceRecordReader(1, ",");
+
+        featureReader.initialize(new FileSplit(new ClassPathResource("empty.txt").getTempFileFromArchive()));
+        labelReader.initialize(new FileSplit(new ClassPathResource("csvsequencelabels_0.txt").getTempFileFromArchive()));
+
+        new SequenceRecordReaderDataSetIterator(featureReader, labelReader, 1, -1, true).next();
+    }
+
+    @Test(expected = ZeroLengthSequenceException.class)
+    public void testSequenceRecordReaderTwoReadersWithEmptyLabelSequenceThrows() throws Exception {
+        SequenceRecordReader featureReader = new CSVSequenceRecordReader(1, ",");
+        SequenceRecordReader labelReader = new CSVSequenceRecordReader(1, ",");
+
+        featureReader.initialize(new FileSplit(new ClassPathResource("csvsequence_0.txt").getTempFileFromArchive()));
+        labelReader.initialize(new FileSplit(new ClassPathResource("empty.txt").getTempFileFromArchive()));
+
+        new SequenceRecordReaderDataSetIterator(featureReader, labelReader, 1, -1, true).next();
     }
 
     @Test


### PR DESCRIPTION
SequenceRecordReaderDataSetIterator would throw null pointer exceptions if it got an empty sequence.
This might happen for example when empty CSV files are read by CSVSequenceRecordReader.
This change makes it very clear to the user what the problem is.

Depends on https://github.com/deeplearning4j/dl4j-test-resources/pull/4 for the empty file.