### PR TITLE
UUID logic change for ParallelWrapper

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper-parameter-server/src/main/java/org/deeplearning4j/parallelism/parameterserver/ParameterServerTrainerContext.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper-parameter-server/src/main/java/org/deeplearning4j/parallelism/parameterserver/ParameterServerTrainerContext.java
@@ -60,7 +60,7 @@ public class ParameterServerTrainerContext implements TrainerContext {
      * @return the created training instance
      */
     @Override
-    public Trainer create(int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
+    public Trainer create(String uuid, int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
                     WorkspaceMode mode, int averagingFrequency) {
         return ParameterServerTrainer.builder().originalModel(model).parameterServerClient(ParameterServerClient
                         .builder().aeron(parameterServerNode.getAeron())

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/DefaultTrainerContext.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/DefaultTrainerContext.java
@@ -39,11 +39,12 @@ public class DefaultTrainerContext implements TrainerContext {
      * @return the created training instance
      */
     @Override
-    public Trainer create(int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
+    public Trainer create(String uuid, int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
                     WorkspaceMode mode, int averagingFrequency) {
 
         DefaultTrainer trainer = DefaultTrainer.builder().originalModel(model).replicatedModel(model).threadId(threadId)
                         .parallelWrapper(wrapper).workspaceMode(mode).useMDS(useMDS)
+                        .uuid(uuid + "_thread_" + threadId)
                         .averagingFrequency(averagingFrequency).build();
 
         trainer.setName("DefaultTrainer thread " + threadId);

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/SymmetricTrainerContext.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/SymmetricTrainerContext.java
@@ -42,10 +42,10 @@ public class SymmetricTrainerContext implements TrainerContext {
      * @return the created training instance
      */
     @Override
-    public Trainer create(int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
+    public Trainer create(String uuid, int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
                     WorkspaceMode mode, int averagingFrequency) {
 
-        SymmetricTrainer trainer = new SymmetricTrainer(model, threadId, mode, wrapper, useMDS);
+        SymmetricTrainer trainer = new SymmetricTrainer(model, uuid, threadId, mode, wrapper, useMDS);
 
         trainer.setName("SymmetricTrainer thread " + threadId);
         trainer.setDaemon(true);

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/TrainerContext.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/TrainerContext.java
@@ -33,7 +33,7 @@ public interface TrainerContext {
      *                for coordination with the {@link ParallelWrapper} 's {@link org.deeplearning4j.optimize.api.IterationListener}
      * @return the created training instance
      */
-    Trainer create(int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
+    Trainer create(String uuid, int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
                     WorkspaceMode workspaceMode, int averagingFrequency);
 
 

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/DefaultTrainer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/DefaultTrainer.java
@@ -1,9 +1,6 @@
 package org.deeplearning4j.parallelism.trainer;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.api.storage.StatsStorageRouter;
 import org.deeplearning4j.api.storage.listener.RoutingIterationListener;
@@ -62,7 +59,7 @@ public class DefaultTrainer extends Thread implements Trainer {
     protected Exception thrownException;
     @Builder.Default
     protected volatile boolean useMDS = false;
-    protected final String uuid = UUID.randomUUID().toString();
+    @Getter protected String uuid;
     @Builder.Default
     protected boolean onRootModel = false;
     @Builder.Default

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/SymmetricTrainer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/SymmetricTrainer.java
@@ -20,9 +20,10 @@ import org.deeplearning4j.parallelism.ParallelWrapper;
 public class SymmetricTrainer extends DefaultTrainer implements CommunicativeTrainer {
     protected GradientsAccumulator accumulator;
 
-    public SymmetricTrainer(@NonNull Model originalModel, int threadIdx, @NonNull WorkspaceMode mode,
+    public SymmetricTrainer(@NonNull Model originalModel, String uuid, int threadIdx, @NonNull WorkspaceMode mode,
                     @NonNull ParallelWrapper wrapper, boolean useMDS) {
         super();
+        this.uuid = uuid + "_thread_" + threadIdx;
         this.useMDS = useMDS;
         this.originalModel = originalModel;
         this.threadId = threadIdx;

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/Trainer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/Trainer.java
@@ -41,6 +41,8 @@ public interface Trainer extends Runnable {
 
     boolean isRunning();
 
+    String getUuid();
+
     /**
      * Shutdown this worker
      */

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/factory/DefaultTrainerContextTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/factory/DefaultTrainerContextTest.java
@@ -1,0 +1,82 @@
+package org.deeplearning4j.parallelism.factory;
+
+import lombok.val;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.WorkspaceMode;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.parallelism.ParallelWrapper;
+import org.deeplearning4j.parallelism.trainer.SymmetricTrainer;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.learning.config.Nesterovs;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import static org.junit.Assert.*;
+
+public class DefaultTrainerContextTest {
+    int nChannels = 1;
+    int outputNum = 10;
+
+    // for GPU you usually want to have higher batchSize
+    int batchSize = 128;
+    int nEpochs = 10;
+    int iterations = 1;
+    int seed = 123;
+
+    @Test
+    public void testEqualUuid1() {
+        MultiLayerConfiguration.Builder builder = new NeuralNetConfiguration.Builder().seed(seed).iterations(iterations)
+                .l2(0.0005)
+                //.learningRateDecayPolicy(LearningRatePolicy.Inverse).lrPolicyDecayRate(0.001).lrPolicyPower(0.75)
+                .weightInit(WeightInit.XAVIER)
+                .updater(new Nesterovs(0.01, 0.9)).list()
+                .layer(0, new ConvolutionLayer.Builder(5, 5)
+                        //nIn and nOut specify depth. nIn here is the nChannels and nOut is the number of filters to be applied
+                        .nIn(nChannels).stride(1, 1).nOut(20).activation(Activation.IDENTITY).build())
+                .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX).kernelSize(2, 2)
+                        .stride(2, 2).build())
+                .layer(2, new ConvolutionLayer.Builder(5, 5)
+                        //Note that nIn needed be specified in later layers
+                        .stride(1, 1).nOut(50).activation(Activation.IDENTITY).build())
+                .layer(3, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX).kernelSize(2, 2)
+                        .stride(2, 2).build())
+                .layer(4, new DenseLayer.Builder().activation(Activation.RELU).nOut(500).build())
+                .layer(5, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
+                        .nOut(outputNum).activation(Activation.SOFTMAX).build())
+                .backprop(true).pretrain(false).setInputType(InputType.convolutionalFlat(28, 28, nChannels));
+
+        MultiLayerConfiguration conf = builder.build();
+        MultiLayerNetwork model = new MultiLayerNetwork(conf);
+        model.init();
+
+        // ParallelWrapper will take care of load balancing between GPUs.
+        ParallelWrapper wrapper = new ParallelWrapper.Builder(model)
+                // DataSets prefetching options. Set this value with respect to number of actual devices
+                .prefetchBuffer(24)
+
+                // set number of workers equal or higher then number of available devices. x1-x2 are good values to start with
+                .workers(2)
+
+                // rare averaging improves performance, but might reduce model accuracy
+                .averagingFrequency(3)
+
+                // if set to TRUE, on every averaging model score will be reported
+                .reportScoreAfterAveraging(true)
+
+                // optinal parameter, set to false ONLY if your system has support P2P memory access across PCIe (hint: AWS do not support P2P)
+                .build();
+
+        val context = new DefaultTrainerContext();
+        val trainer = context.create("alpha", 3, model, 0, true, wrapper, WorkspaceMode.NONE, 3);
+
+        assertEquals("alpha_thread_3", trainer.getUuid());
+    }
+
+}

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/factory/SymmetricTrainerContextTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/factory/SymmetricTrainerContextTest.java
@@ -1,0 +1,80 @@
+package org.deeplearning4j.parallelism.factory;
+
+import lombok.val;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.WorkspaceMode;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.parallelism.ParallelWrapper;
+import org.deeplearning4j.parallelism.trainer.SymmetricTrainer;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.learning.config.Nesterovs;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import static org.junit.Assert.*;
+
+public class SymmetricTrainerContextTest {
+    int nChannels = 1;
+    int outputNum = 10;
+
+    // for GPU you usually want to have higher batchSize
+    int batchSize = 128;
+    int nEpochs = 10;
+    int iterations = 1;
+    int seed = 123;
+
+    @Test
+    public void testEqualUuid1() {
+        MultiLayerConfiguration.Builder builder = new NeuralNetConfiguration.Builder().seed(seed).iterations(iterations)
+                .l2(0.0005)
+                //.learningRateDecayPolicy(LearningRatePolicy.Inverse).lrPolicyDecayRate(0.001).lrPolicyPower(0.75)
+                .weightInit(WeightInit.XAVIER)
+                .updater(new Nesterovs(0.01, 0.9)).list()
+                .layer(0, new ConvolutionLayer.Builder(5, 5)
+                        //nIn and nOut specify depth. nIn here is the nChannels and nOut is the number of filters to be applied
+                        .nIn(nChannels).stride(1, 1).nOut(20).activation(Activation.IDENTITY).build())
+                .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX).kernelSize(2, 2)
+                        .stride(2, 2).build())
+                .layer(2, new ConvolutionLayer.Builder(5, 5)
+                        //Note that nIn needed be specified in later layers
+                        .stride(1, 1).nOut(50).activation(Activation.IDENTITY).build())
+                .layer(3, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX).kernelSize(2, 2)
+                        .stride(2, 2).build())
+                .layer(4, new DenseLayer.Builder().activation(Activation.RELU).nOut(500).build())
+                .layer(5, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
+                        .nOut(outputNum).activation(Activation.SOFTMAX).build())
+                .backprop(true).pretrain(false).setInputType(InputType.convolutionalFlat(28, 28, nChannels));
+
+        MultiLayerConfiguration conf = builder.build();
+        MultiLayerNetwork model = new MultiLayerNetwork(conf);
+        model.init();
+
+        // ParallelWrapper will take care of load balancing between GPUs.
+        ParallelWrapper wrapper = new ParallelWrapper.Builder(model)
+                // DataSets prefetching options. Set this value with respect to number of actual devices
+                .prefetchBuffer(24)
+
+                // set number of workers equal or higher then number of available devices. x1-x2 are good values to start with
+                .workers(2)
+
+                // rare averaging improves performance, but might reduce model accuracy
+                .averagingFrequency(3)
+
+                // if set to TRUE, on every averaging model score will be reported
+                .reportScoreAfterAveraging(true)
+
+                // optinal parameter, set to false ONLY if your system has support P2P memory access across PCIe (hint: AWS do not support P2P)
+                .build();
+
+        val trainer = new SymmetricTrainer(model, "alpha", 3, WorkspaceMode.NONE, wrapper, true);
+
+        assertEquals("alpha_thread_3", trainer.getUuid());
+    }
+}


### PR DESCRIPTION
This PR adds: 

- UUID logic change for StatsListener
- ParallelWrapper javadoc updated

Idea is: let's assign UUID of individual workers as `uuid of PW instance` + `thread_id`. I.e.: `jdiskasdhe2313_thread_1`,  so if we'll have more then one epoch with given PW instance - UI won't spawn more and more additional "sessions" , the same name will be used for all subsequent threads/workers.

cc @AlexDBlack @crockpotveggies 