### PR TITLE
Multiple fixes

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/RegressionEvalTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/RegressionEvalTest.java
@@ -176,4 +176,35 @@ public class RegressionEvalTest {
         }
     }
 
+    @Test
+    public void testRegressionEvalPerOutputMasking(){
+
+        INDArray l = Nd4j.create(new double[][]{
+                {1,2,3},
+                {10,20,30},
+                {-5,-10,-20}});
+
+        INDArray predictions = Nd4j.zeros(l.shape());
+
+        INDArray mask = Nd4j.create(new double[][]{
+                {0,1,1},
+                {1,1,0},
+                {0,1,0}});
+
+
+        RegressionEvaluation re = new RegressionEvaluation();
+
+        re.eval(l, predictions, mask);
+
+        double[] mse = new double[]{
+                (10*10)/1.0,
+                (2*2 + 20*20 + 10*10)/3,
+                (3*3)/1.0};
+
+        for( int i=0; i<3; i++ ){
+            assertEquals(mse[i], re.meanSquaredError(i), 1e-6);
+        }
+
+    }
+
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/RegressionEvalTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/RegressionEvalTest.java
@@ -201,10 +201,20 @@ public class RegressionEvalTest {
                 (2*2 + 20*20 + 10*10)/3,
                 (3*3)/1.0};
 
+        double[] mae = new double[]{
+                10.0,
+                (2 + 20 + 10) / 3.0,
+                3.0};
+
+        double[] rmse = new double[]{
+                10.0,
+                Math.sqrt((2*2 + 20*20 + 10*10) / 3.0),
+                3.0};
+
         for( int i=0; i<3; i++ ){
             assertEquals(mse[i], re.meanSquaredError(i), 1e-6);
+            assertEquals(mae[i], re.meanAbsoluteError(i), 1e-6);
+            assertEquals(rmse[i], re.rootMeanSquaredError(i), 1e-6);
         }
-
     }
-
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -931,8 +931,8 @@ public class TestComputationGraphNetwork {
 
         cg.setInputs(Nd4j.ones(5));
 
-        Map<String, INDArray> layersOnly = cg.feedForward(true, false);
-        Map<String, INDArray> alsoVertices = cg.feedForward(true, true);
+        Map<String, INDArray> layersOnly = cg.feedForward(true, false, false);
+        Map<String, INDArray> alsoVertices = cg.feedForward(true, false, true);
 
         assertEquals(4, layersOnly.size()); //3 layers + 1 input
         assertEquals(5, alsoVertices.size()); //3 layers + 1 input + merge vertex

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/RegressionEvaluation.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/RegressionEvaluation.java
@@ -2,9 +2,7 @@ package org.deeplearning4j.eval;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.Abs;
-import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
-import org.nd4j.linalg.indexing.NDArrayIndex;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +28,6 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
     private boolean initialized;
     private List<String> columnNames;
     private int precision;
-//    private long exampleCount = 0;
     private INDArray exampleCountPerColumn; //Necessary to account for per-output masking
     private INDArray labelsSumPerColumn; //sum(actual) per column -> used to calculate mean
     private INDArray sumSquaredErrorsPerColumn; //(predicted - actual)^2
@@ -172,9 +169,6 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
 
         int nRows = labels.size(0);
 
-//        currentMean.muli(exampleCount).addi(labels.sum(0)).divi(exampleCount + nRows);
-//        currentPredictionMean.muli(exampleCount).addi(predictions.sum(0)).divi(exampleCount + nRows);
-
         INDArray newExampleCountPerColumn;
         if(maskArray == null){
             newExampleCountPerColumn = exampleCountPerColumn.add(nRows);
@@ -183,8 +177,6 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
         }
         currentMean.muliRowVector(exampleCountPerColumn).addi(labels.sum(0)).diviRowVector(newExampleCountPerColumn);
         currentPredictionMean.muliRowVector(exampleCountPerColumn).addi(predictions.sum(0)).divi(newExampleCountPerColumn);
-
-//        exampleCount += nRows;
         exampleCountPerColumn = newExampleCountPerColumn;
     }
 
@@ -215,8 +207,6 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
         this.labelsSumPerColumn.addi(other.labelsSumPerColumn);
         this.sumSquaredErrorsPerColumn.addi(other.sumSquaredErrorsPerColumn);
         this.sumAbsErrorsPerColumn.addi(other.sumAbsErrorsPerColumn);
-//        this.currentMean.muli(exampleCount).addi(other.currentMean.mul(other.exampleCount))
-//                        .divi(exampleCount + other.exampleCount);
         this.currentMean.muliRowVector(exampleCountPerColumn).addi(other.currentMean.mulRowVector(other.exampleCountPerColumn))
                 .diviRowVector(exampleCountPerColumn.add(other.exampleCountPerColumn));
         this.currentPredictionMean.muliRowVector(exampleCountPerColumn).addi(other.currentPredictionMean.mulRowVector(other.exampleCountPerColumn))
@@ -225,7 +215,6 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
         this.sumSquaredLabels.addi(other.sumSquaredLabels);
         this.sumSquaredPredicted.addi(other.sumSquaredPredicted);
 
-//        this.exampleCount += other.exampleCount;
         this.exampleCountPerColumn.addi(other.exampleCountPerColumn);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -2698,6 +2698,7 @@ public class ComputationGraph implements Serializable, Model {
     /**
      * Evaluate the (single output layer only) network for regression performance
      * @param iterator Data to evaluate on
+     * @param columnNames Column names for the regression evaluation. May be null.
      * @return Regression evaluation
      */
     public RegressionEvaluation evaluateRegression(DataSetIterator iterator, List<String> columnNames) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1248,7 +1248,17 @@ public class ComputationGraph implements Serializable, Model {
     }
 
     public Map<String, INDArray> feedForward(boolean train, boolean excludeOutputLayers) {
-        return feedForward(true, excludeOutputLayers, false, true);
+        return feedForward(train, excludeOutputLayers, false, true);
+    }
+
+    /**
+     * @param train                            True: training time. False: test time
+     * @param excludeOutputLayers              Should we exclude the output layers during forward pass? (usually: false)
+     * @param includeNonLayerVertexActivations Include non-layer vertices in the output may?
+     * @return Map of activations. Key: vertex name. Value: activations.
+     */
+    public Map<String, INDArray> feedForward(boolean train, boolean excludeOutputLayers, boolean includeNonLayerVertexActivations) {
+        return feedForward(train, excludeOutputLayers, includeNonLayerVertexActivations, true);
     }
 
     /**
@@ -1260,7 +1270,7 @@ public class ComputationGraph implements Serializable, Model {
      * @param publicApi
      * @return
      */
-    public Map<String, INDArray> feedForward(boolean train, boolean excludeOutputLayers, boolean includeNonLayerVertexActivations, boolean publicApi) {
+    protected Map<String, INDArray> feedForward(boolean train, boolean excludeOutputLayers, boolean includeNonLayerVertexActivations, boolean publicApi) {
         Map<String, INDArray> layerActivations = new HashMap<>();
 
         MemoryWorkspace workspace = configuration.getTrainingWorkspaceMode() == WorkspaceMode.NONE ? dummy :

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/StackVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/StackVertex.java
@@ -122,6 +122,12 @@ public class StackVertex extends BaseGraphVertex {
         if (!canDoForward())
             throw new IllegalStateException("Cannot do forward pass: input not set");
 
+        if(epsilon == null){
+            //Edge case for stack vertex: stack -> embedding
+            //If the null epsilons are a problem in practice, this should be picked up by other layers
+            return new Pair<>(null, new INDArray[inputs.length]);
+        }
+
         int nStack = inputs.length;
         INDArray[] out = new INDArray[nStack];
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/ActivationLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/ActivationLayer.java
@@ -78,8 +78,9 @@ public class ActivationLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers
 
     @Override
     public INDArray activate(boolean training) {
-        if (input == null)
-            throw new IllegalArgumentException("No null input allowed");
+        if (input == null) {
+            throw new IllegalArgumentException("Cannot do forward pass with null input " + layerId());
+        }
         applyDropOutIfNecessary(training);
 
         INDArray in;
@@ -96,7 +97,7 @@ public class ActivationLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported - " + layerId());
     }
 
     @Override
@@ -107,12 +108,12 @@ public class ActivationLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray indArray) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported - " + layerId());
     }
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Not supported - " + layerId());
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseOutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseOutputLayer.java
@@ -89,7 +89,7 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
     @Override
     public double computeScore(double fullNetworkL1, double fullNetworkL2, boolean training) {
         if (input == null || labels == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         this.fullNetworkL1 = fullNetworkL1;
         this.fullNetworkL2 = fullNetworkL2;
         INDArray preOut = preOutput2d(training);
@@ -116,7 +116,7 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
     @Override
     public INDArray computeScoreForExamples(double fullNetworkL1, double fullNetworkL2) {
         if (input == null || labels == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         INDArray preOut = preOutput2d(false);
 
         ILossFunction lossFunction = layerConf().getLossFn();
@@ -143,8 +143,7 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
 
     @Override
     protected void setScoreWithZ(INDArray z) {
-        //        setScore(z, null);
-        throw new RuntimeException("Not yet implemented");
+        throw new RuntimeException("Not supported - " + layerId());
     }
 
     @Override
@@ -176,7 +175,8 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
         INDArray labels2d = getLabels2d();
         if (labels2d.size(1) != preOut.size(1)) {
             throw new DL4JInvalidInputException("Labels array numColumns (size(1) = " + labels2d.size(1)
-                            + ") does not match output layer" + " number of outputs (nOut = " + preOut.size(1) + ")");
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOut.size(1)
+                            + ") " + layerId() );
         }
         //INDArray delta = lossFunction.computeGradient(labels2d, preOut, layerConf().getActivationFunction(), maskArray);
         INDArray delta = lossFunction.computeGradient(labels2d, preOut, layerConf().getActivationFn(), maskArray);
@@ -233,8 +233,9 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
      * @return a probability distribution for each row
      */
     public INDArray output(boolean training) {
-        if (input == null)
-            throw new IllegalArgumentException("No null input allowed");
+        if (input == null) {
+            throw new IllegalArgumentException("Cannot perform forward pass with null input - " + layerId());
+        }
         return super.activate(training);
     }
 
@@ -395,7 +396,7 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
 
     @Override
     public void iterate(INDArray input) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override
@@ -421,7 +422,8 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
         } else {
             throw new IllegalStateException("Invalid mask array: per-example masking should be a column vector, "
                             + "per output masking arrays should be the same shape as the output/labels arrays. Mask shape: "
-                            + Arrays.toString(maskArray.shape()) + ", output shape: " + Arrays.toString(to.shape()));
+                            + Arrays.toString(maskArray.shape()) + ", output shape: " + Arrays.toString(to.shape())
+                            + layerId());
         }
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
@@ -138,7 +138,7 @@ public abstract class BasePretrainNetwork<LayerConfT extends org.deeplearning4j.
     @Override
     protected void setScoreWithZ(INDArray z) {
         if (input == null || z == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         ILossFunction lossFunction = layerConf().getLossFunction().getILossFunction();
 
         //double score = lossFunction.computeScore(input, z, layerConf().getActivationFunction(), maskArray, false);
@@ -194,7 +194,8 @@ public abstract class BasePretrainNetwork<LayerConfT extends org.deeplearning4j.
         }
 
         if (params.length() != paramLength) {
-            throw new IllegalArgumentException("Unable to set parameters: must be of length " + paramLength);
+            throw new IllegalArgumentException("Unable to set parameters: must be of length " + paramLength
+                    + ", got params of length " + params.length() + " " + layerId());
         }
 
         // Set for backprop and only W & hb

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/DropoutLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/DropoutLayer.java
@@ -53,8 +53,9 @@ public class DropoutLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.Dr
 
     @Override
     public INDArray preOutput(boolean training) {
-        if (input == null)
-            throw new IllegalArgumentException("No null input allowed");
+        if (input == null) {
+            throw new IllegalArgumentException("Cannot perform forward pass with null input " + layerId());
+        }
         INDArray dummy = input;
         applyDropOutIfNecessary(training);
 
@@ -81,7 +82,7 @@ public class DropoutLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.Dr
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported - " + layerId());
     }
 
     @Override
@@ -92,12 +93,12 @@ public class DropoutLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.Dr
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray indArray) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Not supported - " + layerId());
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/FrozenLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/FrozenLayer.java
@@ -34,8 +34,9 @@ public class FrozenLayer<LayerT extends Layer> implements Layer {
     private Gradient zeroGradient;
 
     public FrozenLayer(LayerT insideLayer) {
+        this.insideLayer = insideLayer;
         if (insideLayer instanceof OutputLayer) {
-            throw new IllegalArgumentException("Output Layers are not allowed to be frozen");
+            throw new IllegalArgumentException("Output Layers are not allowed to be frozen " + layerId());
         }
         this.insideLayer = insideLayer;
         this.zeroGradient = new DefaultGradient(insideLayer.params());
@@ -43,6 +44,11 @@ public class FrozenLayer<LayerT extends Layer> implements Layer {
             //save memory??
             zeroGradient.setGradientFor(paramType, null);
         }
+    }
+
+    protected String layerId(){
+        String name = insideLayer.conf().getLayer().getLayerName();
+        return "(layer name: " + (name == null ? "\"\"" : name) + ", layer index: " + insideLayer.getIndex() + ")";
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/LossLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/LossLayer.java
@@ -75,7 +75,7 @@ public class LossLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.LossL
     @Override
     public double computeScore(double fullNetworkL1, double fullNetworkL2, boolean training) {
         if (input == null || labels == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         this.fullNetworkL1 = fullNetworkL1;
         this.fullNetworkL2 = fullNetworkL2;
         INDArray preOut = input;
@@ -102,7 +102,7 @@ public class LossLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.LossL
     @Override
     public INDArray computeScoreForExamples(double fullNetworkL1, double fullNetworkL2) {
         if (input == null || labels == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         INDArray preOut = input;
 
         ILossFunction lossFunction = layerConf().getLossFn();
@@ -129,7 +129,7 @@ public class LossLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.LossL
 
     @Override
     protected void setScoreWithZ(INDArray z) {
-        throw new RuntimeException("Not yet implemented");
+        throw new RuntimeException("Not supported " + layerId());
     }
 
     @Override
@@ -235,14 +235,15 @@ public class LossLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.LossL
      * @return a probability distribution for each row
      */
     public INDArray output(boolean training) {
-        if (input == null)
-            throw new IllegalArgumentException("No null input allowed");
+        if (input == null) {
+            throw new IllegalArgumentException("Cannot perform forward pass with null input " + layerId());
+        }
         return activate(training);
     }
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not applicable");
+        throw new UnsupportedOperationException("Not applicable " + layerId());
     }
 
     @Override
@@ -253,12 +254,12 @@ public class LossLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.LossL
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray indArray) {
-        throw new UnsupportedOperationException("Not applicable");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -412,7 +413,7 @@ public class LossLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.LossL
 
     @Override
     public void iterate(INDArray input) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/Convolution1DLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/Convolution1DLayer.java
@@ -43,7 +43,8 @@ public class Convolution1DLayer extends ConvolutionLayer {
             throw new DL4JInvalidInputException("Got rank " + epsilon.rank()
                             + " array as epsilon for Convolution1DLayer backprop with shape "
                             + Arrays.toString(epsilon.shape())
-                            + ". Expected rank 3 array with shape [minibatchSize, features, length].");
+                            + ". Expected rank 3 array with shape [minibatchSize, features, length]. "
+                            + layerId());
 
         // add singleton fourth dimension to input and next layer's epsilon
         epsilon = epsilon.reshape(epsilon.size(0), epsilon.size(1), epsilon.size(2), 1);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -268,7 +268,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                             + "Expected rank 4 array with shape [minibatchSize, layerInputDepth, inputHeight, inputWidth]."
                             + (input.rank() == 2
                                             ? " (Wrong input type (see InputType.convolutionalFlat()) or wrong data type?)"
-                                            : ""));
+                                            : "") + " "  + layerId());
         }
 
         int miniBatch = input.size(0);
@@ -282,7 +282,8 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
             throw new DL4JInvalidInputException("Cannot do forward pass in Convolution layer (layer name = " + layerName
                             + ", layer index = " + index + "): input array depth does not match CNN layer configuration"
                             + " (data input depth = " + input.size(1) + ", [minibatch,inputDepth,height,width]="
-                            + Arrays.toString(input.shape()) + "; expected" + " input depth = " + inDepth + ")");
+                            + Arrays.toString(input.shape()) + "; expected" + " input depth = " + inDepth + ") "
+                            + layerId());
         }
         int kH = weights.size(2);
         int kW = weights.size(3);
@@ -353,8 +354,9 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public INDArray activate(boolean training) {
-        if (input == null)
-            throw new IllegalArgumentException("No null input allowed");
+        if (input == null) {
+            throw new IllegalArgumentException("Cannot perform forward pass with null input " + layerId());
+        }
         applyDropOutIfNecessary(training);
 
         INDArray z = preOutput(training);
@@ -374,7 +376,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported - " + layerId());
     }
 
     @Override
@@ -385,7 +387,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray indArray) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -393,7 +395,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/Subsampling1DLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/Subsampling1DLayer.java
@@ -39,7 +39,8 @@ public class Subsampling1DLayer extends SubsamplingLayer {
             throw new DL4JInvalidInputException("Got rank " + epsilon.rank()
                             + " array as epsilon for Subsampling1DLayer backprop with shape "
                             + Arrays.toString(epsilon.shape())
-                            + ". Expected rank 3 array with shape [minibatchSize, features, length].");
+                            + ". Expected rank 3 array with shape [minibatchSize, features, length]. "
+                            + layerId());
 
         // add singleton fourth dimension to input and next layer's epsilon
         INDArray origInput = input;
@@ -62,7 +63,8 @@ public class Subsampling1DLayer extends SubsamplingLayer {
         if (input.rank() != 3)
             throw new DL4JInvalidInputException("Got rank " + input.rank()
                             + " array as input to Subsampling1DLayer with shape " + Arrays.toString(input.shape())
-                            + ". Expected rank 3 array with shape [minibatchSize, features, length].");
+                            + ". Expected rank 3 array with shape [minibatchSize, features, length]. "
+                            + layerId());
 
         // add singleton fourth dimension to input
         INDArray origInput = input;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -225,7 +225,8 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
             case NONE:
                 return new Pair<>(retGradient, epsilon);
             default:
-                throw new IllegalStateException("Unknown or unsupported pooling type: " + layerConf().getPoolingType());
+                throw new IllegalStateException("Unknown or unsupported pooling type: " + layerConf().getPoolingType()
+                        + " "  + layerId());
         }
 
         //Finally: we want the output strides for the epsilons to match the strides in the activations from the layer below
@@ -253,7 +254,8 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         if (input.rank() != 4) {
             throw new DL4JInvalidInputException("Got rank " + input.rank()
                             + " array as input to SubsamplingLayer with shape " + Arrays.toString(input.shape())
-                            + ". Expected rank 4 array with shape [minibatchSize, depth, inputHeight, inputWidth].");
+                            + ". Expected rank 4 array with shape [minibatchSize, depth, inputHeight, inputWidth]. "
+                            + layerId());
         }
 
         int miniBatch = input.size(0);
@@ -315,25 +317,26 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
             case NONE:
                 return input;
             default:
-                throw new IllegalStateException("Unknown/not supported pooling type: " + layerConf().getPoolingType());
+                throw new IllegalStateException("Unknown/not supported pooling type: " + layerConf().getPoolingType()
+                        + " " + layerId());
         }
         return reduced.reshape('c', miniBatch, inDepth, outH, outW);
     }
 
     @Override
     public Gradient error(INDArray input) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray indArray) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override
@@ -343,7 +346,7 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override
@@ -353,7 +356,7 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public void iterate(INDArray input) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override
@@ -381,7 +384,7 @@ public class SubsamplingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public void accumulateScore(double accum) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/embedding/EmbeddingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/embedding/EmbeddingLayer.java
@@ -89,7 +89,8 @@ public class EmbeddingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.
             //Assume shape is [numExamples,1], and each entry is an integer index
             throw new DL4JInvalidInputException(
                             "Cannot do forward pass for embedding layer with input more than one column. "
-                                            + "Expected input shape: [numExamples,1] with each entry being an integer index");
+                            + "Expected input shape: [numExamples,1] with each entry being an integer index "
+                            + layerId());
         }
 
         int[] indexes = new int[input.length()];
@@ -131,7 +132,7 @@ public class EmbeddingLayer extends BaseLayer<org.deeplearning4j.nn.conf.layers.
 
     @Override
     protected void applyDropOutIfNecessary(boolean training) {
-        throw new UnsupportedOperationException("Dropout not supported with EmbeddingLayer");
+        throw new UnsupportedOperationException("Dropout not supported with EmbeddingLayer " + layerId());
     }
 
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/rbm/RBM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/feedforward/rbm/RBM.java
@@ -258,7 +258,7 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
             }
             default:
                 throw new IllegalStateException(
-                                "Hidden unit type must either be Binary, Gaussian, SoftMax or Rectified");
+                                "Hidden unit type must either be Binary, Gaussian, SoftMax or Rectified " + layerId());
         }
 
         return new Pair<>(hProb, hSample);
@@ -297,7 +297,8 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
                 break;
             }
             default: {
-                throw new IllegalStateException("Visible type must be one of Binary, Gaussian, SoftMax or Linear");
+                throw new IllegalStateException("Visible type must be one of Binary, Gaussian, SoftMax or Linear "
+                        + layerId());
             }
         }
 
@@ -349,7 +350,7 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
                 return Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("softmax", preSig));
             default:
                 throw new IllegalStateException(
-                                "Hidden unit type should either be binary, gaussian, or rectified linear");
+                                "Hidden unit type should either be binary, gaussian, or rectified linear " + layerId());
         }
 
     }
@@ -375,7 +376,7 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
                                 .execAndReturn(Nd4j.getOpFactory().createTransform("softmax", z).derivative());
             default:
                 throw new IllegalStateException(
-                                "Hidden unit type should either be binary, gaussian, or rectified linear");
+                                "Hidden unit type should either be binary, gaussian, or rectified linear " + layerId());
         }
 
     }
@@ -406,7 +407,7 @@ public class RBM extends BasePretrainNetwork<org.deeplearning4j.nn.conf.layers.R
             case SOFTMAX:
                 return Nd4j.getExecutioner().execAndReturn(Nd4j.getOpFactory().createTransform("softmax", vMean));
             default:
-                throw new IllegalStateException("Visible unit type should either be binary or gaussian");
+                throw new IllegalStateException("Visible unit type should either be binary or gaussian " + layerId());
         }
 
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -210,7 +210,7 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
         } else {
             // TODO setup BatchNorm for RNN http://arxiv.org/pdf/1510.01378v1.pdf
             throw new IllegalStateException(
-                            "The layer prior to BatchNorm in the configuration is not currently supported.");
+                            "The layer prior to BatchNorm in the configuration is not currently supported. " + layerId());
         }
 
         return new Pair<>(retGradient, nextEpsilon);
@@ -218,7 +218,7 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override
@@ -269,7 +269,8 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
                     break;
                 default:
                     throw new IllegalStateException(
-                                    "Batch normalization on activations of rank " + x.rank() + " not supported");
+                                    "Batch normalization on activations of rank " + x.rank() + " not supported "
+                                            + layerId());
             }
 
 
@@ -360,7 +361,7 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
         } else {
             // TODO setup BatchNorm for RNN http://arxiv.org/pdf/1510.01378v1.pdf
             throw new IllegalStateException(
-                            "The layer prior to BatchNorm in the configuration is not currently supported.");
+                            "The layer prior to BatchNorm in the configuration is not currently supported. " + layerId());
         }
 
         // store mean and var if using batch mean while training
@@ -398,7 +399,7 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
 
     @Override
     public INDArray activate(TrainingMode training) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override
@@ -413,13 +414,13 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
 
     }
 
     @Override
     public Layer clone() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
 
     }
 
@@ -455,10 +456,10 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
             int wDim = x.size(1);
             int hdim = x.size(2);
             if (x.size(0) > 1 && wDim * hdim == x.length())
-                throw new IllegalArgumentException("Illegal input for batch size");
+                throw new IllegalArgumentException("Illegal input for batch size " + layerId());
             return new int[] {1, wDim * hdim};
         } else
-            throw new IllegalStateException("Unable to process input of rank " + x.rank());
+            throw new IllegalStateException("Unable to process input of rank " + x.rank() + " " + layerId());
     }
 
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
@@ -175,7 +175,7 @@ public class LocalResponseNormalization
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -186,12 +186,12 @@ public class LocalResponseNormalization
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray indArray) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported - " + layerId());
     }
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(layerId());
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingLayer.java
@@ -85,7 +85,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
     public INDArray activate(boolean training) {
         if (input == null) {
             throw new IllegalStateException(
-                            "Cannot perform forward pass: input not set for layer " + layerNameAndIndex());
+                            "Cannot perform forward pass: input not set for layer " + layerId());
         }
 
         int[] poolDim = null;
@@ -109,8 +109,8 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
             }
         } else {
             throw new UnsupportedOperationException("Received rank " + input.rank() + " input (shape = "
-                            + Arrays.toString(input.shape())
-                            + "). Only rank 3 (time series) and rank 4 (images/CNN data) are currently supported for global pooling");
+                            + Arrays.toString(input.shape()) + "). Only rank 3 (time series) and rank 4 (images"
+                            + "/CNN data) are currently supported for global pooling " + layerId());
         }
 
         INDArray reduced2d;
@@ -136,7 +136,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
                                                     + "on CNN data. Got 4d activations array (shape "
                                                     + Arrays.toString(input.shape()) + ") and " + maskArray.rank()
                                                     + "d mask array (shape " + Arrays.toString(maskArray.shape())
-                                                    + ")");
+                                                    + ") " + layerId());
                 }
 
                 int h = input.size(2);
@@ -150,7 +150,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
                                                     + " Got 4d activations array (shape "
                                                     + Arrays.toString(input.shape()) + ") and " + maskArray.rank()
                                                     + "d mask array (shape " + Arrays.toString(maskArray.shape())
-                                                    + ")");
+                                                    + ") " + layerId());
                 }
 
                 //Valid combinations of global pooling + masking for CNNs:
@@ -159,7 +159,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
                     throw new UnsupportedOperationException(
                                     "Masked global pooling with on CNN data currently only supports poolling over dimensions "
                                                     + "[2,3] (i.e., width and height - both required). Got pooling dimensions "
-                                                    + Arrays.toString(poolDim) + ")");
+                                                    + Arrays.toString(poolDim) + ") " + layerId());
                 }
 
                 boolean maskAlongHeight = (h == maskLength); //At this point: can't confuse w and h, as one has to be 1...
@@ -167,7 +167,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
                 reduced2d = MaskedReductionUtil.maskedPoolingConvolution(poolingType, input, maskArray, maskAlongHeight,
                                 pNorm);
             } else {
-                throw new UnsupportedOperationException("Invalid input: is rank " + input.rank());
+                throw new UnsupportedOperationException("Invalid input: is rank " + input.rank() + " " + layerId());
             }
         }
 
@@ -203,7 +203,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
 
                 return Transforms.pow(pNorm, 1.0 / pnorm);
             default:
-                throw new RuntimeException("Unknown or not supported pooling type: " + poolingType);
+                throw new RuntimeException("Unknown or not supported pooling type: " + poolingType + " " + layerId());
         }
     }
 
@@ -254,7 +254,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
                 epsilonNd = MaskedReductionUtil.maskedPoolingEpsilonCnn(poolingType, input, maskArray, epsilon,
                                 maskAlongHeight, pNorm);
             } else {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException(layerId());
             }
 
         }
@@ -319,7 +319,7 @@ public class GlobalPoolingLayer extends BaseLayer<org.deeplearning4j.nn.conf.lay
 
                 return numerator;
             default:
-                throw new RuntimeException("Unknown or not supported pooling type: " + poolingType);
+                throw new RuntimeException("Unknown or not supported pooling type: " + poolingType + " " + layerId());
         }
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesBidirectionalLSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesBidirectionalLSTM.java
@@ -62,12 +62,12 @@ public class GravesBidirectionalLSTM
 
     @Override
     public Gradient gradient() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray activation) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -86,7 +86,8 @@ public class GravesBidirectionalLSTM
 
         if (truncatedBPTT) {
             throw new UnsupportedOperationException(
-                            "you can not time step a bidirectional RNN, it has to run on a batch of data all at once");
+                            "Time step for bidirectional RNN not supported: it has to run on a batch of data all at once "
+                            + layerId());
         }
 
         final FwdPassReturn fwdPass = activateHelperDirectional(true, null, null, true, true);
@@ -237,7 +238,7 @@ public class GravesBidirectionalLSTM
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -283,14 +284,16 @@ public class GravesBidirectionalLSTM
     @Override
     public INDArray rnnTimeStep(INDArray input) {
         throw new UnsupportedOperationException(
-                        "you can not time step a bidirectional RNN, it has to run on a batch of data all at once");
+                        "you can not time step a bidirectional RNN, it has to run on a batch of data all at once "
+                        + layerId());
     }
 
 
 
     @Override
     public INDArray rnnActivateUsingStoredState(INDArray input, boolean training, boolean storeLastForTBPTT) {
-        throw new UnsupportedOperationException("Cannot set stored state: bidirectional RNNs don't have stored state");
+        throw new UnsupportedOperationException("Cannot set stored state: bidirectional RNNs don't have stored state "
+                + layerId());
     }
 
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
@@ -55,12 +55,13 @@ public class GravesLSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.la
     @Override
     public Gradient gradient() {
         throw new UnsupportedOperationException(
-                        "gradient() method for layerwise pretraining: not supported for LSTMs (pretraining not possible)");
+                        "gradient() method for layerwise pretraining: not supported for LSTMs (pretraining not possible)"
+                                + layerId());
     }
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray activation) {
-        throw new UnsupportedOperationException("Not supported");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -158,7 +159,7 @@ public class GravesLSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.la
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not supported");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
@@ -53,12 +53,13 @@ public class LSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.layers.L
     @Override
     public Gradient gradient() {
         throw new UnsupportedOperationException(
-                        "gradient() method for layerwise pretraining: not supported for LSTMs (pretraining not possible)");
+                        "gradient() method for layerwise pretraining: not supported for LSTMs (pretraining not possible) "
+                        + layerId());
     }
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray activation) {
-        throw new UnsupportedOperationException("Not supported");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -156,7 +157,7 @@ public class LSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.layers.L
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not supported");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/RnnOutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/RnnOutputLayer.java
@@ -57,7 +57,8 @@ public class RnnOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn.conf.l
     @Override
     public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon) {
         if (input.rank() != 3)
-            throw new UnsupportedOperationException("Input is not rank 3");
+            throw new UnsupportedOperationException("Input is not rank 3. Got input with rank " + input.rank() + " "
+                    + layerId());
         INDArray inputTemp = input;
         this.input = TimeSeriesUtils.reshape3dTo2d(input);
         Pair<Gradient, INDArray> gradAndEpsilonNext = super.backpropGradient(epsilon);
@@ -119,7 +120,7 @@ public class RnnOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn.conf.l
     @Override
     public INDArray output(INDArray input) {
         if (input.rank() != 3)
-            throw new IllegalArgumentException("Input must be rank 3 (is: " + input.rank());
+            throw new IllegalArgumentException("Input must be rank 3 (is: " + input.rank() + ") " + layerId());
         //Returns 3d activations from 3d input
         setInput(input);
         return output(false);
@@ -129,7 +130,8 @@ public class RnnOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn.conf.l
     public INDArray output(boolean training) {
         //Assume that input is 3d
         if (input.rank() != 3)
-            throw new IllegalArgumentException("input must be rank 3");
+            throw new IllegalArgumentException("input must be rank 3. Got input with rank " + input.rank() + " "
+                    + layerId());
         INDArray preOutput2d = preOutput2d(training);
 
         //if(conf.getLayer().getActivationFunction().equals("softmax")) {
@@ -156,7 +158,8 @@ public class RnnOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn.conf.l
     @Override
     public INDArray activate(boolean training) {
         if (input.rank() != 3)
-            throw new UnsupportedOperationException("Input must be rank 3");
+            throw new UnsupportedOperationException("Input must be rank 3. Got input with rank " + input.rank()
+                    + " " + layerId());
         INDArray b = getParam(DefaultParamInitializer.BIAS_KEY);
         INDArray W = getParam(DefaultParamInitializer.WEIGHT_KEY);
         if (conf.isUseDropConnect() && training) {
@@ -186,7 +189,8 @@ public class RnnOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn.conf.l
                 this.maskArray = TimeSeriesUtils.reshape3dTo2d(maskArray);
             } else {
                 throw new UnsupportedOperationException("Invalid mask array: must be rank 2 or 3 (got: rank "
-                                + maskArray.rank() + ", shape = " + Arrays.toString(maskArray.shape()) + ")");
+                                + maskArray.rank() + ", shape = " + Arrays.toString(maskArray.shape()) + ") "
+                        + layerId());
             }
         } else {
             this.maskArray = null;
@@ -220,7 +224,7 @@ public class RnnOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn.conf.l
         //For RNN: need to sum up the score over each time step before returning.
 
         if (input == null || labels == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         INDArray preOut = preOutput2d(false);
 
         ILossFunction lossFunction = layerConf().getLossFn();

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/training/CenterLossOutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/training/CenterLossOutputLayer.java
@@ -69,7 +69,7 @@ public class CenterLossOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn
     @Override
     public double computeScore(double fullNetworkL1, double fullNetworkL2, boolean training) {
         if (input == null || labels == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         this.fullNetworkL1 = fullNetworkL1;
         this.fullNetworkL2 = fullNetworkL2;
         INDArray preOut = preOutput2d(training);
@@ -119,7 +119,7 @@ public class CenterLossOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn
     @Override
     public INDArray computeScoreForExamples(double fullNetworkL1, double fullNetworkL2) {
         if (input == null || labels == null)
-            throw new IllegalStateException("Cannot calculate score without input and labels");
+            throw new IllegalStateException("Cannot calculate score without input and labels " + layerId());
         INDArray preOut = preOutput2d(false);
 
         // calculate the intra-class score component
@@ -155,8 +155,7 @@ public class CenterLossOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn
 
     @Override
     protected void setScoreWithZ(INDArray z) {
-        //        setScore(z, null);
-        throw new RuntimeException("Not yet implemented");
+        throw new RuntimeException("Not supported " + layerId());
     }
 
     @Override
@@ -195,7 +194,8 @@ public class CenterLossOutputLayer extends BaseOutputLayer<org.deeplearning4j.nn
         INDArray labels2d = getLabels2d();
         if (labels2d.size(1) != preOut.size(1)) {
             throw new DL4JInvalidInputException("Labels array numColumns (size(1) = " + labels2d.size(1)
-                            + ") does not match output layer" + " number of outputs (nOut = " + preOut.size(1) + ")");
+                            + ") does not match output layer" + " number of outputs (nOut = " + preOut.size(1)
+                    + ") " + layerId());
         }
 
         INDArray delta = lossFunction.computeGradient(labels2d, preOut, layerConf().getActivationFn(), maskArray);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/variational/VariationalAutoencoder.java
@@ -89,6 +89,11 @@ public class VariationalAutoencoder implements Layer {
                         .getNumSamples();
     }
 
+    protected String layerId(){
+        String name = this.conf().getLayer().getLayerName();
+        return "(layer name: " + (name == null ? "\"\"" : name) + ", layer index: " + index + ")";
+    }
+
     /**
      * Init the model
      */
@@ -99,12 +104,12 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public void update(Gradient gradient) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public void update(INDArray gradient, String paramType) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -427,7 +432,8 @@ public class VariationalAutoencoder implements Layer {
     public void setParams(INDArray params) {
         if (params.length() != this.paramsFlattened.length()) {
             throw new IllegalArgumentException("Cannot set parameters: expected parameters vector of length "
-                            + this.paramsFlattened.length() + " but got parameters array of length " + params.length());
+                            + this.paramsFlattened.length() + " but got parameters array of length " + params.length()
+                            + " " + layerId());
         }
         this.paramsFlattened.assign(params);
     }
@@ -436,7 +442,7 @@ public class VariationalAutoencoder implements Layer {
     public void setParamsViewArray(INDArray params) {
         if (this.params != null && params.length() != numParams())
             throw new IllegalArgumentException("Invalid input: expect params of length " + numParams()
-                            + ", got params of length " + params.length());
+                            + ", got params of length " + params.length() + " " + layerId());
         this.paramsFlattened = params;
     }
 
@@ -449,7 +455,7 @@ public class VariationalAutoencoder implements Layer {
     public void setBackpropGradientsViewArray(INDArray gradients) {
         if (this.params != null && gradients.length() != numParams()) {
             throw new IllegalArgumentException("Invalid input: expect gradients array of length " + numParams()
-                            + ", got gradient array of length of length " + gradients.length());
+                            + ", got gradient array of length of length " + gradients.length() + " " + layerId());
         }
 
         this.gradientsFlattened = gradients;
@@ -504,7 +510,7 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public void validateInput() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -519,7 +525,7 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public void initParams() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Deprecated " + layerId());
     }
 
     @Override
@@ -545,7 +551,11 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public void setParam(String key, INDArray val) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        if(paramTable().containsKey(key)){
+            paramTable().get(key).assign(val);
+        } else {
+            throw new IllegalArgumentException("Unknown parameter: " + key + " - " + layerId());
+        }
     }
 
     @Override
@@ -601,17 +611,17 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public Gradient error(INDArray input) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public INDArray derivativeActivation(INDArray input) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public Gradient calcGradient(Gradient layerError, INDArray indArray) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -679,12 +689,12 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public void merge(Layer layer, int batchSize) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public INDArray activationMean() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
@@ -719,7 +729,7 @@ public class VariationalAutoencoder implements Layer {
 
     private VAEFwdHelper doForward(boolean training, boolean forBackprop) {
         if (input == null) {
-            throw new IllegalStateException("Cannot do forward pass with null input");
+            throw new IllegalStateException("Cannot do forward pass with null input " + layerId());
         }
 
         //TODO input validation
@@ -791,12 +801,12 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public Layer transpose() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not supported " + layerId());
     }
 
     @Override
     public Layer clone() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not yet implemented " + layerId());
     }
 
     @Override
@@ -877,14 +887,14 @@ public class VariationalAutoencoder implements Layer {
                     int minibatchSize) {
 
 
-        throw new UnsupportedOperationException("Not yet implemented");
+        throw new UnsupportedOperationException("Not yet implemented " + layerId());
     }
 
 
     @Override
     public void fit() {
         if (input == null) {
-            throw new IllegalStateException("Cannot fit layer: layer input is null (not set)");
+            throw new IllegalStateException("Cannot fit layer: layer input is null (not set) " + layerId());
         }
 
         if (solver == null) {
@@ -936,12 +946,14 @@ public class VariationalAutoencoder implements Layer {
      */
     public INDArray reconstructionLogProbability(INDArray data, int numSamples) {
         if (numSamples <= 0) {
-            throw new IllegalArgumentException("Invalid input: numSamples must be > 0. Got: " + numSamples);
+            throw new IllegalArgumentException("Invalid input: numSamples must be > 0. Got: " + numSamples
+                    + " " + layerId());
         }
         if (reconstructionDistribution instanceof LossFunctionWrapper) {
             throw new UnsupportedOperationException("Cannot calculate reconstruction log probability when using "
                             + "a LossFunction (via LossFunctionWrapper) instead of a ReconstructionDistribution: ILossFunction "
-                            + "instances are not in general probabilistic, hence it is not possible to calculate reconstruction probability");
+                            + "instances are not in general probabilistic, hence it is not possible to calculate reconstruction probability "
+                            + layerId());
         }
 
         //Forward pass through the encoder and mean for P(Z|X)
@@ -1036,7 +1048,7 @@ public class VariationalAutoencoder implements Layer {
         if (latentSpaceValues.size(1) != params.get(VariationalAutoencoderParamInitializer.PZX_MEAN_W).size(1)) {
             throw new IllegalArgumentException("Invalid latent space values: expected size "
                             + params.get(VariationalAutoencoderParamInitializer.PZX_MEAN_W).size(1)
-                            + ", got size (dimension 1) = " + latentSpaceValues.size(1));
+                            + ", got size (dimension 1) = " + latentSpaceValues.size(1) + " " + layerId());
         }
 
         //Do forward pass through decoder
@@ -1085,7 +1097,8 @@ public class VariationalAutoencoder implements Layer {
             throw new IllegalStateException(
                             "Cannot use reconstructionError method unless the variational autoencoder is "
                                             + "configured with a standard loss function (via LossFunctionWrapper). For VAEs utilizing a reconstruction "
-                                            + "distribution, use the reconstructionProbability or reconstructionLogProbability methods");
+                                            + "distribution, use the reconstructionProbability or reconstructionLogProbability methods "
+                                            + layerId());
         }
 
         INDArray pZXMean = activate(data, false);


### PR DESCRIPTION
- RegressionEvaluation lazy initialization; fix async iter shutdown in compgraph RE method
- RegressionEvaluation: supports per-output masking (needs more testing)
- Improve exceptions in layers (add layer names and indexes)
- Stack vertex can now handle null epsilons https://github.com/deeplearning4j/deeplearning4j/issues/3335