### PR TITLE
Issue #3468 : Move loss function size assertions into loss functions …

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseOutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseOutputLayer.java
@@ -173,11 +173,6 @@ public abstract class BaseOutputLayer<LayerConfT extends org.deeplearning4j.nn.c
     private Pair<Gradient, INDArray> getGradientsAndDelta(INDArray preOut) {
         ILossFunction lossFunction = layerConf().getLossFn();
         INDArray labels2d = getLabels2d();
-        if (labels2d.size(1) != preOut.size(1)) {
-            throw new DL4JInvalidInputException("Labels array numColumns (size(1) = " + labels2d.size(1)
-                            + ") does not match output layer" + " number of outputs (nOut = " + preOut.size(1)
-                            + ") " + layerId() );
-        }
         //INDArray delta = lossFunction.computeGradient(labels2d, preOut, layerConf().getActivationFunction(), maskArray);
         INDArray delta = lossFunction.computeGradient(labels2d, preOut, layerConf().getActivationFn(), maskArray);
 


### PR DESCRIPTION
Issue #3468 : Move loss function size assertions into loss functions instead of enforcing it universally.  This allows custom loss-functions such as the Bishop Mixture Density Network loss function to have different label size than network output size.

## What changes were proposed in this pull request?

This patch resolves this issue: deeplearning4j/deeplearning4j#3468

## How was this patch tested?

A unit-test was added which verifies the assertion behavior added in nd4j.
