### PR TITLE
Allow setting WorkspaceMode for transfer learning as well

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/transferlearning/FineTuneConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/transferlearning/FineTuneConfiguration.java
@@ -67,6 +67,9 @@ public class FineTuneConfiguration {
     protected Integer tbpttFwdLength;
     protected Integer tbpttBackLength;
 
+    protected WorkspaceMode trainingWorkspaceMode;
+    protected WorkspaceMode inferenceWorkspaceMode;
+
     //Lombok builder. Note that the code below ADDS OR OVERRIDES the lombok implementation; the final builder class
     // is the composite of the lombok parts and the parts defined here
     //partial implementation to allow public no-arg constructor (lombok default is package private)
@@ -268,6 +271,10 @@ public class FineTuneConfiguration {
             confBuilder.setGradientNormalization(gradientNormalization);
         if (gradientNormalizationThreshold != null)
             confBuilder.setGradientNormalizationThreshold(gradientNormalizationThreshold);
+        if (trainingWorkspaceMode != null)
+            confBuilder.trainingWorkspaceMode(trainingWorkspaceMode);
+        if (inferenceWorkspaceMode != null)
+            confBuilder.inferenceWorkspaceMode(inferenceWorkspaceMode);
         return confBuilder;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add trainingWorkspaceMode and inferenceWorkspaceMode fields to FineTuneConfiguration and use them for the NeuralNetConfiguration.

## How was this patch tested?

Builds and tests pass, and manually checked that TransferLearning.GraphBuilder() returns the modified configuration with given trainingWorkspaceMode and inferenceWorkspaceMode.