### PR TITLE
Add DropoutLayer + change default activation for LossLayer

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/DropoutLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/DropoutLayerTest.java
@@ -1,0 +1,236 @@
+package org.deeplearning4j.nn.layers;
+
+import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.DropoutLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ */
+public class DropoutLayerTest {
+
+    @Test
+    public void testInputTypes() {
+        DropoutLayer config = new DropoutLayer.Builder(0.5).build();
+
+        InputType in1 = InputType.feedForward(20);
+        InputType in2 = InputType.convolutional(28, 28, 1);
+
+        assertEquals(in1, config.getOutputType(0, in1));
+        assertEquals(in2, config.getOutputType(0, in2));
+        assertNull(config.getPreProcessorForInputType(in1));
+        assertNull(config.getPreProcessorForInputType(in2));
+    }
+
+    @Test
+    public void testDropoutLayerWithoutTraining() throws Exception {
+        MultiLayerConfiguration confIntegrated = new NeuralNetConfiguration.Builder()
+                .seed(3648)
+                .list()
+                .layer(0, new ConvolutionLayer.Builder(1, 1)
+                        .stride(1, 1).nIn(1).nOut(1)
+                        .dropOut(0.25).activation("identity")
+                        .weightInit(WeightInit.XAVIER).build())
+                .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER)
+                        .activation("identity")
+                        .dropOut(0.25)
+                        .nOut(4).build())
+                .backprop(true).pretrain(false)
+                .setInputType(InputType.convolutionalFlat(2, 2, 1))
+                .build();
+
+        MultiLayerNetwork netIntegrated = new MultiLayerNetwork(confIntegrated);
+        netIntegrated.init();
+        netIntegrated.getLayer(0).setParam("W", Nd4j.eye(1));
+        netIntegrated.getLayer(0).setParam("b", Nd4j.zeros(1, 1));
+        netIntegrated.getLayer(1).setParam("W", Nd4j.eye(4));
+        netIntegrated.getLayer(1).setParam("b", Nd4j.zeros(4, 1));
+
+        MultiLayerConfiguration confSeparate = new NeuralNetConfiguration.Builder()
+                .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                .iterations(1)
+                .seed(3648)
+                .list()
+                .layer(0, new DropoutLayer.Builder(0.25).build())
+                .layer(1, new ConvolutionLayer.Builder(1, 1).stride(1, 1).nIn(1).nOut(1).activation("identity").weightInit(WeightInit.XAVIER).build())
+                .layer(2, new DropoutLayer.Builder(0.25).build())
+                .layer(3, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER)
+                        .activation("identity")
+                        .nOut(4).build())
+                .backprop(true).pretrain(false)
+                .setInputType(InputType.convolutionalFlat(2, 2, 1))
+                .build();
+
+        MultiLayerNetwork netSeparate = new MultiLayerNetwork(confSeparate);
+        netSeparate.init();
+        netSeparate.getLayer(1).setParam("W", Nd4j.eye(1));
+        netSeparate.getLayer(1).setParam("b", Nd4j.zeros(1, 1));
+        netSeparate.getLayer(3).setParam("W", Nd4j.eye(4));
+        netSeparate.getLayer(3).setParam("b", Nd4j.zeros(4, 1));
+
+        INDArray in = Nd4j.arange(1, 5);
+        List<INDArray> actTrainIntegrated = netIntegrated.feedForward(in.dup(), true);
+        List<INDArray> actTrainSeparate = netSeparate.feedForward(in.dup(), true);
+        List<INDArray> actTestIntegrated = netIntegrated.feedForward(in.dup(), false);
+        List<INDArray> actTestSeparate = netSeparate.feedForward(in.dup(), false);
+
+        assertEquals(actTrainIntegrated.get(1), actTrainSeparate.get(2));
+        assertEquals(actTrainIntegrated.get(2), actTrainSeparate.get(4));
+        assertEquals(actTestIntegrated.get(1), actTestSeparate.get(2));
+        assertEquals(actTestIntegrated.get(2), actTestSeparate.get(4));
+    }
+
+    @Test
+    public void testDropoutLayerWithDenseMnist() throws Exception {
+        DataSetIterator iter = new MnistDataSetIterator(2, 2);
+        DataSet next = iter.next();
+
+        // Run without separate activation layer
+        MultiLayerConfiguration confIntegrated = new NeuralNetConfiguration.Builder()
+                .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                .iterations(1)
+                .seed(123)
+                .list()
+                .layer(0, new DenseLayer.Builder().nIn(28 * 28 * 1).nOut(10).activation("relu").weightInit(WeightInit.XAVIER).build())
+                .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER)
+                        .activation("softmax")
+                        .dropOut(0.25)
+                        .nIn(10).nOut(10).build())
+                .backprop(true).pretrain(false)
+                .build();
+
+        MultiLayerNetwork netIntegrated = new MultiLayerNetwork(confIntegrated);
+        netIntegrated.init();
+        netIntegrated.fit(next);
+
+        // Run with separate activation layer
+        MultiLayerConfiguration confSeparate = new NeuralNetConfiguration.Builder()
+                .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                .iterations(1)
+                .seed(123)
+                .list()
+                .layer(0, new DenseLayer.Builder().nIn(28 * 28 * 1).nOut(10).activation("relu").weightInit(WeightInit.XAVIER).build())
+                .layer(1, new DropoutLayer.Builder(0.25).build())
+                .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER)
+                        .activation("softmax")
+                        .nIn(10).nOut(10).build())
+                .backprop(true).pretrain(false)
+                .build();
+
+        MultiLayerNetwork netSeparate = new MultiLayerNetwork(confSeparate);
+        netSeparate.init();
+        netSeparate.fit(next);
+
+        // check parameters
+        assertEquals(netIntegrated.getLayer(0).getParam("W"), netSeparate.getLayer(0).getParam("W"));
+        assertEquals(netIntegrated.getLayer(0).getParam("b"), netSeparate.getLayer(0).getParam("b"));
+        assertEquals(netIntegrated.getLayer(1).getParam("W"), netSeparate.getLayer(2).getParam("W"));
+        assertEquals(netIntegrated.getLayer(1).getParam("b"), netSeparate.getLayer(2).getParam("b"));
+
+        // check activations
+        netIntegrated.setInput(next.getFeatureMatrix());
+        netSeparate.setInput(next.getFeatureMatrix());
+
+        List<INDArray> actTrainIntegrated = netIntegrated.feedForward(true);
+        List<INDArray> actTrainSeparate = netSeparate.feedForward(true);
+        assertEquals(actTrainIntegrated.get(1), actTrainSeparate.get(1));
+        assertEquals(actTrainIntegrated.get(2), actTrainSeparate.get(3));
+
+        List<INDArray> actTestIntegrated = netIntegrated.feedForward(false);
+        List<INDArray> actTestSeparate = netSeparate.feedForward(false);
+        assertEquals(actTestIntegrated.get(1), actTrainSeparate.get(1));
+        assertEquals(actTestIntegrated.get(2), actTestSeparate.get(3));
+    }
+
+    @Test
+    public void testDropoutLayerWithConvMnist() throws Exception {
+        DataSetIterator iter = new MnistDataSetIterator(2, 2);
+        DataSet next = iter.next();
+
+        // Run without separate activation layer
+        MultiLayerConfiguration confIntegrated = new NeuralNetConfiguration.Builder()
+                .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                .iterations(1)
+                .seed(123)
+                .list()
+                .layer(0, new ConvolutionLayer.Builder(4, 4).stride(2, 2)
+                        .nIn(1).nOut(20).activation("relu")
+                        .weightInit(WeightInit.XAVIER).build())
+                .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER)
+                        .activation("softmax")
+                        .dropOut(0.25)
+                        .nOut(10).build())
+                .backprop(true).pretrain(false)
+                .setInputType(InputType.convolutionalFlat(28, 28, 1))
+                .build();
+
+        MultiLayerNetwork netIntegrated = new MultiLayerNetwork(confIntegrated);
+        netIntegrated.init();
+        netIntegrated.fit(next);
+
+        // Run with separate activation layer
+        MultiLayerConfiguration confSeparate = new NeuralNetConfiguration.Builder()
+                .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                .iterations(1)
+                .seed(123)
+                .list()
+                .layer(0, new ConvolutionLayer.Builder(4, 4).stride(2, 2)
+                        .nIn(1).nOut(20).activation("relu")
+                        .weightInit(WeightInit.XAVIER).build())
+                .layer(1, new DropoutLayer.Builder(0.25).build())
+                .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER)
+                        .activation("softmax")
+                        .nOut(10).build())
+                .backprop(true).pretrain(false)
+                .setInputType(InputType.convolutionalFlat(28, 28, 1))
+                .build();
+
+        MultiLayerNetwork netSeparate = new MultiLayerNetwork(confSeparate);
+        netSeparate.init();
+        netSeparate.fit(next);
+
+        // check parameters
+        assertEquals(netIntegrated.getLayer(0).getParam("W"), netSeparate.getLayer(0).getParam("W"));
+        assertEquals(netIntegrated.getLayer(0).getParam("b"), netSeparate.getLayer(0).getParam("b"));
+        assertEquals(netIntegrated.getLayer(1).getParam("W"), netSeparate.getLayer(2).getParam("W"));
+        assertEquals(netIntegrated.getLayer(1).getParam("b"), netSeparate.getLayer(2).getParam("b"));
+
+        // check activations
+        netIntegrated.setInput(next.getFeatureMatrix());
+        netSeparate.setInput(next.getFeatureMatrix());
+
+        List<INDArray> actTrainIntegrated = netIntegrated.feedForward(true);
+        List<INDArray> actTrainSeparate = netSeparate.feedForward(true);
+        assertEquals(actTrainIntegrated.get(1), actTrainSeparate.get(1));
+        assertEquals(actTrainIntegrated.get(2), actTrainSeparate.get(3));
+
+        List<INDArray> actTestIntegrated = netIntegrated.feedForward(false);
+        List<INDArray> actTestSeparate = netSeparate.feedForward(false);
+        assertEquals(actTestIntegrated.get(1), actTrainSeparate.get(1));
+        assertEquals(actTestIntegrated.get(2), actTestSeparate.get(3));
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
@@ -1,0 +1,92 @@
+package org.deeplearning4j.nn.conf.layers;
+
+import lombok.*;
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.params.EmptyParamInitializer;
+import org.deeplearning4j.optimize.api.IterationListener;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class DropoutLayer extends FeedForwardLayer {
+    private DropoutLayer(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public DropoutLayer clone() {
+        return (DropoutLayer) super.clone();
+    }
+
+    @Override
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners, int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        org.deeplearning4j.nn.layers.DropoutLayer ret = new org.deeplearning4j.nn.layers.DropoutLayer(conf);
+        ret.setListeners(iterationListeners);
+        ret.setIndex(layerIndex);
+        ret.setParamsViewArray(layerParamsView);
+        Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);
+        ret.setParamTable(paramTable);
+        ret.setConf(conf);
+        return ret;
+    }
+
+    @Override
+    public ParamInitializer initializer() { return EmptyParamInitializer.getInstance(); }
+
+    @Override
+    public InputType getOutputType(int layerIndex, InputType inputType) {
+        if(inputType == null) throw new IllegalStateException("Invalid input type: null for layer name \"" + getLayerName() + "\"");
+        return inputType;
+    }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override) {
+        //No op: dropout layer doesn't have a fixed nIn value
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        //No input preprocessor required; dropout applies to any input type
+        return null;
+    }
+
+    @Override
+    public double getL1ByParam(String paramName) {
+        //Not applicable
+        return 0;
+    }
+
+    @Override
+    public double getL2ByParam(String paramName) {
+        //Not applicable
+        return 0;
+    }
+
+    @Override
+    public double getLearningRateByParam(String paramName) {
+        //Not applicable
+        return 0;
+    }
+
+    @NoArgsConstructor
+    public static class Builder extends FeedForwardLayer.Builder<DropoutLayer.Builder> {
+        public Builder(double dropOut) {
+            this.dropOut = dropOut;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public DropoutLayer build() {
+
+            return new DropoutLayer(this);
+        }
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
@@ -55,14 +55,18 @@ public class LossLayer extends FeedForwardLayer {
 
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
-        public Builder() {}
+        public Builder() {
+            this.activation("identity");
+        }
 
         public Builder(LossFunctions.LossFunction lossFunction) {
             lossFunction(lossFunction);
+            this.activation("identity");
         }
 
         public Builder(ILossFunction lossFunction) {
             this.lossFn = lossFunction;
+            this.activation("identity");
         }
 
         @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -478,6 +478,7 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
 
     protected void applyDropOutIfNecessary(boolean training) {
         if(conf.getLayer().getDropOut() > 0 && !conf.isUseDropConnect() && training && !dropoutApplied ) {
+            input = input.dup();
             Dropout.applyDropout(input,conf.getLayer().getDropOut());
             dropoutApplied = true;
         }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/DropoutLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/DropoutLayer.java
@@ -1,0 +1,100 @@
+package org.deeplearning4j.nn.layers;
+
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+/**
+ * Created by davekale on 12/7/16.
+ */
+public class DropoutLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.DropoutLayer> {
+
+    public DropoutLayer(NeuralNetConfiguration conf) { super(conf); }
+
+    public DropoutLayer(NeuralNetConfiguration conf, INDArray input) {
+        super(conf, input);
+    }
+
+    @Override
+    public double calcL2() {
+        return 0;
+    }
+
+    @Override
+    public double calcL1() {
+        return 0;
+    }
+
+    @Override
+    public Type type() {
+        return Type.FEED_FORWARD;
+    }
+
+    @Override
+    public void fit(INDArray input) {}
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon) {
+        INDArray delta = epsilon.dup();
+
+        if(maskArray != null){
+            delta.muliColumnVector(maskArray);
+        }
+
+        Gradient ret = new DefaultGradient();
+        return new Pair<>(ret,delta);
+    }
+
+    @Override
+    public INDArray preOutput(boolean training) {
+        if(input == null)
+            throw new IllegalArgumentException("No null input allowed");
+        INDArray dummy = input;
+        applyDropOutIfNecessary(training);
+
+        INDArray ret;
+        if(training) {
+            //dup required: need to keep original input for backprop
+            ret = input.dup();
+        } else {
+            ret = input;
+        }
+
+        if(maskArray != null){
+            ret.muliColumnVector(maskArray);
+        }
+
+        return ret;
+    }
+
+    @Override
+    public INDArray activate(boolean training) {
+        INDArray z = preOutput(training);
+        return z;
+    }
+
+    @Override
+    public Layer transpose(){
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+
+    @Override
+    public Gradient calcGradient(Gradient layerError, INDArray indArray) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void merge(Layer layer, int batchSize) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public INDArray params(){
+        return null;
+    }
+}


### PR DESCRIPTION
A collection of commits related to LossLayer and the proposed DropoutLayer:

* Default activation for LossLayer is now `identity` so that calling `model.output()` gives the activation from the previous layer, not the loss.
* Added separate `DropoutLayer` (files: `nn/layers/DropoutLayer.java` and `nn/conf/layers/DroputLayer.java`).
* Added unit tests for `DropoutLayer`, similar to ActivationLayer unit tests.
* Minor change to `BaseLayer`: call to `applyDropoutIfNecessary` duplicates input so that the in-place dropout doesn't overwrite output of previous layer (in, e.g, calls to `model.feedForward()`.