### PR TITLE
Work around ConvolutionMode.Same issue with cuDNN 6.0

### DIFF
--- a/deeplearning4j-cuda/pom.xml
+++ b/deeplearning4j-cuda/pom.xml
@@ -84,6 +84,7 @@
         </dependency>
     </dependencies>
 
+<!-- Uncomment to run the full test suite using cuDNN.
     <build>
         <testSourceDirectory>../deeplearning4j-core/src/test/java</testSourceDirectory>
         <pluginManagement>
@@ -98,6 +99,7 @@
             </plugins>
         </pluginManagement>
     </build>
+-->
 
     <profiles>
         <profile>

--- a/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
+++ b/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
@@ -198,8 +198,7 @@ public class CudnnConvolutionHelper implements ConvolutionHelper {
         int[] outSize;
         if (convolutionMode == ConvolutionMode.Same) {
             outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, null, convolutionMode); //Also performs validation
-            pad = ConvolutionUtils.getSameModeTopLeftPadding(outSize, new int[] {input.size(2), input.size(3)}, kernel,
-                            strides);
+            pad = ConvolutionUtils.getSameModeBottomRightPadding(outSize, new int[] {inH, inW}, kernel, strides);
         } else {
             outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, pad, convolutionMode); //Also performs validation
         }
@@ -309,8 +308,7 @@ public class CudnnConvolutionHelper implements ConvolutionHelper {
         int[] outSize;
         if (convolutionMode == ConvolutionMode.Same) {
             outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, null, convolutionMode); //Also performs validation
-            pad = ConvolutionUtils.getSameModeTopLeftPadding(outSize, new int[] {input.size(2), input.size(3)}, kernel,
-                            strides);
+            pad = ConvolutionUtils.getSameModeBottomRightPadding(outSize, new int[] {inH, inW}, kernel, strides);
         } else {
             outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, pad, convolutionMode); //Also performs validation
         }

--- a/deeplearning4j-cuda/src/test/java/org/deeplearning4j/convolution/TestConvolution.java
+++ b/deeplearning4j-cuda/src/test/java/org/deeplearning4j/convolution/TestConvolution.java
@@ -13,6 +13,7 @@ import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
@@ -75,7 +76,7 @@ public class TestConvolution {
     @Test
     public void testCompareCudnnStandardOutputsVsMode() throws Exception {
 
-        ConvolutionMode[] cm = new ConvolutionMode[]{ConvolutionMode.Strict, ConvolutionMode.Same};
+        ConvolutionMode[] cm = new ConvolutionMode[]{ConvolutionMode.Strict, ConvolutionMode.Truncate, ConvolutionMode.Same};
 
         for(ConvolutionMode c : cm ) {
             for( boolean conv : new boolean[]{true,false}) {
@@ -144,10 +145,12 @@ public class TestConvolution {
 
                 assertTrue(epsOutStd.equalsWithEps(epsOutCudnn, 1e-4));
 
-                INDArray gradStd = pStd.getFirst().gradient();
-                INDArray gradCudnn = pCudnn.getFirst().gradient();
+                if (conv) {
+                    INDArray gradStd = pStd.getFirst().gradient();
+                    INDArray gradCudnn = pCudnn.getFirst().gradient();
 
-                assertTrue(gradStd.equalsWithEps(gradCudnn, 1e-4));
+                    assertTrue(gradStd.equalsWithEps(gradCudnn, 1e-4));
+                }
             }
         }
     }

--- a/deeplearning4j-cuda/src/test/java/org/deeplearning4j/gradientcheck/CuDNNGradientChecks.java
+++ b/deeplearning4j-cuda/src/test/java/org/deeplearning4j/gradientcheck/CuDNNGradientChecks.java
@@ -18,6 +18,7 @@ import org.deeplearning4j.nn.layers.normalization.LocalResponseNormalizationHelp
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.util.DataTypeUtil;
 import org.nd4j.linalg.api.ndarray.INDArray;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -70,10 +70,10 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         try {
             helper = Class.forName("org.deeplearning4j.nn.layers.convolution.CudnnConvolutionHelper")
                     .asSubclass(ConvolutionHelper.class).newInstance();
-            log.debug("CudnnConvolutionHelper successfully loaded");
+            log.debug("CudnnConvolutionHelper successfully initialized");
         } catch (Throwable t) {
             if (!(t instanceof ClassNotFoundException)) {
-                log.warn("Could not load CudnnConvolutionHelper", t);
+                log.warn("Could not initialize CudnnConvolutionHelper", t);
             }
         }
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -75,10 +75,10 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         try {
             helper = Class.forName("org.deeplearning4j.nn.layers.convolution.subsampling.CudnnSubsamplingHelper")
                             .asSubclass(SubsamplingHelper.class).newInstance();
-            log.debug("CudnnSubsamplingHelper successfully loaded");
+            log.debug("CudnnSubsamplingHelper successfully initialized");
         } catch (Throwable t) {
             if (!(t instanceof ClassNotFoundException)) {
-                log.warn("Could not load CudnnSubsamplingHelper", t);
+                log.warn("Could not initialize CudnnSubsamplingHelper", t);
             }
         }
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -54,10 +54,10 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
         try {
             helper = Class.forName("org.deeplearning4j.nn.layers.normalization.CudnnBatchNormalizationHelper")
                             .asSubclass(BatchNormalizationHelper.class).newInstance();
-            log.debug("CudnnBatchNormalizationHelper successfully loaded");
+            log.debug("CudnnBatchNormalizationHelper successfully initialized");
         } catch (Throwable t) {
             if (!(t instanceof ClassNotFoundException)) {
-                log.warn("Could not load CudnnBatchNormalizationHelper", t);
+                log.warn("Could not initialize CudnnBatchNormalizationHelper", t);
             }
         }
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
@@ -67,10 +67,10 @@ public class LocalResponseNormalization
         try {
             helper = Class.forName("org.deeplearning4j.nn.layers.normalization.CudnnLocalResponseNormalizationHelper")
                             .asSubclass(LocalResponseNormalizationHelper.class).newInstance();
-            log.debug("CudnnLocalResponseNormalizationHelper successfully loaded");
+            log.debug("CudnnLocalResponseNormalizationHelper successfully initialized");
         } catch (Throwable t) {
             if (!(t instanceof ClassNotFoundException)) {
-                log.warn("Could not load CudnnLocalResponseNormalizationHelper", t);
+                log.warn("Could not initialize CudnnLocalResponseNormalizationHelper", t);
             }
         }
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
@@ -156,6 +156,22 @@ public class ConvolutionUtils {
     }
 
     /**
+     * Get bottom and right padding for same mode only.
+     *
+     * @param outSize
+     * @param inSize
+     * @param kernel
+     * @param strides
+     * @return
+     */
+    public static int[] getSameModeBottomRightPadding(int[] outSize, int[] inSize, int[] kernel, int[] strides) {
+        int[] outPad = new int[2];
+        outPad[0] = ((outSize[0] - 1) * strides[0] + kernel[0] - inSize[0] + 1) / 2; //Note that padTop is 1 smaller than this if bracketed term is not divisible by 2
+        outPad[1] = ((outSize[1] - 1) * strides[1] + kernel[1] - inSize[1] + 1) / 2; //As above
+        return outPad;
+    }
+
+    /**
      * Get the height and width
      * from the configuration
      * @param conf the configuration to get height and width from


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add and use `ConvolutionUtils.getSameModeBottomRightPadding()` instead of `getSameModeTopLeftPadding()` for the padding values passed to cuDNN in `ConvolutionMode.Same`. The former works with both cuDNN 5.x and 6.0, but the latter works only with cuDNN 5.x. See #3143

## How was this patch tested?

`TestConvolution` now passes with cuDNN 6.0 as well. Also tested by modifying `LenetMnistExample` with `.convolutionMode(ConvolutionMode.Same)` and `.stride(x, x)` where x > 1.