### PR TITLE
Add check during Spark training if Export approach is supported

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/paramavg/ParameterAveragingTrainingMaster.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/paramavg/ParameterAveragingTrainingMaster.java
@@ -6,6 +6,7 @@ import org.deeplearning4j.api.storage.*;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.spark.impl.listeners.VanillaStatsStorageRouterProvider;
+import org.deeplearning4j.spark.impl.paramavg.util.ExportSupport;
 import org.nd4j.shade.jackson.annotation.JsonAutoDetect;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.PropertyAccessor;
@@ -55,8 +56,6 @@ import org.nd4j.linalg.api.ops.executioner.GridExecutioner;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSet;
 import org.nd4j.linalg.factory.Nd4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -832,6 +831,7 @@ public class ParameterAveragingTrainingMaster implements TrainingMaster<Paramete
 
 
     private JavaRDD<String> exportIfRequired(JavaSparkContext sc, JavaRDD<DataSet> trainingData) {
+        ExportSupport.assertExportSupported(sc);
         if (collectTrainingStats) stats.logExportStart();
 
         //Two possibilities here:
@@ -863,6 +863,7 @@ public class ParameterAveragingTrainingMaster implements TrainingMaster<Paramete
     }
 
     private JavaRDD<String> exportIfRequiredMDS(JavaSparkContext sc, JavaRDD<MultiDataSet> trainingData) {
+        ExportSupport.assertExportSupported(sc);
         if (collectTrainingStats) stats.logExportStart();
 
         //Two possibilities here:

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/paramavg/util/ExportSupport.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/paramavg/util/ExportSupport.java
@@ -1,0 +1,71 @@
+package org.deeplearning4j.spark.impl.paramavg.util;
+
+import lombok.NonNull;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import java.io.IOException;
+
+/**
+ * Utility for checking if exporting data sets is supported
+ *
+ * @author Ede Meijer
+ */
+public class ExportSupport {
+    /**
+     * Verify that exporting data is supported, and throw an informative exception if not.
+     *
+     * @param sc the Spark context
+     */
+    public static void assertExportSupported(@NonNull JavaSparkContext sc) {
+        if (!exportSupported(sc)) {
+            throw new RuntimeException(
+                "Export training approach is not supported in the current environment. " +
+                    "This means that the default Hadoop file system is the local file system and Spark is running " +
+                    "in a non-local mode. You can fix this by either adding hadoop configuration to your environment " +
+                    "or using the Direct training approach. Configuring Hadoop can be done by adding config files (" +
+                    "https://spark.apache.org/docs/1.6.3/configuration.html#inheriting-hadoop-cluster-configuration" +
+                    ") or adding a setting to your SparkConf object with " +
+                    "`sparkConf.set(\"spark.hadoop.fs.defaultFS\", \"hdfs://my-hdfs-host:9000\");`. Alternatively, " +
+                    "you can use some other non-local storage like S3."
+            );
+        }
+    }
+
+    /**
+     * Check if exporting data is supported in the current environment. Exporting is possible in two cases:
+     * - The master is set to local. In this case any file system, including local FS, will work for exporting.
+     * - The file system is not local. Local file systems do not work in cluster modes.
+     *
+     * @param sc the Spark context
+     * @return if export is supported
+     */
+    public static boolean exportSupported(@NonNull JavaSparkContext sc) {
+        try {
+            return exportSupported(
+                sc.master(),
+                FileSystem.get(sc.hadoopConfiguration())
+            );
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Check if exporting data is supported in the current environment. Exporting is possible in two cases:
+     * - The master is set to local. In this case any file system, including local FS, will work for exporting.
+     * - The file system is not local. Local file systems do not work in cluster modes.
+     *
+     * @param sparkMaster the Spark master
+     * @param fs the Hadoop file system
+     * @return if export is supported
+     */
+    public static boolean exportSupported(@NonNull String sparkMaster, @NonNull FileSystem fs) {
+        // Anything is supported with a local master. Regex matches 'local', 'local[DIGITS]' or 'local[*]'
+        if (sparkMaster.matches("^local(\\[(\\d+|\\*)])?$")) {
+            return true;
+        }
+        // Clustered mode is supported as long as the file system is not a local one
+        return !fs.getUri().getScheme().equals("file");
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/paramavg/util/ExportSupportTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/paramavg/util/ExportSupportTest.java
@@ -1,0 +1,62 @@
+package org.deeplearning4j.spark.impl.paramavg.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Ede Meijer
+ */
+public class ExportSupportTest {
+    private static final String FS_CONF = "spark.hadoop.fs.defaultFS";
+
+    @Test
+    public void testLocalSupported() throws IOException {
+        assertSupported(new SparkConf().setMaster("local").set(FS_CONF, "file:///"));
+        assertSupported(new SparkConf().setMaster("local[2]").set(FS_CONF, "file:///"));
+        assertSupported(new SparkConf().setMaster("local[64]").set(FS_CONF, "file:///"));
+        assertSupported(new SparkConf().setMaster("local[*]").set(FS_CONF, "file:///"));
+
+        assertSupported(new SparkConf().setMaster("local").set(FS_CONF, "hdfs://localhost:9000"));
+    }
+
+    @Test
+    public void testClusterWithRemoteFSSupported() throws IOException, URISyntaxException {
+        assertSupported(
+            "spark://localhost:7077",
+            FileSystem.get(new URI("hdfs://localhost:9000"), new Configuration()),
+            true
+        );
+    }
+
+    @Test
+    public void testClusterWithLocalFSNotSupported() throws IOException, URISyntaxException {
+        assertSupported(
+            "spark://localhost:7077",
+            FileSystem.get(new URI("file:///home/test"), new Configuration()),
+            false
+        );
+    }
+
+    private void assertSupported(SparkConf conf) throws IOException {
+        JavaSparkContext sc = new JavaSparkContext(conf.setAppName("Test"));
+        try {
+            assertTrue(ExportSupport.exportSupported(sc));
+        } finally {
+            sc.stop();
+        }
+    }
+
+    private void assertSupported(String master, FileSystem fs, boolean supported) throws IOException {
+        assertEquals(supported, ExportSupport.exportSupported(master, fs));
+    }
+}


### PR DESCRIPTION
Adds a check to prevent issues like https://github.com/deeplearning4j/deeplearning4j/issues/2969.

It will throw an exception when you're trying to do Spark training in a clustered mode, when Export training approach is enabled and the Hadoop file system is configured to local file system. The exception explains what is going on and how you can fix it.

The unit tests use a real SparkContext for the local scenario, but you can't unit test clustered mode (it tries to connect to the master). That's why I added a version of the check that just accepts a master string and a Hadoop FileSystem instance to make the best of it.