### PR TITLE
Use applyMask method in BaseLayer.activate

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestRecordReaders.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/exceptions/TestRecordReaders.java
@@ -12,12 +12,14 @@ import org.deeplearning4j.exception.DL4JException;
 import org.junit.Test;
 import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by Alex on 14/11/2016.
@@ -27,23 +29,21 @@ public class TestRecordReaders {
     @Test
     public void testClassIndexOutsideOfRangeRRDSI() {
 
+        //In previous implementations: this would throw an exception. Now: Skip invalid records
+        // i.e., expect only the first record to be returned
+
         Collection<Collection<Writable>> c = new ArrayList<>();
-        c.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(0)));
-        c.add(Arrays.<Writable>asList(new DoubleWritable(0.0), new IntWritable(2)));
+        c.add(Arrays.<Writable>asList(new DoubleWritable(0.5), new IntWritable(0)));
+        c.add(Arrays.<Writable>asList(new DoubleWritable(1.0), new IntWritable(2)));
 
         CollectionRecordReader crr = new CollectionRecordReader(c);
 
         RecordReaderDataSetIterator iter = new RecordReaderDataSetIterator(crr, 2, 1, 2);
 
-        try {
-            DataSet ds = iter.next();
-            fail("Expected exception");
-        } catch (DL4JException e) {
-            System.out.println("testClassIndexOutsideOfRange(): " + e.getMessage());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail();
-        }
+        DataSet ds = iter.next();
+
+        assertEquals(Nd4j.create(new double[]{0.5}), ds.getFeatures());
+        assertEquals(Nd4j.create(new double[]{1.0, 0.0}), ds.getLabels());
     }
 
     @Test

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -159,7 +159,7 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
         INDArray delta = conf().getLayer().getActivationFn().backprop(z, epsilon).getFirst(); //TODO handle activation function params
 
         if (maskArray != null) {
-            delta.muliColumnVector(maskArray);
+            applyMask(delta);
         }
 
         Gradient ret = new DefaultGradient();
@@ -404,7 +404,7 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
         INDArray ret = conf().getLayer().getActivationFn().getActivation(z, training);
 
         if (maskArray != null) {
-            ret.muliColumnVector(maskArray);
+            applyMask(ret);
         }
 
         return ret;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Correctly use applyMask method in activate (was causing issues with OutputLayer + per-output masking)

## How was this patch tested?

Additional unit test (was failing before changes).
