### PR TITLE
ParameterAveragingTrainingMaster should use treeAggregate

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/paramavg/ParameterAveragingTrainingMaster.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/paramavg/ParameterAveragingTrainingMaster.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.spark.impl.paramavg;
 
 import lombok.extern.slf4j.Slf4j;
+import static com.google.common.base.Preconditions.checkArgument;
 import org.apache.spark.api.java.JavaRDDLike;
 import org.deeplearning4j.api.storage.*;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
@@ -179,16 +180,10 @@ public class ParameterAveragingTrainingMaster
                     int batchSizePerWorker, int averagingFrequency, int aggregationDepth, int prefetchNumBatches,
                     Repartition repartition, RepartitionStrategy repartitionStrategy, StorageLevel storageLevel,
                     boolean collectTrainingStats) {
-        if (numWorkers <= 0)
-            throw new IllegalArgumentException("Invalid number of workers: " + numWorkers + " (must be >= 1)");
-        if (rddDataSetNumExamples <= 0)
-            throw new IllegalArgumentException(
-                            "Invalid rdd data set size: " + rddDataSetNumExamples + " (must be >= 1)");
-        if (averagingFrequency <= 0)
-            throw new IllegalArgumentException("Invalid input: averaging frequency must be >= 1");
-        if (aggregationDepth <= 0) {
-            throw new IllegalArgumentException("Invalid input: tree aggregation depth must be >= 1");
-        }
+        checkArgument(numWorkers > 0, "Invalid number of workers: " + numWorkers + " (must be >= 1)");
+        checkArgument(rddDataSetNumExamples > 0, "Invalid rdd data set size: " + rddDataSetNumExamples + " (must be >= 1)");
+        checkArgument(averagingFrequency > 0, "Invalid input: averaging frequency must be >= 1");
+        checkArgument(aggregationDepth > 0, "Invalid input: tree aggregation depth must be >= 1");
 
         this.saveUpdater = saveUpdater;
         this.numWorkers = numWorkers;
@@ -1170,11 +1165,8 @@ public class ParameterAveragingTrainingMaster
          * @param rddDataSetNumExamples Number of examples in each DataSet object in the {@code RDD<DataSet>}
          */
         public Builder(Integer numWorkers, int rddDataSetNumExamples) {
-            if (numWorkers != null && numWorkers <= 0)
-                throw new IllegalArgumentException("Invalid number of workers: " + numWorkers + " (must be >= 1)");
-            if (rddDataSetNumExamples <= 0)
-                throw new IllegalArgumentException(
-                                "Invalid rdd data set size: " + rddDataSetNumExamples + " (must be >= 1)");
+            checkArgument(numWorkers == null || numWorkers > 0, "Invalid number of workers: " + numWorkers + " (must be >= 1)");
+            checkArgument(rddDataSetNumExamples > 0, "Invalid rdd data set size: " + rddDataSetNumExamples + " (must be >= 1)");
             this.numWorkers = numWorkers;
             this.rddDataSetNumExamples = rddDataSetNumExamples;
         }
@@ -1199,8 +1191,7 @@ public class ParameterAveragingTrainingMaster
          * @param averagingFrequency Frequency (in number of minibatches of size 'batchSizePerWorker') to average parameters
          */
         public Builder averagingFrequency(int averagingFrequency) {
-            if (averagingFrequency <= 0)
-                throw new IllegalArgumentException("Invalid input: averaging frequency must be >= 1");
+            checkArgument(averagingFrequency > 0, "Invalid input: averaging frequency must be >= 1");
             this.averagingFrequency = averagingFrequency;
             return this;
         }
@@ -1213,10 +1204,7 @@ public class ParameterAveragingTrainingMaster
          * @param aggregationDepth RDD tree aggregation depth when averaging parameter updates.
          */
         public Builder aggregationDepth(int aggregationDepth) {
-            if (aggregationDepth <= 0) {
-                throw new IllegalArgumentException("Invalid input: tree aggregation depth must " +
-                        "be >= 1");
-            }
+            checkArgument(aggregationDepth > 0, "Invalid input: tree aggregation depth must be >= 1");
             this.aggregationDepth = aggregationDepth;
             return this;
         }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/paramavg/TestCompareParameterAveragingSparkVsSingleMachine.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/paramavg/TestCompareParameterAveragingSparkVsSingleMachine.java
@@ -112,7 +112,7 @@ public class TestCompareParameterAveragingSparkVsSingleMachine {
     private static TrainingMaster getTrainingMaster(int avgFreq, int miniBatchSize, boolean saveUpdater) {
         ParameterAveragingTrainingMaster tm = new ParameterAveragingTrainingMaster.Builder(1)
                         .averagingFrequency(avgFreq).batchSizePerWorker(miniBatchSize).saveUpdater(saveUpdater)
-                        .workerPrefetchNumBatches(0).build();
+                        .aggregationDepth(2).workerPrefetchNumBatches(0).build();
         return tm;
     }
 

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/paramavg/TestSparkMultiLayerParameterAveraging.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/impl/paramavg/TestSparkMultiLayerParameterAveraging.java
@@ -368,6 +368,7 @@ public class TestSparkMultiLayerParameterAveraging extends BaseSparkTest {
         SparkDl4jMultiLayer sparkNet = new SparkDl4jMultiLayer(sc, conf,
                         new ParameterAveragingTrainingMaster.Builder(numExecutors(), dataSetObjSize)
                                         .batchSizePerWorker(batchSizePerExecutor).averagingFrequency(1)
+                                        .aggregationDepth(1)
                                         .repartionData(Repartition.Always).build());
         sparkNet.setCollectTrainingStats(true);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds a new parameter to the `ParameterAveragingTrainingMaster` called `aggregationDepth` which controls the level of tree aggregation used during parameter averaging. This patch changes `processResults` to use `RDD.treeAggregate` instead of `RDD.aggregate`. 

I could not find prior discussion on this either through the issues or through gitter. I had problems doing transfer learning on VGG16 using Spark, as my driver was running out of memory. Tree aggregation should help alleviate this. Though I'm still new to the project, I can't see a reason not to use tree aggregate here.

This patch also modifies a couple of public constructors, but from taking a look at some past patches, this does not seem to be an issue? I think it could be avoided by adding another alternate constructor.

## How was this patch tested?

I am more than happy to add unit tests. For now, I did not since things like parameter bound checks do not seem to be tested in the current code, and a unit test for this does not seem to me to fit in any of the existing test modules. So for now, I've added the parameter to a couple of existing usages in the tests. Please let me know if I should go ahead and add unit tests to check the bounds on the aggregation depth parameter.
