### PR TITLE
Switch UI asset routing to ND4J classpath resource (which handles spaces in paths for JARs)

### DIFF
--- a/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/staticroutes/Assets.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/staticroutes/Assets.java
@@ -4,7 +4,7 @@ import com.google.common.net.HttpHeaders;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
-import org.datavec.api.util.ClassPathResource;
+import org.nd4j.linalg.io.ClassPathResource;
 import play.api.libs.MimeTypes;
 import play.mvc.Result;
 


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/3215
and https://github.com/deeplearning4j/deeplearning4j/issues/3121

DataVec ClassPathResource can't handle spaces for paths (with JARs) whereas ND4J CPR can.
See: https://github.com/deeplearning4j/nd4j/issues/1764