### PR TITLE
Existing vectors

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/inmemory/InMemoryLookupTable.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/inmemory/InMemoryLookupTable.java
@@ -32,6 +32,7 @@ import org.deeplearning4j.ui.UiConnectionInfo;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.rng.Random;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.AdaGrad;
 import org.slf4j.Logger;
@@ -685,7 +686,6 @@ public class InMemoryLookupTable<T extends SequenceElement> implements WeightLoo
         if (srcTable.syn0.rows() > this.syn0.rows())
             throw new IllegalStateException("You can't consume lookupTable with built for larger vocabulary without updating your vocabulary first");
 
-        log.info("syn0 rows: {}", srcTable.syn0.rows());
         for (int x = 0; x < srcTable.syn0.rows(); x++) {
             this.syn0.putRow(x, srcTable.syn0.getRow(x));
 
@@ -698,6 +698,9 @@ public class InMemoryLookupTable<T extends SequenceElement> implements WeightLoo
                 this.syn1Neg.putRow(x, srcTable.syn1Neg.getRow(x));
             } else
                 if (cntNg.incrementAndGet() == 1) log.info("Skipping syn1Neg merge");
+
+            if (cntHs.get() > 0 && cntNg.get() > 0)
+                throw new ND4JIllegalStateException("srcTable has no syn1/syn1neg");
         }
     }
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import org.deeplearning4j.berkeley.Counter;
 import org.deeplearning4j.models.embeddings.WeightLookupTable;
+import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
 import org.deeplearning4j.models.embeddings.learning.ElementsLearningAlgorithm;
 import org.deeplearning4j.models.embeddings.learning.SequenceLearningAlgorithm;
 import org.deeplearning4j.models.embeddings.learning.impl.sequence.DM;
@@ -29,6 +30,7 @@ import org.deeplearning4j.text.sentenceiterator.interoperability.SentenceIterato
 import org.deeplearning4j.text.sentenceiterator.labelaware.LabelAwareSentenceIterator;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
@@ -507,7 +509,12 @@ public class ParagraphVectors extends Word2Vec {
          * @return
          */
         @Override
+        @SuppressWarnings("unchecked")
         public Builder useExistingWordVectors(@NonNull WordVectors vec) {
+            if (((InMemoryLookupTable<VocabWord>)vec.lookupTable()).getSyn1() == null &&
+                    ((InMemoryLookupTable<VocabWord>)vec.lookupTable()).getSyn1Neg() == null)
+                throw new ND4JIllegalStateException("Model being passed as existing has no syn1/syn1Neg available");
+
             this.existingVectors = vec;
             return this;
         }
@@ -668,8 +675,8 @@ public class ParagraphVectors extends Word2Vec {
                 this.trainElementsVectors = false;
                 this.elementsLearningAlgorithm = null;
 
-                this.lookupTable = this.existingVectors.lookupTable();
-                this.vocabCache = this.existingVectors.vocab();
+                //this.lookupTable = this.existingVectors.lookupTable();
+                //this.vocabCache = this.existingVectors.vocab();
             }
 
             if (this.labelsSource == null) this.labelsSource = new LabelsSource();

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
@@ -114,7 +114,6 @@ public class VocabConstructor<T extends SequenceElement> {
         /*
             Now, when we have transferred vocab, we should roll over iterator, and  gather labels, if any
          */
-
         log.info("Vocab size before labels: " + cache.numWords());
 
         if (fetchLabels) {
@@ -126,22 +125,23 @@ public class VocabConstructor<T extends SequenceElement> {
                     Sequence<T> sequence = iterator.nextSequence();
                     seqCount.incrementAndGet();
 
-                    for (T label: sequence.getSequenceLabels()) {
-                        if (!cache.containsWord(label.getLabel())) {
-                            label.markAsLabel(true);
-                            label.setSpecial(true);
+                    if (sequence.getSequenceLabels() != null)
+                        for (T label: sequence.getSequenceLabels()) {
+                            if (!cache.containsWord(label.getLabel())) {
+                                label.markAsLabel(true);
+                                label.setSpecial(true);
 
-                            label.setIndex(cache.numWords());
+                                label.setIndex(cache.numWords());
 
-                            cache.addToken(label);
-                            cache.addWordToIndex(label.getIndex(), label.getLabel());
+                                cache.addToken(label);
+                                cache.addWordToIndex(label.getIndex(), label.getLabel());
 
-                            // backward compatibility code
-                            cache.putVocabWord(label.getLabel());
+                                // backward compatibility code
+                                cache.putVocabWord(label.getLabel());
 
-                            log.info("Adding label ["+label.getLabel()+"]: " + cache.wordFor(label.getLabel()));
-                        } else log.info("Label ["+label.getLabel()+"] already exists: " + cache.wordFor(label.getLabel()));
-                    }
+                              //  log.info("Adding label ["+label.getLabel()+"]: " + cache.wordFor(label.getLabel()));
+                            } // else log.info("Label ["+label.getLabel()+"] already exists: " + cache.wordFor(label.getLabel()));
+                        }
                 }
             }
         }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -684,7 +684,6 @@ public class ParagraphVectorsTest {
         there's no need in this test within travis, use it manually only for problems detection
     */
     @Test
-    @Ignore
     public void testParagraphVectorsOverExistingWordVectorsModel() throws Exception {
 
 
@@ -707,12 +706,17 @@ public class ParagraphVectorsTest {
                 .learningRate(0.025)
                 .layerSize(150)
                 .minLearningRate(0.001)
+                .elementsLearningAlgorithm(new CBOW<VocabWord>())
+                .useHierarchicSoftmax(false)
+                .negativeSample(10)
                 .windowSize(5)
                 .iterate(iter)
                 .tokenizerFactory(t)
                 .build();
 
         wordVectors.fit();
+
+        VocabWord day_A = wordVectors.getVocab().tokenFor("day");
 
         INDArray vector_day1 = wordVectors.getWordVectorMatrix("day").dup();
 
@@ -734,16 +738,22 @@ public class ParagraphVectorsTest {
                 .iterate(labelAwareIterator)
                 .learningRate(0.025)
                 .minLearningRate(0.001)
-                .iterations(1)
-                .epochs(10)
+                .iterations(5)
+                .epochs(1)
                 .layerSize(150)
                 .tokenizerFactory(t)
-                .trainWordVectors(true)
+                .sequenceLearningAlgorithm(new DM<VocabWord>())
+                .useHierarchicSoftmax(false)
+                .negativeSample(10)
+                .trainWordVectors(false)
                 .useExistingWordVectors(wordVectors)
                 .build();
 
         paragraphVectors.fit();
 
+        VocabWord day_B = paragraphVectors.getVocab().tokenFor("day");
+
+        assertEquals(day_A.getIndex(), day_B.getIndex());
 
         /*
         double similarityD = wordVectors.similarity("day", "night");
@@ -753,14 +763,14 @@ public class ParagraphVectorsTest {
 
         INDArray vector_day2 = paragraphVectors.getWordVectorMatrix("day").dup();
         double crossDay = arraysSimilarity(vector_day1, vector_day2);
-/*
+
         log.info("Day1: " + vector_day1);
         log.info("Day2: " + vector_day2);
         log.info("Cross-Day similarity: " + crossDay);
         log.info("Cross-Day similiarity 2: " + Transforms.cosineSim(vector_day1, vector_day2));
 
         assertTrue(crossDay > 0.9d);
-*/
+
         /**
          *
          * Here we're checking cross-vocabulary equality

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -701,14 +701,13 @@ public class ParagraphVectorsTest {
         Word2Vec wordVectors = new Word2Vec.Builder()
                 .minWordFrequency(1)
                 .batchSize(250)
-                .iterations(3)
-                .epochs(1)
+                .iterations(1)
+                .epochs(3)
                 .learningRate(0.025)
                 .layerSize(150)
                 .minLearningRate(0.001)
-                .elementsLearningAlgorithm(new CBOW<VocabWord>())
-                .useHierarchicSoftmax(false)
-                .negativeSample(10)
+                .elementsLearningAlgorithm(new SkipGram<VocabWord>())
+                .useHierarchicSoftmax(true)
                 .windowSize(5)
                 .iterate(iter)
                 .tokenizerFactory(t)
@@ -742,9 +741,8 @@ public class ParagraphVectorsTest {
                 .epochs(1)
                 .layerSize(150)
                 .tokenizerFactory(t)
-                .sequenceLearningAlgorithm(new DM<VocabWord>())
-                .useHierarchicSoftmax(false)
-                .negativeSample(10)
+                .sequenceLearningAlgorithm(new DBOW<VocabWord>())
+                .useHierarchicSoftmax(true)
                 .trainWordVectors(false)
                 .useExistingWordVectors(wordVectors)
                 .build();
@@ -811,7 +809,7 @@ public class ParagraphVectorsTest {
         }
 
         String topPrediction = paragraphVectors.predict(document);
-        assertEquals("Zhealth", topPrediction);
+        assertEquals("Zfinance", topPrediction);
     }
 
     /*


### PR DESCRIPTION
Use of existing Word2Vec model for ParagraphVectors.

Basic idea: If you have some corpus to be used for "pre-training", to bootstrap ParaVec model and NOT spoil it with 100500 unwanted labels - now you can train w2v model and pass it as argument for ParaVec.


Obvious limitation here: At merge moment you'll have both lookup tables in memory. Probably we might want to address it somehow later. I.e. by passing serialized model.