### PR TITLE
MultiLayerNetwork  - add getTrainingListeners

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1573,7 +1573,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
     *
     * @return trainingListeners
     */
-   public Collection<trainingListeners> getTrainingListeners() {
+   public Collection<TrainingListener> getTrainingListeners() {
        return trainingListeners;
    }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1573,7 +1573,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
     *
     * @return trainingListeners
     */
-   public Collection<IterationListener> getTrainingListeners() {
+   public Collection<trainingListeners> getTrainingListeners() {
        return trainingListeners;
    }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -1563,11 +1563,19 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
 
     /**
      *
-     * @return
+     * @return listeners
      */
     public Collection<IterationListener> getListeners() {
         return listeners;
     }
+
+    /**
+    *
+    * @return trainingListeners
+    */
+   public Collection<IterationListener> getTrainingListeners() {
+       return trainingListeners;
+   }
 
     @Override
     public void setListeners(Collection<IterationListener> listeners) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In MultiLayerNetwork I created getTrainingListeners. It is preparation for solving problem: For pretraing could be necessary other listeners than for backpropagation.

## How was this patch tested?

I checked manually code.
