### PR TITLE
Updaters are no longer cloneable (shouldn't be due to view state)

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/Updater.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/Updater.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
  *
  * @author Adam Gibson
  */
-public interface Updater extends Serializable, Cloneable {
+public interface Updater extends Serializable {
 
     /**
      * Set the internal (historical) state view array for this updater
@@ -43,6 +43,4 @@ public interface Updater extends Serializable, Cloneable {
      * @param iteration
      */
     void update(Layer layer, Gradient gradient, int iteration, int miniBatchSize);
-
-    Updater clone();
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/updater/LayerUpdater.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/updater/LayerUpdater.java
@@ -314,21 +314,4 @@ public class LayerUpdater implements Updater {
         result = 31 * result + (updaterForVariable == null ? 0 : updaterForVariable.hashCode());
         return result;
     }
-
-    @Override
-    public Updater clone() {
-        Map<String, GradientUpdater> newMap = new HashMap<>();
-        for (Map.Entry<String, GradientUpdater> entry : updaterForVariable.entrySet()) {
-            newMap.put(entry.getKey(), entry.getValue().getAggregator(true).getUpdater());
-        }
-
-        LayerUpdater updater;
-        try {
-            updater = this.getClass().getConstructor().newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        updater.updaterForVariable = newMap;
-        return updater;
-    }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/updater/graph/ComputationGraphUpdater.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/updater/graph/ComputationGraphUpdater.java
@@ -21,7 +21,7 @@ import java.util.Map;
  *
  * @author Alex Black
  */
-public class ComputationGraphUpdater implements Serializable, Cloneable {
+public class ComputationGraphUpdater implements Serializable {
 
     private final Updater[] layerUpdaters;
     private final Map<String, Integer> layerUpdatersMap;
@@ -98,18 +98,6 @@ public class ComputationGraphUpdater implements Serializable, Cloneable {
     private ComputationGraphUpdater(int size, Map<String, Integer> layerUpdatersMap) {
         layerUpdaters = new Updater[size];
         this.layerUpdatersMap = layerUpdatersMap;
-    }
-
-    private ComputationGraphUpdater(ComputationGraphUpdater updater) {
-        layerUpdaters = new Updater[updater.layerUpdaters.length];
-        for (int i = 0; i < layerUpdaters.length; i++)
-            layerUpdaters[i] = updater.layerUpdaters[i].clone();
-        layerUpdatersMap = new HashMap<>(updater.layerUpdatersMap);
-    }
-
-    @Override
-    public ComputationGraphUpdater clone() {
-        return new ComputationGraphUpdater(this);
     }
 
     /**


### PR DESCRIPTION
And no longer use removed ND4J method.

Cloning in that way isn't safe, and can't be safe due to view mechanics. It wasn't used anyway.