### PR TITLE
Fix getOutputLayer calling wrong index on eval

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -2199,7 +2199,7 @@ public class ComputationGraph implements Serializable, Model {
      * @return Evaluation object, summarizing the results of the evaluation on the provided DataSetIterator
      */
     public Evaluation evaluate(DataSetIterator iterator, List<String> labelsList, int topN) {
-        if(layers == null || !(getOutputLayer(getNumLayers()-2) instanceof IOutputLayer)){
+        if(layers == null || !(getOutputLayer(0) instanceof IOutputLayer)){
             throw new IllegalStateException("Cannot evaluate network with no output layer");
         }
 


### PR DESCRIPTION
When doing `model.evaluate` there was a bug where a sanity check for an output layer was calling the wrong index. I fix this with a magical `0`.