### PR TITLE
ScaleVertex for scaling activations

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
@@ -46,7 +46,8 @@ import java.io.Serializable;
         @JsonSubTypes.Type(value = PreprocessorVertex.class, name = "PreprocessorVertex"),
         @JsonSubTypes.Type(value = StackVertex.class, name = "StackVertex"),
         @JsonSubTypes.Type(value = UnstackVertex.class, name = "UnstackVertex"),
-        @JsonSubTypes.Type(value = L2Vertex.class, name = "L2Vertex")
+        @JsonSubTypes.Type(value = L2Vertex.class, name = "L2Vertex"),
+        @JsonSubTypes.Type(value = ScaleVertex.class, name = "ScaleVertex")
 })
 public abstract class GraphVertex implements Cloneable, Serializable {
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ScaleVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ScaleVertex.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.conf.graph;
+
+import lombok.Data;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+/**
+ * A ScaleVertex is used to scale the size of activations of a single layer<br>
+ * For example, ResNet activations can be scaled in repeating blocks to keep variance
+ * under control.
+ *
+ * @author Justin Long (@crockpotveggies)
+ */
+@Data
+public class ScaleVertex extends GraphVertex {
+
+    public ScaleVertex(@JsonProperty("scaleFactor") double scaleFactor) {
+        this.scaleFactor = scaleFactor;
+    }
+
+    protected double scaleFactor;
+
+    @Override
+    public ScaleVertex clone() {
+        return new ScaleVertex(scaleFactor);
+    }
+
+    @Override
+    public boolean equals(Object o){
+        if(!(o instanceof ScaleVertex)) return false;
+        return ((ScaleVertex)o).scaleFactor == scaleFactor;
+    }
+
+    @Override
+    public int hashCode(){
+        return 123073088;
+    }
+
+    @Override
+    public int numParams(boolean backprop){
+        return 0;
+    }
+
+    @Override
+    public org.deeplearning4j.nn.graph.vertex.GraphVertex instantiate(ComputationGraph graph, String name, int idx,
+                                                                      INDArray paramsView, boolean initializeParams) {
+
+        return new org.deeplearning4j.nn.graph.vertex.impl.ScaleVertex(graph,name,idx,scaleFactor);
+    }
+
+    @Override
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
+        if(vertexInputs.length == 1) return vertexInputs[0];
+        InputType first = vertexInputs[0];
+
+        return first;   //Same output shape/size as
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/LayerVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/LayerVertex.java
@@ -95,7 +95,8 @@ public class LayerVertex extends BaseGraphVertex {
     @Override
     public Pair<Gradient, INDArray[]> doBackward(boolean tbptt) {
         if (!canDoBackward()) {
-            throw new IllegalStateException("Cannot do backward pass: all epsilons not set");
+            throw new IllegalStateException("Cannot do backward pass: all epsilons not set. Layer "+vertexName+" (idx "+vertexIndex+") numInputs "+
+                getNumInputArrays()+"; numOutputs "+getNumOutputConnections());
         }
 
         Pair<Gradient, INDArray> pair;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/ScaleVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/ScaleVertex.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.graph.vertex.impl;
+
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.graph.vertex.BaseGraphVertex;
+import org.deeplearning4j.nn.graph.vertex.VertexIndices;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * A ScaleVertex is used to scale the size of activations of a single layer<br>
+ * For example, ResNet activations can be scaled in repeating blocks to keep variance
+ * under control.
+ *
+ * @author Justin Long (@crockpotveggies)
+ */
+public class ScaleVertex extends BaseGraphVertex {
+
+    private double scaleFactor;
+
+    public ScaleVertex(ComputationGraph graph, String name, int vertexIndex, double scaleFactor){
+        this(graph,name,vertexIndex,null,null,scaleFactor);
+    }
+
+    public ScaleVertex(ComputationGraph graph, String name, int vertexIndex, VertexIndices[] inputVertices, VertexIndices[] outputVertices, double scaleFactor) {
+        super(graph, name, vertexIndex, inputVertices, outputVertices);
+        this.scaleFactor = scaleFactor;
+    }
+
+    @Override
+    public boolean hasLayer() {
+        return false;
+    }
+
+    @Override
+    public boolean isOutputVertex() {
+        return false;
+    }
+
+    @Override
+    public Layer getLayer() {
+        return null;
+    }
+
+    @Override
+    public INDArray doForward(boolean training) {
+        if(!canDoForward()) throw new IllegalStateException("Cannot do forward pass: inputs not set (ScaleVertex "+vertexName+" idx "+vertexIndex+")");
+
+        if(inputs.length > 1) throw new IllegalArgumentException("ScaleVertex (name "+vertexName+" idx "+vertexIndex+") only supports 1 input.");
+
+        INDArray prod = inputs[0].dup();
+        prod.muli(scaleFactor);
+
+        return prod;
+    }
+
+    @Override
+    public Pair<Gradient, INDArray[]> doBackward(boolean tbptt) {
+        if(!canDoBackward()) throw new IllegalStateException("Cannot do backward pass: errors not set (ScaleVertex "+vertexName+" idx "+vertexIndex+")");
+
+        return new Pair<>(null,new INDArray[]{epsilon.muli(1/scaleFactor)});
+    }
+
+    @Override
+    public void setBackpropGradientsViewArray(INDArray backpropGradientsViewArray) {
+        if(backpropGradientsViewArray != null) throw new RuntimeException("Vertex does not have gradients; gradients view array cannot be set here (ScaleVertex "+vertexName+" idx "+vertexIndex+")");
+    }
+
+    @Override
+    public String toString() {
+        return "ScaleVertex(id=" + this.getVertexIndex() + ",name=\"" + this.getVertexName() + "\",scaleFactor=" + scaleFactor + ")";
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/ScaleVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/ScaleVertex.java
@@ -77,7 +77,7 @@ public class ScaleVertex extends BaseGraphVertex {
     public Pair<Gradient, INDArray[]> doBackward(boolean tbptt) {
         if(!canDoBackward()) throw new IllegalStateException("Cannot do backward pass: errors not set (ScaleVertex "+vertexName+" idx "+vertexIndex+")");
 
-        return new Pair<>(null,new INDArray[]{epsilon.muli(1/scaleFactor)});
+        return new Pair<>(null,new INDArray[]{epsilon.muli(scaleFactor)});
     }
 
     @Override


### PR DESCRIPTION
Repeating blocks such as ResNet can sometimes create variance in activations. This vertex allows for `.muli(double)` scaling of output.

This is equivalent to TensorFlow's `scaleFactor * net`.

Developed in conversation with @AlexDBlack. @turambar should also be aware of this PR since it might impact imports from TensorFlow.

Added in a bonus descriptive error for `LayerVertex`.