### PR TITLE
An implementation of multi-probe LSH for the cosine distance.

### DIFF
--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/LSH.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/LSH.java
@@ -1,0 +1,77 @@
+package org.deeplearning4j.clustering.lsh;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.BaseAccumulation;
+
+/**
+ * This interface gathers the minimal elements for an LSH implementation
+ *
+ * See chapter 3 of :
+ * _Mining Massive Datasets_, Anand Rajaraman and Jeffrey Ullman
+ * http://www.mmds.org/
+ *
+ */
+public interface LSH {
+
+    /**
+     * Returns an instance of the distance measure associated to the LSH family of this implementation.
+     * Beware, hashing families and their amplificaiton constructs are distance-specific.
+     */
+    public String getDistanceMeasure();
+
+    /**
+     * Returns the size of a hash compared against in one hashing bucket, corresponding to an AND construction
+     *
+     * denoting hashLength by h,
+     * amplifies a (d1, d2, p1, p2) hash family into a
+     *                   (d1, d2, p1^h, p2^h)-sensitive one (match probability is decreasing with h)
+     *
+     * @return the length of the hash in the AND construction used by this index
+     */
+    public int getHashLength();
+
+    /**
+     *
+     * denoting numTables by n,
+     * amplifies a (d1, d2, p1, p2) hash family into a
+     *                   (d1, d2, (1-p1^n), (1-p2^n))-sensitive one (match probability is increasing with n)
+     *
+     * @return the # of hash tables in the OR construction used by this index
+     */
+    public int getNumTables();
+
+    /**
+     * @return The dimension of the index vectors and queries
+     */
+    public int getInDimension();
+
+    /**
+     * Popolates the index with data vectors.
+     * @param data the vectors to index
+     */
+    public void makeIndex(INDArray data);
+
+    /**
+     * Returns the set of all vectors that could approximately be considered negihbors of the query,
+     * without selection on the basis of distance or number of neighbors.
+     * @param query a  vector to find neighbors for
+     * @return its approximate neighbors, unfiltered
+     */
+    public INDArray bucket(INDArray query);
+
+    /**
+     * Returns the approximate neighbors within a distance bound.
+     * @param query a vector to find neighbors for
+     * @param maxRange the maximum distance between results and the query
+     * @return approximate neighbors within the distance bounds
+     */
+    public INDArray search(INDArray query, double maxRange);
+
+    /**
+     * Returns the approximate neighbors within a k-closest bound
+     * @param query a vector to find neighbors for
+     * @param k the maximum number of closest neighbors to return
+     * @return at most k neighbors of the query, ordered by increasing distance
+     */
+    public INDArray search(INDArray query, int k);
+}

--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/LSH.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/LSH.java
@@ -15,7 +15,7 @@ public interface LSH {
 
     /**
      * Returns an instance of the distance measure associated to the LSH family of this implementation.
-     * Beware, hashing families and their amplificaiton constructs are distance-specific.
+     * Beware, hashing families and their amplification constructs are distance-specific.
      */
     public String getDistanceMeasure();
 
@@ -46,7 +46,7 @@ public interface LSH {
     public int getInDimension();
 
     /**
-     * Popolates the index with data vectors.
+     * Populates the index with data vectors.
      * @param data the vectors to index
      */
     public void makeIndex(INDArray data);

--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSH.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSH.java
@@ -1,0 +1,230 @@
+package org.deeplearning4j.clustering.lsh;
+
+import lombok.Getter;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.broadcast.BroadcastDivOp;
+import org.nd4j.linalg.api.ops.impl.broadcast.BroadcastEqualTo;
+import org.nd4j.linalg.api.ops.impl.transforms.Sign;
+
+import org.nd4j.linalg.api.ops.random.impl.GaussianDistribution;
+import org.nd4j.linalg.api.ops.random.impl.UniformDistribution;
+import org.nd4j.linalg.api.rng.Random;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.BooleanIndexing;
+import org.nd4j.linalg.indexing.conditions.Conditions;
+import org.nd4j.linalg.ops.transforms.Transforms;
+
+import java.util.Arrays;
+
+
+/**
+ * This class implements Entropy LSH for the cosine distance, in order to preserve memory for large datasets.
+ *
+ * Entropy SLH is the LSH scheme of
+ *
+ * _Entropy based nearest neighbor search in high dimensions_
+ * R Panigrahy - SIAM 2006
+ * https://arxiv.org/pdf/cs/0510019.pdf
+ *
+ * To read more about LSH, in particular for the Cosine distance, see
+ * chapter 3 of :
+ * _Mining Massive Datasets_, Anand Rajaraman and Jeffrey Ullman
+ * http://www.mmds.org/
+ *
+ * The original development of LSH for the cosine distance is from
+ * Similarity estimation techniques from rounding algorithms
+ * MS Charikar - STOCS, 2002
+ *
+ * Note for high-precision or distributed settings, you should not
+ * use this and rather extend this to layered LSH ( https://arxiv.org/abs/1210.7057 )
+ *
+ */
+public class RandomProjectionLSH implements LSH {
+
+    @Override
+    public String getDistanceMeasure(){
+        return "cosinedistance";
+    }
+
+    @Getter int hashLength;
+
+    @Getter int numTables;
+
+    @Getter int inDimension;
+
+
+    @Getter double radius;
+
+    INDArray randomProjection;
+
+    INDArray index;
+
+    INDArray indexData;
+
+
+    private INDArray gaussianRandomMatrix(int[] shape, Random rng){
+        INDArray res = Nd4j.create(shape);
+
+        GaussianDistribution op1 = new GaussianDistribution(res, 0.0, 1.0 / Math.sqrt(shape[0]));
+
+        Nd4j.getExecutioner().exec(op1, rng);
+        return res;
+    }
+
+    public RandomProjectionLSH(int hashLength, int numTables, int inDimension, double radius){
+        this(hashLength, numTables, inDimension, radius, Nd4j.getRandom());
+    }
+
+    /**
+     * Creates a locality-sensitive hashing index for the cosine distance,
+     * a (d1, d2, (180 − d1)/180,(180 − d2)/180)-sensitive hash family before amplification
+     *
+     * @param hashLength the length of the compared hash in an AND construction,
+     * @param numTables the entropy-equivalent of a nb of hash tables in an OR construction, implemented here with the multiple
+     *                  probes of Panigraphi (op. cit).
+     * @param inDimension the dimendionality of the points being indexed
+     * @param radius the radius of points to generate probes for. Instead of using multiple physical hash tables in an OR construction
+     * @param rng a Random object to draw samples from
+     */
+    public RandomProjectionLSH(int hashLength, int numTables, int inDimension, double radius, Random rng){
+        this.hashLength = hashLength;
+        this.numTables = numTables;
+        this.inDimension = inDimension;
+        this.radius = radius;
+        randomProjection = gaussianRandomMatrix(new int[]{inDimension, hashLength}, rng);
+    }
+
+    /**
+     * This picks uniformaly distributed random points on the unit of a sphere using the method of:
+     *
+     * An efficient method for generating uniformly distributed points on the surface of an n-dimensional sphere
+     * JS Hicks, RF Wheeling - Communications of the ACM, 1959
+     * @param data a query to generate multiple probes for
+     * @return `numTables`
+     */
+    public INDArray entropy(INDArray data){
+
+        INDArray data2 =
+                    Nd4j.getExecutioner().exec(new GaussianDistribution(Nd4j.create(numTables, inDimension), radius));
+
+        INDArray norms = Nd4j.norm2(data2.dup(), -1);
+
+        assert(norms.shape()[0] == numTables);
+        assert(norms.shape()[1] == 1);
+
+        data2.diviColumnVector(norms);
+        data2.addiRowVector(data);
+        return data2;
+    }
+
+    /**
+     * Returns hash values for a particular query
+     * @param data a query vector
+     * @return its hashed value
+     */
+    public INDArray hash(INDArray data) {
+        if (data.shape()[1] != inDimension){
+            throw new ND4JIllegalStateException(
+                    String.format("Invalid shape: Requested INDArray shape %s, this table expects dimension %d",
+                            Arrays.toString(data.shape()), inDimension));
+        }
+        INDArray projected = data.mmul(randomProjection);
+        INDArray res = Nd4j.getExecutioner().execAndReturn(new Sign(projected));
+        return res;
+    }
+
+    /**
+     * Populates the index. Beware, not incremental, any further call replaces the index instead of adding to it.
+     * @param data the vectors to index
+     */
+    @Override
+    public void makeIndex(INDArray data) {
+        index = hash(data);
+        indexData = data;
+    }
+
+    // data elements in the same bucket as the query, without entropy
+    INDArray rawBucketOf(INDArray query){
+        INDArray pattern = hash(query);
+
+        INDArray res = Nd4j.zeros(index.shape());
+        Nd4j.getExecutioner().exec(new BroadcastEqualTo(index, pattern, res, -1));
+        return res.min(-1);
+    }
+
+    @Override
+    public INDArray bucket(INDArray query) {
+        INDArray queryRes = rawBucketOf(query);
+
+        if(numTables > 1) {
+            INDArray entropyQueries = entropy(query);
+
+            // loop, addi + conditionalreplace -> poor man's OR function
+            for (int i = 0; i < numTables; i++) {
+                INDArray row = entropyQueries.getRow(i);
+                queryRes.addi(rawBucketOf(row));
+            }
+            BooleanIndexing.replaceWhere(queryRes, 1.0, Conditions.greaterThan(0.0));
+        }
+
+        return queryRes;
+    }
+
+    // data elements in the same entropy bucket as the query,
+    INDArray bucketData(INDArray query){
+        INDArray mask = bucket(query);
+        int nRes = mask.sum(0).getInt(0);
+        INDArray res = Nd4j.create(new int[] {nRes, inDimension});
+        int j = 0;
+        for (int i = 0; i < nRes; i++){
+            while (mask.getInt(j) == 0 && j < mask.length() - 1) {
+                j += 1;
+            }
+            if (mask.getInt(j) == 1) res.putRow(i, indexData.getRow(j));
+            j += 1;
+        }
+        return res;
+    }
+
+    @Override
+    public INDArray search(INDArray query, double maxRange) {
+        if (maxRange < 0)
+            throw new IllegalArgumentException("ANN search should have a positive maximum search radius");
+
+        INDArray bucketData = bucketData(query);
+        INDArray distances = Transforms.allCosineDistances(bucketData, query, -1);
+        INDArray[] idxs = Nd4j.sortWithIndices(distances, -1, true);
+
+        INDArray shuffleIndexes = idxs[0];
+        INDArray sortedDistances = idxs[1];
+        int accepted = 0;
+        while (accepted < sortedDistances.length() && sortedDistances.getInt(accepted) <= maxRange) accepted +=1;
+
+        INDArray res = Nd4j.create(new int[] {accepted, inDimension});
+        for(int i = 0; i < accepted; i++){
+            res.putRow(i, bucketData.getRow(shuffleIndexes.getInt(i)));
+        }
+        return res;
+    }
+
+    @Override
+    public INDArray search(INDArray query, int k) {
+        if (k < 1)
+            throw new IllegalArgumentException("An ANN search for k neighbors should at least seek one neighbor");
+
+        INDArray bucketData = bucketData(query);
+        INDArray distances = Transforms.allCosineDistances(bucketData, query, -1);
+        INDArray[] idxs = Nd4j.sortWithIndices(distances, -1, true);
+
+        INDArray shuffleIndexes = idxs[0];
+        INDArray sortedDistances = idxs[1];
+        int accepted = Math.min(k, sortedDistances.shape()[1]);
+
+        INDArray res = Nd4j.create(new int[] {accepted, inDimension});
+        for(int i = 0; i < accepted; i++){
+            res.putRow(i, bucketData.getRow(shuffleIndexes.getInt(i)));
+        }
+        return res;
+    }
+}

--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSH.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSH.java
@@ -47,14 +47,14 @@ public class RandomProjectionLSH implements LSH {
         return "cosinedistance";
     }
 
-    @Getter int hashLength;
+    @Getter private int hashLength;
 
-    @Getter int numTables;
+    @Getter private int numTables;
 
-    @Getter int inDimension;
+    @Getter private int inDimension;
 
 
-    @Getter double radius;
+    @Getter private double radius;
 
     INDArray randomProjection;
 

--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSHTest.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSHTest.java
@@ -23,7 +23,7 @@ public class RandomProjectionLSHTest {
 
     @Before
     public void setUp() {
-        rpLSH = new RandomProjectionLSH(hashLength, numTables, intDimensions);
+        rpLSH = new RandomProjectionLSH(hashLength, numTables, intDimensions, 0.1f);
     }
 
     @Test

--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSHTest.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSHTest.java
@@ -1,0 +1,188 @@
+package org.deeplearning4j.clustering.lsh;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.broadcast.BroadcastEqualTo;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RandomProjectionLSHTest {
+
+    int hashLength = 31;
+    int numTables = 2;
+    int intDimensions = 13;
+
+    RandomProjectionLSH rpLSH;
+    INDArray e1 = Nd4j.ones(1, intDimensions);
+
+    @Before
+    public void setUp() {
+        rpLSH = new RandomProjectionLSH(hashLength, numTables, intDimensions);
+    }
+
+    @Test
+    public void testEntropyDims(){
+        assertArrayEquals(new int[]{numTables, intDimensions}, rpLSH.entropy(e1).shape());
+    }
+
+    @Test
+    public void testHashDims(){
+        assertArrayEquals(new int[]{1, hashLength}, rpLSH.hash(e1).shape());
+    }
+
+    @Test
+    public void testHashDimsMultiple(){
+        INDArray data = Nd4j.ones(1, intDimensions);
+        assertArrayEquals(new int[]{1, hashLength}, rpLSH.hash(data).shape());
+
+        data = Nd4j.ones(100, intDimensions);
+        assertArrayEquals(new int[]{100, hashLength}, rpLSH.hash(data).shape());
+    }
+
+    @Test
+    public void testSigNums(){
+        assertEquals(1.0f, rpLSH.hash(e1).aminNumber().floatValue(),1e-3f);
+    }
+
+
+    @Test
+    public void testIndexDims(){
+        rpLSH.makeIndex(Nd4j.rand(100, intDimensions));
+        assertArrayEquals(new int[]{100, hashLength}, rpLSH.index.shape());
+    }
+
+
+    @Test
+    public void testGetRawBucketOfDims(){
+        rpLSH.makeIndex(Nd4j.rand(100, intDimensions));
+        assertArrayEquals(new int[]{100, 1}, rpLSH.rawBucketOf(e1).shape());
+    }
+
+    @Test
+    public void testRawBucketOfReflexive(){
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+        assertEquals(1.0f, rpLSH.rawBucketOf(row).maxNumber().floatValue(), 1e-3f);
+    }
+
+    @Test
+    public void testBucketDims(){
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        assertArrayEquals(new int[]{100, 1}, rpLSH.bucket(e1).shape());
+    }
+
+    @Test
+    public void testBucketReflexive(){
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+        assertEquals(1.0f, rpLSH.bucket(row).maxNumber().floatValue(), 1e-3f);
+    }
+
+
+    @Test
+    public void testBucketDataReflexiveDimensions() {
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+        INDArray bucketData = rpLSH.bucketData(row);
+
+        assertEquals(intDimensions, bucketData.shape()[1]);
+        assertTrue(1 <= bucketData.shape()[0]);
+    }
+
+    @Test
+    public void testBucketDataReflexive(){
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+        INDArray bucketData =  rpLSH.bucketData(row);
+
+        INDArray res = Nd4j.zeros(bucketData.shape());
+        Nd4j.getExecutioner().exec(new BroadcastEqualTo(bucketData, row, res, -1));
+
+        assertEquals(
+                String.format("Expected one bucket content to be the query %s, but found %s", row, rpLSH.bucket(row)),
+                1.0f, res.min(-1).maxNumber().floatValue(), 1e-3f);
+    }
+
+
+    @Test
+    public void testSearchReflexiveDimensions() {
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+        INDArray searchResults = rpLSH.search(row, 10.0f);
+
+        assertTrue(
+                String.format("Expected the search to return at least one result, the query %s but found %s yielding %d results", row, searchResults, searchResults.shape()[0]),
+                searchResults.shape()[0] >= 1);
+    }
+
+
+    @Test
+    public void testSearchReflexive() {
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+
+        INDArray searchResults = rpLSH.search(row, 10.0f);
+
+
+        INDArray res = Nd4j.zeros(searchResults.shape());
+        Nd4j.getExecutioner().exec(new BroadcastEqualTo(searchResults, row, res, -1));
+
+        assertEquals(
+                String.format("Expected one search result to be the query %s, but found %s", row, searchResults),
+                1.0f, res.min(-1).maxNumber().floatValue(), 1e-3f);
+    }
+
+
+
+    @Test
+    public void testANNSearchReflexiveDimensions() {
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+        INDArray searchResults = rpLSH.search(row, 100);
+
+        assertTrue(
+                String.format("Expected the search to return at least one result, the query %s but found %s yielding %d results", row, searchResults, searchResults.shape()[0]),
+                searchResults.shape()[0] >= 1);
+    }
+
+
+    @Test
+    public void testANNSearchReflexive() {
+        INDArray inputs = Nd4j.rand(100, intDimensions);
+        rpLSH.makeIndex(inputs);
+        int idx = (new Random()).nextInt(100);
+        INDArray row = inputs.getRow(idx);
+
+        INDArray searchResults = rpLSH.search(row, 100);
+
+
+        INDArray res = Nd4j.zeros(searchResults.shape());
+        Nd4j.getExecutioner().exec(new BroadcastEqualTo(searchResults, row, res, -1));
+
+        assertEquals(
+                String.format("Expected one search result to be the query %s, but found %s", row, searchResults),
+                1.0f, res.min(-1).maxNumber().floatValue(), 1e-3f);
+    }
+
+}

--- a/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSHTest.java
+++ b/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/lsh/RandomProjectionLSHTest.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.clustering.lsh;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -20,11 +21,17 @@ public class RandomProjectionLSHTest {
 
     RandomProjectionLSH rpLSH;
     INDArray e1 = Nd4j.ones(1, intDimensions);
+    INDArray inputs;
 
     @Before
     public void setUp() {
         rpLSH = new RandomProjectionLSH(hashLength, numTables, intDimensions, 0.1f);
+        inputs = Nd4j.rand(100, intDimensions);
     }
+
+
+    @After
+    public void tearDown() { inputs = null; }
 
     @Test
     public void testEntropyDims(){
@@ -60,13 +67,12 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testGetRawBucketOfDims(){
-        rpLSH.makeIndex(Nd4j.rand(100, intDimensions));
+        rpLSH.makeIndex(inputs);
         assertArrayEquals(new int[]{100, 1}, rpLSH.rawBucketOf(e1).shape());
     }
 
     @Test
     public void testRawBucketOfReflexive(){
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);
@@ -75,14 +81,12 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testBucketDims(){
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         assertArrayEquals(new int[]{100, 1}, rpLSH.bucket(e1).shape());
     }
 
     @Test
     public void testBucketReflexive(){
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);
@@ -92,7 +96,6 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testBucketDataReflexiveDimensions() {
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);
@@ -104,7 +107,6 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testBucketDataReflexive(){
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);
@@ -121,7 +123,6 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testSearchReflexiveDimensions() {
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);
@@ -135,7 +136,6 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testSearchReflexive() {
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);
@@ -155,7 +155,6 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testANNSearchReflexiveDimensions() {
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);
@@ -169,7 +168,6 @@ public class RandomProjectionLSHTest {
 
     @Test
     public void testANNSearchReflexive() {
-        INDArray inputs = Nd4j.rand(100, intDimensions);
         rpLSH.makeIndex(inputs);
         int idx = (new Random()).nextInt(100);
         INDArray row = inputs.getRow(idx);


### PR DESCRIPTION
This can be used as guidelines for a poor man's ANN if the distribution of
the data is well-known enough to be able to predict an average distance
 between ANNs (the radius parameter of Panigraphi's entropy LSH).

However, because if uses a single hash table (as opposed to the several of the
vanilla LSH impelementation), it is relatively reasonable in its memory usage.

In the case of a very large index that would have to be split on several machins
the flavor of LSH that should be used is Layered LSH ( https://arxiv.org/abs/1210.7057 )

WIP, in particular the index creation does not use workspaces for now.

Opened as a request for comments (hi @turambar!) and perhaps an inspiration
to upgrade this to another implementation (hi @turambar!).

From the discard pile of high-performance ANN experiments.

review by @turambar for the math, @agibsonccc and @raver119 for the perf opts