### PR TITLE
Add coefficient of determination metric

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/RegressionEvalTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/RegressionEvalTest.java
@@ -57,19 +57,21 @@ public class RegressionEvalTest {
             assertEquals(0.0, eval.rootMeanSquaredError(i), 1e-6);
             assertEquals(0.0, eval.relativeSquaredError(i), 1e-6);
             assertEquals(1.0, eval.correlationR2(i), 1e-6);
+            assertEquals(1.0, eval.pearsonCorrelation(i), 1e-6);
+            assertEquals(1.0, eval.rSquared(i), 1e-6);
         }
     }
 
     @Test
     public void testKnownValues() {
         double[][] labelsD = new double[][] {{1, 2, 3}, {0.1, 0.2, 0.3}, {6, 5, 4}};
-
         double[][] predictedD = new double[][] {{2.5, 3.2, 3.8}, {2.15, 1.3, -1.2}, {7, 4.5, 3}};
 
         double[] expMSE = {2.484166667, 0.966666667, 1.296666667};
         double[] expMAE = {1.516666667, 0.933333333, 1.1};
         double[] expRSE = {0.368813923, 0.246598639, 0.530937216};
         double[] expCorrs = {0.997013483, 0.968619605, 0.915603032};
+        double[] expR2 = {0.63118608, 0.75340136 , 0.46906278};
 
         INDArray labels = Nd4j.create(labelsD);
         INDArray predicted = Nd4j.create(predictedD);
@@ -79,13 +81,13 @@ public class RegressionEvalTest {
         for (int xe = 0; xe < 2; xe++) {
             eval.eval(labels, predicted);
 
-            for (int i = 0; i < 3; i++) {
-                assertEquals(expMSE[i], eval.meanSquaredError(i), 1e-5);
-                assertEquals(expMAE[i], eval.meanAbsoluteError(i), 1e-5);
-                assertEquals(Math.sqrt(expMSE[i]), eval.rootMeanSquaredError(i), 1e-5);
-                assertEquals(expRSE[i], eval.relativeSquaredError(i), 1e-5);
-                assertEquals(expCorrs[i], eval.correlationR2(i), 1e-5);
-
+            for (int col = 0; col < 3; col++) {
+                assertEquals(expMSE[col], eval.meanSquaredError(col), 1e-5);
+                assertEquals(expMAE[col], eval.meanAbsoluteError(col), 1e-5);
+                assertEquals(Math.sqrt(expMSE[col]), eval.rootMeanSquaredError(col), 1e-5);
+                assertEquals(expRSE[col], eval.relativeSquaredError(col), 1e-5);
+                assertEquals(expCorrs[col], eval.pearsonCorrelation(col), 1e-5);
+                assertEquals(expR2[col], eval.rSquared(col), 1e-5);
             }
 
             eval.reset();

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/RegressionEvaluation.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/RegressionEvaluation.java
@@ -21,7 +21,8 @@ import java.util.List;
  * - MAE: mean absolute error<br>
  * - RMSE: root mean squared error<br>
  * - RSE: relative squared error<br>
- * - correlation coefficient<br>
+ * - PC: pearson correlation coefficient<br>
+ * - R^2: coefficient of determination
  * See for example: http://www.saedsayad.com/model_evaluation_r.htm
  * For classification, see {@link Evaluation}
  *
@@ -63,6 +64,9 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
     @JsonSerialize(using = RowVectorSerializer.class)
     @JsonDeserialize(using = RowVectorDeserializer.class)
     private INDArray sumSquaredPredicted;
+    @JsonSerialize(using = RowVectorSerializer.class)
+    @JsonDeserialize(using = RowVectorDeserializer.class)
+    private INDArray sumSquaredLabelDeviations;
 
     public RegressionEvaluation() {
         this(null, DEFAULT_PRECISION);
@@ -131,6 +135,7 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
         sumOfProducts = Nd4j.zeros(n);
         sumSquaredLabels = Nd4j.zeros(n);
         sumSquaredPredicted = Nd4j.zeros(n);
+        sumSquaredLabelDeviations = Nd4j.zeros(n);
 
         initialized = true;
     }
@@ -198,6 +203,7 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
         sumSquaredLabels.addi(labels.mul(labels).sum(0));
         sumSquaredPredicted.addi(predictions.mul(predictions).sum(0));
 
+
         int nRows = labels.size(0);
 
         INDArray newExampleCountPerColumn;
@@ -210,6 +216,9 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
         currentPredictionMean.muliRowVector(exampleCountPerColumn).addi(predictions.sum(0))
                         .divi(newExampleCountPerColumn);
         exampleCountPerColumn = newExampleCountPerColumn;
+
+        final INDArray n = labels.dup().subRowVector(currentMean);
+        sumSquaredLabelDeviations.addi(n.muli(n).sum(0));
     }
 
     @Override
@@ -266,29 +275,38 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
             int labelWidth = maxLabelLength + 5;
             int columnWidth = precision + 10;
 
-            String format = "%-" + labelWidth + "s" + "%-" + columnWidth + "." + precision + "e" //MSE
-                            + "%-" + columnWidth + "." + precision + "e" //MAE
-                            + "%-" + columnWidth + "." + precision + "e" //RMSE
-                            + "%-" + columnWidth + "." + precision + "e" //RSE
-                            + "%-" + columnWidth + "." + precision + "e"; //R2 (correlation coefficient)
-
+            String resultFormat = "%-" + labelWidth + "s" +
+                "%-" + columnWidth + "." + precision + "e" + //MSE
+                "%-" + columnWidth + "." + precision + "e" + //MAE
+                "%-" + columnWidth + "." + precision + "e" + //RMSE
+                "%-" + columnWidth + "." + precision + "e" + //RSE
+                "%-" + columnWidth + "." + precision + "e" + //PC
+                "%-" + columnWidth + "." + precision + "e";  //R2
 
             //Print header:
             StringBuilder sb = new StringBuilder();
-            String headerFormat = "%-" + labelWidth + "s" + "%-" + columnWidth + "s" + "%-" + columnWidth + "s" + "%-"
-                            + columnWidth + "s" + "%-" + columnWidth + "s" + "%-" + columnWidth + "s";
-            sb.append(String.format(headerFormat, "Column", "MSE", "MAE", "RMSE", "RSE", "R^2"));
+            String headerFormat = "%-" + labelWidth + "s" +
+                "%-" + columnWidth + "s" + // MSE
+                "%-" + columnWidth + "s" + // MAE
+                "%-" + columnWidth + "s" + // RMSE
+                "%-" + columnWidth + "s" + // RSE
+                "%-" + columnWidth + "s" + // PC
+                "%-" + columnWidth + "s";  // R2
+
+            sb.append(String.format(headerFormat, "Column", "MSE", "MAE", "RMSE", "RSE", "PC", "R^2"));
             sb.append("\n");
 
             //Print results for each column:
             for (int i = 0; i < columnNames.size(); i++) {
+                String name = columnNames.get(i);
                 double mse = meanSquaredError(i);
                 double mae = meanAbsoluteError(i);
                 double rmse = rootMeanSquaredError(i);
                 double rse = relativeSquaredError(i);
-                double corr = correlationR2(i);
+                double corr = pearsonCorrelation(i);
+                double r2 = rSquared(i);
 
-                sb.append(String.format(format, columnNames.get(i), mse, mae, rmse, rse, corr));
+                sb.append(String.format(resultFormat, name, mse, mae, rmse, rse, corr, r2));
                 sb.append("\n");
             }
 
@@ -321,22 +339,54 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
         return Math.sqrt(sumSquaredErrorsPerColumn.getDouble(column) / exampleCountPerColumn.getDouble(column));
     }
 
+    /**
+     * Legacy method for the correlation score.
+     *
+     * @param column Column to evaluate
+     * @return Pearson Correlation for the given column
+     * @see {@link #pearsonCorrelation(int)}
+     * @deprecated Use {@link #pearsonCorrelation(int)} instead.
+     * For the R2 score use {@link #rSquared(int)}.
+     */
+    @Deprecated
     public double correlationR2(int column) {
-        //r^2 Correlation coefficient
+        return pearsonCorrelation(column);
+    }
 
+    /**
+     * Pearson Correlation Coefficient for samples
+     *
+     * @param column Column to evaluate
+     * @return Pearson Correlation Coefficient for column with index {@code column}
+     * @see <a href="https://en.wikipedia.org/wiki/Pearson_correlation_coefficient#For_a_sample">Wikipedia</a>
+     */
+    public double pearsonCorrelation(int column) {
         double sumxiyi = sumOfProducts.getDouble(column);
-        double predictionMean = this.currentPredictionMean.getDouble(column);
-        double labelMean = this.currentMean.getDouble(column);
+        double predictionMean = currentPredictionMean.getDouble(column);
+        double labelMean = currentMean.getDouble(column);
 
         double sumSquaredLabels = this.sumSquaredLabels.getDouble(column);
         double sumSquaredPredicted = this.sumSquaredPredicted.getDouble(column);
 
         double exampleCount = exampleCountPerColumn.getDouble(column);
-        double r2 = sumxiyi - exampleCount * predictionMean * labelMean;
-        r2 /= Math.sqrt(sumSquaredLabels - exampleCount * labelMean * labelMean)
-                        * Math.sqrt(sumSquaredPredicted - exampleCount * predictionMean * predictionMean);
+        double r = sumxiyi - exampleCount * predictionMean * labelMean;
+        r /= Math.sqrt(sumSquaredLabels - exampleCount * labelMean * labelMean)
+            * Math.sqrt(sumSquaredPredicted - exampleCount * predictionMean * predictionMean);
 
-        return r2;
+        return r;
+    }
+
+    /**
+     * Coefficient of Determination (R^2 Score)
+     *
+     * @param column Column to evaluate
+     * @return R^2 score for column with index {@code column}
+     * @see <a href="https://en.wikipedia.org/wiki/Coefficient_of_determination">Wikipedia</a>
+     */
+    public double rSquared(int column) {
+        final double sstot = sumSquaredLabelDeviations.getDouble(column);
+        final double ssres = sumSquaredErrorsPerColumn.getDouble(column);
+        return (sstot - ssres) / sstot;
     }
 
     public double relativeSquaredError(int column) {
@@ -410,13 +460,41 @@ public class RegressionEvaluation extends BaseEvaluation<RegressionEvaluation> {
 
 
     /**
-     * Average R2 across all columns
-     * @return
+     * Legacy method for the correlation average across all columns.
+     *
+     * @return Pearson Correlation averaged over all columns
+     * @see {@link #averagePearsonCorrelation()}
+     * @deprecated Use {@link #averagePearsonCorrelation()} instead.
+     * For the R2 score use {@link #averageRSquared()}.
      */
+    @Deprecated
     public double averagecorrelationR2() {
+        return averagePearsonCorrelation();
+    }
+
+    /**
+     * Average Pearson Correlation Coefficient across all columns
+     *
+     * @return Pearson Correlation Coefficient across all columns
+     */
+    public double averagePearsonCorrelation() {
         double ret = 0.0;
         for (int i = 0; i < numColumns(); i++) {
-            ret += correlationR2(i);
+            ret += pearsonCorrelation(i);
+        }
+
+        return ret / (double) numColumns();
+    }
+
+    /**
+     * Average R2 across all columns
+     *
+     * @return R2 score accross all columns
+     */
+    public double averageRSquared() {
+        double ret = 0.0;
+        for (int i = 0; i < numColumns(); i++) {
+            ret += rSquared(i);
         }
 
         return ret / (double) numColumns();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Distinguish between Pearson Correlation and Coefficient of Determination as for the implementation of `correlationR2` actually calculated the Pearson Correlation. Additionally the `rSquared` method was added, which calculates the Coefficient of Determination.

Fixes: #4342

## How was this patch tested?
Test values were added in `RegressionEvalTest` and computed with [sklearn.metrics.r2_score](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html)
