### PR TITLE
Sanity check that pnorm is not 0.

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -194,6 +194,8 @@ public class SubsamplingLayer extends Layer {
         @Override
         @SuppressWarnings("unchecked")
         public SubsamplingLayer build() {
+            if(poolingType==PoolingType.PNORM && pnorm <= 0) throw new IllegalStateException("Incorrect Subsampling config: p-norm must be set when using PoolingType.PNORM");
+
             return new SubsamplingLayer(this);
         }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -296,7 +296,6 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                 // applying the exponent to the input and recovering the signal by multiplying the kernel of
                 // the pooling layer and then applying the same inverse exponent
                 int pnorm = layerConf().getPnorm();
-                if(pnorm <= 0) throw new IllegalStateException("Incorrect Subsampling config: pnorm must be set when using PoolingType.PNORM");
 
                 Transforms.abs(col2d, false);
                 Transforms.pow(col2d, pnorm, false);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -296,6 +296,8 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                 // applying the exponent to the input and recovering the signal by multiplying the kernel of
                 // the pooling layer and then applying the same inverse exponent
                 int pnorm = layerConf().getPnorm();
+                if(pnorm <= 0) throw new IllegalStateException("Incorrect Subsampling config: pnorm must be set when using PoolingType.PNORM")
+
                 Transforms.abs(col2d, false);
                 Transforms.pow(col2d, pnorm, false);
                 reduced = col2d.sum(1);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -296,7 +296,7 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                 // applying the exponent to the input and recovering the signal by multiplying the kernel of
                 // the pooling layer and then applying the same inverse exponent
                 int pnorm = layerConf().getPnorm();
-                if(pnorm <= 0) throw new IllegalStateException("Incorrect Subsampling config: pnorm must be set when using PoolingType.PNORM")
+                if(pnorm <= 0) throw new IllegalStateException("Incorrect Subsampling config: pnorm must be set when using PoolingType.PNORM");
 
                 Transforms.abs(col2d, false);
                 Transforms.pow(col2d, pnorm, false);


### PR DESCRIPTION
Just discovered that infs are thrown if pnorm is not properly set. This fixes it.