### PR TITLE
Fixed vectorizers to set stopWords and make uniform use of Collection…

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BagOfWordsVectorizer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BagOfWordsVectorizer.java
@@ -111,7 +111,7 @@ public class BagOfWordsVectorizer extends  BaseTextVectorizer {
         protected int minWordFrequency;
         protected VocabCache<VocabWord> vocabCache;
         protected LabelsSource labelsSource = new LabelsSource();
-        protected List<String> stopWords = new ArrayList<>();
+        protected Collection<String> stopWords = new ArrayList<>();
 
         public Builder() {
         }
@@ -147,7 +147,7 @@ public class BagOfWordsVectorizer extends  BaseTextVectorizer {
         }
 
         public Builder setStopWords(Collection<String> stopWords) {
-
+        	this.stopWords = stopWords;
             return this;
         }
 
@@ -158,6 +158,7 @@ public class BagOfWordsVectorizer extends  BaseTextVectorizer {
             vectorizer.iterator = this.iterator;
             vectorizer.minWordFrequency = this.minWordFrequency;
             vectorizer.labelsSource = this.labelsSource;
+            vectorizer.stopWords = this.stopWords;
 
             if (this.vocabCache == null) {
                 this.vocabCache = new AbstractCache.Builder<VocabWord>().build();

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BaseTextVectorizer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BaseTextVectorizer.java
@@ -14,6 +14,7 @@ import org.deeplearning4j.text.invertedindex.InvertedIndex;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -25,7 +26,7 @@ public abstract class BaseTextVectorizer implements TextVectorizer {
     protected int minWordFrequency;
     @Getter protected VocabCache<VocabWord> vocabCache;
     protected LabelsSource labelsSource;
-    protected List<String> stopWords = new ArrayList<>();
+    protected Collection<String> stopWords = new ArrayList<>();
     @Getter protected transient InvertedIndex<VocabWord> index;
 
     protected LabelsSource getLabelsSource() {
@@ -46,7 +47,7 @@ public abstract class BaseTextVectorizer implements TextVectorizer {
 
         VocabConstructor<VocabWord> constructor = new VocabConstructor.Builder<VocabWord>()
                 .addSource(iterator, minWordFrequency)
-                .setTargetVocabCache(vocabCache)
+                .setTargetVocabCache(vocabCache).setStopWords(stopWords)
                 .build();
 
         constructor.buildJointVocabulary(false, true);

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/TfidfVectorizer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/TfidfVectorizer.java
@@ -150,7 +150,7 @@ public class TfidfVectorizer extends BaseTextVectorizer {
         protected int minWordFrequency;
         protected VocabCache<VocabWord> vocabCache;
         protected LabelsSource labelsSource = new LabelsSource();
-        protected List<String> stopWords = new ArrayList<>();
+        protected Collection<String> stopWords = new ArrayList<>();
 
         public Builder() {
         }
@@ -186,7 +186,7 @@ public class TfidfVectorizer extends BaseTextVectorizer {
         }
 
         public Builder setStopWords(Collection<String> stopWords) {
-
+        	this.stopWords = stopWords;
             return this;
         }
 
@@ -203,6 +203,7 @@ public class TfidfVectorizer extends BaseTextVectorizer {
             }
 
             vectorizer.vocabCache = this.vocabCache;
+            vectorizer.stopWords = this.stopWords;
 
             return vectorizer;
         }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/VectorsConfiguration.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/VectorsConfiguration.java
@@ -10,6 +10,7 @@ import org.apache.commons.codec.binary.Base64;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -55,7 +56,7 @@ public class VectorsConfiguration implements Serializable {
     private String UNK = "UNK";
     private String STOP = "STOP";
 
-    private List<String> stopList = new ArrayList<>();
+    private Collection<String> stopList = new ArrayList<>();
 
     // overall model info
     private int vocabSize;

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
@@ -88,7 +88,7 @@ public class WordVectorsImpl<T extends SequenceElement> implements WordVectors {
     public final static String DEFAULT_UNK = "UNK";
     @Getter @Setter private String UNK = DEFAULT_UNK;
 
-    @Getter protected List<String> stopWords = new ArrayList<>(); //StopWords.getStopWords();
+    @Getter protected Collection<String> stopWords = new ArrayList<>(); //StopWords.getStopWords();
     /**
      * Returns true if the model has this word in the vocab
      * @param word the word to test for

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
@@ -365,7 +365,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
 
         protected boolean preciseWeightInit = false;
 
-        protected List<String> stopWords = new ArrayList<>();
+        protected Collection<String> stopWords = new ArrayList<>();
 
         protected VectorsConfiguration configuration = new VectorsConfiguration();
 
@@ -979,9 +979,9 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
         private final int limitLower;
         private AtomicBoolean isRunning = new AtomicBoolean(true);
         private AtomicLong nextRandom;
-        private List<String> stopList;
+        private Collection<String> stopList;
 
-        public AsyncSequencer(SequenceIterator<T> iterator, @NonNull List<String> stopList) {
+        public AsyncSequencer(SequenceIterator<T> iterator, @NonNull Collection<String> stopList) {
             this.iterator = iterator;
 //            this.linesCounter = linesCounter;
             this.setName("AsyncSequencer thread");

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructor.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class VocabConstructor<T extends SequenceElement> {
     private List<VocabSource<T>> sources = new ArrayList<>();
     private VocabCache<T> cache;
-    private List<String> stopWords;
+    private Collection<String> stopWords;
     private boolean useAdaGrad = false;
     private boolean fetchLabels = false;
     private int limit;
@@ -373,7 +373,7 @@ public class VocabConstructor<T extends SequenceElement> {
     public static class Builder<T extends SequenceElement> {
         private List<VocabSource<T>> sources = new ArrayList<>();
         private VocabCache<T> cache;
-        private List<String> stopWords = new ArrayList<>();
+        private Collection<String> stopWords = new ArrayList<>();
         private boolean useAdaGrad = false;
         private boolean fetchLabels = false;
         private InvertedIndex<T> index;
@@ -449,7 +449,7 @@ public class VocabConstructor<T extends SequenceElement> {
             return this;
         }
 */
-        public Builder<T> setStopWords(@NonNull List<String> stopWords) {
+        public Builder<T> setStopWords(@NonNull Collection<String> stopWords) {
             this.stopWords = stopWords;
             return this;
         }


### PR DESCRIPTION
…<String> as the stopWord collection, as it may use more efficient data structures for contains() compared to List.

(the code on origin/master is not setting the stopwords correctly in the Builders and has mixed use of Collection<String> and List<String> as the stopwords datatype). Please check the changes for more detail, they are trivial. 