### PR TITLE
Add ReverseTimeSeriesVertex to allow backward processing of time series

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.nn.conf.graph;
 
 import org.deeplearning4j.nn.conf.graph.rnn.DuplicateToTimeSeriesVertex;
 import org.deeplearning4j.nn.conf.graph.rnn.LastTimeStepVertex;
+import org.deeplearning4j.nn.conf.graph.rnn.ReverseTimeSeriesVertex;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
 import org.deeplearning4j.nn.conf.memory.MemoryReport;
@@ -42,6 +43,7 @@ import java.io.Serializable;
                 @JsonSubTypes.Type(value = SubsetVertex.class, name = "SubsetVertex"),
                 @JsonSubTypes.Type(value = LayerVertex.class, name = "LayerVertex"),
                 @JsonSubTypes.Type(value = LastTimeStepVertex.class, name = "LastTimeStepVertex"),
+                @JsonSubTypes.Type(value = ReverseTimeSeriesVertex.class, name = "ReverseTimeSeriesVertex"),
                 @JsonSubTypes.Type(value = DuplicateToTimeSeriesVertex.class, name = "DuplicateToTimeSeriesVertex"),
                 @JsonSubTypes.Type(value = PreprocessorVertex.class, name = "PreprocessorVertex"),
                 @JsonSubTypes.Type(value = StackVertex.class, name = "StackVertex"),

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/ReverseTimeSeriesVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/rnn/ReverseTimeSeriesVertex.java
@@ -1,0 +1,104 @@
+package org.deeplearning4j.nn.conf.graph.rnn;
+
+import lombok.Data;
+import org.deeplearning4j.nn.conf.graph.GraphVertex;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
+import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.nn.conf.memory.MemoryReport;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * ReverseTimeSeriesVertex is used in recurrent neural networks to revert the order of time series.
+ * As a result, the last time step is moved to the beginning of the time series and the first time step
+ * is moved to the end. This allows recurrent layers to backward process time series.<p>
+ *
+ * <b>Masks</b>: The input might be masked (to allow for varying time series lengths in one minibatch). In this case the
+ * present input (mask array = 1) will be reverted in place and the padding (mask array = 0) will be left untouched at
+ * the same place. For a time series of length n, this would normally mean, that the first n time steps are reverted and
+ * the following padding is left untouched, but more complex masks are supported (e.g. [1, 0, 1, 0, ...].<br>
+ * <b>Note</b>: In order to use mask arrays, the {@link #ReverseTimeSeriesVertex(String) constructor} must be called with
+ * the name of an network input. The mask of this input is then used in this vertex, too.
+ *
+ * @author Klaus Broelemann (SCHUFA Holding AG)
+ */
+@Data
+public class ReverseTimeSeriesVertex extends GraphVertex {
+    private final String maskArrayInputName;
+
+    /**
+     * Creates a new ReverseTimeSeriesVertex that doesn't pay attention to masks
+     */
+    public ReverseTimeSeriesVertex() {
+        this(null);
+    }
+
+    /**
+     * Creates a new ReverseTimeSeriesVertex that uses the mask array of a given input
+     * @param maskArrayInputName The name of the input that holds the mask.
+     */
+    public ReverseTimeSeriesVertex(String maskArrayInputName) {
+        this.maskArrayInputName = maskArrayInputName;
+    }
+
+    public ReverseTimeSeriesVertex clone() {
+        return new ReverseTimeSeriesVertex(maskArrayInputName);
+    }
+
+    public boolean equals(Object o) {
+        if (!(o instanceof ReverseTimeSeriesVertex))
+            return false;
+        ReverseTimeSeriesVertex rsgv = (ReverseTimeSeriesVertex) o;
+        if (maskArrayInputName == null && rsgv.maskArrayInputName != null
+                || maskArrayInputName != null && rsgv.maskArrayInputName == null)
+            return false;
+        return maskArrayInputName == null || maskArrayInputName.equals(rsgv.maskArrayInputName);
+    }
+
+    @Override
+    public int hashCode() {
+        return maskArrayInputName != null ? maskArrayInputName.hashCode() : 0;
+    }
+
+    public int numParams(boolean backprop) {
+        return 0;
+    }
+
+    public int minVertexInputs() {
+        return 1;
+    }
+
+    public int maxVertexInputs() {
+        return 1;
+    }
+
+    public org.deeplearning4j.nn.graph.vertex.impl.rnn.ReverseTimeSeriesVertex instantiate(ComputationGraph graph, String name, int idx, INDArray paramsView, boolean initializeParams) {
+        return new org.deeplearning4j.nn.graph.vertex.impl.rnn.ReverseTimeSeriesVertex(graph, name, idx, maskArrayInputName);
+    }
+
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
+        if (vertexInputs.length != 1)
+            throw new InvalidInputTypeException("Invalid input type: cannot revert more than 1 input");
+        if (vertexInputs[0].getType() != InputType.Type.RNN) {
+            throw new InvalidInputTypeException(
+                    "Invalid input type: cannot revert non RNN input (got: " + vertexInputs[0] + ")");
+        }
+
+        return vertexInputs[0];
+    }
+
+    public MemoryReport getMemoryReport(InputType... inputTypes) {
+        //No additional working memory (beyond activations/epsilons)
+        return new LayerMemoryReport.Builder(null, getClass(), inputTypes[0], getOutputType(-1, inputTypes))
+                .standardMemory(0, 0)
+                .workingMemory(0, 0, 0, 0)
+                .cacheMemory(0, 0)
+                .build();
+    }
+
+    public String toString() {
+        final String paramStr = (maskArrayInputName == null) ? "" : "inputName=" + maskArrayInputName;
+        return "ReverseTimeSeriesVertex(" + paramStr + ")";
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/rnn/ReverseTimeSeriesVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/rnn/ReverseTimeSeriesVertex.java
@@ -1,0 +1,187 @@
+package org.deeplearning4j.nn.graph.vertex.impl.rnn;
+
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.graph.vertex.BaseGraphVertex;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.indexing.INDArrayIndex;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.primitives.Pair;
+
+/**
+ * ReverseTimeSeriesVertex is used in recurrent neural networks to revert the order of time series.
+ * As a result, the last time step is moved to the beginning of the time series and the first time step
+ * is moved to the end. This allows recurrent layers to backward process time series.<p>
+ *
+ * <b>Masks</b>: The input might be masked (to allow for varying time series lengths in one minibatch). In this case the
+ * present input (mask array = 1) will be reverted in place and the padding (mask array = 0) will be left untouched at
+ * the same place. For a time series of length n, this would normally mean, that the first n time steps are reverted and
+ * the following padding is left untouched, but more complex masks are supported (e.g. [1, 0, 1, 0, ...].<br>
+ *
+ * @author Klaus Broelemann (SCHUFA Holding AG)
+ */
+public class ReverseTimeSeriesVertex extends BaseGraphVertex {
+    private final String inputName;
+    private final int inputIdx;
+
+    public ReverseTimeSeriesVertex(ComputationGraph graph, String name, int vertexIndex, String inputName) {
+        super(graph, name, vertexIndex, null, null);
+        this.inputName = inputName;
+
+
+        if (inputName == null) {
+            // Don't use masks
+            this.inputIdx = -1;
+        } else {
+            // Find the given input
+            this.inputIdx = graph.getConfiguration().getNetworkInputs().indexOf(inputName);
+            if (inputIdx == -1)
+                throw new IllegalArgumentException("Invalid input name: \"" + inputName + "\" not found in list "
+                        + "of network inputs (" + graph.getConfiguration().getNetworkInputs() + ")");
+        }
+    }
+
+    public boolean hasLayer() {
+        return false;
+    }
+
+    public boolean isOutputVertex() {
+        return false;
+    }
+
+    public Layer getLayer() {
+        return null;
+    }
+
+    public INDArray doForward(boolean training) {
+        // Get the mask arrays for the given input, if any
+        final INDArray mask = getMask();
+
+        // Store the input
+        final INDArray input = inputs[0];
+
+        // Compute the output
+        return revertTimeSeries(input, mask);
+    }
+
+    public Pair<Gradient, INDArray[]> doBackward(boolean tbptt) {
+
+        // Get the mask arrays for the given input, if any
+        INDArray mask = getMask();
+
+        // Backpropagate the output error (epsilon) to the input variables:
+        //      Just undo the revert (which can be done by another revert)
+        INDArray epsilonsOut = revertTimeSeries(epsilon, mask);
+
+        return new Pair<>(null, new INDArray[] {epsilonsOut});
+    }
+
+    /**
+     * Gets the current mask array from the provided input
+     * @return The mask or null, if no input was provided
+     */
+    private INDArray getMask() {
+        // If no input is provided, no mask is used and null is returned
+        if (inputIdx < 0) {
+            return null;
+        }
+
+        final INDArray[] inputMaskArrays = graph.getInputMaskArrays();
+        return (inputMaskArrays != null ? inputMaskArrays[inputIdx] : null);
+    }
+
+    /**
+     * Reverts the element order of a tensor along the 3rd axis (time series axis).
+     * A masking tensor is used to restrict the revert to meaningful elements and keep the padding in place.
+     *
+     * This method is self-inverse in the following sense:
+     * {@code revertTensor( revertTensor (input, mask), mask )}
+     * equals
+     * {@code input}
+     * @param input The input tensor
+     * @param mask The masking tensor (1 for meaningful entries, 0 for padding)
+     * @return The reverted mask.
+     */
+    private static INDArray revertTimeSeries(INDArray input, INDArray mask) {
+        // Get number of samples
+        int n = input.size(0);
+
+        // Get maximal length of a time series
+        int m = input.size(2);
+
+        // Create empty output
+        INDArray out = input.dup();
+
+        // Iterate over all samples
+        for (int s = 0; s < n; s++) {
+            int t1 = 0;       // Original time step
+            int t2 = m - 1;   // Destination time step
+
+            // Revert Sample: Copy from origin (t1) to destination (t2)
+            while (t1 < m && t2 >= 0) {
+
+                // If mask is set: ignore padding
+                if (mask != null) {
+                    // Origin: find next time step
+                    while (t1 < m && mask.getDouble(s, t1) == 0) {
+                        t1++;
+                    }
+                    // Destination: find next time step
+                    while (t2 >= 0 && mask.getDouble(s, t2) == 0) {
+                        t2--;
+                    }
+                }
+
+                // Get the feature vector for the given sample and origin time step
+                // The vector contains features (forward pass) or errors (backward pass)
+                INDArray vec = input.get(
+                        NDArrayIndex.point(s),
+                        NDArrayIndex.all(),
+                        NDArrayIndex.point(t1)
+                );
+
+                // Put the feature vector to the given destination in the output
+                out.put(new INDArrayIndex[]{
+                                NDArrayIndex.point(s),
+                                NDArrayIndex.all(),
+                                NDArrayIndex.point(t2)
+                        },
+                        vec
+                );
+
+                // Move on
+                t1++;
+                t2--;
+            }
+        }
+
+        // Return the output
+        return out;
+    }
+
+    public void setBackpropGradientsViewArray(INDArray backpropGradientsViewArray) {
+        if (backpropGradientsViewArray != null)
+            throw new RuntimeException("Vertex does not have gradients; gradients view array cannot be set here");
+    }
+
+    public Pair<INDArray, MaskState> feedForwardMaskArrays(INDArray[] maskArrays, MaskState currentMaskState,
+                                                           int minibatchSize)
+    {
+        if (maskArrays.length > 1) {
+            throw new IllegalArgumentException("This vertex can only handle one input and hence only one mask");
+        }
+
+        // The mask does not change.
+        return new Pair<>(maskArrays[0], currentMaskState);
+    }
+
+    @Override
+    public String toString() {
+        final String paramStr = (inputName == null) ? "" : "inputName=" + inputName;
+        return "ReverseTimeSeriesVertex(" + paramStr + ")";
+    }
+
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
We propose a new vertex type for usage with RNNs that reverts the order of time series.
This allows to backward process times series. 
We used this in one project to establish two stacks of layers - one for forward and one for backward processing - that were combined at the end of the computation pipeline.

## How was this patch tested?
- The vertex is used in one project and were tested manually and on base of the overall system output.
- Some changes were made to improve code quality for this pull request. These were only tested manually.

This is our first pull request to this project (hence a small class) and we are looking forward to some feedback.
