### PR TITLE
add profiles necessary for running tests

### DIFF
--- a/deeplearning4j-keras/pom.xml
+++ b/deeplearning4j-keras/pom.xml
@@ -167,5 +167,11 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>test-nd4j-native</id>
+    </profile>
+    <profile>
+      <id>test-nd4j-cuda-8.0</id>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This is due to a workaround of https://issues.apache.org/jira/browse/MENFORCER-226