### PR TITLE
Fix potential memory corruption from occuring in HDF5

### DIFF
--- a/deeplearning4j-keras/src/main/java/org/deeplearning4j/keras/NDArrayHDF5Reader.java
+++ b/deeplearning4j-keras/src/main/java/org/deeplearning4j/keras/NDArrayHDF5Reader.java
@@ -19,6 +19,8 @@ import static org.bytedeco.javacpp.hdf5.H5F_ACC_RDONLY;
  */
 public class NDArrayHDF5Reader {
 
+    private hdf5.DataType dataType = new hdf5.DataType(hdf5.PredType.NATIVE_FLOAT());
+
     /**
      * Reads an HDF5 file into an NDArray.
      *
@@ -43,7 +45,7 @@ public class NDArrayHDF5Reader {
     private DataBuffer readFromDataSet(hdf5.DataSet dataSet, int total) {
         float[] dataBuffer = new float[total];
         FloatPointer fp = new FloatPointer(dataBuffer);
-        dataSet.read(fp, new hdf5.DataType(hdf5.PredType.NATIVE_FLOAT()));
+        dataSet.read(fp, dataType);
         fp.get(dataBuffer);
         return Nd4j.createBuffer(dataBuffer);
     }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/Hdf5Archive.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/Hdf5Archive.java
@@ -55,6 +55,7 @@ public class Hdf5Archive {
     }
 
     private hdf5.H5File file;
+    private hdf5.DataType dataType = new hdf5.DataType(hdf5.PredType.NATIVE_FLOAT());
 
     public Hdf5Archive(String archiveFilename) {
         this.file = new hdf5.H5File(archiveFilename, H5F_ACC_RDONLY);
@@ -158,7 +159,7 @@ public class Hdf5Archive {
             case 4: /* 2D Convolution weights */
                 dataBuffer = new float[(int) (dims[0] * dims[1] * dims[2] * dims[3])];
                 fp = new FloatPointer(dataBuffer);
-                dataset.read(fp, new hdf5.DataType(hdf5.PredType.NATIVE_FLOAT()));
+                dataset.read(fp, dataType);
                 fp.get(dataBuffer);
                 data = Nd4j.create((int) dims[0], (int) dims[1], (int) dims[2], (int) dims[3]);
                 j = 0;
@@ -171,7 +172,7 @@ public class Hdf5Archive {
             case 3:
                 dataBuffer = new float[(int) (dims[0] * dims[1] * dims[2])];
                 fp = new FloatPointer(dataBuffer);
-                dataset.read(fp, new hdf5.DataType(hdf5.PredType.NATIVE_FLOAT()));
+                dataset.read(fp, dataType);
                 fp.get(dataBuffer);
                 data = Nd4j.create((int) dims[0], (int) dims[1], (int) dims[2]);
                 j = 0;
@@ -183,7 +184,7 @@ public class Hdf5Archive {
             case 2: /* Dense and Recurrent weights */
                 dataBuffer = new float[(int) (dims[0] * dims[1])];
                 fp = new FloatPointer(dataBuffer);
-                dataset.read(fp, new hdf5.DataType(hdf5.PredType.NATIVE_FLOAT()));
+                dataset.read(fp, dataType);
                 fp.get(dataBuffer);
                 data = Nd4j.create((int) dims[0], (int) dims[1]);
                 j = 0;
@@ -194,7 +195,7 @@ public class Hdf5Archive {
             case 1: /* Bias */
                 dataBuffer = new float[(int) dims[0]];
                 fp = new FloatPointer(dataBuffer);
-                dataset.read(fp, new hdf5.DataType(hdf5.PredType.NATIVE_FLOAT()));
+                dataset.read(fp, dataType);
                 fp.get(dataBuffer);
                 data = Nd4j.create((int) dims[0]);
                 j = 0;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure memory used by HDF5 doesn't get prematurely deallocated. See #3190 

## How was this patch tested?

Unit tests pass.