### PR TITLE
SequenceRecordReaderDataSetIterator calls preProcess twice per next()

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/SequenceRecordReaderDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/datavec/SequenceRecordReaderDataSetIterator.java
@@ -330,10 +330,6 @@ public class SequenceRecordReaderDataSetIterator implements DataSetIterator {
         MultiDataSet mds = underlying.next(num);
         DataSet ds = mdsToDataSet(mds);
 
-        if (preProcessor != null) {
-            preProcessor.preProcess(ds);
-        }
-
         if (totalOutcomes == -1) {
             inputColumns = ds.getFeatures().size(1);
             totalOutcomes = ds.getLabels().size(1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

don't preProcess() twice,  already done unconditionally in mdsToDataSet()

## How was this patch tested?

manual tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
