### PR TITLE
Yolov2OutputLayer - class predictions per bounding box

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/YoloGradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/YoloGradientCheckTests.java
@@ -62,7 +62,7 @@ public class YoloGradientCheckTests {
         int c = 3;
         int b = 3;
 
-        int yoloDepth = 5*b + c;
+        int yoloDepth = b * (5 + c);
         Activation a = Activation.TANH;
 
         Nd4j.getRandom().setSeed(1234567);
@@ -185,7 +185,7 @@ public class YoloGradientCheckTests {
         rr.initialize(new FileSplit(jpg));
 
         int nClasses = rr.getLabels().size();
-        int depthOut = 5*bbPriors.size(0) + nClasses;
+        int depthOut = bbPriors.size(0) * (5 + nClasses);
 
 
         DataSetIterator iter = new RecordReaderDataSetIterator(rr,2,1,1,true);

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
@@ -57,7 +57,7 @@ public class TestYolo2OutputLayer {
         int mb = 3;
         int b = 4;
         int c = 3;
-        int depth = 5 * b + c;
+        int depth = b * (5 + c);
         int w = 6;
         int h = 6;
 
@@ -86,28 +86,28 @@ public class TestYolo2OutputLayer {
 
 
         //Check score method (simple)
-        int labelDepth = 4 + c;
-        INDArray labels = Nd4j.zeros(mb, labelDepth, h, w);
+        INDArray labels = Nd4j.zeros(mb, b, 4+c, h, w);
         //put 1 object per minibatch, at positions (0,0), (1,1) etc.
-        //Positions for label boxes: (1,1) to (2,2), (2,2) to (4,4) etc
-        labels.putScalar(0, 4 + 0, 0, 0, 1);
-        labels.putScalar(1, 4 + 1, 1, 1, 1);
-        labels.putScalar(2, 4 + 2, 2, 2, 1);
+        //Positions for label boxes: (1,1) to (2,2), (2,2) to (4,4) etc. For BB 0, 1, 2
+        labels.putScalar(new int[]{0, 0, 4 + 0, 0, 0}, 1);
+        labels.putScalar(new int[]{1, 1, 4 + 1, 0, 0}, 1);
+        labels.putScalar(new int[]{2, 2, 4 + 2, 0, 0}, 1);
 
-        labels.putScalar(0, 0, 0, 0, 1);
-        labels.putScalar(0, 1, 0, 0, 1);
-        labels.putScalar(0, 2, 0, 0, 2);
-        labels.putScalar(0, 3, 0, 0, 2);
+        labels.putScalar(new int[]{0, 0, 0, 0, 0}, 1);
+        labels.putScalar(new int[]{0, 0, 1, 0, 0}, 1);
+        labels.putScalar(new int[]{0, 0, 2, 0, 0}, 2);
+        labels.putScalar(new int[]{0, 0, 3, 0, 0}, 2);
 
-        labels.putScalar(1, 0, 1, 1, 2);
-        labels.putScalar(1, 1, 1, 1, 2);
-        labels.putScalar(1, 2, 1, 1, 4);
-        labels.putScalar(1, 3, 1, 1, 4);
 
-        labels.putScalar(2, 0, 2, 2, 3);
-        labels.putScalar(2, 1, 2, 2, 3);
-        labels.putScalar(2, 2, 2, 2, 6);
-        labels.putScalar(2, 3, 2, 2, 6);
+        labels.putScalar(new int[]{1, 1, 0, 1, 1}, 2);
+        labels.putScalar(new int[]{1, 1, 1, 1, 1}, 2);
+        labels.putScalar(new int[]{1, 1, 2, 1, 1}, 4);
+        labels.putScalar(new int[]{1, 1, 3, 1, 1}, 4);
+
+        labels.putScalar(new int[]{2, 2, 0, 2, 2}, 3);
+        labels.putScalar(new int[]{2, 2, 1, 2, 2}, 3);
+        labels.putScalar(new int[]{2, 2, 2, 2, 2}, 6);
+        labels.putScalar(new int[]{2, 2, 3, 2, 2}, 6);
 
         y2impl.setInput(input);
         y2impl.setLabels(labels);

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
@@ -135,7 +135,7 @@ public class TestYolo2OutputLayer {
         int mb = 3;
         int b = 4;
         int c = 3;
-        int depth = 5 * b + c;
+        int depth = b * (5 + c);
         int w = 6;
         int h = 6;
 
@@ -163,8 +163,7 @@ public class TestYolo2OutputLayer {
 
 
         //Check values for x/y, confidence: all should be 0 to 1
-        INDArray out4 = out.get(all(), interval(0,5*b), all(), all()).dup('c');
-        INDArray out5 = out4.reshape(mb, b, 5, h, w);
+        INDArray out5 = out.reshape('c', mb, b, 5+c, h, w);
 
         INDArray predictedXYCenterGrid = out5.get(all(), all(), interval(0,2), all(), all());
         INDArray predictedWH = out5.get(all(), all(), interval(2,4), all(), all());   //Shape: [mb, B, 2, H, W]
@@ -179,11 +178,11 @@ public class TestYolo2OutputLayer {
 
 
         //Check classes:
-        INDArray probs = out.get(all(), interval(5*b, 5*b+c), all(), all());   //Shape: [minibatch, C, H, W]
+        INDArray probs = out5.get(all(), all(), interval(5, 5+c), all(), all());   //Shape: [minibatch, C, H, W]
         assertTrue(probs.minNumber().doubleValue() >= 0.0);
         assertTrue(probs.maxNumber().doubleValue() <= 1.0);
 
-        INDArray probsSum = probs.sum(1);
+        INDArray probsSum = probs.sum(2);
         assertEquals(1.0, probsSum.minNumber().doubleValue(), 1e-6);
         assertEquals(1.0, probsSum.maxNumber().doubleValue(), 1e-6);
     }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
@@ -86,28 +86,28 @@ public class TestYolo2OutputLayer {
 
 
         //Check score method (simple)
-        INDArray labels = Nd4j.zeros(mb, b, 4+c, h, w);
+        int labelDepth = 4 + c;
+        INDArray labels = Nd4j.zeros(mb, labelDepth, h, w);
         //put 1 object per minibatch, at positions (0,0), (1,1) etc.
-        //Positions for label boxes: (1,1) to (2,2), (2,2) to (4,4) etc. For BB 0, 1, 2
-        labels.putScalar(new int[]{0, 0, 4 + 0, 0, 0}, 1);
-        labels.putScalar(new int[]{1, 1, 4 + 1, 0, 0}, 1);
-        labels.putScalar(new int[]{2, 2, 4 + 2, 0, 0}, 1);
+        //Positions for label boxes: (1,1) to (2,2), (2,2) to (4,4) etc
+        labels.putScalar(0, 4 + 0, 0, 0, 1);
+        labels.putScalar(1, 4 + 1, 1, 1, 1);
+        labels.putScalar(2, 4 + 2, 2, 2, 1);
 
-        labels.putScalar(new int[]{0, 0, 0, 0, 0}, 1);
-        labels.putScalar(new int[]{0, 0, 1, 0, 0}, 1);
-        labels.putScalar(new int[]{0, 0, 2, 0, 0}, 2);
-        labels.putScalar(new int[]{0, 0, 3, 0, 0}, 2);
+        labels.putScalar(0, 0, 0, 0, 1);
+        labels.putScalar(0, 1, 0, 0, 1);
+        labels.putScalar(0, 2, 0, 0, 2);
+        labels.putScalar(0, 3, 0, 0, 2);
 
+        labels.putScalar(1, 0, 1, 1, 2);
+        labels.putScalar(1, 1, 1, 1, 2);
+        labels.putScalar(1, 2, 1, 1, 4);
+        labels.putScalar(1, 3, 1, 1, 4);
 
-        labels.putScalar(new int[]{1, 1, 0, 1, 1}, 2);
-        labels.putScalar(new int[]{1, 1, 1, 1, 1}, 2);
-        labels.putScalar(new int[]{1, 1, 2, 1, 1}, 4);
-        labels.putScalar(new int[]{1, 1, 3, 1, 1}, 4);
-
-        labels.putScalar(new int[]{2, 2, 0, 2, 2}, 3);
-        labels.putScalar(new int[]{2, 2, 1, 2, 2}, 3);
-        labels.putScalar(new int[]{2, 2, 2, 2, 2}, 6);
-        labels.putScalar(new int[]{2, 2, 3, 2, 2}, 6);
+        labels.putScalar(2, 0, 2, 2, 3);
+        labels.putScalar(2, 1, 2, 2, 3);
+        labels.putScalar(2, 2, 2, 2, 6);
+        labels.putScalar(2, 3, 2, 2, 6);
 
         y2impl.setInput(input);
         y2impl.setLabels(labels);
@@ -221,7 +221,8 @@ public class TestYolo2OutputLayer {
                 {3, 3}});
 
         VocLabelProvider lp = new VocLabelProvider(dir.getPath());
-        int depthOut = bbPriors.size(0)*5 + 20;
+        int c = 20;
+        int depthOut = bbPriors.size(0) * (bbPriors.size(0) + c);
 
         int origW = 500;
         int origH = 375;

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/objdetect/TestYolo2OutputLayer.java
@@ -445,7 +445,7 @@ public class TestYolo2OutputLayer {
         rr.initialize(fileSplit);
 
         int nClasses = rr.getLabels().size();
-        int depthOut = bbPriors.size(0)*5 + nClasses;
+        int depthOut = bbPriors.size(0) * (5 + nClasses);
         // make sure idxCat is not 0 to test DetectedObject.getPredictedClass()
         List<String> labels = rr.getLabels();
         labels.add(labels.remove(labels.indexOf("cat")));

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
@@ -33,6 +33,12 @@ import java.util.Map;
  * currently support simultaneous training on both detection and classification datasets as described in the
  * YOlO9000 paper.
  *
+ * Note: Input activations to the Yolo2OutputLayer should have shape: [minibatch, b*(5+c), H, W], where:<br>
+ * b = number of bounding boxes (determined by config)<br>
+ * c = number of classes<br>
+ * H = output/label height<br>
+ * W = output/label width<br>
+ *
  * @author Alex Black
  */
 @Data

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/Yolo2OutputLayer.java
@@ -671,7 +671,7 @@ public class Yolo2OutputLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
 
                         INDArray sm;
                         try (MemoryWorkspace wsO = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
-                            sm = softmax.get(point(i), point(box), all(), point(x), point(y)).dup();
+                            sm = softmax.get(point(i), point(box), all(), point(y), point(x)).dup();
                         }
 
                         out.add(new DetectedObject(i, px, py, pw, ph, sm, conf));

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/Yolo2OutputLayer.java
@@ -57,7 +57,11 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.*;
  * y2 = as above y axis<br>
  * Note: labels are represented as a multiple of grid size - for a 13x13 grid, (0,0) is top left, (13,13) is bottom right<br>
  * <br>
- * Input format: [minibatch, B*(5+C), H, W]    ->      Reshape to [minibatch, B, 5+C, H, W]
+ * Input format: [minibatch, B*(5+C), H, W]    ->      Reshape to [minibatch, B, 5+C, H, W]<br>
+ * B = number of bounding boxes (determined by config)<br>
+ * C = number of classes<br>
+ * H = output/label height<br>
+ * W = output/label width<br>
  * <br>
  * Note that mask arrays are not required - this implementation infers the presence or absence of objects in each grid
  * cell from the class labels (which should be 1-hot if an object is present, or all 0s otherwise).
@@ -155,7 +159,6 @@ public class Yolo2OutputLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
         //We also need 1_ij^noobj, which is (a) no object, or (b) object present in grid cell, but this box doesn't
         // have the highest IOU
         INDArray mask1_ij_obj = Nd4j.getExecutioner().execAndReturn(new IsMax(iou.dup('c'), 1));
-//        mask1_ij_obj.muli(maskObjectPresent);
         Nd4j.getExecutioner().execAndReturn(new BroadcastMulOp(mask1_ij_obj, maskObjectPresent, mask1_ij_obj, 0,2,3));
         INDArray mask1_ij_noobj = Transforms.not(mask1_ij_obj);
 
@@ -176,15 +179,11 @@ public class Yolo2OutputLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
 
         INDArray mask1_ij_obj_2d = mask1_ij_obj.reshape(mb*b*h*w, 1);  //Must be C order before reshaping
         INDArray mask1_ij_noobj_2d = Transforms.not(mask1_ij_obj_2d);   //Not op is copy op; mask has 1 where box is not responsible for prediction
-//        INDArray mask2d = maskObjectPresent.reshape('c', new int[]{mb*b*h*w, 1});
 
         INDArray predictedXYCenter2d = predictedXYCenterGrid.permute(0,1,3,4,2)  //From: [mb, B, 2, H, W] to [mb, B, H, W, 2]
                 .dup('c').reshape('c', mb*b*h*w, 2);
         //Don't use INDArray.broadcast(int...) until ND4J issue is fixed: https://github.com/deeplearning4j/nd4j/issues/2066
         //INDArray labelsCenterXYInGridBroadcast = labelsCenterXYInGrid.broadcast(mb, b, 2, h, w);
-        //Broadcast labelsCenterXYInGrid from [mb, 2, h, w} to [mb, b, 2, h, w]
-//        INDArray labelsCenterXYInGridBroadcast = labelsCenterXYInGridBox; //Nd4j.createUninitialized(new int[]{mb, b, 2, h, w}, 'c');
-//        INDArray labelXYCenter2d = labelsCenterXYInGridBroadcast.permute(0,1,3,4,2).dup('c').reshape('c', mb*b*h*w, 2);    //[mb, b, 2, h, w] to [mb, b, h, w, 2] to [mb*b*h*w, 2]
         //Broadcast labelsCenterXYInGrid from [mb, 2, h, w} to [mb, b, 2, h, w]
         INDArray labelsCenterXYInGridBroadcast = Nd4j.createUninitialized(new int[]{mb, b, 2, h, w}, 'c');
         for(int i=0; i<b; i++ ){
@@ -195,8 +194,6 @@ public class Yolo2OutputLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
         //Width/height (sqrt)
         INDArray predictedWHSqrt2d = predictedWHSqrt.permute(0,1,3,4,2).dup('c').reshape(mb*b*h*w, 2).dup('c'); //from [mb, b, 2, h, w] to [mb, b, h, w, 2] to [mb*b*h*w, 2]
         //Broadcast labelWHSqrt from [mb, 2, h, w} to [mb, b, 2, h, w]
-//        INDArray labelWHSqrtBroadcast = labelWHSqrt;    //Nd4j.createUninitialized(new int[]{mb, b, 2, h, w}, 'c');
-//        INDArray labelWHSqrt2d = labelWHSqrtBroadcast.permute(0,1,3,4,2).dup('c').reshape(mb*b*h*w, 2).dup('c');   //[mb, b, 2, h, w] to [mb, b, h, w, 2] to [mb*b*h*w, 2]
         INDArray labelWHSqrtBroadcast = Nd4j.createUninitialized(new int[]{mb, b, 2, h, w}, 'c');
         for(int i=0; i<b; i++ ){
             labelWHSqrtBroadcast.get(all(), point(i), all(), all(), all()).assign(labelWHSqrt); //[mb, 2, h, w] to [mb, b, 2, h, w]
@@ -212,7 +209,6 @@ public class Yolo2OutputLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
         //Class prediction loss
         INDArray classPredictionsPreSoftmax2d = inputClassesPreSoftmax.permute(0,1,3,4,2) //[minibatch, b, c, h, w] To [mb, b, h, w, c]
                 .dup('c').reshape('c', new int[]{mb*b*h*w, c});
-//        INDArray classLabels2d = classLabels.permute(0,1,3,4,2).dup('c').reshape('c', new int[]{mb*b*h*w, c});
         INDArray classLabelsBroadcast = Nd4j.createUninitialized(new int[]{mb, b, c, h, w}, 'c');
         for(int i=0; i<b; i++ ){
             classLabelsBroadcast.get(all(), point(i), all(), all(), all()).assign(classLabels); //[mb, c, h, w] to [mb, b, c, h, w]
@@ -241,7 +237,6 @@ public class Yolo2OutputLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
         // ----- Gradient Calculation (specifically: return dL/dIn -----
 
         INDArray epsOut = Nd4j.create(input.shape(), 'c');
-//        INDArray epsOut5 = Shape.newShapeNoCopy(epsOut.get(all(), interval(0,5*b), all(), all()), new int[]{mb, b, 5, h, w}, false);
         INDArray epsOut5 = Shape.newShapeNoCopy(epsOut, new int[]{mb, b, 5+c, h, w}, false);
         INDArray epsClassPredictions = epsOut5.get(all(), all(), interval(5, 5+c), all(), all());    //Shape: [mb, b, 5+c, h, w]
         INDArray epsXY = epsOut5.get(all(), all(), interval(0,2), all(), all());


### PR DESCRIPTION
***WIP DO NOT MERGE***

Fixes Yolo2OutputLayer to match paper.
- Current implementation: was as per Yolo v1 loss function, for class predictions (per grid cell)
- New implementation (and as per v2 paper), class predictions are per bounding box, instead of per grid cell