### PR TITLE
Fix running Spark tests on localhost

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/test/java/org/deeplearning4j/spark/text/BaseSparkTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-nlp/src/test/java/org/deeplearning4j/spark/text/BaseSparkTest.java
@@ -51,8 +51,9 @@ public abstract class BaseSparkTest implements Serializable {
         if (sc != null)
             return sc;
         // set to test mode
-        SparkConf sparkConf = new SparkConf().setMaster("local[4]").setAppName("sparktest")
-                        .set(Word2VecVariables.NUM_WORDS, String.valueOf(1));
+        SparkConf sparkConf = new SparkConf().setMaster("local[4]").set("spark.driver.host", "localhost")
+            .setAppName("sparktest")
+            .set(Word2VecVariables.NUM_WORDS, String.valueOf(1));
 
 
         sc = new JavaSparkContext(sparkConf);

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/BaseSparkTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/BaseSparkTest.java
@@ -86,7 +86,7 @@ public abstract class BaseSparkTest implements Serializable {
         if (sc != null)
             return sc;
         // set to test mode
-        SparkConf sparkConf = new SparkConf().setMaster("local[" + numExecutors() + "]").setAppName("sparktest");
+        SparkConf sparkConf = new SparkConf().setMaster("local[" + numExecutors() + "]").set("spark.driver.host", "localhost").setAppName("sparktest");
 
 
         sc = new JavaSparkContext(sparkConf);


### PR DESCRIPTION
Sister PR of https://github.com/deeplearning4j/DataVec/pull/370


Symptom is binding error on port 0, when localhost not in /etc/hosts
(which should never happen except when the driver host is confusing to spark).