### PR TITLE
Add restoring Normalizer from a model file InputStream

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
@@ -612,6 +612,20 @@ public class ModelSerializer {
         }
     }
 
+
+    /**
+     * This method restores the normalizer form a persisted model file.
+     *
+     * @param is A stream to load data from.
+     * @return the loaded normalizer
+     */
+    public static <T extends Normalizer> T restoreNormalizerFromInputStream(InputStream is) throws IOException {
+        File tmpFile = File.createTempFile("restore", "normalizer");
+        tmpFile.deleteOnExit();
+        FileUtils.copyInputStreamToFile(is, tmpFile);
+        return restoreNormalizerFromFile(tmpFile);
+    }
+
     /**
      * @deprecated
      *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds a method that can restore a normalizer that is included in a model file.

The new method is restoreNormalizerFromInputStream instead of an overload because the File version is named in an objective-c style restoreNormalizerFromFile.

## How was this patch tested?

I've added tests for the happy and sad case and verified that the restored normalizer restores values correctly.
