### PR TITLE
Bugfix for merge layers that fixes import of ResNet50

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/Hdf5Archive.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/Hdf5Archive.java
@@ -93,6 +93,22 @@ public class Hdf5Archive {
     }
 
     /**
+     * Check whether group path contains string attribute.
+     *
+     * @param attributeName     Name of attribute
+     * @param groups            Array of zero or more ancestor groups from root to parent.
+     * @return                  Boolean indicating whether attribute exists in group path.
+     */
+    public boolean hasAttribute(String attributeName, String... groups) {
+        if (groups.length == 0)
+            return this.file.attrExists(attributeName);
+        hdf5.Group group = this.file.asCommonFG().openGroup(groups[0]);
+        for (int i = 1; i < groups.length; i++)
+            group = group.asCommonFG().openGroup(groups[i]);
+        return group.attrExists(attributeName);
+    }
+
+    /**
      * Get list of data sets from group path.
      *
      * @param groups    Array of zero or more ancestor groups from root to parent.

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
@@ -519,11 +519,15 @@ public class KerasModel {
             return this;
         }
 
-        public ModelBuilder modelHdf5Filename(String modelHdf5Filename) throws UnsupportedKerasConfigurationException {
+        public ModelBuilder modelHdf5Filename(String modelHdf5Filename)
+                throws UnsupportedKerasConfigurationException, InvalidKerasConfigurationException {
             this.weightsArchive = this.trainingArchive = new Hdf5Archive(modelHdf5Filename);
             this.weightsRoot = HDF5_MODEL_WEIGHTS_ROOT;
+            if (!this.weightsArchive.hasAttribute(HDF5_MODEL_CONFIG_ATTRIBUTE))
+                throw new InvalidKerasConfigurationException("Model configuration attribute missing from " + modelHdf5Filename + " archive.");
             this.modelJson = this.weightsArchive.readAttributeAsJson(HDF5_MODEL_CONFIG_ATTRIBUTE);
-            this.trainingJson = this.weightsArchive.readAttributeAsJson(HDF5_TRAINING_CONFIG_ATTRIBUTE);
+            if (this.trainingArchive.hasAttribute(HDF5_TRAINING_CONFIG_ATTRIBUTE))
+                this.trainingJson = this.trainingArchive.readAttributeAsJson(HDF5_TRAINING_CONFIG_ATTRIBUTE);
             return this;
         }
 

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasMerge.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasMerge.java
@@ -13,6 +13,9 @@ import java.util.Map;
 /**
  * Imports a Keras Merge layer as a DL4J Merge (graph) vertex.
  *
+ * TODO: handle axes arguments that alter merge behavior (requires changes to DL4J?)
+ * TODO: unsupported merge modes (require changes to DL4J)
+ *
  * @author dave@skymind.io
  */
 @Slf4j

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasMerge.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasMerge.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.nn.modelimport.keras.layers;
 
 import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.nn.conf.graph.ElementWiseVertex;
 import org.deeplearning4j.nn.conf.graph.MergeVertex;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.modelimport.keras.InvalidKerasConfigurationException;
@@ -16,6 +17,17 @@ import java.util.Map;
  */
 @Slf4j
 public class KerasMerge extends KerasLayer {
+
+    public static final String LAYER_FIELD_MODE = "mode";
+    public static final String LAYER_MERGE_MODE_SUM = "sum";
+    public static final String LAYER_MERGE_MODE_MUL = "mul";
+    public static final String LAYER_MERGE_MODE_CONCAT = "concat";
+    public static final String LAYER_MERGE_MODE_AVE = "ave";
+    public static final String LAYER_MERGE_MODE_COS = "cos";
+    public static final String LAYER_MERGE_MODE_DOT = "dot";
+    public static final String LAYER_MERGE_MODE_MAX = "max";
+
+    private ElementWiseVertex.Op mergeMode = null;
 
     /**
      * Constructor from parsed Keras layer configuration dictionary.
@@ -41,16 +53,38 @@ public class KerasMerge extends KerasLayer {
     public KerasMerge(Map<String,Object> layerConfig, boolean enforceTrainingConfig)
             throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         super(layerConfig, enforceTrainingConfig);
-        this.vertex = new MergeVertex();
+        this.mergeMode = getMergeMode(layerConfig);
+        if (this.mergeMode == null)
+            this.vertex = new MergeVertex();
+        else
+            this.vertex = new ElementWiseVertex(mergeMode);
     }
 
-    /**
-     * Get DL4J MergeVertex.
-     *
-     * @return  MergeVertex
-     */
-    public MergeVertex getMergeVertex() {
-        return (MergeVertex)this.vertex;
+    public ElementWiseVertex.Op getMergeMode(Map<String,Object> layerConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        Map<String, Object> innerConfig = getInnerLayerConfigFromConfig(layerConfig);
+        if (!innerConfig.containsKey(LAYER_FIELD_MODE))
+            throw new InvalidKerasConfigurationException("Keras Merge layer config missing " + LAYER_FIELD_MODE + " field");
+        ElementWiseVertex.Op op = null;
+        String mergeMode = (String)innerConfig.get(LAYER_FIELD_MODE);
+        switch (mergeMode) {
+            case LAYER_MERGE_MODE_SUM:
+                op = ElementWiseVertex.Op.Add;
+                break;
+            case LAYER_MERGE_MODE_MUL:
+                op = ElementWiseVertex.Op.Product;
+                break;
+            case LAYER_MERGE_MODE_CONCAT:
+                // leave null
+                break;
+            case LAYER_MERGE_MODE_AVE:
+            case LAYER_MERGE_MODE_COS:
+            case LAYER_MERGE_MODE_DOT:
+            case LAYER_MERGE_MODE_MAX:
+            default:
+                throw new UnsupportedKerasConfigurationException("Keras Merge layer mode " + mergeMode + " not supported");
+        }
+        return op;
     }
 
     /**
@@ -62,6 +96,6 @@ public class KerasMerge extends KerasLayer {
      */
     @Override
     public InputType getOutputType(InputType... inputType) {
-        return getMergeVertex().getOutputType(-1, inputType);
+        return this.vertex.getOutputType(-1, inputType);
     }
 }


### PR DESCRIPTION
Keras Merge layers actually allow, e.g., summation, which means certain merge configurations should be mapped to DL4J ElementwiseVertex vertices. Added this fix, though Keras merge layers allow a wider range of operations than DL4J currently supports (e.g., max, dot products, etc.).