### PR TITLE
Improve DL4J exceptions on invalid config/input

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
@@ -31,6 +31,7 @@ import org.datavec.api.records.reader.RecordReaderMeta;
 import org.datavec.api.records.reader.SequenceRecordReader;
 import org.datavec.api.writable.Writable;
 import org.datavec.common.data.NDArrayWritable;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
@@ -253,8 +254,11 @@ public class RecordReaderDataSetIterator implements DataSetIterator {
                     label = Nd4j.scalar(current.toDouble());
                 } else {
                     int curr = current.toInt();
-                    if (curr >= numPossibleLabels)
-                        curr--;
+                    if (curr < 0 || curr >= numPossibleLabels) {
+                        throw new DL4JInvalidInputException("Invalid classification data: expect label value (at label index column = " + labelIndex
+                            + ") to be in range 0 to " + (numPossibleLabels-1) + " inclusive (0 to numClasses-1, with numClasses=" + numPossibleLabels
+                            + "); got label value of " + current);
+                    }
                     label = FeatureUtil.toOutcomeVector(curr, numPossibleLabels);
                 }
             } else {

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/SequenceRecordReaderDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/SequenceRecordReaderDataSetIterator.java
@@ -10,6 +10,7 @@ import org.datavec.api.records.reader.SequenceRecordReaderMeta;
 import org.datavec.api.writable.Writable;
 import org.datavec.common.data.NDArrayWritable;
 import org.deeplearning4j.datasets.datavec.exception.ZeroLengthSequenceException;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
@@ -71,6 +72,19 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
     private boolean collectMetaData = false;
 
     /**
+     * Constructor where features and labels come from different RecordReaders (for example, different files),
+     * and labels are for classification.
+     *
+     * @param featuresReader       SequenceRecordReader for the features
+     * @param labels               Labels: assume single value per time step, where values are integers in the range 0 to numPossibleLables-1
+     * @param miniBatchSize        Minibatch size for each call of next()
+     * @param numPossibleLabels    Number of classes for the labels
+     */
+    public SequenceRecordReaderDataSetIterator(SequenceRecordReader featuresReader, SequenceRecordReader labels,
+                                               int miniBatchSize, int numPossibleLabels) {
+        this(featuresReader, labels, miniBatchSize, numPossibleLabels, false);
+    }
+    /**
      * Constructor where features and labels come from different RecordReaders (for example, different files)
      */
     public SequenceRecordReaderDataSetIterator(SequenceRecordReader featuresReader, SequenceRecordReader labels,
@@ -91,6 +105,17 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
         this.regression = regression;
         this.alignmentMode = alignmentMode;
         this.singleSequenceReaderMode = false;
+    }
+
+    /** Constructor where features and labels come from the SAME RecordReader (i.e., target/label is a column in the
+     * same data as the features). Defaults to regression = false - i.e., for classification
+     * @param reader SequenceRecordReader with data
+     * @param miniBatchSize size of each minibatch
+     * @param numPossibleLabels number of labels/classes for classification (or not used if regression == true)
+     * @param labelIndex index in input of the label index
+     */
+    public SequenceRecordReaderDataSetIterator(SequenceRecordReader reader, int miniBatchSize, int numPossibleLabels, int labelIndex){
+        this(reader, miniBatchSize, numPossibleLabels, labelIndex, false);
     }
 
     /** Constructor where features and labels come from the SAME RecordReader (i.e., target/label is a column in the
@@ -567,6 +592,11 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
                 //Expect a single value (index) -> convert to one-hot vector
                 Writable value = timeStepIter.next();
                 int idx = value.toInt();
+                if(idx < 0 || idx >= numPossibleLabels){
+                    throw new DL4JInvalidInputException("Invalid classification data: expect label value to be in range 0 to " +
+                            (numPossibleLabels-1) + " inclusive (0 to numClasses-1, with numClasses=" + numPossibleLabels
+                            + "); got label value of " + idx);
+                }
                 INDArray line = FeatureUtil.toOutcomeVector(idx, numPossibleLabels);
                 out.getRow(i).assign(line);
             }
@@ -631,6 +661,12 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
                             labels.put(i,0,current.toDouble());
                         }
                     } else {
+                        int idx = current.toInt();
+                        if(idx < 0 || idx >= numPossibleLabels){
+                            throw new DL4JInvalidInputException("Invalid classification data: expect label value (at label index column = " + labelIndex
+                                    + ") to be in range 0 to " + (numPossibleLabels-1) + " inclusive (0 to numClasses-1, with numClasses=" + numPossibleLabels
+                                    + "); got label value of " + current);
+                        }
                         labels.putScalar(i,current.toInt(),1.0);    //Labels initialized as 0s
                     }
                 } else {

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
@@ -1,7 +1,175 @@
 package org.deeplearning4j.exceptions;
 
+import org.deeplearning4j.exception.DL4JException;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.*;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
 /**
- * Created by Alex on 12/11/2016.
+ * A set of tests to ensure that useful exceptions are thrown on invalid network configurations
  */
 public class TestInvalidConfigurations {
+
+    public static MultiLayerNetwork getDensePlusOutput(int nIn, int nOut){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new DenseLayer.Builder().nIn(nIn).nOut(10).build())
+                .layer(1, new OutputLayer.Builder().nIn(10).nOut(nOut).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        return net;
+    }
+
+    public static MultiLayerNetwork getLSTMPlusRnnOutput(int nIn, int nOut){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new GravesLSTM.Builder().nIn(nIn).nOut(10).build())
+                .layer(1, new RnnOutputLayer.Builder().nIn(10).nOut(nOut).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        return net;
+    }
+
+    public static MultiLayerNetwork getCnnPlusOutputLayer(int depthIn, int inH, int inW, int nOut){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new ConvolutionLayer.Builder().nIn(depthIn).nOut(5).build())
+                .layer(1, new OutputLayer.Builder().nOut(nOut).build())
+                .setInputType(InputType.convolutional(inH,inW,depthIn))
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        return net;
+    }
+
+    @Test
+    public void testDenseNin0(){
+        try{
+            getDensePlusOutput(0,10);
+        }catch (DL4JException e){
+            System.out.println("testDenseNin0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testDenseNout0(){
+        try{
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .list()
+                    .layer(0, new DenseLayer.Builder().nIn(10).nOut(0).build())
+                    .layer(1, new OutputLayer.Builder().nIn(10).nOut(10).build())
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+        }catch (DL4JException e){
+            System.out.println("testDenseNout0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testOutputLayerNin0(){
+        try{
+            getDensePlusOutput(10,0);
+        }catch (DL4JException e){
+            System.out.println("testOutputLayerNin0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testRnnOutputLayerNin0(){
+        try{
+            getLSTMPlusRnnOutput(10,0);
+        }catch (DL4JException e){
+            System.out.println("testRnnOutputLayerNin0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testLSTMNIn0(){
+        try{
+            getLSTMPlusRnnOutput(0,10);
+        }catch (DL4JException e){
+            System.out.println("testLSTMNIn0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testLSTMNOut0(){
+        try{
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .list()
+                    .layer(0, new GravesLSTM.Builder().nIn(10).nOut(0).build())
+                    .layer(1, new RnnOutputLayer.Builder().nIn(10).nOut(10).build())
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+        }catch (DL4JException e){
+            System.out.println("testLSTMNOut0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testConvolutionalNin0(){
+        try{
+            getCnnPlusOutputLayer(0,10,10,10);
+        }catch (DL4JException e){
+            System.out.println("testConvolutionalNin0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testConvolutionalNOut0(){
+        try{
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .list()
+                    .layer(0, new ConvolutionLayer.Builder().nIn(5).nOut(0).build())
+                    .layer(1, new OutputLayer.Builder().nOut(10).build())
+                    .setInputType(InputType.convolutional(10,10,5))
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+        }catch (DL4JException e){
+            System.out.println("testConvolutionalNOut0(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
@@ -175,7 +175,7 @@ public class TestInvalidConfigurations {
 
 
     @Test
-    public void testCnnInvalidConfigPaddingStrides() {
+    public void testCnnInvalidConfigPaddingStridesHeight() {
         //Idea: some combination of padding/strides are invalid.
 
         int depthIn = 3;
@@ -188,7 +188,7 @@ public class TestInvalidConfigurations {
         try {
             MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                     .list()
-                    .layer(0, new ConvolutionLayer.Builder().kernelSize(3,3).stride(2,2).padding(0,0).nOut(5).build())
+                    .layer(0, new ConvolutionLayer.Builder().kernelSize(3,2).stride(2,2).padding(0,0).nOut(5).build())
                     .layer(1, new OutputLayer.Builder().nOut(10).build())
                     .setInputType(InputType.convolutional(hIn, wIn, depthIn))
                     .build();
@@ -196,8 +196,63 @@ public class TestInvalidConfigurations {
             MultiLayerNetwork net = new MultiLayerNetwork(conf);
             net.init();
         } catch (DL4JException e) {
-//            e.printStackTrace();
-            System.out.println("testCnnInvalidConfigPaddingStrides(): " + e.getMessage());
+            System.out.println("testCnnInvalidConfigPaddingStridesHeight(): " + e.getMessage());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testCnnInvalidConfigPaddingStridesWidth() {
+        //Idea: some combination of padding/strides are invalid.
+        int depthIn = 3;
+        int hIn = 10;
+        int wIn = 10;
+
+        //Using kernel size of 3, stride of 2:
+        //(10-3+2*0)/2+1 = 7/2 + 1
+
+        try {
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .list()
+                    .layer(0, new ConvolutionLayer.Builder().kernelSize(2,3).stride(2,2).padding(0,0).nOut(5).build())
+                    .layer(1, new OutputLayer.Builder().nOut(10).build())
+                    .setInputType(InputType.convolutional(hIn, wIn, depthIn))
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+        } catch (DL4JException e) {
+            System.out.println("testCnnInvalidConfigPaddingStridesWidth(): " + e.getMessage());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testCnnInvalidConfigPaddingStridesWidthSubsampling() {
+        //Idea: some combination of padding/strides are invalid.
+        int depthIn = 3;
+        int hIn = 10;
+        int wIn = 10;
+
+        //Using kernel size of 3, stride of 2:
+        //(10-3+2*0)/2+1 = 7/2 + 1
+
+        try {
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .list()
+                    .layer(0, new SubsamplingLayer.Builder().kernelSize(2,3).stride(2,2).padding(0,0).build())
+                    .layer(1, new OutputLayer.Builder().nOut(10).build())
+                    .setInputType(InputType.convolutional(hIn, wIn, depthIn))
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+        } catch (DL4JException e) {
+            System.out.println("testCnnInvalidConfigPaddingStridesWidthSubsampling(): " + e.getMessage());
         } catch (Exception e) {
             e.printStackTrace();
             fail();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
@@ -1,0 +1,7 @@
+package org.deeplearning4j.exceptions;
+
+/**
+ * Created by Alex on 12/11/2016.
+ */
+public class TestInvalidConfigurations {
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidConfigurations.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
  */
 public class TestInvalidConfigurations {
 
-    public static MultiLayerNetwork getDensePlusOutput(int nIn, int nOut){
+    public static MultiLayerNetwork getDensePlusOutput(int nIn, int nOut) {
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .list()
                 .layer(0, new DenseLayer.Builder().nIn(nIn).nOut(10).build())
@@ -28,7 +28,7 @@ public class TestInvalidConfigurations {
         return net;
     }
 
-    public static MultiLayerNetwork getLSTMPlusRnnOutput(int nIn, int nOut){
+    public static MultiLayerNetwork getLSTMPlusRnnOutput(int nIn, int nOut) {
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .list()
                 .layer(0, new GravesLSTM.Builder().nIn(nIn).nOut(10).build())
@@ -41,12 +41,12 @@ public class TestInvalidConfigurations {
         return net;
     }
 
-    public static MultiLayerNetwork getCnnPlusOutputLayer(int depthIn, int inH, int inW, int nOut){
+    public static MultiLayerNetwork getCnnPlusOutputLayer(int depthIn, int inH, int inW, int nOut) {
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .list()
                 .layer(0, new ConvolutionLayer.Builder().nIn(depthIn).nOut(5).build())
                 .layer(1, new OutputLayer.Builder().nOut(nOut).build())
-                .setInputType(InputType.convolutional(inH,inW,depthIn))
+                .setInputType(InputType.convolutional(inH, inW, depthIn))
                 .build();
 
         MultiLayerNetwork net = new MultiLayerNetwork(conf);
@@ -56,20 +56,20 @@ public class TestInvalidConfigurations {
     }
 
     @Test
-    public void testDenseNin0(){
-        try{
-            getDensePlusOutput(0,10);
-        }catch (DL4JException e){
+    public void testDenseNin0() {
+        try {
+            getDensePlusOutput(0, 10);
+        } catch (DL4JException e) {
             System.out.println("testDenseNin0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
     }
 
     @Test
-    public void testDenseNout0(){
-        try{
+    public void testDenseNout0() {
+        try {
             MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                     .list()
                     .layer(0, new DenseLayer.Builder().nIn(10).nOut(0).build())
@@ -78,53 +78,53 @@ public class TestInvalidConfigurations {
 
             MultiLayerNetwork net = new MultiLayerNetwork(conf);
             net.init();
-        }catch (DL4JException e){
+        } catch (DL4JException e) {
             System.out.println("testDenseNout0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
     }
 
     @Test
-    public void testOutputLayerNin0(){
-        try{
-            getDensePlusOutput(10,0);
-        }catch (DL4JException e){
+    public void testOutputLayerNin0() {
+        try {
+            getDensePlusOutput(10, 0);
+        } catch (DL4JException e) {
             System.out.println("testOutputLayerNin0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
     }
 
     @Test
-    public void testRnnOutputLayerNin0(){
-        try{
-            getLSTMPlusRnnOutput(10,0);
-        }catch (DL4JException e){
+    public void testRnnOutputLayerNin0() {
+        try {
+            getLSTMPlusRnnOutput(10, 0);
+        } catch (DL4JException e) {
             System.out.println("testRnnOutputLayerNin0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
     }
 
     @Test
-    public void testLSTMNIn0(){
-        try{
-            getLSTMPlusRnnOutput(0,10);
-        }catch (DL4JException e){
+    public void testLSTMNIn0() {
+        try {
+            getLSTMPlusRnnOutput(0, 10);
+        } catch (DL4JException e) {
             System.out.println("testLSTMNIn0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
     }
 
     @Test
-    public void testLSTMNOut0(){
-        try{
+    public void testLSTMNOut0() {
+        try {
             MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                     .list()
                     .layer(0, new GravesLSTM.Builder().nIn(10).nOut(0).build())
@@ -133,41 +133,72 @@ public class TestInvalidConfigurations {
 
             MultiLayerNetwork net = new MultiLayerNetwork(conf);
             net.init();
-        }catch (DL4JException e){
+        } catch (DL4JException e) {
             System.out.println("testLSTMNOut0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
     }
 
     @Test
-    public void testConvolutionalNin0(){
-        try{
-            getCnnPlusOutputLayer(0,10,10,10);
-        }catch (DL4JException e){
+    public void testConvolutionalNin0() {
+        try {
+            getCnnPlusOutputLayer(0, 10, 10, 10);
+        } catch (DL4JException e) {
             System.out.println("testConvolutionalNin0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
     }
 
     @Test
-    public void testConvolutionalNOut0(){
-        try{
+    public void testConvolutionalNOut0() {
+        try {
             MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                     .list()
                     .layer(0, new ConvolutionLayer.Builder().nIn(5).nOut(0).build())
                     .layer(1, new OutputLayer.Builder().nOut(10).build())
-                    .setInputType(InputType.convolutional(10,10,5))
+                    .setInputType(InputType.convolutional(10, 10, 5))
                     .build();
 
             MultiLayerNetwork net = new MultiLayerNetwork(conf);
             net.init();
-        }catch (DL4JException e){
+        } catch (DL4JException e) {
             System.out.println("testConvolutionalNOut0(): " + e.getMessage());
-        } catch (Exception e){
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+
+    @Test
+    public void testCnnInvalidConfigPaddingStrides() {
+        //Idea: some combination of padding/strides are invalid.
+
+        int depthIn = 3;
+        int hIn = 10;
+        int wIn = 10;
+
+        //Using kernel size of 3, stride of 2:
+        //(10-3+2*0)/2+1 = 7/2 + 1
+
+        try {
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .list()
+                    .layer(0, new ConvolutionLayer.Builder().kernelSize(3,3).stride(2,2).padding(0,0).nOut(5).build())
+                    .layer(1, new OutputLayer.Builder().nOut(10).build())
+                    .setInputType(InputType.convolutional(hIn, wIn, depthIn))
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+        } catch (DL4JException e) {
+//            e.printStackTrace();
+            System.out.println("testCnnInvalidConfigPaddingStrides(): " + e.getMessage());
+        } catch (Exception e) {
             e.printStackTrace();
             fail();
         }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
@@ -254,11 +254,38 @@ public class TestInvalidInput {
             net.feedForward(Nd4j.create(10,5));
             fail("Expected DL4JException");
         }catch (DL4JException e){
-            System.out.println("testInputNinMismatchDense(): " + e.getMessage());
+            System.out.println("testInputNinMismatchEmbeddingLayer(): " + e.getMessage());
         }catch (Exception e){
             e.printStackTrace();
             fail("Expected DL4JException");
         }
     }
-    
+
+
+    @Test
+    public void testInvalidRnnTimeStep(){
+        //Idea: Using rnnTimeStep with a different number of examples between calls
+        //(i.e., not calling reset between time steps)
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new GravesLSTM.Builder().nIn(5).nOut(5).build())
+                .layer(1, new RnnOutputLayer.Builder().nIn(5).nOut(5).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        net.rnnTimeStep(Nd4j.create(3,5,10));
+
+        try{
+            net.rnnTimeStep(Nd4j.create(5,5,10));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInvalidRnnTimeStep(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
@@ -4,20 +4,16 @@ import org.deeplearning4j.exception.DL4JException;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
-import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
-import org.deeplearning4j.nn.conf.layers.DenseLayer;
-import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.*;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.nd4j.linalg.factory.Nd4j;
 
 import static org.junit.Assert.fail;
 
 /**
- * A set of
+ * A set of tests to ensure that useful exceptions are thrown on invalid input
  */
-@Ignore
 public class TestInvalidInput {
 
     @Test
@@ -87,6 +83,28 @@ public class TestInvalidInput {
     }
 
     @Test
+    public void testLabelsNOutMismatchRnnOutputLayer(){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new GravesLSTM.Builder().nIn(5).nOut(5).build())
+                .layer(1, new RnnOutputLayer.Builder().nIn(5).nOut(5).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.fit(Nd4j.create(1,5,8), Nd4j.create(1,10,8));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testLabelsNOutMismatchRnnOutputLayer(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+
+    @Test
     public void testInputNinMismatchConvolutional(){
         //Rank 4 input, but input depth does not match nIn depth
 
@@ -142,6 +160,53 @@ public class TestInvalidInput {
             e.printStackTrace();
             fail("Expected DL4JException");
         }
+    }
+
+    @Test
+    public void testInputNinRank2Subsampling(){
+        //Rank 2 input, instead of rank 4 input. For example, using the wrong input type
+        int h = 16;
+        int w = 16;
+        int d = 3;
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new SubsamplingLayer.Builder().kernelSize(2,2).build())
+                .layer(1, new OutputLayer.Builder().nOut(10).build())
+                .setInputType(InputType.convolutional(h,w,d))
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.feedForward(Nd4j.create(1,5*h*w));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinRank2Subsampling(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+
+
+    @Test
+    public void testInputNinMismatchLSTM(){
+
+        fail();
+    }
+
+    @Test
+    public void testInputNinMismatchBidirectionalLSTM(){
+
+        fail();
+    }
+
+    @Test
+    public void testInputNinMismatchEmbeddingLayer(){
+
+        fail();
     }
 
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
@@ -1,0 +1,147 @@
+package org.deeplearning4j.exceptions;
+
+import org.deeplearning4j.exception.DL4JException;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.nd4j.linalg.factory.Nd4j;
+
+import static org.junit.Assert.fail;
+
+/**
+ * A set of
+ */
+@Ignore
+public class TestInvalidInput {
+
+    @Test
+    public void testInputNinMismatchDense(){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new DenseLayer.Builder().nIn(10).nOut(10).build())
+                .layer(1, new OutputLayer.Builder().nIn(10).nOut(10).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.feedForward(Nd4j.create(1,20));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinMismatchDense(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+
+    @Test
+    public void testInputNinMismatchOutputLayer(){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new DenseLayer.Builder().nIn(10).nOut(20).build())
+                .layer(1, new OutputLayer.Builder().nIn(10).nOut(10).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.feedForward(Nd4j.create(1,10));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinMismatchOutputLayer(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+
+    @Test
+    public void testLabelsNOutMismatchOutputLayer(){
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new DenseLayer.Builder().nIn(10).nOut(10).build())
+                .layer(1, new OutputLayer.Builder().nIn(10).nOut(10).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.fit(Nd4j.create(1,10), Nd4j.create(1,20));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testLabelsNOutMismatchOutputLayer(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+
+    @Test
+    public void testInputNinMismatchConvolutional(){
+        //Rank 4 input, but input depth does not match nIn depth
+
+        int h = 16;
+        int w = 16;
+        int d = 3;
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new ConvolutionLayer.Builder().nIn(d).nOut(5).build())
+                .layer(1, new OutputLayer.Builder().nOut(10).build())
+                .setInputType(InputType.convolutional(h,w,d))
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.feedForward(Nd4j.create(1,5,h,w));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinMismatchConvolutional(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+
+    @Test
+    public void testInputNinRank2Convolutional(){
+        //Rank 2 input, instead of rank 4 input. For example, forgetting the
+
+        int h = 16;
+        int w = 16;
+        int d = 3;
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new ConvolutionLayer.Builder().nIn(d).nOut(5).build())
+                .layer(1, new OutputLayer.Builder().nOut(10).build())
+                .setInputType(InputType.convolutional(h,w,d))
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.feedForward(Nd4j.create(1,5*h*w));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinRank2Convolutional(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestInvalidInput.java
@@ -194,19 +194,71 @@ public class TestInvalidInput {
     @Test
     public void testInputNinMismatchLSTM(){
 
-        fail();
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new GravesLSTM.Builder().nIn(5).nOut(5).build())
+                .layer(1, new RnnOutputLayer.Builder().nIn(5).nOut(5).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.fit(Nd4j.create(1,10,5), Nd4j.create(1,5,5));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinMismatchLSTM(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
     }
 
     @Test
     public void testInputNinMismatchBidirectionalLSTM(){
 
-        fail();
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new GravesBidirectionalLSTM.Builder().nIn(5).nOut(5).build())
+                .layer(1, new RnnOutputLayer.Builder().nIn(5).nOut(5).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.fit(Nd4j.create(1,10,5), Nd4j.create(1,5,5));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinMismatchBidirectionalLSTM(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+
     }
 
     @Test
     public void testInputNinMismatchEmbeddingLayer(){
 
-        fail();
-    }
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new EmbeddingLayer.Builder().nIn(10).nOut(10).build())
+                .layer(1, new OutputLayer.Builder().nIn(10).nOut(10).build())
+                .build();
 
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        try{
+            net.feedForward(Nd4j.create(10,5));
+            fail("Expected DL4JException");
+        }catch (DL4JException e){
+            System.out.println("testInputNinMismatchDense(): " + e.getMessage());
+        }catch (Exception e){
+            e.printStackTrace();
+            fail("Expected DL4JException");
+        }
+    }
+    
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestRecordReaders.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestRecordReaders.java
@@ -1,0 +1,117 @@
+package org.deeplearning4j.exceptions;
+
+import org.datavec.api.records.reader.SequenceRecordReader;
+import org.datavec.api.records.reader.impl.collection.CollectionRecordReader;
+import org.datavec.api.records.reader.impl.collection.CollectionSequenceRecordReader;
+import org.datavec.api.writable.DoubleWritable;
+import org.datavec.api.writable.IntWritable;
+import org.datavec.api.writable.Writable;
+import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
+import org.deeplearning4j.datasets.datavec.SequenceRecordReaderDataSetIterator;
+import org.deeplearning4j.exception.DL4JException;
+import org.junit.Test;
+import org.nd4j.linalg.dataset.api.DataSet;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static junit.framework.TestCase.fail;
+
+/**
+ * Created by Alex on 14/11/2016.
+ */
+public class TestRecordReaders {
+
+    @Test
+    public void testClassIndexOutsideOfRangeRRDSI(){
+
+        Collection<Collection<Writable>> c = new ArrayList<>();
+        c.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(0)));
+        c.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(2)));
+
+        CollectionRecordReader crr = new CollectionRecordReader(c);
+
+        RecordReaderDataSetIterator iter = new RecordReaderDataSetIterator(crr, 2, 1, 2);
+
+        try{
+            DataSet ds = iter.next();
+            fail("Expected exception");
+        } catch (DL4JException e){
+            System.out.println("testClassIndexOutsideOfRange(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testClassIndexOutsideOfRangeRRMDSI(){
+
+        Collection<Collection<Collection<Writable>>> c = new ArrayList<>();
+        Collection<Collection<Writable>> seq1 = new ArrayList<>();
+        seq1.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(0)));
+        seq1.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(1)));
+        c.add(seq1);
+
+        Collection<Collection<Writable>> seq2 = new ArrayList<>();
+        seq2.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(0)));
+        seq2.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(2)));
+        c.add(seq2);
+
+        CollectionSequenceRecordReader csrr = new CollectionSequenceRecordReader(c);
+        DataSetIterator dsi = new SequenceRecordReaderDataSetIterator(csrr, 2, 2, 1);
+
+        try{
+            DataSet ds = dsi.next();
+            fail("Expected exception");
+        } catch (DL4JException e){
+            System.out.println("testClassIndexOutsideOfRangeRRMDSI(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void testClassIndexOutsideOfRangeRRMDSI_MultipleReaders(){
+
+        Collection<Collection<Collection<Writable>>> c1 = new ArrayList<>();
+        Collection<Collection<Writable>> seq1 = new ArrayList<>();
+        seq1.add(Arrays.<Writable>asList(new DoubleWritable(0.0)));
+        seq1.add(Arrays.<Writable>asList(new DoubleWritable(0.0)));
+        c1.add(seq1);
+
+        Collection<Collection<Writable>> seq2 = new ArrayList<>();
+        seq2.add(Arrays.<Writable>asList(new DoubleWritable(0.0)));
+        seq2.add(Arrays.<Writable>asList(new DoubleWritable(0.0)));
+        c1.add(seq2);
+
+        Collection<Collection<Collection<Writable>>> c2 = new ArrayList<>();
+        Collection<Collection<Writable>> seq1a = new ArrayList<>();
+        seq1a.add(Arrays.<Writable>asList(new IntWritable(0)));
+        seq1a.add(Arrays.<Writable>asList(new IntWritable(1)));
+        c2.add(seq1a);
+
+        Collection<Collection<Writable>> seq2a = new ArrayList<>();
+        seq2a.add(Arrays.<Writable>asList(new IntWritable(0)));
+        seq2a.add(Arrays.<Writable>asList(new IntWritable(2)));
+        c2.add(seq2a);
+
+        CollectionSequenceRecordReader csrr = new CollectionSequenceRecordReader(c1);
+        CollectionSequenceRecordReader csrrLabels = new CollectionSequenceRecordReader(c2);
+        DataSetIterator dsi = new SequenceRecordReaderDataSetIterator(csrr, csrrLabels, 2, 2);
+
+        try{
+            DataSet ds = dsi.next();
+            fail("Expected exception");
+        } catch (DL4JException e){
+            System.out.println("testClassIndexOutsideOfRangeRRMDSI_MultipleReaders(): " + e.getMessage());
+        } catch (Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/ComputationGraphConfigurationTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/ComputationGraphConfigurationTest.java
@@ -246,7 +246,7 @@ public class ComputationGraphConfigurationTest {
         }
 
         @Override
-        public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+        public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
             throw new UnsupportedOperationException();
         }
     }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/misc/TestGraphVertex.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/misc/TestGraphVertex.java
@@ -33,7 +33,7 @@ public class TestGraphVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         throw new UnsupportedOperationException();
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/ActivationLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/ActivationLayerTest.java
@@ -37,8 +37,8 @@ public class ActivationLayerTest {
         InputType in1 = InputType.feedForward(20);
         InputType in2 = InputType.convolutional(28,28,1);
 
-        assertEquals(in1, l.getOutputType(in1));
-        assertEquals(in2, l.getOutputType(in2));
+        assertEquals(in1, l.getOutputType(0, in1));
+        assertEquals(in2, l.getOutputType(0, in2));
         assertNull(l.getPreProcessorForInputType(in1));
         assertNull(l.getPreProcessorForInputType(in2));
     }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
@@ -2,6 +2,7 @@ package org.deeplearning4j.nn.layers.convolution;
 
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.exception.DL4JException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
@@ -136,7 +137,7 @@ public class ConvolutionLayerTest {
     }
 
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = DL4JException.class)
     public void testCNNTooLargeKernel(){
         int imageHeight= 20;
         int imageWidth= 23;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayerTest.java
@@ -250,7 +250,7 @@ public class ConvolutionLayerTest {
     @Test
     public void testFeatureMapShapeMNIST() throws Exception  {
         int inputWidth = 28;
-        int[] stride = new int[] {2, 2};
+        int[] stride = new int[] {1, 1};
         int[] padding = new int[] {0,0};
         int[] kernelSize = new int[] {9, 9};
         int nChannelsIn = 1;
@@ -308,7 +308,7 @@ public class ConvolutionLayerTest {
 
     public Layer getMNISTConfig(){
         int[] kernelSize = new int[] {9, 9};
-        int[] stride = new int[] {2,2};
+        int[] stride = new int[] {1,1};
         int[] padding = new int[] {1,1};
         int nChannelsIn = 1;
         int depth = 20;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/custom/testlayers/CustomLayer.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/custom/testlayers/CustomLayer.java
@@ -63,7 +63,7 @@ public class CustomLayer extends FeedForwardLayer {
     }
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         return InputType.feedForward(10);
     }
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
@@ -23,6 +23,7 @@ import org.deeplearning4j.datasets.iterator.impl.CifarDataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.exception.DL4JException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
@@ -766,7 +767,7 @@ public class MultiLayerTest {
     }
 
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = DL4JException.class)
     public void testCnnInvalidData(){
 
         int miniBatch = 3;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/exception/DL4JException.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/exception/DL4JException.java
@@ -1,0 +1,24 @@
+package org.deeplearning4j.exception;
+
+/**
+ * Base exception for DL4J
+ *
+ * @author Alex Black
+ */
+public class DL4JException extends RuntimeException {
+
+    public DL4JException() {
+    }
+
+    public DL4JException(String message) {
+        super(message);
+    }
+
+    public DL4JException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DL4JException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/exception/DL4JInvalidConfigException.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/exception/DL4JInvalidConfigException.java
@@ -1,0 +1,23 @@
+package org.deeplearning4j.exception;
+
+/**
+ * Exception signifying that the specified configuration is invalid
+ *
+ * @author Alex Black
+ */
+public class DL4JInvalidConfigException extends DL4JException {
+    public DL4JInvalidConfigException() {
+    }
+
+    public DL4JInvalidConfigException(String message) {
+        super(message);
+    }
+
+    public DL4JInvalidConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DL4JInvalidConfigException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/exception/DL4JInvalidInputException.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/exception/DL4JInvalidInputException.java
@@ -1,0 +1,24 @@
+package org.deeplearning4j.exception;
+
+/**
+ * DL4J Exception thrown when invalid input is provided (wrong rank, wrong size, etc)
+ *
+ * @author Alex Black
+ */
+public class DL4JInvalidInputException extends DL4JException {
+
+    public DL4JInvalidInputException() {
+    }
+
+    public DL4JInvalidInputException(String message) {
+        super(message);
+    }
+
+    public DL4JInvalidInputException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DL4JInvalidInputException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
@@ -329,6 +329,7 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
 
         //Now, given the topological sort: do equivalent of forward pass
         Map<String, InputType> vertexOutputs = new HashMap<>();
+        int currLayerIdx = -1;
         for (String s : topologicalOrdering) {
             int inputIdx = networkInputs.indexOf(s);
             if (inputIdx != -1) {
@@ -364,6 +365,7 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
                 }
                 l.setNIn(afterPreproc, false);
 
+                currLayerIdx++;
             } else {
                 List<String> inputs = vertexInputs.get(s);
                 if (inputs != null) {
@@ -373,7 +375,7 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
                 }
             }
 
-            InputType outputFromVertex = gv.getOutputType(inputTypeList.toArray(new InputType[inputTypeList.size()]));
+            InputType outputFromVertex = gv.getOutputType(currLayerIdx, inputTypeList.toArray(new InputType[inputTypeList.size()]));
             vertexOutputs.put(s, outputFromVertex);
         }
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/MultiLayerConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/MultiLayerConfiguration.java
@@ -440,7 +440,7 @@ public class MultiLayerConfiguration implements Serializable, Cloneable {
                     }
                     l.setNIn(currentInputType, false);  //Don't override the nIn setting, if it's manually set by the user
 
-                    currentInputType = l.getOutputType(currentInputType);
+                    currentInputType = l.getOutputType(i, currentInputType);
                 }
             }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ElementWiseVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ElementWiseVertex.java
@@ -83,7 +83,7 @@ public class ElementWiseVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if(vertexInputs.length == 1) return vertexInputs[0];
         InputType first = vertexInputs[0];
         if(first.getType() != InputType.Type.CNN){

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
@@ -80,10 +80,11 @@ public abstract class GraphVertex implements Cloneable, Serializable {
      * processing or modifications of the inputs, the output types can be quite different to the input type(s).<br>
      * This is generally used to determine when to add preprocessors, as well as the input sizes etc for layers
      *
+     * @param layerIndex The index of the layer (if appropriate/necessary).
      * @param vertexInputs The inputs to this vertex
      * @return The type of output for this vertex
      * @throws InvalidInputTypeException If the input type is invalid for this type of GraphVertex
      */
-    public abstract InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException;
+    public abstract InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException;
 
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/L2Vertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/L2Vertex.java
@@ -65,7 +65,7 @@ public class L2Vertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         return InputType.feedForward(1);
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/LayerVertex.java
@@ -88,7 +88,7 @@ public class LayerVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if (vertexInputs.length != 1) {
             throw new InvalidInputTypeException("LayerVertex expects exactly one input. Got: " + Arrays.toString(vertexInputs));
         }
@@ -98,6 +98,6 @@ public class LayerVertex extends GraphVertex {
         if (preProcessor == null) afterPreprocessor = vertexInputs[0];
         else afterPreprocessor = preProcessor.getOutputType(vertexInputs[0]);
 
-        return layerConf.getLayer().getOutputType(afterPreprocessor);
+        return layerConf.getLayer().getOutputType(layerIndex, afterPreprocessor);
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
@@ -62,7 +62,7 @@ public class MergeVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if(vertexInputs.length == 1) return vertexInputs[0];
         InputType first = vertexInputs[0];
         if(first.getType() == InputType.Type.CNNFlat){

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/PreprocessorVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/PreprocessorVertex.java
@@ -82,7 +82,7 @@ public class PreprocessorVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if (vertexInputs.length != 1) throw new InvalidInputTypeException("Invalid input: Preprocessor vertex expects "
                 + "exactly one input");
         if (outputType != null) return outputType;   //Allows user to override for custom preprocessors

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/StackVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/StackVertex.java
@@ -65,7 +65,7 @@ public class StackVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if(vertexInputs.length == 1) return vertexInputs[0];
         InputType first = vertexInputs[0];
         if(first.getType() == InputType.Type.CNNFlat){

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/SubsetVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/SubsetVertex.java
@@ -81,7 +81,7 @@ public class SubsetVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if (vertexInputs.length != 1) {
             throw new InvalidInputTypeException("SubsetVertex expects single input type. Received: " + Arrays.toString(vertexInputs));
         }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/UnstackVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/UnstackVertex.java
@@ -79,7 +79,7 @@ public class UnstackVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if(vertexInputs.length == 1) return vertexInputs[0];
         InputType first = vertexInputs[0];
         if(first.getType() == InputType.Type.CNNFlat){

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/DuplicateToTimeSeriesVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/DuplicateToTimeSeriesVertex.java
@@ -81,7 +81,7 @@ public class DuplicateToTimeSeriesVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if (vertexInputs.length != 1)
             throw new InvalidInputTypeException("Invalid input type: cannot duplicate more than 1 input");
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/LastTimeStepVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/LastTimeStepVertex.java
@@ -81,7 +81,7 @@ public class LastTimeStepVertex extends GraphVertex {
     }
 
     @Override
-    public InputType getOutputType(InputType... vertexInputs) throws InvalidInputTypeException {
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
         if(vertexInputs.length != 1) throw new InvalidInputTypeException("Invalid input type: cannot get last time step of more than 1 input");
         if(vertexInputs[0].getType() != InputType.Type.RNN){
             throw new InvalidInputTypeException("Invalid input type: cannot get subset of non RNN input (got: " + vertexInputs[0] + ")");

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
@@ -49,7 +49,7 @@ public class ActivationLayer extends FeedForwardLayer {
     }
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if(inputType == null) throw new IllegalStateException("Invalid input type: null for layer name \"" + getLayerName() + "\"");
         return inputType;
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -15,9 +15,10 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
     }
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
-            throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: " + inputType);
+            throw new IllegalStateException("Invalid input for RNN layer (layer index = " + layerIndex +
+                    ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: " + inputType);
         }
 
         return InputType.recurrent(nOut);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -68,7 +68,7 @@ public class BatchNormalization extends FeedForwardLayer {
 
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if(inputType == null){
             throw new IllegalStateException("Invalid input type: Batch norm layer expected input of type CNN, got null for layer \"" + getLayerName() + "\"");
         }
@@ -80,7 +80,8 @@ public class BatchNormalization extends FeedForwardLayer {
             case CNNFlat:
                 return inputType; //OK
             default:
-                throw new IllegalStateException("Invalid input type: Batch norm layer expected input of type CNN, CNN Flat or FF, got " + inputType + " for layer " + getLayerName() + "\"");
+                throw new IllegalStateException("Invalid input type: Batch norm layer expected input of type CNN, CNN Flat or FF, got "
+                        + inputType + " for layer index " + layerIndex + ", layer name = " + getLayerName() );
         }
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -84,12 +84,12 @@ public class ConvolutionLayer extends FeedForwardLayer {
     }
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if(inputType == null || inputType.getType() != InputType.Type.CNN){
             throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName() + "\"): Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, nOut, getLayerName());
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, nOut, layerIndex, getLayerName(), ConvolutionLayer.class);
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -8,6 +8,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
+import org.deeplearning4j.util.LayerValidation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.convolution.Convolution;
 
@@ -64,6 +65,8 @@ public class ConvolutionLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners, int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        LayerValidation.assertNInNOutSet("ConvolutionLayer", getLayerName(), layerIndex, getNIn(), getNOut());
+
         org.deeplearning4j.nn.layers.convolution.ConvolutionLayer ret
                 = new org.deeplearning4j.nn.layers.convolution.ConvolutionLayer(conf);
         ret.setListeners(iterationListeners);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -19,11 +19,13 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import lombok.*;
+import org.deeplearning4j.exception.DL4JInvalidConfigException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
+import org.deeplearning4j.util.LayerValidation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.util.Collection;
@@ -43,6 +45,8 @@ public class DenseLayer extends FeedForwardLayer {
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners, int layerIndex,
                              INDArray layerParamsView, boolean initializeParams) {
+        LayerValidation.assertNInNOutSet("DenseLayer", getLayerName(), layerIndex, getNIn(), getNOut());
+
         org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer ret
                 = new org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer(conf);
         ret.setListeners(iterationListeners);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -29,9 +29,9 @@ public abstract class FeedForwardLayer extends Layer {
 
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF && inputType.getType() != InputType.Type.CNNFlat)) {
-            throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
+            throw new IllegalStateException("Invalid input type (layer index = " + layerIndex + ", layer name=\"" + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         return InputType.feedForward(nOut);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
@@ -24,6 +24,7 @@ import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.params.GravesLSTMParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
+import org.deeplearning4j.util.LayerValidation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.util.Collection;
@@ -47,6 +48,7 @@ public class GravesLSTM extends BaseRecurrentLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners, int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        LayerValidation.assertNInNOutSet("GravesLSTM", getLayerName(), layerIndex, getNIn(), getNOut());
         org.deeplearning4j.nn.layers.recurrent.GravesLSTM ret
                 = new org.deeplearning4j.nn.layers.recurrent.GravesLSTM(conf);
         ret.setListeners(iterationListeners);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
@@ -69,9 +69,15 @@ public class InputTypeUtil {
 
 
         if ((inWidth - kW + 2 * padW) % sW != 0) {
-            throw new IllegalStateException("Invalid input configuration (layer name = \"" + layerName + "\") for width: inWidth=" + inWidth + ", kernelW="
-                    + kW + ", padW=" + padW + ", strideW=" + sW + "; (" + inWidth + "-" + kW + "+2*" + padW + ")/" + sW
-                    + " is not an integer");
+            double d = (inWidth - kW + 2 * padW) / ((double)sW) + 1.0;
+            String str = String.format("%.2f",d);
+            throw new DL4JInvalidConfigException(
+                    getConfigErrorCommonLine1(layerIdx, layerName, layerClass, false )
+                            + "\nCombination of kernel size, stride and padding are not valid for given input width.\n"
+                            + "Require: (input - kernelSize + 2*padding)/stride + 1 in width dimension to be an integer. Got: ("
+                            + inWidth + " - " + kW + " + 2*" + padW + ")/" + sW + " + 1 = " + str + "\n"
+                            + "See \"Constraints on strides\" at http://cs231n.github.io/convolutional-networks/\n"
+                            + getConfigErrorCommonLastLine(inputType, kernelSize, stride, padding, outputDepth));
         }
 
         int hOut = (inHeight - kH + 2 * padH) / sH + 1;
@@ -83,7 +89,7 @@ public class InputTypeUtil {
         String name = layerName == null ? "(not named)" : layerName;
         String layerType = layerClass.getSimpleName();
 
-        return "Invalid configuration for convolutional layer (idx=" + layerIdx + ", name=" + name + ", type=" + layerType
+        return "Invalid configuration for layer (idx=" + layerIdx + ", name=" + name + ", type=" + layerType
                 + ") for " + (isHeight ? "height" : "width") + " dimension: ";
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -135,11 +135,12 @@ public abstract class Layer implements Serializable, Cloneable {
     /**
      * For a given type of input to this layer, what is the type of the output?
      *
+     * @param layerIndex Index of the layer
      * @param inputType Type of input for the layer
      * @return Type of output from the layer
      * @throws IllegalStateException if input type is invalid for this layer
      */
-    public abstract InputType getOutputType(InputType inputType);
+    public abstract InputType getOutputType(int layerIndex, InputType inputType);
 
     /**
      * Set the nIn value (number of inputs, or input depth for CNNs) based on the given input type

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -61,9 +61,10 @@ public class LocalResponseNormalization extends Layer {
 
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
-            throw new IllegalStateException("Invalid input type for LRN layer (layer name = \"" + getLayerName() + "\"): Expected input of type CNN, got " + inputType);
+            throw new IllegalStateException("Invalid input type for LRN layer (layer index = " + layerIndex +
+                    ", layer name = \"" + getLayerName() + "\"): Expected input of type CNN, got " + inputType);
         }
         return inputType;
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
@@ -22,11 +22,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.deeplearning4j.exception.DL4JInvalidConfigException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
+import org.deeplearning4j.util.LayerValidation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
@@ -50,6 +52,8 @@ public class OutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners, int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        LayerValidation.assertNInNOutSet("OutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
+
         org.deeplearning4j.nn.layers.OutputLayer ret
                 = new org.deeplearning4j.nn.layers.OutputLayer(conf);
         ret.setListeners(iterationListeners);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -50,9 +50,10 @@ public class RnnOutputLayer extends BaseOutputLayer {
     }
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
-            throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
+            throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer index = " + layerIndex +
+                    ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
         }
         return InputType.recurrent(nOut);
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -11,6 +11,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
+import org.deeplearning4j.util.LayerValidation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
@@ -30,6 +31,8 @@ public class RnnOutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners, int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        LayerValidation.assertNInNOutSet("RnnOutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
+
         org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer ret
                 = new org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer(conf);
         ret.setListeners(iterationListeners);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -77,12 +77,13 @@ public class SubsamplingLayer extends Layer {
     }
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         if(inputType == null || inputType.getType() != InputType.Type.CNN){
             throw new IllegalStateException("Invalid input for Subsampling layer (layer name=\"" + getLayerName() + "\"): Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, ((InputType.InputTypeConvolutional) inputType).getDepth(), getLayerName());
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, ((InputType.InputTypeConvolutional) inputType).getDepth(),
+                layerIndex, getLayerName(), SubsamplingLayer.class);
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.layers;
 
 import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.Updater;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -347,6 +348,17 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
         applyDropOutIfNecessary(training);
         INDArray b = getParam(DefaultParamInitializer.BIAS_KEY);
         INDArray W = getParam(DefaultParamInitializer.WEIGHT_KEY);
+
+        //Input validation:
+        if(input.rank() != 2 || input.columns() != W.rows() ){
+            if(input.rank() != 2){
+                throw new DL4JInvalidInputException("Input that is not a matrix; expected matrix (rank 2), got rank " + input.rank()
+                        + " array with shape " + Arrays.toString(input.shape()));
+            }
+            throw new DL4JInvalidInputException("Input size (" + input.columns() + " columns; shape = " + Arrays.toString(input.shape())
+                    + ") is invalid: does not match layer input size (layer # inputs = " + W.size(0) + ")");
+        }
+
         if(conf.isUseDropConnect() && training && conf.getLayer().getDropOut() > 0) {
             W = Dropout.applyDropConnect(this,DefaultParamInitializer.WEIGHT_KEY);
         }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseOutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseOutputLayer.java
@@ -21,6 +21,7 @@ package org.deeplearning4j.nn.layers;
 import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.berkeley.Triple;
 import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.api.Updater;
 import org.deeplearning4j.nn.api.layers.IOutputLayer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -164,7 +165,12 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
     /** Returns tuple: {Gradient,Delta,Output} given preOut */
     private Pair<Gradient,INDArray> getGradientsAndDelta(INDArray preOut) {
         ILossFunction lossFunction = layerConf().getLossFn();
-        INDArray delta = lossFunction.computeGradient(getLabels2d(), preOut, layerConf().getActivationFunction(), maskArray);
+        INDArray labels2d = getLabels2d();
+        if(labels2d.size(1) != preOut.size(1)){
+            throw new DL4JInvalidInputException("Labels array numColumns (size(1) = " + labels2d.size(1) + ") does not match output layer"
+                    + " number of outputs (nOut = " + preOut.size(1) + ")");
+        }
+        INDArray delta = lossFunction.computeGradient(labels2d, preOut, layerConf().getActivationFunction(), maskArray);
 
         Gradient gradient = new DefaultGradient();
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.nn.layers.convolution;
 
 
 import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
@@ -190,6 +191,15 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
             weights = Dropout.applyDropConnect(this, ConvolutionParamInitializer.WEIGHT_KEY);
         }
 
+        //Input validation: expect rank 4 matrix
+        if(input.rank() != 4){
+            throw new DL4JInvalidInputException("Got rank " + input.rank() + " array as input to ConvolutionLayer with shape "
+                    + Arrays.toString(input.shape()) + ". "
+                    + "Expected rank 4 array with shape [minibatchSize, layerInputDepth, inputHeight, inputWidth]."
+                    + (input.rank() == 2 ? " (Wrong input type (see InputType.convolutionalFlat()) or wrong data type?)" : "")
+            );
+        }
+
         int miniBatch = input.size(0);
         int inH = input.size(2);
         int inW = input.size(3);
@@ -197,8 +207,8 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         int outDepth = weights.size(0);
         int inDepth = weights.size(1);
         if(input.size(1) != inDepth){
-            throw new IllegalStateException("Cannot do forward pass: data input depth does not match CNN layer configuration"
-                    + " (data input depth = " + input.size(1) + ", shape=" + Arrays.toString(input.shape()) + "; expected"
+            throw new DL4JInvalidInputException("Cannot do forward pass: input array depth does not match CNN layer configuration"
+                    + " (data input depth = " + input.size(1) + ", [minibatch,inputDepth,height,width]=" + Arrays.toString(input.shape()) + "; expected"
                     + " input depth = " + inDepth + ")");
         }
         int kH = weights.size(2);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -27,6 +27,7 @@ import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.BaseLayer;
 import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
+import org.deeplearning4j.util.ConvolutionUtils;
 import org.deeplearning4j.util.Dropout;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.Shape;
@@ -106,8 +107,11 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         int[] strides = layerConf().getStride();
         int[] pad = layerConf().getPadding();
 
-        int outH = Convolution.outSize(inH, kernel[0], strides[0], pad[0],false);
-        int outW = Convolution.outSize(inW, kernel[1], strides[1], pad[1], false);
+        int[] outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, pad);    //Also performs validation
+        int outH = outSize[0];
+        int outW = outSize[1];
+
+
 
 
         INDArray biasGradView = gradientViews.get(ConvolutionParamInitializer.BIAS_KEY);
@@ -207,7 +211,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         int outDepth = weights.size(0);
         int inDepth = weights.size(1);
         if(input.size(1) != inDepth){
-            throw new DL4JInvalidInputException("Cannot do forward pass: input array depth does not match CNN layer configuration"
+            throw new DL4JInvalidInputException("Cannot do forward pass in Convolution layer: input array depth does not match CNN layer configuration"
                     + " (data input depth = " + input.size(1) + ", [minibatch,inputDepth,height,width]=" + Arrays.toString(input.shape()) + "; expected"
                     + " input depth = " + inDepth + ")");
         }
@@ -218,8 +222,10 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         int[] strides = layerConf().getStride();
         int[] pad = layerConf().getPadding();
 
-        int outH = Convolution.outSize(inH, kernel[0], strides[0], pad[0],false);
-        int outW = Convolution.outSize(inW, kernel[1], strides[1], pad[1], false);
+        int[] outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, pad);    //Also performs validation
+        int outH = outSize[0];
+        int outW = outSize[1];
+
 
         if (helper != null) {
             INDArray ret = helper.preOutput(input, weights, bias, kernel, strides, pad, layerConf().getCudnnAlgoMode());

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.layers.convolution.subsampling;
 
 import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
@@ -197,6 +198,12 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
     public INDArray activate(boolean training) {
         if(training && conf.getLayer().getDropOut() > 0) {
             Dropout.applyDropout(input,conf.getLayer().getDropOut());
+        }
+
+        //Input validation: expect rank 4 matrix
+        if(input.rank() != 4){
+            throw new DL4JInvalidInputException("Got rank " + input.rank() + " array as input to SubsamplingLayer with shape "
+                    + Arrays.toString(input.shape()) + ". Expected rank 4 array with shape [minibatchSize, depth, inputHeight, inputWidth].");
         }
 
         int miniBatch = input.size(0);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/embedding/EmbeddingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/embedding/EmbeddingLayer.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.layers.feedforward.embedding;
 
 import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
@@ -80,7 +81,7 @@ public class EmbeddingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.
     public INDArray preOutput(boolean training){
         if(input.columns() != 1){
             //Assume shape is [numExamples,1], and each entry is an integer index
-            throw new IllegalStateException("Cannot do forward pass for embedding layer with input more than one column. "
+            throw new DL4JInvalidInputException("Cannot do forward pass for embedding layer with input more than one column. "
                     + "Expected input shape: [numExamples,1] with each entry being an integer index");
         }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelpers.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelpers.java
@@ -127,9 +127,15 @@ public class LSTMHelpers {
 
         //Input validation: check input data matches nIn
         if(input.size(1) != inputWeights.size(0)){
-            throw new DL4JInvalidInputException(
-                    "Received input with size(1) = " + input.size(1) + " (input array shape = " + Arrays.toString(input.shape()) +
-                            "); input.size(1) must match layer nIn size (nIn = " + inputWeights.size(0) + ")");
+            throw new DL4JInvalidInputException("Received input with size(1) = " + input.size(1) + " (input array shape = "
+                    + Arrays.toString(input.shape()) + "); input.size(1) must match layer nIn size (nIn = " + inputWeights.size(0) + ")");
+        }
+        //Input validation: check that if past state is provided, that it has same
+        //These can be different if user forgets to call rnnClearPreviousState() between calls of rnnTimeStep
+        if(prevOutputActivations != null && prevOutputActivations.size(0) != input.size(0)){
+            throw new DL4JInvalidInputException("Previous activations (stored state) number of examples = " + prevOutputActivations.size(0)
+                + " but input array number of examples = " + input.size(0) + ". Possible cause: using rnnTimeStep() without calling"
+                + " rnnClearPreviousState() between different sequences?");
         }
 
         //initialize prevOutputActivations to zeroes

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelpers.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelpers.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.layers.recurrent;
 
 import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
@@ -14,6 +15,7 @@ import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
@@ -122,6 +124,13 @@ public class LSTMHelpers {
         }
 
         Level1 l1BLAS = Nd4j.getBlasWrapper().level1();
+
+        //Input validation: check input data matches nIn
+        if(input.size(1) != inputWeights.size(0)){
+            throw new DL4JInvalidInputException(
+                    "Received input with size(1) = " + input.size(1) + " (input array shape = " + Arrays.toString(input.shape()) +
+                            "); input.size(1) must match layer nIn size (nIn = " + inputWeights.size(0) + ")");
+        }
 
         //initialize prevOutputActivations to zeroes
         if (prevOutputActivations == null) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/LayerValidation.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/LayerValidation.java
@@ -1,0 +1,26 @@
+package org.deeplearning4j.util;
+
+import org.deeplearning4j.exception.DL4JInvalidConfigException;
+
+/**
+ * Created by Alex on 12/11/2016.
+ */
+public class LayerValidation {
+
+    /**
+     * Asserts that the layer nIn and nOut values are set for the layer
+     *
+     * @param layerType     Type of layer ("DenseLayer", etc)
+     * @param layerName     Name of the layer (may be null if not set)
+     * @param layerIndex    Index of the layer
+     * @param nIn           nIn value
+     * @param nOut          nOut value
+     */
+    public static void assertNInNOutSet(String layerType, String layerName, int layerIndex, int nIn, int nOut){
+        if (nIn <= 0 || nOut <= 0) {
+            if(layerName == null) layerName = "(name not set)";
+            throw new DL4JInvalidConfigException(layerType + " (index=" + layerIndex + ", name=" + layerName +
+                    ") nIn=" + nIn + ", nOut=" + nOut + "; nIn and nOut must be > 0");
+        }
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/customlayer/layer/CustomLayer.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/customlayer/layer/CustomLayer.java
@@ -63,7 +63,7 @@ public class CustomLayer extends FeedForwardLayer {
     }
 
     @Override
-    public InputType getOutputType(InputType inputType) {
+    public InputType getOutputType(int layerIndex, InputType inputType) {
         return InputType.feedForward(10);
     }
 


### PR DESCRIPTION
***WIP DO NOT MERGE***
(Tests are passing, so this *can* be merged - but more tests/improvements to come)


Some examples (before + after):

Wrong sized input to DenseLayer:
Before: java.lang.IllegalStateException: Column of left array 20 != rows of right 10 or rows of left array 1 != columns of right 10
After:  Input size (20 columns; shape = [1, 20]) is invalid: does not match expected input size (layer # inputs = 10)

Wrong labels size (not matching nOut):
Before: java.lang.IllegalStateException: Mis matched lengths: [20] != [10]
After:  Labels array numColumns (size(1) = 20) does not match output layer number of outputs (nOut = 10)

Feeding 2d data to CNN:
Before: java.lang.IllegalArgumentException: Invalid size index 2 wher it's >= rank 2
After:  Got rank 2 array as input to ConvolutionLayer with shape [1, 1280]. Expected rank 4 array with shape [minibatchSize, layerInputDepth, inputHeight, inputWidth]. (Wrong input type (see InputType.convolutionalFlat()) or wrong data type?)

Feeding 2d data to Subsampling layer:
Before: java.lang.IllegalArgumentException: Invalid size index 2 wher it's >= rank 2
After:  Got rank 2 array as input to SubsamplingLayer with shape [1, 1280]. Expected rank 4 array with shape [minibatchSize, depth, inputHeight, inputWidth].

Creating DenseLayer, GravesLSTM with nIn or nOut = 0
Before:	java.lang.IllegalArgumentException: Length must be >= 1
After:  DenseLayer (index=0, name=(name not set)) nIn=0, nOut=10; nIn and nOut must be > 0

Creating OutputLayer, GravesLSTM, RnnOutputLayer with nOut = 0
Before: java.lang.NullPointerException
After:	OutputLayer (index=1, name=(name not set)) nIn=10, nOut=0; nIn and nOut must be > 0



Not resetting properly between calls of rnnTimeStep:
Before:	java.lang.IllegalArgumentException: A rows must equal C rows. MMul attempt: [3, 5]x[5, 20]; result array provided: [5, 20]
After:	testInvalidRnnTimeStep(): Previous activations (stored state) number of examples = 3 but input array number of examples = 5. Possible cause: using rnnTimeStep() without calling rnnClearPreviousState() between different sequences?


Invalid CNN config:
Before: java.lang.IllegalStateException: Invalid input configuration (layer name = "null") for height: inHeight=10, kernelH=3, padH=0, strideH=2; (10-3+2*0)/2 is not an integer
After:  
```Invalid configuration for layer (idx=0, name=(not named), type=ConvolutionLayer) for height dimension: 
Combination of kernel size, stride and padding are not valid for given input height.
Require: (input - kernelSize + 2*padding)/stride + 1 in height dimension to be an integer. Got: (10 - 3 + 2*0)/2 + 1 = 4.50
See "Constraints on strides" at http://cs231n.github.io/convolutional-networks/
Input type = InputTypeConvolutional(h=10,w=10,d=3), kernel = [3, 2], strides = [2, 2], padding = [0, 0], layer size (output depth) = 5
```



CNN: Feed in data size smaller than kernel size:
Before: JVM crash :/
After:	Invalid input data or configuration: kernel height and input height must satisfy 0 < kernel height <= input height + 2 * padding height. 
Got kernel height = 7, input height = 5 and padding height = 0 which do not satisfy 0 < 7 <= 5
Input size: [numExamples,inputDepth,inputHeight,inputWidth]=[3, 3, 5, 5], kernel=[7, 7], strides=[1, 1], padding=[0, 0]

CNN: Feed in data size that does not satisfy constraints (bad data or not using InputType functionality):
Before: No error (not detected) :(
After:  Invalid input data or configuration: Combination of kernel size, stride and padding are not valid for given input height.
Require: (input - kernelSize + 2*padding)/stride + 1 in height dimension to be an integer. Got: (10 - 3 + 2*0)/2 + 1 = 4.50
See "Constraints on strides" at http://cs231n.github.io/convolutional-networks/
Input size: [numExamples,inputDepth,inputHeight,inputWidth]=[3, 3, 10, 10], kernel=[3, 3], strides=[2, 2], padding=[0, 0]


SequenceRecordReaderDataSetIterator - index > numPossibleLabels (1 and 2 reader cases)
Before:	java.lang.IllegalArgumentException: Invalid indices: cannot get [1,2] from a [2, 2] NDArray
Before: java.lang.ArrayIndexOutOfBoundsException: 2
After:	Invalid classification data: expect label value (at label index column = 1) to be in range 0 to 1 inclusive (0 to numClasses-1, with numClasses=2); got label value of 2
After:  Invalid classification data: expect label value to be in range 0 to 1 inclusive (0 to numClasses-1, with numClasses=2); got label value of 2
