### PR TITLE
Add setInput methods to Transfer API.

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/transferlearning/TransferLearningCompGraphTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/transferlearning/TransferLearningCompGraphTest.java
@@ -287,6 +287,8 @@ public class TransferLearningCompGraphTest {
                         new TransferLearning.GraphBuilder(modelToFineTune).fineTuneConfiguration(fineTuneConfiguration)
                                         .setFeatureExtractor("layer1").nOutReplace("layer4", 600, WeightInit.XAVIER)
                                         .removeVertexAndConnections("layer5").removeVertexAndConnections("layer6")
+                                        .setInputs("layer0In")
+                                        .setInputTypes(InputType.convolutionalFlat(28, 28,3))
                                         .addLayer("layer5",
                                                         new DenseLayer.Builder().activation(Activation.RELU).nIn(600)
                                                                         .nOut(300).build(),

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/transferlearning/TransferLearning.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/transferlearning/TransferLearning.java
@@ -688,6 +688,27 @@ public class TransferLearning {
             }
         }
 
+        /**
+         * Sets new inputs for the computation graph. This method will remove any
+         * pre-existing inputs.
+         * @param inputs String names of each graph input.
+         * @return {@code GraphBuilder} instance.
+         */
+        protected GraphBuilder setInputs(String... inputs) {
+            editedConfigBuilder.setNetworkInputs(Arrays.asList(inputs));
+            return this;
+        }
+
+        /**
+         * Sets the input type of corresponding inputs.
+         * @param inputTypes The type of input (such as convolutional).
+         * @return {@code GraphBuilder} instance.
+         */
+        protected GraphBuilder setInputTypes(InputType... inputTypes) {
+            editedConfigBuilder.setInputTypes(inputTypes);
+            return this;
+        }
+
         protected GraphBuilder addInputs(String... inputNames) {
             editedConfigBuilder.addInputs(inputNames);
             return this;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds the ability to override inputs and input types for transfer learning.

## How was this patch tested?

Ran `testAllWithCNN()` in tests with new inputs. Output below:

```
o.n.l.f.Nd4jBackend - Loaded [JCublasBackend] backend
o.n.n.NativeOpsHolder - Number of threads used for NativeOps: 32
o.n.l.a.o.e.DefaultOpExecutioner - Backend used: [CUDA]; OS: [Linux]
o.n.l.a.o.e.DefaultOpExecutioner - Cores: [12]; Memory: [14.0GB];
o.n.l.a.o.e.DefaultOpExecutioner - Blas vendor: [CUBLAS]
o.n.l.j.o.e.CudaExecutioner - Device name: [TITAN X (Pascal)]; CC: [6.1]; Total/free memory: [12779978752]
o.n.l.j.o.e.CudaExecutioner - Device name: [TITAN X (Pascal)]; CC: [6.1]; Total/free memory: [12782075904]
o.d.n.l.FrozenLayer - Gradients for the frozen layer are not set and will therefore will not be updated.Warning will be issued only once per instance
o.d.n.l.FrozenLayer - Gradients for the frozen layer are not set and will therefore will not be updated.Warning will be issued only once per instance
o.d.n.l.FrozenLayer - Frozen layer instance found! Frozen layers are treated as always in test mode. Warning will only be issued once per instance
o.n.n.Nd4jBlas - Number of threads used for BLAS: 0
o.d.n.l.FrozenLayer - Frozen layer instance found! Frozen layers are treated as always in test mode. Warning will only be issued once per instance
o.d.n.l.FrozenLayer - Frozen layer instance found! Frozen layers are treated as always in test mode. Warning will only be issued once per instance
o.d.n.l.FrozenLayer - Frozen layer instance found! Frozen layers are treated as always in test mode. Warning will only be issued once per instance
```