### PR TITLE
Add random time series offsets for RecordReaderMultiDataSetIterator

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderMultiDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderMultiDataSetIterator.java
@@ -77,6 +77,9 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
     @Setter
     private boolean collectMetaData = false;
 
+    private boolean timeSeriesRandomOffset = false;
+    private Random timeSeriesRandomOffsetRng;
+
     private MultiDataSetPreProcessor preProcessor;
 
     private RecordReaderMultiDataSetIterator(Builder builder) {
@@ -86,6 +89,10 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
         this.sequenceRecordReaders = builder.sequenceRecordReaders;
         this.inputs.addAll(builder.inputs);
         this.outputs.addAll(builder.outputs);
+        this.timeSeriesRandomOffset = builder.timeSeriesRandomOffset;
+        if(this.timeSeriesRandomOffset){
+            timeSeriesRandomOffsetRng = new Random(builder.timeSeriesRandomOffsetSeed);
+        }
     }
 
     @Override
@@ -175,7 +182,7 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
         //In order to align data at the end (for each example individually), we need to know the length of the
         // longest time series for each example
         int[] longestSequence = null;
-        if (alignmentMode == AlignmentMode.ALIGN_END) {
+        if (timeSeriesRandomOffset || alignmentMode == AlignmentMode.ALIGN_END) {
             longestSequence = new int[minExamples];
             for (Map.Entry<String, List<List<List<Writable>>>> entry : nextSeqRRVals.entrySet()) {
                 List<List<List<Writable>>> list = entry.getValue();
@@ -201,6 +208,9 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
         INDArray[] inputArrMasks = new INDArray[inputs.size()];
         boolean inputMasks = false;
         int i = 0;
+
+        long rngSeed = (timeSeriesRandomOffset ? timeSeriesRandomOffsetRng.nextLong() : -1);
+
         for (SubsetDetails d : inputs) {
             if (nextRRVals.containsKey(d.readerName)) {
                 //Standard reader
@@ -209,7 +219,7 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
             } else {
                 //Sequence reader
                 List<List<List<Writable>>> list = nextSeqRRVals.get(d.readerName);
-                Pair<INDArray, INDArray> p = convertWritablesSequence(list, minExamples, longestTS, d, longestSequence);
+                Pair<INDArray, INDArray> p = convertWritablesSequence(list, minExamples, longestTS, d, longestSequence, rngSeed);
                 inputArrs[i] = p.getFirst();
                 inputArrMasks[i] = p.getSecond();
                 if (inputArrMasks[i] != null)
@@ -234,7 +244,7 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
             } else {
                 //Sequence reader
                 List<List<List<Writable>>> list = nextSeqRRVals.get(d.readerName);
-                Pair<INDArray, INDArray> p = convertWritablesSequence(list, minExamples, longestTS, d, longestSequence);
+                Pair<INDArray, INDArray> p = convertWritablesSequence(list, minExamples, longestTS, d, longestSequence, rngSeed);
                 outputArrs[i] = p.getFirst();
                 outputArrMasks[i] = p.getSecond();
                 if (outputArrMasks[i] != null)
@@ -361,7 +371,7 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
      * Convert the writables to a sequence (3d) data set, and also return the mask array (if necessary)
      */
     private Pair<INDArray, INDArray> convertWritablesSequence(List<List<List<Writable>>> list, int minValues,
-                    int maxTSLength, SubsetDetails details, int[] longestSequence) {
+                    int maxTSLength, SubsetDetails details, int[] longestSequence, long rngSeed) {
         if (maxTSLength == -1)
             maxTSLength = list.get(0).size();
         INDArray arr;
@@ -391,6 +401,12 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
         else
             maskArray = null;
 
+        //Don't use the global RNG as we need repeatability for each subset (i.e., features and labels must be aligned)
+        Random rng = null;
+        if(timeSeriesRandomOffset){
+            rng = new Random(rngSeed);
+        }
+
         for (int i = 0; i < minValues; i++) {
             List<List<Writable>> sequence = list.get(i);
 
@@ -402,6 +418,11 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
                 //Align end
                 //Only practical differences here are: (a) offset, and (b) masking
                 startOffset = longestSequence[i] - sequence.size();
+            }
+
+            if(timeSeriesRandomOffset){
+                int maxPossible = maxTSLength - sequence.size() + 1;
+                startOffset = rng.nextInt(maxPossible);
             }
 
             int t = 0;
@@ -453,11 +474,9 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
                         } catch (UnsupportedOperationException e) {
                             // This isn't a scalar, so check if we got an array already
                             if (w instanceof NDArrayWritable) {
-                                arr.get(NDArrayIndex.point(i), NDArrayIndex.all(), NDArrayIndex.point(k)).putRow(0,
-                                                ((NDArrayWritable) w).get()
-                                                                .get(NDArrayIndex.all(), NDArrayIndex.interval(
-                                                                                details.subsetStart, details.subsetEndInclusive
-                                                                                                + 1)));
+                                arr.get(NDArrayIndex.point(i), NDArrayIndex.all(), NDArrayIndex.point(k))
+                                        .putRow(0,((NDArrayWritable) w).get()
+                                                .get(NDArrayIndex.all(),NDArrayIndex.interval(details.subsetStart, details.subsetEndInclusive + 1)));
                             } else {
                                 throw e;
                             }
@@ -469,21 +488,21 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
             //For any remaining time steps: set mask array to 0 (just padding)
             if (needMaskArray) {
                 //Masking array entries at start (for align end)
-                if (alignmentMode == AlignmentMode.ALIGN_END) {
+                if (timeSeriesRandomOffset || alignmentMode == AlignmentMode.ALIGN_END) {
                     for (int t2 = 0; t2 < startOffset; t2++) {
                         maskArray.putScalar(i, t2, 0.0);
                     }
                 }
 
                 //Masking array entries at end (for align start)
-                if (alignmentMode == AlignmentMode.ALIGN_START) {
-                    for (int t2 = t; t2 < maxTSLength; t2++) {
+                if (timeSeriesRandomOffset || alignmentMode == AlignmentMode.ALIGN_START) {
+                    int lastStep = startOffset + sequence.size();
+                    for (int t2 = lastStep; t2 < maxTSLength; t2++) {
                         maskArray.putScalar(i, t2, 0.0);
                     }
                 }
             }
         }
-
 
         return new Pair<>(arr, maskArray);
     }
@@ -537,6 +556,9 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
 
         private List<SubsetDetails> inputs = new ArrayList<>();
         private List<SubsetDetails> outputs = new ArrayList<>();
+
+        private boolean timeSeriesRandomOffset = false;
+        private long timeSeriesRandomOffsetSeed = System.currentTimeMillis();
 
         /**
          * @param batchSize The batch size for the RecordReaderMultiDataSetIterator
@@ -640,6 +662,12 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator {
          */
         public Builder addOutputOneHot(String readerName, int column, int numClasses) {
             outputs.add(new SubsetDetails(readerName, false, true, numClasses, column, -1));
+            return this;
+        }
+
+        public Builder timeSeriesRandomOffset(boolean timeSeriesRandomOffset, long rngSeed){
+            this.timeSeriesRandomOffset = timeSeriesRandomOffset;
+            this.timeSeriesRandomOffsetSeed = rngSeed;
             return this;
         }
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/datavec/RecordReaderMultiDataSetIteratorTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/datavec/RecordReaderMultiDataSetIteratorTest.java
@@ -9,11 +9,14 @@ import org.datavec.api.io.labels.ParentPathLabelGenerator;
 import org.datavec.api.records.metadata.RecordMetaData;
 import org.datavec.api.records.reader.RecordReader;
 import org.datavec.api.records.reader.SequenceRecordReader;
+import org.datavec.api.records.reader.impl.collection.CollectionSequenceRecordReader;
 import org.datavec.api.records.reader.impl.csv.CSVRecordReader;
 import org.datavec.api.records.reader.impl.csv.CSVSequenceRecordReader;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputSplit;
 import org.datavec.api.split.NumberedFileInputSplit;
+import org.datavec.api.writable.DoubleWritable;
+import org.datavec.api.writable.Writable;
 import org.datavec.image.recordreader.ImageRecordReader;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -21,10 +24,14 @@ import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.nd4j.linalg.io.ClassPathResource;
 
 import java.io.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -601,5 +608,78 @@ public class RecordReaderMultiDataSetIteratorTest {
         try (OutputStream os = new BufferedOutputStream(new FileOutputStream(out))) {
             os.write(b);
         }
+    }
+
+
+
+
+    @Test
+    public void testTimeSeriesRandomOffset(){
+        //2 in, 2 out, 3 total sequences of length [1,3,5]
+
+        List<List<Writable>> seq1 = Arrays.asList(
+                Arrays.<Writable>asList(new DoubleWritable(1.0), new DoubleWritable(2.0)));
+        List<List<Writable>> seq2 = Arrays.asList(
+                Arrays.<Writable>asList(new DoubleWritable(10.0), new DoubleWritable(11.0)),
+                Arrays.<Writable>asList(new DoubleWritable(20.0), new DoubleWritable(21.0)),
+                Arrays.<Writable>asList(new DoubleWritable(30.0), new DoubleWritable(31.0)));
+        List<List<Writable>> seq3 = Arrays.asList(
+                Arrays.<Writable>asList(new DoubleWritable(100.0), new DoubleWritable(101.0)),
+                Arrays.<Writable>asList(new DoubleWritable(200.0), new DoubleWritable(201.0)),
+                Arrays.<Writable>asList(new DoubleWritable(300.0), new DoubleWritable(301.0)),
+                Arrays.<Writable>asList(new DoubleWritable(400.0), new DoubleWritable(401.0)),
+                Arrays.<Writable>asList(new DoubleWritable(500.0), new DoubleWritable(501.0)));
+
+        Collection<List<List<Writable>>> seqs = Arrays.asList(seq1, seq2, seq3);
+
+        SequenceRecordReader rr = new CollectionSequenceRecordReader(seqs);
+
+        RecordReaderMultiDataSetIterator rrmdsi = new RecordReaderMultiDataSetIterator.Builder(3)
+                .addSequenceReader("rr", rr)
+                .addInput("rr",0,0)
+                .addOutput("rr",1,1)
+                .timeSeriesRandomOffset(true, 1234L)
+                .build();
+
+
+        Random r = new Random(1234);    //Provides seed for each minibatch
+        long seed = r.nextLong();
+        Random r2 = new Random(seed);      //Use same RNG seed in new RNG for each minibatch
+        int expOffsetSeq1 = r2.nextInt(5-1+1);   //0 to 4 inclusive
+        int expOffsetSeq2 = r2.nextInt(5-3+1);
+        int expOffsetSeq3 = 0;                        //Longest TS, always 0
+        //With current seed: 3, 1, 0
+//        System.out.println(expOffsetSeq1 + "\t" + expOffsetSeq2 + "\t" + expOffsetSeq3);
+
+        MultiDataSet mds = rrmdsi.next();
+
+        INDArray expMask = Nd4j.create(new double[][]{
+                {0,0,0,1,0},
+                {0,1,1,1,0},
+                {1,1,1,1,1}});
+
+        assertEquals(expMask, mds.getFeaturesMaskArray(0));
+        assertEquals(expMask, mds.getLabelsMaskArray(0));
+
+        INDArray f = mds.getFeatures(0);
+        INDArray l = mds.getLabels(0);
+
+        INDArray expF1 = Nd4j.create(new double[]{1.0});
+        INDArray expL1 = Nd4j.create(new double[]{2.0});
+
+        INDArray expF2 = Nd4j.create(new double[]{10, 20, 30});
+        INDArray expL2 = Nd4j.create(new double[]{11, 21, 31});
+
+        INDArray expF3 = Nd4j.create(new double[]{100,200,300,400,500});
+        INDArray expL3 = Nd4j.create(new double[]{101,201,301,401,501});
+
+        assertEquals(expF1, f.get(NDArrayIndex.point(0), NDArrayIndex.all(), NDArrayIndex.interval(expOffsetSeq1, expOffsetSeq1+1)));
+        assertEquals(expL1, l.get(NDArrayIndex.point(0), NDArrayIndex.all(), NDArrayIndex.interval(expOffsetSeq1, expOffsetSeq1+1)));
+
+        assertEquals(expF2, f.get(NDArrayIndex.point(1), NDArrayIndex.all(), NDArrayIndex.interval(expOffsetSeq2, expOffsetSeq2+3)));
+        assertEquals(expL2, l.get(NDArrayIndex.point(1), NDArrayIndex.all(), NDArrayIndex.interval(expOffsetSeq2, expOffsetSeq2+3)));
+
+        assertEquals(expF3, f.get(NDArrayIndex.point(2), NDArrayIndex.all(), NDArrayIndex.interval(expOffsetSeq3, expOffsetSeq3+5)));
+        assertEquals(expL3, l.get(NDArrayIndex.point(2), NDArrayIndex.all(), NDArrayIndex.interval(expOffsetSeq3, expOffsetSeq3+5)));
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
@@ -97,7 +97,7 @@ public class GravesLSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.la
         return LSTMHelpers.backpropGradientHelper(this.conf, this.layerConf().getGateActivationFn(), this.input,
                         recurrentWeights, inputWeights, epsilon, truncatedBPTT, tbpttBackwardLength, fwdPass, true,
                         GravesLSTMParamInitializer.INPUT_WEIGHT_KEY, GravesLSTMParamInitializer.RECURRENT_WEIGHT_KEY,
-                        GravesLSTMParamInitializer.BIAS_KEY, gradientViews, null, true);
+                        GravesLSTMParamInitializer.BIAS_KEY, gradientViews, maskArray, true);
     }
 
 
@@ -144,7 +144,7 @@ public class GravesLSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.la
 
         return LSTMHelpers.activateHelper(this, this.conf, this.layerConf().getGateActivationFn(), this.input,
                         recurrentWeights, inputWeights, biases, training, prevOutputActivations, prevMemCellState,
-                        forBackprop, true, GravesLSTMParamInitializer.INPUT_WEIGHT_KEY, null, true);
+                        forBackprop, true, GravesLSTMParamInitializer.INPUT_WEIGHT_KEY, maskArray, true);
     }
 
     @Override


### PR DESCRIPTION
***WIP DO NOT MERGE***

For very long and very imbalanced time series + TBPTT: aligning them all at the start can mean that many updates at the end are mostly masked out. Experiments suggest that this can have a small but noticeable effect on accuracy in practice. By randomly offsetting the time series + masking appropriately, we can lessen the effect.

Needs javadoc + final review and tests before merging.