### PR TITLE
Fix SvhnDataFetcher failing to download more than one dataset

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/CacheableDataSet.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/CacheableDataSet.java
@@ -14,6 +14,7 @@ public interface CacheableDataSet {
     public String remoteDataUrl();
     public String remoteDataUrl(DataSetType set);
     public String localCacheName();
+    public String dataSetName(DataSetType set);
     public long expectedChecksum();
     public long expectedChecksum(DataSetType set);
     public boolean isCached();

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/CacheableExtractableDataSetFetcher.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/CacheableExtractableDataSetFetcher.java
@@ -22,8 +22,9 @@ public abstract class CacheableExtractableDataSetFetcher implements CacheableDat
     public final static File ROOT_CACHE_DIR = new File(System.getProperty("user.home"), DL4J_DIR);
     public File LOCAL_CACHE = new File(ROOT_CACHE_DIR, localCacheName());
 
-    public String remoteDataUrl() { return remoteDataUrl(DataSetType.TRAIN); }
-    public long expectedChecksum() { return expectedChecksum(DataSetType.TRAIN); }
+    @Override public String dataSetName(DataSetType set) { return ""; }
+    @Override public String remoteDataUrl() { return remoteDataUrl(DataSetType.TRAIN); }
+    @Override public long expectedChecksum() { return expectedChecksum(DataSetType.TRAIN); }
     public void downloadAndExtract() throws IOException { downloadAndExtract(DataSetType.TRAIN); }
 
     /**
@@ -41,7 +42,7 @@ public abstract class CacheableExtractableDataSetFetcher implements CacheableDat
             if(LOCAL_CACHE.listFiles().length<1) LOCAL_CACHE.delete();
         }
 
-        if(!LOCAL_CACHE.exists()) {
+        if(!new File(LOCAL_CACHE, dataSetName(set)).exists()) {
             LOCAL_CACHE.mkdirs();
             tmpFile.delete();
             log.info("Downloading dataset to " + tmpFile.getAbsolutePath());

--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/SvhnDataFetcher.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/fetchers/SvhnDataFetcher.java
@@ -62,6 +62,20 @@ public class SvhnDataFetcher extends CacheableExtractableDataSetFetcher {
     }
 
     @Override
+    public String dataSetName(DataSetType set) {
+        switch (set) {
+            case TRAIN:
+                return "train";
+            case TEST:
+                return "test";
+            case VALIDATION:
+                return "extra";
+            default:
+                throw new IllegalArgumentException("Unknown DataSetType:" + set);
+        }
+    }
+
+    @Override
     public long expectedChecksum(DataSetType set) {
         switch (set) {
             case TRAIN:


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the cache was not empty, but did not contain all datasets, SvhnDataFetcher would fail to start the download. Add a dataSetName() method to be able to check for that.

## How was this patch tested?

Unit test now passes after cleaning up ~/.deeplearning4j too.