### PR TITLE
Update to latest scala maven plugin 

### DIFF
--- a/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/pom.xml
@@ -70,8 +70,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
                 <version>${maven-scala-plugin.version}</version>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <reflections.version>0.9.10</reflections.version>
         <javax.ws.rs.version>2.0</javax.ws.rs.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>
+        <maven-scala-plugin.version>3.2.2</maven-scala-plugin.version>
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <sbt-compiler-maven-plugin.version>1.0.0-beta8</sbt-compiler-maven-plugin.version>
         <maven-build-helper-plugin.version>3.0.0</maven-build-helper-plugin.version>


### PR DESCRIPTION


## What changes were proposed in this pull request?

Update to latest scala maven plugin version (note groupId and artifact name change circa 2012, see new plugin at https://mvnrepository.com/artifact/net.alchim31.maven/scala-maven-plugin). This is needed to prevent the creation of /tmp/scala-maven directories that clutter tmp and bother our system administrators.

## How was this patch tested?
In directory deeplearning4j-scaleout/spark/dl4j-spark, I ran:
mvn -U package -Ptest-nd4j-native -DskipTests=true

[INFO] Building jar: []/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/target/dl4j-spark_2.11-0.8.1_spark_1-SNAPSHOT-sources.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 13.343 s
[INFO] Finished at: 2017-04-07T13:30:11-04:00
[INFO] Final Memory: 69M/608M
[INFO] ------------------------------------------------------------------------


Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
