### PR TITLE
Deprecate NetSaverLoaderUtils

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/NetSaverLoaderUtils.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/NetSaverLoaderUtils.java
@@ -18,7 +18,7 @@ import java.util.Map;
 /**
  * Utility to save and load network configuration and parameters.
  */
-
+@Deprecated
 public class NetSaverLoaderUtils {
     private static final Logger log = LoggerFactory.getLogger(NetSaverLoaderUtils.class);
 


### PR DESCRIPTION
For some releases now ModelSerializer is supposed to be used instead of NetSaverLoaderUtils. After the next release, this should be deleted all together.