### PR TITLE
Evaluation: custom binary thresholds and cost array

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalCustomThreshold.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalCustomThreshold.java
@@ -163,7 +163,10 @@ public class EvalCustomThreshold {
             assertArrayEquals(eStd.getCountTrueNegative(), eb2.getCountTrueNegative());
             assertArrayEquals(eStd.getCountFalseNegative(), eb2.getCountFalseNegative());
 
-            assertEquals(eStd.stats(), eb2.stats());
+            for( int j=0; j<nOut; j++ ){
+                assertEquals(eStd.accuracy(j), eb2.accuracy(j), 1e-6);
+                assertEquals(eStd.f1(j), eb2.f1(j), 1e-6);
+            }
         }
 
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalCustomThreshold.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalCustomThreshold.java
@@ -1,0 +1,88 @@
+package org.deeplearning4j.eval;
+
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.transforms.comparison.GreaterThan;
+import org.nd4j.linalg.api.ops.random.impl.BernoulliDistribution;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.ops.transforms.Transforms;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by Alex on 19/06/2017.
+ */
+public class EvalCustomThreshold {
+
+    @Test
+    public void testEvaluationCustomThreshold(){
+
+        fail();
+    }
+
+    @Test
+    public void testEvaluationBinaryCustomThreshold(){
+
+        //Sanity check: same results for 0.5 threshold vs.
+
+        int nExamples = 20;
+        int nOut = 2;
+
+        INDArray probs = Nd4j.rand(nExamples, nOut);
+        INDArray labels = Nd4j.getExecutioner().exec(new BernoulliDistribution(Nd4j.createUninitialized(nExamples,nOut),0.5));
+
+        EvaluationBinary eStd = new EvaluationBinary();
+        eStd.eval(labels, probs);
+
+        EvaluationBinary eb05 = new EvaluationBinary(Nd4j.create(new double[]{0.5, 0.5}));
+        eb05.eval(labels, probs);
+
+        EvaluationBinary eb05v2 = new EvaluationBinary(Nd4j.create(new double[]{0.5, 0.5}));
+        for( int i=0; i<nExamples; i++ ){
+            eb05v2.eval(labels.getRow(i), probs.getRow(i));
+        }
+
+        for(EvaluationBinary eb2 : new EvaluationBinary[]{eb05, eb05v2}){
+            assertArrayEquals(eStd.getCountTruePositive(), eb2.getCountTruePositive());
+            assertArrayEquals(eStd.getCountFalsePositive(), eb2.getCountFalsePositive());
+            assertArrayEquals(eStd.getCountTrueNegative(), eb2.getCountTrueNegative());
+            assertArrayEquals(eStd.getCountFalseNegative(), eb2.getCountFalseNegative());
+
+            assertEquals(eStd.stats(), eb2.stats());
+        }
+
+
+        //Check with decision threshold of 0.25 and 0.125 (for different outputs)
+        //In this test, we'll cheat a bit: multiply probabilities by 2 (max of 1.0) and threshold of 0.25 should give
+        // an identical result to a threshold of 0.5
+        //Ditto for 4x and 0.125 threshold
+
+        INDArray probs2 = probs.mul(2);
+        probs2 = Transforms.min(probs2, 1.0);
+
+        INDArray probs4 = probs.mul(4);
+        probs4 = Transforms.min(probs4, 1.0);
+
+        EvaluationBinary ebThreshold = new EvaluationBinary(Nd4j.create(new double[]{0.25, 0.125}));
+        ebThreshold.eval(labels, probs);
+
+        EvaluationBinary ebStd2 = new EvaluationBinary();
+        ebStd2.eval(labels, probs2);
+
+        EvaluationBinary ebStd4 = new EvaluationBinary();
+        ebStd4.eval(labels, probs4);
+
+        assertEquals(ebThreshold.truePositives(0), ebStd2.truePositives(0));
+        assertEquals(ebThreshold.trueNegatives(0), ebStd2.trueNegatives(0));
+        assertEquals(ebThreshold.falsePositives(0), ebStd2.falsePositives(0));
+        assertEquals(ebThreshold.falseNegatives(0), ebStd2.falseNegatives(0));
+
+        assertEquals(ebThreshold.truePositives(1), ebStd4.truePositives(1));
+        assertEquals(ebThreshold.trueNegatives(1), ebStd4.trueNegatives(1));
+        assertEquals(ebThreshold.falsePositives(1), ebStd4.falsePositives(1));
+        assertEquals(ebThreshold.falseNegatives(1), ebStd4.falseNegatives(1));
+    }
+
+}

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalJsonTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalJsonTest.java
@@ -202,6 +202,8 @@ public class EvalJsonTest {
     @Test
     public void testJsonWithCustomThreshold(){
 
+
+
         INDArray threshold = Nd4j.create(new double[]{1.0, 0.5, 0.25});
         EvaluationBinary eb = new EvaluationBinary(threshold);
 
@@ -214,7 +216,7 @@ public class EvalJsonTest {
         assertEquals(threshold, ebFromJson.getDecisionThreshold());
         assertEquals(threshold, ebFromYaml.getDecisionThreshold());
 
-        fail();
+
     }
 
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalJsonTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalJsonTest.java
@@ -202,13 +202,39 @@ public class EvalJsonTest {
     @Test
     public void testJsonWithCustomThreshold(){
 
+        //Evaluation - binary threshold
+        Evaluation e = new Evaluation(0.25);
+        String json = e.toJson();
+        String yaml = e.toYaml();
+
+        Evaluation eFromJson = Evaluation.fromJson(json);
+        Evaluation eFromYaml = Evaluation.fromYaml(yaml);
+
+        assertEquals(0.25, eFromJson.getBinaryDecisionThreshold(), 1e-6);
+        assertEquals(0.25, eFromYaml.getBinaryDecisionThreshold(), 1e-6);
 
 
+        //Evaluation: custom cost array
+        INDArray costArray = Nd4j.create(new double[]{1.0, 2.0, 3.0});
+        Evaluation e2 = new Evaluation(costArray);
+
+        json = e2.toJson();
+        yaml = e2.toYaml();
+
+        eFromJson = Evaluation.fromJson(json);
+        eFromYaml = Evaluation.fromYaml(yaml);
+
+        assertEquals(costArray, eFromJson.getCostArray());
+        assertEquals(costArray, eFromYaml.getCostArray());
+
+
+
+        //EvaluationBinary - per-output binary threshold
         INDArray threshold = Nd4j.create(new double[]{1.0, 0.5, 0.25});
         EvaluationBinary eb = new EvaluationBinary(threshold);
 
-        String json = eb.toJson();
-        String yaml = eb.toYaml();
+        json = eb.toJson();
+        yaml = eb.toYaml();
 
         EvaluationBinary ebFromJson = EvaluationBinary.fromJson(json);
         EvaluationBinary ebFromYaml = EvaluationBinary.fromYaml(yaml);
@@ -216,8 +242,6 @@ public class EvalJsonTest {
         assertEquals(threshold, ebFromJson.getDecisionThreshold());
         assertEquals(threshold, ebFromYaml.getDecisionThreshold());
 
-
     }
-
 
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalJsonTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalJsonTest.java
@@ -9,8 +9,7 @@ import org.nd4j.linalg.api.ops.random.impl.BernoulliDistribution;
 import org.nd4j.linalg.factory.Nd4j;
 
 import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 public class EvalJsonTest {
@@ -199,4 +198,24 @@ public class EvalJsonTest {
 
 //        System.out.println(json1);
     }
+
+    @Test
+    public void testJsonWithCustomThreshold(){
+
+        INDArray threshold = Nd4j.create(new double[]{1.0, 0.5, 0.25});
+        EvaluationBinary eb = new EvaluationBinary(threshold);
+
+        String json = eb.toJson();
+        String yaml = eb.toYaml();
+
+        EvaluationBinary ebFromJson = EvaluationBinary.fromJson(json);
+        EvaluationBinary ebFromYaml = EvaluationBinary.fromYaml(yaml);
+
+        assertEquals(threshold, ebFromJson.getDecisionThreshold());
+        assertEquals(threshold, ebFromYaml.getDecisionThreshold());
+
+        fail();
+    }
+
+
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/Evaluation.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/Evaluation.java
@@ -48,7 +48,7 @@ import java.util.*;
 
 /**
  * Evaluation metrics:<br>
- * - precision, recall, f1, accuracy<br>
+ * - precision, recall, f1, fBeta, accuracy, Matthews correlation coefficient, gMeasure<br>
  * - Top N accuracy (if using constructor {@link #Evaluation(List, int)})<br>
  * - Custom binary evaluation decision threshold (use constructor {@link #Evaluation(double)} (default if not set is
  *   argmax / 0.5)<br>
@@ -585,6 +585,12 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
         }
         if(nClasses > 2){
             builder.append("\nPrecision, recall & F1: macro-averaged (equally weighted avg. of ").append(nClasses).append(" classes)");
+        }
+        if(binaryDecisionThreshold != null){
+            builder.append("\nBinary decision threshold: ").append(binaryDecisionThreshold);
+        }
+        if(costArray != null){
+            builder.append("\nCost array: ").append(Arrays.toString(costArray.dup().data().asFloat()));
         }
         //Note that we could report micro-averaged too - but these are the same as accuracy
         //"Note that for “micro”-averaging in a multiclass setting with all labels included will produce equal precision, recall and F,"
@@ -1594,5 +1600,14 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
             out.add(new Prediction(actualClass, predictedClass, meta));
         }
         return out;
+    }
+
+
+    public static Evaluation fromJson(String json){
+        return fromJson(json, Evaluation.class);
+    }
+
+    public static Evaluation fromYaml(String yaml){
+        return fromYaml(yaml, Evaluation.class);
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/EvaluationBinary.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/EvaluationBinary.java
@@ -3,10 +3,18 @@ package org.deeplearning4j.eval;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.nd4j.linalg.api.ndarray.BaseNDArray;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.scalar.comparison.ScalarGreaterThan;
 import org.nd4j.linalg.api.ops.impl.transforms.Not;
+import org.nd4j.linalg.api.ops.impl.transforms.comparison.GreaterThan;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorDeserializer;
+import org.nd4j.linalg.lossfunctions.serde.RowVectorSerializer;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
+import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +25,9 @@ import java.util.List;
  * Note that {@link ROCBinary} is also used internally to calculate AUC for each output, but only when using an
  * appropriate constructor, {@link #EvaluationBinary(int, Integer)}
  * <p>
- * Note that EvaluationBinary supports both per-example and per-output masking.
+ * Note that EvaluationBinary supports both per-example and per-output masking.<br>
+ * EvaluationBinary by default uses a decision threshold of 0.5, however decision thresholds can be set on a per-output
+ * basis using {@link #EvaluationBinary(INDArray)}.
  * <p>
  * The most common use case: multi-task networks, where each output is a binary value. This differs from {@link Evaluation}
  * in that {@link Evaluation} is for a single class (binary or non-binary) evaluation.
@@ -41,6 +51,33 @@ public class EvaluationBinary extends BaseEvaluation<EvaluationBinary> {
 
     private List<String> labels;
 
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
+    private INDArray decisionThreshold;
+
+    /**
+     * Create an EvaulationBinary instance with an optional decision threshold array.
+     *
+     * @param decisionThreshold Decision threshold for each output; may be null. Should be a row vector with length
+     *                          equal to the number of outputs, with values in range 0 to 1. An array of 0.5 values is
+     *                          equivalent to the default (no manually specified decision threshold).
+     */
+    public EvaluationBinary(@Nullable INDArray decisionThreshold){
+        if(decisionThreshold != null){
+            if(!decisionThreshold.isRowVector()){
+                throw new IllegalArgumentException("Decision threshold array must be a row vector; got array with shape "
+                        + Arrays.toString(decisionThreshold.shape()));
+            }
+            if(decisionThreshold.minNumber().doubleValue() < 0.0){
+                throw new IllegalArgumentException("Invalid decision threshold array: minimum value is less than 0");
+            }
+            if(decisionThreshold.maxNumber().doubleValue() > 1.0){
+                throw new IllegalArgumentException("invalid decision threshold array: maximum value is greater than 1.0");
+            }
+
+            this.decisionThreshold = decisionThreshold;
+        }
+    }
 
     /**
      * This constructor allows for ROC to be calculated in addition to the standard evaluation metrics, when the
@@ -94,9 +131,37 @@ public class EvaluationBinary extends BaseEvaluation<EvaluationBinary> {
             return;
         }
 
-        //First: binarize the network prediction probabilities, threshold 0.5
+        //First: binarize the network prediction probabilities, threshold 0.5 unless otherwise specified
         //This gives us 3 binary arrays: labels, predictions, masks
-        INDArray classPredictions = networkPredictions.gt(0.5);
+        INDArray classPredictions;
+        if(decisionThreshold != null){
+            //Need to do a broadcast greater-than op...
+            //TODO replace the (rather inelegant) implementation below with proper broadcast comparison ops once implemented
+            // https://github.com/deeplearning4j/nd4j/issues/1884
+
+            classPredictions = Nd4j.createUninitialized(networkPredictions.shape());
+            if(networkPredictions.rows() <= networkPredictions.columns()){
+                //Do fewer ops by looping over rows
+                int nRows = networkPredictions.rows();
+                for( int i=0; i<nRows; i++ ){
+                    INDArray inRow = networkPredictions.getRow(i);
+                    INDArray outRow = classPredictions.getRow(i);
+                    Nd4j.getExecutioner().exec(new GreaterThan(inRow, decisionThreshold, outRow, inRow.length()));
+                }
+            } else {
+                //Do fewer ops by looping over columns
+                int nCol = networkPredictions.size(1);
+                for( int i=0; i<nCol; i++ ){
+                    INDArray inCol = networkPredictions.getColumn(i);
+                    INDArray outCol = classPredictions.getColumn(i);
+                    double currThreshold = decisionThreshold.getDouble(i);
+                    Nd4j.getExecutioner().exec(
+                            new ScalarGreaterThan(inCol, null, outCol, inCol.length(), currThreshold));
+                }
+            }
+        } else {
+            classPredictions = networkPredictions.gt(0.5);
+        }
 
         INDArray notLabels = Nd4j.getExecutioner().execAndReturn(new Not(labels.dup()));
         INDArray notClassPredictions = Nd4j.getExecutioner().execAndReturn(new Not(classPredictions.dup()));
@@ -506,4 +571,14 @@ public class EvaluationBinary extends BaseEvaluation<EvaluationBinary> {
 
         return sb.toString();
     }
+
+    public static EvaluationBinary fromJson(String json) {
+        return fromJson(json, EvaluationBinary.class);
+    }
+
+    public static EvaluationBinary fromYaml(String yaml) {
+        return fromYaml(yaml, EvaluationBinary.class);
+    }
+
+
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/EvaluationBinary.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/EvaluationBinary.java
@@ -564,6 +564,10 @@ public class EvaluationBinary extends BaseEvaluation<EvaluationBinary> {
 
                 sb.append("\n").append(String.format(pattern, args.toArray()));
             }
+
+            if(decisionThreshold != null){
+                sb.append("\nPer-output decision thresholds: ").append(Arrays.toString(decisionThreshold.dup().data().asFloat()));
+            }
         } else {
             //Empty evaluation
             sb.append("\n-- No Data --\n");


### PR DESCRIPTION

Adds 2 things:
(a) Custom binary thresholds for Evaluation and EvaluationBinary classes, for binary classifiers
- Evaluation: use ```new Evaluation(double threshold)``` to set threshold
- EvaluationBinary: use ```new EvaluationBinary(INDArray perOutputThreshold)``` to set threshold

(b) Per-class cost arrays for Evaluation, used to bias multi-class predictions
Essentially: instead of standard ```argMax(probabilities)``` we do ```argMax(costArray * probabilites)```. Specify via ```new Evaluation(INDArray costArray)```