### PR TITLE
Changes for child of MultiLayerNetwork

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -97,8 +97,8 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
     protected INDArray input, labels;
 
     protected boolean initCalled = false;
-    private Collection<IterationListener> listeners = new ArrayList<>();
-    private Collection<TrainingListener> trainingListeners = new ArrayList<>();
+    protected Collection<IterationListener> listeners = new ArrayList<>();
+    protected Collection<TrainingListener> trainingListeners = new ArrayList<>();
 
     protected NeuralNetConfiguration defaultConfiguration;
     protected MultiLayerConfiguration layerWiseConfigurations;
@@ -1015,8 +1015,8 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         }
         return ret;
     }
-
-    private boolean hasAFrozenLayer() {
+    
+    protected boolean hasAFrozenLayer() {
         for (int i = 0; i < layers.length - 1; i++) {
             if (layers[i] instanceof FrozenLayer)
                 return true;
@@ -2953,8 +2953,8 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
 
         return e;
     }
-
-    private void update(Task task) {
+    
+    protected void update(Task task) {
         if (!initDone) {
             initDone = true;
             Heartbeat heartbeat = Heartbeat.getInstance();


### PR DESCRIPTION
## What changes were proposed in this pull request?

If some method of MultiLayerNetwork is unsuitable is fast make child of MultiLayerNetwork and method override. But some variables and method are private and not visible.
I change private to protected.
I created getTrainingListeners. It is preparation for solving problem: For pretraing could be necessary other listeners than for backpropagation.

## How was this patch tested?

I checked manually code.