### PR TITLE
Make JapaneseTokenizer thread-safe and much more efficient.

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/JapaneseTokenizer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/JapaneseTokenizer.java
@@ -21,10 +21,11 @@ package org.deeplearning4j.text.tokenization.tokenizer;
 import com.atilika.kuromoji.ipadic.Token;
 import com.atilika.kuromoji.ipadic.Tokenizer;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
- * modified by kepricon on 16. 10. 28.
  * A thin wrapper for Japanese Morphological Analyzer Kuromoji (ver.0.9.0),
  * it tokenizes texts which is written in languages
  * that words are not separated by whitespaces.
@@ -41,6 +42,15 @@ public class JapaneseTokenizer implements org.deeplearning4j.text.tokenization.t
     private int currentToken;
     private TokenPreProcess preProcessor;
 
+
+    /**
+     * Tokenize the string with Kuromoji, optionally using baseForms.
+     *
+     * Note: It is safe to create new instances from multiple threads.
+     * @param kuromoji The kuromoji instance.
+     * @param toTokenize The string to tokenize.
+     * @param useBaseForm normalize conjugations "走った" -> "走る" instead of "走っ"
+     */
     public JapaneseTokenizer(Tokenizer kuromoji, String toTokenize, boolean useBaseForm) {
         this.useBaseForm = useBaseForm;
         this.tokens = kuromoji.tokenize(toTokenize);
@@ -59,7 +69,7 @@ public class JapaneseTokenizer implements org.deeplearning4j.text.tokenization.t
     }
 
     private String getToken(int i) {
-        Token t = this.tokens.get(i);
+        Token t = tokens.get(i);
         String ret = (useBaseForm) ? t.getBaseForm() : t.getSurface();
         return (preProcessor == null) ? ret : preProcessor.preProcess(ret);
     }
@@ -74,9 +84,9 @@ public class JapaneseTokenizer implements org.deeplearning4j.text.tokenization.t
 
     @Override
     public List<String> getTokens() {
-        ArrayList<String> ret = new ArrayList<>(this.tokenCount);
+        List<String> ret = new ArrayList<String>(tokenCount);
 
-        for (int i = 0; i < this.tokenCount; i++) {
+        for (int i = 0; i < tokenCount; i++) {
             ret.add(getToken(i));
         }
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/org/deeplearning4j/text/tokenization/tokenizerfactory/JapaneseTokenizerFactory.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/org/deeplearning4j/text/tokenization/tokenizerfactory/JapaneseTokenizerFactory.java
@@ -1,23 +1,45 @@
 package org.deeplearning4j.text.tokenization.tokenizerfactory;
 
+import org.deeplearning4j.text.tokenization.tokenizer.JapaneseTokenizer;
 import org.deeplearning4j.text.tokenization.tokenizer.TokenPreProcess;
 import org.deeplearning4j.text.tokenization.tokenizer.Tokenizer;
-import org.deeplearning4j.text.tokenization.tokenizer.JapaneseTokenizer;
 
 import java.io.InputStream;
 
 public class JapaneseTokenizerFactory implements TokenizerFactory {
-    private TokenPreProcess preProcess;
-    private boolean useBaseForm;
+    private final com.atilika.kuromoji.ipadic.Tokenizer kuromoji;
+    private final boolean useBaseForm;
+    private TokenPreProcess preProcessor;
 
-    public JapaneseTokenizerFactory() {}
+    public JapaneseTokenizerFactory() {
+        this(new com.atilika.kuromoji.ipadic.Tokenizer.Builder(), false);
+    }
+
+    public JapaneseTokenizerFactory(boolean useBaseForm) {
+        this(new com.atilika.kuromoji.ipadic.Tokenizer.Builder(), true);
+    }
+
+    public JapaneseTokenizerFactory(com.atilika.kuromoji.ipadic.Tokenizer.Builder builder) {
+        this(builder, false);
+    }
+
+    public JapaneseTokenizerFactory(com.atilika.kuromoji.ipadic.Tokenizer.Builder builder, boolean baseForm) {
+        kuromoji = builder.build();
+        useBaseForm = baseForm;
+    }
 
     @Override
     public Tokenizer create(String toTokenize) {
         if (toTokenize.isEmpty()) {
             throw new IllegalArgumentException("Unable to proceed; no sentence to tokenize");
         }
-        JapaneseTokenizer t = new JapaneseTokenizer(toTokenize);
+
+        JapaneseTokenizer t = new JapaneseTokenizer(kuromoji, toTokenize, useBaseForm);
+
+        if (preProcessor != null) {
+            t.setTokenPreProcessor(preProcessor);
+        }
+
         return t;
     }
 
@@ -28,12 +50,12 @@ public class JapaneseTokenizerFactory implements TokenizerFactory {
 
     @Override
     public void setTokenPreProcessor(TokenPreProcess preProcessor) {
-        this.preProcess = preProcess;
+        this.preProcessor = preProcessor;
     }
 
     @Override
     public TokenPreProcess getTokenPreProcessor() {
-        return this.preProcess;
+        return this.preProcessor;
     }
 
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/org/deeplearning4j/text/tokenization/tokenizerfactory/JapaneseTokenizerFactory.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/org/deeplearning4j/text/tokenization/tokenizerfactory/JapaneseTokenizerFactory.java
@@ -6,35 +6,62 @@ import org.deeplearning4j.text.tokenization.tokenizer.Tokenizer;
 
 import java.io.InputStream;
 
+/**
+ * Tokenizer Factory for Japanese based on Kuromoji.
+ */
 public class JapaneseTokenizerFactory implements TokenizerFactory {
     private final com.atilika.kuromoji.ipadic.Tokenizer kuromoji;
     private final boolean useBaseForm;
     private TokenPreProcess preProcessor;
 
+
+    /**
+     * Creates a factory that uses the defaults for Kuromoji.
+     */
     public JapaneseTokenizerFactory() {
         this(new com.atilika.kuromoji.ipadic.Tokenizer.Builder(), false);
     }
 
+    /**
+     * Creates a factory that uses the Kuomoji defaults but returns normalized/stemmed "baseForm" tokens.
+     * @param useBaseForm normalize conjugations "走った" -> "走る" instead of "走っ"
+     */
     public JapaneseTokenizerFactory(boolean useBaseForm) {
-        this(new com.atilika.kuromoji.ipadic.Tokenizer.Builder(), true);
+        this(new com.atilika.kuromoji.ipadic.Tokenizer.Builder(), useBaseForm);
     }
 
+    /**
+     * Create a factory using the supplied Kuromoji configuration.  Use this for setting custom dictionaries or modes.
+     * @param builder The Kuromoji Tokenizer builder with your configuration in place.
+     */
     public JapaneseTokenizerFactory(com.atilika.kuromoji.ipadic.Tokenizer.Builder builder) {
         this(builder, false);
     }
 
+    /**
+     * Create a factory using the supplied Kuromoji configuration.  Use this for setting custom dictionaries or modes.
+     * @param builder The Kuromoji Tokenizer builder with your configuration in place.
+     * @param baseForm normalize conjugations "走った" -> "走る" instead of "走っ"
+     */
     public JapaneseTokenizerFactory(com.atilika.kuromoji.ipadic.Tokenizer.Builder builder, boolean baseForm) {
         kuromoji = builder.build();
         useBaseForm = baseForm;
     }
 
+    /**
+     * Create a Tokenizer instance for the given sentence.
+     *
+     * Note: This method is thread-safe.
+     * @param toTokenize the string to tokenize.
+     * @return The tokenizer.
+     */
     @Override
     public Tokenizer create(String toTokenize) {
         if (toTokenize.isEmpty()) {
             throw new IllegalArgumentException("Unable to proceed; no sentence to tokenize");
         }
 
-        JapaneseTokenizer t = new JapaneseTokenizer(kuromoji, toTokenize, useBaseForm);
+        Tokenizer t = new JapaneseTokenizer(kuromoji, toTokenize, useBaseForm);
 
         if (preProcessor != null) {
             t.setTokenPreProcessor(preProcessor);
@@ -43,6 +70,10 @@ public class JapaneseTokenizerFactory implements TokenizerFactory {
         return t;
     }
 
+    /**
+     * InputStreams are currently unsupported.
+     * @param toTokenize the string to tokenize.
+     */
     @Override
     public Tokenizer create(InputStream toTokenize) {
         throw new UnsupportedOperationException();

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/JapaneseTokenizerTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/JapaneseTokenizerTest.java
@@ -1,25 +1,119 @@
 package org.deeplearning4j.text.tokenization.tokenizer;
 
-import static org.junit.Assert.assertEquals;
-
-import org.deeplearning4j.text.tokenization.tokenizer.JapaneseTokenizer;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.JapaneseTokenizerFactory;
-import org.deeplearning4j.text.tokenization.tokenizer.Tokenizer;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class JapaneseTokenizerTest {
+
+    private String toTokenize = "黒い瞳の綺麗な女の子";
+    private String[] expect = {"黒い", "瞳", "の", "綺麗", "な", "女の子"};
+    private String baseString = "驚いた彼は道を走っていった。";
 
     @Test
     public void testJapaneseTokenizer() throws Exception {
-        String toTokenize = "黒い瞳の綺麗な女の子";
         TokenizerFactory t = new JapaneseTokenizerFactory();
         Tokenizer tokenizer = t.create(toTokenize);
-        String[] expect = {"黒い", "瞳", "の", "綺麗", "な", "女の子"};
 
         assertEquals(expect.length, tokenizer.countTokens());
         for (int i = 0; i < tokenizer.countTokens(); ++i) {
             assertEquals(tokenizer.nextToken(), expect[i]);
+        }
+    }
+
+    @Test
+    public void testBaseForm() throws Exception {
+        JapaneseTokenizerFactory tf = new JapaneseTokenizerFactory(true);
+
+        Tokenizer tokenizer1 = tf.create(toTokenize);
+        Tokenizer tokenizer2 = tf.create(baseString);
+
+        assertEquals("黒い", tokenizer1.nextToken());
+        assertEquals("驚く", tokenizer2.nextToken());
+    }
+
+
+    @Test
+    public void testGetTokens() throws Exception {
+        JapaneseTokenizerFactory tf = new JapaneseTokenizerFactory();
+
+        Tokenizer tokenizer = tf.create(toTokenize);
+
+        // Exhaust iterator.
+        assertEquals(expect.length, tokenizer.countTokens());
+        for (int i = 0; i < tokenizer.countTokens(); ++i) {
+            assertEquals(tokenizer.nextToken(), expect[i]);
+        }
+
+        // Ensure exhausted.
+        assertEquals(false, tokenizer.hasMoreTokens());
+
+        // Count doesn't change.
+        assertEquals(expect.length, tokenizer.countTokens());
+
+        // getTokens still returns everything.
+        List<String> tokens = tokenizer.getTokens();
+        assertEquals(expect.length, tokens.size());
+    }
+
+    @Test
+    public void testKuromojiMultithreading() throws Exception {
+        class Worker implements Runnable {
+            private final JapaneseTokenizerFactory tf;
+            private final String[] jobs;
+            private int runs;
+            private boolean passed = false;
+
+            public Worker(JapaneseTokenizerFactory tf, String[] jobs, int runs) {
+                this.tf = tf;
+                this.jobs = jobs;
+                this.runs = runs;
+            }
+
+            @Override
+            public void run() {
+                while (runs > 0) {
+                    String s = jobs[runs-- % jobs.length];
+                    List<String> tokens = tf.create(s).getTokens();
+                    StringBuilder sb = new StringBuilder();
+                    for (String token : tokens) {
+                        sb.append(token);
+                    }
+
+                    if (sb.toString().length() != s.length()) {
+                        return;
+                    }
+                }
+                passed = true;
+            }
+        }
+
+        JapaneseTokenizerFactory tf = new JapaneseTokenizerFactory();
+
+        String[] work = {toTokenize, baseString, toTokenize, baseString};
+        Worker[] workers = new Worker[10];
+
+        for (int i = 0; i < workers.length; i++) {
+            workers[i] = new Worker(tf, work, 50);
+        }
+
+        Thread[] threads = new Thread[10];
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(workers[i]);
+            threads[i].start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        for (int i = 0; i < workers.length; i++) {
+            assertTrue(workers[i].passed);
         }
     }
 }

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/JapaneseTokenizerTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/JapaneseTokenizerTest.java
@@ -28,7 +28,7 @@ public class JapaneseTokenizerTest {
 
     @Test
     public void testBaseForm() throws Exception {
-        JapaneseTokenizerFactory tf = new JapaneseTokenizerFactory(true);
+        TokenizerFactory tf = new JapaneseTokenizerFactory(true);
 
         Tokenizer tokenizer1 = tf.create(toTokenize);
         Tokenizer tokenizer2 = tf.create(baseString);
@@ -40,7 +40,7 @@ public class JapaneseTokenizerTest {
 
     @Test
     public void testGetTokens() throws Exception {
-        JapaneseTokenizerFactory tf = new JapaneseTokenizerFactory();
+        TokenizerFactory tf = new JapaneseTokenizerFactory();
 
         Tokenizer tokenizer = tf.create(toTokenize);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

JapaneseTokenizer implementation creates new instances of the kuromoji Tokenizer which load the entire dictionary on startup.  By caching the Tokenizer inside the JapaneseTokenizerFactory it becomes much more efficient.  A side effect is that the JapaneseTokenizerFactory also becomes thread-safe.  In Kuromoji only a single thread can create a Tokenizer at a time the tokenizer method is thread-safe.

I also added support for tokenizing into base forms. (A form of stemming.)

## How was this patch tested?

I added tests for the base form functionality and a test that uses threads.