### PR TITLE
added epochs to spark ml

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetworkWrapper.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetworkWrapper.scala
@@ -24,6 +24,7 @@ abstract class SparkDl4jNetworkWrapper[T, E <: SparkDl4jNetworkWrapper[T, E, M],
  protected val multiLayerConfiguration : MultiLayerConfiguration,
  protected val numLabels: Int,
  protected val trainingMaster: ParamSerializer,
+ protected val epochs : Int,
  protected val listeners : util.Collection[IterationListener],
  protected val collectStats: Boolean = false
 ) extends Predictor[T, E, M]  {
@@ -54,7 +55,10 @@ abstract class SparkDl4jNetworkWrapper[T, E <: SparkDl4jNetworkWrapper[T, E, M],
                     new DataSet(Nd4j.create(features.toArray), Nd4j.create(Array(label)))
                 }
             })
-        sparkNet.fit(lps)
+        val epochsToUse = if (epochs < 1) 1 else epochs
+        for (i <- List.range(0, epochsToUse)) {
+            sparkNet.fit(lps)
+        }
         sparkNet
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
@@ -17,19 +17,22 @@ final class SparkDl4jNetwork(
                             override val multiLayerConfiguration: MultiLayerConfiguration,
                             override val numLabels: Int,
                             override val trainingMaster: ParamSerializer,
+                            override val epochs : Int,
                             override val listeners: util.Collection[IterationListener],
                             override val collectStats: Boolean = false,
                             override val uid: String = Identifiable.randomUID("dl4j"))
     extends SparkDl4jNetworkWrapper[Vector, SparkDl4jNetwork, SparkDl4jModel](
-        uid, multiLayerConfiguration, numLabels, trainingMaster, listeners, collectStats
+        uid, multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, collectStats
     ) {
 
-    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, listeners: util.Collection[IterationListener]) {
-        this(multiLayerConfiguration, numLabels, trainingMaster, listeners, false, Identifiable.randomUID("dl4j"))
+    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, epochs: Int,
+             listeners: util.Collection[IterationListener]) {
+        this(multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, false, Identifiable.randomUID("dl4j"))
     }
 
-    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, listeners: util.Collection[IterationListener], collectStats: Boolean) {
-        this(multiLayerConfiguration, numLabels, trainingMaster, listeners, collectStats, Identifiable.randomUID("dl4j"))
+    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, epochs: Int,
+             listeners: util.Collection[IterationListener], collectStats: Boolean) {
+        this(multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, collectStats, Identifiable.randomUID("dl4j"))
     }
 
     override val mapVectorFunc: (Row) => LabeledPoint = row => new LabeledPoint(row.getAs[Double]($(labelCol)), row.getAs[Vector]($(featuresCol)))

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
@@ -25,11 +25,13 @@ final class SparkDl4jNetwork(
     extends SparkDl4jNetworkWrapper[Vector, SparkDl4jNetwork, SparkDl4jModel](
         uid, multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, collectStats) {
 
-    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, listeners: util.Collection[IterationListener]) {
+    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, epochs: Int,
+             listeners: util.Collection[IterationListener]) {
         this(multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, false, Identifiable.randomUID("dl4j"))
     }
 
-    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, listeners: util.Collection[IterationListener], collectStats: Boolean) {
+    def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, epochs: Int,
+             listeners: util.Collection[IterationListener], collectStats: Boolean) {
         this(multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, collectStats, Identifiable.randomUID("dl4j"))
     }
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
@@ -18,18 +18,19 @@ final class SparkDl4jNetwork(
                                 override val multiLayerConfiguration: MultiLayerConfiguration,
                                 override val numLabels: Int,
                                 override val trainingMaster: ParamSerializer,
+                                override val epochs : Int,
                                 override val listeners: util.Collection[IterationListener],
                                 override val collectStats: Boolean = false,
                                 override val uid: String = Identifiable.randomUID("dl4j"))
     extends SparkDl4jNetworkWrapper[Vector, SparkDl4jNetwork, SparkDl4jModel](
-        uid, multiLayerConfiguration, numLabels, trainingMaster, listeners, collectStats) {
+        uid, multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, collectStats) {
 
     def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, listeners: util.Collection[IterationListener]) {
-        this(multiLayerConfiguration, numLabels, trainingMaster, listeners, false, Identifiable.randomUID("dl4j"))
+        this(multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, false, Identifiable.randomUID("dl4j"))
     }
 
     def this(multiLayerConfiguration: MultiLayerConfiguration, numLabels: Int, trainingMaster: ParamSerializer, listeners: util.Collection[IterationListener], collectStats: Boolean) {
-        this(multiLayerConfiguration, numLabels, trainingMaster, listeners, collectStats, Identifiable.randomUID("dl4j"))
+        this(multiLayerConfiguration, numLabels, trainingMaster, epochs, listeners, collectStats, Identifiable.randomUID("dl4j"))
     }
 
     override val mapVectorFunc: Row => LabeledPoint = row => new LabeledPoint(row.getAs[Double]($(labelCol)), Vectors.fromML(row.getAs[Vector]($(featuresCol))))

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/java/org/deeplearning4j/spark/ml/impl/SparkDl4jNetworkTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/test/java/org/deeplearning4j/spark/ml/impl/SparkDl4jNetworkTest.java
@@ -44,7 +44,7 @@ public class SparkDl4jNetworkTest  {
         Collection<IterationListener> il = new ArrayList<>();
         il.add(new ScoreIterationListener(1));
 
-        SparkDl4jNetwork sparkDl4jNetwork = new SparkDl4jNetwork(mc, 2, ps, il)
+        SparkDl4jNetwork sparkDl4jNetwork = new SparkDl4jNetwork(mc, 2, ps, 1, il)
                 .setFeaturesCol("features")
                 .setLabelCol("label");
 


### PR DESCRIPTION
I noticed a difference in the model performance when using multilayer configuration's iterations, than when calling the sparkNet.fit function over a series of the same number of epochs. I don't know if that is expected, but I added this epoch parameter, just in case.