### PR TITLE
Fix issue #4057.

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1215,7 +1215,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             i++;
         }
 
-        Map<Integer, Set<Integer>> inputEdges = new HashMap<>(); //key: vertex. Values: vertices that the key vertex receives input from
+        Map<Integer, Set<Integer>> inputEdges = new LinkedHashMap<>(); //key: vertex. Values: vertices that the key vertex receives input from. And type is LinkedHashMap for the stable topological sort
         Map<Integer, Set<Integer>> outputEdges = new HashMap<>(); //key: vertex. Values: vertices that the key vertex outputs to
 
         for (String s : configuration.getNetworkInputs()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix issue #4057.

ComputationGraph#topologicalSortOrder() is not stable on ARM CPU. Neural-net parameters will be invalid when calling ModelSerializer#restoreComputationGraph()/ComputatonGraph.init() with parameters.

## How was this patch tested?

Just run `mvn test -Dlombok.version=1.16.16 -Dcommonsio.version=2.4 -Dnd4j.version=0.9.2-SNAPSHOT -P test-nd4j-native` on the deeplearning4j-nn directory.

Sorry, I can't add tests because I don't know how to add ARM test.