### PR TITLE
Makes `ListDataSetIterator` take a subtype of `DataSet` as elements.

### DIFF
--- a/deeplearning4j-nearestneighbor-server/pom.xml
+++ b/deeplearning4j-nearestneighbor-server/pom.xml
@@ -87,4 +87,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>test-nd4j-native</id>
+        </profile>
+        <profile>
+            <id>test-nd4j-cuda-8.0</id>
+        </profile>
+    </profiles>
+
 </project>

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/impl/ListDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/impl/ListDataSetIterator.java
@@ -32,16 +32,16 @@ import java.util.List;
  *
  * @author Adam Gibson
  */
-public class ListDataSetIterator implements DataSetIterator {
+public class ListDataSetIterator<T extends DataSet> implements DataSetIterator {
 
     private static final long serialVersionUID = -7569201667767185411L;
     private int curr = 0;
     private int batch = 10;
-    private List<DataSet> list;
+    private List<T> list;
     @Getter
     private DataSetPreProcessor preProcessor;
 
-    public ListDataSetIterator(Collection<DataSet> coll, int batch) {
+    public ListDataSetIterator(Collection<T> coll, int batch) {
         list = new ArrayList<>(coll);
         this.batch = batch;
 
@@ -52,7 +52,7 @@ public class ListDataSetIterator implements DataSetIterator {
      *
      * @param coll the collection to iterate over
      */
-    public ListDataSetIterator(Collection<DataSet> coll) {
+    public ListDataSetIterator(Collection<T> coll) {
         this(coll, 5);
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,7 @@
                   <directory>deeplearning4j-nn</directory>
                   <directory>deeplearning4j-modelimport</directory>
                   <directory>deeplearning4j-keras</directory>
+                  <directory>deeplearning4j-nearestneighbor-server</directory>
                   <directory>deeplearning4j-zoo</directory>
                 </directories>
               </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Makes `ListDataSetIterator` take a subtype of `DataSet` as elements.
Fixes nd4j#1484

## How was this patch tested?

Passes all `TestDataSetiterator` tests.
