### PR TITLE
Simplifies re-partitioning & introduces a faster (approximate) balanced partitioner

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/api/RepartitionStrategy.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/api/RepartitionStrategy.java
@@ -13,6 +13,6 @@ package org.deeplearning4j.spark.api;
  * @author Alex Black
  */
 public enum RepartitionStrategy {
-    SparkDefault, Balanced
+    SparkDefault, Balanced, ApproximateBalanced
 
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/data/shuffle/IntPartitioner.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/data/shuffle/IntPartitioner.java
@@ -8,7 +8,9 @@ import org.apache.spark.Partitioner;
  * Maps each value to key % numPartitions
  *
  * @author Alex Black
+ * @deprecated Use {@link org.apache.spark.HashPartitioner} instead
  */
+@Deprecated
 @AllArgsConstructor
 public class IntPartitioner extends Partitioner {
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/AssignIndexFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/AssignIndexFunction.java
@@ -26,8 +26,8 @@ public class AssignIndexFunction<T> implements Function2<Integer, Iterator<T>, I
     }
 
     @Override
-    public Iterator<Tuple2<Integer, T>> call(Integer partionNum, Iterator<T> v2) throws Exception {
-        int currIdx = partitionElementStartIdxs[partionNum];
+    public Iterator<Tuple2<Integer, T>> call(Integer partitionNum, Iterator<T> v2) throws Exception {
+        int currIdx = partitionElementStartIdxs[partitionNum];
         List<Tuple2<Integer, T>> list = new ArrayList<>();
         while (v2.hasNext()) {
             list.add(new Tuple2<>(currIdx++, v2.next()));

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/AssignIndexFunction.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/AssignIndexFunction.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.spark.impl.common.repartition;
 
 import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.rdd.RDD;
 import scala.Tuple2;
 
 import java.util.ArrayList;
@@ -12,7 +13,9 @@ import java.util.List;
  * to enable partitioning to be done in a way that is more reliable (less random) than standard .repartition calls
  *
  * @author Alex Black
+ * @deprecated Use {@link RDD#zipWithIndex()} instead
  */
+@Deprecated
 public class AssignIndexFunction<T> implements Function2<Integer, Iterator<T>, Iterator<Tuple2<Integer, T>>> {
     private final int[] partitionElementStartIdxs;
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitioner.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitioner.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author huitseeker
  */
- public class HashingBalancedPartitioner extends Partitioner {
+public class HashingBalancedPartitioner extends Partitioner {
     private final int numClasses; // Total number of element classes
     private final int numPartitions; // Total number of partitions
     // partitionWeightsByClass : numClasses lists of numPartitions elements
@@ -43,29 +43,31 @@ import static com.google.common.base.Preconditions.checkNotNull;
         checkArgument(!checkNotNull(pw.get(0)).isEmpty(), "At least one partition is required");
         this.numClasses = pw.size();
         this.numPartitions = pw.get(0).size();
-        for(int i = 1; i < pw.size(); i++) {
-            checkArgument(checkNotNull(pw.get(i)).size() == this.numPartitions, "Non-consistent partition weight specification");
+        for (int i = 1; i < pw.size(); i++) {
+            checkArgument(checkNotNull(pw.get(i)).size() == this.numPartitions,
+                            "Non-consistent partition weight specification");
             // you also should have sum(pw.get(i)) = this.numPartitions
         }
         this.partitionWeightsByClass = partitionWeightsByClass; // p_(j, i)
 
         List<List<Double>> jumpsByClass = new ArrayList<List<Double>>();;
-        for (int j=0; j < numClasses; j++){
+        for (int j = 0; j < numClasses; j++) {
             Double totalImbalance = 0D; // i_j = sum(max(1 - p_(j, i), 0) , i = 1..numPartitions)
-            for (int i=0; i < numPartitions; i++){
-                totalImbalance +=
-                        partitionWeightsByClass.get(j).get(i) >= 0 ? Math.max(1 - partitionWeightsByClass.get(j).get(i), 0) : 0;
+            for (int i = 0; i < numPartitions; i++) {
+                totalImbalance += partitionWeightsByClass.get(j).get(i) >= 0
+                                ? Math.max(1 - partitionWeightsByClass.get(j).get(i), 0) : 0;
             }
             Double sumProb = 0D;
             List<Double> cumulProbsThisClass = new ArrayList<Double>();
-            for (int i = 0; i < numPartitions; i++){
+            for (int i = 0; i < numPartitions; i++) {
                 if (partitionWeightsByClass.get(j).get(i) >= 0 && (totalImbalance > 0 || sumProb >= 1)) {
-                    Double thisPartitionRelProb = Math.max(1 - partitionWeightsByClass.get(j).get(i), 0) / totalImbalance;
+                    Double thisPartitionRelProb =
+                                    Math.max(1 - partitionWeightsByClass.get(j).get(i), 0) / totalImbalance;
                     if (thisPartitionRelProb > 0) {
                         sumProb += thisPartitionRelProb;
                         cumulProbsThisClass.add(sumProb);
                     } else {
-                       cumulProbsThisClass.add(0D);
+                        cumulProbsThisClass.add(0D);
                     }
                 } else {
                     // There's no more imbalance, every jumpProb is > 1
@@ -93,7 +95,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
         checkArgument(key instanceof Tuple2, "The key should be in the form: Tuple2(SparkUID, class) ...");
         Tuple2<Long, Integer> uidNclass = (Tuple2<Long, Integer>) key;
         Long uid = uidNclass._1();
-        Integer partitionId = (int)(uid % numPartitions);
+        Integer partitionId = (int) (uid % numPartitions);
         Integer elementClass = uidNclass._2();
 
         Double jumpProbability = Math.max(1D - 1D / partitionWeightsByClass.get(elementClass).get(partitionId), 0D);
@@ -107,7 +109,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
             Double destination = rand.nextDouble();
             Integer probe = 0;
 
-            while (jumpsTo.get(probe) < destination){
+            while (jumpsTo.get(probe) < destination) {
                 probe++;
             }
             thisPartition = probe;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitioner.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitioner.java
@@ -1,0 +1,128 @@
+package org.deeplearning4j.spark.impl.common.repartition;
+
+import org.apache.spark.Partitioner;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * This is a custom partitioner that rebalances a minimum of elements
+ * it expects a key in the form (SparkUID, class)
+ *
+ * @author huitseeker
+ */
+ public class HashingBalancedPartitioner extends Partitioner {
+    private final int numClasses; // Total number of element classes
+    private final int numPartitions; // Total number of partitions
+    // partitionWeightsByClass : numClasses lists of numPartitions elements
+    // where each element is the partition's relative share of its # of elements w.r.t the per-partition mean
+    // e.g. we have 3 partitions, with red and blue elements, red is indexed by 0, blue by 1:
+    //  [ r, r, r, r, b, b, b ], [r, b, b], [b, b, b, b, b, r, r]
+    // avg # red elems per partition : 2.33
+    // avg # blue elems per partition : 3.33
+    // partitionWeightsByClass = [[1.714, .429, .857], [0.9, 0.6, 1.5]]
+    private List<List<Double>> partitionWeightsByClass;
+
+    // The cumulative distribution of jump probabilities of extra elements by partition, by class
+    // 0 for partitions that already have enough elements
+    private List<List<Double>> jumpTable;
+    private Random r;
+
+    public HashingBalancedPartitioner(List<List<Double>> partitionWeightsByClass) {
+        List<List<Double>> pw = checkNotNull(partitionWeightsByClass);
+        checkArgument(!pw.isEmpty(), "Partition weights are required");
+        checkArgument(pw.size() >= 1, "There should be at least one element class");
+        checkArgument(!checkNotNull(pw.get(0)).isEmpty(), "At least one partition is required");
+        this.numClasses = pw.size();
+        this.numPartitions = pw.get(0).size();
+        for(int i = 1; i < pw.size(); i++) {
+            checkArgument(checkNotNull(pw.get(i)).size() == this.numPartitions, "Non-consistent partition weight specification");
+            // you also should have sum(pw.get(i)) = this.numPartitions
+        }
+        this.partitionWeightsByClass = partitionWeightsByClass; // p_(j, i)
+
+        List<List<Double>> jumpsByClass = new ArrayList<List<Double>>();;
+        for (int j=0; j < numClasses; j++){
+            Double totalImbalance = 0D; // i_j = sum(max(1 - p_(j, i), 0) , i = 1..numPartitions)
+            for (int i=0; i < numPartitions; i++){
+                totalImbalance += Math.max( 1 - partitionWeightsByClass.get(j).get(i), 0);
+            }
+            Double sumProb = 0D;
+            List<Double> cumulProbsThisClass = new ArrayList<Double>();
+            for (int i = 0; i < numPartitions; i++){
+                if (totalImbalance > 0 || sumProb >= 1) {
+                    Double thisPartitionRelProb = Math.max(1 - partitionWeightsByClass.get(j).get(i), 0) / totalImbalance;
+                    if (thisPartitionRelProb > 0) {
+                        sumProb += thisPartitionRelProb;
+                        cumulProbsThisClass.add(sumProb);
+                    } else {
+                       cumulProbsThisClass.add(0D);
+                    }
+                } else {
+                    // There's no more imbalance, every jumpProb is > 1
+                    cumulProbsThisClass.add(0D);
+                }
+            }
+            jumpsByClass.add(cumulProbsThisClass);
+        }
+
+        this.jumpTable = jumpsByClass;
+    }
+
+    @Override
+    public int numPartitions() {
+        return numPartitions;
+    }
+
+    @Override
+    public int getPartition(Object key) {
+        checkArgument(key instanceof Tuple2, "The key should be in the form: Tuple2(SparkUID, class) ...");
+        Tuple2<Long, Integer> uidNclass = (Tuple2<Long, Integer>) key;
+        Long uid = uidNclass._1();
+        Integer partitionId = (int)(uid % numPartitions);
+        Integer elementClass = uidNclass._2();
+
+        Double jumpProbability = Math.max(1D - 1D / partitionWeightsByClass.get(elementClass).get(partitionId), 0D);
+        LinearCongruentialGenerator rand = new LinearCongruentialGenerator(uid);
+
+        Double thisJumps = rand.nextDouble();
+        Integer thisPartition = partitionId;
+        if (thisJumps < jumpProbability) {
+            // Where do we jump ?
+            List<Double> jumpsTo = jumpTable.get(elementClass);
+            Double destination = rand.nextDouble();
+            Integer probe = 0;
+
+            while (jumpsTo.get(probe) < destination){
+                probe++;
+            }
+            thisPartition = probe;
+        }
+
+        return thisPartition;
+    }
+
+    // Multiplier chosen for nice distribution properties when successive random values are used to form tuples,
+    // which is the case with Spark's uid.
+    // See P. L'Ecuyer. Tables of Linear Congruential Generators of Different Sizes and Good Lattice
+    // Structure. In Mathematics of Computation 68 (225): pages 249–260
+    //
+    static final class LinearCongruentialGenerator {
+        private long state;
+
+        public LinearCongruentialGenerator(long seed) {
+            this.state = seed;
+        }
+
+        public double nextDouble() {
+            state = 2862933555777941757L * state + 1;
+            return ((double) ((int) (state >>> 33) + 1)) / (0x1.0p31);
+        }
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
@@ -209,15 +209,14 @@ public class MLLibUtil {
     public static JavaRDD<DataSet> fromLabeledPoint(JavaRDD<LabeledPoint> data, final int numPossibleLabels,
                     int batchSize) {
 
-        JavaRDD<DataSet> mappedData = data.map(
-                new Function<LabeledPoint, DataSet>() {
-                    @Override
-                    public DataSet call(LabeledPoint lp) {
-                        return fromLabeledPoint(lp, numPossibleLabels);
-                    }
-                });
+        JavaRDD<DataSet> mappedData = data.map(new Function<LabeledPoint, DataSet>() {
+            @Override
+            public DataSet call(LabeledPoint lp) {
+                return fromLabeledPoint(lp, numPossibleLabels);
+            }
+        });
 
-        return mappedData.repartition((int) (mappedData.count()/ batchSize));
+        return mappedData.repartition((int) (mappedData.count() / batchSize));
     }
 
     /**
@@ -231,13 +230,12 @@ public class MLLibUtil {
     @Deprecated
     public static JavaRDD<DataSet> fromLabeledPoint(JavaSparkContext sc, JavaRDD<LabeledPoint> data,
                     final int numPossibleLabels) {
-        return data.map(
-                new Function<LabeledPoint, DataSet>() {
-                    @Override
-                    public DataSet call(LabeledPoint lp) {
-                        return fromLabeledPoint(lp, numPossibleLabels);
-                    }
-                });
+        return data.map(new Function<LabeledPoint, DataSet>() {
+            @Override
+            public DataSet call(LabeledPoint lp) {
+                return fromLabeledPoint(lp, numPossibleLabels);
+            }
+        });
     }
 
     /**

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/MLLibUtil.java
@@ -208,44 +208,16 @@ public class MLLibUtil {
      */
     public static JavaRDD<DataSet> fromLabeledPoint(JavaRDD<LabeledPoint> data, final int numPossibleLabels,
                     int batchSize) {
-        //map by index
-        JavaPairRDD<Long, LabeledPoint> dataWithIndex = data.zipWithIndex()
-                        .mapToPair(new PairFunction<Tuple2<LabeledPoint, Long>, Long, LabeledPoint>() {
-                            @Override
-                            public Tuple2<Long, LabeledPoint> call(Tuple2<LabeledPoint, Long> labeledPointLongTuple2)
-                                            throws Exception {
-                                return new Tuple2<>(labeledPointLongTuple2._2(), labeledPointLongTuple2._1());
-                            }
-                        });
 
-        JavaPairRDD<Long, DataSet> mappedData =
-                        dataWithIndex.mapToPair(new PairFunction<Tuple2<Long, LabeledPoint>, Long, DataSet>() {
-                            @Override
-                            public Tuple2<Long, DataSet> call(Tuple2<Long, LabeledPoint> longLabeledPointTuple2)
-                                            throws Exception {
-                                return new Tuple2<>(longLabeledPointTuple2._1(), MLLibUtil
-                                                .fromLabeledPoint(longLabeledPointTuple2._2(), numPossibleLabels));
-                            }
-                        });
+        JavaRDD<DataSet> mappedData = data.map(
+                new Function<LabeledPoint, DataSet>() {
+                    @Override
+                    public DataSet call(LabeledPoint lp) {
+                        return fromLabeledPoint(lp, numPossibleLabels);
+                    }
+                });
 
-        JavaPairRDD<Long, DataSet> aggregated = mappedData.reduceByKey(new Function2<DataSet, DataSet, DataSet>() {
-            @Override
-            public DataSet call(DataSet v1, DataSet v2) throws Exception {
-                return new DataSet(Nd4j.vstack(v1.getFeatureMatrix(), v2.getFeatureMatrix()),
-                                Nd4j.vstack(v1.getLabels(), v2.getLabels()));
-            }
-        }, (int) (mappedData.count() / batchSize));
-
-
-        JavaRDD<DataSet> data2 = aggregated.flatMap(new BaseFlatMapFunctionAdaptee<Tuple2<Long, DataSet>, DataSet>(
-                        new FlatMapFunctionAdapter<Tuple2<Long, DataSet>, DataSet>() {
-                            @Override
-                            public Iterable<DataSet> call(Tuple2<Long, DataSet> longDataSetTuple2) throws Exception {
-                                return longDataSetTuple2._2();
-                            }
-                        }));
-
-        return data2;
+        return mappedData.repartition((int) (mappedData.count()/ batchSize));
     }
 
     /**

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -6,6 +6,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.spark.HashPartitioner;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
@@ -441,7 +442,7 @@ public class SparkUtils {
                         rdd.flatMapToPair(new SplitDataSetExamplesPairFlatMapFunction(numPartitions));
 
         //Step 2: repartition according to the random keys
-        singleExampleDataSets = singleExampleDataSets.partitionBy(new IntPartitioner(numPartitions));
+        singleExampleDataSets = singleExampleDataSets.partitionBy(new HashPartitioner(numPartitions));
 
         //Step 3: Recombine
         return singleExampleDataSets.values().mapPartitions(new BatchDataSetsFunction(newBatchSize));

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -11,6 +11,9 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFunction;
 import org.apache.spark.serializer.SerializerInstance;
 import org.deeplearning4j.spark.api.Repartition;
@@ -21,6 +24,7 @@ import org.deeplearning4j.spark.impl.common.CountPartitionsFunction;
 import org.deeplearning4j.spark.impl.common.SplitPartitionsFunction;
 import org.deeplearning4j.spark.impl.common.SplitPartitionsFunction2;
 import org.deeplearning4j.spark.impl.common.repartition.BalancedPartitioner;
+import org.deeplearning4j.spark.impl.common.repartition.HashingBalancedPartitioner;
 import org.deeplearning4j.spark.impl.common.repartition.MapTupleToPairFlatMap;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
@@ -32,9 +36,7 @@ import java.io.*;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 /**
  * Various utilities for Spark
@@ -241,11 +243,75 @@ public class SparkUtils {
                 return rdd.repartition(numPartitions);
             case Balanced:
                 return repartitionBalanceIfRequired(rdd, repartition, objectsPerPartition, numPartitions);
+            case ApproximateBalanced:
+                return repartitionApproximateBalance(rdd, repartition, numPartitions);
             default:
                 throw new RuntimeException("Unknown repartition strategy: " + repartitionStrategy);
         }
     }
 
+    public static<T> JavaRDD<T> repartitionApproximateBalance(JavaRDD<T> rdd, Repartition repartition, int numPartitions){
+        int origNumPartitions = rdd.partitions().size();
+        switch (repartition) {
+            case Never:
+                return rdd;
+            case NumPartitionsWorkersDiffers:
+                if (origNumPartitions == numPartitions) return rdd;
+            case Always:
+                // Count each partition...
+                List<Integer> partitionCounts =
+                        rdd.mapPartitionsWithIndex(new Function2<Integer, Iterator<T>, Iterator<Integer>>() {
+                            @Override
+                            public Iterator<Integer> call(Integer integer, Iterator<T> tIterator) throws Exception {
+                                int count = 0;
+                                while (tIterator.hasNext()) {
+                                    tIterator.next();
+                                    count++;
+                                }
+                                return Collections.singletonList(count).iterator();
+                            }
+                        }, true).collect();
+
+                Integer totalCount = 0;
+                for (Integer i : partitionCounts) totalCount += i;
+                List<Double> partitionWeights = new ArrayList<>(Math.max(numPartitions, origNumPartitions));
+                Double ideal = (double)totalCount / numPartitions;
+                // partitions in the initial set and not in the final one get -1 => elements always jump
+                // partitions in the final set not in the initial one get 0 => aim to receive the average amount
+                for(int i = 0; i < Math.min(origNumPartitions, numPartitions); i++){
+                    partitionWeights.add((double)partitionCounts.get(i) / ideal);
+                }
+                for (int i = Math.min(origNumPartitions, numPartitions); i < Math.max(origNumPartitions, numPartitions); i++){
+                    // we shrink the # of partitions
+                    if (i >= numPartitions) partitionWeights.add(-1D);
+                        // we enlarge the # of partitions
+                    else  partitionWeights.add(0D);
+                }
+
+                // this method won't trigger a spark job, which is different from {@link org.apache.spark.rdd.RDD#zipWithIndex}
+
+                JavaPairRDD<Tuple2<Long, Integer>, T> indexedRDD = rdd.zipWithUniqueId().mapToPair(
+                        new PairFunction<Tuple2<T, Long>, Tuple2<Long, Integer>, T>() {
+                            @Override
+                            public Tuple2<Tuple2<Long, Integer>, T> call(Tuple2<T, Long> tLongTuple2) {
+                                return new Tuple2<Tuple2<Long, Integer>, T>(
+                                        new Tuple2<Long, Integer>(tLongTuple2._2(), 0), tLongTuple2._1());
+                            }
+                        });
+
+                HashingBalancedPartitioner hbp = new HashingBalancedPartitioner(Collections.singletonList(partitionWeights));
+                JavaPairRDD<Tuple2<Long, Integer>, T> partitionedRDD = indexedRDD.partitionBy(hbp);
+
+                return partitionedRDD.map(new Function<Tuple2<Tuple2<Long,Integer>,T>, T>() {
+                    @Override
+                    public T call(Tuple2<Tuple2<Long, Integer>, T> indexNPayload){
+                        return indexNPayload._2();
+                    }
+                });
+            default:
+                throw new RuntimeException("Unknown setting for repartition: " + repartition);
+        }
+    }
 
     /**
      * Repartition a RDD (given the {@link Repartition} setting) such that we have approximately

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/data/TestShuffleExamples.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/data/TestShuffleExamples.java
@@ -52,31 +52,26 @@ public class TestShuffleExamples extends BaseSparkTest {
         assertEquals(100, totalExampleCount);
     }
 
-  @Test
-  public void testIntPartitioner() {
-    int nTest = 10000;
-    int nPartitions = 42;
+    @Test
+    public void testIntPartitioner() {
+        int nTest = 10000;
+        int nPartitions = 42;
 
-    Partitioner intPartitioner = new IntPartitioner(nPartitions);
-    Partitioner hashPartitioner = new HashPartitioner(nPartitions);
+        Partitioner intPartitioner = new IntPartitioner(nPartitions);
+        Partitioner hashPartitioner = new HashPartitioner(nPartitions);
 
-    Random r = new Random();
+        Random r = new Random();
 
-    List<Integer> samples = new ArrayList();
-    for (int i = 0; i < nTest; i++) {
-      samples.add(Math.abs(r.nextInt()));
-    }
+        List<Integer> samples = new ArrayList();
+        for (int i = 0; i < nTest; i++) {
+            samples.add(Math.abs(r.nextInt()));
+        }
 
-    for (int i : samples) {
-      assertTrue(
-          "Found intPartitioner "
-              + intPartitioner.getPartition(i)
-              + " for value "
-              + i
-              + " with hashPartitioner "
-              + hashPartitioner.getPartition(i),
-          intPartitioner.getPartition(i) == hashPartitioner.getPartition(i));
-    }
+        for (int i : samples) {
+            assertTrue("Found intPartitioner " + intPartitioner.getPartition(i) + " for value " + i
+                            + " with hashPartitioner " + hashPartitioner.getPartition(i),
+                            intPartitioner.getPartition(i) == hashPartitioner.getPartition(i));
+        }
 
     }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/data/TestShuffleExamples.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/data/TestShuffleExamples.java
@@ -1,7 +1,10 @@
 package org.deeplearning4j.spark.data;
 
+import org.apache.spark.HashPartitioner;
+import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaRDD;
 import org.deeplearning4j.spark.BaseSparkTest;
+import org.deeplearning4j.spark.data.shuffle.IntPartitioner;
 import org.deeplearning4j.spark.util.SparkUtils;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -11,8 +14,10 @@ import org.nd4j.linalg.factory.Nd4j;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Alex on 06/01/2017.
@@ -47,4 +52,31 @@ public class TestShuffleExamples extends BaseSparkTest {
         assertEquals(100, totalExampleCount);
     }
 
+  @Test
+  public void testIntPartitioner() {
+    int nTest = 10000;
+    int nPartitions = 42;
+
+    Partitioner intPartitioner = new IntPartitioner(nPartitions);
+    Partitioner hashPartitioner = new HashPartitioner(nPartitions);
+
+    Random r = new Random();
+
+    List<Integer> samples = new ArrayList();
+    for (int i = 0; i < nTest; i++) {
+      samples.add(Math.abs(r.nextInt()));
+    }
+
+    for (int i : samples) {
+      assertTrue(
+          "Found intPartitioner "
+              + intPartitioner.getPartition(i)
+              + " for value "
+              + i
+              + " with hashPartitioner "
+              + hashPartitioner.getPartition(i),
+          intPartitioner.getPartition(i) == hashPartitioner.getPartition(i));
+    }
+
+    }
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitionerTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitionerTest.java
@@ -42,7 +42,7 @@ public class BalancedPartitionerTest {
             countPerPartition[p] += 1;
         }
         for (int i = 0; i < 10; i++) {
-            assertTrue(countPerPartition[i] == 10);
+            assertEquals(countPerPartition[i], 10);
         }
     }
 
@@ -56,9 +56,9 @@ public class BalancedPartitionerTest {
         }
         for (int i = 0; i < 10; i++) {
             if (i < 7)
-                assertTrue(countPerPartition[i] == 10 + 1);
+                assertEquals(countPerPartition[i], 10 + 1);
             else
-                assertTrue(countPerPartition[i] == 10);
+                assertEquals(countPerPartition[i], 10);
         }
     }
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitionerTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitionerTest.java
@@ -17,7 +17,7 @@ public class BalancedPartitionerTest {
     public void balancedPartitionerFirstElements() {
         BalancedPartitioner bp = new BalancedPartitioner(10, 10, 0);
         // the 10 first elements should go in the 1st partition
-        for (int i = 0; i < 10; i++){
+        for (int i = 0; i < 10; i++) {
             int p = bp.getPartition(i);
             assertEquals("Found wrong partition output " + p + ", not 0", p, 0);
         }
@@ -27,34 +27,34 @@ public class BalancedPartitionerTest {
     public void balancedPartitionerFirstElementsWithRemainder() {
         BalancedPartitioner bp = new BalancedPartitioner(10, 10, 1);
         // the 10 first elements should go in the 1st partition
-        for (int i = 0; i < 10; i++){
+        for (int i = 0; i < 10; i++) {
             int p = bp.getPartition(i);
             assertEquals("Found wrong partition output " + p + ", not 0", p, 0);
         }
     }
 
     @Test
-    public void balancedPartitionerDoesBalance(){
+    public void balancedPartitionerDoesBalance() {
         BalancedPartitioner bp = new BalancedPartitioner(10, 10, 0);
         int[] countPerPartition = new int[10];
-        for (int i = 0; i < 10 * 10; i++){
+        for (int i = 0; i < 10 * 10; i++) {
             int p = bp.getPartition(i);
             countPerPartition[p] += 1;
         }
-        for (int i = 0; i < 10; i++){
+        for (int i = 0; i < 10; i++) {
             assertTrue(countPerPartition[i] == 10);
         }
     }
 
     @Test
-    public void balancedPartitionerDoesBalanceWithRemainder(){
+    public void balancedPartitionerDoesBalanceWithRemainder() {
         BalancedPartitioner bp = new BalancedPartitioner(10, 10, 7);
         int[] countPerPartition = new int[10];
-        for (int i = 0; i < 10 * 10 + 7; i++){
+        for (int i = 0; i < 10 * 10 + 7; i++) {
             int p = bp.getPartition(i);
             countPerPartition[p] += 1;
         }
-        for (int i = 0; i < 10; i++){
+        for (int i = 0; i < 10; i++) {
             if (i < 7)
                 assertTrue(countPerPartition[i] == 10 + 1);
             else

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitionerTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitionerTest.java
@@ -1,0 +1,65 @@
+package org.deeplearning4j.spark.impl.common.repartition;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Created by huitseeker on 4/4/17.
+ */
+public class BalancedPartitionerTest {
+
+
+    @Test
+    public void balancedPartitionerFirstElements() {
+        BalancedPartitioner bp = new BalancedPartitioner(10, 10, 0);
+        // the 10 first elements should go in the 1st partition
+        for (int i = 0; i < 10; i++){
+            int p = bp.getPartition(i);
+            assertEquals("Found wrong partition output " + p + ", not 0", p, 0);
+        }
+    }
+
+    @Test
+    public void balancedPartitionerFirstElementsWithRemainder() {
+        BalancedPartitioner bp = new BalancedPartitioner(10, 10, 1);
+        // the 10 first elements should go in the 1st partition
+        for (int i = 0; i < 10; i++){
+            int p = bp.getPartition(i);
+            assertEquals("Found wrong partition output " + p + ", not 0", p, 0);
+        }
+    }
+
+    @Test
+    public void balancedPartitionerDoesBalance(){
+        BalancedPartitioner bp = new BalancedPartitioner(10, 10, 0);
+        int[] countPerPartition = new int[10];
+        for (int i = 0; i < 10 * 10; i++){
+            int p = bp.getPartition(i);
+            countPerPartition[p] += 1;
+        }
+        for (int i = 0; i < 10; i++){
+            assertTrue(countPerPartition[i] == 10);
+        }
+    }
+
+    @Test
+    public void balancedPartitionerDoesBalanceWithRemainder(){
+        BalancedPartitioner bp = new BalancedPartitioner(10, 10, 7);
+        int[] countPerPartition = new int[10];
+        for (int i = 0; i < 10 * 10 + 7; i++){
+            int p = bp.getPartition(i);
+            countPerPartition[p] += 1;
+        }
+        for (int i = 0; i < 10; i++){
+            if (i < 7)
+                assertTrue(countPerPartition[i] == 10 + 1);
+            else
+                assertTrue(countPerPartition[i] == 10);
+        }
+    }
+
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitionerTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitionerTest.java
@@ -1,0 +1,190 @@
+package org.deeplearning4j.spark.impl.common.repartition;
+
+import org.apache.spark.HashPartitioner;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFunction;
+import org.deeplearning4j.spark.BaseSparkTest;
+import org.junit.Test;
+import scala.Tuple2;
+
+import java.util.*;
+
+import static org.junit.Assert.assertTrue;
+import org.deeplearning4j.spark.impl.common.repartition.HashingBalancedPartitioner.LinearCongruentialGenerator;
+
+
+/**
+ * Created by huitseeker on 4/4/17.
+ */
+public class HashingBalancedPartitionerTest extends BaseSparkTest{
+
+    // e.g. we have 3 partitions, with red and blue elements, red is indexed by 0, blue by 1:
+    //  [ r, r, r, r, b, b, b ], [r, b, b], [b, b, b, b, b, r, r]
+    // avg # red elems per partition : 2.33
+    // avg # blue elems per partition : 3.33
+    // partitionWeightsByClass = [[1.714, .429, .857], [0.9, 0.6, 1.5]]
+
+    @Test
+    public void hashingBalancedPartitionerDoesBalance(){
+        // partitionWeightsByClass = [[1.714, .429, .857], [0.9, 0.6, 1.5]]
+        List<Double> reds = Arrays.asList(1.714D, 0.429D, .857D);
+        List<Double> blues = Arrays.asList(0.9D, 0.6D, 1.5D);
+        List<List<Double>> partitionWeights = Arrays.asList(reds, blues);
+
+        HashingBalancedPartitioner hbp = new HashingBalancedPartitioner(partitionWeights);
+        List<Tuple2<Integer, String>> l = new ArrayList<>();
+
+        for (int i=0; i <4; i++) {
+            l.add(new Tuple2<Integer, String>(0, "red"));
+        }
+        for (int i=0; i <3; i++) {
+            l.add(new Tuple2<Integer, String>(0, "blue"));
+        }
+        for (int i=0; i< 1; i++) {
+            l.add(new Tuple2<Integer, String>(1, "red"));
+        }
+        for (int i=0; i< 2; i++) {
+            l.add(new Tuple2<Integer, String>(1, "blue"));
+        }
+        for (int i=0; i< 2; i++) {
+            l.add(new Tuple2<Integer, String>(2, "red"));
+        }
+        for (int i=0; i< 5; i++) {
+            l.add(new Tuple2<Integer, String>(2, "blue"));
+        }
+        // This should give exactly the sought distribution
+        JavaPairRDD<Integer, String> rdd = JavaPairRDD.fromJavaRDD(sc.parallelize(l)).partitionBy(new HashPartitioner(3));
+
+        // Let's reproduce UIDs
+        JavaPairRDD<Tuple2<Long,Integer>, String> indexedRDD = rdd.zipWithUniqueId().mapToPair(
+                new PairFunction<Tuple2<Tuple2<Integer, String>, Long>, Tuple2<Long, Integer>, String>() {
+            @Override
+            public Tuple2<Tuple2<Long, Integer>, String> call(Tuple2<Tuple2<Integer, String>, Long> payLoadNuid) {
+                Long uid = payLoadNuid._2();
+                String value = payLoadNuid._1()._2();
+                Integer elemClass = value.equals("red") ? 0 : 1;
+                return new Tuple2<Tuple2<Long, Integer>, String>(new Tuple2<Long, Integer>(uid, elemClass), value);
+            }
+        });
+
+        List<Tuple2<Tuple2<Long, Integer>, String>> testList = indexedRDD.collect();
+
+        int[][] colorCountsByPartition = new int[3][2];
+        for (final Tuple2<Tuple2<Long, Integer>, String> val:testList){
+            System.out.println(val);
+            Integer partition = hbp.getPartition(val._1());
+            System.out.println(partition);
+
+            if (val._2().equals("red"))
+                colorCountsByPartition[partition][0] += 1;
+            else
+                colorCountsByPartition[partition][1] += 1;
+        }
+
+        for (int i = 0; i < 3; i++) {
+            System.out.println(Arrays.toString(colorCountsByPartition[i]));
+        }
+        for (int i = 0; i < 3; i++){
+            // avg red per partition : 2.33
+            assertTrue(colorCountsByPartition[i][0] >= 1 && colorCountsByPartition[i][0] < 4);
+            // avg blue per partition : 3.33
+            assertTrue(colorCountsByPartition[i][1] >= 2 && colorCountsByPartition[i][1 ] < 5);
+        }
+
+    }
+
+    @Test
+    public void hashPartitionerBalancesAtScale(){
+        LinearCongruentialGenerator r = new LinearCongruentialGenerator(10000);
+        List<String> elements = new ArrayList<String>();
+        for (int i = 0; i < 10000; i++){
+            // The red occur towards the end
+            if (r.nextDouble() < ((double)i / 10000D)) elements.add("red");
+            // The blue occur towards the front
+            if (r.nextDouble() < (1 - (double) i / 10000D)) elements.add("blue");
+        }
+        Integer countRed = 0;
+        Integer countBlue = 0;
+        for (String elem: elements){
+            if (elem.equals("red")) countRed++; else countBlue++;
+        }
+        JavaRDD<String> rdd = sc.parallelize(elements);
+        JavaPairRDD<Tuple2<Long, Integer>, String> indexedRDD = rdd.zipWithUniqueId()
+                .mapToPair(new PairFunction<Tuple2<String, Long>, Tuple2<Long, Integer>, String>() {
+                    @Override
+                    public Tuple2<Tuple2<Long, Integer>, String> call(Tuple2<String, Long> stringLongTuple2) throws Exception {
+                        Integer elemClass = stringLongTuple2._1().equals("red") ? 0 : 1;
+                        return new Tuple2<Tuple2<Long, Integer>, String>(
+                                new Tuple2<Long, Integer>(stringLongTuple2._2(), elemClass), stringLongTuple2._1());
+                    }
+                });
+
+        Integer numPartitions = indexedRDD.getNumPartitions();
+
+        // rdd and indexedRDD have the same partition distribution
+        List<Tuple2<Integer, Integer>> partitionTuples =
+                rdd.mapPartitionsWithIndex(new CountRedBluePartitionsFunction(), true).collect();
+        List<Double> redWeights = new ArrayList<Double>();
+        List<Double> blueWeights = new ArrayList<Double>();
+        Float avgRed = (float) countRed / numPartitions;
+        Float avgBlue = (float) countBlue / numPartitions;
+        for (int i = 0; i < partitionTuples.size(); i++){
+            Tuple2<Integer, Integer> counts = partitionTuples.get(i);
+            redWeights.add((double) counts._1() / avgRed);
+            blueWeights.add((double) counts._2() / avgBlue);
+        }
+        List<List<Double>> partitionWeights = Arrays.asList(
+                redWeights, blueWeights
+        );
+
+
+        HashingBalancedPartitioner hbp = new HashingBalancedPartitioner(partitionWeights);
+
+        List<Tuple2<Tuple2<Long, Integer>, String>> testList = indexedRDD.collect();
+
+        int[][] colorCountsByPartition = new int[numPartitions][2];
+        for (final Tuple2<Tuple2<Long, Integer>, String> val:testList){
+            Integer partition = hbp.getPartition(val._1());
+
+            if (val._2().equals("red"))
+                colorCountsByPartition[partition][0] += 1;
+            else
+                colorCountsByPartition[partition][1] += 1;
+        }
+
+        for (int i = 0; i < numPartitions; i++) {
+            System.out.println(Arrays.toString(colorCountsByPartition[i]));
+        }
+
+        System.out.println("Ideal red # per partition: " + avgRed);
+        System.out.println("Ideal blue # per partition: " + avgBlue);
+
+        for (int i = 0; i < numPartitions; i++){
+            // avg red per partition : 2.33
+            assertTrue(colorCountsByPartition[i][0] >= Math.round(avgRed*.99) && colorCountsByPartition[i][0] < Math.round(avgRed*1.01) + 1);
+            // avg blue per partition : 3.33
+            assertTrue(colorCountsByPartition[i][1] >= Math.round(avgBlue*.99) && colorCountsByPartition[i][1] < Math.round(avgBlue*1.01) + 1);
+        }
+
+
+    }
+
+    class CountRedBluePartitionsFunction implements Function2<Integer, Iterator<String>, Iterator<Tuple2<Integer, Integer>>> {
+        @Override
+        public Iterator<Tuple2<Integer, Integer>> call(Integer v1, Iterator<String> v2) throws Exception {
+
+            int redCount = 0;
+            int blueCount = 0;
+            while (v2.hasNext()) {
+                String elem = v2.next();
+                if (elem.equals("red")) redCount++;
+                else blueCount++;
+            }
+
+            return Collections.singletonList(new Tuple2<>(redCount, blueCount)).iterator();
+        }
+    }
+
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitionerTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/common/repartition/HashingBalancedPartitionerTest.java
@@ -18,7 +18,7 @@ import org.deeplearning4j.spark.impl.common.repartition.HashingBalancedPartition
 /**
  * Created by huitseeker on 4/4/17.
  */
-public class HashingBalancedPartitionerTest extends BaseSparkTest{
+public class HashingBalancedPartitionerTest extends BaseSparkTest {
 
     // e.g. we have 3 partitions, with red and blue elements, red is indexed by 0, blue by 1:
     //  [ r, r, r, r, b, b, b ], [r, b, b], [b, b, b, b, b, r, r]
@@ -27,7 +27,7 @@ public class HashingBalancedPartitionerTest extends BaseSparkTest{
     // partitionWeightsByClass = [[1.714, .429, .857], [0.9, 0.6, 1.5]]
 
     @Test
-    public void hashingBalancedPartitionerDoesBalance(){
+    public void hashingBalancedPartitionerDoesBalance() {
         // partitionWeightsByClass = [[1.714, .429, .857], [0.9, 0.6, 1.5]]
         List<Double> reds = Arrays.asList(1.714D, 0.429D, .857D);
         List<Double> blues = Arrays.asList(0.9D, 0.6D, 1.5D);
@@ -36,43 +36,46 @@ public class HashingBalancedPartitionerTest extends BaseSparkTest{
         HashingBalancedPartitioner hbp = new HashingBalancedPartitioner(partitionWeights);
         List<Tuple2<Integer, String>> l = new ArrayList<>();
 
-        for (int i=0; i <4; i++) {
+        for (int i = 0; i < 4; i++) {
             l.add(new Tuple2<Integer, String>(0, "red"));
         }
-        for (int i=0; i <3; i++) {
+        for (int i = 0; i < 3; i++) {
             l.add(new Tuple2<Integer, String>(0, "blue"));
         }
-        for (int i=0; i< 1; i++) {
+        for (int i = 0; i < 1; i++) {
             l.add(new Tuple2<Integer, String>(1, "red"));
         }
-        for (int i=0; i< 2; i++) {
+        for (int i = 0; i < 2; i++) {
             l.add(new Tuple2<Integer, String>(1, "blue"));
         }
-        for (int i=0; i< 2; i++) {
+        for (int i = 0; i < 2; i++) {
             l.add(new Tuple2<Integer, String>(2, "red"));
         }
-        for (int i=0; i< 5; i++) {
+        for (int i = 0; i < 5; i++) {
             l.add(new Tuple2<Integer, String>(2, "blue"));
         }
         // This should give exactly the sought distribution
-        JavaPairRDD<Integer, String> rdd = JavaPairRDD.fromJavaRDD(sc.parallelize(l)).partitionBy(new HashPartitioner(3));
+        JavaPairRDD<Integer, String> rdd =
+                        JavaPairRDD.fromJavaRDD(sc.parallelize(l)).partitionBy(new HashPartitioner(3));
 
         // Let's reproduce UIDs
-        JavaPairRDD<Tuple2<Long,Integer>, String> indexedRDD = rdd.zipWithUniqueId().mapToPair(
-                new PairFunction<Tuple2<Tuple2<Integer, String>, Long>, Tuple2<Long, Integer>, String>() {
-            @Override
-            public Tuple2<Tuple2<Long, Integer>, String> call(Tuple2<Tuple2<Integer, String>, Long> payLoadNuid) {
-                Long uid = payLoadNuid._2();
-                String value = payLoadNuid._1()._2();
-                Integer elemClass = value.equals("red") ? 0 : 1;
-                return new Tuple2<Tuple2<Long, Integer>, String>(new Tuple2<Long, Integer>(uid, elemClass), value);
-            }
-        });
+        JavaPairRDD<Tuple2<Long, Integer>, String> indexedRDD = rdd.zipWithUniqueId().mapToPair(
+                        new PairFunction<Tuple2<Tuple2<Integer, String>, Long>, Tuple2<Long, Integer>, String>() {
+                            @Override
+                            public Tuple2<Tuple2<Long, Integer>, String> call(
+                                            Tuple2<Tuple2<Integer, String>, Long> payLoadNuid) {
+                                Long uid = payLoadNuid._2();
+                                String value = payLoadNuid._1()._2();
+                                Integer elemClass = value.equals("red") ? 0 : 1;
+                                return new Tuple2<Tuple2<Long, Integer>, String>(
+                                                new Tuple2<Long, Integer>(uid, elemClass), value);
+                            }
+                        });
 
         List<Tuple2<Tuple2<Long, Integer>, String>> testList = indexedRDD.collect();
 
         int[][] colorCountsByPartition = new int[3][2];
-        for (final Tuple2<Tuple2<Long, Integer>, String> val:testList){
+        for (final Tuple2<Tuple2<Long, Integer>, String> val : testList) {
             System.out.println(val);
             Integer partition = hbp.getPartition(val._1());
             System.out.println(partition);
@@ -86,58 +89,63 @@ public class HashingBalancedPartitionerTest extends BaseSparkTest{
         for (int i = 0; i < 3; i++) {
             System.out.println(Arrays.toString(colorCountsByPartition[i]));
         }
-        for (int i = 0; i < 3; i++){
+        for (int i = 0; i < 3; i++) {
             // avg red per partition : 2.33
             assertTrue(colorCountsByPartition[i][0] >= 1 && colorCountsByPartition[i][0] < 4);
             // avg blue per partition : 3.33
-            assertTrue(colorCountsByPartition[i][1] >= 2 && colorCountsByPartition[i][1 ] < 5);
+            assertTrue(colorCountsByPartition[i][1] >= 2 && colorCountsByPartition[i][1] < 5);
         }
 
     }
 
     @Test
-    public void hashPartitionerBalancesAtScale(){
+    public void hashPartitionerBalancesAtScale() {
         LinearCongruentialGenerator r = new LinearCongruentialGenerator(10000);
         List<String> elements = new ArrayList<String>();
-        for (int i = 0; i < 10000; i++){
+        for (int i = 0; i < 10000; i++) {
             // The red occur towards the end
-            if (r.nextDouble() < ((double)i / 10000D)) elements.add("red");
+            if (r.nextDouble() < ((double) i / 10000D))
+                elements.add("red");
             // The blue occur towards the front
-            if (r.nextDouble() < (1 - (double) i / 10000D)) elements.add("blue");
+            if (r.nextDouble() < (1 - (double) i / 10000D))
+                elements.add("blue");
         }
         Integer countRed = 0;
         Integer countBlue = 0;
-        for (String elem: elements){
-            if (elem.equals("red")) countRed++; else countBlue++;
+        for (String elem : elements) {
+            if (elem.equals("red"))
+                countRed++;
+            else
+                countBlue++;
         }
         JavaRDD<String> rdd = sc.parallelize(elements);
         JavaPairRDD<Tuple2<Long, Integer>, String> indexedRDD = rdd.zipWithUniqueId()
-                .mapToPair(new PairFunction<Tuple2<String, Long>, Tuple2<Long, Integer>, String>() {
-                    @Override
-                    public Tuple2<Tuple2<Long, Integer>, String> call(Tuple2<String, Long> stringLongTuple2) throws Exception {
-                        Integer elemClass = stringLongTuple2._1().equals("red") ? 0 : 1;
-                        return new Tuple2<Tuple2<Long, Integer>, String>(
-                                new Tuple2<Long, Integer>(stringLongTuple2._2(), elemClass), stringLongTuple2._1());
-                    }
-                });
+                        .mapToPair(new PairFunction<Tuple2<String, Long>, Tuple2<Long, Integer>, String>() {
+                            @Override
+                            public Tuple2<Tuple2<Long, Integer>, String> call(Tuple2<String, Long> stringLongTuple2)
+                                            throws Exception {
+                                Integer elemClass = stringLongTuple2._1().equals("red") ? 0 : 1;
+                                return new Tuple2<Tuple2<Long, Integer>, String>(
+                                                new Tuple2<Long, Integer>(stringLongTuple2._2(), elemClass),
+                                                stringLongTuple2._1());
+                            }
+                        });
 
         Integer numPartitions = indexedRDD.getNumPartitions();
 
         // rdd and indexedRDD have the same partition distribution
         List<Tuple2<Integer, Integer>> partitionTuples =
-                rdd.mapPartitionsWithIndex(new CountRedBluePartitionsFunction(), true).collect();
+                        rdd.mapPartitionsWithIndex(new CountRedBluePartitionsFunction(), true).collect();
         List<Double> redWeights = new ArrayList<Double>();
         List<Double> blueWeights = new ArrayList<Double>();
         Float avgRed = (float) countRed / numPartitions;
         Float avgBlue = (float) countBlue / numPartitions;
-        for (int i = 0; i < partitionTuples.size(); i++){
+        for (int i = 0; i < partitionTuples.size(); i++) {
             Tuple2<Integer, Integer> counts = partitionTuples.get(i);
             redWeights.add((double) counts._1() / avgRed);
             blueWeights.add((double) counts._2() / avgBlue);
         }
-        List<List<Double>> partitionWeights = Arrays.asList(
-                redWeights, blueWeights
-        );
+        List<List<Double>> partitionWeights = Arrays.asList(redWeights, blueWeights);
 
 
         HashingBalancedPartitioner hbp = new HashingBalancedPartitioner(partitionWeights);
@@ -145,7 +153,7 @@ public class HashingBalancedPartitionerTest extends BaseSparkTest{
         List<Tuple2<Tuple2<Long, Integer>, String>> testList = indexedRDD.collect();
 
         int[][] colorCountsByPartition = new int[numPartitions][2];
-        for (final Tuple2<Tuple2<Long, Integer>, String> val:testList){
+        for (final Tuple2<Tuple2<Long, Integer>, String> val : testList) {
             Integer partition = hbp.getPartition(val._1());
 
             if (val._2().equals("red"))
@@ -161,17 +169,20 @@ public class HashingBalancedPartitionerTest extends BaseSparkTest{
         System.out.println("Ideal red # per partition: " + avgRed);
         System.out.println("Ideal blue # per partition: " + avgBlue);
 
-        for (int i = 0; i < numPartitions; i++){
+        for (int i = 0; i < numPartitions; i++) {
             // avg red per partition : 2.33
-            assertTrue(colorCountsByPartition[i][0] >= Math.round(avgRed*.99) && colorCountsByPartition[i][0] < Math.round(avgRed*1.01) + 1);
+            assertTrue(colorCountsByPartition[i][0] >= Math.round(avgRed * .99)
+                            && colorCountsByPartition[i][0] < Math.round(avgRed * 1.01) + 1);
             // avg blue per partition : 3.33
-            assertTrue(colorCountsByPartition[i][1] >= Math.round(avgBlue*.99) && colorCountsByPartition[i][1] < Math.round(avgBlue*1.01) + 1);
+            assertTrue(colorCountsByPartition[i][1] >= Math.round(avgBlue * .99)
+                            && colorCountsByPartition[i][1] < Math.round(avgBlue * 1.01) + 1);
         }
 
 
     }
 
-    class CountRedBluePartitionsFunction implements Function2<Integer, Iterator<String>, Iterator<Tuple2<Integer, Integer>>> {
+    class CountRedBluePartitionsFunction
+                    implements Function2<Integer, Iterator<String>, Iterator<Tuple2<Integer, Integer>>> {
         @Override
         public Iterator<Tuple2<Integer, Integer>> call(Integer v1, Iterator<String> v2) throws Exception {
 
@@ -179,8 +190,10 @@ public class HashingBalancedPartitionerTest extends BaseSparkTest{
             int blueCount = 0;
             while (v2.hasNext()) {
                 String elem = v2.next();
-                if (elem.equals("red")) redCount++;
-                else blueCount++;
+                if (elem.equals("red"))
+                    redCount++;
+                else
+                    blueCount++;
             }
 
             return Collections.singletonList(new Tuple2<>(redCount, blueCount)).iterator();

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestRepartitioning.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestRepartitioning.java
@@ -1,10 +1,14 @@
 package org.deeplearning4j.spark.util;
 
+import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.deeplearning4j.spark.BaseSparkTest;
 import org.deeplearning4j.spark.api.Repartition;
 import org.deeplearning4j.spark.api.RepartitionStrategy;
 import org.deeplearning4j.spark.impl.common.CountPartitionsFunction;
+import org.deeplearning4j.spark.impl.common.repartition.AssignIndexFunction;
+import org.deeplearning4j.spark.impl.common.repartition.BalancedPartitioner;
+import org.deeplearning4j.spark.impl.common.repartition.MapTupleToPairFlatMap;
 import org.junit.Test;
 import scala.Tuple2;
 
@@ -13,12 +17,60 @@ import java.util.List;
 import java.util.Random;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.deeplearning4j.spark.util.SparkUtils.indexedRDD;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Alex on 03/07/2016.
  */
 public class TestRepartitioning extends BaseSparkTest {
+
+  public void testAssignIdx() {
+    List<String> list = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      list.add(String.valueOf(i));
+    }
+
+    JavaRDD<String> rdd = sc.parallelize(list, 10);
+
+    int numPartitions = rdd.getNumPartitions();
+    int objectsPerPartition = 100;
+
+    List<Tuple2<Integer, Integer>> partitionCounts =
+        rdd.mapPartitionsWithIndex(new CountPartitionsFunction<String>(), true).collect();
+    int totalObjects = 0;
+    int initialPartitions = partitionCounts.size();
+
+    int[] countPerPartition = new int[partitionCounts.size()];
+    int x = 0;
+    for (Tuple2<Integer, Integer> t2 : partitionCounts) {
+      int partitionSize = t2._2();
+      countPerPartition[x++] = partitionSize;
+    }
+
+    int[] elementStartOffsetByPartitions = new int[countPerPartition.length];
+    for (int i = 1; i < elementStartOffsetByPartitions.length; i++) {
+      elementStartOffsetByPartitions[i] =
+          elementStartOffsetByPartitions[i - 1] + countPerPartition[i - 1];
+    }
+
+    JavaRDD<Tuple2<Integer, String>> indexed =
+        rdd.mapPartitionsWithIndex(
+            new AssignIndexFunction<String>(elementStartOffsetByPartitions), true);
+    JavaPairRDD<Integer, String> pairIndexed =
+        indexed.mapPartitionsToPair(new MapTupleToPairFlatMap<Integer, String>(), true);
+
+    JavaPairRDD<Integer, String> withIndexes = indexedRDD(rdd);
+
+    List<Integer> pairKeys = pairIndexed.keys().collect();
+    List<Integer> indexedKeys = withIndexes.keys().collect();
+
+    assertTrue(indexedKeys.size() == pairKeys.size());
+    for (int i = 0; i < pairKeys.size(); i++) {
+      assertTrue(pairKeys.get(i) == indexedKeys.get(i));
+    }
+  }
 
     @Test
     public void testRepartitioning() {

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestRepartitioning.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestRepartitioning.java
@@ -66,7 +66,7 @@ public class TestRepartitioning extends BaseSparkTest {
 
         assertTrue(indexedKeys.size() == pairKeys.size());
         for (int i = 0; i < pairKeys.size(); i++) {
-            assertTrue(pairKeys.get(i) == indexedKeys.get(i));
+            assertEquals(pairKeys.get(i), indexedKeys.get(i));
         }
     }
 


### PR DESCRIPTION
The approximate balanced partitioner (`HashingBalancedPartitioner`) supports specifying elements classes (or outcomes), and produces balanced output across classes (i.e. each partition gets as many elements of each class as the others).

Front-end for BalancedMinibatches-equivalent functionality (https://github.com/deeplearning4j/nd4j/issues/1082) is still TODO — though this PR gives the means to do that.