### PR TITLE
Add P-norm pooling to SubsamplingLayer.

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/CNNGradientCheckTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/CNNGradientCheckTest.java
@@ -230,6 +230,7 @@ public class CNNGradientCheckTest {
         int[] kernel = {2,2};
         int[] stride = {1,1};
         int[] padding = {0,0};
+        int pnorm = 2;
 
         String[] activations = {"sigmoid","tanh"};
         SubsamplingLayer.PoolingType[] poolingTypes = new SubsamplingLayer.PoolingType[]{SubsamplingLayer.PoolingType.MAX, SubsamplingLayer.PoolingType.AVG, SubsamplingLayer.PoolingType.PNORM};
@@ -256,6 +257,7 @@ public class CNNGradientCheckTest {
                                     .kernelSize(kernel)
                                     .stride(stride)
                                     .padding(padding)
+                                    .pnorm(pnorm)
                                     .build())   //output: (4-2+0)/1+1 =3 -> 3x3x3
                             .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT).activation("softmax")
                                     .nIn(3 * 3 * 3)

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/CNNGradientCheckTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/CNNGradientCheckTest.java
@@ -232,7 +232,7 @@ public class CNNGradientCheckTest {
         int[] padding = {0,0};
 
         String[] activations = {"sigmoid","tanh"};
-        SubsamplingLayer.PoolingType[] poolingTypes = new SubsamplingLayer.PoolingType[]{SubsamplingLayer.PoolingType.MAX, SubsamplingLayer.PoolingType.AVG};
+        SubsamplingLayer.PoolingType[] poolingTypes = new SubsamplingLayer.PoolingType[]{SubsamplingLayer.PoolingType.MAX, SubsamplingLayer.PoolingType.AVG, SubsamplingLayer.PoolingType.PNORM};
 
         for(String afn : activations) {
             for (SubsamplingLayer.PoolingType poolingType : poolingTypes) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -33,9 +33,10 @@ public class SubsamplingLayer extends Layer {
     protected int[] kernelSize; // Same as filter size from the last conv layer
     protected int[] stride; // Default is 2. Down-sample by a factor of 2
     protected int[] padding;
+    protected int pnorm;
 
     public enum PoolingType {
-        MAX, AVG, SUM, NONE
+        MAX, AVG, SUM, PNORM, NONE
     }
 
     private SubsamplingLayer(Builder builder) {
@@ -49,6 +50,7 @@ public class SubsamplingLayer extends Layer {
         this.stride = builder.stride;
         this.padding = builder.padding;
         this.convolutionMode = builder.convolutionMode;
+        this.pnorm = builder.pnorm;
     }
 
     @Override
@@ -121,6 +123,10 @@ public class SubsamplingLayer extends Layer {
         return 0;
     }
 
+    public int getPnorm() {
+        return pnorm;
+    }
+
     @AllArgsConstructor
     public static class Builder extends Layer.Builder<Builder> {
         private PoolingType poolingType = PoolingType.MAX;
@@ -128,6 +134,7 @@ public class SubsamplingLayer extends Layer {
         private int[] stride = new int[] {2, 2}; // Default is 2. Down-sample by a factor of 2
         private int[] padding = new int[] {0, 0};
         private ConvolutionMode convolutionMode = null;
+        private int pnorm;
 
         public Builder(PoolingType poolingType, int[] kernelSize, int[] stride) {
             this.poolingType = poolingType;
@@ -220,6 +227,12 @@ public class SubsamplingLayer extends Layer {
         public Builder padding(int... padding){
             if(padding.length != 2) throw new IllegalArgumentException("Invalid input: must be length 2");
             this.padding = padding;
+            return this;
+        }
+
+        public Builder pnorm(int pnorm){
+            if(pnorm <= 0) throw new IllegalArgumentException("Invalid input: p-norm value must be greater than 0");
+            this.pnorm = pnorm;
             return this;
         }
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -99,7 +99,7 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
     @Override
     public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon) {
         int miniBatch = input.size(0);
-        int depth = input.size(1);
+        int inDepth = input.size(1);
         int inH = input.size(2);
         int inW = input.size(3);
 
@@ -153,7 +153,7 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         }
         if(!cOrderStrides && Shape.strideDescendingCAscendingF(epsilon)){
             cOrderStrides = true;
-        } else if(!Arrays.equals(new int[]{outH*outW, depth*outH*outW, outW, 1}, epsilon.stride())){
+        } else if(!Arrays.equals(new int[]{outH*outW, inDepth*outH*outW, outW, 1}, epsilon.stride())){
             //Unexpected/unusual strides, not either (a) or (b) cases above
             epsilon = epsilon.dup('c');
             cOrderStrides = true;
@@ -164,19 +164,19 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         INDArray epsilon1d;
         if(cOrderStrides){
             //"Dense/Output layer above strides... i.e., standard c-order strides
-            col6d = Nd4j.create(new int[]{miniBatch,depth,outH,outW,kernel[0],kernel[1]},'c');
+            col6d = Nd4j.create(new int[]{miniBatch,inDepth,outH,outW,kernel[0],kernel[1]},'c');
             col6dPermuted = col6d.permute(0,1,4,5,2,3);
             epsilon1d = epsilon.reshape('c', ArrayUtil.prod(epsilon.length()), 1);  //zero copy reshape
         } else {
             //"CNN layer above" strides...
-            col6d = Nd4j.create(new int[]{depth,miniBatch,outH,outW,kernel[0],kernel[1]},'c');
+            col6d = Nd4j.create(new int[]{inDepth,miniBatch,outH,outW,kernel[0],kernel[1]},'c');
             col6dPermuted = col6d.permute(1,0,4,5,2,3);
 
             INDArray epsilonTemp = epsilon.permute(1,0,2,3);
             epsilon1d = epsilonTemp.reshape('c', new int[]{ArrayUtil.prod(epsilon.length()),1} );   //Should be a zero-copy reshape always
         }
 
-        INDArray col2d = col6d.reshape('c',miniBatch*depth*outH*outW,kernel[0]*kernel[1]);
+        INDArray col2d = col6d.reshape('c',miniBatch*inDepth*outH*outW,kernel[0]*kernel[1]);
 
 
         switch(layerConf().getPoolingType()) {
@@ -192,8 +192,15 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                 col2d.addiColumnVector(epsilon1d);
                 break;
             case PNORM:
-                col2d.addiColumnVector(epsilon1d);
-                col2d.muli(kernel[0]*kernel[1]);
+                INDArray out = activate(true);
+                INDArray fwdPassCol2d = out.reshape('c',miniBatch*inDepth*outH*outW,1);
+                int pnorm = layerConf().getPnorm();
+                INDArray absp2 = Transforms.pow(Transforms.abs(input, true), pnorm-2, true);
+                INDArray numerator = input.mul(absp2);
+                INDArray denom = Transforms.pow(fwdPassCol2d, pnorm-1, false);
+
+                INDArray dPNormdIn = numerator.diviColumnVector(denom);
+                INDArray epsNext = dPNormdIn.muliColumnVector(epsilon1d);
                 break;
             case NONE:
                 return new Pair<>(retGradient, epsilon);
@@ -205,7 +212,7 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         // c-order [depth*H*W, H*W, W, 1] strides
         //To achieve this: [depth, miniBatch, H, W] in c order, then permute to [miniBatch, depth, H, W]
         //This gives us proper strides of 1 on the muli...
-        INDArray tempEpsilon = Nd4j.create(new int[]{depth,miniBatch,inH, inW},'c');
+        INDArray tempEpsilon = Nd4j.create(new int[]{inDepth,miniBatch,inH, inW},'c');
         INDArray outEpsilon = tempEpsilon.permute(1,0,2,3);
         Convolution.col2im(col6dPermuted, outEpsilon, strides[0], strides[1], pad[0], pad[1], inputHeight, inputWidth);
 
@@ -279,10 +286,11 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                 // applying the exponent to the input and recovering the signal by multiplying the kernel of
                 // the pooling layer and then applying the same inverse exponent
                 int pnorm = layerConf().getPnorm();
+                Transforms.abs(col2d, false);
                 Transforms.pow(col2d, pnorm, false);
-                reduced = col2d.mean(1);
-                reduced.muli(kernel[0]*kernel[1]);
-                Transforms.pow(reduced, (1/pnorm));
+                reduced = col2d.sum(1);
+                reduced.muli(reduced.size(1));
+                Transforms.pow(reduced, (1/pnorm), false);
                 break;
             case NONE:
                 return input;


### PR DESCRIPTION
`PNORM` setting is a direct port of Torch's `SpatialLPPooling` functionality: https://github.com/torch/nn/blob/master/SpatialLPPooling.lua

Literature can be found here: http://yann.lecun.com/exdb/publis/pdf/bruna-icml-14.pdf

Suggest @AlexDBlack review the PR.