### PR TITLE
DimOrdering check from backend in keras 2

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
@@ -70,6 +70,7 @@ public class KerasModel {
     boolean useTruncatedBPTT = false; // whether to use truncated BPTT
     int truncatedBPTT = 0; // truncated BPTT value
     int kerasMajorVersion;
+    String kerasBackend;
 
     public KerasModel() {
     }
@@ -113,6 +114,7 @@ public class KerasModel {
 
         Map<String, Object> modelConfig = KerasModelUtils.parseModelConfig(modelJson, modelYaml);
         this.kerasMajorVersion = KerasModelUtils.determineKerasMajorVersion(modelConfig, config);
+        this.kerasBackend = KerasModelUtils.determineKerasBackend(modelConfig, config);
         this.enforceTrainingConfig = enforceTrainingConfig;
 
         /* Determine model configuration type. */
@@ -180,8 +182,12 @@ public class KerasModel {
         DimOrder dimOrder = DimOrder.NONE;
         for (Object layerConfig : layerConfigs) {
             Map<String, Object> layerConfigMap = (Map<String, Object>) layerConfig;
-            // Append major keras version to each layer config.
+            // Append major keras version and backend to each layer config.
             layerConfigMap.put(config.getFieldKerasVersion(), this.kerasMajorVersion);
+            if (this.kerasBackend != null) {
+                layerConfigMap.put(config.getFieldBackend(), this.kerasBackend);
+            }
+
             KerasLayerConfiguration kerasLayerConf = new KerasLayer(this.kerasMajorVersion).conf;
             KerasLayer layer = KerasLayerUtils.getKerasLayerFromConfig(layerConfigMap, this.enforceTrainingConfig,
                     kerasLayerConf, customLayers);

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
@@ -80,6 +80,7 @@ public class KerasSequentialModel extends KerasModel {
 
         Map<String, Object> modelConfig = KerasModelUtils.parseModelConfig(modelJson, modelYaml);
         this.kerasMajorVersion = KerasModelUtils.determineKerasMajorVersion(modelConfig, config);
+        this.kerasBackend = KerasModelUtils.determineKerasBackend(modelConfig, config);
         this.enforceTrainingConfig = enforceTrainingConfig;
 
         /* Determine model configuration type. */

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
@@ -37,7 +37,7 @@ public class KerasLayerConfiguration {
 
     /* Basic layer names */
     // Missing Layers: Permute, RepeatVector, Lambda, ActivityRegularization, Masking
-    // Conv3D, SeparableConv2D, Deconvolution2D/Conv2DTranspose, Cropping1D-3D, UpSampling3D,
+    // Conv3D, Cropping1D-3D, UpSampling3D,
     // ZeroPadding3D, LocallyConnected1D-2D
     // Missing layers from keras 1: Highway, MaxoutDense
     private final String LAYER_CLASS_NAME_ACTIVATION = "Activation";
@@ -47,19 +47,26 @@ public class KerasLayerConfiguration {
     private final String LAYER_CLASS_NAME_GAUSSIAN_DROPOUT = "GaussianDropout";
     private final String LAYER_CLASS_NAME_GAUSSIAN_NOISE = "GaussianNoise";
     private final String LAYER_CLASS_NAME_DENSE = "Dense";
+
     private final String LAYER_CLASS_NAME_LSTM = "LSTM";
     private final String LAYER_CLASS_NAME_SIMPLE_RNN = "SimpleRNN";
+
+    private final String LAYER_CLASS_NAME_BIDIRECTIONAL = "Bidirectional";
+    private final String LAYER_CLASS_NAME_TIME_DISTRIBUTED = "TimeDistributed";
+
+
     private final String LAYER_CLASS_NAME_MAX_POOLING_1D = "MaxPooling1D";
     private final String LAYER_CLASS_NAME_MAX_POOLING_2D = "MaxPooling2D";
     private final String LAYER_CLASS_NAME_AVERAGE_POOLING_1D = "AveragePooling1D";
     private final String LAYER_CLASS_NAME_AVERAGE_POOLING_2D = "AveragePooling2D";
     private final String LAYER_CLASS_NAME_ZERO_PADDING_1D = "ZeroPadding1D";
     private final String LAYER_CLASS_NAME_ZERO_PADDING_2D = "ZeroPadding2D";
+
     private final String LAYER_CLASS_NAME_FLATTEN = "Flatten";
     private final String LAYER_CLASS_NAME_RESHAPE = "Reshape";
     private final String LAYER_CLASS_NAME_MERGE = "Merge";
+
     private final String LAYER_CLASS_NAME_BATCHNORMALIZATION = "BatchNormalization";
-    private final String LAYER_CLASS_NAME_TIME_DISTRIBUTED = "TimeDistributed";
     private final String LAYER_CLASS_NAME_EMBEDDING = "Embedding";
     private final String LAYER_CLASS_NAME_GLOBAL_MAX_POOLING_1D = "GlobalMaxPooling1D";
     private final String LAYER_CLASS_NAME_GLOBAL_MAX_POOLING_2D = "GlobalMaxPooling2D";
@@ -75,7 +82,6 @@ public class KerasLayerConfiguration {
     private final String LAYER_CLASS_NAME_UPSAMPLING_2D = "UpSampling2D";
     private final String LAYER_CLASS_NAME_SEPARABLE_CONVOLUTION_2D = ""; // 1: SeparableConvolution2D, 2: SeparableConv2D
     private final String LAYER_CLASS_NAME_DECONVOLUTION_2D = ""; // 1: Deconvolution2D, 2: Conv2DTranspose
-    private final String LAYER_CLASS_NAME_BIDIRECTIONAL = "Bidirectional";
 
     /* Partially shared layer configurations. */
     private final String LAYER_FIELD_INPUT_SHAPE = "input_shape";
@@ -96,6 +102,7 @@ public class KerasLayerConfiguration {
 
 
     /* Keras dimension ordering for, e.g., convolutional layersOrdered. */
+    private final String LAYER_FIELD_BACKEND = "backend"; // not available in keras 1, caught in code
     private final String LAYER_FIELD_DIM_ORDERING = ""; // 1: dim_ordering, 2: data_format
     private final String DIM_ORDERING_THEANO = ""; // 1: th, 2: channels_first
     private final String DIM_ORDERING_TENSORFLOW = ""; // 1: tf, 2: channels_last
@@ -175,11 +182,12 @@ public class KerasLayerConfiguration {
     private final String LAYER_BORDER_MODE_FULL = "full";
 
     /* Noise layers */
-    // Missing: GaussianNoise, GaussianDropout, AlphaDropout
+    private final String LAYER_FIELD_RATE = "rate";
     private final String LAYER_FIELD_GAUSSIAN_VARIANCE = ""; // 1: sigma, 2: stddev
 
     /* Layer wrappers */
-    // Missing: TimeDistributed, Bidirectional
+    // Missing: TimeDistributed
+
 
     /* Keras weight regularizers. */
     private final String LAYER_FIELD_W_REGULARIZER = ""; // 1: W_regularizer, 2: kernel_regularizer

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasModelConfiguration.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasModelConfiguration.java
@@ -33,6 +33,8 @@ public class KerasModelConfiguration {
     private final String fieldClassNameSequential = "Sequential";
     private final String fieldClassNameModel = "Model";
     private final String fieldKerasVersion = "keras_version";
+    private final String fieldBackend = "backend";
+
 
     /* Model configuration field. */
     private final String modelFieldConfig = "config";

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasAlphaDropout.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasAlphaDropout.java
@@ -70,11 +70,12 @@ public class KerasAlphaDropout extends KerasLayer {
             throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         super(layerConfig, enforceTrainingConfig);
         Map<String, Object> innerConfig = KerasLayerUtils.getInnerLayerConfigFromConfig(layerConfig, conf);
-        if (!innerConfig.containsKey("rate")) {
-            throw new InvalidKerasConfigurationException("Keras configuration does not contain 'rate' parameter" +
+        if (!innerConfig.containsKey(conf.getLAYER_FIELD_RATE())) {
+            throw new InvalidKerasConfigurationException("Keras configuration does not contain " +
+                    "parameter" + conf.getLAYER_FIELD_RATE() +
                     "needed for AlphaDropout");
         }
-        double rate = (double) innerConfig.get("rate"); // Keras stores drop rates
+        double rate = (double) innerConfig.get(conf.getLAYER_FIELD_RATE()); // Keras stores drop rates
         double retainRate = 1 - rate;
 
         this.layer = new DropoutLayer.Builder().name(this.layerName)

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianDropout.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianDropout.java
@@ -48,11 +48,12 @@ public class KerasGaussianDropout extends KerasLayer {
             throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         super(layerConfig, enforceTrainingConfig);
         Map<String, Object> innerConfig = KerasLayerUtils.getInnerLayerConfigFromConfig(layerConfig, conf);
-        if (!innerConfig.containsKey("rate")) {
-            throw new InvalidKerasConfigurationException("Keras configuration does not contain 'rate' parameter" +
+        if (!innerConfig.containsKey(conf.getLAYER_FIELD_RATE())) {
+            throw new InvalidKerasConfigurationException("Keras configuration does not contain " +
+                    "parameter" + conf.getLAYER_FIELD_RATE() +
                     "needed for GaussianDropout");
         }
-        double rate = (double) innerConfig.get("rate"); // Keras stores drop rates
+        double rate = (double) innerConfig.get(conf.getLAYER_FIELD_RATE()); // Keras stores drop rates
         double retainRate = 1 - rate;
 
         this.layer = new DropoutLayer.Builder().name(this.layerName)

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianNoise.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianNoise.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.nn.modelimport.keras.layers.noise;
 
-import org.deeplearning4j.nn.conf.dropout.GaussianDropout;
+import org.deeplearning4j.nn.conf.dropout.GaussianNoise;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.DropoutLayer;
 import org.deeplearning4j.nn.modelimport.keras.KerasLayer;
@@ -47,14 +47,15 @@ public class KerasGaussianNoise extends KerasLayer {
             throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         super(layerConfig, enforceTrainingConfig);
         Map<String, Object> innerConfig = KerasLayerUtils.getInnerLayerConfigFromConfig(layerConfig, conf);
-        if (!innerConfig.containsKey("stddev")) {
-            throw new InvalidKerasConfigurationException("Keras configuration does not contain 'stddev' parameter" +
+        if (!innerConfig.containsKey(conf.getLAYER_FIELD_GAUSSIAN_VARIANCE())) {
+            throw new InvalidKerasConfigurationException("Keras configuration does not contain "
+                    + conf.getLAYER_FIELD_GAUSSIAN_VARIANCE() + " parameter" +
                     "needed for GaussianNoise");
         }
-        double stddev = (double) innerConfig.get("stddev");
+        double stddev = (double) innerConfig.get(conf.getLAYER_FIELD_GAUSSIAN_VARIANCE());
 
         this.layer = new DropoutLayer.Builder().name(this.layerName)
-                .dropOut(new GaussianDropout(stddev)).build();
+                .dropOut(new GaussianNoise(stddev)).build();
     }
 
     /**

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLayerUtils.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLayerUtils.java
@@ -357,6 +357,14 @@ public class KerasLayerUtils {
             throws InvalidKerasConfigurationException {
         Map<String, Object> innerConfig = KerasLayerUtils.getInnerLayerConfigFromConfig(layerConfig, conf);
         KerasLayer.DimOrder dimOrder = KerasLayer.DimOrder.NONE;
+        if (layerConfig.containsKey(conf.getLAYER_FIELD_BACKEND())) {
+            String backend = (String) layerConfig.get(conf.getLAYER_FIELD_BACKEND());
+            if (backend.equals("tensorflow") || backend.equals("cntk")) {
+                dimOrder = KerasLayer.DimOrder.TENSORFLOW;
+            } else if (backend.equals("theano")) {
+                dimOrder = KerasLayer.DimOrder.THEANO;
+            }
+        }
         if (innerConfig.containsKey(conf.getLAYER_FIELD_DIM_ORDERING())) {
             String dimOrderStr = (String) innerConfig.get(conf.getLAYER_FIELD_DIM_ORDERING());
             if (dimOrderStr.equals(conf.getDIM_ORDERING_TENSORFLOW())) {

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelUtils.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelUtils.java
@@ -85,6 +85,7 @@ public class KerasModelUtils {
     }
 
     /**
+     * Determine Keras major version
      *
      * @param modelConfig parsed model configuration for keras model
      * @param config basic model configuration (KerasModelConfiguration)
@@ -111,6 +112,27 @@ public class KerasModelUtils {
             }
         }
         return kerasMajorVersion;
+    }
+
+    /**
+     * Determine Keras backend
+     *
+     * @param modelConfig parsed model configuration for keras model
+     * @param config basic model configuration (KerasModelConfiguration)
+     * @return Keras backend string
+     * @throws InvalidKerasConfigurationException
+     */
+    public static String determineKerasBackend(Map<String, Object> modelConfig, KerasModelConfiguration config)
+            throws InvalidKerasConfigurationException {
+        String kerasBackend = null;
+        if (!modelConfig.containsKey(config.getFieldBackend())) {
+            log.warn("Could not read keras backend used (no "
+                    + config.getFieldBackend() + " field found) \n"
+            );
+        } else {
+            kerasBackend = (String) modelConfig.get(config.getFieldBackend());
+            }
+        return kerasBackend;
     }
 
     public static String findParameterName(String parameter, String[] fragmentList) {

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/configurations/Keras2ModelConfigurationTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/configurations/Keras2ModelConfigurationTest.java
@@ -39,6 +39,11 @@ public class Keras2ModelConfigurationTest {
     ClassLoader classLoader = getClass().getClassLoader();
 
     @Test
+    public void convPooling1dTfConfigTest() throws Exception {
+        runSequentialConfigTest("configs/keras2/keras2_conv1d_pooling1d_tf_config.json");
+    }
+
+    @Test
     public void bidirectionalLstmConfigTest() throws Exception {
         runSequentialConfigTest("configs/keras2/bidirectional_lstm_tf_keras_2_config.json");
     }

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasAlphaDropoutTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasAlphaDropoutTest.java
@@ -56,7 +56,7 @@ public class KerasAlphaDropoutTest {
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_DROPOUT());
         Map<String, Object> config = new HashMap<String, Object>();
         config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
-        config.put("rate", RATE_KERAS);
+        config.put(conf.getLAYER_FIELD_RATE(), RATE_KERAS);
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianDropoutTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianDropoutTest.java
@@ -45,18 +45,18 @@ public class KerasGaussianDropoutTest {
 
 
     @Test
-    public void testAlphaDropoutLayer() throws Exception {
-        buildAlphaDropoutLayer(conf1, keras1);
-        buildAlphaDropoutLayer(conf2, keras2);
+    public void testGaussianDropoutLayer() throws Exception {
+        buildGaussianDropoutLayer(conf1, keras1);
+        buildGaussianDropoutLayer(conf2, keras2);
     }
 
 
-    public void buildAlphaDropoutLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
+    public void buildGaussianDropoutLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
         Map<String, Object> layerConfig = new HashMap<String, Object>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_DROPOUT());
         Map<String, Object> config = new HashMap<String, Object>();
         config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
-        config.put("rate", RATE_KERAS);
+        config.put(conf.getLAYER_FIELD_RATE(), RATE_KERAS);
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianNoiseTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/noise/KerasGaussianNoiseTest.java
@@ -17,7 +17,6 @@
  */
 package org.deeplearning4j.nn.modelimport.keras.layers.noise;
 
-import org.deeplearning4j.nn.conf.dropout.GaussianDropout;
 import org.deeplearning4j.nn.conf.dropout.GaussianNoise;
 import org.deeplearning4j.nn.conf.layers.DropoutLayer;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras1LayerConfiguration;
@@ -45,18 +44,18 @@ public class KerasGaussianNoiseTest {
 
 
     @Test
-    public void testAlphaDropoutLayer() throws Exception {
-        buildAlphaDropoutLayer(conf1, keras1);
-        buildAlphaDropoutLayer(conf2, keras2);
+    public void testGaussianNoiseLayer() throws Exception {
+        buildGaussianNoiseLayer(conf1, keras1);
+        buildGaussianNoiseLayer(conf2, keras2);
     }
 
 
-    public void buildAlphaDropoutLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
+    public void buildGaussianNoiseLayer(KerasLayerConfiguration conf, Integer kerasVersion) throws Exception {
         Map<String, Object> layerConfig = new HashMap<>();
         layerConfig.put(conf.getLAYER_FIELD_CLASS_NAME(), conf.getLAYER_CLASS_NAME_DROPOUT());
         Map<String, Object> config = new HashMap<>();
         config.put(conf.getLAYER_FIELD_NAME(), LAYER_NAME);
-        config.put("stddev", STDDEV);
+        config.put(conf.getLAYER_FIELD_GAUSSIAN_VARIANCE(), STDDEV);
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 

--- a/deeplearning4j-modelimport/src/test/resources/configs/keras2/keras2_conv1d_pooling1d_tf_config.json
+++ b/deeplearning4j-modelimport/src/test/resources/configs/keras2/keras2_conv1d_pooling1d_tf_config.json
@@ -1,0 +1,174 @@
+{
+  "class_name": "Sequential",
+  "keras_version": "2.0.4",
+  "config": [
+    {
+      "class_name": "Embedding",
+      "config": {
+        "embeddings_initializer": {
+          "class_name": "VarianceScaling",
+          "config": {
+            "distribution": "normal",
+            "scale": 2,
+            "seed": null,
+            "mode": "fan_in"
+          }
+        },
+        "name": "embedding_1",
+        "dtype": "int32",
+        "output_dim": 100,
+        "trainable": true,
+        "embeddings_regularizer": null,
+        "input_dim": 11000,
+        "mask_zero": false,
+        "embeddings_constraint": null,
+        "batch_input_shape": [
+          null,
+          200
+        ],
+        "activity_regularizer": null,
+        "input_length": 200
+      }
+    },
+    {
+      "class_name": "Conv1D",
+      "config": {
+        "kernel_constraint": null,
+        "kernel_initializer": {
+          "class_name": "VarianceScaling",
+          "config": {
+            "distribution": "uniform",
+            "scale": 1,
+            "seed": null,
+            "mode": "fan_avg"
+          }
+        },
+        "name": "conv1d_1",
+        "bias_regularizer": null,
+        "bias_constraint": null,
+        "activation": "relu",
+        "trainable": true,
+        "padding": "valid",
+        "strides": [
+          1
+        ],
+        "dilation_rate": [
+          1
+        ],
+        "kernel_regularizer": null,
+        "filters": 1,
+        "bias_initializer": {
+          "class_name": "Zeros",
+          "config": {}
+        },
+        "use_bias": true,
+        "activity_regularizer": null,
+        "kernel_size": [
+          3
+        ]
+      }
+    },
+    {
+      "class_name": "MaxPooling1D",
+      "config": {
+        "padding": "valid",
+        "strides": [
+          3
+        ],
+        "trainable": true,
+        "name": "max_pooling1d_1",
+        "pool_size": [
+          3
+        ]
+      }
+    },
+    {
+      "class_name": "Conv1D",
+      "config": {
+        "kernel_constraint": null,
+        "kernel_initializer": {
+          "class_name": "VarianceScaling",
+          "config": {
+            "distribution": "uniform",
+            "scale": 1,
+            "seed": null,
+            "mode": "fan_avg"
+          }
+        },
+        "name": "conv1d_2",
+        "bias_regularizer": null,
+        "bias_constraint": null,
+        "activation": "relu",
+        "trainable": true,
+        "padding": "valid",
+        "strides": [
+          1
+        ],
+        "dilation_rate": [
+          1
+        ],
+        "kernel_regularizer": null,
+        "filters": 1,
+        "bias_initializer": {
+          "class_name": "Zeros",
+          "config": {}
+        },
+        "use_bias": true,
+        "activity_regularizer": null,
+        "kernel_size": [
+          3
+        ]
+      }
+    },
+    {
+      "class_name": "MaxPooling1D",
+      "config": {
+        "padding": "valid",
+        "strides": [
+          3
+        ],
+        "trainable": true,
+        "name": "max_pooling1d_2",
+        "pool_size": [
+          3
+        ]
+      }
+    },
+    {
+      "class_name": "Flatten",
+      "config": {
+        "trainable": true,
+        "name": "flatten_1"
+      }
+    },
+    {
+      "class_name": "Dense",
+      "config": {
+        "kernel_initializer": {
+          "class_name": "VarianceScaling",
+          "config": {
+            "distribution": "uniform",
+            "scale": 1,
+            "seed": null,
+            "mode": "fan_avg"
+          }
+        },
+        "name": "dense_1",
+        "kernel_constraint": null,
+        "bias_regularizer": null,
+        "bias_constraint": null,
+        "activation": "sigmoid",
+        "trainable": true,
+        "kernel_regularizer": null,
+        "bias_initializer": {
+          "class_name": "Zeros",
+          "config": {}
+        },
+        "units": 1,
+        "use_bias": true,
+        "activity_regularizer": null
+      }
+    }
+  ],
+  "backend": "tensorflow"
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Addressing #4395 by including full config test and determining dim ordering by checking for backend in keras 2 (dim ordering info might be missing in layers in keras 2, I learned).

Also, minor clean-up of previously merged noise layers.