### PR TITLE
Table styles for scalability calculation form in docs

### DIFF
--- a/_includes/scalability.html
+++ b/_includes/scalability.html
@@ -1,61 +1,72 @@
-<form>
-    <table style="width: 100%; padding-bottom: 30px;"  align="left" style="text-align: left;">
-        <tr>
-            <td>
-                <table style="border-spacing: 5px; border-collapse: separate;">
-                    <tr>
-                        <td style="padding: 5px;"><small><strong>Iteration time</strong></small></td>
-                        <td style="padding: 5px;"><small><strong>Encode time</strong></small></td>
-                        <td style="padding: 5px;"><small><strong>Decode time</strong></small></td>
-                        <td style="padding: 5px;"><small><strong>Update time</strong></small></td>
-                        <td style="padding: 5px;"><small><strong>Service overhead</strong></small></td>
-                    </tr>
-                    <tr>
-                        <td style="padding: 5px;"><input type="text" id="iter" value="550" style="width: 50px;" onchange="refreshCalculations()"/></td>
-                        <td style="padding: 5px;"><input type="text" id="enc" value="50" style="width: 50px;" onchange="refreshCalculations()"/></td>
-                        <td style="padding: 5px;"><input type="text" id="dec" value="5" style="width: 50px;" onchange="refreshCalculations()"/></td>
-                        <td style="padding: 5px;"><input type="text" id="upd" value="50" style="width: 50px;" onchange="refreshCalculations()"/></td>
-                        <td style="padding: 5px;"><input type="text" id="srv" value="20" style="width: 50px;" onchange="refreshCalculations()"/></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td align="left" style="text-align: left;">
-                <table style="border-spacing: 5px; border-collapse: separate;">
-                    <tr>
-                        <td style="padding: 5px;"><small><strong>Number of nodes</strong></small></td>
-                        <td style="padding: 5px;"><small><strong>Workers per node</strong></small></td>
-                    </tr>
-                    <tr>
-                        <td style="padding: 5px;"><input type="text" id="nodes" value="8" style="width: 50px;" onchange="refreshCalculations()"/></td>
-                        <td style="padding: 5px;"><input type="text" id="workers" value="4" style="width: 50px;" onchange="refreshCalculations()"/></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td align="left" style="text-align: left;">
-                <table>
-                    <tr>
-                        <td>Scalability ratio: <p id="rscal">0%</p></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
-</form>
-<br />
-<br />
+<div class="row">
+  <div class="col-sm-12">
+    <form>
+      <div>
+        <table class="table">
+          <thead>
+          <th>
+            Iteration time
+          </th>
+          <th>
+            Encode time
+          </th>
+          <th>
+            Decode time
+          </th>
+          <th>
+            Update time
+          </th>
+          <th>
+            Service overhead
+          </th>
+          </thead>
+          <tr>
+            <td><input type="text" id="iter" value="550" style="width: 50px;"
+                       onkeyup="refreshCalculations()"/></td>
+            <td><input type="text" id="enc" value="50" style="width: 50px;"
+                       onkeyup="refreshCalculations()"/></td>
+            <td><input type="text" id="dec" value="5" style="width: 50px;"
+                       onkeyup="refreshCalculations()"/></td>
+            <td><input type="text" id="upd" value="50" style="width: 50px;"
+                       onkeyup="refreshCalculations()"/></td>
+            <td><input type="text" id="srv" value="20" style="width: 50px;"
+                       onkeyup="refreshCalculations()"/></td>
+          </tr>
+        </table>
+      </div>
+      <div>
+        <table class="table">
+          <thead>
+          <th>
+            Number of nodes
+          </th>
+          <th>
+            Workers per node
+          </th>
+          </thead>
+          <tr>
+            <td><input type="text" id="nodes" value="8" style="width: 50px;"
+                       onkeyup="refreshCalculations()"/></td>
+            <td><input type="text" id="workers" value="4" style="width: 50px;"
+                       onkeyup="refreshCalculations()"/></td>
+          </tr>
+        </table>
+      </div>
+      <div style="padding-bottom: 30px;">
+        <h4>Scalability ratio: <span id="rscal">0%</span></h4>
+      </div>
+    </form>
+  </div>
+</div>
 
 <script language="JavaScript">
-function getValue(id) {
+  function getValue(id) {
     return document.getElementById(id).value;
-}
+  }
 
-function refreshCalculations() {
- // to be implemented
- // 60000 / (A2 + B2 + (C2 * (A5 * B5)) + E2) * (A5 * B5)
+  function refreshCalculations() {
+    // to be implemented
+    // 60000 / (A2 + B2 + (C2 * (A5 * B5)) + E2) * (A5 * B5)
     var a2 = parseInt(getValue("iter"));
     var b2 = parseInt(getValue("enc"));
     var c2 = parseInt(getValue("dec"));
@@ -82,13 +93,13 @@ function refreshCalculations() {
     console.log("h13: " + h13);
     */
 
-    var h13 = g13/g12;
+    var h13 = g13 / g12;
 
     var i13 = parseFloat((h13 * 100) / (a5 * b5)).toFixed(2);
 
     document.getElementById("rscal").innerHTML = i13 + '%';
-}
+  }
 
-// fire this one, once document is loaded
-refreshCalculations();
+  // fire this one, once document is loaded
+  refreshCalculations();
 </script>

--- a/cn/archieved/artificialintelligence.md
+++ b/cn/archieved/artificialintelligence.md
@@ -1,6 +1,6 @@
 ---
 title: Artificial Intelligence Resources
-layout: cn- default
+layout: cn-default
 ---
 
 ## Artificial Intelligence Resources

--- a/distributed.md
+++ b/distributed.md
@@ -1,5 +1,5 @@
 ---
-title: Distributed Training: Gradients Sharing
+title: Distributed Training - Gradients Sharing
 layout: default
 ---
 

--- a/etl-userguide.md
+++ b/etl-userguide.md
@@ -20,20 +20,6 @@ Data may also need to be pre-processed in other ways: transformed, scaled, norma
 
 ## Record Readers
 
-<!-- put border on the table -->
-<style>
-table
-{border:1px solid black;
-}
-td
-{border:1px solid black;
-}
-th
-{border:1px solid black;
-}
-
-</style>
-
 Record Readers are part of the DataVec library, which the Skymind team created to manage ETL processes. Their class is `RecordReader`.
 
 ### Available RecordReaders
@@ -64,7 +50,7 @@ Record Readers are part of the DataVec library, which the Skymind team created t
 | TfidfRecordReader              | TFIDF record reader (wraps a tfidf vectorizer for delivering labels and conforming to the record reader interface)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | NLP processing, Term Frequency Inverse Document Frequency |
 | VideoRecordReader              | A video is just a moving window of pictures. It should be processed as such. This iterates over a root folder and returns a                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Video                                                     |
 | WavFileRecordReader            | Wav file loader                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Audio                                                     |
-
+{: .table}
 
 
 --------------------
@@ -133,7 +119,7 @@ Image training data can be augmented by rotating samples, or applying skew to th
 | ScaleImageTransform      | Scales images deterministically or randomly                                       |
 | ShowImageTransform       | Shows images on the screen, for visualization only, does not transform            |
 | WarpImageTransform.      | Warps the perspective of images deterministically or randomly                     |
-
+{: .table}
 
 
 ## Data Transforms
@@ -183,7 +169,7 @@ Here is what is currently possible with DataVec:
 | StringToTimeTransform                 | Generate numeric time from String                                                   |
 | SubtractMeanNormalizer                | Subtract mean                                                                       |
 | TimeMathOpTransform                   | Time conversions                                                                    |
-
+{: .table}
 
 ## Scaling and Normalizing 
 
@@ -205,7 +191,7 @@ From the `RecordReader` data typically travels to a dataset iterator that traver
 | ImagePreProcessingScaler   | Applies min max scaling Can take a range . Pixel values can be scaled from 0->255 to minRange->maxRange default minRange = 0 and maxRange = 1 |
 | NormalizerMinMaxScaler     | Applies min max scaling Can take a range X -> (X - min/(max-min)) * (given_max - given_min) + given_mi                                        |
 | NormalizerStandardize      | Standard scaler calculates a moving column wise variance and mean                                                                             |
-
+{: .table}
 
 	
 ## Image Transformations with JavaCV, OpenCV and ffmpeg Filters


### PR DESCRIPTION
Basic styling for the scalability calculator. 

Also fixes a few issues with jekyll and table styles on the etl page.

<img width="805" alt="screenshot 2017-07-20 14 26 48" src="https://user-images.githubusercontent.com/1197406/28439615-7dcc8366-6d57-11e7-88f7-bfacdf15c410.png">
