### PR TITLE
Add optional labels for KNN results returned by `/knnnew` endpoint.

### DIFF
--- a/deeplearning4j-nearestneighbors-parent/deeplearning4j-nearestneighbors-model/src/main/java/org/deeplearning4j/nearestneighbor/model/NearestNeighborsResult.java
+++ b/deeplearning4j-nearestneighbors-parent/deeplearning4j-nearestneighbors-model/src/main/java/org/deeplearning4j/nearestneighbor/model/NearestNeighborsResult.java
@@ -10,6 +10,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class NearestNeighborsResult {
+    public NearestNeighborsResult(int index, double distance) {
+        this(index, distance, null);
+    }
+
     private int index;
     private double distance;
+    private String label;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need a convenient and reliable way to "identify" the neighbors returned by a KNN search (besides row indeces, that is). To facilitate this, we're making two small changes to KNN functionality:

- add a String field named`label` to the `NearestNeighborResult` class
- add an optional commandline arg to the `NearestNeighborServer` that allows us to pass in one or more text files containing labels for the rows in our points matrix. If provided, we feed these labels to the NearestNeighborResult.

## How was this patch tested?

Mostly manual testing