### PR TITLE
Added ShiftVertex

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/graph/ShiftVertexTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/graph/ShiftVertexTest.java
@@ -1,0 +1,248 @@
+package org.deeplearning4j.nn.conf.graph;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.commons.math3.util.Pair;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.Updater;
+import org.deeplearning4j.nn.conf.graph.ShiftVertex;
+import org.deeplearning4j.nn.conf.layers.ActivationLayer;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.activations.BaseActivationFunction;
+import org.nd4j.linalg.activations.impl.ActivationSigmoid;
+import org.nd4j.linalg.activations.impl.ActivationTanH;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
+
+/**
+ * Created by binesh on 6/13/2017. 
+ */
+
+public class ShiftVertexTest {
+	@Test
+	public void testShiftVertexNumParamsTrue() {
+		/*
+		 * https://github.com/deeplearning4j/deeplearning4j/pull/3514#issuecomment-307754386
+		 * from @agibsonccc: check for the basics: like 0 numParams
+		 */
+		
+		ShiftVertex sv = new ShiftVertex(0.7); // The 0.7 doesn't really matter.
+		Assert.assertEquals(0, sv.numParams(true));
+	}
+	
+	@Test
+	public void testShiftVertexNumParamsFalse() {
+		/*
+		 * https://github.com/deeplearning4j/deeplearning4j/pull/3514#issuecomment-307754386
+		 * from @agibsonccc: check for the basics: like 0 numParams
+		 */
+		
+		ShiftVertex sv = new ShiftVertex(0.7); // The 0.7 doesn't really matter.
+		Assert.assertEquals(0, sv.numParams(false));
+	}
+	
+	@Test
+	public void testGet() {
+		ShiftVertex sv = new ShiftVertex(0.7);
+		Assert.assertEquals(0.7, sv.getShiftFactor(), this.epsilon);
+	}
+	
+	@Test
+	public void testSimple() {
+		/*
+		 * This function _simply_ tests whether ShiftVertex is _in fact_ adding the shift value to it's inputs.
+		 */
+		// Just first n primes / 10.
+		INDArray input = Nd4j.create(new double[][]{
+				{0.2,0.3,0.5},
+				{0.7,1.1,1.3},
+				{1.7,1.9,2.3},
+				{2.9,3.1,3.7}
+		});
+		double sf = 4.1;
+		ComputationGraphConfiguration cgc = new NeuralNetConfiguration.Builder()
+			.graphBuilder()
+			.addInputs("input")
+			.addLayer("denselayer", new DenseLayer.Builder().nIn(input.columns()).nOut(1).activation(Activation.IDENTITY).build(), "input")
+				/* denselayer is not actually used, but it seems that you _need_ to have trainable parameters, otherwise, you get
+				 * Invalid shape: Requested INDArray shape [1, 0] contains dimension size values < 1 (all dimensions must be 1 or more)
+				 * at org.nd4j.linalg.factory.Nd4j.checkShapeValues(Nd4j.java:4877)
+				 * at org.nd4j.linalg.factory.Nd4j.create(Nd4j.java:4867)
+				 * at org.nd4j.linalg.factory.Nd4j.create(Nd4j.java:4820)
+				 * at org.nd4j.linalg.factory.Nd4j.create(Nd4j.java:3948)
+				 * at org.deeplearning4j.nn.graph.ComputationGraph.init(ComputationGraph.java:409)
+				 * at org.deeplearning4j.nn.graph.ComputationGraph.init(ComputationGraph.java:341)
+				 */
+			.addLayer("identityinputactivation", new ActivationLayer.Builder().activation(Activation.IDENTITY).build(), "input")
+			.addVertex("shiftvertex", new ShiftVertex(sf), "identityinputactivation")
+			.addLayer("identityshiftvertex", new ActivationLayer.Builder().activation(Activation.IDENTITY).build(), "shiftvertex")
+			.setOutputs("identityshiftvertex")
+			.build();
+		
+		ComputationGraph cg = new ComputationGraph(cgc);
+		cg.init();
+
+		// We can call outputSingle, because we only have a single output layer. It has nothing to do with minibatches.
+		INDArray output = cg.outputSingle(true, input);
+		INDArray target = Nd4j.zeros(input.shape());
+		target.addi(input);
+		target.addi(sf);
+
+		INDArray squared = output.sub(target);
+		double rms = squared.mul(squared).sumNumber().doubleValue();
+		Assert.assertEquals(0.0, rms, this.epsilon);
+	}
+	
+	@Test
+	public void testComprehensive() {
+		/*
+		 * This function tests ShiftVertex more comprehensively. Specifically, it verifies that the lossfunction works as
+		 * expected on a ComputationGraph _with_ a ShiftVertex and it verifies that the derivatives produced by 
+		 * back propagating work as expected.
+		 */
+		BaseActivationFunction a1 = new ActivationTanH();
+		BaseActivationFunction a2 = new ActivationSigmoid();
+		// Just first n primes / 10.
+		INDArray input = Nd4j.create(new double[][]{
+				{0.2,0.3,0.5},
+				{0.7,1.1,1.3},
+				{1.7,1.9,2.3},
+				{2.9,3.1,3.7}
+		});
+		double sf = 4.1;
+		INDArray target = Nd4j.create(new double[][]{
+				{ 4.3, 4.7, 5.3, 5.9, 6.1 },
+				{ 6.7, 7.1, 7.3, 7.9, 8.3 },
+				{ 8.9, 9.7,10.1,10.3,10.7 },
+				{10.9,11.3,12.7,13.1,13.7 }
+		});
+		
+		ComputationGraphConfiguration cgc = new NeuralNetConfiguration.Builder()
+			.weightInit(WeightInit.XAVIER)
+			.learningRate(0.01)
+			.updater(Updater.SGD)
+			.optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+			.graphBuilder()
+			.addInputs("input")
+			.addLayer("denselayer", new DenseLayer.Builder().nIn(input.columns()).nOut(input.columns()).activation(a1).build(), "input")
+			.addVertex("shiftvertex", new ShiftVertex(sf), "denselayer")
+			.addLayer("output", new OutputLayer.Builder().nIn(input.columns()).nOut(target.columns()).activation(a2).lossFunction(LossFunction.MSE).build(), "shiftvertex")
+			.setOutputs("output")
+			.backprop(true)
+			.build();
+		ComputationGraph cg = new ComputationGraph(cgc);
+		cg.init();
+		cg.setInput(0, input);
+		cg.setLabel(0, target);
+		cg.computeGradientAndScore();
+		double score_dl4j = cg.score();
+		Map<String, INDArray> weights = cg.paramTable();
+		Gradient g = cg.gradient();
+		Map<String, INDArray> gradients = g.gradientForVariable();
+		Map<String, INDArray> manual_gradients = new TreeMap<String, INDArray>();
+		
+		INDArray W = nullsafe(weights.get("denselayer_W"));
+		INDArray b = nullsafe(weights.get("denselayer_b"));
+		INDArray V = nullsafe(weights.get("output_W"));
+		INDArray c = nullsafe(weights.get("output_b"));
+		
+		Map<String, INDArray> manual_weights = new TreeMap<String, INDArray>();
+		manual_weights.put("denselayer_W", W);
+		manual_weights.put("denselayer_b", b);
+		manual_weights.put("output_W", V);
+		manual_weights.put("output_b", c);
+
+		// First things first, let's calculate the score.
+		int batchsz = input.shape()[0];
+		INDArray z = input.mmul(W).add(b.repmat(batchsz, 1));
+		INDArray a = a1.getActivation(z.dup(), true).add(sf); // activation modifies it's input!!
+		INDArray q = a.mmul(V).add(c.repmat(batchsz, 1));
+		INDArray o = nullsafe(a2.getActivation(q.dup(), true));
+		double score_manual = sum_errors(o, target) / (o.columns() * o.rows());
+
+		/*
+		 * So. We have
+		 * z5 = input1 * W15 + input2 * W25 + input3 * W35 + b5
+		 * a5 = activation(z5) + sr
+		 * q9 = a1 * V19 + a2 * V29 + a3 * V39 + c9
+		 * o9 = activation(q9)
+		 *  
+		 * dE/do = 2(o-t)
+		 * doj/dqj = activation'(qj)
+		 * dqj/dVij = ai dqj/dai = Vij dqj/dbj = 1
+		 * 
+		 * dq1/dv11 = a1 dq2/dV12 = a1 dq3/dV13 = a1 ...
+		 * dq1/dv21 = a2 dq2...
+		 */
+		INDArray dEdo = Nd4j.zeros(target.shape());
+		dEdo.addi(o).subi(target).muli(2); // This should be of size batchsz x outputsz
+		dEdo.divi(target.shape()[1]); // Why? Because the LossFunction divides by the _element size_ of the output.
+		
+		Pair<INDArray, INDArray> derivs2 = a2.backprop(q, dEdo);
+		INDArray dEdq = derivs2.getFirst(); // This should be of size batchsz x outputsz (dE/do * do/dq) this _should_ be o * (1-o) * dE/do for Sigmoid.
+		// Should be o = q^3 do/dq = 3 q^2 for Cube.
+		/*
+		INDArray dodq = q.mul(q).mul(3);
+		INDArray tbv = dodq.mul(dEdo);
+		System.err.println("----");
+		System.err.println(q);
+		System.err.println(o);
+		System.err.println(tbv);
+		System.err.println(dEdq);
+		*/
+		
+		INDArray dqdc = Nd4j.ones(1,batchsz);
+		INDArray dEdc = dqdc.mmul(dEdq); // This should be of size 1 x outputsz
+		INDArray dEdV = a.transpose().mmul(dEdq);
+		INDArray dEda = dEdq.mmul(V.transpose()); // This should be dEdo * dodq * dqda
+		
+		Pair<INDArray, INDArray> derivs1 = a1.backprop(z, dEda);
+		INDArray dEdz = derivs1.getFirst();
+		INDArray dzdb = Nd4j.ones(1,batchsz);
+		INDArray dEdb = dzdb.mmul(dEdz);
+		INDArray dEdW = input.transpose().mmul(dEdz);
+		
+		manual_gradients.put("output_b", dEdc);
+		manual_gradients.put("output_W", dEdV);
+		manual_gradients.put("denselayer_b", dEdb);
+		manual_gradients.put("denselayer_W", dEdW);
+
+		double summse = Math.pow((score_manual - score_dl4j), 2);
+		int denominator = 1;
+
+		for (Map.Entry<String, INDArray> mesi : gradients.entrySet()) {
+			String name = mesi.getKey();
+			INDArray dl4j_gradient = nullsafe(mesi.getValue());
+			INDArray manual_gradient = nullsafe(manual_gradients.get(name));
+			double se = sum_errors(dl4j_gradient, manual_gradient);
+			summse += se;
+			denominator += dl4j_gradient.columns() * dl4j_gradient.rows();
+		}
+
+		Assert.assertEquals(0.0, summse / denominator, this.epsilon);
+
+	}
+	private static double sum_errors(INDArray a, INDArray b) {
+		INDArray o = a.sub(b);
+		return o.mul(o).sumNumber().doubleValue();
+	}
+	
+	private static <T> T nullsafe(T obj) {
+		if (obj == null) throw new NullPointerException();
+		T clean = obj;
+		return clean;
+	}
+	
+	private double epsilon = 1e-10;
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/graph/ShiftVertexTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/graph/ShiftVertexTest.java
@@ -121,11 +121,13 @@ public class ShiftVertexTest {
 				{2.9,3.1,3.7}
 		});
 		double sf = 4.1;
+		// Actually, given that I'm using a sigmoid on the output,
+		// these should really be between 0 and 1
 		INDArray target = Nd4j.create(new double[][]{
-				{ 4.3, 4.7, 5.3, 5.9, 6.1 },
-				{ 6.7, 7.1, 7.3, 7.9, 8.3 },
-				{ 8.9, 9.7,10.1,10.3,10.7 },
-				{10.9,11.3,12.7,13.1,13.7 }
+				{ 0.05, 0.10, 0.15, 0.20, 0.25 },
+				{ 0.30, 0.35, 0.40, 0.45, 0.50 },
+				{ 0.55, 0.60, 0.65, 0.70, 0.75 },
+				{ 0.80, 0.85, 0.90, 0.95, 0.99 }
 		});
 		
 		ComputationGraphConfiguration cgc = new NeuralNetConfiguration.Builder()

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ShiftVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ShiftVertex.java
@@ -1,0 +1,84 @@
+/*-
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.conf.graph;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+/**
+ * A ShiftVertex is used to shift the activations of a single layer<br>
+ * One could use it to add a bias or as part of some other calculation.
+ * For example, Highway Layers need them in two places. One, it's often
+ * useful to have the gate weights have a large negative bias. (Of course
+ * for this, we could just initialize the biases that way.)
+ * But, _also_ it needs to do this:
+ * (1-sigmoid(weight * input + bias)) (*) input + sigmoid(weight * input + bias) (*) activation(w2 * input + bias) ((*) is hadamard product)
+ * So, here, we could have
+ * 1. a DenseLayer that does the sigmoid
+ * 2. a ScaleVertex(-1) and
+ * 3. a ShiftVertex(1)
+ * to accomplish that.
+ *
+ * @author Binesh Bannerjee (binesh_binesh@hotmail.com, @bnsh on gitter)
+ */
+@Data
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode()
+public class ShiftVertex extends GraphVertex {
+
+    public ShiftVertex(@JsonProperty("shiftFactor") double shiftFactor) {
+        this.shiftFactor = shiftFactor;
+    }
+
+    protected double shiftFactor = 0.0; // Shift by zero if it's not specified.
+
+    @Override
+    public ShiftVertex clone() {
+        return new ShiftVertex(shiftFactor);
+    }
+
+    @Override
+    public int numParams(boolean backprop) {
+        return 0;
+    }
+
+    @Override
+    public org.deeplearning4j.nn.graph.vertex.GraphVertex instantiate(ComputationGraph graph, String name, int idx,
+                    INDArray paramsView, boolean initializeParams) {
+
+        return new org.deeplearning4j.nn.graph.vertex.impl.ShiftVertex(graph, name, idx, shiftFactor);
+    }
+
+    @Override
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
+        if (vertexInputs.length == 1)
+            return vertexInputs[0];
+        InputType first = vertexInputs[0];
+
+        return first; //Same output shape/size as
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/ShiftVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/ShiftVertex.java
@@ -1,0 +1,124 @@
+/*-
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+
+package org.deeplearning4j.nn.graph.vertex.impl;
+
+import org.deeplearning4j.berkeley.Pair;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.graph.vertex.BaseGraphVertex;
+import org.deeplearning4j.nn.graph.vertex.VertexIndices;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * A ShiftVertex is used to shift the activations of a single layer<br>
+ * One could use it to add a bias or as part of some other calculation.
+ * For example, Highway Layers need them in two places. One, it's often
+ * useful to have the gate weights have a large negative bias. (Of course
+ * for this, we could just initialize the biases that way.)
+ * But, _also_ it needs to do this:
+ * (1-sigmoid(weight * input + bias)) (*) input + sigmoid(weight * input + bias) (*) activation(w2 * input + bias) ((*) is hadamard product)
+ * So, here, we could have
+ * 1. a DenseLayer that does the sigmoid
+ * 2. a ScaleVertex(-1) and
+ * 3. a ShiftVertex(1)
+ * to accomplish that.
+ *
+ * @author Binesh Bannerjee (binesh_binesh@hotmail.com, @bnsh on gitter)
+ */
+public class ShiftVertex extends BaseGraphVertex {
+
+    private double shiftFactor;
+
+    public ShiftVertex(ComputationGraph graph, String name, int vertexIndex, double shiftFactor) {
+        this(graph, name, vertexIndex, null, null, shiftFactor);
+    }
+
+    public ShiftVertex(ComputationGraph graph, String name, int vertexIndex, VertexIndices[] inputVertices,
+                    VertexIndices[] outputVertices, double shiftFactor) {
+        super(graph, name, vertexIndex, inputVertices, outputVertices);
+        this.shiftFactor = shiftFactor;
+    }
+
+    @Override
+    public boolean hasLayer() {
+        return false;
+    }
+
+    @Override
+    public boolean isOutputVertex() {
+        return false;
+    }
+
+    @Override
+    public Layer getLayer() {
+        return null;
+    }
+
+    @Override
+    public INDArray doForward(boolean training) {
+        if (!canDoForward())
+            throw new IllegalStateException("Cannot do forward pass: inputs not set (ShiftVertex " + vertexName
+                            + " idx " + vertexIndex + ")");
+
+        if (inputs.length > 1)
+            throw new IllegalArgumentException(
+                            "ShiftVertex (name " + vertexName + " idx " + vertexIndex + ") only supports 1 input.");
+
+        INDArray shifted = inputs[0].dup();
+        shifted.addi(shiftFactor);
+
+        return shifted;
+    }
+
+    @Override
+    public Pair<Gradient, INDArray[]> doBackward(boolean tbptt) {
+        if (!canDoBackward())
+            throw new IllegalStateException("Cannot do backward pass: errors not set (ShiftVertex " + vertexName
+                            + " idx " + vertexIndex + ")");
+
+        return new Pair<>(null, new INDArray[] {epsilon.addi(0)});
+    }
+
+    @Override
+    public void setBackpropGradientsViewArray(INDArray backpropGradientsViewArray) {
+        if (backpropGradientsViewArray != null)
+            throw new RuntimeException(
+                            "Vertex does not have gradients; gradients view array cannot be set here (ShiftVertex "
+                                            + vertexName + " idx " + vertexIndex + ")");
+    }
+
+    @Override
+    public String toString() {
+        return "ShiftVertex(id=" + this.getVertexIndex() + ",name=\"" + this.getVertexName() + "\",shiftFactor="
+                        + shiftFactor + ")";
+    }
+
+    @Override
+    public Pair<INDArray, MaskState> feedForwardMaskArrays(INDArray[] maskArrays, MaskState currentMaskState,
+                    int minibatchSize) {
+        //No op
+        if (maskArrays == null || maskArrays.length == 0) {
+            return null;
+        }
+
+        return new Pair<>(maskArrays[0], currentMaskState);
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch will add ShiftVertex, something sort of complementary to ScaleVertex. It will _add_ a constant, rather than multiplying a constant.

## How was this patch tested?

I tested the derivatives manually, and have a test program that tested all the ActivationFunctions (except RReLU, because that's random, and my manual code didn't account for non-deterministic functions.) The gist below is that program.
https://gist.github.com/bnsh/a0458d28e79aa3f159cec43ebeb8b177

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
