### PR TITLE
fit(DataSetIterator) without pretrain

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -857,8 +857,11 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
     }
 
     /**
-     * Fit the ComputationGraph using a DataSetIterator.
-     * Note that this method can only be used with ComputationGraphs with 1 input and 1 output
+     * Fit the ComputationGraph using a DataSetIterator.<br>
+     * Note that this method can only be used with ComputationGraphs with 1 input and 1 output<br>
+     * Method doesn't do layerwise  pretraining.<br>
+     * For pretraining use method pretrain.. {@link #pretrain(DataSetIterator)}<br>
+     * @param iterator Training data (DataSetIterator)
      */
     public void fit(DataSetIterator iterator) {
         if (flattenedGradients == null) {
@@ -888,10 +891,6 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             for (TrainingListener tl : trainingListeners) {
                 tl.onEpochStart(this);
             }
-        }
-
-        if (configuration.isPretrain()) {
-            pretrain(dataSetIterator);
         }
 
         MemoryWorkspace workspace =
@@ -984,6 +983,9 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
 
     /**
      * Fit the ComputationGraph using a MultiDataSetIterator
+     * Method doesn't do layerwise  pretraining.<br>
+     * For pretraining use method pretrain.. {@link #pretrain(MultiDataSetIterator)}<br>
+     * @param multi Training data (MultiDataSetIterator)
      */
     public void fit(MultiDataSetIterator multi) {
         if (flattenedGradients == null) {
@@ -1000,11 +1002,6 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             destructable = true;
         } else
             multiDataSetIterator = multi;
-
-        if (configuration.isPretrain()) {
-            pretrain(multiDataSetIterator);
-        }
-
 
         MemoryWorkspace workspace =
                 configuration.getTrainingWorkspaceMode() == WorkspaceMode.NONE ? new DummyWorkspace()

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1157,6 +1157,11 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
     }
 
     @Override
+    /**
+     * Method doesn't do layerwise  pretraining.<br>
+     * For pretraining use method pretrain.. {@link #pretrain(DataSetIterator)}<br>
+     * @param iterator Training data (DataSetIterator)
+     */
     public void fit(DataSetIterator iterator) {
         // we're wrapping all iterators into AsyncDataSetIterator to provide background prefetch - where appropriate
         DataSetIterator iter;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -224,6 +224,10 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         if (!layerWiseConfigurations.isPretrain())
             return;
 
+        for (TrainingListener tl : trainingListeners) {
+            tl.onEpochStart(this);
+        }
+
         for (int i = 0; i < getnLayers(); i++) {
             pretrainLayer(i, iter);
         }
@@ -1168,22 +1172,6 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         for (TrainingListener tl : trainingListeners) {
             tl.onEpochStart(this);
         }
-
-        if (layerWiseConfigurations.isPretrain()) {
-            pretrain(iter);
-            if (iter.resetSupported()) {
-                iter.reset();
-            }
-            //            while (iter.hasNext()) {
-            //                DataSet next = iter.next();
-            //                if (next.getFeatureMatrix() == null || next.getLabels() == null)
-            //                    break;
-            //                setInput(next.getFeatureMatrix());
-            //                setLabels(next.getLabels());
-            //                finetune();
-            //            }
-        }
-
 
         MemoryWorkspace workspace =
                         layerWiseConfigurations.getTrainingWorkspaceMode() == WorkspaceMode.NONE ? new DummyWorkspace()


### PR DESCRIPTION
## What changes were proposed in this pull request?

MultiLayerNetwork method fit( DataSetIterator) do in one epoch pretraining and backpropagation too. It is not suitable.

Training NN needs some epochs only pretraining and later some epochs only backpropagation.

I suggest:
- do pretraning for DataSetIterator in method pretrain(DataSetIterator)
- in method fit(DataSetIterator) do only backpropagation

In pretrain(DataSetIterator) method I added for TrainingListener's set onEpochStart(this).

## How was this patch tested?

I checked manually code.