### PR TITLE
2402 Method org.apache.spark.input.PortableDataStream#close is deprecated and shouldn't be used

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/LoadSerializedDataSetFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/LoadSerializedDataSetFunction.java
@@ -4,6 +4,7 @@ import org.apache.spark.api.java.function.Function;
 import org.apache.spark.input.PortableDataStream;
 import org.nd4j.linalg.dataset.DataSet;
 
+import java.io.DataInputStream;
 import java.io.InputStream;
 
 /**
@@ -14,13 +15,10 @@ import java.io.InputStream;
 public class LoadSerializedDataSetFunction implements Function<PortableDataStream,DataSet> {
     @Override
     public DataSet call(PortableDataStream pds) throws Exception {
-        try {
-            InputStream is = pds.open();
+        try(DataInputStream is = pds.open()) {
             DataSet d = new DataSet();
             d.load(is);
             return d;
-        } finally {
-            pds.close();
         }
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/LoadSerializedDataSetFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/LoadSerializedDataSetFunction.java
@@ -4,7 +4,6 @@ import org.apache.spark.api.java.function.Function;
 import org.apache.spark.input.PortableDataStream;
 import org.nd4j.linalg.dataset.DataSet;
 
-import java.io.DataInputStream;
 import java.io.InputStream;
 
 /**
@@ -15,7 +14,7 @@ import java.io.InputStream;
 public class LoadSerializedDataSetFunction implements Function<PortableDataStream,DataSet> {
     @Override
     public DataSet call(PortableDataStream pds) throws Exception {
-        try(DataInputStream is = pds.open()) {
+        try(InputStream is = pds.open()) {
             DataSet d = new DataSet();
             d.load(is);
             return d;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamDataSetIterator.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamDataSetIterator.java
@@ -5,6 +5,8 @@ import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Iterator;
@@ -144,10 +146,10 @@ public class PortableDataStreamDataSetIterator implements DataSetIterator {
 
     private DataSet load(PortableDataStream pds){
         DataSet ds = new DataSet();
-        try{
-            ds.load(pds.open());
-        } finally {
-            pds.close();
+        try(DataInputStream is = pds.open()){
+            ds.load(is);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
         cursor++;
         return ds;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamDataSetIterator.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamDataSetIterator.java
@@ -5,7 +5,7 @@ import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 
-import java.io.DataInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
@@ -146,7 +146,7 @@ public class PortableDataStreamDataSetIterator implements DataSetIterator {
 
     private DataSet load(PortableDataStream pds){
         DataSet ds = new DataSet();
-        try(DataInputStream is = pds.open()){
+        try(InputStream is = pds.open()){
             ds.load(is);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamMultiDataSetIterator.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamMultiDataSetIterator.java
@@ -5,8 +5,8 @@ import org.nd4j.linalg.dataset.api.MultiDataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
 import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
 
-import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Iterator;
@@ -68,7 +68,7 @@ public class PortableDataStreamMultiDataSetIterator implements MultiDataSetItera
     public MultiDataSet next() {
         MultiDataSet ds = new org.nd4j.linalg.dataset.MultiDataSet();
         PortableDataStream pds = iter.next();
-        try(DataInputStream is = pds.open()) {
+        try(InputStream is = pds.open()) {
             ds.load(is);
         } catch(IOException e){
             throw new RuntimeException(e);

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamMultiDataSetIterator.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/iterator/PortableDataStreamMultiDataSetIterator.java
@@ -5,6 +5,7 @@ import org.nd4j.linalg.dataset.api.MultiDataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
 import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
 
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
@@ -67,8 +68,8 @@ public class PortableDataStreamMultiDataSetIterator implements MultiDataSetItera
     public MultiDataSet next() {
         MultiDataSet ds = new org.nd4j.linalg.dataset.MultiDataSet();
         PortableDataStream pds = iter.next();
-        try {
-            ds.load(pds.open());
+        try(DataInputStream is = pds.open()) {
+            ds.load(is);
         } catch(IOException e){
             throw new RuntimeException(e);
         } finally {


### PR DESCRIPTION
This patch make sure handling of closing stream is done using try block, rather than using close method on class that doesn't implement InputStream interface