### PR TITLE
Enable doc-jar for deeplearning4j-scaleout/spark

### DIFF
--- a/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j-scaleout/spark/pom.xml
@@ -78,6 +78,7 @@
                         <goals>
                             <goal>compile</goal>
                             <goal>testCompile</goal>
+                            <goal>doc-jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Fixes #3681

## What changes were proposed in this pull request?

Enables Javadoc generation required for release.

## How was this patch tested?

Builds pass and javadoc artifacts get created.