### PR TITLE
Keras backend server - building a shaded jar with all deps

### DIFF
--- a/deeplearning4j-keras/pom.xml
+++ b/deeplearning4j-keras/pom.xml
@@ -151,7 +151,7 @@
 
   <profiles>
     <profile>
-      <id>assembly</id>
+      <id>server-jar</id>
       <dependencies>
         <dependency>
           <groupId>ch.qos.logback</groupId>

--- a/deeplearning4j-keras/pom.xml
+++ b/deeplearning4j-keras/pom.xml
@@ -138,12 +138,34 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.deeplearning4j.keras.Server</mainClass>
+                </transformer>
               </transformers>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>assembly</id>
+      <dependencies>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.nd4j</groupId>
+          <artifactId>nd4j-native</artifactId>
+          <version>${nd4j.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Adds a new profile to deeplearning4j-keras (server-jar) which enables creating a shaded jar with all necessary deps (including a backend and a log lib).

Maven log from the build: 
https://gist.github.com/pkoperek/d34dadcd15248579f9ec94f6f6ed4dd3
(spoiler alert - it ends with success) 