### PR TITLE
Fix for issue #3327

### DIFF
--- a/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/weights/ConvolutionalIterationListener.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui/src/main/java/org/deeplearning4j/ui/weights/ConvolutionalIterationListener.java
@@ -132,7 +132,7 @@ public class ConvolutionalIterationListener implements IterationListener {
             if (model instanceof MultiLayerNetwork) {
                 MultiLayerNetwork l = (MultiLayerNetwork) model;
                 for (Layer layer : l.getLayers()) {
-                    if (layer.type() == Layer.Type.CONVOLUTIONAL) {
+                    if (!(layer instanceof FrozenLayer) && layer.type() == Layer.Type.CONVOLUTIONAL) {
                         INDArray output = layer.activate();
                         int sampleDim = rnd.nextInt(output.shape()[0] - 1) + 1;
                         if (cnt == 0) {
@@ -157,7 +157,7 @@ public class ConvolutionalIterationListener implements IterationListener {
             } else if (model instanceof ComputationGraph) {
                 ComputationGraph l = (ComputationGraph) model;
                 for (Layer layer : l.getLayers()) {
-                    if (layer.type() == Layer.Type.CONVOLUTIONAL) {
+                    if (!(layer instanceof FrozenLayer) && layer.type() == Layer.Type.CONVOLUTIONAL) {
                         INDArray output = layer.activate();
                         int sampleDim = rnd.nextInt(output.shape()[0] - 1) + 1;
                         if (cnt == 0) {


### PR DESCRIPTION
Addresses ClassCast exception when visualizing activations. https://github.com/deeplearning4j/deeplearning4j/issues/3327

## What changes were proposed in this pull request?

Adds instanceof check to ensure layer is not a frozen layer.

## How was this patch tested?

Ran with existing repo and tests.