### PR TITLE
Flattened tensors separate method spark-ml

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetworkWrapper.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetworkWrapper.scala
@@ -5,7 +5,7 @@ import java.util
 import org.apache.spark.ml.{PredictionModel, Predictor}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util._
-import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.sql.Row
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration
@@ -13,10 +13,12 @@ import org.deeplearning4j.nn.multilayer.MultiLayerNetwork
 import org.deeplearning4j.optimize.api.IterationListener
 import org.deeplearning4j.spark.impl.multilayer.SparkDl4jMultiLayer
 import org.deeplearning4j.spark.ml.utils.{DatasetFacade, ParamSerializer}
+import org.deeplearning4j.spark.util.MLLibUtil
 import org.deeplearning4j.util.ModelSerializer
 import org.nd4j.linalg.dataset.DataSet
 import org.nd4j.linalg.factory.Nd4j
 import org.nd4j.linalg.util.FeatureUtil
+import org.nd4j.linalg.api.ndarray.INDArray
 
 
 abstract class SparkDl4jNetworkWrapper[T, E <: SparkDl4jNetworkWrapper[T, E, M], M <: SparkDl4jModelWrapper[T, M]]
@@ -75,6 +77,10 @@ abstract class SparkDl4jModelWrapper[T, E <: SparkDl4jModelWrapper[T, E]](overri
 
     protected def output(vector: Vector) : Vector = network.predict(vector)
 
+    protected def outputTensor(vector: Vector) : INDArray = getMultiLayerNetwork.output(MLLibUtil.toVector(vector))
+
+    protected def outputFlattenedTensor(vector: Vector) : Vector = Vectors.dense(flattenTensor(outputTensor(vector)))
+
     protected[SparkDl4jModelWrapper] class SparkDl4jModelWriter(instance: SparkDl4jModelWrapper[T,E]) extends MLWriter {
         override protected def saveImpl(path: String): Unit = {
             ModelSerializer.writeModel(network.getNetwork, path, true)
@@ -82,6 +88,8 @@ abstract class SparkDl4jModelWrapper[T, E <: SparkDl4jModelWrapper[T, E]](overri
     }
 
     override def write : MLWriter = new SparkDl4jModelWriter(this)
+
+    private def flattenTensor(indArray: INDArray) : Array[Double] = indArray.data().asDouble()
 }
 
 trait SparkDl4jModelWrap extends MLReadable[SparkDl4jModel] {

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-1/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
@@ -11,6 +11,7 @@ import org.deeplearning4j.nn.conf.MultiLayerConfiguration
 import org.deeplearning4j.optimize.api.IterationListener
 import org.deeplearning4j.spark.impl.multilayer.SparkDl4jMultiLayer
 import org.deeplearning4j.spark.ml.utils.{DatasetFacade, ParamSerializer}
+import org.nd4j.linalg.api.ndarray.INDArray
 
 
 final class SparkDl4jNetwork(
@@ -44,7 +45,12 @@ class SparkDl4jModel(override val uid: String, network: SparkDl4jMultiLayer)
     extends SparkDl4jModelWrapper[Vector, SparkDl4jModel](uid, network) {
 
     override def copy(extra: ParamMap) : SparkDl4jModel = copyValues(new SparkDl4jModel(uid, network)).setParent(parent)
+
     override def predict(features: Vector) : Double = predictor(features)
+
+    override def outputFlattenedTensor(vector: Vector): Vector = super.outputFlattenedTensor(vector)
+
+    override def outputTensor(vector: Vector) : INDArray = super.outputTensor(vector)
 
 }
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-ml/src/main/spark-2/scala/org/deeplearning4j/spark/ml/impl/SparkDl4jNetwork.scala
@@ -12,6 +12,7 @@ import org.deeplearning4j.nn.conf.MultiLayerConfiguration
 import org.deeplearning4j.optimize.api.IterationListener
 import org.deeplearning4j.spark.impl.multilayer.SparkDl4jMultiLayer
 import org.deeplearning4j.spark.ml.utils.{DatasetFacade, ParamSerializer}
+import org.nd4j.linalg.api.ndarray.INDArray
 
 
 final class SparkDl4jNetwork(
@@ -52,6 +53,10 @@ class SparkDl4jModel(override val uid: String, network: SparkDl4jMultiLayer)
     }
 
     def output(vector: Vector): Vector = org.apache.spark.ml.linalg.Vectors.dense(super.output(Vectors.fromML(vector)).toArray)
+
+    def outputFlattenedTensor(vector: Vector) : Vector = org.apache.spark.ml.linalg.Vectors.dense(super.outputFlattenedTensor(Vectors.fromML(vector)).toArray)
+
+    def outputTensor(vector: Vector) : INDArray = super.outputTensor(Vectors.fromML(vector))
 
 }
 


### PR DESCRIPTION
Here is a solution to https://github.com/deeplearning4j/deeplearning4j/issues/3182 for spark-ml. This actually creates an explicit method to flatten tensors, or to just get the INDArray return value. This is what I am doing for my own project right now.
