### PR TITLE
nlp parallelism

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
@@ -50,6 +50,8 @@ public class AsyncIterator<T extends Object> implements Iterator<T> {
     @Override
     public T next() {
         T temp = nextElement;
+        if (temp == null)
+            throw new IllegalStateException("temp is NULL");
         nextElement = null;
         return temp;
     }
@@ -57,6 +59,11 @@ public class AsyncIterator<T extends Object> implements Iterator<T> {
     @Override
     public void remove() {
         // no-op
+    }
+
+    public void shutdown() {
+        thread.interrupt();
+        nextElement = terminator;
     }
 
 
@@ -81,7 +88,10 @@ public class AsyncIterator<T extends Object> implements Iterator<T> {
                     buffer.put(iterator.next());
                 }
                 buffer.put(terminator);
+            } catch (InterruptedException e) {
+                // do nothing
             } catch (Exception e) {
+                // TODO: pass that forward
                 throw new RuntimeException(e);
             }
         }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
@@ -1,0 +1,89 @@
+package org.deeplearning4j.parallelism;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Iterator;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Asynchronous Iterator for better performance of iterators in dl4j-nn & dl4j-nlp
+ *
+ * @author raver119@gmail.com
+ */
+@Slf4j
+public class AsyncIterator<T extends Object> implements Iterator<T> {
+    protected LinkedBlockingQueue<T> buffer;
+    protected ReaderThread<T> thread;
+    protected Iterator<T> iterator;
+    protected T terminator = (T) new Object();
+    protected T nextElement;
+
+    public AsyncIterator(@NonNull Iterator<T> iterator, int bufferSize) {
+        this.buffer = new LinkedBlockingQueue<>(bufferSize);
+        this.iterator = iterator;
+
+        thread = new ReaderThread<>(iterator, this.buffer, terminator);
+        thread.start();
+    }
+
+    public AsyncIterator(@NonNull Iterator<T> iterator) {
+        this(iterator, 1024);
+    }
+
+    @Override
+    public boolean hasNext() {
+        try {
+            if (nextElement != null) {
+                return true;
+            }
+            nextElement = buffer.take();
+            if (nextElement == terminator)
+                return false;
+            return true;
+        } catch (Exception e) {
+            log.error("Premature end of loop!");
+            return false;
+        }
+    }
+
+    @Override
+    public T next() {
+        T temp = nextElement;
+        nextElement = null;
+        return temp;
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
+
+
+    private class ReaderThread<T> extends Thread implements Runnable {
+        private LinkedBlockingQueue<T> buffer;
+        private Iterator<T> iterator;
+        private T terminator;
+
+        public ReaderThread(Iterator<T> iterator, LinkedBlockingQueue<T> buffer, T terminator) {
+            this.buffer = buffer;
+            this.iterator = iterator;
+            this.terminator = terminator;
+
+            setDaemon(true);
+            setName("AsyncIterator Reader thread");
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (iterator.hasNext()) {
+                    buffer.put(iterator.next());
+                }
+                buffer.put(terminator);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.parallelism;
 
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,7 +14,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  */
 @Slf4j
 public class AsyncIterator<T extends Object> implements Iterator<T> {
-    protected LinkedBlockingQueue<T> buffer;
+    @Getter protected LinkedBlockingQueue<T> buffer;
     protected ReaderThread<T> thread;
     protected Iterator<T> iterator;
     protected T terminator = (T) new Object();
@@ -50,8 +51,6 @@ public class AsyncIterator<T extends Object> implements Iterator<T> {
     @Override
     public T next() {
         T temp = nextElement;
-        if (temp == null)
-            throw new IllegalStateException("temp is NULL");
         nextElement = null;
         return temp;
     }

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
@@ -17,7 +17,7 @@ public class AsyncIterator<T extends Object> implements Iterator<T> {
     @Getter protected LinkedBlockingQueue<T> buffer;
     protected ReaderThread<T> thread;
     protected Iterator<T> iterator;
-    protected T terminator = (T) new Object();
+    @Getter protected T terminator = (T) new Object();
     protected T nextElement;
 
     public AsyncIterator(@NonNull Iterator<T> iterator, int bufferSize) {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/parallelism/AsyncIterator.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Iterator;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Asynchronous Iterator for better performance of iterators in dl4j-nn & dl4j-nlp
@@ -35,7 +36,7 @@ public class AsyncIterator<T extends Object> implements Iterator<T> {
     @Override
     public boolean hasNext() {
         try {
-            if (nextElement != null) {
+            if (nextElement != null && nextElement != terminator) {
                 return true;
             }
             nextElement = buffer.take();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/parallelism/AsyncIteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/parallelism/AsyncIteratorTest.java
@@ -1,0 +1,31 @@
+package org.deeplearning4j.parallelism;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author raver119@gmail.com
+ */
+public class AsyncIteratorTest {
+
+    @Test
+    public void hasNext() throws Exception {
+        ArrayList<Integer> integers = new ArrayList<>();
+        for (int x = 0; x < 100000; x++ ) {
+            integers.add(x);
+        }
+
+        AsyncIterator<Integer> iterator = new AsyncIterator<Integer>(integers.iterator(), 512);
+        int cnt = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            cnt++;
+        }
+
+        assertEquals(integers.size(), cnt);
+    }
+
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/parallelism/AsyncIteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/parallelism/AsyncIteratorTest.java
@@ -18,12 +18,16 @@ public class AsyncIteratorTest {
             integers.add(x);
         }
 
-        AsyncIterator<Integer> iterator = new AsyncIterator<Integer>(integers.iterator(), 512);
+        AsyncIterator<Integer> iterator = new AsyncIterator<>(integers.iterator(), 512);
         int cnt = 0;
+        Integer val= null;
         while (iterator.hasNext()) {
-            iterator.next();
+             val = iterator.next();
+            assertEquals(cnt, val.intValue());
             cnt++;
         }
+
+        System.out.println("Last val: " + val);
 
         assertEquals(integers.size(), cnt);
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/pom.xml
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>deeplearning4j-nlp</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
@@ -25,6 +25,8 @@ public class PerformanceTests {
     @Test
     public void testWord2VecCBOWBig() throws Exception {
         SentenceIterator iter = new BasicLineIterator("/home/raver119/Downloads/corpus/namuwiki_raw.txt");
+        //SentenceIterator iter = new BasicLineIterator("/home/raver119/Downloads/corpus/ru_sentences.txt");
+        //SentenceIterator iter = new BasicLineIterator("/ext/DATASETS/ru/Socials/ru_sentences.txt");
 
         TokenizerFactory t = new KoreanTokenizerFactory();
         //t.setTokenPreProcessor(new CommonPreprocessor());

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
@@ -1,0 +1,58 @@
+package org.deeplearning4j.text.tokenization.tokenizer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.models.embeddings.learning.impl.elements.CBOW;
+import org.deeplearning4j.models.embeddings.reader.impl.BasicModelUtils;
+import org.deeplearning4j.models.word2vec.VocabWord;
+import org.deeplearning4j.models.word2vec.Word2Vec;
+import org.deeplearning4j.text.sentenceiterator.BasicLineIterator;
+import org.deeplearning4j.text.sentenceiterator.SentenceIterator;
+import org.deeplearning4j.text.tokenization.tokenizer.preprocessor.CommonPreprocessor;
+import org.deeplearning4j.text.tokenization.tokenizerfactory.DefaultTokenizerFactory;
+import org.deeplearning4j.text.tokenization.tokenizerfactory.KoreanTokenizerFactory;
+import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author raver119@gmail.com
+ */
+@Slf4j
+public class PerformanceTests {
+
+
+    @Ignore
+    @Test
+    public void testWord2VecCBOWBig() throws Exception {
+        SentenceIterator iter = new BasicLineIterator("/home/raver119/Downloads/corpus/namuwiki_raw.txt");
+
+        TokenizerFactory t = new KoreanTokenizerFactory();
+        //t.setTokenPreProcessor(new CommonPreprocessor());
+
+        Word2Vec vec = new Word2Vec.Builder()
+                .minWordFrequency(1)
+                .iterations(5)
+                .learningRate(0.025)
+                .layerSize(150)
+                .seed(42)
+                .sampling(0)
+                .negativeSample(0)
+                .useHierarchicSoftmax(true)
+                .windowSize(5)
+                .modelUtils(new BasicModelUtils<VocabWord>())
+                .useAdaGrad(false)
+                .iterate(iter)
+                .workers(8)
+                .tokenizerFactory(t)
+                .elementsLearningAlgorithm(new CBOW<VocabWord>())
+                .build();
+
+        long time1 = System.currentTimeMillis();
+
+        vec.fit();
+
+        long time2 = System.currentTimeMillis();
+
+        log.info("Total execution time: {}", (time2 - time1));
+    }
+}

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
@@ -25,11 +25,11 @@ public class PerformanceTests {
     @Test
     public void testWord2VecCBOWBig() throws Exception {
         SentenceIterator iter = new BasicLineIterator("/home/raver119/Downloads/corpus/namuwiki_raw.txt");
-        iter = new BasicLineIterator("/home/raver119/Downloads/corpus/ru_sentences.txt");
+        //iter = new BasicLineIterator("/home/raver119/Downloads/corpus/ru_sentences.txt");
         //SentenceIterator iter = new BasicLineIterator("/ext/DATASETS/ru/Socials/ru_sentences.txt");
 
         TokenizerFactory t = new KoreanTokenizerFactory();
-        t = new DefaultTokenizerFactory();
+        //t = new DefaultTokenizerFactory();
         //t.setTokenPreProcessor(new CommonPreprocessor());
 
         Word2Vec vec = new Word2Vec.Builder()

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-korean/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/PerformanceTests.java
@@ -25,10 +25,11 @@ public class PerformanceTests {
     @Test
     public void testWord2VecCBOWBig() throws Exception {
         SentenceIterator iter = new BasicLineIterator("/home/raver119/Downloads/corpus/namuwiki_raw.txt");
-        //SentenceIterator iter = new BasicLineIterator("/home/raver119/Downloads/corpus/ru_sentences.txt");
+        iter = new BasicLineIterator("/home/raver119/Downloads/corpus/ru_sentences.txt");
         //SentenceIterator iter = new BasicLineIterator("/ext/DATASETS/ru/Socials/ru_sentences.txt");
 
         TokenizerFactory t = new KoreanTokenizerFactory();
+        t = new DefaultTokenizerFactory();
         //t.setTokenPreProcessor(new CommonPreprocessor());
 
         Word2Vec vec = new Word2Vec.Builder()
@@ -45,6 +46,7 @@ public class PerformanceTests {
                 .useAdaGrad(false)
                 .iterate(iter)
                 .workers(8)
+                .allowParallelTokenization(true)
                 .tokenizerFactory(t)
                 .elementsLearningAlgorithm(new CBOW<VocabWord>())
                 .build();

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/preprocessor/CustomStemmingPreprocessor.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/preprocessor/CustomStemmingPreprocessor.java
@@ -7,7 +7,7 @@ import org.tartarus.snowball.SnowballProgram;
  * This is StemmingPreprocessor compatible with different StemmingProcessors defined as lucene/tartarus SnowballProgram
  * Like, but not limited to: RussianStemmer, DutchStemmer, FrenchStemmer etc
  *
- * PLEASE NOTE: This preprocessor is NOT thread-safe.
+ * PLEASE NOTE: This preprocessor is thread-safe by using synchronized method
  *
  * @author raver119@gmail.com
  */
@@ -18,7 +18,7 @@ public class CustomStemmingPreprocessor extends CommonPreprocessor {
     }
 
     @Override
-    public String preProcess(String token) {
+    public synchronized String preProcess(String token) {
         String prep = super.preProcess(token);
         stemmer.setCurrent(prep);
         stemmer.stem();

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/preprocessor/StemmingPreprocessor.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/preprocessor/StemmingPreprocessor.java
@@ -5,11 +5,13 @@ import org.tartarus.snowball.ext.PorterStemmer;
 /**
  * This tokenizer preprocessor implements basic cleaning inherited from CommonPreprocessor + does english Porter stemming on tokens
  *
+ * PLEASE NOTE: This preprocessor is thread-safe by using synchronized method
+ *
  * @author raver119@gmail.com
  */
 public class StemmingPreprocessor extends CommonPreprocessor {
     @Override
-    public String preProcess(String token) {
+    public synchronized String preProcess(String token) {
         String prep = super.preProcess(token);
         PorterStemmer stemmer = new PorterStemmer();
         stemmer.setCurrent(prep);

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTests.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTests.java
@@ -221,6 +221,7 @@ public class Word2VecTests {
                 //.negativeSample(10)
                 .epochs(1)
                 .windowSize(5)
+                .allowParallelTokenization(true)
                 .modelUtils(new BasicModelUtils<VocabWord>())
                 .iterate(iter)
                 .tokenizerFactory(t)

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTests.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTests.java
@@ -33,6 +33,7 @@ import org.deeplearning4j.text.tokenization.tokenizer.preprocessor.CommonPreproc
 import org.deeplearning4j.text.tokenization.tokenizerfactory.DefaultTokenizerFactory;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
@@ -192,6 +193,9 @@ public class Word2VecTests {
         assertTrue(lst.contains("year"));
         assertTrue(sim > 0.65f);
     }
+
+
+
 
 
     @Test

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
@@ -631,6 +631,19 @@ public class ParagraphVectors extends Word2Vec {
         }
 
         /**
+         * This method enables/disables parallel tokenization.
+         *
+         * Default value: TRUE
+         * @param allow
+         * @return
+         */
+        @Override
+        public Builder allowParallelTokenization(boolean allow) {
+            super.allowParallelTokenization(allow);
+            return this;
+        }
+
+        /**
          * This method allows you to specify, if UNK word should be used internally
          *
          * @param reallyUse
@@ -685,6 +698,7 @@ public class ParagraphVectors extends Word2Vec {
                 SentenceTransformer transformer = new SentenceTransformer.Builder()
                         .iterator(labelAwareIterator)
                         .tokenizerFactory(tokenizerFactory)
+                        .allowMultithreading(allowParallelTokenization)
                         .build();
                 this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
             }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
@@ -1061,7 +1061,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                         for (int x = 0; x< sequences.size(); x++) {
                             Sequence<T> sequence = sequences.get(x);
 
-                            alpha = Math.max(minLearningRate, learningRate.get() * (1 - (1.0 * this.wordsCounter.get() / (double) this.totalWordsCount)));
+                            alpha = Math.max(minLearningRate, learningRate.get() * (1 - (1.0 * this.wordsCounter.get() / ((double) this.totalWordsCount) / numIterations)));
 
                             trainSequence(sequence, nextRandom, alpha);
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
@@ -783,6 +783,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                         .useAdaGrad(this.useAdaGrad)
                         .cache(vocabCache)
                         .negative(negative)
+                        .useHierarchicSoftmax(useHierarchicSoftmax)
                         .vectorLength(layerSize)
                         .lr(learningRate)
                         .seed(seed)

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/SequenceTransformer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/SequenceTransformer.java
@@ -25,4 +25,7 @@ public interface SequenceTransformer<T extends SequenceElement, V extends Object
      * @return
      */
     Sequence<T> transformToSequence(V object);
+
+
+    void reset();
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/SentenceTransformer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/SentenceTransformer.java
@@ -34,7 +34,8 @@ public class SentenceTransformer implements SequenceTransformer<VocabWord, Strin
     protected LabelAwareIterator iterator;
     protected boolean readOnly = false;
     protected AtomicInteger sentenceCounter = new AtomicInteger(0);
-    protected boolean allowMultithreading = true;
+    protected boolean allowMultithreading = false;
+    protected BasicTransformerIterator currentIterator;
 
     protected static final Logger log = LoggerFactory.getLogger(SentenceTransformer.class);
 
@@ -62,10 +63,21 @@ public class SentenceTransformer implements SequenceTransformer<VocabWord, Strin
 
     @Override
     public Iterator<Sequence<VocabWord>> iterator() {
-        if (allowMultithreading == false)
-            return new BasicTransformerIterator(iterator, this);
+        if (currentIterator != null)
+            reset();
+
+        if (!allowMultithreading)
+            currentIterator = new BasicTransformerIterator(iterator, this);
         else
-            return new ParallelTransformerIterator(iterator, this, true);
+            currentIterator = new ParallelTransformerIterator(iterator, this, true);
+
+        return currentIterator;
+    }
+
+    @Override
+    public void reset() {
+        if (currentIterator != null)
+            currentIterator.reset();
     }
 
 
@@ -74,7 +86,7 @@ public class SentenceTransformer implements SequenceTransformer<VocabWord, Strin
         protected LabelAwareIterator iterator;
         protected VocabCache<VocabWord> vocabCache;
         protected boolean readOnly = false;
-        protected boolean allowMultithreading = true;
+        protected boolean allowMultithreading = false;
 
         public Builder() {
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/SentenceTransformer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/SentenceTransformer.java
@@ -4,6 +4,7 @@ import lombok.NonNull;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.transformers.SequenceTransformer;
 import org.deeplearning4j.models.sequencevectors.transformers.impl.iterables.BasicTransformerIterator;
+import org.deeplearning4j.models.sequencevectors.transformers.impl.iterables.ParallelTransformerIterator;
 import org.deeplearning4j.models.word2vec.VocabWord;
 import org.deeplearning4j.models.word2vec.wordstore.VocabCache;
 import org.deeplearning4j.text.documentiterator.BasicLabelAwareIterator;
@@ -61,7 +62,10 @@ public class SentenceTransformer implements SequenceTransformer<VocabWord, Strin
 
     @Override
     public Iterator<Sequence<VocabWord>> iterator() {
-        return new BasicTransformerIterator(iterator, this);
+        if (allowMultithreading == false)
+            return new BasicTransformerIterator(iterator, this);
+        else
+            return new ParallelTransformerIterator(iterator, this, true);
     }
 
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/BasicTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/BasicTransformerIterator.java
@@ -49,6 +49,11 @@ public class BasicTransformerIterator implements Iterator<Sequence<VocabWord>> {
         return sequence;
     }
 
+
+    public void reset() {
+        //
+    }
+
     @Override
     public void remove() {
         throw new UnsupportedOperationException();

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/BasicTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/BasicTransformerIterator.java
@@ -1,0 +1,54 @@
+package org.deeplearning4j.models.sequencevectors.transformers.impl.iterables;
+
+import lombok.NonNull;
+import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
+import org.deeplearning4j.models.sequencevectors.transformers.impl.SentenceTransformer;
+import org.deeplearning4j.models.word2vec.VocabWord;
+import org.deeplearning4j.text.documentiterator.LabelAwareIterator;
+import org.deeplearning4j.text.documentiterator.LabelledDocument;
+
+import java.util.Iterator;
+
+/**
+ * @author raver119@gmail.com
+ */
+public class BasicTransformerIterator implements Iterator<Sequence<VocabWord>> {
+    protected final LabelAwareIterator iterator;
+    protected boolean allowMultithreading;
+    protected final SentenceTransformer sentenceTransformer;
+
+    public BasicTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer) {
+        this.iterator = iterator;
+        this.allowMultithreading = false;
+        this.sentenceTransformer = transformer;
+
+        this.iterator.reset();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.iterator.hasNextDocument();
+    }
+
+    @Override
+    public Sequence<VocabWord> next() {
+        LabelledDocument document = iterator.nextDocument();
+        if  (document.getContent() == null) return new Sequence<>();
+        Sequence<VocabWord> sequence = sentenceTransformer.transformToSequence(document.getContent());
+
+        for (String label: document.getLabels()) {
+            sequence.addSequenceLabel(new VocabWord(1.0, label));
+        }
+                /*
+                if (document.getLabel() != null && !document.getLabel().isEmpty()) {
+                    sequence.setSequenceLabel(new VocabWord(1.0, document.getLabel()));
+                }*/
+
+        return sequence;
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/BasicTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/BasicTransformerIterator.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.models.sequencevectors.transformers.impl.iterables;
 
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.transformers.impl.SentenceTransformer;
 import org.deeplearning4j.models.word2vec.VocabWord;
@@ -12,6 +13,7 @@ import java.util.Iterator;
 /**
  * @author raver119@gmail.com
  */
+@Slf4j
 public class BasicTransformerIterator implements Iterator<Sequence<VocabWord>> {
     protected final LabelAwareIterator iterator;
     protected boolean allowMultithreading;

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
@@ -52,7 +52,9 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
         try {
             int cnt = 0;
             while (cnt < 100 && stringBuffer.size() < 1000 && iterator.hasNextDocument()) {
-                stringBuffer.add(iterator.nextDocument());
+                Object object = iterator.nextDocument();
+                if (object != null && object instanceof LabelledDocument)
+                    stringBuffer.add((LabelledDocument) object);
                 cnt++;
             }
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
@@ -26,7 +26,7 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
 
     protected LinkedBlockingQueue<Sequence<VocabWord>> buffer = new LinkedBlockingQueue<>(1024);
     protected Queue<LabelledDocument> stringBuffer = new ConcurrentLinkedQueue<>();
-    protected TokenizerThread[] threads = new TokenizerThread[5];
+    protected TokenizerThread[] threads = new TokenizerThread[6];
 
     public ParallelTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer) {
         this(iterator, transformer, true);
@@ -94,6 +94,12 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
+                } else {
+                    try {
+                        Thread.sleep(100);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
@@ -1,0 +1,31 @@
+package org.deeplearning4j.models.sequencevectors.transformers.impl.iterables;
+
+import lombok.NonNull;
+import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
+import org.deeplearning4j.models.sequencevectors.transformers.impl.SentenceTransformer;
+import org.deeplearning4j.models.word2vec.VocabWord;
+import org.deeplearning4j.text.documentiterator.LabelAwareIterator;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * TransformerIterator implementation that's does transformation/tokenization/normalization/whatever in parallel threads.
+ * Suitable for cases when tokenization takes too much time for single thread.
+ *
+ * @author raver119@gmail.com
+ */
+public class ParallelTransformerIterator extends BasicTransformerIterator {
+
+    protected Queue<Sequence<VocabWord>> buffer = new ConcurrentLinkedQueue<>();
+
+    public ParallelTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer) {
+        this(iterator, transformer, true);
+    }
+
+    public ParallelTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer, boolean allowMultithreading) {
+        super(iterator, transformer);
+        this.allowMultithreading = allowMultithreading;
+    }
+
+}

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
@@ -30,9 +30,8 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
 
     protected LinkedBlockingQueue<Sequence<VocabWord>> buffer = new LinkedBlockingQueue<>(1024);
     protected LinkedBlockingQueue<LabelledDocument> stringBuffer;
-    protected TokenizerThread[] threads = new TokenizerThread[Runtime.getRuntime().availableProcessors()];
+    protected TokenizerThread[] threads;
     protected boolean underlyingHas = true;
-    protected boolean exhausted = false;
     protected AtomicInteger processing = new AtomicInteger(0);
 
     public ParallelTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer) {
@@ -44,9 +43,11 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
         this.allowMultithreading = allowMultithreading;
         this.stringBuffer = new LinkedBlockingQueue<>();
 
+        threads = new TokenizerThread[allowMultithreading ? Runtime.getRuntime().availableProcessors() : 1];
+
         try {
             int cnt = 0;
-            while (this.iterator.hasNextDocument() && cnt < 32) {
+            while (this.iterator.hasNextDocument() && cnt < 64) {
                 stringBuffer.put(this.iterator.nextDocument());
                 cnt++;
             }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
@@ -8,16 +8,20 @@ import org.deeplearning4j.text.documentiterator.LabelAwareIterator;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * TransformerIterator implementation that's does transformation/tokenization/normalization/whatever in parallel threads.
  * Suitable for cases when tokenization takes too much time for single thread.
  *
+ * TL/DR: we read data from sentence iterator, and apply tokenization in parallel threads.
+ *
  * @author raver119@gmail.com
  */
 public class ParallelTransformerIterator extends BasicTransformerIterator {
 
-    protected Queue<Sequence<VocabWord>> buffer = new ConcurrentLinkedQueue<>();
+    protected Queue<Sequence<VocabWord>> buffer = new LinkedBlockingQueue<>(1024);
+    protected Queue<String> stringBuffer = new ConcurrentLinkedQueue<>();
 
     public ParallelTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer) {
         this(iterator, transformer, true);
@@ -28,4 +32,33 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
         this.allowMultithreading = allowMultithreading;
     }
 
+    @Override
+    public boolean hasNext() {
+        return super.hasNext();
+    }
+
+    @Override
+    public Sequence<VocabWord> next() {
+        return super.next();
+    }
+
+
+
+    private static class TokenizerThread extends Thread implements Runnable {
+        protected Queue<Sequence<VocabWord>> sequencesBuffer;
+        protected Queue<String> stringsBuffer;
+
+        public TokenizerThread(int threadIdx, Queue<String> stringsBuffer, Queue<Sequence<VocabWord>> sequencesBuffer) {
+            this.stringsBuffer = stringsBuffer;
+            this.sequencesBuffer = sequencesBuffer;
+
+            this.setDaemon(true);
+            this.setName("Tokenization thread " + threadIdx);
+        }
+
+        @Override
+        public void run() {
+
+        }
+    }
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
@@ -51,6 +51,7 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
     public Sequence<VocabWord> next() {
         try {
             int cnt = 0;
+            stringBuffer.add(iterator.nextDocument());
             while (cnt < 100 && stringBuffer.size() < 1000 && iterator.hasNextDocument()) {
                 Object object = iterator.nextDocument();
                 if (object != null && object instanceof LabelledDocument)

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIterator.java
@@ -2,13 +2,17 @@ package org.deeplearning4j.models.sequencevectors.transformers.impl.iterables;
 
 import lombok.NonNull;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
+import org.deeplearning4j.models.sequencevectors.transformers.SequenceTransformer;
 import org.deeplearning4j.models.sequencevectors.transformers.impl.SentenceTransformer;
 import org.deeplearning4j.models.word2vec.VocabWord;
 import org.deeplearning4j.text.documentiterator.LabelAwareIterator;
+import org.deeplearning4j.text.documentiterator.LabelledDocument;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * TransformerIterator implementation that's does transformation/tokenization/normalization/whatever in parallel threads.
@@ -20,8 +24,9 @@ import java.util.concurrent.LinkedBlockingQueue;
  */
 public class ParallelTransformerIterator extends BasicTransformerIterator {
 
-    protected Queue<Sequence<VocabWord>> buffer = new LinkedBlockingQueue<>(1024);
-    protected Queue<String> stringBuffer = new ConcurrentLinkedQueue<>();
+    protected LinkedBlockingQueue<Sequence<VocabWord>> buffer = new LinkedBlockingQueue<>(1024);
+    protected Queue<LabelledDocument> stringBuffer = new ConcurrentLinkedQueue<>();
+    protected TokenizerThread[] threads = new TokenizerThread[5];
 
     public ParallelTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer) {
         this(iterator, transformer, true);
@@ -30,27 +35,46 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
     public ParallelTransformerIterator(@NonNull LabelAwareIterator iterator, @NonNull SentenceTransformer transformer, boolean allowMultithreading) {
         super(iterator, transformer);
         this.allowMultithreading = allowMultithreading;
+
+        for (int x = 0; x < threads.length; x++) {
+            threads[x] = new TokenizerThread(x, transformer,stringBuffer, buffer);
+            threads[x].start();
+        }
     }
 
     @Override
     public boolean hasNext() {
-        return super.hasNext();
+        return buffer.size() > 0 || stringBuffer.size() > 0 || iterator.hasNextDocument();
     }
 
     @Override
     public Sequence<VocabWord> next() {
-        return super.next();
+        try {
+            int cnt = 0;
+            while (cnt < 100 && stringBuffer.size() < 1000 && iterator.hasNextDocument()) {
+                stringBuffer.add(iterator.nextDocument());
+                cnt++;
+            }
+
+            Sequence<VocabWord> sequence = buffer.take();
+            return sequence;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
 
 
     private static class TokenizerThread extends Thread implements Runnable {
-        protected Queue<Sequence<VocabWord>> sequencesBuffer;
-        protected Queue<String> stringsBuffer;
+        protected LinkedBlockingQueue<Sequence<VocabWord>> sequencesBuffer;
+        protected Queue<LabelledDocument> stringsBuffer;
+        protected SentenceTransformer sentenceTransformer;
+        protected AtomicBoolean shouldWork = new AtomicBoolean(true);
 
-        public TokenizerThread(int threadIdx, Queue<String> stringsBuffer, Queue<Sequence<VocabWord>> sequencesBuffer) {
+        public TokenizerThread(int threadIdx, SentenceTransformer transformer, Queue<LabelledDocument> stringsBuffer, LinkedBlockingQueue<Sequence<VocabWord>> sequencesBuffer) {
             this.stringsBuffer = stringsBuffer;
             this.sequencesBuffer = sequencesBuffer;
+            this.sentenceTransformer = transformer;
 
             this.setDaemon(true);
             this.setName("Tokenization thread " + threadIdx);
@@ -58,7 +82,24 @@ public class ParallelTransformerIterator extends BasicTransformerIterator {
 
         @Override
         public void run() {
+            while (shouldWork.get()) {
+                LabelledDocument document = stringsBuffer.poll();
 
+                if (document != null) {
+                    Sequence<VocabWord> sequence = sentenceTransformer.transformToSequence(document.getContent());
+
+                    if (sequence != null)
+                        try {
+                            sequencesBuffer.put(sequence);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                }
+            }
+        }
+
+        public void shutdown() {
+            shouldWork.set(false);
         }
     }
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
@@ -69,6 +69,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
     public static class Builder extends SequenceVectors.Builder<VocabWord> {
         protected SentenceIterator sentenceIterator;
         protected TokenizerFactory tokenizerFactory;
+        protected boolean allowParallelTokenization = true;
 
 
         public Builder() {
@@ -445,6 +446,18 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
             return this;
         }
 
+        /**
+         * This method enables/disables parallel tokenization.
+         *
+         * Default value: TRUE
+         * @param allow
+         * @return
+         */
+        public Builder allowParallelTokenization(boolean allow) {
+            this.allowParallelTokenization = allow;
+            return this;
+        }
+
         @Override
         public Builder useHierarchicSoftmax(boolean reallyUse) {
             super.useHierarchicSoftmax(reallyUse);
@@ -468,6 +481,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
                 SentenceTransformer transformer = new SentenceTransformer.Builder()
                         .iterator(sentenceIterator)
                         .tokenizerFactory(tokenizerFactory)
+                        .allowMultithreading(allowParallelTokenization)
                         .build();
                 this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
             }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
@@ -164,7 +164,8 @@ public class VocabConstructor<T extends SequenceElement> {
         long lastSequences = 0;
         long lastElements = 0;
         long startTime = lastTime;
-        long startWords = cache.numWords();
+        long startWords = 0;
+        AtomicLong parsedCount = new AtomicLong(0);
         if (resetCounters && buildHuffmanTree) throw new IllegalStateException("You can't reset counters and build Huffman tree at the same time!");
 
         if (cache == null) cache = new AbstractCache.Builder<T>().build();
@@ -191,6 +192,7 @@ public class VocabConstructor<T extends SequenceElement> {
             while (iterator.hasMoreSequences()) {
                 Sequence<T> document = iterator.nextSequence();
                 seqCount.incrementAndGet();
+                parsedCount.addAndGet(document.size());
 
                 tempHolder.incrementTotalDocCount();
 
@@ -246,13 +248,13 @@ public class VocabConstructor<T extends SequenceElement> {
                 if (seqCount.get() % 100000 == 0) {
                     long currentTime = System.currentTimeMillis();
                     long currentSequences = seqCount.get();
-                    long currentElements = tempHolder.numWords();
+                    long currentElements = parsedCount.get();
 
                     double seconds = (currentTime - lastTime) / (double) 1000;
 
                     double seqPerSec = (currentSequences - lastSequences) / seconds;
                     double elPerSec = (currentElements - lastElements) / seconds;
-                    log.info("Sequences checked: [{}]; Current vocabulary size: [{}]; Seqs per second: {}; Words per second: {};", seqCount.get(), elementsCounter.get(), String.format("%.2f", seqPerSec), String.format("%.2f", elPerSec));
+                    log.info("Sequences checked: [{}]; Current vocabulary size: [{}]; Sequences/sec: {}; Words/sec: {};", seqCount.get(), elementsCounter.get(), String.format("%.2f", seqPerSec), String.format("%.2f", elPerSec));
                     lastTime = currentTime;
                     lastElements = currentElements;
                     lastSequences = currentSequences;

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
@@ -160,6 +160,7 @@ public class VocabConstructor<T extends SequenceElement> {
      * @return
      */
     public VocabCache<T> buildJointVocabulary(boolean resetCounters, boolean buildHuffmanTree) {
+        long lastTime = System.currentTimeMillis();
         if (resetCounters && buildHuffmanTree) throw new IllegalStateException("You can't reset counters and build Huffman tree at the same time!");
 
         if (cache == null) cache = new AbstractCache.Builder<T>().build();
@@ -238,7 +239,11 @@ public class VocabConstructor<T extends SequenceElement> {
                 }
 
                 sequences++;
-                if (seqCount.get() % 100000 == 0) log.info("Sequences checked: [" + seqCount.get() +"], Current vocabulary size: [" + elementsCounter.get() +"]");
+                if (seqCount.get() % 100000 == 0) {
+                    long currentTime = System.currentTimeMillis();
+                    log.info("Sequences checked: [" + seqCount.get() +"], Current vocabulary size: [" + elementsCounter.get() +"]");
+                    lastTime = currentTime;
+                }
             }
             // apply minWordFrequency set for this source
             log.debug("Vocab size before truncation: [" + tempHolder.numWords() + "],  NumWords: [" + tempHolder.totalWordOccurrences()+ "], sequences parsed: [" + sequences+ "], counter: ["+counter+"]");

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIterator.java
@@ -45,6 +45,12 @@ public class AsyncLabelAwareIterator implements LabelAwareIterator, Iterator<Lab
     }
 
     @Override
+    public void shutdown() {
+        asyncIterator.shutdown();
+        backedIterator.shutdown();
+    }
+
+    @Override
     public LabelsSource getLabelsSource() {
         return backedIterator.getLabelsSource();
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIterator.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.text.documentiterator;
 
+import lombok.Getter;
 import lombok.NonNull;
 import org.deeplearning4j.parallelism.AsyncIterator;
 
@@ -12,7 +13,7 @@ import java.util.Iterator;
 public class AsyncLabelAwareIterator implements LabelAwareIterator, Iterator<LabelledDocument>{
 
     protected LabelAwareIterator backedIterator;
-    protected AsyncIterator<LabelledDocument> asyncIterator;
+    @Getter protected AsyncIterator<LabelledDocument> asyncIterator;
     protected int bufferSize;
 
     public AsyncLabelAwareIterator(@NonNull LabelAwareIterator iterator, int bufferSize) {

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIterator.java
@@ -1,0 +1,60 @@
+package org.deeplearning4j.text.documentiterator;
+
+import lombok.NonNull;
+import org.deeplearning4j.parallelism.AsyncIterator;
+
+
+import java.util.Iterator;
+
+/**
+ * @author raver119@gmail.com
+ */
+public class AsyncLabelAwareIterator implements LabelAwareIterator, Iterator<LabelledDocument>{
+
+    protected LabelAwareIterator backedIterator;
+    protected AsyncIterator<LabelledDocument> asyncIterator;
+    protected int bufferSize;
+
+    public AsyncLabelAwareIterator(@NonNull LabelAwareIterator iterator, int bufferSize) {
+        this.backedIterator = iterator;
+        this.bufferSize = bufferSize;
+        this.asyncIterator = new AsyncIterator<LabelledDocument>(backedIterator, bufferSize);
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
+
+    @Override
+    public boolean hasNextDocument() {
+        return asyncIterator.hasNext();
+    }
+
+    @Override
+    public LabelledDocument nextDocument() {
+        return asyncIterator.next();
+    }
+
+    @Override
+    public void reset() {
+        asyncIterator.shutdown();
+        backedIterator.reset();
+        asyncIterator = new AsyncIterator<LabelledDocument>(backedIterator, bufferSize);
+    }
+
+    @Override
+    public LabelsSource getLabelsSource() {
+        return backedIterator.getLabelsSource();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+}

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/BasicLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/BasicLabelAwareIterator.java
@@ -69,6 +69,11 @@ public class BasicLabelAwareIterator implements LabelAwareIterator {
     }
 
     @Override
+    public void shutdown() {
+        // no-op
+    }
+
+    @Override
     public void remove() {
         // no-op
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/BasicLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/BasicLabelAwareIterator.java
@@ -58,6 +58,21 @@ public class BasicLabelAwareIterator implements LabelAwareIterator {
         return generator;
     }
 
+    @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
+
     public static class Builder {
         private String labelTemplate = "DOC_";
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FileLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FileLabelAwareIterator.java
@@ -71,6 +71,21 @@ public class FileLabelAwareIterator implements LabelAwareIterator {
     }
 
     @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
+
+    @Override
     public void reset() {
         position.set(0);
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FileLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FileLabelAwareIterator.java
@@ -86,6 +86,11 @@ public class FileLabelAwareIterator implements LabelAwareIterator {
     }
 
     @Override
+    public void shutdown() {
+        // no-op
+    }
+
+    @Override
     public void reset() {
         position.set(0);
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FilenamesLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FilenamesLabelAwareIterator.java
@@ -81,6 +81,12 @@ public class FilenamesLabelAwareIterator implements LabelAwareIterator {
     public void remove() {
         // no-op
     }
+
+    @Override
+    public void shutdown() {
+        // no-op
+    }
+
     @Override
     public void reset() {
         position.set(0);

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FilenamesLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/FilenamesLabelAwareIterator.java
@@ -68,6 +68,20 @@ public class FilenamesLabelAwareIterator implements LabelAwareIterator {
     }
 
     @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
+    @Override
     public void reset() {
         position.set(0);
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelAwareIterator.java
@@ -1,5 +1,7 @@
 package org.deeplearning4j.text.documentiterator;
 
+import java.util.Iterator;
+
 /**
  * This simple iterator interface assumes, that all documents are packed into strings OR into references to VocabWords.
  * Basic idea is: for tasks like ParagraphVectors we need unified interface for reading Sentences (read: lines of text) or Documents (read: set of lines) with label support.
@@ -10,7 +12,7 @@ package org.deeplearning4j.text.documentiterator;
  *
  * @author raver119@gmail.com
  */
-public interface LabelAwareIterator {
+public interface LabelAwareIterator extends Iterator<LabelledDocument> {
 
     boolean hasNextDocument();
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelAwareIterator.java
@@ -21,4 +21,6 @@ public interface LabelAwareIterator extends Iterator<LabelledDocument> {
     void reset();
 
     LabelsSource getLabelsSource();
+
+    void shutdown();
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/SimpleLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/SimpleLabelAwareIterator.java
@@ -56,6 +56,20 @@ public class SimpleLabelAwareIterator implements LabelAwareIterator {
         return document;
     }
 
+    @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
     /**
      * This methods resets LabelAwareIterator by creating new Iterator from Iterable internally
      */

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/SimpleLabelAwareIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/SimpleLabelAwareIterator.java
@@ -70,6 +70,12 @@ public class SimpleLabelAwareIterator implements LabelAwareIterator {
     public void remove() {
         // no-op
     }
+
+    @Override
+    public void shutdown() {
+        // no-op
+    }
+
     /**
      * This methods resets LabelAwareIterator by creating new Iterator from Iterable internally
      */

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/interoperability/DocumentIteratorConverter.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/interoperability/DocumentIteratorConverter.java
@@ -78,6 +78,11 @@ public class DocumentIteratorConverter implements LabelAwareIterator {
         return generator;
     }
 
+    @Override
+    public void shutdown() {
+
+    }
+
     protected String readStream(InputStream stream) throws IOException {
         StringBuilder builder = new StringBuilder();
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/interoperability/DocumentIteratorConverter.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/interoperability/DocumentIteratorConverter.java
@@ -59,6 +59,21 @@ public class DocumentIteratorConverter implements LabelAwareIterator {
     }
 
     @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
+
+    @Override
     public LabelsSource getLabelsSource() {
         return generator;
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/BasicLineIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/BasicLineIterator.java
@@ -59,7 +59,7 @@ public class BasicLineIterator implements SentenceIterator, Iterable<String> {
             if (backendStream instanceof FileInputStream) {
                 ((FileInputStream) backendStream).getChannel().position(0);
             } else backendStream.reset();
-            reader = new BufferedReader(new InputStreamReader(new BufferedInputStream(backendStream, 8192)));
+            reader = new BufferedReader(new InputStreamReader(new BufferedInputStream(backendStream, 10 * 10 * 1024)));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/MutipleEpochsSentenceIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/MutipleEpochsSentenceIterator.java
@@ -1,0 +1,64 @@
+package org.deeplearning4j.text.sentenceiterator;
+
+import lombok.NonNull;
+import org.deeplearning4j.datasets.iterator.MultipleEpochsIterator;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * This SentenceIterator implemenation wraps existing sentence iterator, and resets it numEpochs times
+ *
+ * This class is usable for tests purposes mostly.
+ *
+ * @author raver119@gmail.com
+ */
+public class MutipleEpochsSentenceIterator implements SentenceIterator {
+    private SentenceIterator iterator;
+    private int numEpochs;
+    private AtomicInteger counter = new AtomicInteger(0);
+
+    public MutipleEpochsSentenceIterator(@NonNull SentenceIterator iterator, int numEpochs) {
+        this.numEpochs = numEpochs;
+        this.iterator = iterator;
+
+        this.iterator.reset();
+    }
+
+    @Override
+    public String nextSentence() {
+        return iterator.nextSentence();
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (!iterator.hasNext()) {
+            if (counter.get() < numEpochs - 1) {
+                counter.incrementAndGet();
+                iterator.reset();
+                return true;
+            } else return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void reset() {
+        this.counter.set(0);
+        this.iterator.reset();
+    }
+
+    @Override
+    public void finish() {
+        // no-op
+    }
+
+    @Override
+    public SentencePreProcessor getPreProcessor() {
+        return this.iterator.getPreProcessor();
+    }
+
+    @Override
+    public void setPreProcessor(SentencePreProcessor preProcessor) {
+        this.iterator.setPreProcessor(preProcessor);
+    }
+}

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/PrefetchingSentenceIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/PrefetchingSentenceIterator.java
@@ -18,6 +18,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * @author raver119@gmail.com
  */
+@Deprecated
 public class PrefetchingSentenceIterator implements SentenceIterator {
 
     private SentenceIterator sourceIterator;

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/interoperability/SentenceIteratorConverter.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/interoperability/SentenceIteratorConverter.java
@@ -73,4 +73,9 @@ public class SentenceIteratorConverter implements LabelAwareIterator {
     public LabelsSource getLabelsSource() {
         return generator;
     }
+
+    @Override
+    public void shutdown() {
+        // no-op
+    }
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/interoperability/SentenceIteratorConverter.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/sentenceiterator/interoperability/SentenceIteratorConverter.java
@@ -55,6 +55,21 @@ public class SentenceIteratorConverter implements LabelAwareIterator {
     }
 
     @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+
+    @Override
+    public void remove() {
+        // no-op
+    }
+
+    @Override
     public LabelsSource getLabelsSource() {
         return generator;
     }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -469,6 +469,7 @@ public class ParagraphVectorsTest {
                 .vocabCache(cache)
                 .tokenizerFactory(t)
                 .negativeSample(0)
+                .allowParallelTokenization(true)
                 .useHierarchicSoftmax(true)
                 .sampling(0)
                 .workers(2)

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
@@ -96,6 +96,48 @@ public class ParallelTransformerIteratorTest {
         time2 = System.currentTimeMillis();
 
         log.info("Multi-threaded time: {} ms", time2 - time1);
+
+
+        SentenceIterator baseIterator = iterator;
+        baseIterator.reset();
+
+        iterator = new PrefetchingSentenceIterator.Builder(baseIterator)
+                .setFetchSize(1024)
+                .build();
+
+
+        iter = transformer.iterator();
+        time1 = System.currentTimeMillis();
+        while (iter.hasNext()) {
+            Sequence<VocabWord> sequence = iter.next();
+            assertNotEquals("Failed on [" + cnt + "] iteration", null, sequence);
+            assertNotEquals("Failed on [" + cnt + "] iteration", 0, sequence.size());
+            cnt++;
+        }
+        time2 = System.currentTimeMillis();
+
+        log.info("Prefetched Single-threaded time: {} ms", time2 - time1);
+        iterator.reset();
+
+        transformer = new SentenceTransformer.Builder()
+                .iterator(iterator)
+                .allowMultithreading(true)
+                .tokenizerFactory(factory)
+                .build();
+
+        iter = transformer.iterator();
+
+        time1 = System.currentTimeMillis();
+        while (iter.hasNext()) {
+            Sequence<VocabWord> sequence = iter.next();
+            assertNotEquals("Failed on [" + cnt + "] iteration", null, sequence);
+            assertNotEquals("Failed on [" + cnt + "] iteration", 0, sequence.size());
+            cnt++;
+        }
+        time2 = System.currentTimeMillis();
+
+        log.info("Prefetched Multi-threaded time: {} ms", time2 - time1);
+
     }
 
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
@@ -1,0 +1,51 @@
+package org.deeplearning4j.models.sequencevectors.transformers.impl.iterables;
+
+import org.datavec.api.util.ClassPathResource;
+import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
+import org.deeplearning4j.models.sequencevectors.transformers.impl.SentenceTransformer;
+import org.deeplearning4j.models.word2vec.VocabWord;
+import org.deeplearning4j.text.sentenceiterator.BasicLineIterator;
+import org.deeplearning4j.text.sentenceiterator.SentenceIterator;
+import org.deeplearning4j.text.tokenization.tokenizerfactory.DefaultTokenizerFactory;
+import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author raver119@gmail.com
+ */
+public class ParallelTransformerIteratorTest {
+    private TokenizerFactory factory = new DefaultTokenizerFactory();
+
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    @Test
+    public void hasNext() throws Exception {
+        SentenceIterator iterator = new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile());
+
+        SentenceTransformer transformer = new SentenceTransformer.Builder()
+                .iterator(iterator)
+                .allowMultithreading(true)
+                .tokenizerFactory(factory)
+                .build();
+
+        Iterator<Sequence<VocabWord>> iter = transformer.iterator();
+        int cnt = 0;
+        while (iter.hasNext()) {
+            Sequence<VocabWord> sequence = iter.next();
+            assertNotEquals("Failed on [" + cnt + "] iteration", null, sequence);
+            assertNotEquals("Failed on [" + cnt + "] iteration", 0, sequence.size());
+            cnt++;
+        }
+
+        assertEquals(97162, cnt);
+    }
+
+}

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
@@ -1,10 +1,13 @@
 package org.deeplearning4j.models.sequencevectors.transformers.impl.iterables;
 
+import lombok.extern.slf4j.Slf4j;
 import org.datavec.api.util.ClassPathResource;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.transformers.impl.SentenceTransformer;
 import org.deeplearning4j.models.word2vec.VocabWord;
 import org.deeplearning4j.text.sentenceiterator.BasicLineIterator;
+import org.deeplearning4j.text.sentenceiterator.MutipleEpochsSentenceIterator;
+import org.deeplearning4j.text.sentenceiterator.PrefetchingSentenceIterator;
 import org.deeplearning4j.text.sentenceiterator.SentenceIterator;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.DefaultTokenizerFactory;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
@@ -18,6 +21,7 @@ import static org.junit.Assert.*;
 /**
  * @author raver119@gmail.com
  */
+@Slf4j
 public class ParallelTransformerIteratorTest {
     private TokenizerFactory factory = new DefaultTokenizerFactory();
 
@@ -28,7 +32,9 @@ public class ParallelTransformerIteratorTest {
 
     @Test
     public void hasNext() throws Exception {
-        SentenceIterator iterator = new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile());
+        SentenceIterator iterator = new PrefetchingSentenceIterator.Builder(new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile()))
+                .setFetchSize(1000)
+                .build();
 
         SentenceTransformer transformer = new SentenceTransformer.Builder()
                 .iterator(iterator)
@@ -46,6 +52,50 @@ public class ParallelTransformerIteratorTest {
         }
 
         assertEquals(97162, cnt);
+    }
+
+    @Test
+    public void testSpeedComparison1() throws Exception {
+        SentenceIterator iterator = new MutipleEpochsSentenceIterator(new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile()), 25);
+
+        SentenceTransformer transformer = new SentenceTransformer.Builder()
+                .iterator(iterator)
+                .allowMultithreading(false)
+                .tokenizerFactory(factory)
+                .build();
+
+        Iterator<Sequence<VocabWord>> iter = transformer.iterator();
+        int cnt = 0;
+        long time1 = System.currentTimeMillis();
+        while (iter.hasNext()) {
+            Sequence<VocabWord> sequence = iter.next();
+            assertNotEquals("Failed on [" + cnt + "] iteration", null, sequence);
+            assertNotEquals("Failed on [" + cnt + "] iteration", 0, sequence.size());
+            cnt++;
+        }
+        long time2 = System.currentTimeMillis();
+
+        log.info("Single-threaded time: {} ms", time2 - time1);
+        iterator.reset();
+
+        transformer = new SentenceTransformer.Builder()
+                .iterator(iterator)
+                .allowMultithreading(true)
+                .tokenizerFactory(factory)
+                .build();
+
+        iter = transformer.iterator();
+
+        time1 = System.currentTimeMillis();
+        while (iter.hasNext()) {
+            Sequence<VocabWord> sequence = iter.next();
+            assertNotEquals("Failed on [" + cnt + "] iteration", null, sequence);
+            assertNotEquals("Failed on [" + cnt + "] iteration", 0, sequence.size());
+            cnt++;
+        }
+        time2 = System.currentTimeMillis();
+
+        log.info("Multi-threaded time: {} ms", time2 - time1);
     }
 
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
@@ -55,7 +55,7 @@ public class ParallelTransformerIteratorTest {
 
      //   log.info("Last element: {}", sequence.asLabels());
 
-     //   assertEquals(97162, cnt);
+        assertEquals(97162, cnt);
     }
 
     @Test

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/sequencevectors/transformers/impl/iterables/ParallelTransformerIteratorTest.java
@@ -35,9 +35,7 @@ public class ParallelTransformerIteratorTest {
 
     @Test
     public void hasNext() throws Exception {
-        SentenceIterator iterator = new PrefetchingSentenceIterator.Builder(new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile()))
-                .setFetchSize(1000)
-                .build();
+        SentenceIterator iterator = new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile());
 
         SentenceTransformer transformer = new SentenceTransformer.Builder()
                 .iterator(iterator)
@@ -47,14 +45,17 @@ public class ParallelTransformerIteratorTest {
 
         Iterator<Sequence<VocabWord>> iter = transformer.iterator();
         int cnt = 0;
+        Sequence<VocabWord> sequence  = null;
         while (iter.hasNext()) {
-            Sequence<VocabWord> sequence = iter.next();
+            sequence = iter.next();
             assertNotEquals("Failed on [" + cnt + "] iteration", null, sequence);
             assertNotEquals("Failed on [" + cnt + "] iteration", 0, sequence.size());
             cnt++;
         }
 
-        assertEquals(97162, cnt);
+     //   log.info("Last element: {}", sequence.asLabels());
+
+     //   assertEquals(97162, cnt);
     }
 
     @Test
@@ -108,10 +109,8 @@ public class ParallelTransformerIteratorTest {
         LabelAwareIterator lai = new BasicLabelAwareIterator.Builder(new MutipleEpochsSentenceIterator(new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile()), 25))
                 .build();
 
-        LabelAwareIterator alai = new AsyncLabelAwareIterator(lai, 1024);
-
         transformer = new SentenceTransformer.Builder()
-                .iterator(alai)
+                .iterator(lai)
                 .allowMultithreading(false)
                 .tokenizerFactory(factory)
                 .build();
@@ -128,10 +127,11 @@ public class ParallelTransformerIteratorTest {
         time2 = System.currentTimeMillis();
 
         log.info("Prefetched Single-threaded time: {} ms", time2 - time1);
-        alai.reset();
+        lai.reset();
+
 
         transformer = new SentenceTransformer.Builder()
-                .iterator(alai)
+                .iterator(lai)
                 .allowMultithreading(true)
                 .tokenizerFactory(factory)
                 .build();

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIteratorTest.java
@@ -1,0 +1,37 @@
+package org.deeplearning4j.text.documentiterator;
+
+import org.datavec.api.util.ClassPathResource;
+import org.deeplearning4j.text.sentenceiterator.BasicLineIterator;
+import org.deeplearning4j.text.sentenceiterator.SentenceIterator;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author raver119@gmail.com
+ */
+public class AsyncLabelAwareIteratorTest {
+    @Test
+    public void nextDocument() throws Exception {
+        SentenceIterator sentence = new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile());
+        BasicLabelAwareIterator backed = new BasicLabelAwareIterator.Builder(sentence).build();
+
+        int cnt = 0;
+        while (backed.hasNextDocument()) {
+            backed.nextDocument();
+            cnt++;
+        }
+        assertEquals(97162, cnt);
+
+        backed.reset();
+
+        AsyncLabelAwareIterator iterator = new AsyncLabelAwareIterator(backed, 64);
+        cnt = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            cnt++;
+        }
+        assertEquals(97162, cnt);
+    }
+
+}

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/documentiterator/AsyncLabelAwareIteratorTest.java
@@ -30,8 +30,11 @@ public class AsyncLabelAwareIteratorTest {
         while (iterator.hasNext()) {
             iterator.next();
             cnt++;
+
+            if (cnt == 10)
+                iterator.reset();
         }
-        assertEquals(97162, cnt);
+        assertEquals(97172, cnt);
     }
 
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/sentenceiterator/MutipleEpochsSentenceIteratorTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/sentenceiterator/MutipleEpochsSentenceIteratorTest.java
@@ -1,0 +1,25 @@
+package org.deeplearning4j.text.sentenceiterator;
+
+import org.datavec.api.util.ClassPathResource;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author raver119@gmail.com
+ */
+public class MutipleEpochsSentenceIteratorTest {
+    @Test
+    public void hasNext() throws Exception {
+        SentenceIterator iterator = new MutipleEpochsSentenceIterator(new BasicLineIterator(new ClassPathResource("/big/raw_sentences.txt").getFile()), 100);
+
+        int cnt = 0;
+        while (iterator.hasNext()) {
+            iterator.nextSentence();
+            cnt++;
+        }
+
+        assertEquals(9716200, cnt);
+    }
+
+}


### PR DESCRIPTION
***WIP; DO NOT MERGE***

To address performance issues with computation-heavy tokenizers we need to add parallel tokenization support. 

Basic idea is: keep fetching data in single thread (to avoid problems with custom sentence iterators that might use JDBC or something like that), and tokenize/normalize/preprocess in multiple threads.