### PR TITLE
Reverse updatePolicy = never

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
             </releases>
             <snapshots>
                 <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
             </snapshots>
         </repository>
     </repositories>


### PR DESCRIPTION
This extreme setting should not be enforced by the build. I assume it
is seen as useful by some devleopers that are building snapshots
locally and do not want them overridden by distant snapshots from the
repo. But developers are not the main users of this library

It will lead to users being unable to build, and to CI not updating,
not to mention it concerns nearly all snapshots from sonatype, not
just ours.

See https://blog.saddey.net/2010/02/07/maven-never-say-never-in-an-updatepolicy/

If you want this edge setting, you can have it in your local settings.xml
as an override.