### PR TITLE
Only rebuild needed modules between different scala/spark version builds

### DIFF
--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -13,7 +13,7 @@ set -eu
 ./change-scala-versions.sh 2.11 # should be idempotent, this is the default
 mvn "$@"
 ./change-spark-versions.sh 2
-mvn -Dspark.major.version=2 -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
+mvn -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
 ./change-scala-versions.sh 2.10
 ./change-spark-versions.sh 1
 mvn -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"

--- a/buildmultiplescalaversions.sh
+++ b/buildmultiplescalaversions.sh
@@ -1,10 +1,20 @@
 #! /bin/bash
+BASEDIR=$(dirname $(readlink -f "$0"))
+
+function whatchanged() {
+    cd $BASEDIR
+    for i in $(git status -s --porcelain -- $(find ./ -mindepth 2 -name pom.xml)|awk '{print $2}'); do
+	echo $(dirname $i)
+	cd $BASEDIR
+    done
+}
+
 set -eu
 ./change-scala-versions.sh 2.11 # should be idempotent, this is the default
 mvn "$@"
 ./change-spark-versions.sh 2
-mvn -Dspark.major.version=2 "$@"
+mvn -Dspark.major.version=2 -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
 ./change-scala-versions.sh 2.10
 ./change-spark-versions.sh 1
-mvn "$@"
+mvn -Dmaven.clean.skip=true -pl $(whatchanged| tr '\n' ',') -amd "$@"
 ./change-scala-versions.sh 2.11 # back to the default


### PR DESCRIPTION
Reduces build time of `./buildmultiplescalaversions.sh clean install -DskipTests=true`
 from 293s to 199s
Fixes #2873