### PR TITLE
two fixes in RBM and BasePretrainNetwork

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
@@ -23,13 +23,11 @@ import org.deeplearning4j.berkeley.Pair;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
-import org.deeplearning4j.nn.params.DefaultParamInitializer;
 import org.deeplearning4j.nn.params.PretrainParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
-import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.nd4j.linalg.lossfunctions.ILossFunction;
 
 import java.util.*;
@@ -97,9 +95,12 @@ public abstract class BasePretrainNetwork<LayerConfT extends org.deeplearning4j.
 
     protected Gradient createGradient(INDArray wGradient, INDArray vBiasGradient, INDArray hBiasGradient) {
         Gradient ret = new DefaultGradient();
-        ret.gradientForVariable().put(PretrainParamInitializer.VISIBLE_BIAS_KEY, vBiasGradient);
-        ret.gradientForVariable().put(PretrainParamInitializer.BIAS_KEY, hBiasGradient);
+        // The order of the following statements matters!! The gradient is being flattened and applied to
+        // flattened params in this order.
+        // The order might need to be handled via ordering
         ret.gradientForVariable().put(PretrainParamInitializer.WEIGHT_KEY, wGradient);
+        ret.gradientForVariable().put(PretrainParamInitializer.BIAS_KEY, hBiasGradient);
+        ret.gradientForVariable().put(PretrainParamInitializer.VISIBLE_BIAS_KEY, vBiasGradient);
         return ret;
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/rbm/RBM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/rbm/RBM.java
@@ -232,13 +232,11 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
             }
             case BINARY: {
                 dist = Nd4j.getDistributions().createBinomial(1, hProb);
-                dist.reseedRandomGenerator(seed);
                 hSample = dist.sample(hProb.shape());
                 break;
             }
             case GAUSSIAN: {
                 dist = Nd4j.getDistributions().createNormal(hProb, 1);
-                dist.reseedRandomGenerator(seed);
                 hSample = dist.sample(hProb.shape());
                 break;
             }
@@ -285,16 +283,13 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
             }
             case BINARY: {
                 Distribution dist = Nd4j.getDistributions().createBinomial(1, vProb);
-                dist.reseedRandomGenerator(seed);
                 vSample = dist.sample(vProb.shape());
                 break;
             }
             case GAUSSIAN:
             case LINEAR: {
                 Distribution dist = Nd4j.getDistributions().createNormal(vProb, 1);
-                dist.reseedRandomGenerator(seed);
                 vSample = dist.sample(vProb.shape());
-                // this also works but needs reseedRnadomGenerator applied before sampling: Nd4j.getDistributions().createNormal(v1Mean, 1).sample(v1Mean.shape());
                 break;
             }
             case SOFTMAX: {
@@ -345,7 +340,6 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
                 return sigmoid(preSig);
             case GAUSSIAN:
                 Distribution dist = Nd4j.getDistributions().createNormal(preSig, 1);
-                dist.reseedRandomGenerator(seed);
                 preSig = dist.sample(preSig.shape());
                 return preSig;
             case RECTIFIED:
@@ -370,7 +364,6 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
                                 .execAndReturn(Nd4j.getOpFactory().createTransform("sigmoid", z).derivative());
             case GAUSSIAN: {
                 Distribution dist = Nd4j.getDistributions().createNormal(z, 1);
-                dist.reseedRandomGenerator(seed);
                 INDArray gaussian = dist.sample(z.shape());
                 INDArray derivative = z.mul(-2).mul(gaussian);
                 return derivative;
@@ -406,7 +399,6 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
                 return sigmoid(vMean);
             case GAUSSIAN:
                 Distribution dist = Nd4j.getDistributions().createNormal(vMean, 1);
-                dist.reseedRandomGenerator(seed);
                 vMean = dist.sample(vMean.shape());
                 return vMean;
             case LINEAR:


### PR DESCRIPTION
Fix for #3024 - gradient is flattened in an incorrect order vb,b,W and then applied to parameters that are flattened in the order W,b,vb
Fix for #1699 - reseed is only required at layer initialization.