### PR TITLE
Mitigate absence of source file for KerasModelConfigurationTest/importMnistCnnTensorFlowConfigurationTest

### DIFF
--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasModelConfigurationTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasModelConfigurationTest.java
@@ -6,6 +6,7 @@ import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.nd4j.linalg.io.ClassPathResource;
 
 import java.io.File;
@@ -99,7 +100,7 @@ public class KerasModelConfigurationTest {
         model.init();
     }
 
-    @Test
+    @Ignore
     public void importMnistCnnTensorFlowConfigurationTest() throws Exception {
         ClassPathResource configResource = new ClassPathResource("modelimport/keras/examples/mnist_cnn/mnist_cnn_tf_config.json",
                 KerasModelConfigurationTest.class.getClassLoader());


### PR DESCRIPTION
Mitigates #2868 until proper resolution in dl4j-test-resources
/cc @turambar