### PR TITLE
Fixes

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/ReshapePreprocessor.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/ReshapePreprocessor.java
@@ -84,7 +84,7 @@ public class ReshapePreprocessor extends BaseInputPreProcessor {
 
     @Override
     public INDArray backprop(INDArray output, int miniBatchSize) {
-        if (targetShape != output.shape()) {
+        if (!Arrays.equals(targetShape, output.shape())) {
             throw new IllegalStateException("Unexpected output shape" + Arrays.toString(output.shape())
                     + " (expected to be " + Arrays.toString(targetShape) + ")");
         }

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/TensorFlowCnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/TensorFlowCnnToFeedForwardPreProcessor.java
@@ -3,6 +3,7 @@ package org.deeplearning4j.nn.modelimport.keras.preprocessors;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.nn.conf.preprocessor.CnnToFeedForwardPreProcessor;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
@@ -38,15 +39,22 @@ public class TensorFlowCnnToFeedForwardPreProcessor extends CnnToFeedForwardPreP
          * TensorFlow convolutional input: # rows, # cols, # channels
          * Theano convolutional input:     # channels, # rows, # cols
          */
-        INDArray permuted = input.permute(0, 2, 3, 1);
-        INDArray flatPermuted = super.preProcess(permuted, miniBatchSize);
-        return flatPermuted;
+        INDArray permuted = input.permute(0, 2, 3, 1).dup('c'); //To: [n, h, w, c]
+
+        int[] inShape = input.shape(); //[miniBatch,depthOut,outH,outW]
+        int[] outShape = new int[] {inShape[0], inShape[1] * inShape[2] * inShape[3]};
+
+        return permuted.reshape('c', outShape);
     }
 
     @Override
     public INDArray backprop(INDArray epsilons, int miniBatchSize) {
-        INDArray epsilonsReshaped = super.backprop(epsilons, miniBatchSize);
-        return epsilonsReshaped.permute(0, 3, 1, 2);
+        if (epsilons.ordering() != 'c' || !Shape.strideDescendingCAscendingF(epsilons))
+            epsilons = epsilons.dup('c');
+
+        INDArray epsilonsReshaped = epsilons.reshape('c', epsilons.size(0), inputHeight, inputWidth, numChannels);
+
+        return epsilonsReshaped.permute(0, 3, 1, 2);    //To [n, c, h, w]
     }
 
     @Override

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasModelEndToEndTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasModelEndToEndTest.java
@@ -19,13 +19,27 @@ package org.deeplearning4j.nn.modelimport.keras.e2e;
 
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.eval.ROCMultiClass;
+import org.deeplearning4j.gradientcheck.GradientCheckUtil;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.layers.IOutputLayer;
+import org.deeplearning4j.nn.conf.layers.FeedForwardLayer;
+import org.deeplearning4j.nn.conf.layers.LossLayer;
 import org.deeplearning4j.nn.modelimport.keras.Hdf5Archive;
 import org.deeplearning4j.nn.modelimport.keras.KerasModel;
 import org.deeplearning4j.nn.modelimport.keras.utils.KerasModelUtils;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.transferlearning.FineTuneConfiguration;
+import org.deeplearning4j.nn.transferlearning.TransferLearning;
 import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.activations.IActivation;
+import org.nd4j.linalg.activations.impl.*;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.io.ClassPathResource;
+import org.nd4j.linalg.learning.config.NoOp;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -33,9 +47,11 @@ import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for end-to-end Keras model import.
@@ -104,7 +120,7 @@ public class KerasModelEndToEndTest {
     public void importMnistCnnTfKeras2() throws Exception {
         String modelPath = "modelimport/keras/examples/mnist_cnn/mnist_cnn_tf_keras_2_model.h5";
         String inputsOutputPath = "modelimport/keras/examples/mnist_cnn/mnist_cnn_tf_keras_2_inputs_and_outputs.h5";
-        importEndModelTest(modelPath, inputsOutputPath, true, true);
+        importEndModelTest(modelPath, inputsOutputPath, true, true, true);
     }
 
     /**
@@ -220,6 +236,11 @@ public class KerasModelEndToEndTest {
 
 
     void importEndModelTest(String modelPath, String inputsOutputsPath, boolean tfOrdering, boolean checkPredictions) throws Exception {
+        importEndModelTest(modelPath, inputsOutputsPath, tfOrdering, checkPredictions, false);
+    }
+
+    void importEndModelTest(String modelPath, String inputsOutputsPath, boolean tfOrdering, boolean checkPredictions,
+                            boolean checkGradients) throws Exception {
         ClassPathResource modelResource =
                 new ClassPathResource(modelPath,
                         KerasModelEndToEndTest.class.getClassLoader());
@@ -255,6 +276,19 @@ public class KerasModelEndToEndTest {
              */
             INDArray outputs = getOutputs(outputsArchive, true)[0];
             compareMulticlassAUC("predictions", outputs, predictionsKeras, predictionsDl4j, 10, EPS);
+        }
+
+        if (checkGradients){
+            Random r = new Random(12345);
+            INDArray input = getInputs(outputsArchive, tfOrdering)[0];
+            INDArray predictionsDl4j = model.output(input, false);
+
+            //Infer one-hot labels... this probably won't work for all
+            INDArray testLabels = Nd4j.create(predictionsDl4j.shape());
+            for( int i=0; i<testLabels.size(0); i++ ){
+                testLabels.putScalar(i, r.nextInt(testLabels.size(1)), 1.0);
+            }
+            checkGradients(model, input, testLabels);
         }
     }
 
@@ -306,7 +340,7 @@ public class KerasModelEndToEndTest {
         return predictions;
     }
 
-    static public void compareINDArrays(String label, INDArray a, INDArray b, double eps) {
+    public static void compareINDArrays(String label, INDArray a, INDArray b, double eps) {
         INDArray diff = a.sub(b);
         double min = diff.minNumber().doubleValue();
         double max = diff.maxNumber().doubleValue();
@@ -314,7 +348,7 @@ public class KerasModelEndToEndTest {
         assert (a.equalsWithEps(b, eps));
     }
 
-    static public void compareMulticlassAUC(String label, INDArray target, INDArray a, INDArray b, int nbClasses,
+    public static void compareMulticlassAUC(String label, INDArray target, INDArray a, INDArray b, int nbClasses,
                                             double eps) {
         ROCMultiClass evalA = new ROCMultiClass(100);
         evalA.eval(target, a);
@@ -331,5 +365,50 @@ public class KerasModelEndToEndTest {
             aucB[i] = evalB.calculateAUC(i);
         }
         assertArrayEquals(aucA, aucB, EPS);
+    }
+
+    public static void checkGradients(MultiLayerNetwork net, INDArray input, INDArray labels){
+        double eps = 1e-6;
+        double max_rel_error = 1e-3;
+        double min_abs_error = 1e-8;
+
+        MultiLayerNetwork netToTest;
+        if(net.getOutputLayer() instanceof IOutputLayer){
+            netToTest = net;
+        } else {
+            netToTest = new TransferLearning.Builder(net)
+                    .fineTuneConfiguration(new FineTuneConfiguration.Builder()
+                            .updater(new NoOp())
+                            .dropOut(0.0)
+                    .build())
+                    .addLayer(new LossLayer.Builder()
+                    .lossFunction(LossFunctions.LossFunction.MSE)
+                    .activation(Activation.IDENTITY)
+                    .build())
+                    .build();
+        }
+
+        System.out.println("Num params: " + net.numParams());
+
+        //Remove any dropout manually - until this is fixed: https://github.com/deeplearning4j/deeplearning4j/issues/4368
+        for(Layer l : netToTest.getLayers()){
+            l.conf().getLayer().setIDropout(null);
+
+            //Also swap out activation functions... this is a bit of a hack, but should make the net gradient checkable...
+            if(l instanceof FeedForwardLayer){
+                FeedForwardLayer ffl = (FeedForwardLayer)l;
+                IActivation activation = ffl.getActivationFn();
+                if(activation instanceof ActivationReLU || activation instanceof ActivationLReLU){
+                    ffl.setActivationFn(new ActivationSoftPlus());
+                } else if(activation instanceof ActivationHardTanH){
+                    ffl.setActivationFn(new ActivationTanH());
+                }
+            }
+        }
+
+        Nd4j.setDataType(DataBuffer.Type.DOUBLE);
+        boolean passed = GradientCheckUtil.checkGradients(netToTest, eps, max_rel_error, min_abs_error, true, false,
+                input, labels, null, null, true, 9);
+        assertTrue("Gradient check failed", passed);
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/gradientcheck/GradientCheckUtil.java
@@ -33,10 +33,7 @@ import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.impl.LossMCXENT;
 import org.nd4j.linalg.primitives.Pair;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /** A utility for numerically checking gradients. <br>
  * Basic idea: compare calculated gradients with those calculated numerically,
@@ -117,6 +114,14 @@ public class GradientCheckUtil {
     public static boolean checkGradients(MultiLayerNetwork mln, double epsilon, double maxRelError,
                                          double minAbsoluteError, boolean print, boolean exitOnFirstError,
                                          INDArray input, INDArray labels, INDArray inputMask, INDArray labelMask) {
+        return checkGradients(mln, epsilon, maxRelError, minAbsoluteError, print, exitOnFirstError,
+                input, labels, inputMask, labelMask, false, -1);
+    }
+
+    public static boolean checkGradients(MultiLayerNetwork mln, double epsilon, double maxRelError,
+                                         double minAbsoluteError, boolean print, boolean exitOnFirstError,
+                                         INDArray input, INDArray labels, INDArray inputMask, INDArray labelMask,
+                                         boolean subset, int maxPerParam) {
         //Basic sanity checks on input:
         if (epsilon <= 0.0 || epsilon > 0.1)
             throw new IllegalArgumentException("Invalid epsilon: expect epsilon in range (0,0.1], usually 1e-4 or so");
@@ -193,8 +198,32 @@ public class GradientCheckUtil {
         List<String> paramNames = new ArrayList<>(paramTable.keySet());
         int[] paramEnds = new int[paramNames.size()];
         paramEnds[0] = paramTable.get(paramNames.get(0)).length();
+        Map<String,Integer> stepSizeForParam;
+        if(subset){
+            stepSizeForParam = new HashMap<>();
+            stepSizeForParam.put(paramNames.get(0), Math.max(1, paramTable.get(paramNames.get(0)).length() / maxPerParam));
+        } else {
+            stepSizeForParam = null;
+        }
         for (int i = 1; i < paramEnds.length; i++) {
-            paramEnds[i] = paramEnds[i - 1] + paramTable.get(paramNames.get(i)).length();
+            int n = paramTable.get(paramNames.get(i)).length();
+            paramEnds[i] = paramEnds[i - 1] + n;
+            if(subset){
+                int ss = n / maxPerParam;
+                if(ss == 0){
+                    ss = n;
+                }
+                stepSizeForParam.put(paramNames.get(i), ss);
+            }
+        }
+
+        if(print) {
+            int i=0;
+            for (Layer l : mln.getLayers()) {
+                Set<String> s = l.paramTable().keySet();
+                System.out.println("Layer " + i + ": " + l.getClass().getSimpleName() + " - params " + s);
+                i++;
+            }
         }
 
 
@@ -204,7 +233,7 @@ public class GradientCheckUtil {
         int currParamNameIdx = 0;
 
         INDArray params = mln.params(); //Assumption here: params is a view that we can modify in-place
-        for (int i = 0; i < nParams; i++) {
+        for (int i = 0; i < nParams; ) {
             //Get param name
             if (i >= paramEnds[currParamNameIdx]) {
                 currParamNameIdx++;
@@ -259,6 +288,18 @@ public class GradientCheckUtil {
                 log.info("Param " + i + " (" + paramName + ") passed: grad= " + backpropGradient + ", numericalGrad= "
                                 + numericalGradient + ", relError= " + relError);
             }
+
+            int step;
+            if(subset){
+                step = stepSizeForParam.get(paramName);
+                if(i + step > paramEnds[currParamNameIdx]+1){
+                    step = paramEnds[currParamNameIdx]+1 - i;
+                }
+            } else {
+                step = 1;
+            }
+
+            i += step;
         }
 
         if (print) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
@@ -146,6 +146,11 @@ public class ZeroPaddingLayer extends Layer {
         }
 
         public Builder(int[] padding) {
+            if(padding.length == 2){
+                padding = new int[]{padding[0], padding[0], padding[1], padding[1]};
+            } else if(padding.length != 4){
+                throw new IllegalArgumentException("Padding must have exactly 2 or 4 values - got " + Arrays.toString(padding));
+            }
             this.padding = padding;
         }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/CnnToFeedForwardPreProcessor.java
@@ -48,9 +48,9 @@ import java.util.Arrays;
  */
 @Data
 public class CnnToFeedForwardPreProcessor implements InputPreProcessor {
-    private int inputHeight;
-    private int inputWidth;
-    private int numChannels;
+    protected int inputHeight;
+    protected int inputWidth;
+    protected int numChannels;
 
     /**
      * @param inputHeight the columns


### PR DESCRIPTION
Ready to review/merge.

- GradientCheckUtil: support checking a subset of params (for very large networks) - MLN only so far
- Add gradient checks to a number of keras import tests
- Fixes TensorFlowCnnToFeedForwardFeedForwardPreProcessor - https://github.com/deeplearning4j/deeplearning4j/issues/4360 plus another backprop gradient issue I found in the process
- Fix other failing test in https://github.com/deeplearning4j/deeplearning4j/issues/4360
- Fixes ReshapePreProcessor backprop shape check