### PR TITLE
create ngram tokens as space delimited words

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/NGramTokenizer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/NGramTokenizer.java
@@ -47,7 +47,7 @@ public class NGramTokenizer implements Tokenizer {
             for (int i = minN; i < min; i++) {
                 for (int j = 0; j < nOriginalTokens - i + 1; j++) {
                     List<String> originalTokensSlice = this.originalTokens.subList(j, j+ i);
-                    this.tokens.add(StringUtils.join(" ", originalTokensSlice));
+                    this.tokens.add(StringUtils.join(originalTokensSlice, " "));
                 }
             }
         }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/NGramTokenizerTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/NGramTokenizerTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -42,10 +43,28 @@ public class NGramTokenizerTest {
         while (tokenizer.hasMoreTokens()) {
             assertEquals(tokenizer.nextToken(), tokenizer2.nextToken());
         }
+
         int stringCount = factory.create(toTokenize).countTokens();
-        assertEquals(9, stringCount);
-        factory = new NGramTokenizerFactory(new DefaultTokenizerFactory(), 2, 2);
         List<String> tokens = factory.create(toTokenize).getTokens();
+        assertEquals(9, stringCount);
+
+        assertTrue(tokens.contains("Mary"));
+        assertTrue(tokens.contains("had"));
+        assertTrue(tokens.contains("a"));
+        assertTrue(tokens.contains("little"));
+        assertTrue(tokens.contains("lamb."));
+        assertTrue(tokens.contains("Mary had"));
+        assertTrue(tokens.contains("had a"));
+        assertTrue(tokens.contains("a little"));
+        assertTrue(tokens.contains("little lamb."));
+
+        factory = new NGramTokenizerFactory(new DefaultTokenizerFactory(), 2, 2);
+        tokens = factory.create(toTokenize).getTokens();
         assertEquals(4,tokens.size());
+
+        assertTrue(tokens.contains("Mary had"));
+        assertTrue(tokens.contains("had a"));
+        assertTrue(tokens.contains("a little"));
+        assertTrue(tokens.contains("little lamb."));
     }
 }


### PR DESCRIPTION
This change makes the NGramTokenizer behave as I believe it was originally intended - with words delimited by spaces.  

This pull request does not address the other items in the issue, namely:

> a) configurable brackets
> b) no spaces if brackets are used

#2819 