### PR TITLE
Map ones and identity initializers for model import

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasInitilizationUtils.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasInitilizationUtils.java
@@ -43,10 +43,6 @@ public class KerasInitilizationUtils {
      */
     public static WeightInit mapWeightInitialization(String kerasInit, KerasLayerConfiguration conf)
             throws UnsupportedKerasConfigurationException {
-        /* INIT_IDENTITY INIT_ORTHOGONAL INIT_LECUN_UNIFORM, INIT_NORMAL
-         * INIT_VARIANCE_SCALING, INIT_CONSTANT, INIT_ONES missing.
-         * Remaining dl4j distributions: DISTRIBUTION, SIZE, NORMALIZED,VI
-         */
         WeightInit init = WeightInit.XAVIER;
         if (kerasInit != null) {
             if (kerasInit.equals(conf.getINIT_GLOROT_NORMAL())) {
@@ -63,12 +59,18 @@ public class KerasInitilizationUtils {
                 init = WeightInit.RELU;
             } else if (kerasInit.equals(conf.getINIT_HE_UNIFORM())) {
                 init = WeightInit.RELU_UNIFORM;
+            } else if (kerasInit.equals(conf.getINIT_ONE()) ||
+                    kerasInit.equals(conf.getINIT_ONES()) ||
+                    kerasInit.equals(conf.getINIT_ONES_ALIAS())) {
+                init = WeightInit.ONES;
             } else if (kerasInit.equals(conf.getINIT_ZERO()) ||
-                    kerasInit.equals(conf.getINIT_ZEROS()) ||
-                    kerasInit.equals(conf.getINIT_ZEROS_ALIAS())) {
-                init = WeightInit.ZERO;
+                kerasInit.equals(conf.getINIT_ZEROS()) ||
+                kerasInit.equals(conf.getINIT_ZEROS_ALIAS())) {
+            init = WeightInit.ZERO;
+            } else if (kerasInit.equals(conf.getINIT_IDENTITY()) ||
+                    kerasInit.equals(conf.getINIT_IDENTITY_ALIAS())) {
+                init = WeightInit.IDENTITY;
             } else if (kerasInit.equals(conf.getINIT_VARIANCE_SCALING())) {
-                // TODO: This is incorrect, but we need it in tests for now
                 init = WeightInit.XAVIER_UNIFORM;
             } else {
                 throw new UnsupportedKerasConfigurationException("Unknown keras weight initializer " + kerasInit);
@@ -81,7 +83,7 @@ public class KerasInitilizationUtils {
      * Get weight initialization from Keras layer configuration.
      *
      * @param layerConfig           dictionary containing Keras layer configuration
-     * @param enforceTrainingConfig
+     * @param enforceTrainingConfig whether to enforce loading configuration for further training
      * @return
      * @throws InvalidKerasConfigurationException
      * @throws UnsupportedKerasConfigurationException

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/configurations/KerasInitilizationTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/configurations/KerasInitilizationTest.java
@@ -1,0 +1,94 @@
+package org.deeplearning4j.nn.modelimport.keras.configurations;
+
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.modelimport.keras.config.Keras1LayerConfiguration;
+import org.deeplearning4j.nn.modelimport.keras.config.Keras2LayerConfiguration;
+import org.deeplearning4j.nn.modelimport.keras.config.KerasLayerConfiguration;
+import org.deeplearning4j.nn.modelimport.keras.layers.core.KerasDense;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class KerasInitilizationTest {
+
+    private Keras1LayerConfiguration conf1 = new Keras1LayerConfiguration();
+    private Keras2LayerConfiguration conf2 = new Keras2LayerConfiguration();
+
+    @Test
+    public void testInitializers() throws Exception {
+
+        Integer keras1 = 1;
+        Integer keras2 = 2;
+
+        String[] keras1Inits = initializers(conf1);
+        String[] keras2Inits = initializers(conf2);
+        WeightInit[] dl4jInits = dl4jInitializers();
+
+        for (int i=0; i< dl4jInits.length; i++) {
+            initilizationDenseLayer(conf1, keras1, keras1Inits[i], dl4jInits[i]);
+            initilizationDenseLayer(conf2, keras2,  keras2Inits[i], dl4jInits[i]);
+        }
+    }
+
+    private String[] initializers(KerasLayerConfiguration conf) {
+        return new String[] {
+                conf.getINIT_GLOROT_NORMAL(),
+                conf.getINIT_GLOROT_UNIFORM(),
+                conf.getINIT_LECUN_NORMAL(),
+                conf.getINIT_RANDOM_UNIFORM(),
+                conf.getINIT_HE_NORMAL(),
+                conf.getINIT_HE_UNIFORM(),
+                conf.getINIT_ONES(),
+                conf.getINIT_ZERO(),
+                conf.getINIT_IDENTITY(),
+                conf.getINIT_VARIANCE_SCALING()
+                // TODO: add these initializations
+                // conf.getINIT_CONSTANT(),
+                // conf.getINIT_NORMAL(),
+                // conf.getINIT_ORTHOGONAL(),
+                // conf.getINIT_LECUN_UNIFORM()
+        };
+    }
+
+    private WeightInit[] dl4jInitializers() {
+        return new WeightInit[] {
+                WeightInit.XAVIER,
+                WeightInit.XAVIER_UNIFORM,
+                WeightInit.NORMAL,
+                WeightInit.UNIFORM,
+                WeightInit.RELU,
+                WeightInit.RELU_UNIFORM,
+                WeightInit.ONES,
+                WeightInit.ZERO,
+                WeightInit.IDENTITY,
+                WeightInit.XAVIER_UNIFORM // TODO: Variance scaling is incorrectly mapped
+        };
+    }
+    
+    private void initilizationDenseLayer(KerasLayerConfiguration conf, Integer kerasVersion,
+                                 String initializer, WeightInit dl4jInitializer)
+            throws Exception {
+        Map<String, Object> layerConfig = new HashMap<>();
+        layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_DENSE());
+        Map<String, Object> config = new HashMap<>();
+        config.put(conf.getLAYER_FIELD_ACTIVATION(), "linear");
+        config.put(conf.getLAYER_FIELD_NAME(), "init_test");
+        if (kerasVersion == 1) {
+            config.put(conf.getLAYER_FIELD_INIT(), initializer);
+        } else {
+            Map<String, Object> init = new HashMap<>();
+            init.put("class_name", initializer);
+            config.put(conf.getLAYER_FIELD_INIT(), init);
+        }
+        config.put(conf.getLAYER_FIELD_OUTPUT_DIM(), 1337);
+        layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
+        layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
+
+        DenseLayer layer = new KerasDense(layerConfig, false).getDenseLayer();
+        assertEquals(dl4jInitializer, layer.getWeightInit());
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Map new `ONES` and `IDENTITY` inits in model import and tests.