### PR TITLE
Micro-perf on MergeVertex.

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/MergeVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/MergeVertex.java
@@ -172,7 +172,7 @@ public class MergeVertex extends BaseGraphVertex {
         //Split the epsilons in the opposite way that the activations were merged
         INDArray[] out = new INDArray[forwardPassShapes.length];
         for (int i = 0; i < out.length; i++)
-            out[i] = Nd4j.create(forwardPassShapes[i]);
+            out[i] = Nd4j.createUnitialized(forwardPassShapes[i]);
 
         int cumulative = 0;
         switch (fwdPassRank) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In an effort to continually improve performance on DL4J, this PR uses createUnitialized() in MergeVertex.

## How was this patch tested?

Tested in real-world CNN training and inference scenario.