### PR TITLE
Add compgraph FF method for non-layer activations

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -915,4 +915,32 @@ public class TestComputationGraphNetwork {
                         new TransferLearning.GraphBuilder(modelToTune).setFeatureExtractor("denseCentre2").build();
         System.out.println(modelNow.summary());
     }
+
+    @Test
+    public void testFeedForwardIncludeNonLayerVertices(){
+
+        ComputationGraphConfiguration c = new NeuralNetConfiguration.Builder()
+                .graphBuilder()
+                .addInputs("in")
+                .addLayer("0",new DenseLayer.Builder().nIn(5).nOut(5).build(), "in")
+                .addLayer("1",new DenseLayer.Builder().nIn(5).nOut(5).build(), "in")
+                .addVertex("merge", new MergeVertex(), "0", "1")
+                .addLayer("out", new OutputLayer.Builder().nIn(10).nOut(5).build(), "merge")
+                .setOutputs("out")
+                .build();
+
+        ComputationGraph cg = new ComputationGraph(c);
+        cg.init();
+
+        cg.setInputs(Nd4j.ones(5));
+
+        Map<String,INDArray> layersOnly = cg.feedForward(true, false);
+        Map<String,INDArray> alsoVertices = cg.feedForward(true, true);
+
+        assertEquals(4, layersOnly.size()); //3 layers + 1 input
+        assertEquals(5, alsoVertices.size());   //3 layers + 1 input + merge vertex
+
+        assertFalse(layersOnly.containsKey("merge"));
+        assertTrue(alsoVertices.containsKey("merge"));
+    }
 }


### PR DESCRIPTION
Adds compgraph feed-forward method that returns non-layer activations also.
Detaches feedForward arrays for public API methods, to avoid leaking workspace activations.
