### PR TITLE
Fix ConcurrentModificationException in MathUtils.partitionVariable

### DIFF
--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/util/MathUtils.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/util/MathUtils.java
@@ -27,6 +27,7 @@ import org.apache.commons.math3.util.FastMath;
 import org.deeplearning4j.clustering.berkeley.Counter;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;

--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/util/MathUtils.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/util/MathUtils.java
@@ -616,9 +616,10 @@ public class MathUtils {
 
         }
         //All data sets must be same size
-        for (List<Double> lists : ret) {
+        for (Iterator<Double> iterator = ret.iterator(); iterator().hasNext();) {
+            List<Double> lists = iterator.next();
             if (lists.size() < chunk)
-                ret.remove(lists);
+                iterator.remove();
         }
         return ret;
     }//end partitionVariable


### PR DESCRIPTION
Proposed fix:

Refactor MathUtils.partitionVariable to use iterator.remove().

Otherwise, the implicit ArrayList iterator in the for loop may throw a ConcurrentModificationException

I encountered the exception in PlayUIServer and then searched for similar bugs. This is the only other occurrence I found.