### PR TITLE
MultiLayerNetwork - pretrainLayer - allow/block, check

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -1135,4 +1135,11 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
         }
     }
 
+    /**
+     * If pretrain == true pretrain is allowed
+     * @return pretrain
+     */
+    public boolean doPretrain() {
+    	return pretrain;
+    }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -308,7 +308,6 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         Layer layer = layers[layerIdx];
         if (!layer.isPretrainLayer())
             return;
-        layer.conf().setPretrain(true);
 
         MemoryWorkspace workspace = layerWiseConfigurations.getTrainingWorkspaceMode() == WorkspaceMode.NONE
                         ? new DummyWorkspace()
@@ -339,8 +338,6 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
             layer.fit(layerInput);
         }
 
-        // Turn off pretrain after it is complete
-        layer.conf().setPretrain(false);
     }
 
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -308,6 +308,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         Layer layer = layers[layerIdx];
         if (!layer.isPretrainLayer())
             return;
+        layer.conf().setPretrain(true);
 
         MemoryWorkspace workspace = layerWiseConfigurations.getTrainingWorkspaceMode() == WorkspaceMode.NONE
                         ? new DummyWorkspace()
@@ -337,7 +338,9 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
             }
             layer.fit(layerInput);
         }
-
+    
+        // Turn off pretrain after it is complete
+        layer.conf().setPretrain(false);
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) Method pretrainLayer(int layerIdx, INDArray features) in MultiLayerNetwork includes code:
        layer.conf().setPretrain(true);
        layer.conf().setPretrain(false);
  It is allow pretrain and block pretrain.

1a) Allow pretrain is not good idea.
  If user doesn't allow pretrain, code  may not allow it. Not pretrain is not usual, but it is user option and/or problem.

1b) Block pretrain is not good idea.
  Pretraining usualy includes more epochs and it is never sure this epoch is the last.

2) Methods pretrainLayer should check if pretran is alowed. If is not allowed get info and return.

  I created method doPretrain() in NeuralNetConfiguration. This method allow this checking.

## How was this patch tested?

I checked manually code.