### PR TITLE
Support Atrous convolution layers (1D & 2D) for keras 1 and 2

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras1LayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras1LayerConfiguration.java
@@ -70,6 +70,8 @@ public class Keras1LayerConfiguration extends KerasLayerConfiguration {
     private final String LAYER_FIELD_CONVOLUTION_STRIDES = "subsample";
     private final String LAYER_FIELD_FILTER_LENGTH = "filter_length";
     private final String LAYER_FIELD_SUBSAMPLE_LENGTH = "subsample_length";
+    private final String LAYER_FIELD_DILATION_RATE = "atrous_rate";
+
 
     /* Pooling / Upsampling layer properties */
     private final String LAYER_FIELD_POOL_1D_SIZE = "pool_length";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras2LayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/Keras2LayerConfiguration.java
@@ -69,6 +69,7 @@ public class Keras2LayerConfiguration extends KerasLayerConfiguration {
     private final String LAYER_FIELD_CONVOLUTION_STRIDES = "strides";
     private final String LAYER_FIELD_FILTER_LENGTH = "kernel_size";
     private final String LAYER_FIELD_SUBSAMPLE_LENGTH = "strides";
+    private final String LAYER_FIELD_DILATION_RATE = "dilation_rate";
 
     /* Pooling / Upsampling layer properties */
     private final String LAYER_FIELD_POOL_1D_SIZE = "pool_size";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
@@ -131,10 +131,9 @@ public class KerasLayerConfiguration {
     private final String LAYER_FIELD_KERNEL_SIZE = "kernel_size"; // keras 2 only
     private final String LAYER_FIELD_POOL_SIZE = "pool_size";
     private final String LAYER_FIELD_CONVOLUTION_STRIDES = ""; // 1: subsample, 2: strides
-    private final String LAYER_FIELD_DILATION_RATE = "dilation_rate"; // keras 2 only, replaces Atrous layers
     private final String LAYER_FIELD_FILTER_LENGTH = ""; // 1: filter_length, 2: kernel_size
     private final String LAYER_FIELD_SUBSAMPLE_LENGTH = ""; // 1: subsample_length, 2: strides
-    private final String LAYER_FIELD_ATROUS_RATE = "atrous_rate"; // keras 1 only
+    private final String LAYER_FIELD_DILATION_RATE = ""; // 1: atrous_rate, 2: dilation_rate
 
     /* Pooling / Upsampling layer properties */
     private final String LAYER_FIELD_POOL_STRIDES = "strides";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
@@ -62,6 +62,8 @@ public class KerasLayerConfiguration {
     private final String LAYER_CLASS_NAME_GLOBAL_AVERAGE_POOLING_1D = "GlobalAveragePooling1D";
     private final String LAYER_CLASS_NAME_GLOBAL_AVERAGE_POOLING_2D = "GlobalAveragePooling2D";
     private final String LAYER_CLASS_NAME_TIME_DISTRIBUTED_DENSE = "TimeDistributedDense"; // Keras 1 only
+    private final String LAYER_CLASS_NAME_ATROUS_CONVOLUTION_1D = "AtrousConvolution1D"; // Keras 1 only
+    private final String LAYER_CLASS_NAME_ATROUS_CONVOLUTION_2D = "AtrousConvolution2D"; // Keras 1 only
     private final String LAYER_CLASS_NAME_CONVOLUTION_1D = ""; // 1: Convolution1D, 2: Conv1D
     private final String LAYER_CLASS_NAME_CONVOLUTION_2D = ""; // 1: Convolution2D, 2: Conv2D
     private final String LAYER_CLASS_NAME_LEAKY_RELU = "LeakyReLU";
@@ -132,6 +134,7 @@ public class KerasLayerConfiguration {
     private final String LAYER_FIELD_DILATION_RATE = "dilation_rate"; // keras 2 only, replaces Atrous layers
     private final String LAYER_FIELD_FILTER_LENGTH = ""; // 1: filter_length, 2: kernel_size
     private final String LAYER_FIELD_SUBSAMPLE_LENGTH = ""; // 1: subsample_length, 2: strides
+    private final String LAYER_FIELD_ATROUS_RATE = "atrous_rate"; // keras 1 only
 
     /* Pooling / Upsampling layer properties */
     private final String LAYER_FIELD_POOL_STRIDES = "strides";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
@@ -78,7 +78,7 @@ public class KerasAtrousConvolution1D extends KerasConvolution {
                 .activation(getActivationFromConfig(layerConfig, conf))
                 .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
                         enforceTrainingConfig, conf, kerasMajorVersion))
-                .dilation(getAtrousRate(layerConfig, 2, conf))
+                .dilation(getDilationRate(layerConfig, 2, conf, true))
                 .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 1,  conf, kerasMajorVersion)[0])

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
@@ -1,0 +1,4 @@
+package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
+
+public class KerasAtrousConvolution1D {
+}

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
@@ -73,18 +73,20 @@ public class KerasAtrousConvolution1D extends KerasConvolution {
         hasBias = getHasBiasFromConfig(layerConfig, conf);
         numTrainableParams = hasBias ? 2 : 1;
 
-        // TODO: add dilation argument
         Convolution1DLayer.Builder builder = new Convolution1DLayer.Builder().name(this.layerName)
                 .nOut(getNOutFromConfig(layerConfig, conf)).dropOut(this.dropout)
                 .activation(getActivationFromConfig(layerConfig, conf))
                 .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
                         enforceTrainingConfig, conf, kerasMajorVersion))
-                .biasInit(0.0)
+                .dilation(getAtrousRate(layerConfig, 2, conf))
                 .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 1,  conf, kerasMajorVersion)[0])
-                .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 1, conf)[0]);
+                .hasBias(hasBias)
+                .stride(getStrideFromConfig(layerConfig, 1, conf)[0]);
         int[] padding = getPaddingFromBorderModeConfig(layerConfig, 1, conf, kerasMajorVersion);
+        if (hasBias)
+            builder.biasInit(0.0);
         if (padding != null)
             builder.padding(padding[0]);
         this.layer = builder.build();

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
@@ -1,4 +1,116 @@
+/*-
+ *
+ *  * Copyright 2017 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
 package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
 
-public class KerasAtrousConvolution1D {
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.Convolution1DLayer;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
+
+import java.util.Map;
+
+import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.*;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasActivationUtils.getActivationFromConfig;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasInitilizationUtils.getWeightInitFromConfig;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getHasBiasFromConfig;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getNOutFromConfig;
+
+/**
+ * Keras 1D atrous / dilated convolution layer. Note that in keras 2 this layer has been
+ * removed and dilations are now available through the "dilated" argument in regular Conv1D layers
+ *
+ * author: Max Pumperla
+ */
+public class KerasAtrousConvolution1D extends KerasConvolution {
+
+    /**
+     * Pass-through constructor from KerasLayer
+     * @param kerasVersion major keras version
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasAtrousConvolution1D(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
+        super(kerasVersion);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig       dictionary containing Keras layer configuration
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasAtrousConvolution1D(Map<String, Object> layerConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        this(layerConfig, true);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig               dictionary containing Keras layer configuration
+     * @param enforceTrainingConfig     whether to enforce training-related configuration options
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasAtrousConvolution1D(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        super(layerConfig, enforceTrainingConfig);
+        hasBias = getHasBiasFromConfig(layerConfig, conf);
+        numTrainableParams = hasBias ? 2 : 1;
+
+        // TODO: add dilation argument
+        Convolution1DLayer.Builder builder = new Convolution1DLayer.Builder().name(this.layerName)
+                .nOut(getNOutFromConfig(layerConfig, conf)).dropOut(this.dropout)
+                .activation(getActivationFromConfig(layerConfig, conf))
+                .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
+                        enforceTrainingConfig, conf, kerasMajorVersion))
+                .biasInit(0.0)
+                .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
+                .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
+                .kernelSize(getKernelSizeFromConfig(layerConfig, 1,  conf, kerasMajorVersion)[0])
+                .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 1, conf)[0]);
+        int[] padding = getPaddingFromBorderModeConfig(layerConfig, 1, conf, kerasMajorVersion);
+        if (padding != null)
+            builder.padding(padding[0]);
+        this.layer = builder.build();
+    }
+
+    /**
+     * Get DL4J ConvolutionLayer.
+     *
+     * @return  ConvolutionLayer
+     */
+    public Convolution1DLayer getAtrousConvolution1D() {
+        return (Convolution1DLayer) this.layer;
+    }
+
+    /**
+     * Get layer output type.
+     *
+     * @param inputType Array of InputTypes
+     * @return output type as InputType
+     * @throws InvalidKerasConfigurationException
+     */
+    @Override
+    public InputType getOutputType(InputType... inputType) throws InvalidKerasConfigurationException {
+        if (inputType.length > 1)
+            throw new InvalidKerasConfigurationException(
+                    "Keras Convolution layer accepts only one input (received " + inputType.length + ")");
+        return this.getAtrousConvolution1D().getOutputType(-1, inputType[0]);
+    }
 }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution1D.java
@@ -78,7 +78,7 @@ public class KerasAtrousConvolution1D extends KerasConvolution {
                 .activation(getActivationFromConfig(layerConfig, conf))
                 .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
                         enforceTrainingConfig, conf, kerasMajorVersion))
-                .dilation(getDilationRate(layerConfig, 2, conf, true))
+                .dilation(getDilationRate(layerConfig, 1, conf, true))
                 .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 1,  conf, kerasMajorVersion)[0])

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
@@ -75,18 +75,20 @@ public class KerasAtrousConvolution2D extends KerasConvolution {
         hasBias = getHasBiasFromConfig(layerConfig, conf);
         numTrainableParams = hasBias ? 2 : 1;
 
-        // TODO: add dilation argument
         ConvolutionLayer.Builder builder = new ConvolutionLayer.Builder().name(this.layerName)
                 .nOut(getNOutFromConfig(layerConfig, conf)).dropOut(this.dropout)
                 .activation(getActivationFromConfig(layerConfig, conf))
                 .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
                         enforceTrainingConfig, conf, kerasMajorVersion))
-                .biasInit(0.0)
+                .dilation(getAtrousRate(layerConfig, 2, conf))
                 .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 2, conf, kerasMajorVersion))
-                .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 2, conf));
+                .hasBias(hasBias)
+                .stride(getStrideFromConfig(layerConfig, 2, conf));
         int[] padding = getPaddingFromBorderModeConfig(layerConfig, 2, conf, kerasMajorVersion);
+        if (hasBias)
+            builder.biasInit(0.0);
         if (padding != null)
             builder.padding(padding);
         this.layer = builder.build();

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
@@ -1,4 +1,119 @@
+/*-
+ *
+ *  * Copyright 2017 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
 package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
 
-public class KerasAtrousConvolution2D {
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
+
+import java.util.Map;
+
+import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.*;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasActivationUtils.getActivationFromConfig;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasInitilizationUtils.getWeightInitFromConfig;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getHasBiasFromConfig;
+import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getNOutFromConfig;
+
+/**
+ * Keras 1D atrous / dilated convolution layer. Note that in keras 2 this layer has been
+ * removed and dilations are now available through the "dilated" argument in regular Conv1D layers
+ *
+ * author: Max Pumperla
+ */
+public class KerasAtrousConvolution2D extends KerasConvolution {
+
+    /**
+     * Pass-through constructor from KerasLayer
+     *
+     * @param kerasVersion major keras version
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasAtrousConvolution2D(Integer kerasVersion) throws UnsupportedKerasConfigurationException {
+        super(kerasVersion);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig dictionary containing Keras layer configuration
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasAtrousConvolution2D(Map<String, Object> layerConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        this(layerConfig, true);
+    }
+
+    /**
+     * Constructor from parsed Keras layer configuration dictionary.
+     *
+     * @param layerConfig           dictionary containing Keras layer configuration
+     * @param enforceTrainingConfig whether to enforce training-related configuration options
+     * @throws InvalidKerasConfigurationException
+     * @throws UnsupportedKerasConfigurationException
+     */
+    public KerasAtrousConvolution2D(Map<String, Object> layerConfig, boolean enforceTrainingConfig)
+            throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        super(layerConfig, enforceTrainingConfig);
+
+        hasBias = getHasBiasFromConfig(layerConfig, conf);
+        numTrainableParams = hasBias ? 2 : 1;
+
+        // TODO: add dilation argument
+        ConvolutionLayer.Builder builder = new ConvolutionLayer.Builder().name(this.layerName)
+                .nOut(getNOutFromConfig(layerConfig, conf)).dropOut(this.dropout)
+                .activation(getActivationFromConfig(layerConfig, conf))
+                .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
+                        enforceTrainingConfig, conf, kerasMajorVersion))
+                .biasInit(0.0)
+                .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
+                .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
+                .kernelSize(getKernelSizeFromConfig(layerConfig, 2, conf, kerasMajorVersion))
+                .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 2, conf));
+        int[] padding = getPaddingFromBorderModeConfig(layerConfig, 2, conf, kerasMajorVersion);
+        if (padding != null)
+            builder.padding(padding);
+        this.layer = builder.build();
+    }
+
+    /**
+     * Get DL4J ConvolutionLayer.
+     *
+     * @return ConvolutionLayer
+     */
+    public ConvolutionLayer getAtrousConvolution2D() {
+        return (ConvolutionLayer) this.layer;
+    }
+
+    /**
+     * Get layer output type.
+     *
+     * @param inputType Array of InputTypes
+     * @return output type as InputType
+     * @throws InvalidKerasConfigurationException
+     */
+    @Override
+    public InputType getOutputType(InputType... inputType) throws InvalidKerasConfigurationException {
+        if (inputType.length > 1)
+            throw new InvalidKerasConfigurationException(
+                    "Keras Convolution layer accepts only one input (received " + inputType.length + ")");
+        return this.getAtrousConvolution2D().getOutputType(-1, inputType[0]);
+    }
+
 }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
@@ -1,0 +1,4 @@
+package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
+
+public class KerasAtrousConvolution2D {
+}

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasAtrousConvolution2D.java
@@ -80,7 +80,7 @@ public class KerasAtrousConvolution2D extends KerasConvolution {
                 .activation(getActivationFromConfig(layerConfig, conf))
                 .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
                         enforceTrainingConfig, conf, kerasMajorVersion))
-                .dilation(getAtrousRate(layerConfig, 2, conf))
+                .dilation(getDilationRate(layerConfig, 2, conf, true))
                 .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 2, conf, kerasMajorVersion))

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
@@ -83,12 +83,14 @@ public class KerasConvolution1D extends KerasConvolution {
                 .activation(getActivationFromConfig(layerConfig, conf))
                 .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
                         enforceTrainingConfig, conf, kerasMajorVersion))
-                .biasInit(0.0)
                 .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 1,  conf, kerasMajorVersion)[0])
-                .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 1, conf)[0]);
+                .hasBias(hasBias)
+                .stride(getStrideFromConfig(layerConfig, 1, conf)[0]);
         int[] padding = getPaddingFromBorderModeConfig(layerConfig, 1, conf, kerasMajorVersion);
+        if (hasBias)
+            builder.biasInit(0.0);
         if (padding != null)
             builder.padding(padding[0]);
         this.layer = builder.build();

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.nn.modelimport.keras.layers.convolutional;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.Convolution1DLayer;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
@@ -100,5 +101,20 @@ public class KerasConvolution1D extends KerasConvolution {
      */
     public Convolution1DLayer getConvolution1DLayer() {
         return (Convolution1DLayer) this.layer;
+    }
+
+    /**
+     * Get layer output type.
+     *
+     * @param inputType Array of InputTypes
+     * @return output type as InputType
+     * @throws InvalidKerasConfigurationException
+     */
+    @Override
+    public InputType getOutputType(InputType... inputType) throws InvalidKerasConfigurationException {
+        if (inputType.length > 1)
+            throw new InvalidKerasConfigurationException(
+                    "Keras Convolution layer accepts only one input (received " + inputType.length + ")");
+        return this.getConvolution1DLayer().getOutputType(-1, inputType[0]);
     }
 }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
@@ -74,7 +74,7 @@ public class KerasConvolution1D extends KerasConvolution {
         super(layerConfig, enforceTrainingConfig);
         hasBias = getHasBiasFromConfig(layerConfig, conf);
         numTrainableParams = hasBias ? 2 : 1;
-        int[] dilationRate = getDilationRate(layerConfig, 2, conf, false);
+        int[] dilationRate = getDilationRate(layerConfig, 1, conf, false);
 
         Convolution1DLayer.Builder builder = new Convolution1DLayer.Builder().name(this.layerName)
                 .nOut(getNOutFromConfig(layerConfig, conf)).dropOut(this.dropout)

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution1D.java
@@ -25,14 +25,11 @@ import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurat
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
 import java.util.Map;
 
+import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.*;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasActivationUtils.getActivationFromConfig;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasInitilizationUtils.getWeightInitFromConfig;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getHasBiasFromConfig;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getNOutFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getConvolutionModeFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getKernelSizeFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getStrideFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getPaddingFromBorderModeConfig;
 
 /**
  * Imports a 1D Convolution layer from Keras.
@@ -77,6 +74,7 @@ public class KerasConvolution1D extends KerasConvolution {
         super(layerConfig, enforceTrainingConfig);
         hasBias = getHasBiasFromConfig(layerConfig, conf);
         numTrainableParams = hasBias ? 2 : 1;
+        int[] dilationRate = getDilationRate(layerConfig, 2, conf, false);
 
         Convolution1DLayer.Builder builder = new Convolution1DLayer.Builder().name(this.layerName)
                 .nOut(getNOutFromConfig(layerConfig, conf)).dropOut(this.dropout)
@@ -93,6 +91,8 @@ public class KerasConvolution1D extends KerasConvolution {
             builder.biasInit(0.0);
         if (padding != null)
             builder.padding(padding[0]);
+        if (dilationRate != null)
+            builder.dilation(dilationRate);
         this.layer = builder.build();
     }
 

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
@@ -26,14 +26,11 @@ import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfig
 
 import java.util.Map;
 
+import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.*;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasActivationUtils.getActivationFromConfig;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasInitilizationUtils.getWeightInitFromConfig;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getHasBiasFromConfig;
 import static org.deeplearning4j.nn.modelimport.keras.utils.KerasLayerUtils.getNOutFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getConvolutionModeFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getKernelSizeFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getStrideFromConfig;
-import static org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolutionUtils.getPaddingFromBorderModeConfig;
 
 
 /**
@@ -81,6 +78,7 @@ public class KerasConvolution2D extends KerasConvolution {
 
         hasBias = getHasBiasFromConfig(layerConfig, conf);
         numTrainableParams = hasBias ? 2 : 1;
+        int[] dilationRate = getDilationRate(layerConfig, 2, conf, false);
 
         ConvolutionLayer.Builder builder = new ConvolutionLayer.Builder().name(this.layerName)
                 .nOut(getNOutFromConfig(layerConfig, conf)).dropOut(this.dropout)
@@ -97,6 +95,8 @@ public class KerasConvolution2D extends KerasConvolution {
             builder.biasInit(0.0);
         if (padding != null)
             builder.padding(padding);
+        if (dilationRate != null)
+            builder.dilation(dilationRate);
         this.layer = builder.build();
     }
 

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution2D.java
@@ -87,12 +87,14 @@ public class KerasConvolution2D extends KerasConvolution {
                 .activation(getActivationFromConfig(layerConfig, conf))
                 .weightInit(getWeightInitFromConfig(layerConfig, conf.getLAYER_FIELD_INIT(),
                         enforceTrainingConfig, conf, kerasMajorVersion))
-                .biasInit(0.0)
                 .l1(this.weightL1Regularization).l2(this.weightL2Regularization)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 2, conf, kerasMajorVersion))
-                .hasBias(hasBias).stride(getStrideFromConfig(layerConfig, 2, conf));
+                .hasBias(hasBias)
+                .stride(getStrideFromConfig(layerConfig, 2, conf));
         int[] padding = getPaddingFromBorderModeConfig(layerConfig, 2, conf, kerasMajorVersion);
+        if (hasBias)
+            builder.biasInit(0.0);
         if (padding != null)
             builder.padding(padding);
         this.layer = builder.build();

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolutionUtils.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolutionUtils.java
@@ -73,23 +73,30 @@ public class KerasConvolutionUtils {
      * @param layerConfig dictionary containing Keras layer configuration
      * @param dimension dimension of the convolution layer (1 or 2)
      * @param conf Keras layer configuration
+     * @param forceDilation boolean to indicate if dilation argument should be in config
      * @return list of integers with atrous rates
      *
      * @throws InvalidKerasConfigurationException
      */
-    public static int[] getAtrousRate(Map<String, Object> layerConfig, int dimension, KerasLayerConfiguration conf)
+    public static int[] getDilationRate(Map<String, Object> layerConfig, int dimension, KerasLayerConfiguration conf,
+                                        boolean forceDilation)
             throws InvalidKerasConfigurationException {
         Map<String, Object> innerConfig = KerasLayerUtils.getInnerLayerConfigFromConfig(layerConfig, conf);
         int[] atrousRate;
-        if (innerConfig.containsKey(conf.getLAYER_FIELD_ATROUS_RATE()) && dimension == 2) {
-            List<Integer> atrousRateList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_ATROUS_RATE());
+        if (innerConfig.containsKey(conf.getLAYER_FIELD_DILATION_RATE()) && dimension == 2) {
+            List<Integer> atrousRateList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_DILATION_RATE());
             atrousRate = ArrayUtil.toArray(atrousRateList);
-        } else if (innerConfig.containsKey(conf.getLAYER_FIELD_ATROUS_RATE()) && dimension == 1) {
-            int atrousValue = (int) innerConfig.get(conf.getLAYER_FIELD_ATROUS_RATE());
+        } else if (innerConfig.containsKey(conf.getLAYER_FIELD_DILATION_RATE()) && dimension == 1) {
+            int atrousValue = (int) innerConfig.get(conf.getLAYER_FIELD_DILATION_RATE());
             atrousRate = new int[]{ atrousValue };
         } else {
-            throw new InvalidKerasConfigurationException("Could not determine kernel size: no "
-                    + conf.getLAYER_FIELD_ATROUS_RATE() + " field found");
+            // If we are using keras 1, for regular convolutions, there is no "atrous" argument, for keras
+            // 2 there always is.
+            if (forceDilation)
+            throw new InvalidKerasConfigurationException("Could not determine dilation rate: no "
+                    + conf.getLAYER_FIELD_DILATION_RATE() + " field found");
+            else
+                atrousRate = null;
         }
         return atrousRate;
 

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolutionUtils.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolutionUtils.java
@@ -66,6 +66,36 @@ public class KerasConvolutionUtils {
         return strides;
     }
 
+
+    /**
+     * Get atrous / dilation rate from config
+     *
+     * @param layerConfig dictionary containing Keras layer configuration
+     * @param dimension dimension of the convolution layer (1 or 2)
+     * @param conf Keras layer configuration
+     * @return list of integers with atrous rates
+     *
+     * @throws InvalidKerasConfigurationException
+     */
+    public static int[] getAtrousRate(Map<String, Object> layerConfig, int dimension, KerasLayerConfiguration conf)
+            throws InvalidKerasConfigurationException {
+        Map<String, Object> innerConfig = KerasLayerUtils.getInnerLayerConfigFromConfig(layerConfig, conf);
+        int[] atrousRate;
+        if (innerConfig.containsKey(conf.getLAYER_FIELD_ATROUS_RATE()) && dimension == 2) {
+            List<Integer> atrousRateList = (List<Integer>) innerConfig.get(conf.getLAYER_FIELD_ATROUS_RATE());
+            atrousRate = ArrayUtil.toArray(atrousRateList);
+        } else if (innerConfig.containsKey(conf.getLAYER_FIELD_ATROUS_RATE()) && dimension == 1) {
+            int atrousValue = (int) innerConfig.get(conf.getLAYER_FIELD_ATROUS_RATE());
+            atrousRate = new int[]{ atrousValue };
+        } else {
+            throw new InvalidKerasConfigurationException("Could not determine kernel size: no "
+                    + conf.getLAYER_FIELD_ATROUS_RATE() + " field found");
+        }
+        return atrousRate;
+
+    }
+
+
     /**
      * Get (convolution) kernel size from Keras layer configuration.
      *
@@ -77,7 +107,7 @@ public class KerasConvolutionUtils {
                                                 KerasLayerConfiguration conf, int kerasMajorVersion)
             throws InvalidKerasConfigurationException {
         Map<String, Object> innerConfig = KerasLayerUtils.getInnerLayerConfigFromConfig(layerConfig, conf);
-        int[] kernelSize = null;
+        int[] kernelSize;
         if (kerasMajorVersion != 2) {
             if (innerConfig.containsKey(conf.getLAYER_FIELD_NB_ROW()) && dimension == 2
                     && innerConfig.containsKey(conf.getLAYER_FIELD_NB_COL())) {

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLayerUtils.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLayerUtils.java
@@ -25,9 +25,7 @@ import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurat
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.layers.*;
 import org.deeplearning4j.nn.modelimport.keras.layers.advanced.activations.KerasLeakyReLU;
-import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution1D;
-import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution2D;
-import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasZeroPadding;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.*;
 import org.deeplearning4j.nn.modelimport.keras.layers.core.*;
 import org.deeplearning4j.nn.modelimport.keras.layers.embeddings.KerasEmbedding;
 import org.deeplearning4j.nn.modelimport.keras.layers.normalization.KerasBatchNormalization;
@@ -184,6 +182,10 @@ public class KerasLayerUtils {
             layer = new KerasConvolution2D(layerConfig, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_CONVOLUTION_1D())) {
             layer = new KerasConvolution1D(layerConfig, enforceTrainingConfig);
+        } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_ATROUS_CONVOLUTION_2D())) {
+            layer = new KerasAtrousConvolution2D(layerConfig, enforceTrainingConfig);
+        } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_ATROUS_CONVOLUTION_1D())) {
+            layer = new KerasAtrousConvolution1D(layerConfig, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_MAX_POOLING_2D()) ||
                 layerClassName.equals(conf.getLAYER_CLASS_NAME_AVERAGE_POOLING_2D())) {
             layer = new KerasPooling(layerConfig, enforceTrainingConfig);

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
@@ -65,6 +65,7 @@ public class KerasLayerTest {
     private final double DROPOUT_KERAS = 0.3;
     private final double DROPOUT_DL4J = 1 - DROPOUT_KERAS;
     private final int[] KERNEL_SIZE = new int[]{1, 2};
+    private final int[] DILATION = new int[]{2, 2};
     private final int[] INPUT_SHAPE = new int[]{100, 20};
     private final int[] STRIDE = new int[]{3, 4};
     private final PoolingType POOLING_TYPE = PoolingType.MAX;
@@ -94,14 +95,16 @@ public class KerasLayerTest {
 
     @Test
     public void testConvolution2DLayer() throws Exception {
-        buildConvolution2DLayer(conf1, keras1);
-        buildConvolution2DLayer(conf2, keras2);
+        buildConvolution2DLayer(conf1, keras1, false);
+        buildConvolution2DLayer(conf2, keras2, false);
+        buildConvolution2DLayer(conf2, keras2, true);
     }
 
     @Test
     public void testConvolution1DLayer() throws Exception {
-        buildConvolution1DLayer(conf1, keras1);
-        buildConvolution1DLayer(conf2, keras2);
+        buildConvolution1DLayer(conf1, keras1, false);
+        buildConvolution1DLayer(conf2, keras2, false);
+        buildConvolution1DLayer(conf2, keras2, true);
     }
 
     @Test
@@ -146,7 +149,8 @@ public class KerasLayerTest {
         buildLReshapeLayer(conf2, keras2);
     }
 
-    public void buildConvolution1DLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
+    public void buildConvolution1DLayer(KerasLayerConfiguration conf, Integer kerasVersion, boolean withDilation)
+            throws Exception {
         Map<String, Object> layerConfig = new HashMap<String, Object>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_CONVOLUTION_1D());
         Map<String, Object> config = new HashMap<String, Object>();
@@ -159,6 +163,9 @@ public class KerasLayerTest {
             Map<String, Object> init = new HashMap<String, Object>();
             init.put("class_name", conf.getINIT_GLOROT_NORMAL());
             config.put(conf.getLAYER_FIELD_INIT(), init);
+        }
+        if (withDilation){
+            config.put(conf.getLAYER_FIELD_DILATION_RATE(), DILATION[0]);
         }
         Map<String, Object> W_reg = new HashMap<String, Object>();
         W_reg.put(conf.getREGULARIZATION_TYPE_L1(), L1_REGULARIZATION);
@@ -183,6 +190,9 @@ public class KerasLayerTest {
         assertEquals(N_OUT, layer.getNOut());
         assertEquals(ConvolutionMode.Truncate, layer.getConvolutionMode());
         assertEquals(VALID_PADDING[0], layer.getPadding()[0]);
+        if (withDilation) {
+            assertEquals(DILATION[0], layer.getDilation()[0]);
+        }
     }
 
     public void buildEmbeddingLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
@@ -312,7 +322,8 @@ public class KerasLayerTest {
         assertEquals(N_OUT, layer.getNOut());
     }
 
-    public void buildConvolution2DLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
+    public void buildConvolution2DLayer(KerasLayerConfiguration conf, Integer kerasVersion, boolean withDilation)
+            throws Exception {
         Map<String, Object> layerConfig = new HashMap<String, Object>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_CONVOLUTION_2D());
         Map<String, Object> config = new HashMap<String, Object>();
@@ -339,6 +350,12 @@ public class KerasLayerTest {
             }};
             config.put(conf.getLAYER_FIELD_KERNEL_SIZE(), kernel);
         }
+        if (withDilation){
+            ArrayList dilation = new ArrayList<Integer>() {{
+                for (int i : DILATION) add(i);
+            }};
+            config.put(conf.getLAYER_FIELD_DILATION_RATE(), dilation);
+        }
         List<Integer> subsampleList = new ArrayList<>();
         subsampleList.add(STRIDE[0]);
         subsampleList.add(STRIDE[1]);
@@ -361,6 +378,10 @@ public class KerasLayerTest {
         assertEquals(N_OUT, layer.getNOut());
         assertEquals(ConvolutionMode.Truncate, layer.getConvolutionMode());
         assertArrayEquals(VALID_PADDING, layer.getPadding());
+        if (withDilation) {
+            assertEquals(DILATION[0], layer.getDilation()[0]);
+            assertEquals(DILATION[1], layer.getDilation()[1]);
+        }
     }
 
     public void buildSubsamplingLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/KerasLayerTest.java
@@ -26,6 +26,7 @@ import org.deeplearning4j.nn.modelimport.keras.config.Keras2LayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.config.KerasLayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.layers.advanced.activations.KerasLeakyReLU;
+import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasAtrousConvolution1D;
 import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution1D;
 import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution2D;
 import org.deeplearning4j.nn.modelimport.keras.layers.core.KerasActivation;
@@ -92,6 +93,17 @@ public class KerasLayerTest {
         buildActivationLayer(conf1, keras1);
         buildActivationLayer(conf2, keras2);
     }
+
+    @Test
+    public void testAtrousConvolution1DLayer() throws Exception {
+        buildAtrousConvolution1DLayer(conf1, keras1);
+    }
+
+    @Test
+    public void testAtrousConvolution2DLayer() throws Exception {
+        buildAtrousConvolution2DLayer(conf1, keras1);
+    }
+
 
     @Test
     public void testConvolution2DLayer() throws Exception {
@@ -193,6 +205,48 @@ public class KerasLayerTest {
         if (withDilation) {
             assertEquals(DILATION[0], layer.getDilation()[0]);
         }
+    }
+
+    public void buildAtrousConvolution1DLayer(KerasLayerConfiguration conf, Integer kerasVersion)
+            throws Exception {
+        Map<String, Object> layerConfig = new HashMap<String, Object>();
+        layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_CONVOLUTION_1D());
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put(conf.getLAYER_FIELD_ACTIVATION(), ACTIVATION_KERAS);
+        config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
+        layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
+        if (kerasVersion == 1) {
+            config.put(conf.getLAYER_FIELD_INIT(), INIT_KERAS);
+        } else {
+            Map<String, Object> init = new HashMap<String, Object>();
+            init.put("class_name", conf.getINIT_GLOROT_NORMAL());
+            config.put(conf.getLAYER_FIELD_INIT(), init);
+        }
+        config.put(conf.getLAYER_FIELD_DILATION_RATE(), DILATION[0]);
+        Map<String, Object> W_reg = new HashMap<String, Object>();
+        W_reg.put(conf.getREGULARIZATION_TYPE_L1(), L1_REGULARIZATION);
+        W_reg.put(conf.getREGULARIZATION_TYPE_L2(), L2_REGULARIZATION);
+        config.put(conf.getLAYER_FIELD_W_REGULARIZER(), W_reg);
+        config.put(conf.getLAYER_FIELD_DROPOUT(), DROPOUT_KERAS);
+        config.put(conf.getLAYER_FIELD_FILTER_LENGTH(), KERNEL_SIZE[0]);
+        config.put(conf.getLAYER_FIELD_SUBSAMPLE_LENGTH(), STRIDE[0]);
+        config.put(conf.getLAYER_FIELD_NB_FILTER(), N_OUT);
+        config.put(conf.getLAYER_FIELD_BORDER_MODE(), BORDER_MODE_VALID);
+        layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
+
+        Convolution1DLayer layer = new KerasAtrousConvolution1D(layerConfig).getAtrousConvolution1D();
+        assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
+        assertEquals(LAYER_NAME, layer.getLayerName());
+        assertEquals(INIT_DL4J, layer.getWeightInit());
+        assertEquals(L1_REGULARIZATION, layer.getL1(), 0.0);
+        assertEquals(L2_REGULARIZATION, layer.getL2(), 0.0);
+        assertEquals(DROPOUT_DL4J, layer.getDropOut(), 0.0);
+        assertEquals(KERNEL_SIZE[0], layer.getKernelSize()[0]);
+        assertEquals(STRIDE[0], layer.getStride()[0]);
+        assertEquals(N_OUT, layer.getNOut());
+        assertEquals(ConvolutionMode.Truncate, layer.getConvolutionMode());
+        assertEquals(VALID_PADDING[0], layer.getPadding()[0]);
+        assertEquals(DILATION[0], layer.getDilation()[0]);
     }
 
     public void buildEmbeddingLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
@@ -382,6 +436,64 @@ public class KerasLayerTest {
             assertEquals(DILATION[0], layer.getDilation()[0]);
             assertEquals(DILATION[1], layer.getDilation()[1]);
         }
+    }
+
+    public void buildAtrousConvolution2DLayer(KerasLayerConfiguration conf, Integer kerasVersion)
+            throws Exception {
+        Map<String, Object> layerConfig = new HashMap<String, Object>();
+        layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_CONVOLUTION_2D());
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put(conf.getLAYER_FIELD_ACTIVATION(), ACTIVATION_KERAS); // keras linear -> dl4j identity
+        config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
+        if (kerasVersion == 1) {
+            config.put(conf.getLAYER_FIELD_INIT(), INIT_KERAS);
+        } else {
+            Map<String, Object> init = new HashMap<String, Object>();
+            init.put("class_name", conf.getINIT_GLOROT_NORMAL());
+            config.put(conf.getLAYER_FIELD_INIT(), init);
+        }
+        Map<String, Object> W_reg = new HashMap<String, Object>();
+        W_reg.put(conf.getREGULARIZATION_TYPE_L1(), L1_REGULARIZATION);
+        W_reg.put(conf.getREGULARIZATION_TYPE_L2(), L2_REGULARIZATION);
+        config.put(conf.getLAYER_FIELD_W_REGULARIZER(), W_reg);
+        config.put(conf.getLAYER_FIELD_DROPOUT(), DROPOUT_KERAS);
+        if (kerasVersion == 1) {
+            config.put(conf.getLAYER_FIELD_NB_ROW(), KERNEL_SIZE[0]);
+            config.put(conf.getLAYER_FIELD_NB_COL(), KERNEL_SIZE[1]);
+        } else {
+            ArrayList kernel = new ArrayList<Integer>() {{
+                for (int i : KERNEL_SIZE) add(i);
+            }};
+            config.put(conf.getLAYER_FIELD_KERNEL_SIZE(), kernel);
+        }
+        ArrayList dilation = new ArrayList<Integer>() {{
+            for (int i : DILATION) add(i);
+        }};
+        config.put(conf.getLAYER_FIELD_DILATION_RATE(), dilation);
+        List<Integer> subsampleList = new ArrayList<>();
+        subsampleList.add(STRIDE[0]);
+        subsampleList.add(STRIDE[1]);
+        config.put(conf.getLAYER_FIELD_CONVOLUTION_STRIDES(), subsampleList);
+        config.put(conf.getLAYER_FIELD_NB_FILTER(), N_OUT);
+        config.put(conf.getLAYER_FIELD_BORDER_MODE(), BORDER_MODE_VALID);
+        layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
+        layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
+
+
+        ConvolutionLayer layer = new KerasConvolution2D(layerConfig).getConvolution2DLayer();
+        assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
+        assertEquals(LAYER_NAME, layer.getLayerName());
+        assertEquals(INIT_DL4J, layer.getWeightInit());
+        assertEquals(L1_REGULARIZATION, layer.getL1(), 0.0);
+        assertEquals(L2_REGULARIZATION, layer.getL2(), 0.0);
+        assertEquals(DROPOUT_DL4J, layer.getDropOut(), 0.0);
+        assertArrayEquals(KERNEL_SIZE, layer.getKernelSize());
+        assertArrayEquals(STRIDE, layer.getStride());
+        assertEquals(N_OUT, layer.getNOut());
+        assertEquals(ConvolutionMode.Truncate, layer.getConvolutionMode());
+        assertArrayEquals(VALID_PADDING, layer.getPadding());
+        assertEquals(DILATION[0], layer.getDilation()[0]);
+        assertEquals(DILATION[1], layer.getDilation()[1]);
     }
 
     public void buildSubsamplingLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support Atrous convolution layers (1D & 2D) for keras 1 and 2, with respective layer tests.
