### PR TITLE
Excludes com.google.code.findbugs:annotations and dependencies

### DIFF
--- a/deeplearning4j-core/pom.xml
+++ b/deeplearning4j-core/pom.xml
@@ -54,6 +54,11 @@
                 <groupId>org.nd4j</groupId>
                 <artifactId>nd4j-common</artifactId>
                 <version>${nd4j.version}</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                  </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.nd4j</groupId>
@@ -112,6 +117,12 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/deeplearning4j-keras/pom.xml
+++ b/deeplearning4j-keras/pom.xml
@@ -62,6 +62,13 @@
       <version>${py4j.version}</version>
     </dependency>
 
+    <!-- Used to alleviate licensing issues with findbugs -->
+    <dependency>
+      <groupId>com.github.stephenc.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+      <version>1.3.9-1</version>
+    </dependency>
+
     <!-- Test deps -->
     <dependency>
       <groupId>junit</groupId>

--- a/deeplearning4j-keras/src/test/java/org/deeplearning4j/keras/StringsEndsWithPredicate.java
+++ b/deeplearning4j-keras/src/test/java/org/deeplearning4j/keras/StringsEndsWithPredicate.java
@@ -2,7 +2,7 @@ package org.deeplearning4j.keras;
 
 import com.google.common.base.Predicate;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.anotations.Nullable;
 
 public class StringsEndsWithPredicate implements Predicate<String> {
 

--- a/deeplearning4j-modelimport/pom.xml
+++ b/deeplearning4j-modelimport/pom.xml
@@ -53,6 +53,11 @@
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-api</artifactId>
             <version>${nd4j.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/deeplearning4j-nearestneighbor-server/pom.xml
+++ b/deeplearning4j-nearestneighbor-server/pom.xml
@@ -37,6 +37,12 @@
             <groupId>com.typesafe.play</groupId>
             <artifactId>play-java_2.11</artifactId>
             <version>${playframework.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.mashape.unirest</groupId>

--- a/deeplearning4j-nn/pom.xml
+++ b/deeplearning4j-nn/pom.xml
@@ -34,6 +34,11 @@
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-api</artifactId>
             <version>${nd4j.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- ND4J Shaded Jackson Dependency -->

--- a/deeplearning4j-scaleout/dl4j-streaming/pom.xml
+++ b/deeplearning4j-scaleout/dl4j-streaming/pom.xml
@@ -62,6 +62,12 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_2.11</artifactId>
             <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.datavec</groupId>

--- a/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/pom.xml
@@ -112,10 +112,14 @@
             <artifactId>spark-core_2.11</artifactId>
             <version>${spark.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>servlet-api</artifactId>
-                </exclusion>
+              <exclusion>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
             </exclusions>
 
         </dependency>

--- a/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
+++ b/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
@@ -96,6 +96,12 @@
             <groupId>com.typesafe.play</groupId>
             <artifactId>play-java_2.11</artifactId>
             <version>${playframework.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -113,6 +119,12 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>${reflections.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- ///////////////// Jackson Dependencies ///////////////// -->
@@ -142,6 +154,12 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_2.11</artifactId>
             <version>${spark.jackson.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Jackson Datatype -->

--- a/deeplearning4j-ui-parent/deeplearning4j-ui-resources/pom.xml
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui-resources/pom.xml
@@ -25,6 +25,12 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>19.0</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Also known as an exercise in futility, since findbugs is notoriously BSD, now
see findbugsproject/findbugs#128
But this should cut down discussion time with lawyers.