### PR TITLE
Add LeNet architecture caffe reference

### DIFF
--- a/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/LeNet.java
+++ b/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/LeNet.java
@@ -24,7 +24,9 @@ import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 /**
  * LeNet was an early promising achiever on the ImageNet dataset.
- * Reference: http://yann.lecun.com/exdb/publis/pdf/lecun-98.pdf
+ * References:
+ * - http://yann.lecun.com/exdb/publis/pdf/lecun-98.pdf
+ * - https://github.com/BVLC/caffe/blob/master/examples/mnist/lenet.prototxt
  *
  * <p>MNIST weights for this model are available and have been converted from https://github.com/f00-/mnist-lenet-keras.</p>
  *


### PR DESCRIPTION
## What changes were proposed in this pull request?

The LeNet model had a reference to the original paper, though the implemented architecture was a different one. This change adds the caffe reference which this model is built upon. 

## How was this patch tested?

No tests due to only documentation changes.