### PR TITLE
Repairs build-dl4j-stack under OSX

### DIFF
--- a/build-dl4j-stack.sh
+++ b/build-dl4j-stack.sh
@@ -90,10 +90,12 @@ done
 # default for chip
 if [[ -z "$CHIP" ]]; then
     # test for cuda libraries
-    if (ldconfig -p | grep -q libcuda\.so) then
-        CHIP="cuda"
-    else
-        CHIP="cpu"
+    if (type ldconfig &> /dev/null); then
+       if (ldconfig -p | grep -q libcuda\.so); then
+           CHIP="cuda"
+       else
+           CHIP="cpu"
+        fi
     fi
 fi
 


### PR DESCRIPTION
OSX has no ldconfig to autodetect with
Fixes #3841