### PR TITLE
Fix DetectedObject.getPredictedClass() always returning 0

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/DetectedObject.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/DetectedObject.java
@@ -69,7 +69,8 @@ public class DetectedObject {
      */
     public int getPredictedClass(){
         if(predictedClass == -1){
-            predictedClass = classPredictions.argMax(1).getInt(0);
+            // ravel in case we get a column vector
+            predictedClass = classPredictions.ravel().argMax(1).getInt(0);
         }
         return predictedClass;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bug fix for DetectedObject.getPredictedClass() when classPredictions is not a row vector.

## How was this patch tested?

Updated TestYolo2OutputLayer to test that case and the unit test passes.