### PR TITLE
Small cleanups to reduce code size.

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -945,19 +945,14 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer {
 
     @Override
     public void fit(DataSetIterator iterator) {
-        DataSetIterator iter;
         // we're wrapping all iterators into AsyncDataSetIterator to provide background prefetch - where appropriate
-        if (iterator.asyncSupported()) {
-            iter = new AsyncDataSetIterator(iterator, 2);
-        } else {
-            iter = iterator;
-        }
+        DataSetIterator iter = (iterator.asyncSupported())
+                ? new AsyncDataSetIterator(iterator, 2)
+                : iterator;
 
-        if (trainingListeners.size() > 0) {
-            for (TrainingListener tl : trainingListeners) {
+        for (TrainingListener tl : trainingListeners) {
                 tl.onEpochStart(this);
             }
-        }
 
         if (layerWiseConfigurations.isPretrain()) {
             pretrain(iter);


### PR DESCRIPTION
Declare and initialize the Dataiterator in 3 lines down from 6.
Remove size check form for loop. Java will not enter a loop with an
empty collection.