### PR TITLE
Add an option to deploy from the build-dl4j-script

### DIFF
--- a/build-dl4j-stack.sh
+++ b/build-dl4j-stack.sh
@@ -55,6 +55,9 @@ case $key in
     REPO_STRATEGY="$2"
     shift # past argument
     ;;
+    --deploy)
+    DEPLOY="YES"
+    ;;
     --testnd4j)
     TEST_ND4J="YES"
     ;;
@@ -115,9 +118,17 @@ else
     GIT_CLONE="git clone --depth 1"
 fi
 
+# set git cloning to a shallow depth if the option says so
+if [[ -z "$DEPLOY" ]]; then
+    MVN_GOAL="install"
+else
+    MVN_GOAL="deploy"
+fi
+
 # Report argument values
 echo CHIP          = "${CHIP}"
 echo COMPUTE       = "${COMPUTE}"
+echo DEPLOY        = "${DEPLOY}"
 echo NATIVE        = "${NATIVE}"
 echo LIBTYPE       = "${LIBTYPE}"
 echo SCALAV        = "${SCALAV}"
@@ -211,9 +222,9 @@ if [[ -z "$SKIP_ND4J" ]]; then
     pushd nd4j
     maybeUpdateRepo
     if [ "$CHIP" == "cpu" ]; then
-        checkexit bash buildmultiplescalaversions.sh clean install -Dmaven.javadoc.skip=true -pl '!nd4j-backends/nd4j-backend-impls/nd4j-cuda,!nd4j-backends/nd4j-backend-impls/nd4j-cuda-platform,!nd4j-backends/nd4j-tests' $ND4J_OPTIONS $MVN_OPTS
+        checkexit bash buildmultiplescalaversions.sh clean $MVN_GOAL -Dmaven.javadoc.skip=true -pl '!nd4j-backends/nd4j-backend-impls/nd4j-cuda,!nd4j-backends/nd4j-backend-impls/nd4j-cuda-platform,!nd4j-backends/nd4j-tests' $ND4J_OPTIONS $MVN_OPTS
     else
-        checkexit bash buildmultiplescalaversions.sh clean install -Dmaven.javadoc.skip=true $ND4J_OPTIONS $MVN_OPTS
+        checkexit bash buildmultiplescalaversions.sh clean $MVN_GOAL -Dmaven.javadoc.skip=true $ND4J_OPTIONS $MVN_OPTS
     fi
     popd
 fi
@@ -235,9 +246,9 @@ if [[ -z "$SKIP_DATAVEC" ]]; then
     pushd datavec
     maybeUpdateRepo
     if [ "$SCALAV" == "" ]; then
-        checkexit bash buildmultiplescalaversions.sh clean install -Dmaven.javadoc.skip=true $DATAVEC_OPTIONS $MVN_OPTS
+        checkexit bash buildmultiplescalaversions.sh clean $MVN_GOAL -Dmaven.javadoc.skip=true $DATAVEC_OPTIONS $MVN_OPTS
     else
-        checkexit mvn clean install -Dmaven.javadoc.skip=true -Dscala.binary.version="$SCALAV" -Dscala.version="$SCALA" $DATAVEC_OPTIONS $MVN_OPTS
+        checkexit mvn clean $MVN_GOAL -Dmaven.javadoc.skip=true -Dscala.binary.version="$SCALAV" -Dscala.version="$SCALA" $DATAVEC_OPTIONS $MVN_OPTS
     fi
     popd
 fi
@@ -266,12 +277,12 @@ if [[ -z "$SKIP_DL4J" ]]; then
     fi
     if [ "$SCALAV" == "" ]; then
         if [ "$CHIP" == "cpu" ]; then
-            checkexit bash buildmultiplescalaversions.sh clean install -Dmaven.javadoc.skip=true -pl '!./deeplearning4j-cuda/' $DL4J_OPTIONS $MVN_OPTS
+            checkexit bash buildmultiplescalaversions.sh clean $MVN_GOAL -Dmaven.javadoc.skip=true -pl '!./deeplearning4j-cuda/' $DL4J_OPTIONS $MVN_OPTS
         else
-            checkexit bash buildmultiplescalaversions.sh clean install -Dmaven.javadoc.skip=true $DL4J_OPTIONS $MVN_OPTS
+            checkexit bash buildmultiplescalaversions.sh clean $MVN_GOAL -Dmaven.javadoc.skip=true $DL4J_OPTIONS $MVN_OPTS
         fi
     else
-        checkexit mvn clean install -Dmaven.javadoc.skip=true -Dscala.binary.version="$SCALAV" -Dscala.version="$SCALA" $DL4J_OPTIONS $MVN_OPTS
+        checkexit mvn clean $MVN_GOAL -Dmaven.javadoc.skip=true -Dscala.binary.version="$SCALAV" -Dscala.version="$SCALA" $DL4J_OPTIONS $MVN_OPTS
     fi
     popd
 fi


### PR DESCRIPTION
With this option alone I've been able to push a build repo to completion. This PR helps with the last step. 

1. set up a maven repo in your favorite nexus server
https://books.sonatype.com/nexus-book/2.11/reference/config-sect-new-repo.html

2. Configure it to allow re-uploads (a.k.a overwriting assets or multiple versions of the same asset)
Configure it to allow snapshots & releases.
In Nexus 3, this is the setup you want :
https://i.imgur.com/9urlzFl.png

3. set a server section in your ~/.m2/settings.xml:

```
   <servers>
    <server>
      <id>mynexus.repo</id>
      <username>my.password</username>
      <password>my.password</password>
    </server>
    </servers>
```

4. 
run 
```
./build-dl4j-stack.sh -r update --deploy --mvnopts "-DaltDeploymentRepository=mynexus.repo::default::http://url.to.my.nexus.repo"
```

/cc @emsixteeen 