### PR TITLE
1D Convolution layer support

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasLayer.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasLayer.java
@@ -116,7 +116,7 @@ public class KerasLayer {
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_LSTM())) {
             layer = new KerasLstm(layerConfig, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_CONVOLUTION_2D())) {
-            layer = new KerasConvolution(layerConfig, enforceTrainingConfig);
+            layer = new KerasConvolution2D(layerConfig, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_MAX_POOLING_2D()) ||
                 layerClassName.equals(conf.getLAYER_CLASS_NAME_AVERAGE_POOLING_2D())) {
             layer = new KerasPooling(layerConfig, enforceTrainingConfig);

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasLayer.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasLayer.java
@@ -31,6 +31,9 @@ import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurat
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.layers.*;
 import org.deeplearning4j.nn.modelimport.keras.layers.advanced.activations.KerasLeakyReLU;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution1D;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution2D;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.nd4j.linalg.activations.IActivation;
 import org.nd4j.linalg.activations.impl.*;
@@ -117,6 +120,8 @@ public class KerasLayer {
             layer = new KerasLstm(layerConfig, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_CONVOLUTION_2D())) {
             layer = new KerasConvolution2D(layerConfig, enforceTrainingConfig);
+        } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_CONVOLUTION_1D())) {
+            layer = new KerasConvolution1D(layerConfig, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_MAX_POOLING_2D()) ||
                 layerClassName.equals(conf.getLAYER_CLASS_NAME_AVERAGE_POOLING_2D())) {
             layer = new KerasPooling(layerConfig, enforceTrainingConfig);
@@ -139,11 +144,9 @@ public class KerasLayer {
             layer = new KerasReshape(layerConfig, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_ZERO_PADDING_2D())) {
             layer = new KerasZeroPadding(layerConfig, enforceTrainingConfig);
-        } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_CONVOLUTION_1D()) ||
-                layerClassName.equals(conf.getLAYER_CLASS_NAME_MAX_POOLING_1D()) ||
-                layerClassName.equals(conf.getLAYER_CLASS_NAME_AVERAGE_POOLING_1D()) ||
-                layerClassName.equals(conf.getLAYER_CLASS_NAME_ZERO_PADDING_1D())) {
-            layer = new KerasGlobalPooling(layerConfig, enforceTrainingConfig);
+        } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_MAX_POOLING_1D()) ||
+                layerClassName.equals(conf.getLAYER_CLASS_NAME_AVERAGE_POOLING_1D())) {
+            layer = new KerasPooling(layerConfig, enforceTrainingConfig);
         } else {
             // check if user registered a custom config
             Class<? extends KerasLayer> customConfig = customLayers.get(layerClassName);
@@ -1005,13 +1008,17 @@ public class KerasLayer {
      * @return
      * @throws InvalidKerasConfigurationException
      */
-    public int[] getStrideFromConfig(Map<String, Object> layerConfig) throws InvalidKerasConfigurationException {
+    public int[] getStrideFromConfig(Map<String, Object> layerConfig, int dimension) throws InvalidKerasConfigurationException {
         Map<String, Object> innerConfig = getInnerLayerConfigFromConfig(layerConfig);
         int[] strides = null;
-        if (innerConfig.containsKey(conf.getLAYER_FIELD_CONVOLUTION_STRIDES())) {
-            /* Convolutional layers. */
+        if (innerConfig.containsKey(conf.getLAYER_FIELD_CONVOLUTION_STRIDES()) && dimension == 2) {
+            /* 2D Convolutional layers. */
             List<Integer> stridesList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_CONVOLUTION_STRIDES());
             strides = ArrayUtil.toArray(stridesList);
+        } else if (innerConfig.containsKey(conf.getLAYER_FIELD_SUBSAMPLE_LENGTH()) && dimension == 1) {
+           /* 1D Convolutional layers. */
+            int subsample_length = (int) innerConfig.get(conf.getLAYER_FIELD_SUBSAMPLE_LENGTH());
+            strides = new int[]{subsample_length};
         } else if (innerConfig.containsKey(conf.getLAYER_FIELD_POOL_STRIDES())) {
             /* Pooling layers. */
             List<Integer> stridesList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_POOL_STRIDES());
@@ -1030,17 +1037,22 @@ public class KerasLayer {
      * @return
      * @throws InvalidKerasConfigurationException
      */
-    public int[] getKernelSizeFromConfig(Map<String, Object> layerConfig)
+    public int[] getKernelSizeFromConfig(Map<String, Object> layerConfig, int dimension)
             throws InvalidKerasConfigurationException {
         Map<String, Object> innerConfig = getInnerLayerConfigFromConfig(layerConfig);
         int[] kernelSize = null;
         if (kerasMajorVersion != 2) {
-            if (innerConfig.containsKey(conf.getLAYER_FIELD_NB_ROW()) && innerConfig.containsKey(conf.getLAYER_FIELD_NB_COL())) {
-            /* Convolutional layers. */
+            if (innerConfig.containsKey(conf.getLAYER_FIELD_NB_ROW()) && dimension == 2
+                    && innerConfig.containsKey(conf.getLAYER_FIELD_NB_COL())) {
+            /* 2D Convolutional layers. */
                 List<Integer> kernelSizeList = new ArrayList<Integer>();
                 kernelSizeList.add((Integer) innerConfig.get(conf.getLAYER_FIELD_NB_ROW()));
                 kernelSizeList.add((Integer) innerConfig.get(conf.getLAYER_FIELD_NB_COL()));
                 kernelSize = ArrayUtil.toArray(kernelSizeList);
+            } else if (innerConfig.containsKey(conf.getLAYER_FIELD_FILTER_LENGTH()) && dimension == 1) {
+            /* 1D Convolutional layers. */
+                int filter_length = (int) innerConfig.get(conf.getLAYER_FIELD_FILTER_LENGTH());
+                kernelSize = new int[]{ filter_length };
             } else if (innerConfig.containsKey(conf.getLAYER_FIELD_POOL_SIZE())) {
             /* Pooling layers. */
                 List<Integer> kernelSizeList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_POOL_SIZE());
@@ -1049,13 +1061,18 @@ public class KerasLayer {
                 throw new InvalidKerasConfigurationException("Could not determine kernel size: no "
                         + conf.getLAYER_FIELD_NB_ROW() + ", "
                         + conf.getLAYER_FIELD_NB_COL() + ", or "
+                        + conf.getLAYER_FIELD_FILTER_LENGTH() + ", or "
                         + conf.getLAYER_FIELD_POOL_SIZE() + " field found");
             }
         } else {
-            /* Convolutional layers. */
-            if (innerConfig.containsKey(conf.getLAYER_FIELD_KERNEL_SIZE())) {
+            /* 2D Convolutional layers. */
+            if (innerConfig.containsKey(conf.getLAYER_FIELD_KERNEL_SIZE()) && dimension == 2) {
                 List<Integer> kernelSizeList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_KERNEL_SIZE());
                 kernelSize = ArrayUtil.toArray(kernelSizeList);
+            } else if (innerConfig.containsKey(conf.getLAYER_FIELD_FILTER_LENGTH()) && dimension == 1) {
+            /* 1D Convolutional layers. */
+                int filter_length = (int) innerConfig.get(conf.getLAYER_FIELD_FILTER_LENGTH());
+                kernelSize = new int[]{ filter_length };
             } else if (innerConfig.containsKey(conf.getLAYER_FIELD_POOL_SIZE())) {
             /* Pooling layers. */
                 List<Integer> kernelSizeList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_POOL_SIZE());
@@ -1063,6 +1080,7 @@ public class KerasLayer {
             } else {
                 throw new InvalidKerasConfigurationException("Could not determine kernel size: no "
                         + conf.getLAYER_FIELD_KERNEL_SIZE() + ", or "
+                        + conf.getLAYER_FIELD_FILTER_LENGTH() + ", or "
                         + conf.getLAYER_FIELD_POOL_SIZE() + " field found");
             }
         }
@@ -1121,7 +1139,7 @@ public class KerasLayer {
      * @return
      * @throws InvalidKerasConfigurationException
      */
-    public int[] getPaddingFromBorderModeConfig(Map<String, Object> layerConfig)
+    public int[] getPaddingFromBorderModeConfig(Map<String, Object> layerConfig, int dimension)
             throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         Map<String, Object> innerConfig = getInnerLayerConfigFromConfig(layerConfig);
         int[] padding = null;
@@ -1130,7 +1148,7 @@ public class KerasLayer {
                     + conf.getLAYER_FIELD_BORDER_MODE() + " field found");
         String borderMode = (String) innerConfig.get(conf.getLAYER_FIELD_BORDER_MODE());
         if (borderMode == conf.getLAYER_FIELD_BORDER_MODE()) {
-            padding = getKernelSizeFromConfig(layerConfig);
+            padding = getKernelSizeFromConfig(layerConfig, dimension);
             for (int i = 0; i < padding.length; i++)
                 padding[i]--;
         }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras1LayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras1LayerConfiguration.java
@@ -68,6 +68,8 @@ public class Keras1LayerConfiguration extends KerasLayerConfiguration {
     /* Convolutional layer properties */
     private final String LAYER_FIELD_NB_FILTER = "nb_filter";
     private final String LAYER_FIELD_CONVOLUTION_STRIDES = "subsample";
+    private final String LAYER_FIELD_FILTER_LENGTH = "filter_length";
+    private final String LAYER_FIELD_SUBSAMPLE_LENGTH = "subsample_length";
 
     /* Pooling / Upsampling layer properties */
     private final String LAYER_FIELD_POOL_1D_SIZE = "pool_length";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras2LayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras2LayerConfiguration.java
@@ -67,6 +67,8 @@ public class Keras2LayerConfiguration extends KerasLayerConfiguration {
     /* Convolutional layer properties */
     private final String LAYER_FIELD_NB_FILTER = "filters";
     private final String LAYER_FIELD_CONVOLUTION_STRIDES = "strides";
+    private final String LAYER_FIELD_FILTER_LENGTH = "kernel_size";
+    private final String LAYER_FIELD_SUBSAMPLE_LENGTH = "strides";
 
     /* Pooling / Upsampling layer properties */
     private final String LAYER_FIELD_POOL_1D_SIZE = "pool_size";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
@@ -36,8 +36,8 @@ public class KerasLayerConfiguration {
     private final String LAYER_FIELD_LAYER = "layer";
 
     /* Basic layer names */
-    // Missing Layers: Reshape, Permute, RepeatVector, Lambda, ActivityRegularization, Masking
-    // Conv1D, Conv3D, SeparableConv2D, Deconvolution2D/Conv2DTranspose, Cropping1D-3D, UpSampling1D-3D,
+    // Missing Layers: Permute, RepeatVector, Lambda, ActivityRegularization, Masking
+    // Conv3D, SeparableConv2D, Deconvolution2D/Conv2DTranspose, Cropping1D-3D, UpSampling1D-3D,
     // ZeroPadding3D, LocallyConnected1D-2D
     // Missing layers from keras 1: AtrousConvolution1D-2D, Highway, MaxoutDense
     private final String LAYER_CLASS_NAME_ACTIVATION = "Activation";
@@ -130,6 +130,8 @@ public class KerasLayerConfiguration {
     private final String LAYER_FIELD_POOL_SIZE = "pool_size";
     private final String LAYER_FIELD_CONVOLUTION_STRIDES = ""; // 1: subsample, 2: strides
     private final String LAYER_FIELD_DILATION_RATE = "dilation_rate"; // keras 2 only, replaces Atrous layers
+    private final String LAYER_FIELD_FILTER_LENGTH = ""; // 1: filter_length, 2: kernel_size
+    private final String LAYER_FIELD_SUBSAMPLE_LENGTH = ""; // 1: subsample_length, 2: strides
 
     /* Pooling / Upsampling layer properties */
     private final String LAYER_FIELD_POOL_STRIDES = "strides";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasConvolution2D.java
@@ -23,7 +23,7 @@ import java.util.Set;
  */
 @Slf4j
 @Data
-public class KerasConvolution extends KerasLayer {
+public class KerasConvolution2D extends KerasLayer {
 
     /* Keras layer parameter names. */
     private int numTrainableParams;
@@ -35,7 +35,7 @@ public class KerasConvolution extends KerasLayer {
      * @param kerasVersion major keras version
      * @throws UnsupportedKerasConfigurationException
      */
-    public KerasConvolution(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
+    public KerasConvolution2D(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
         super(kerasVersion);
     }
 
@@ -46,7 +46,7 @@ public class KerasConvolution extends KerasLayer {
      * @throws InvalidKerasConfigurationException
      * @throws UnsupportedKerasConfigurationException
      */
-    public KerasConvolution(Map<String, Object> layerConfig)
+    public KerasConvolution2D(Map<String, Object> layerConfig)
                     throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         this(layerConfig, true);
     }
@@ -59,7 +59,7 @@ public class KerasConvolution extends KerasLayer {
      * @throws InvalidKerasConfigurationException
      * @throws UnsupportedKerasConfigurationException
      */
-    public KerasConvolution(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
+    public KerasConvolution2D(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
                     throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         super(layerConfig, enforceTrainingConfig);
         hasBias = getHasBiasFromConfig(layerConfig);

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasPooling.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/KerasPooling.java
@@ -44,8 +44,8 @@ public class KerasPooling extends KerasLayer {
         SubsamplingLayer.Builder builder = new SubsamplingLayer.Builder(mapPoolingType(this.className))
                         .name(this.layerName).dropOut(this.dropout)
                         .convolutionMode(getConvolutionModeFromConfig(layerConfig))
-                        .kernelSize(getKernelSizeFromConfig(layerConfig)).stride(getStrideFromConfig(layerConfig));
-        int[] padding = getPaddingFromBorderModeConfig(layerConfig);
+                        .kernelSize(getKernelSizeFromConfig(layerConfig, 2)).stride(getStrideFromConfig(layerConfig, 2));
+        int[] padding = getPaddingFromBorderModeConfig(layerConfig, 2);
         if (padding != null)
             builder.padding(padding);
         this.layer = builder.build();

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution.java
@@ -1,10 +1,10 @@
-package org.deeplearning4j.nn.modelimport.keras.layers;
+package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.deeplearning4j.nn.conf.inputs.InputType;
-import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.Convolution1DLayer;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.KerasLayer;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
@@ -17,25 +17,24 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Imports a Convolution layer from Keras.
+ * Keras Convolution base layer
  *
- * @author dave@skymind.io
+ * @author Max Pumperla
  */
+
 @Slf4j
 @Data
-public class KerasConvolution2D extends KerasLayer {
+abstract public class KerasConvolution extends KerasLayer {
 
-    /* Keras layer parameter names. */
-    private int numTrainableParams;
-    private boolean hasBias;
-
+    protected int numTrainableParams;
+    protected boolean hasBias;
 
     /**
      * Pass-through constructor from KerasLayer
      * @param kerasVersion major keras version
      * @throws UnsupportedKerasConfigurationException
      */
-    public KerasConvolution2D(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
+    public KerasConvolution(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
         super(kerasVersion);
     }
 
@@ -46,8 +45,8 @@ public class KerasConvolution2D extends KerasLayer {
      * @throws InvalidKerasConfigurationException
      * @throws UnsupportedKerasConfigurationException
      */
-    public KerasConvolution2D(Map<String, Object> layerConfig)
-                    throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+    public KerasConvolution(Map<String, Object> layerConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         this(layerConfig, true);
     }
 
@@ -59,50 +58,10 @@ public class KerasConvolution2D extends KerasLayer {
      * @throws InvalidKerasConfigurationException
      * @throws UnsupportedKerasConfigurationException
      */
-    public KerasConvolution2D(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
-                    throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+    public KerasConvolution(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         super(layerConfig, enforceTrainingConfig);
-        hasBias = getHasBiasFromConfig(layerConfig);
-        numTrainableParams = hasBias ? 2 : 1;
 
-        ConvolutionLayer.Builder builder = new ConvolutionLayer.Builder().name(this.layerName)
-                        .nOut(getNOutFromConfig(layerConfig)).dropOut(this.dropout)
-                        .activation(getActivationFromConfig(layerConfig))
-                        .weightInit(getWeightInitFromConfig(
-                                layerConfig, conf.getLAYER_FIELD_INIT(), enforceTrainingConfig))
-                        .biasInit(0.0)
-                        .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
-                        .convolutionMode(getConvolutionModeFromConfig(layerConfig))
-                        .kernelSize(getKernelSizeFromConfig(layerConfig))
-                        .hasBias(hasBias).stride(getStrideFromConfig(layerConfig));
-        int[] padding = getPaddingFromBorderModeConfig(layerConfig);
-        if (padding != null)
-            builder.padding(padding);
-        this.layer = builder.build();
-    }
-
-    /**
-     * Get DL4J ConvolutionLayer.
-     *
-     * @return  ConvolutionLayer
-     */
-    public ConvolutionLayer getConvolutionLayer() {
-        return (ConvolutionLayer) this.layer;
-    }
-
-    /**
-     * Get layer output type.
-     *
-     * @param  inputType    Array of InputTypes
-     * @return              output type as InputType
-     * @throws InvalidKerasConfigurationException
-     */
-    @Override
-    public InputType getOutputType(InputType... inputType) throws InvalidKerasConfigurationException {
-        if (inputType.length > 1)
-            throw new InvalidKerasConfigurationException(
-                            "Keras Convolution layer accepts only one input (received " + inputType.length + ")");
-        return this.getConvolutionLayer().getOutputType(-1, inputType[0]);
     }
 
     /**
@@ -159,7 +118,7 @@ public class KerasConvolution2D extends KerasLayer {
             this.weights.put(ConvolutionParamInitializer.WEIGHT_KEY, paramValue);
         } else
             throw new InvalidKerasConfigurationException(
-                            "Parameter " + conf.getKERAS_PARAM_NAME_W() + " does not exist in weights");
+                    "Parameter " + conf.getKERAS_PARAM_NAME_W() + " does not exist in weights");
 
         if (hasBias) {
             if (weights.containsKey(conf.getKERAS_PARAM_NAME_B()))
@@ -174,7 +133,7 @@ public class KerasConvolution2D extends KerasLayer {
             paramNames.remove(conf.getKERAS_PARAM_NAME_B());
             String unknownParamNames = paramNames.toString();
             log.warn("Attemping to set weights for unknown parameters: "
-                            + unknownParamNames.substring(1, unknownParamNames.length() - 1));
+                    + unknownParamNames.substring(1, unknownParamNames.length() - 1));
         }
     }
 }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution.java
@@ -1,3 +1,20 @@
+/*-
+ *
+ *  * Copyright 2017 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
 package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
 
 import lombok.Data;

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
@@ -1,0 +1,88 @@
+package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ArrayUtils;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.Convolution1DLayer;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
+import org.deeplearning4j.nn.modelimport.keras.KerasLayer;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
+import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Imports a 1D Convolution layer from Keras.
+ *
+ * @author Max Pumperla
+ */
+@Slf4j
+@Data
+public class KerasConvolution1D extends KerasConvolution {
+
+    /**
+     * Pass-through constructor from KerasLayer
+     * @param kerasVersion major keras version
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasConvolution1D(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
+        super(kerasVersion);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig       dictionary containing Keras layer configuration
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasConvolution1D(Map<String, Object> layerConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        this(layerConfig, true);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig               dictionary containing Keras layer configuration
+     * @param enforceTrainingConfig     whether to enforce training-related configuration options
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasConvolution1D(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        super(layerConfig, enforceTrainingConfig);
+        hasBias = getHasBiasFromConfig(layerConfig);
+        numTrainableParams = hasBias ? 2 : 1;
+
+        Convolution1DLayer.Builder builder = new Convolution1DLayer.Builder().name(this.layerName)
+                .nOut(getNOutFromConfig(layerConfig)).dropOut(this.dropout)
+                .activation(getActivationFromConfig(layerConfig))
+                .weightInit(getWeightInitFromConfig(
+                        layerConfig, conf.getLAYER_FIELD_INIT(), enforceTrainingConfig))
+                .biasInit(0.0)
+                .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
+                .convolutionMode(getConvolutionModeFromConfig(layerConfig))
+                .kernelSize(getKernelSizeFromConfig(layerConfig, 1)[0])
+                .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 1)[0]);
+        int[] padding = getPaddingFromBorderModeConfig(layerConfig, 1);
+        if (padding != null)
+            builder.padding(padding[0]);
+        this.layer = builder.build();
+    }
+
+    /**
+     * Get DL4J ConvolutionLayer.
+     *
+     * @return  ConvolutionLayer
+     */
+    public Convolution1DLayer getConvolution1DLayer() {
+        return (Convolution1DLayer) this.layer;
+    }
+}

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
@@ -1,3 +1,20 @@
+/*-
+ *
+ *  * Copyright 2017 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
 package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
 
 import lombok.Data;

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
@@ -1,0 +1,104 @@
+package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ArrayUtils;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
+import org.deeplearning4j.nn.modelimport.keras.KerasLayer;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
+import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Imports a 2D Convolution layer from Keras.
+ *
+ * @author dave@skymind.io
+ */
+@Slf4j
+@Data
+public class KerasConvolution2D extends KerasConvolution {
+
+    /**
+     * Pass-through constructor from KerasLayer
+     * @param kerasVersion major keras version
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasConvolution2D(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
+        super(kerasVersion);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig       dictionary containing Keras layer configuration
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasConvolution2D(Map<String, Object> layerConfig)
+                    throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        this(layerConfig, true);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig               dictionary containing Keras layer configuration
+     * @param enforceTrainingConfig     whether to enforce training-related configuration options
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasConvolution2D(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
+                    throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        super(layerConfig, enforceTrainingConfig);
+
+        hasBias = getHasBiasFromConfig(layerConfig);
+        numTrainableParams = hasBias ? 2 : 1;
+
+        ConvolutionLayer.Builder builder = new ConvolutionLayer.Builder().name(this.layerName)
+                        .nOut(getNOutFromConfig(layerConfig)).dropOut(this.dropout)
+                        .activation(getActivationFromConfig(layerConfig))
+                        .weightInit(getWeightInitFromConfig(
+                                layerConfig, conf.getLAYER_FIELD_INIT(), enforceTrainingConfig))
+                        .biasInit(0.0)
+                        .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
+                        .convolutionMode(getConvolutionModeFromConfig(layerConfig))
+                        .kernelSize(getKernelSizeFromConfig(layerConfig, 2))
+                        .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 2));
+        int[] padding = getPaddingFromBorderModeConfig(layerConfig, 2);
+        if (padding != null)
+            builder.padding(padding);
+        this.layer = builder.build();
+    }
+
+    /**
+     * Get DL4J ConvolutionLayer.
+     *
+     * @return  ConvolutionLayer
+     */
+    public ConvolutionLayer getConvolution2DLayer() {
+        return (ConvolutionLayer) this.layer;
+    }
+
+    /**
+     * Get layer output type.
+     *
+     * @param  inputType    Array of InputTypes
+     * @return              output type as InputType
+     * @throws InvalidKerasConfigurationException
+     */
+    @Override
+    public InputType getOutputType(InputType... inputType) throws InvalidKerasConfigurationException {
+        if (inputType.length > 1)
+            throw new InvalidKerasConfigurationException(
+                            "Keras Convolution layer accepts only one input (received " + inputType.length + ")");
+        return this.getConvolution2DLayer().getOutputType(-1, inputType[0]);
+    }
+
+}

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
@@ -1,3 +1,20 @@
+/*-
+ *
+ *  * Copyright 2017 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
 package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
 
 import lombok.Data;

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
@@ -1,3 +1,20 @@
+/*-
+ *
+ *  * Copyright 2017 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
 package org.deeplearning4j.nn.modelimport.keras;
 
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +27,6 @@ import org.deeplearning4j.nn.modelimport.keras.config.KerasLayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.layers.*;
 import org.deeplearning4j.nn.modelimport.keras.layers.advanced.activations.KerasLeakyReLU;
-import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution;
 import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution1D;
 import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution2D;
 import org.deeplearning4j.nn.modelimport.keras.preprocessors.ReshapePreprocessor;

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
@@ -19,8 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.deeplearning4j.nn.modelimport.keras.layers.KerasBatchNormalization.*;
-import static org.deeplearning4j.nn.modelimport.keras.layers.KerasLstm.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -284,7 +282,7 @@ public class KerasLayerTest {
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 
 
-        ConvolutionLayer layer = new KerasConvolution(layerConfig).getConvolutionLayer();
+        ConvolutionLayer layer = new KerasConvolution2D(layerConfig).getConvolutionLayer();
         assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
         assertEquals(LAYER_NAME, layer.getLayerName());
         assertEquals(INIT_DL4J, layer.getWeightInit());

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
@@ -10,6 +10,9 @@ import org.deeplearning4j.nn.modelimport.keras.config.KerasLayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.layers.*;
 import org.deeplearning4j.nn.modelimport.keras.layers.advanced.activations.KerasLeakyReLU;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution1D;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution2D;
 import org.deeplearning4j.nn.modelimport.keras.preprocessors.ReshapePreprocessor;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.junit.Test;
@@ -46,15 +49,10 @@ public class KerasLayerTest {
     private final String BORDER_MODE_VALID = "valid";
     private final int[] VALID_PADDING = new int[]{0, 0};
 
-    public static final String LAYER_FIELD_LEAKY_RELU_ALPHA = "alpha";
-    public static final String LAYER_FIELD_TARGET_SHAPE = "target_shape";
-    public static final double EPSILON = 1E-5;
-    public static final double MOMENTUM = 0.99;
-
-    Integer keras1 = 1;
-    Integer keras2 = 2;
-    Keras1LayerConfiguration conf1 = new Keras1LayerConfiguration();
-    Keras2LayerConfiguration conf2 = new Keras2LayerConfiguration();
+    private Integer keras1 = 1;
+    private Integer keras2 = 2;
+    private Keras1LayerConfiguration conf1 = new Keras1LayerConfiguration();
+    private Keras2LayerConfiguration conf2 = new Keras2LayerConfiguration();
 
     public KerasLayerTest() throws UnsupportedKerasConfigurationException {
     }
@@ -72,9 +70,15 @@ public class KerasLayerTest {
     }
 
     @Test
-    public void testConvolutionLayer() throws Exception {
-        buildConvolutionLayer(conf1, keras1);
-        buildConvolutionLayer(conf2, keras2);
+    public void testConvolution2DLayer() throws Exception {
+        buildConvolution2DLayer(conf1, keras1);
+        buildConvolution2DLayer(conf2, keras2);
+    }
+
+    @Test
+    public void testConvolution1DLayer() throws Exception {
+        buildConvolution1DLayer(conf1, keras1);
+        buildConvolution1DLayer(conf2, keras2);
     }
 
     @Test
@@ -119,6 +123,45 @@ public class KerasLayerTest {
         buildLReshapeLayer(conf2, keras2);
     }
 
+    public void buildConvolution1DLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
+        Map<String, Object> layerConfig = new HashMap<String, Object>();
+        layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_CONVOLUTION_1D());
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put(conf.getLAYER_FIELD_ACTIVATION(), ACTIVATION_KERAS);
+        config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
+        layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
+        if (kerasVersion == 1) {
+            config.put(conf.getLAYER_FIELD_INIT(), INIT_KERAS);
+        } else {
+            Map<String, Object> init = new HashMap<String, Object>();
+            init.put("class_name", conf.getINIT_GLOROT_NORMAL());
+            config.put(conf.getLAYER_FIELD_INIT(), init);
+        }
+        Map<String, Object> W_reg = new HashMap<String, Object>();
+        W_reg.put(conf.getREGULARIZATION_TYPE_L1(), L1_REGULARIZATION);
+        W_reg.put(conf.getREGULARIZATION_TYPE_L2(), L2_REGULARIZATION);
+        config.put(conf.getLAYER_FIELD_W_REGULARIZER(), W_reg);
+        config.put(conf.getLAYER_FIELD_DROPOUT(), DROPOUT_KERAS);
+        config.put(conf.getLAYER_FIELD_FILTER_LENGTH(), KERNEL_SIZE[0]);
+        config.put(conf.getLAYER_FIELD_SUBSAMPLE_LENGTH(), STRIDE[0]);
+        config.put(conf.getLAYER_FIELD_NB_FILTER(), N_OUT);
+        config.put(conf.getLAYER_FIELD_BORDER_MODE(), BORDER_MODE_VALID);
+        layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
+
+        Convolution1DLayer layer = new KerasConvolution1D(layerConfig).getConvolution1DLayer();
+        assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
+        assertEquals(LAYER_NAME, layer.getLayerName());
+        assertEquals(INIT_DL4J, layer.getWeightInit());
+        assertEquals(L1_REGULARIZATION, layer.getL1(), 0.0);
+        assertEquals(L2_REGULARIZATION, layer.getL2(), 0.0);
+        assertEquals(DROPOUT_DL4J, layer.getDropOut(), 0.0);
+        assertEquals(KERNEL_SIZE[0], layer.getKernelSize()[0]);
+        assertEquals(STRIDE[0], layer.getStride()[0]);
+        assertEquals(N_OUT, layer.getNOut());
+        assertEquals(ConvolutionMode.Truncate, layer.getConvolutionMode());
+        assertEquals(VALID_PADDING[0], layer.getPadding()[0]);
+    }
+
     public void buildEmbeddingLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
         Map<String, Object> layerConfig = new HashMap<String, Object>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_EMBEDDING());
@@ -136,11 +179,11 @@ public class KerasLayerTest {
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
         if (kerasVersion == 1) {
-            config.put(conf.getLAYER_FIELD_INIT(), INIT_KERAS);
+            config.put(conf.getLAYER_FIELD_EMBEDDING_INIT(), INIT_KERAS);
         } else {
             Map<String, Object> init = new HashMap<String, Object>();
             init.put("class_name", conf.getINIT_GLOROT_NORMAL());
-            config.put(conf.getLAYER_FIELD_INIT(), init);
+            config.put(conf.getLAYER_FIELD_EMBEDDING_INIT(), init);
         }
         KerasEmbedding kerasEmbedding = new KerasEmbedding(layerConfig, false);
         assertEquals(kerasEmbedding.getNumParams(), 1);
@@ -168,6 +211,7 @@ public class KerasLayerTest {
         Map<String, Object> layerConfig = new HashMap<String, Object>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_LEAKY_RELU());
         Map<String, Object> config = new HashMap<String, Object>();
+        String LAYER_FIELD_LEAKY_RELU_ALPHA = "alpha";
         config.put(LAYER_FIELD_LEAKY_RELU_ALPHA, 0.3); // set leaky ReLU alpha
         config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
@@ -182,10 +226,11 @@ public class KerasLayerTest {
         Map<String, Object> layerConfig = new HashMap<String, Object>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_RESHAPE());
         Map<String, Object> config = new HashMap<String, Object>();
-        int[] targetShape = new int[] {10, 5};
+        int[] targetShape = new int[]{10, 5};
         List<Integer> targetShapeList = new ArrayList<>();
         targetShapeList.add(targetShape[0]);
         targetShapeList.add(targetShape[1]);
+        String LAYER_FIELD_TARGET_SHAPE = "target_shape";
         config.put(LAYER_FIELD_TARGET_SHAPE, targetShapeList);
         config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
@@ -234,7 +279,6 @@ public class KerasLayerTest {
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 
-
         DenseLayer layer = new KerasDense(layerConfig, false).getDenseLayer();
         assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
         assertEquals(LAYER_NAME, layer.getLayerName());
@@ -245,7 +289,7 @@ public class KerasLayerTest {
         assertEquals(N_OUT, layer.getNOut());
     }
 
-    public void buildConvolutionLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
+    public void buildConvolution2DLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
         Map<String, Object> layerConfig = new HashMap<String, Object>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_CONVOLUTION_2D());
         Map<String, Object> config = new HashMap<String, Object>();
@@ -282,7 +326,7 @@ public class KerasLayerTest {
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 
 
-        ConvolutionLayer layer = new KerasConvolution2D(layerConfig).getConvolutionLayer();
+        ConvolutionLayer layer = new KerasConvolution2D(layerConfig).getConvolution2DLayer();
         assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
         assertEquals(LAYER_NAME, layer.getLayerName());
         assertEquals(INIT_DL4J, layer.getWeightInit());
@@ -338,10 +382,13 @@ public class KerasLayerTest {
         config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
         if (kerasVersion == 1) {
             config.put(conf.getLAYER_FIELD_INNER_INIT(), INIT_KERAS);
+            config.put(conf.getLAYER_FIELD_INIT(), INIT_KERAS);
+
         } else {
             Map<String, Object> init = new HashMap<String, Object>();
             init.put("class_name", conf.getINIT_GLOROT_NORMAL());
             config.put(conf.getLAYER_FIELD_INNER_INIT(), init);
+            config.put(conf.getLAYER_FIELD_INIT(), init);
         }
         Map<String, Object> W_reg = new HashMap<String, Object>();
         W_reg.put(conf.getREGULARIZATION_TYPE_L1(), L1_REGULARIZATION);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Support 1D conv layers
- Factored out a KerasConvolution base layer to remove duplicate functionality.

## How was this patch tested?

- Conv 1D layer construction test for keras 1 & 2 added.