### PR TITLE
Fix vertex ordering issue when cloning computation graph config

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/ComputationGraphConfigurationTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/ComputationGraphConfigurationTest.java
@@ -223,6 +223,25 @@ public class ComputationGraphConfigurationTest {
         assertEquals(5,sigv.getSecondVal());
     }
 
+    @Test
+    public void testOutputOrderDoesntChangeWhenCloning() {
+        ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder()
+            .graphBuilder()
+            .addInputs("in")
+            .addLayer("out1", new OutputLayer.Builder().nIn(1).nOut(1).build(), "in")
+            .addLayer("out2", new OutputLayer.Builder().nIn(1).nOut(1).build(), "in")
+            .addLayer("out3", new OutputLayer.Builder().nIn(1).nOut(1).build(), "in")
+            .setOutputs("out1", "out2", "out3")
+            .build();
+
+        ComputationGraphConfiguration cloned = conf.clone();
+
+        String json = conf.toJson();
+        String jsonCloned = cloned.toJson();
+
+        assertEquals(json, jsonCloned);
+    }
+
     @AllArgsConstructor @NoArgsConstructor @Data @EqualsAndHashCode(callSuper=false)
     public static class StaticInnerGraphVertex extends GraphVertex {
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
@@ -184,12 +184,12 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
     public ComputationGraphConfiguration clone() {
         ComputationGraphConfiguration conf = new ComputationGraphConfiguration();
 
-        conf.vertices = new HashMap<>();
+        conf.vertices = new LinkedHashMap<>();
         for (Map.Entry<String, GraphVertex> entry : this.vertices.entrySet()) {
             conf.vertices.put(entry.getKey(), entry.getValue().clone());
         }
 
-        conf.vertexInputs = new HashMap<>();
+        conf.vertexInputs = new LinkedHashMap<>();
         for (Map.Entry<String, List<String>> entry : this.vertexInputs.entrySet()) {
             conf.vertexInputs.put(entry.getKey(), new ArrayList<>(entry.getValue()));
         }


### PR DESCRIPTION
When using `SparkComputationGraph.calculateScoreMultiDataSet()` I was getting different scores than when not using Spark. I found out that the problem was that the `clone()` function in `ComputationGraphConfiguration` class used `HashMap` instead of `LinkedHashMap`, resulting in a random ordering of outputs when JSON serializing the configuration. Effectively, the weights for outputs were being assigned to the wrong outputs when restoring the network, resulting in wrong scores.

This change fixes it.