### PR TITLE
API Cleanup

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/NeuralNetConfigurationTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/conf/NeuralNetConfigurationTest.java
@@ -72,8 +72,6 @@ public class NeuralNetConfigurationTest {
     @Test
     public void testJson() {
         NeuralNetConfiguration conf = getRBMConfig(1, 1, WeightInit.XAVIER, true);
-
-        assertFalse(conf.useRegularization);
         String json = conf.toJson();
         NeuralNetConfiguration read = NeuralNetConfiguration.fromJson(json);
 
@@ -84,8 +82,6 @@ public class NeuralNetConfigurationTest {
     @Test
     public void testYaml() {
         NeuralNetConfiguration conf = getRBMConfig(1, 1, WeightInit.XAVIER, true);
-
-        assertFalse(conf.useRegularization);
         String json = conf.toYaml();
         NeuralNetConfiguration read = NeuralNetConfiguration.fromYaml(json);
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
@@ -1121,4 +1121,34 @@ public class MultiLayerTest {
         assertEquals(net1.params(), net2.params());
         assertEquals(net1.paramTable(), net2.paramTable());
     }
+
+
+    @Test
+    public void testCompareLayerMethods(){
+        //Simple test: compare .layer(int, Layer) and .layer(Layer) are identical
+
+        MultiLayerConfiguration conf1 = new NeuralNetConfiguration.Builder().seed(123).list()
+                .layer(0, new DenseLayer.Builder().nIn(4).nOut(3).weightInit(WeightInit.XAVIER)
+                        .activation(Activation.TANH).build())
+                .layer(1, new DenseLayer.Builder().nIn(3).nOut(2).weightInit(WeightInit.XAVIER)
+                        .activation(Activation.TANH).build())
+                .layer(2, new LSTM.Builder().nIn(2).nOut(2).build())
+                .layer(3, new RnnOutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER).activation(Activation.SOFTMAX).nIn(2).nOut(3)
+                        .build())
+                .backprop(true).pretrain(false).build();
+
+        MultiLayerConfiguration conf2 = new NeuralNetConfiguration.Builder().seed(123).list()
+                .layer(new DenseLayer.Builder().nIn(4).nOut(3).weightInit(WeightInit.XAVIER)
+                        .activation(Activation.TANH).build())
+                .layer(new DenseLayer.Builder().nIn(3).nOut(2).weightInit(WeightInit.XAVIER)
+                        .activation(Activation.TANH).build())
+                .layer(new LSTM.Builder().nIn(2).nOut(2).build())
+                .layer(new RnnOutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .weightInit(WeightInit.XAVIER).activation(Activation.SOFTMAX).nIn(2).nOut(3)
+                        .build())
+                .backprop(true).pretrain(false).build();
+
+        assertEquals(conf1, conf2);
+    }
 }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
@@ -472,9 +472,6 @@ public class KerasModel {
             inboundTypeList.toArray(inboundTypeArray);
             InputPreProcessor preprocessor = layer.getInputPreprocessor(inboundTypeArray);
 
-            if (layer.usesRegularization())
-                modelBuilder.setUseRegularization(true);
-
             if (layer.isLayer()) {
                 /* Add DL4J layer. */
                 if (preprocessor != null)

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
@@ -159,8 +159,6 @@ public class KerasSequentialModel extends KerasModel {
         KerasLayer prevLayer = null;
         int layerIndex = 0;
         for (KerasLayer layer : this.layersOrdered) {
-            if (layer.usesRegularization())
-                modelBuilder.setUseRegularization(true);
             if (layer.isLayer()) {
                 int nbInbound = layer.getInboundLayerNames().size();
                 if (nbInbound != 1)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
@@ -151,7 +151,7 @@ public class GradientCheckUtil {
             }
 
             double dropout = n.getLayer().getDropOut();
-            if (n.isUseRegularization() && dropout != 0.0) {
+            if (dropout != 0.0) {
                 throw new IllegalStateException("Must have dropout == 0.0 for gradient checks - got dropout = "
                                 + dropout + " for layer " + layerCount);
             }
@@ -331,7 +331,7 @@ public class GradientCheckUtil {
             }
 
             double dropout = lv.getLayerConf().getLayer().getDropOut();
-            if (lv.getLayerConf().isUseRegularization() && dropout != 0.0) {
+            if (dropout != 0.0) {
                 throw new IllegalStateException("Must have dropout == 0.0 for gradient checks - got dropout = "
                                 + dropout + " for layer " + layerCount);
             }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -1022,7 +1022,7 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
          * Note 2: This sets the probability per-layer. Care should be taken when setting lower values for
          * complex networks (too much information may be lost with aggressive (very low) dropout values).<br>
          * Note 3: Frequently, dropout is not applied to (or, has higher retain probability for) input (first layer)
-         * layers. Dropout is also often not applied to our output layer. This needs to be handled MANUALLY by the user
+         * layers. Dropout is also often not applied to output layers. This needs to be handled MANUALLY by the user
          * - set .dropout(0) on those layers when using global dropout setting.<br>
          * Note 4: Implementation detail (most users can ignore): DL4J uses inverted dropout, as described here:
          * <a href="http://cs231n.github.io/neural-networks-2/">http://cs231n.github.io/neural-networks-2/</a>

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -98,7 +98,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
     //whether to constrain the gradient to unit norm or not
     //adadelta - weight for how much to consider previous history
     protected StepFunction stepFunction;
-    protected boolean useRegularization = false;
     protected boolean useDropConnect = false;
     //minimize or maximize objective
     protected boolean minimize = true;
@@ -620,7 +619,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
         protected int numIterations = 1;
         protected int maxNumLineSearchIterations = 5;
         protected long seed = System.currentTimeMillis();
-        protected boolean useRegularization = false;
         protected OptimizationAlgorithm optimizationAlgo = OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT;
         protected StepFunction stepFunction = null;
         protected boolean useDropConnect = false;
@@ -649,7 +647,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
                 maxNumLineSearchIterations = newConf.maxNumLineSearchIterations;
                 layer = newConf.layer;
                 numIterations = newConf.numIterations;
-                useRegularization = newConf.useRegularization;
                 optimizationAlgo = newConf.optimizationAlgo;
                 seed = newConf.seed;
                 stepFunction = newConf.stepFunction;
@@ -853,10 +850,10 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
         }
 
         /**
-         * Whether to use regularization (l1, l2, dropout, etc
+         * @deprecated Now: no-op. Regularization is always used when l1/l2/dropout is > 0
          */
+        @Deprecated
         public Builder regularization(boolean useRegularization) {
-            this.useRegularization = useRegularization;
             return this;
         }
 
@@ -980,7 +977,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
 
         /**
          * L1 regularization coefficient for the weights.
-         * Use with .regularization(true)
          */
         public Builder l1(double l1) {
             this.l1 = l1;
@@ -989,7 +985,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
 
         /**
          * L2 regularization coefficient for the weights.
-         * Use with .regularization(true)
          */
         public Builder l2(double l2) {
             this.l2 = l2;
@@ -998,7 +993,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
 
         /**
          * L1 regularization coefficient for the bias.
-         * Use with .regularization(true)
          */
         public Builder l1Bias(double l1Bias) {
             this.l1Bias = l1Bias;
@@ -1007,7 +1001,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
 
         /**
          * L2 regularization coefficient for the bias.
-         * Use with .regularization(true)
          */
         public Builder l2Bias(double l2Bias) {
             this.l2Bias = l2Bias;
@@ -1280,7 +1273,6 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
             conf.maxNumLineSearchIterations = maxNumLineSearchIterations;
             conf.layer = layer;
             conf.numIterations = numIterations;
-            conf.useRegularization = useRegularization;
             conf.optimizationAlgo = optimizationAlgo;
             conf.seed = seed;
             conf.stepFunction = stepFunction;
@@ -1329,7 +1321,7 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
                     sl.setConvolutionMode(convolutionMode);
                 }
             }
-            LayerValidation.generalValidation(layerName, layer, useRegularization, useDropConnect, dropOut, l2, l2Bias,
+            LayerValidation.generalValidation(layerName, layer, useDropConnect, dropOut, l2, l2Bias,
                             l1, l1Bias, dist);
         }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.ClassUtils;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
 import org.deeplearning4j.nn.conf.graph.GraphVertex;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.*;
 import org.deeplearning4j.nn.conf.layers.misc.FrozenLayer;
 import org.deeplearning4j.nn.conf.layers.variational.ReconstructionDistribution;
@@ -261,6 +262,19 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
             return layerwise;
         }
 
+        @Override
+        public ListBuilder setInputType(InputType inputType){
+            return (ListBuilder)super.setInputType(inputType);
+        }
+
+        /**
+         * A convenience method for setting input types: note that for example .inputType().convolutional(h,w,d)
+         * is equivalent to .setInputType(InputType.convolutional(h,w,d))
+         */
+        public ListBuilder.InputTypeBuilder inputType(){
+            return new InputTypeBuilder();
+        }
+
         /**
          * Build the multi layer network
          * based on this neural network and
@@ -296,6 +310,36 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
                             .inferenceWorkspaceMode(globalConfig.inferenceWorkspaceMode).confs(list).build();
         }
 
+        /** Helper class for setting input types */
+        public class InputTypeBuilder {
+            /**
+             * See {@link InputType#convolutional(int, int, int)}
+             */
+            public ListBuilder convolutional(int height, int width, int depth){
+                return ListBuilder.this.setInputType(InputType.convolutional(height, width, depth));
+            }
+
+            /**
+             * * See {@link InputType#convolutionalFlat(int, int, int)}
+             */
+            public ListBuilder convolutionalFlat(int height, int width, int depth){
+                return ListBuilder.this.setInputType(InputType.convolutionalFlat(height, width, depth));
+            }
+
+            /**
+             * See {@link InputType#feedForward(int)}
+             */
+            public ListBuilder feedForward(int size){
+                return ListBuilder.this.setInputType(InputType.feedForward(size));
+            }
+
+            /**
+             * See {@link InputType#recurrent(int)}}
+             */
+            public ListBuilder recurrent(int size){
+                return ListBuilder.this.setInputType(InputType.recurrent(size));
+            }
+        }
     }
 
     /**

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -1008,17 +1008,23 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
         }
 
         /**
-         * Dropout probability. This is the probability of <it>retaining</it> an activation. So dropOut(x) will keep an
-         * activation with probability x, and set to 0 with probability 1-x.<br>
-         * dropOut(0.0) is disabled (default).
+         * Dropout probability. This is the probability of <it>retaining</it> an input activation for a layer. So
+         * dropOut(x) will keep an input activation with probability x, and set to 0 with probability 1-x.<br>
+         * dropOut(0.0) is disabled (default). When {@link #useDropConnect(boolean)} is set to true (false by default),
+         * this method sets the drop connect probability instead.
          * <p>
-         * Note: This sets the probability per-layer. Care should be taken when setting lower values for complex networks.
+         * Note 1: This sets the probability per-layer. Care should be taken when setting lower values for
+         * complex networks (too much information may be lost with aggressive dropout values).<br>
+         * Note 2: Frequently, dropout is not applied to input (first layer) our output layer. This needs to be
+         * handled MANUALLY by the user - set .dropout(0) on those layers when using global dropout setting.<br>
+         * Note 3: Implementation detail (most users can ignore): DL4J uses inverted dropout, as described here:
+         * <a href="http://cs231n.github.io/neural-networks-2/">http://cs231n.github.io/neural-networks-2/</a>
          * </p>
          *
-         * @param dropOut Dropout probability (probability of retaining an activation)
+         * @param inputRetainFraction Dropout probability (probability of retaining an input activation for a layer)
          */
-        public Builder dropOut(double dropOut) {
-            this.dropOut = dropOut;
+        public Builder dropOut(double inputRetainFraction) {
+            this.dropOut = inputRetainFraction;
             return this;
         }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
@@ -217,17 +217,27 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
             return activation(Activation.fromString(activationFunction));
         }
 
+        /**
+         * Set the activation function for the layer. This overload can be used for custom {@link IActivation} instances
+         *
+         * @param activationFunction Activation function to use for the layer
+         */
         public T activation(IActivation activationFunction) {
             this.activationFn = activationFunction;
             return (T) this;
         }
 
+        /**
+         * Set the activation function for the layer, from an {@link Activation} enumeration value.
+         *
+         * @param activation Activation function to use for the layer
+         */
         public T activation(Activation activation) {
             return activation(activation.getActivationFunction());
         }
 
         /**
-         * Weight initialization scheme.
+         * Weight initialization scheme to use, for initial weight values
          *
          * @see WeightInit
          */
@@ -236,6 +246,11 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
             return (T) this;
         }
 
+        /**
+         * Bias initialization value, for layers with biases. Defaults to 0
+         *
+         * @param biasInit Value to use for initializing biases
+         */
         public T biasInit(double biasInit) {
             this.biasInit = biasInit;
             return (T) this;
@@ -435,8 +450,5 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
             this.learningRatePolicy = policy;
             return (T) this;
         }
-
-        //        @Override
-        //        public abstract <E extends BaseLayer> E build();
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -443,17 +443,6 @@ public class ConvolutionLayer extends FeedForwardLayer {
         }
 
         /**
-         * Dropout. Value is probability of retaining an activation - thus 1.0 is equivalent to no dropout.
-         * Note that 0.0 (the default) disables dropout.
-         *
-         * @param dropOut
-         */
-        @Override
-        public Builder dropOut(double dropOut) {
-            return super.dropOut(dropOut);
-        }
-
-        /**
          * Momentum rate.
          *
          * @param momentum

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -132,14 +132,37 @@ public abstract class FeedForwardLayer extends BaseLayer {
         protected int nIn = 0;
         protected int nOut = 0;
 
+        /**
+         * Number of inputs for the layer (usually the size of the last layer). <br>
+         * Note that for Convolutional layers, this is the input depth, otherwise is the previous layer size.
+         *
+         * @param nIn Number of inputs for the layer
+         */
         public T nIn(int nIn) {
             this.nIn = nIn;
             return (T) this;
         }
 
+        /**
+         * Number of outputs - used to set the layer size (number of units/nodes for the current layer).
+         * Note that this is equivalent to {@link #units(int)}
+         *
+         * @param nOut Number of outputs / layer size
+         */
         public T nOut(int nOut) {
             this.nOut = nOut;
             return (T) this;
+        }
+
+        /**
+         * Set the number of units / layer size for this layer.<br>
+         * This is equivalent to {@link #nOut(int)}
+         *
+         * @param units Size of the layer (number of units) / nOut
+         * @see #nOut(int)
+         */
+        public T units(int units){
+            return nOut(units);
         }
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -224,11 +224,23 @@ public abstract class Layer implements Serializable, Cloneable {
         }
 
         /**
-         * Dropout. Value is probability of retaining an activation - thus 1.0 is equivalent to no dropout.
-         * Note that 0.0 (the default) disables dropout.
+         * Dropout probability. This is the probability of <it>retaining</it> an input activation for a layer. So
+         * dropOut(x) will keep an input activation with probability x, and set to 0 with probability 1-x.<br>
+         * dropOut(0.0) is disabled (default). When useDropConnect is set to true (false by default),
+         * this method sets the drop connect probability instead.
+         * <p>
+         * Note 1: This sets the probability per-layer. Care should be taken when setting lower values for
+         * complex networks (too much information may be lost with aggressive dropout values).<br>
+         * Note 2: Frequently, dropout is not applied to input (first layer) our output layer. This needs to be
+         * handled MANUALLY by the user - set .dropout(0) on those layers when using global dropout setting.<br>
+         * Note 3: Implementation detail (most users can ignore): DL4J uses inverted dropout, as described here:
+         * <a href="http://cs231n.github.io/neural-networks-2/">http://cs231n.github.io/neural-networks-2/</a>
+         * </p>
+         *
+         * @param inputRetainFraction Dropout probability (probability of retaining an input activation for a layer)
          */
-        public T dropOut(double dropOut) {
-            this.dropOut = dropOut;
+        public T dropOut(double inputRetainFraction) {
+            this.dropOut = inputRetainFraction;
             return (T) this;
         }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -229,7 +229,7 @@ public abstract class Layer implements Serializable, Cloneable {
          * dropOut(0.0) is a special value / special case - when set to 0.0., dropout is disabled (not applied). Note
          * that a dropout value of 1.0 is functionally equivalent to no dropout: i.e., 100% probability of retaining
          * each input activation.<br>
-         * When {@link #useDropConnect(boolean)} is set to true (false by default), this method sets the drop connect
+         * When useDropConnect(boolean) is set to true (false by default), this method sets the drop connect
          * probability instead.
          * <p>
          * Note 1: Dropout is applied at training time only - and is automatically not applied at test time

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -224,23 +224,29 @@ public abstract class Layer implements Serializable, Cloneable {
         }
 
         /**
-         * Dropout probability. This is the probability of <it>retaining</it> an input activation for a layer. So
+         * Dropout probability. This is the probability of <it>retaining</it> each input activation value for a layer.
          * dropOut(x) will keep an input activation with probability x, and set to 0 with probability 1-x.<br>
-         * dropOut(0.0) is disabled (default). When useDropConnect is set to true (false by default),
-         * this method sets the drop connect probability instead.
+         * dropOut(0.0) is a special value / special case - when set to 0.0., dropout is disabled (not applied). Note
+         * that a dropout value of 1.0 is functionally equivalent to no dropout: i.e., 100% probability of retaining
+         * each input activation.<br>
+         * When {@link #useDropConnect(boolean)} is set to true (false by default), this method sets the drop connect
+         * probability instead.
          * <p>
-         * Note 1: This sets the probability per-layer. Care should be taken when setting lower values for
-         * complex networks (too much information may be lost with aggressive dropout values).<br>
-         * Note 2: Frequently, dropout is not applied to input (first layer) our output layer. This needs to be
-         * handled MANUALLY by the user - set .dropout(0) on those layers when using global dropout setting.<br>
-         * Note 3: Implementation detail (most users can ignore): DL4J uses inverted dropout, as described here:
+         * Note 1: Dropout is applied at training time only - and is automatically not applied at test time
+         * (for evaluation, etc)<br>
+         * Note 2: This sets the probability per-layer. Care should be taken when setting lower values for
+         * complex networks (too much information may be lost with aggressive (very low) dropout values).<br>
+         * Note 3: Frequently, dropout is not applied to (or, has higher retain probability for) input (first layer)
+         * layers. Dropout is also often not applied to our output layer. This needs to be handled MANUALLY by the user
+         * - set .dropout(0) on those layers when using global dropout setting.<br>
+         * Note 4: Implementation detail (most users can ignore): DL4J uses inverted dropout, as described here:
          * <a href="http://cs231n.github.io/neural-networks-2/">http://cs231n.github.io/neural-networks-2/</a>
          * </p>
          *
-         * @param inputRetainFraction Dropout probability (probability of retaining an input activation for a layer)
+         * @param inputRetainProbability Dropout probability (probability of retaining each input activation value for a layer)
          */
-        public T dropOut(double inputRetainFraction) {
-            this.dropOut = inputRetainFraction;
+        public T dropOut(double inputRetainProbability) {
+            this.dropOut = inputRetainProbability;
             return (T) this;
         }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -237,7 +237,7 @@ public abstract class Layer implements Serializable, Cloneable {
          * Note 2: This sets the probability per-layer. Care should be taken when setting lower values for
          * complex networks (too much information may be lost with aggressive (very low) dropout values).<br>
          * Note 3: Frequently, dropout is not applied to (or, has higher retain probability for) input (first layer)
-         * layers. Dropout is also often not applied to our output layer. This needs to be handled MANUALLY by the user
+         * layers. Dropout is also often not applied to output layers. This needs to be handled MANUALLY by the user
          * - set .dropout(0) on those layers when using global dropout setting.<br>
          * Note 4: Implementation detail (most users can ignore): DL4J uses inverted dropout, as described here:
          * <a href="http://cs231n.github.io/neural-networks-2/">http://cs231n.github.io/neural-networks-2/</a>

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LayerValidation.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LayerValidation.java
@@ -288,16 +288,16 @@ public class LayerValidation {
         }
     }
 
-    public static void generalValidation(String layerName, Layer layer, boolean useRegularization,
-                    boolean useDropConnect, Double dropOut, Double l2, Double l2Bias, Double l1, Double l1Bias,
+    public static void generalValidation(String layerName, Layer layer, boolean useDropConnect, Double dropOut,
+                                         Double l2, Double l2Bias, Double l1, Double l1Bias,
                     Distribution dist) {
-        generalValidation(layerName, layer, useRegularization, useDropConnect, dropOut == null ? 0.0 : dropOut,
+        generalValidation(layerName, layer, useDropConnect, dropOut == null ? 0.0 : dropOut,
                         l2 == null ? Double.NaN : l2, l2Bias == null ? Double.NaN : l2Bias,
                         l1 == null ? Double.NaN : l1, l1Bias == null ? Double.NaN : l1Bias, dist);
     }
 
-    public static void generalValidation(String layerName, Layer layer, boolean useRegularization,
-                    boolean useDropConnect, double dropOut, double l2, double l2Bias, double l1, double l1Bias,
+    public static void generalValidation(String layerName, Layer layer, boolean useDropConnect, double dropOut,
+                                         double l2, double l2Bias, double l1, double l1Bias,
                     Distribution dist) {
 
         if (layer != null) {
@@ -311,48 +311,31 @@ public class LayerValidation {
 
             if (layer instanceof BaseLayer) {
                 BaseLayer bLayer = (BaseLayer) layer;
-                configureBaseLayer(layerName, bLayer, useRegularization, useDropConnect, dropOut, l2, l2Bias, l1,
+                configureBaseLayer(layerName, bLayer, useDropConnect, dropOut, l2, l2Bias, l1,
                                 l1Bias, dist);
             } else if (layer instanceof FrozenLayer && ((FrozenLayer) layer).getLayer() instanceof BaseLayer) {
                 BaseLayer bLayer = (BaseLayer) ((FrozenLayer) layer).getLayer();
-                configureBaseLayer(layerName, bLayer, useRegularization, useDropConnect, dropOut, l2, l2Bias, l1,
+                configureBaseLayer(layerName, bLayer, useDropConnect, dropOut, l2, l2Bias, l1,
                                 l1Bias, dist);
             }
         }
     }
 
-    private static void configureBaseLayer(String layerName, BaseLayer bLayer, boolean useRegularization,
-                    boolean useDropConnect, Double dropOut, Double l2, Double l2Bias, Double l1, Double l1Bias,
+    private static void configureBaseLayer(String layerName, BaseLayer bLayer,  boolean useDropConnect,
+                                           Double dropOut, Double l2, Double l2Bias, Double l1, Double l1Bias,
                     Distribution dist) {
-        if (useRegularization && (Double.isNaN(l1) && Double.isNaN(bLayer.getL1()) && Double.isNaN(l2)
-                        && Double.isNaN(bLayer.getL2()) && Double.isNaN(l2Bias) && Double.isNaN(l1Bias)
-                        && (Double.isNaN(dropOut) || dropOut == 0.0)
-                        && (Double.isNaN(bLayer.getDropOut()) || bLayer.getDropOut() == 0.0)))
-            OneTimeLogger.warn(log, "Layer \"" + layerName
-                            + "\" regularization is set to true but l1, l2 or dropout has not been added to configuration.");
 
-        if (useRegularization) {
-            if (!Double.isNaN(l1) && Double.isNaN(bLayer.getL1())) {
-                bLayer.setL1(l1);
-            }
-            if (!Double.isNaN(l2) && Double.isNaN(bLayer.getL2())) {
-                bLayer.setL2(l2);
-            }
-            if (!Double.isNaN(l1Bias) && Double.isNaN(bLayer.getL1Bias())) {
-                bLayer.setL1Bias(l1Bias);
-            }
-            if (!Double.isNaN(l2Bias) && Double.isNaN(bLayer.getL2Bias())) {
-                bLayer.setL2Bias(l2Bias);
-            }
-        } else if (!useRegularization && ((!Double.isNaN(l1) && l1 > 0.0)
-                        || (!Double.isNaN(bLayer.getL1()) && bLayer.getL1() > 0.0) || (!Double.isNaN(l2) && l2 > 0.0)
-                        || (!Double.isNaN(bLayer.getL2()) && bLayer.getL2() > 0.0)
-                        || (!Double.isNaN(l1Bias) && l1Bias > 0.0)
-                        || (!Double.isNaN(bLayer.getL1Bias()) && bLayer.getL1Bias() > 0.0)
-                        || (!Double.isNaN(l2Bias) && l2Bias > 0.0)
-                        || (!Double.isNaN(bLayer.getL2Bias()) && bLayer.getL2Bias() > 0.0))) {
-            OneTimeLogger.warn(log, "Layer \"" + layerName
-                            + "\" l1 or l2 has been added to configuration but useRegularization is set to false.");
+        if (!Double.isNaN(l1) && Double.isNaN(bLayer.getL1())) {
+            bLayer.setL1(l1);
+        }
+        if (!Double.isNaN(l2) && Double.isNaN(bLayer.getL2())) {
+            bLayer.setL2(l2);
+        }
+        if (!Double.isNaN(l1Bias) && Double.isNaN(bLayer.getL1Bias())) {
+            bLayer.setL1Bias(l1Bias);
+        }
+        if (!Double.isNaN(l2Bias) && Double.isNaN(bLayer.getL2Bias())) {
+            bLayer.setL2Bias(l2Bias);
         }
 
         if (Double.isNaN(l2) && Double.isNaN(bLayer.getL2())) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -339,9 +339,6 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
 
     @Override
     public double calcL2(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         //L2 norm: sqrt( sum_i x_i^2 ) -> want sum squared weights, so l2 norm squared
         double l2Sum = 0.0;
         if (conf.getL2ByParam(DefaultParamInitializer.WEIGHT_KEY) > 0.0) {
@@ -357,8 +354,6 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
 
     @Override
     public double calcL1(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
         double l1Sum = 0.0;
         if (conf.getL1ByParam(DefaultParamInitializer.WEIGHT_KEY) > 0.0) {
             l1Sum += conf.getL1ByParam(DefaultParamInitializer.WEIGHT_KEY)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BasePretrainNetwork.java
@@ -218,8 +218,6 @@ public abstract class BasePretrainNetwork<LayerConfT extends org.deeplearning4j.
 
     @Override
     public double calcL2(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
         double l2Sum = super.calcL2(true);
         if (backpropParamsOnly)
             return l2Sum;
@@ -232,8 +230,6 @@ public abstract class BasePretrainNetwork<LayerConfT extends org.deeplearning4j.
 
     @Override
     public double calcL1(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
         double l1Sum = super.calcL1(true);
         if (conf.getL1ByParam(PretrainParamInitializer.VISIBLE_BIAS_KEY) > 0) {
             l1Sum += conf.getL1ByParam(PretrainParamInitializer.VISIBLE_BIAS_KEY)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -84,9 +84,6 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public double calcL2(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l2Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l2 = conf.getL2ByParam(entry.getKey());
@@ -101,9 +98,6 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
     @Override
     public double calcL1(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l1Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l1 = conf.getL1ByParam(entry.getKey());

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesBidirectionalLSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesBidirectionalLSTM.java
@@ -287,9 +287,6 @@ public class GravesBidirectionalLSTM
 
     @Override
     public double calcL2(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l2Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l2 = conf.getL2ByParam(entry.getKey());
@@ -305,9 +302,6 @@ public class GravesBidirectionalLSTM
 
     @Override
     public double calcL1(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l1Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l1 = conf.getL1ByParam(entry.getKey());

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTM.java
@@ -205,9 +205,6 @@ public class GravesLSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.la
 
     @Override
     public double calcL2(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l2Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l2 = conf.getL2ByParam(entry.getKey());
@@ -222,9 +219,6 @@ public class GravesLSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.la
 
     @Override
     public double calcL1(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l1Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l1 = conf.getL1ByParam(entry.getKey());

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
@@ -220,9 +220,6 @@ public class LSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.layers.L
 
     @Override
     public double calcL2(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l2Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l2 = conf.getL2ByParam(entry.getKey());
@@ -237,9 +234,6 @@ public class LSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.layers.L
 
     @Override
     public double calcL1(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l1Sum = 0.0;
         for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
             double l1 = conf.getL1ByParam(entry.getKey());

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/variational/VariationalAutoencoder.java
@@ -588,9 +588,6 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public double calcL2(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l2Sum = 0.0;
         for (Map.Entry<String, INDArray> e : paramTable().entrySet()) {
             double l2 = conf().getL2ByParam(e.getKey());
@@ -607,9 +604,6 @@ public class VariationalAutoencoder implements Layer {
 
     @Override
     public double calcL1(boolean backpropParamsOnly) {
-        if (!conf.isUseRegularization())
-            return 0.0;
-
         double l1Sum = 0.0;
         for (Map.Entry<String, INDArray> e : paramTable().entrySet()) {
             double l1 = conf().getL1ByParam(e.getKey());

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/transferlearning/FineTuneConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/transferlearning/FineTuneConfiguration.java
@@ -65,7 +65,6 @@ public class FineTuneConfiguration {
     protected Integer numIterations;
     protected Integer maxNumLineSearchIterations;
     protected Long seed;
-    protected Boolean useRegularization;
     protected OptimizationAlgorithm optimizationAlgo;
     protected StepFunction stepFunction;
     protected Boolean useDropConnect;
@@ -101,8 +100,11 @@ public class FineTuneConfiguration {
             return this;
         }
 
+        /**
+         * @deprecated No longer used
+         */
+        @Deprecated
         public Builder regularization(boolean regularization) {
-            this.useRegularization = regularization;
             return this;
         }
 
@@ -207,8 +209,6 @@ public class FineTuneConfiguration {
             nnc.setMaxNumLineSearchIterations(maxNumLineSearchIterations);
         if (seed != null)
             nnc.setSeed(seed);
-        if (useRegularization != null)
-            nnc.setUseRegularization(useRegularization);
         if (optimizationAlgo != null)
             nnc.setOptimizationAlgo(optimizationAlgo);
         if (stepFunction != null)
@@ -284,8 +284,7 @@ public class FineTuneConfiguration {
                             adamMeanDecay, adamVarDecay, rho, rmsDecay, epsilon);
 
             boolean useDropCon = (useDropConnect == null ? nnc.isUseDropConnect() : useDropConnect);
-            LayerValidation.generalValidation(l.getLayerName(), l, nnc.isUseRegularization(), useDropCon, dropOut, l2,
-                            l2Bias, l1, l1Bias, dist);
+            LayerValidation.generalValidation(l.getLayerName(), l, useDropCon, dropOut, l2, l2Bias, l1, l1Bias, dist);
         }
 
         //Also: update the LR, L1 and L2 maps, based on current config (which might be different to original config)
@@ -378,8 +377,6 @@ public class FineTuneConfiguration {
             confBuilder.setMaxNumLineSearchIterations(maxNumLineSearchIterations);
         if (seed != null)
             confBuilder.setSeed(seed);
-        if (useRegularization != null)
-            confBuilder.setUseRegularization(useRegularization);
         if (optimizationAlgo != null)
             confBuilder.setOptimizationAlgo(optimizationAlgo);
         if (stepFunction != null)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/updater/UpdaterBlock.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/updater/UpdaterBlock.java
@@ -179,14 +179,14 @@ public class UpdaterBlock {
         //TODO: do this for multiple contiguous params/layers (fewer, larger ops)
 
         double l2 = conf.getL2ByParam(paramName);
-        if (conf.isUseRegularization() && l2 > 0) {
+        if (l2 > 0) {
             //This can be an axpy op, saving an allocation...
             //gradientView += params * l2           i.e., dC/dw = dC0/dw + lambda/n * w where C0 is pre-l2 cost function
             //Equivalent to gradientView.addi(paramsView.mul(conf.getL2ByParam(paramName)));
             int length = gradientView.length();
             Nd4j.getBlasWrapper().level1().axpy(length, l2, paramsView, gradientView);
         }
-        if (conf.isUseRegularization() && conf.getL1ByParam(paramName) > 0) {
+        if (conf.getL1ByParam(paramName) > 0) {
             gradientView.addi(Transforms.sign(paramsView, true).muli(conf.getL1ByParam(paramName)));
         }
     }


### PR DESCRIPTION
Good to go IMO. I'll leave this open a bit longer for reviews.

Addresses:
- https://github.com/deeplearning4j/deeplearning4j/issues/3889 (Fixed override, added proposed convenience method: ```.inputType().convolutional(h,w,d)```)
- https://github.com/deeplearning4j/deeplearning4j/issues/3888 (.layer(Layer) overload now exists, in addition to .layer(int, Layer))
- https://github.com/deeplearning4j/deeplearning4j/issues/3897 (.regularization(boolean) deprecated, use removed internally)
- https://github.com/deeplearning4j/deeplearning4j/issues/3896 (improved dropout javadoc)
- https://github.com/deeplearning4j/deeplearning4j/issues/3895 (.units(int) is equivalent to .nOut(int))