### PR TITLE
Catch Play UI server no application.conf issue

### DIFF
--- a/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/PlayUIServer.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/PlayUIServer.java
@@ -202,8 +202,20 @@ public class PlayUIServer extends UIServer {
         }
 
         Router router = routingDsl.build();
-        server = Server.forRouter(router, Mode.PROD, port);
-        this.port = port;
+        try {
+            server = Server.forRouter(router, Mode.PROD, port);
+        } catch (Throwable e){
+            if(e.getMessage().contains("'play.crypto.provider")){
+                //Usual cause: user's uber-jar does not include application.conf
+                log.error("Error starting UI server: No application.conf found. This usually occurs due to missing" +
+                        " application.conf file. DL4J's UI (based on the Play framework) requires this file in order" +
+                        " to run. File can be missing due to incorrect creation of uber-jars that do not include resource" +
+                        " files. See https://deeplearning4j.org/visualization#issues for more information", e);
+            } else {
+                log.error("Unknown error when starting UI server",e);
+            }
+            throw e;
+        }
 
         log.info("DL4J UI Server started at {}", getAddress());
 

--- a/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/PlayUIServer.java
+++ b/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/PlayUIServer.java
@@ -207,7 +207,7 @@ public class PlayUIServer extends UIServer {
         } catch (Throwable e){
             if(e.getMessage().contains("'play.crypto.provider")){
                 //Usual cause: user's uber-jar does not include application.conf
-                log.error("Error starting UI server: No application.conf found. This usually occurs due to missing" +
+                log.error("Error starting UI server due to missing play.crypto.provider config: This usually occurs due to missing" +
                         " application.conf file. DL4J's UI (based on the Play framework) requires this file in order" +
                         " to run. File can be missing due to incorrect creation of uber-jars that do not include resource" +
                         " files. See https://deeplearning4j.org/visualization#issues for more information", e);


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/3496

Related docs update: https://github.com/deeplearning4j/deeplearning4j/pull/4374

Before:
```
Exception in thread "main" com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'play.crypto.provider'
at com.typesafe.config.impl.SimpleConfig.findKeyOrNull(SimpleConfig.java:152)
at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:170)
at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:176)
at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:176)
```

After:
```
o.d.u.p.PlayUIServer - Error starting UI server due to missing play.crypto.provider config:  This usually occurs due to missing application.conf file. DL4J's UI (based on the Play framework) requires this file in order to run. File can be missing due to incorrect creation of uber-jars that do not include resource files. See https://deeplearning4j.org/visualization#issues for more information
com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'play.crypto.provider'
        at com.typesafe.config.impl.SimpleConfig.findKeyOrNull(SimpleConfig.java:152)
        at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:170)
        at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:176)
```