### PR TITLE
Fix RecordReaderDataSetIterator.hasNext() with SequenceRecordReader

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
@@ -403,7 +403,7 @@ public class RecordReaderDataSetIterator implements DataSetIterator {
 
     @Override
     public boolean hasNext() {
-        return (recordReader.hasNext() && (maxNumBatches < 0 || batchNum < maxNumBatches));
+        return (((sequenceIter != null && sequenceIter.hasNext()) || recordReader.hasNext()) && (maxNumBatches < 0 || batchNum < maxNumBatches));
     }
 
     @Override

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetiteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetiteratorTest.java
@@ -60,6 +60,16 @@ public class RecordReaderDataSetiteratorTest {
         DataSetIterator iter = new RecordReaderDataSetIterator(recordReader, 34);
         DataSet next = iter.next();
         assertEquals(34, next.numExamples());
+
+        recordReader = new CSVSequenceRecordReader();
+        recordReader.initialize(csv);
+        iter = new RecordReaderDataSetIterator(recordReader, 1);
+        int count = 0;
+        while (iter.hasNext() && count < 34) {
+            iter.next();
+            count++;
+        }
+        assertEquals(34, count);
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RecordReaderDataSetIterator.hasNext()` wasn't checking if the sequence was empty or not before checking the next file.

Fixes #1590

## How was this patch tested?

Updated unit tests pass.