### PR TITLE
Added auto encoders for spark-ml

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/AutoEncoderWrapper.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/AutoEncoderWrapper.scala
@@ -1,0 +1,143 @@
+package org.deeplearning4j.spark.ml.impl
+
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.param.{IntParam, Param, ParamMap, Params}
+import org.apache.spark.ml.util._
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.sql.{Row, UserDefinedFunction}
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork
+import org.deeplearning4j.spark.impl.multilayer.SparkDl4jMultiLayer
+import org.deeplearning4j.spark.ml.utils.{DatasetFacade, ParamSerializer, SparkDl4jUtil}
+import org.deeplearning4j.util.ModelSerializer
+import org.nd4j.linalg.dataset.DataSet
+import org.nd4j.linalg.factory.Nd4j
+
+
+trait AutoEncoderParams extends Params {
+
+    final val compressedLayer  = new IntParam(this, "outputLayer", "Layer where to place autoencoder")
+    def getCompressedLayer : Int = $(compressedLayer)
+    final val inputCol: Param[String] = new Param[String](this, "inputCol", "input column name")
+    final def getInputCol: String = $(inputCol)
+    final val outputCol: Param[String] = new Param[String](this, "outputCol", "output column name")
+    setDefault(outputCol, uid + "__output")
+    /** @group getParam */
+    final def getOutputCol: String = $(outputCol)
+}
+
+abstract class AutoEncoderWrapper[E <: AutoEncoderWrapper[E, M], M <: AutoEncoderModelWrapper[M]](override val uid: String) extends Estimator[M] with AutoEncoderParams {
+    private var _multiLayerConfiguration : MultiLayerConfiguration = _
+    private var _trainingMaster : ParamSerializer = _
+
+    def this() = this(Identifiable.randomUID("dl4j_autoencoder"))
+
+    protected def mapVectorFunc : Row => Vector
+
+    override def copy(extra: ParamMap) : E = defaultCopy(extra)
+
+    protected def fitter(datasetFacade: DatasetFacade) : SparkDl4jMultiLayer = {
+        validator()
+        val dataset = datasetFacade.get
+        val sparkNet = new SparkDl4jMultiLayer(dataset.sqlContext.sparkContext, _multiLayerConfiguration, _trainingMaster())
+        val layerCount = sparkNet.getNetwork.getLayers.length
+        if ($(compressedLayer) < 1 || $(compressedLayer) >= layerCount) {
+            set(compressedLayer, layerCount / 2)
+        }
+        val set2 = dataset.select($(inputCol)).rdd.map(mapVectorFunc)
+        val ds = set2.map(v => new DataSet(Nd4j.create(v.toArray), Nd4j.create(v.toArray)))
+        val fitted = sparkNet.fit(ds)
+        sparkNet
+    }
+
+    def setCompressedLayer(value: Int) : E = {
+        set(compressedLayer, value)
+        this.asInstanceOf[E]
+    }
+
+    def setInputCol(value: String) : E = {
+        set(inputCol, value)
+        this.asInstanceOf[E]
+    }
+
+    def setOutputCol(value: String) : E = {
+        set(outputCol, value)
+        this.asInstanceOf[E]
+    }
+
+    def setMultiLayerConfiguration(multiLayerConfiguration: MultiLayerConfiguration) : E = {
+        this._multiLayerConfiguration = multiLayerConfiguration
+        this.asInstanceOf[E]
+    }
+
+    def setTrainingMaster(tm: ParamSerializer) : E = {
+        this._trainingMaster = tm
+        this.asInstanceOf[E]
+    }
+
+    private def validator(): Unit ={
+        if (_multiLayerConfiguration == null) {
+            throw new RuntimeException("multiLayerConfiguration must be set")
+        }
+        if (_trainingMaster == null) {
+            throw new RuntimeException("Training Master must be set")
+        }
+    }
+}
+
+abstract class AutoEncoderModelWrapper[E <: AutoEncoderModelWrapper[E]](override val uid : String,
+                                                                        sparkDl4jMultiLayer: SparkDl4jMultiLayer) extends Model[E] with MLWritable with AutoEncoderParams {
+
+    protected def udfTransformer : UserDefinedFunction
+
+    def getNetwork : MultiLayerNetwork = sparkDl4jMultiLayer.getNetwork
+
+    def setCompressedLayer(value: Int) : E = {
+        set(compressedLayer, value)
+        this.asInstanceOf[E]
+    }
+
+    def setInputCol(value: String) : E = {
+        set(inputCol, value)
+        this.asInstanceOf[E]
+    }
+
+    def setOutputCol(value: String) : E = {
+        set(outputCol, value)
+        this.asInstanceOf[E]
+    }
+
+    override def write : MLWriter = new AutoEncoderWriter(this)
+
+    protected[AutoEncoderModelWrapper] class AutoEncoderWriter(instance: AutoEncoderModelWrapper[E]) extends MLWriter {
+        override protected def saveImpl(path: String) : Unit = {
+            SparkDl4jUtil.saveMetadata(instance, path, sc)
+            ModelSerializer.writeModel(instance.getNetwork, path, true)
+        }
+    }
+
+}
+
+trait AutoEncoderModelLoader extends MLReadable[AutoEncoderModel] {
+
+    override def read: MLReader[AutoEncoderModel] = new AutoEncoderReader
+
+    override def load(path: String) : AutoEncoderModel = super.load(path)
+
+    private class AutoEncoderReader extends MLReader[AutoEncoderModel] {
+
+        private val className = classOf[AutoEncoderModel].getName
+
+        override def load(path: String) : AutoEncoderModel = {
+            val metaData = SparkDl4jUtil.loadMetadata(path, sc, className)
+            val mln = ModelSerializer.restoreMultiLayerNetwork(path)
+            val model = new AutoEncoderModel(
+                Identifiable.randomUID("dl4j_autoencoder"),
+                new SparkDl4jMultiLayer(sc, mln, null)
+            )
+            SparkDl4jUtil.getAndSetParams(model, metaData)
+            model
+        }
+
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/AutoEncoderWrapper.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/AutoEncoderWrapper.scala
@@ -50,26 +50,51 @@ abstract class AutoEncoderWrapper[E <: AutoEncoderWrapper[E, M], M <: AutoEncode
         sparkNet
     }
 
+    /**
+      * The compressed layer of the autoencoder
+      * @param value 0 based index of the compressed layer
+      * @return Returns the class that extends the wrapper
+      */
     def setCompressedLayer(value: Int) : E = {
         set(compressedLayer, value)
         this.asInstanceOf[E]
     }
 
+    /**
+      * The input column name
+      * @param value name of the input column
+      * @return Returns the class that extends the wrapper
+      */
     def setInputCol(value: String) : E = {
         set(inputCol, value)
         this.asInstanceOf[E]
     }
 
+    /**
+      * The output column name
+      * @param value name of the output column
+      * @return Returns the class that extends the wrapper
+      */
     def setOutputCol(value: String) : E = {
         set(outputCol, value)
         this.asInstanceOf[E]
     }
 
+    /**
+      * The multilayer configuration of the autoencoder
+      * @param multiLayerConfiguration MultiLayerConfiguration
+      * @return Returns the class that extends the wrapper
+      */
     def setMultiLayerConfiguration(multiLayerConfiguration: MultiLayerConfiguration) : E = {
         this._multiLayerConfiguration = multiLayerConfiguration
         this.asInstanceOf[E]
     }
 
+    /**
+      * The training master configuration for the spark network
+      * @param tm ParamSerializer -> a wrapper around the Training Master
+      * @return Returns the class that extends the wrapper
+      */
     def setTrainingMaster(tm: ParamSerializer) : E = {
         this._trainingMaster = tm
         this.asInstanceOf[E]
@@ -90,18 +115,37 @@ abstract class AutoEncoderModelWrapper[E <: AutoEncoderModelWrapper[E]](override
 
     protected def udfTransformer : UserDefinedFunction
 
+    /**
+      *
+      * @return Returns the multiLayerNetwork
+      */
     def getNetwork : MultiLayerNetwork = sparkDl4jMultiLayer.getNetwork
 
+    /**
+      * The compressed layer of the autoencoder
+      * @param value Int
+      * @return Returns the class that extends the wrapper
+      */
     def setCompressedLayer(value: Int) : E = {
         set(compressedLayer, value)
         this.asInstanceOf[E]
     }
 
+    /**
+      * The input column name
+      * @param value name of the input column
+      * @return Returns the class that extends the wrapper
+      */
     def setInputCol(value: String) : E = {
         set(inputCol, value)
         this.asInstanceOf[E]
     }
 
+    /**
+      * The output column name
+      * @param value name of the output column
+      * @return Returns the class that extends the wrapper
+      */
     def setOutputCol(value: String) : E = {
         set(outputCol, value)
         this.asInstanceOf[E]
@@ -122,6 +166,11 @@ trait AutoEncoderModelLoader extends MLReadable[AutoEncoderModel] {
 
     override def read: MLReader[AutoEncoderModel] = new AutoEncoderReader
 
+    /**
+      * Loads the autoencoder model
+      * @param path where to load the model
+      * @return AutoEncoderModel
+      */
     override def load(path: String) : AutoEncoderModel = super.load(path)
 
     private class AutoEncoderReader extends MLReader[AutoEncoderModel] {

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/org/deeplearning4j/spark/ml/impl/AutoEncoder.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/org/deeplearning4j/spark/ml/impl/AutoEncoder.scala
@@ -24,6 +24,11 @@ class AutoEncoder(uid: String) extends AutoEncoderWrapper[AutoEncoder, AutoEncod
         SchemaUtils.appendColumn(schema, $(outputCol), new VectorUDT(), false)
     }
 
+    /**
+      * Fits a dataframe to the specified network configuration
+      * @param dataset DataFrame
+      * @return Returns an autoencoder model, which can run transformations on the vector
+      */
     override def fit(dataset: DataFrame) : AutoEncoderModel = {
         val sparkdl4j = fitter(DatasetFacade.dataRows(dataset))
         new AutoEncoderModel(uid, sparkdl4j)
@@ -48,14 +53,29 @@ class AutoEncoderModel(uid: String, sparkDl4jMultiLayer: SparkDl4jMultiLayer) ex
         Vectors.dense(values)
     })
 
+    /**
+      * copys an autoencoder model, including the param map
+      * @param extra ParamMap
+      * @return returns a copy of the autoencoder model
+      */
     override def copy(extra: ParamMap) : AutoEncoderModel = {
         copyValues(new AutoEncoderModel(uid, sparkDl4jMultiLayer)).setParent(parent)
     }
 
+    /**
+      * Transforms an incoming dataframe
+      * @param dataFrame DataFrame
+      * @return Returns a transformed dataframe.
+      */
     override def transform(dataFrame: DataFrame) : DataFrame = {
         dataFrame.withColumn($(outputCol), udfTransformer(col($(inputCol))))
     }
 
+    /**
+      * Updates the schema from the new dataframe
+      * @param schema StructType
+      * @return Returns a struct type
+      */
     override def transformSchema(schema: StructType) : StructType = {
         SchemaUtils.appendColumn(schema, $(outputCol), new VectorUDT(), false)
     }

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/org/deeplearning4j/spark/ml/impl/AutoEncoder.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/org/deeplearning4j/spark/ml/impl/AutoEncoder.scala
@@ -1,0 +1,64 @@
+package org.deeplearning4j.spark.ml.impl
+
+
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.mllib.linalg.{Vector, VectorUDT, Vectors}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.StructType
+import org.deeplearning4j.spark.impl.multilayer.SparkDl4jMultiLayer
+import org.deeplearning4j.spark.ml.utils.{DatasetFacade, SchemaUtils}
+import org.nd4j.linalg.factory.Nd4j
+
+
+class AutoEncoder(uid: String) extends AutoEncoderWrapper[AutoEncoder, AutoEncoderModel](uid){
+
+    def this() {
+        this(Identifiable.randomUID("dl4j"))
+    }
+
+    override def mapVectorFunc = row => row.get(0).asInstanceOf[Vector]
+
+    override def transformSchema(schema: StructType) : StructType = {
+        SchemaUtils.appendColumn(schema, $(outputCol), new VectorUDT(), false)
+    }
+
+    override def fit(dataset: DataFrame) : AutoEncoderModel = {
+        val sparkdl4j = fitter(DatasetFacade.dataRows(dataset))
+        new AutoEncoderModel(uid, sparkdl4j)
+            .setInputCol($(inputCol))
+            .setOutputCol($(outputCol))
+            .setCompressedLayer($(compressedLayer))
+    }
+
+}
+
+class AutoEncoderModel(uid: String, sparkDl4jMultiLayer: SparkDl4jMultiLayer) extends AutoEncoderModelWrapper[AutoEncoderModel](uid, sparkDl4jMultiLayer) {
+
+    override def udfTransformer = udf[Vector, Vector](vec => {
+        val out = sparkDl4jMultiLayer.getNetwork.feedForwardToLayer($(compressedLayer), Nd4j.create(vec.toArray))
+        val mainLayer = out.get(out.size() - 1)
+        val size = mainLayer.size(1)
+        println(size)
+        val values = Array.fill(size)(0.0)
+        for (i <- 0 until size) {
+            values(i) = mainLayer.getDouble(i)
+        }
+        Vectors.dense(values)
+    })
+
+    override def copy(extra: ParamMap) : AutoEncoderModel = {
+        copyValues(new AutoEncoderModel(uid, sparkDl4jMultiLayer)).setParent(parent)
+    }
+
+    override def transform(dataFrame: DataFrame) : DataFrame = {
+        dataFrame.withColumn($(outputCol), udfTransformer(col($(inputCol))))
+    }
+
+    override def transformSchema(schema: StructType) : StructType = {
+        SchemaUtils.appendColumn(schema, $(outputCol), new VectorUDT(), false)
+    }
+}
+
+object AutoEncoderModel extends AutoEncoderModelLoader

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/org/deeplearning4j/spark/ml/impl/AutoEncoder.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/org/deeplearning4j/spark/ml/impl/AutoEncoder.scala
@@ -1,0 +1,63 @@
+package org.deeplearning4j.spark.ml.impl
+
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.StructType
+import org.deeplearning4j.spark.impl.multilayer.SparkDl4jMultiLayer
+import org.nd4j.linalg.factory.Nd4j
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+import org.deeplearning4j.spark.ml.utils._
+
+
+class AutoEncoder(uid: String) extends AutoEncoderWrapper[AutoEncoder, AutoEncoderModel](uid){
+
+    def this() {
+        this(Identifiable.randomUID("dl4j"))
+    }
+
+    override def mapVectorFunc = row => org.apache.spark.mllib.linalg.Vectors.fromML(row.get(0).asInstanceOf[Vector])
+
+    override def fit(dataset: Dataset[_]) : AutoEncoderModel = {
+        val sparkdl4j = fitter(DatasetFacade.dataRows(dataset))
+        new AutoEncoderModel(uid, sparkdl4j)
+            .setInputCol($(inputCol))
+            .setOutputCol($(outputCol))
+            .setCompressedLayer($(compressedLayer))
+    }
+
+    override def transformSchema(schema: StructType) : StructType = {
+        SchemaUtils.appendColumn(schema, $(outputCol), VectorType, false)
+    }
+}
+
+class AutoEncoderModel(uid: String, sparkDl4jMultiLayer: SparkDl4jMultiLayer) extends AutoEncoderModelWrapper[AutoEncoderModel](uid, sparkDl4jMultiLayer) {
+
+    override def udfTransformer = udf[Vector, Vector](vec => {
+        val out = sparkDl4jMultiLayer.getNetwork.feedForwardToLayer($(compressedLayer), Nd4j.create(vec.toArray))
+        val mainLayer = out.get(out.size() - 1)
+        val size = mainLayer.size(1)
+        println(size)
+        val values = Array.fill(size)(0.0)
+        for (i <- 0 until size) {
+            values(i) = mainLayer.getDouble(i)
+        }
+        Vectors.dense(values)
+    })
+
+    override def copy(extra: ParamMap) : AutoEncoderModel = {
+        copyValues(new AutoEncoderModel(uid, sparkDl4jMultiLayer)).setParent(parent)
+    }
+
+    override def transform(dataFrame: Dataset[_]) : Dataset[Row] = {
+        dataFrame.withColumn($(outputCol), udfTransformer(col($(inputCol))))
+    }
+
+    override def transformSchema(schema: StructType) : StructType = {
+        SchemaUtils.appendColumn(schema, $(outputCol), VectorType, false)
+    }
+}
+
+object AutoEncoderModel extends AutoEncoderModelLoader

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/java/org/deeplearning4j/spark/ml/impl/AutoEncoderNetworkTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/java/org/deeplearning4j/spark/ml/impl/AutoEncoderNetworkTest.java
@@ -1,0 +1,101 @@
+package org.deeplearning4j.spark.ml.impl;
+
+
+import com.google.common.collect.Lists;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.ml.Pipeline;
+import org.apache.spark.ml.PipelineStage;
+import org.apache.spark.ml.feature.VectorAssembler;
+import org.apache.spark.mllib.linalg.VectorUDT;
+import org.apache.spark.mllib.linalg.Vectors;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.RBM;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.spark.impl.paramavg.ParameterAveragingTrainingMaster;
+import org.deeplearning4j.spark.ml.utils.ParamSerializer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import java.util.List;
+
+public class AutoEncoderNetworkTest {
+
+    private SparkConf sparkConf = new SparkConf().setAppName("testing").setMaster("local[4]");
+    private JavaSparkContext sparkContext = new JavaSparkContext(sparkConf);
+    private SQLContext sqlContext = new SQLContext(sparkContext);
+
+    @Test
+    public void testNetwork() {
+        List<Row> dubs = Lists.newArrayList(
+                RowFactory.create(Vectors.dense(100., 125., 644., 3432., 1233., 5435., 7675., 32423., 6456457.,2., 4, 6., 1.0)),
+                RowFactory.create(Vectors.dense(100., 165., 6234., 3132., 1533., 54365., 762345., 1423., 56457.,2.3, 41, 64., 16.0))
+        );
+        DataFrame df = sqlContext.createDataFrame(dubs, createStruct());
+        Pipeline p = new Pipeline().setStages(new PipelineStage[]{getAssembler(new String[]{"x"}, "features")});
+        DataFrame part2 = p.fit(df).transform(df).select("features");
+
+        AutoEncoder sparkDl4jNetwork = new AutoEncoder()
+                .setInputCol("features")
+                .setOutputCol("auto_encoded")
+                .setCompressedLayer(2)
+                .setTrainingMaster(new ParamHelper())
+                .setMultiLayerConfiguration(getNNConfiguration());
+
+        AutoEncoderModel sm = sparkDl4jNetwork.fit(part2);
+        DataFrame d2 = sm.transform(part2);
+        MultiLayerNetwork mln = sm.getNetwork();
+        Assert.assertNotNull(mln);
+    }
+
+    private StructType createStruct() {
+        return  new StructType(new StructField[]{
+                new StructField("x", new VectorUDT(), true, Metadata.empty())
+        });
+    }
+
+    private MultiLayerConfiguration getNNConfiguration(){
+        return new NeuralNetConfiguration.Builder()
+                .seed(12345)
+                .iterations(5)
+                .learningRate(.9)
+                .optimizationAlgo(OptimizationAlgorithm.LINE_GRADIENT_DESCENT)
+                .list()
+                .layer(0, new RBM.Builder().nIn(13).nOut(9).lossFunction(LossFunctions.LossFunction.KL_DIVERGENCE).build())
+                .layer(1, new RBM.Builder().nIn(9).nOut(5).lossFunction(LossFunctions.LossFunction.KL_DIVERGENCE).build())
+                .layer(2, new RBM.Builder().nIn(5).nOut(2).lossFunction(LossFunctions.LossFunction.KL_DIVERGENCE).build())
+                .layer(3, new RBM.Builder().nIn(2).nOut(5).lossFunction(LossFunctions.LossFunction.KL_DIVERGENCE).build())
+                .layer(4, new RBM.Builder().nIn(5).nOut(9).lossFunction(LossFunctions.LossFunction.KL_DIVERGENCE).build()) //decoding starts
+                .layer(5, new OutputLayer.Builder(LossFunctions.LossFunction.MSE).activation("sigmoid").nIn(9).nOut(13).build())
+                .pretrain(true).backprop(true)
+                .build();
+    }
+
+    public static VectorAssembler getAssembler(String[] input, String output){
+        return new VectorAssembler()
+                .setInputCols(input)
+                .setOutputCol(output);
+    }
+
+    static public class ParamHelper implements ParamSerializer {
+
+        public ParameterAveragingTrainingMaster apply() {
+            return new ParameterAveragingTrainingMaster.Builder(3)
+                    .averagingFrequency(2)
+                    .workerPrefetchNumBatches(2)
+                    .batchSizePerWorker(2)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
Had this ready to go from the last merge. This actually allows you to do transformation to the features, similar to spark's PCA, with autoencoders. The test provided has an example of the usage.