### PR TITLE
Add LastTimeStep wrapper layer

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
@@ -4,9 +4,12 @@ import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.WorkspaceMode;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.LSTM;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RnnOutputLayer;
 import org.deeplearning4j.nn.conf.layers.recurrent.Bidirectional;
+import org.deeplearning4j.nn.conf.layers.recurrent.LastTimeStep;
 import org.deeplearning4j.nn.conf.layers.recurrent.SimpleRnn;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
@@ -171,6 +174,69 @@ public class RnnGradientChecks {
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testLastTimeStepLayer(){
+        int nIn = 3;
+        int nOut = 5;
+        int tsLength = 4;
+        int layerSize = 8;
+
+        Bidirectional.Mode[] modes = new Bidirectional.Mode[]{Bidirectional.Mode.CONCAT, Bidirectional.Mode.ADD,
+                Bidirectional.Mode.AVERAGE, Bidirectional.Mode.MUL};
+
+        Random r = new Random(12345);
+        for (int mb : new int[]{1, 3}) {
+            for (boolean inputMask : new boolean[]{false, true}) {
+                for (boolean simple : new boolean[]{false, true}) {
+
+                    INDArray in = Nd4j.rand(new int[]{mb, nIn, tsLength});
+                    INDArray labels = Nd4j.create(mb, nOut);
+                    for (int i = 0; i < mb; i++) {
+                        labels.putScalar(i, r.nextInt(nOut), 1.0);
+                    }
+                    String maskType = (inputMask ? "inputMask" : "none");
+
+                    INDArray inMask = null;
+                    if (inputMask) {
+                        inMask = Nd4j.ones(mb, tsLength);
+                        for (int i = 0; i < mb; i++) {
+                            int firstMaskedStep = tsLength - 1 - i;
+                            if (firstMaskedStep == 0) {
+                                firstMaskedStep = tsLength;
+                            }
+                            for (int j = firstMaskedStep; j < tsLength; j++) {
+                                inMask.putScalar(i, j, 0.0);
+                            }
+                        }
+                    }
+
+                    String name = "testSimpleRnn() - mb=" + mb + ", tsLength = " + tsLength + ", maskType=" + maskType;
+
+                    MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                            .activation(Activation.TANH)
+                            .updater(new NoOp())
+                            .weightInit(WeightInit.XAVIER)
+                            .list()
+                            .layer(simple ? new SimpleRnn.Builder().nOut(layerSize).build() :
+                                    new LSTM.Builder().nOut(layerSize).build())
+                            .layer(new LastTimeStep(simple ? new SimpleRnn.Builder().nOut(layerSize).build() :
+                                    new LSTM.Builder().nOut(layerSize).build()))
+                            .layer(new OutputLayer.Builder().nOut(nOut).activation(Activation.SOFTMAX)
+                                    .lossFunction(LossFunctions.LossFunction.MCXENT).build())
+                            .setInputType(InputType.recurrent(nIn))
+                            .build();
+
+                    MultiLayerNetwork net = new MultiLayerNetwork(conf);
+                    net.init();
+
+                    boolean gradOK = GradientCheckUtil.checkGradients(net, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
+                            DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, in, labels, inMask, null);
+                    assertTrue(gradOK);
                 }
             }
         }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
@@ -215,7 +215,11 @@ public class RnnGradientChecks {
                         }
                     }
 
-                    String name = "testSimpleRnn() - mb=" + mb + ", tsLength = " + tsLength + ", maskType=" + maskType;
+                    String name = "testLastTimeStepLayer() - mb=" + mb + ", tsLength = " + tsLength + ", maskType=" + maskType
+                            + ", rnnType=" + (simple ? "SimpleRnn" : "LSTM");
+                    if(PRINT_RESULTS){
+                        System.out.println("Starting test: " + name);
+                    }
 
                     MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                             .activation(Activation.TANH)
@@ -236,7 +240,7 @@ public class RnnGradientChecks {
 
                     boolean gradOK = GradientCheckUtil.checkGradients(net, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, in, labels, inMask, null);
-                    assertTrue(gradOK);
+                    assertTrue(name, gradOK);
                 }
             }
         }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/recurrent/TestLastTimeStepLayer.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/recurrent/TestLastTimeStepLayer.java
@@ -1,0 +1,61 @@
+package org.deeplearning4j.nn.layers.recurrent;
+
+import org.deeplearning4j.TestUtils;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.recurrent.LastTimeStep;
+import org.deeplearning4j.nn.conf.layers.recurrent.SimpleRnn;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.NDArrayIndex;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestLastTimeStepLayer {
+
+    @Test
+    public void testLastTimeStepVertex() {
+
+        ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder().graphBuilder().addInputs("in")
+                .addLayer("lastTS", new LastTimeStep(new SimpleRnn.Builder()
+                        .nIn(5).nOut(6).build()), "in")
+                .setOutputs("lastTS")
+                .build();
+
+        ComputationGraph graph = new ComputationGraph(conf);
+        graph.init();
+
+        //First: test without input mask array
+        Nd4j.getRandom().setSeed(12345);
+        Layer l = graph.getLayer("lastTS");
+        INDArray in = Nd4j.rand(new int[]{3, 5, 6});
+        INDArray outUnderlying = ((LastTimeStepLayer)l).getUnderlying().activate(in);
+        INDArray expOut = outUnderlying.get(NDArrayIndex.all(), NDArrayIndex.all(), NDArrayIndex.point(5));
+
+
+        //Forward pass:
+        INDArray outFwd = l.activate(in);
+        assertEquals(expOut, outFwd);
+
+        //Second: test with input mask array
+        INDArray inMask = Nd4j.zeros(3, 6);
+        inMask.putRow(0, Nd4j.create(new double[]{1, 1, 1, 0, 0, 0}));
+        inMask.putRow(1, Nd4j.create(new double[]{1, 1, 1, 1, 0, 0}));
+        inMask.putRow(2, Nd4j.create(new double[]{1, 1, 1, 1, 1, 0}));
+        graph.setLayerMaskArrays(new INDArray[]{inMask}, null);
+
+        expOut = Nd4j.zeros(3, 6);
+        expOut.putRow(0, outUnderlying.get(NDArrayIndex.point(0), NDArrayIndex.all(), NDArrayIndex.point(2)));
+        expOut.putRow(1, outUnderlying.get(NDArrayIndex.point(1), NDArrayIndex.all(), NDArrayIndex.point(3)));
+        expOut.putRow(2, outUnderlying.get(NDArrayIndex.point(2), NDArrayIndex.all(), NDArrayIndex.point(4)));
+
+        outFwd = l.activate(in);
+        assertEquals(expOut, outFwd);
+
+        TestUtils.testModelSerialization(graph);
+    }
+
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/ParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/ParamInitializer.java
@@ -19,6 +19,7 @@
 package org.deeplearning4j.nn.api;
 
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.Layer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.util.List;
@@ -61,17 +62,21 @@ public interface ParamInitializer {
 
     /**
      * Is the specified parameter a weight?
+     *
+     * @param layer Layer
      * @param key Key to check
      * @return True if parameter is a weight
      */
-    boolean isWeightParam(String key);
+    boolean isWeightParam(Layer layer, String key);
 
     /**
      * Is the specified parameter a bias?
+     *
+     * @param layer Layer
      * @param key Key to check
      * @return True if parameter is a bias
      */
-    boolean isBiasParam(String key);
+    boolean isBiasParam(Layer layer, String key);
 
     /**
      * Initialize the parameters

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -35,6 +35,7 @@ import org.deeplearning4j.nn.conf.layers.*;
 import org.deeplearning4j.nn.conf.layers.misc.FrozenLayer;
 import org.deeplearning4j.nn.conf.layers.recurrent.Bidirectional;
 import org.deeplearning4j.nn.conf.layers.variational.ReconstructionDistribution;
+import org.deeplearning4j.nn.conf.layers.wrapper.BaseWrapperLayer;
 import org.deeplearning4j.nn.conf.serde.ComputationGraphConfigurationDeserializer;
 import org.deeplearning4j.nn.conf.serde.MultiLayerConfigurationDeserializer;
 import org.deeplearning4j.nn.conf.stepfunctions.StepFunction;
@@ -1079,6 +1080,11 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
                 Bidirectional b = (Bidirectional)layer;
                 copyConfigToLayer(b.getFwd().getLayerName(), b.getFwd());
                 copyConfigToLayer(b.getBwd().getLayerName(), b.getBwd());
+            }
+
+            if(layer instanceof BaseWrapperLayer){
+                BaseWrapperLayer bwr = (BaseWrapperLayer)layer;
+                configureLayer(bwr.getUnderlying());
             }
 
             if (layer instanceof ConvolutionLayer) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
@@ -108,7 +108,7 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
      */
     @Override
     public IUpdater getUpdaterByParam(String paramName) {
-        if(biasUpdater != null && initializer().isBiasParam(paramName)){
+        if(biasUpdater != null && initializer().isBiasParam(this, paramName)){
             return biasUpdater;
         }
         return iUpdater;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
@@ -1,11 +1,10 @@
 package org.deeplearning4j.nn.conf.layers.recurrent;
 
-import org.deeplearning4j.nn.api.ParamInitializer;
-import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.Layer;
-import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.nn.conf.layers.wrapper.BaseWrapperLayer;
+import org.deeplearning4j.nn.layers.recurrent.LastTimeStepLayer;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
@@ -16,58 +15,26 @@ import java.util.Collection;
  * and returns it as a row vector. That is, for 3d (time series) input, we take the last time step and
  *
  */
-public class LastTimeStep extends Layer {
-
-    private Layer underlying;
+public class LastTimeStep extends BaseWrapperLayer {
 
     public LastTimeStep(Layer underlying){
-        this.underlying = underlying;
+        super(underlying);
     }
 
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners,
                                                        int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        return null;
-    }
-
-    @Override
-    public ParamInitializer initializer() {
-        return null;
+        return new LastTimeStepLayer(underlying.instantiate(conf, iterationListeners, layerIndex, layerParamsView, initializeParams));
     }
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        return null;
-    }
-
-    @Override
-    public void setNIn(InputType inputType, boolean override) {
-
-    }
-
-    @Override
-    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
-        return null;
-    }
-
-    @Override
-    public double getL1ByParam(String paramName) {
-        return 0;
-    }
-
-    @Override
-    public double getL2ByParam(String paramName) {
-        return 0;
-    }
-
-    @Override
-    public boolean isPretrainParam(String paramName) {
-        return false;
-    }
-
-    @Override
-    public LayerMemoryReport getMemoryReport(InputType inputType) {
-        return null;
+        if(inputType.getType() != InputType.Type.RNN){
+            throw new IllegalArgumentException("Require RNN input type - got " + inputType);
+        }
+        InputType outType = underlying.getOutputType(layerIndex, inputType);
+        InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent)outType;
+        return InputType.feedForward(r.getSize());
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
@@ -1,0 +1,73 @@
+package org.deeplearning4j.nn.conf.layers.recurrent;
+
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.optimize.api.IterationListener;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.Collection;
+
+/**
+ * LastTimeStep is a "wrapper" layer: it wraps any RNN layer, and extracts out the last time step during forward pass,
+ * and returns it as a row vector. That is, for 3d (time series) input, we take the last time step and
+ *
+ */
+public class LastTimeStep extends Layer {
+
+    private Layer underlying;
+
+    public LastTimeStep(Layer underlying){
+        this.underlying = underlying;
+    }
+
+
+    @Override
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners,
+                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        return null;
+    }
+
+    @Override
+    public ParamInitializer initializer() {
+        return null;
+    }
+
+    @Override
+    public InputType getOutputType(int layerIndex, InputType inputType) {
+        return null;
+    }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override) {
+
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        return null;
+    }
+
+    @Override
+    public double getL1ByParam(String paramName) {
+        return 0;
+    }
+
+    @Override
+    public double getL2ByParam(String paramName) {
+        return 0;
+    }
+
+    @Override
+    public boolean isPretrainParam(String paramName) {
+        return false;
+    }
+
+    @Override
+    public LayerMemoryReport getMemoryReport(InputType inputType) {
+        return null;
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
@@ -25,7 +25,11 @@ public class LastTimeStep extends BaseWrapperLayer {
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners,
                                                        int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        return new LastTimeStepLayer(underlying.instantiate(conf, iterationListeners, layerIndex, layerParamsView, initializeParams));
+        Layer temp = conf.getLayer();
+        conf.setLayer(((LastTimeStep)conf.getLayer()).getUnderlying());
+        LastTimeStepLayer l = new LastTimeStepLayer(underlying.instantiate(conf, iterationListeners, layerIndex, layerParamsView, initializeParams));
+        conf.setLayer(temp);
+        return l;
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
@@ -23,6 +23,8 @@ public abstract class BaseWrapperLayer extends Layer {
 
     protected Layer underlying;
 
+    protected BaseWrapperLayer(){ }
+
     public BaseWrapperLayer(@NonNull Layer underlying){
         this.underlying = underlying;
     }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
@@ -1,0 +1,66 @@
+package org.deeplearning4j.nn.conf.layers.wrapper;
+
+import lombok.NonNull;
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.optimize.api.IterationListener;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.Collection;
+
+/**
+ * Base wrapper layer
+ *
+ */
+public abstract class BaseWrapperLayer extends Layer {
+
+    protected Layer underlying;
+
+    public BaseWrapperLayer(@NonNull Layer underlying){
+        this.underlying = underlying;
+    }
+
+    @Override
+    public ParamInitializer initializer() {
+        
+    }
+
+    @Override
+    public InputType getOutputType(int layerIndex, InputType inputType) {
+
+    }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override) {
+        underlying.setNIn(inputType, override);
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        return underlying.getPreProcessorForInputType(inputType);
+    }
+
+    @Override
+    public double getL1ByParam(String paramName) {
+        return underlying.getL1ByParam(paramName);
+    }
+
+    @Override
+    public double getL2ByParam(String paramName) {
+        return underlying.getL2ByParam(paramName);
+    }
+
+    @Override
+    public boolean isPretrainParam(String paramName) {
+        return underlying.isPretrainParam(paramName);
+    }
+
+    @Override
+    public LayerMemoryReport getMemoryReport(InputType inputType) {
+        return underlying.getMemoryReport(inputType);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.nn.conf.layers.wrapper;
 
+import lombok.Data;
 import lombok.NonNull;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
@@ -7,6 +8,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.Layer;
 import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.nn.params.WrapperLayerParamInitializer;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
@@ -16,6 +18,7 @@ import java.util.Collection;
  * Base wrapper layer
  *
  */
+@Data
 public abstract class BaseWrapperLayer extends Layer {
 
     protected Layer underlying;
@@ -26,12 +29,12 @@ public abstract class BaseWrapperLayer extends Layer {
 
     @Override
     public ParamInitializer initializer() {
-        
+        return WrapperLayerParamInitializer.getInstance();
     }
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-
+        return null;
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
@@ -15,8 +15,10 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import java.util.Collection;
 
 /**
- * Base wrapper layer
+ * Base wrapper layer: the idea is to pass through all methods to the underlying layer, and selectively override
+ * them as required. This is to save implementing every single passthrough method for all 'wrapper' layer subtypes
  *
+ * @author Alex Black
  */
 @Data
 public abstract class BaseWrapperLayer extends Layer {
@@ -36,7 +38,7 @@ public abstract class BaseWrapperLayer extends Layer {
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        return null;
+        return underlying.getOutputType(layerIndex, inputType);
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/weightnoise/DropConnect.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/weightnoise/DropConnect.java
@@ -72,7 +72,8 @@ public class DropConnect implements IWeightNoise {
             p = weightRetainProbSchedule.valueAt(iteration, epoch);
         }
 
-        if (train && init.isWeightParam(paramKey) || (applyToBiases && init.isBiasParam(paramKey))) {
+        if (train && init.isWeightParam(layer.conf().getLayer(), paramKey)
+                || (applyToBiases && init.isBiasParam(layer.conf().getLayer(), paramKey))) {
             INDArray out = Nd4j.createUninitialized(param.shape(), param.ordering());
             Nd4j.getExecutioner().exec(new DropOut(param, out, p));
             return out;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/weightnoise/WeightNoise.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/weightnoise/WeightNoise.java
@@ -6,8 +6,6 @@ import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
 import org.deeplearning4j.nn.conf.distribution.Distributions;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.AddOp;
-import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.MulOp;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.OldAddOp;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.OldMulOp;
 import org.nd4j.linalg.factory.Nd4j;
@@ -62,7 +60,8 @@ public class WeightNoise implements IWeightNoise {
 
         ParamInitializer init = layer.conf().getLayer().initializer();
         INDArray param = layer.getParam(paramKey);
-        if (train && init.isWeightParam(paramKey) || (applyToBias && init.isBiasParam(paramKey))) {
+        if (train && init.isWeightParam(layer.conf().getLayer(), paramKey) ||
+                (applyToBias && init.isBiasParam(layer.conf().getLayer(), paramKey))) {
 
             org.nd4j.linalg.api.rng.distribution.Distribution dist = Distributions.createDistribution(distribution);
             INDArray noise = dist.sample(param.shape());

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LastTimeStepLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LastTimeStepLayer.java
@@ -1,0 +1,121 @@
+package org.deeplearning4j.nn.layers.recurrent;
+
+import lombok.NonNull;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.wrapper.BaseWrapperLayer;
+import org.deeplearning4j.util.TimeSeriesUtils;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.INDArrayIndex;
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.Arrays;
+
+import static org.nd4j.linalg.indexing.NDArrayIndex.all;
+import static org.nd4j.linalg.indexing.NDArrayIndex.point;
+
+public class LastTimeStepLayer extends BaseWrapperLayer {
+
+    private Layer underlying;
+    private int[] lastTimeStepIdxs;
+    private int[] origOutputShape;
+
+    public LastTimeStepLayer(@NonNull Layer underlying){
+        super(underlying);
+    }
+
+    @Override
+    public Type type() {
+        return Type.FEED_FORWARD;
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon) {
+        INDArray newEps = Nd4j.create(origOutputShape, 'f');
+        if(lastTimeStepIdxs == null){
+            //no mask case
+            newEps.put(new INDArrayIndex[]{all(), all(), point(origOutputShape[2]-1)}, epsilon);
+        } else {
+            INDArrayIndex[] arr = new INDArrayIndex[]{null, all(), null};
+            //TODO probably possible to optimize this with reshape + scatter ops...
+            for( int i=0; i<lastTimeStepIdxs.length; i++ ){
+                arr[0] = point(i);
+                arr[2] = point(lastTimeStepIdxs[i]);
+                newEps.put(arr, epsilon.getRow(i));
+            }
+        }
+        return underlying.backpropGradient(newEps);
+    }
+
+
+    @Override
+    public INDArray preOutput(INDArray x) {
+        return getLastStep(underlying.preOutput(x));
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x, TrainingMode training) {
+        return getLastStep(underlying.preOutput(x, training));
+    }
+
+    @Override
+    public INDArray activate(TrainingMode training) {
+        return getLastStep(underlying.activate(training));
+    }
+
+    @Override
+    public INDArray activate(INDArray input, TrainingMode training) {
+        return getLastStep(underlying.activate(input, training));
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x, boolean training) {
+        return getLastStep(underlying.activate(x, training));
+    }
+
+    @Override
+    public INDArray activate(boolean training) {
+        return getLastStep(underlying.activate(training));
+    }
+
+    @Override
+    public INDArray activate(INDArray input, boolean training) {
+        return getLastStep(underlying.activate(input, training));
+    }
+
+    @Override
+    public INDArray activate() {
+        return getLastStep(underlying.activate());
+    }
+
+    @Override
+    public INDArray activate(INDArray input) {
+        return getLastStep(underlying.activate(input));
+    }
+
+
+    @Override
+    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState, int minibatchSize) {
+        underlying.feedForwardMaskArray(maskArray, currentMaskState, minibatchSize);
+
+        //Input: 2d mask array, for masking a time series. After extracting out the last time step, we no longer need the mask array
+        return new Pair<>(null, currentMaskState);
+    }
+
+
+    private INDArray getLastStep(INDArray in){
+        if(in.rank() != 3){
+            throw new IllegalArgumentException("Expected rank 3 input with shape [minibatch, layerSize, tsLength]. Got " +
+                    "rank " + in.rank() + " with shape " + Arrays.toString(in.shape()));
+        }
+
+        INDArray mask = underlying.getMaskArray();
+        Pair<INDArray,int[]> p = TimeSeriesUtils.pullLastTimeSteps(in, mask);
+        lastTimeStepIdxs = p.getSecond();
+        origOutputShape = p.getFirst().shape();
+        return p.getFirst();
+    }
+
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LastTimeStepLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LastTimeStepLayer.java
@@ -16,6 +16,15 @@ import java.util.Arrays;
 import static org.nd4j.linalg.indexing.NDArrayIndex.all;
 import static org.nd4j.linalg.indexing.NDArrayIndex.point;
 
+/**
+ * LastTimeStep is a "wrapper" layer: it wraps any RNN layer, and extracts out the last time step during forward pass,
+ * and returns it as a row vector (per example). That is, for 3d (time series) input (with shape [minibatch, layerSize,
+ * timeSeriesLength]), we take the last time step and return it as a 2d array with shape [minibatch, layerSize].<br>
+ * Note that the last time step operation takes into account any mask arrays, if present: thus, variable length time
+ * series (in the same minibatch) are handled as expected here.
+ *
+ * @author Alex Black
+ */
 public class LastTimeStepLayer extends BaseWrapperLayer {
 
     private int[] lastTimeStepIdxs;
@@ -110,12 +119,11 @@ public class LastTimeStepLayer extends BaseWrapperLayer {
             throw new IllegalArgumentException("Expected rank 3 input with shape [minibatch, layerSize, tsLength]. Got " +
                     "rank " + in.rank() + " with shape " + Arrays.toString(in.shape()));
         }
+        origOutputShape = in.shape();
 
         INDArray mask = underlying.getMaskArray();
         Pair<INDArray,int[]> p = TimeSeriesUtils.pullLastTimeSteps(in, mask);
         lastTimeStepIdxs = p.getSecond();
-        origOutputShape = p.getFirst().shape();
         return p.getFirst();
     }
-
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LastTimeStepLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LastTimeStepLayer.java
@@ -18,7 +18,6 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.point;
 
 public class LastTimeStepLayer extends BaseWrapperLayer {
 
-    private Layer underlying;
     private int[] lastTimeStepIdxs;
     private int[] origOutputShape;
 
@@ -82,7 +81,8 @@ public class LastTimeStepLayer extends BaseWrapperLayer {
 
     @Override
     public INDArray activate(INDArray input, boolean training) {
-        return getLastStep(underlying.activate(input, training));
+        INDArray a = underlying.activate(input, training);
+        return getLastStep(a);
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/wrapper/BaseWrapperLayer.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.nn.layers.wrapper;
 
+import lombok.Data;
 import lombok.NonNull;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.MaskState;
@@ -17,10 +18,11 @@ import java.util.Map;
 /**
  * Abstract wrapper layer. The idea: this class passes through all methods to the underlying layer.
  * Then, subclasses of BaseWrapperLayer can selectively override specific methods, rather than having
- * to implement every single one of them each time
+ * to implement every single one of the passthrough methods in each subclass.
  *
  * @author Alex Black
  */
+@Data
 public abstract class BaseWrapperLayer implements Layer {
 
     protected Layer underlying;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/wrapper/BaseWrapperLayer.java
@@ -1,0 +1,361 @@
+package org.deeplearning4j.nn.layers.wrapper;
+
+import lombok.NonNull;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
+import org.deeplearning4j.nn.conf.CacheMode;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.optimize.api.ConvexOptimizer;
+import org.deeplearning4j.optimize.api.IterationListener;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Abstract wrapper layer. The idea: this class passes through all methods to the underlying layer.
+ * Then, subclasses of BaseWrapperLayer can selectively override specific methods, rather than having
+ * to implement every single one of them each time
+ *
+ * @author Alex Black
+ */
+public abstract class BaseWrapperLayer implements Layer {
+
+    protected Layer underlying;
+
+    public BaseWrapperLayer(@NonNull Layer underlying){
+        this.underlying = underlying;
+    }
+
+    @Override
+    public void setCacheMode(CacheMode mode) {
+        underlying.setCacheMode(mode);
+    }
+
+    @Override
+    public double calcL2(boolean backpropOnlyParams) {
+        return underlying.calcL2(backpropOnlyParams);
+    }
+
+    @Override
+    public double calcL1(boolean backpropOnlyParams) {
+        return underlying.calcL1(backpropOnlyParams);
+    }
+
+    @Override
+    public Type type() {
+        return underlying.type();
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon) {
+        return underlying.backpropGradient(epsilon);
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x) {
+        return underlying.preOutput(x);
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x, TrainingMode training) {
+        return underlying.preOutput(x, training);
+    }
+
+    @Override
+    public INDArray activate(TrainingMode training) {
+        return underlying.activate(training);
+    }
+
+    @Override
+    public INDArray activate(INDArray input, TrainingMode training) {
+        return underlying.activate(input, training);
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x, boolean training) {
+        return underlying.preOutput(x, training);
+    }
+
+    @Override
+    public INDArray activate(boolean training) {
+        return underlying.activate(training);
+    }
+
+    @Override
+    public INDArray activate(INDArray input, boolean training) {
+        return underlying.activate(input, training);
+    }
+
+    @Override
+    public INDArray activate() {
+        return underlying.activate();
+    }
+
+    @Override
+    public INDArray activate(INDArray input) {
+        return underlying.activate(input);
+    }
+
+    @Override
+    public Layer transpose() {
+        throw new UnsupportedOperationException("Not supported");   //If required, implement in subtype (so traspose is wrapped)
+    }
+
+    @Override
+    public Layer clone() {
+        throw new UnsupportedOperationException("Clone not supported");
+    }
+
+    @Override
+    public Collection<IterationListener> getListeners() {
+        return underlying.getListeners();
+    }
+
+    @Override
+    public void setListeners(IterationListener... listeners) {
+        underlying.setListeners(listeners);
+    }
+
+    @Override
+    public void addListeners(IterationListener... listener) {
+        underlying.addListeners(listener);
+    }
+
+    @Override
+    public void fit() {
+        underlying.fit();
+    }
+
+    @Override
+    public void update(Gradient gradient) {
+        underlying.update(gradient);
+    }
+
+    @Override
+    public void update(INDArray gradient, String paramType) {
+        underlying.update(gradient, paramType);
+    }
+
+    @Override
+    public double score() {
+        return underlying.score();
+    }
+
+    @Override
+    public void computeGradientAndScore() {
+        underlying.computeGradientAndScore();
+    }
+
+    @Override
+    public void accumulateScore(double accum) {
+        underlying.accumulateScore(accum);
+    }
+
+    @Override
+    public INDArray params() {
+        return underlying.params();
+    }
+
+    @Override
+    public int numParams() {
+        return underlying.numParams();
+    }
+
+    @Override
+    public int numParams(boolean backwards) {
+        return underlying.numParams();
+    }
+
+    @Override
+    public void setParams(INDArray params) {
+        underlying.setParams(params);
+    }
+
+    @Override
+    public void setParamsViewArray(INDArray params) {
+        underlying.setParamsViewArray(params);
+    }
+
+    @Override
+    public INDArray getGradientsViewArray() {
+        return underlying.getGradientsViewArray();
+    }
+
+    @Override
+    public void setBackpropGradientsViewArray(INDArray gradients) {
+        underlying.setBackpropGradientsViewArray(gradients);
+    }
+
+    @Override
+    public void fit(INDArray data) {
+        underlying.fit(data);
+    }
+
+    @Override
+    public void iterate(INDArray input) {
+        underlying.iterate(input);
+    }
+
+    @Override
+    public Gradient gradient() {
+        return underlying.gradient();
+    }
+
+    @Override
+    public Pair<Gradient, Double> gradientAndScore() {
+        return underlying.gradientAndScore();
+    }
+
+    @Override
+    public int batchSize() {
+        return underlying.batchSize();
+    }
+
+    @Override
+    public NeuralNetConfiguration conf() {
+        return underlying.conf();
+    }
+
+    @Override
+    public void setConf(NeuralNetConfiguration conf) {
+        underlying.setConf(conf);
+    }
+
+    @Override
+    public INDArray input() {
+        return underlying.input();
+    }
+
+    @Override
+    public void validateInput() {
+        underlying.validateInput();
+    }
+
+    @Override
+    public ConvexOptimizer getOptimizer() {
+        return underlying.getOptimizer();
+    }
+
+    @Override
+    public INDArray getParam(String param) {
+        return underlying.getParam(param);
+    }
+
+    @Override
+    public void initParams() {
+        underlying.initParams();
+    }
+
+    @Override
+    public Map<String, INDArray> paramTable() {
+        return underlying.paramTable();
+    }
+
+    @Override
+    public Map<String, INDArray> paramTable(boolean backpropParamsOnly) {
+        return underlying.paramTable(backpropParamsOnly);
+    }
+
+    @Override
+    public void setParamTable(Map<String, INDArray> paramTable) {
+        underlying.setParamTable(paramTable);
+    }
+
+    @Override
+    public void setParam(String key, INDArray val) {
+        underlying.setParam(key, val);
+    }
+
+    @Override
+    public void clear() {
+        underlying.clear();
+    }
+
+    @Override
+    public void applyConstraints(int iteration, int epoch) {
+        underlying.applyConstraints(iteration, epoch);
+    }
+
+    @Override
+    public void init() {
+        underlying.init();
+    }
+
+    @Override
+    public void setListeners(Collection<IterationListener> listeners) {
+        underlying.setListeners(listeners);
+    }
+
+    @Override
+    public void setIndex(int index) {
+        underlying.setIndex(index);
+    }
+
+    @Override
+    public int getIndex() {
+        return 0;
+    }
+
+    @Override
+    public int getIterationCount() {
+        return underlying.getIterationCount();
+    }
+
+    @Override
+    public int getEpochCount() {
+        return underlying.getEpochCount();
+    }
+
+    @Override
+    public void setIterationCount(int iterationCount) {
+        underlying.setIterationCount(iterationCount);
+    }
+
+    @Override
+    public void setEpochCount(int epochCount) {
+        underlying.setEpochCount(epochCount);
+    }
+
+    @Override
+    public void setInput(INDArray input) {
+        underlying.setInput(input);
+    }
+
+    @Override
+    public void setInputMiniBatchSize(int size) {
+        underlying.setInputMiniBatchSize(size);
+    }
+
+    @Override
+    public int getInputMiniBatchSize() {
+        return underlying.getInputMiniBatchSize();
+    }
+
+    @Override
+    public void setMaskArray(INDArray maskArray) {
+        underlying.setMaskArray(maskArray);
+    }
+
+    @Override
+    public INDArray getMaskArray() {
+        return underlying.getMaskArray();
+    }
+
+    @Override
+    public boolean isPretrainLayer() {
+        return underlying.isPretrainLayer();
+    }
+
+    @Override
+    public void clearNoiseWeightParams() {
+        underlying.clearNoiseWeightParams();
+    }
+
+    @Override
+    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState, int minibatchSize) {
+        return underlying.feedForwardMaskArray(maskArray, currentMaskState, minibatchSize);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/BatchNormalizationParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/BatchNormalizationParamInitializer.java
@@ -67,12 +67,12 @@ public class BatchNormalizationParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return false;
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return false;
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/BidirectionalParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/BidirectionalParamInitializer.java
@@ -77,13 +77,13 @@ public class BidirectionalParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
-        return weightKeys(layer).contains(key);
+    public boolean isWeightParam(Layer layer, String key) {
+        return weightKeys(this.layer).contains(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
-        return biasKeys(layer).contains(key);
+    public boolean isBiasParam(Layer layer, String key) {
+        return biasKeys(this.layer).contains(key);
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/ConvolutionParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/ConvolutionParamInitializer.java
@@ -92,12 +92,12 @@ public class ConvolutionParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return WEIGHT_KEY.equals(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return BIAS_KEY.equals(key);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/DefaultParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/DefaultParamInitializer.java
@@ -84,12 +84,12 @@ public class DefaultParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return WEIGHT_KEY.equals(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return BIAS_KEY.equals(key);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/EmptyParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/EmptyParamInitializer.java
@@ -46,12 +46,12 @@ public class EmptyParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return false;
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return false;
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/FrozenLayerParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/FrozenLayerParamInitializer.java
@@ -51,12 +51,12 @@ public class FrozenLayerParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return false;
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return false;
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/GravesBidirectionalLSTMParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/GravesBidirectionalLSTMParamInitializer.java
@@ -96,13 +96,13 @@ public class GravesBidirectionalLSTMParamInitializer implements ParamInitializer
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return RECURRENT_WEIGHT_KEY_FORWARDS.equals(key) || INPUT_WEIGHT_KEY_FORWARDS.equals(key)
                 || RECURRENT_WEIGHT_KEY_BACKWARDS.equals(key) || INPUT_WEIGHT_KEY_BACKWARDS.equals(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return BIAS_KEY_FORWARDS.equals(key) || BIAS_KEY_BACKWARDS.equals(key);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/GravesLSTMParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/GravesLSTMParamInitializer.java
@@ -83,12 +83,12 @@ public class GravesLSTMParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return RECURRENT_WEIGHT_KEY.equals(key) || INPUT_WEIGHT_KEY.equals(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return BIAS_KEY.equals(key);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/LSTMParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/LSTMParamInitializer.java
@@ -84,12 +84,12 @@ public class LSTMParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return RECURRENT_WEIGHT_KEY.equals(key) || INPUT_WEIGHT_KEY.equals(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return BIAS_KEY.equals(key);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SeparableConvolutionParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SeparableConvolutionParamInitializer.java
@@ -127,12 +127,12 @@ public class SeparableConvolutionParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return DEPTH_WISE_WEIGHT_KEY.equals(key) || POINT_WISE_WEIGHT_KEY.equals(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return BIAS_KEY.equals(key);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SimpleRnnParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SimpleRnnParamInitializer.java
@@ -60,12 +60,12 @@ public class SimpleRnnParamInitializer implements ParamInitializer {
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return WEIGHT_KEY.equals(key) || RECURRENT_WEIGHT_KEY.equals(key);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return BIAS_KEY.equals(key);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/VariationalAutoencoderParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/VariationalAutoencoderParamInitializer.java
@@ -142,7 +142,7 @@ public class VariationalAutoencoderParamInitializer extends DefaultParamInitiali
     public List<String> weightKeys(Layer layer) {
         List<String> out = new ArrayList<>();
         for(String s : paramKeys(layer)){
-            if(isWeightParam(s)){
+            if(isWeightParam(layer, s)){
                 out.add(s);
             }
         }
@@ -153,7 +153,7 @@ public class VariationalAutoencoderParamInitializer extends DefaultParamInitiali
     public List<String> biasKeys(Layer layer) {
         List<String> out = new ArrayList<>();
         for(String s : paramKeys(layer)){
-            if(isBiasParam(s)){
+            if(isBiasParam(layer, s)){
                 out.add(s);
             }
         }
@@ -161,12 +161,12 @@ public class VariationalAutoencoderParamInitializer extends DefaultParamInitiali
     }
 
     @Override
-    public boolean isWeightParam(String key) {
+    public boolean isWeightParam(Layer layer, String key) {
         return key.endsWith(WEIGHT_KEY_SUFFIX);
     }
 
     @Override
-    public boolean isBiasParam(String key) {
+    public boolean isBiasParam(Layer layer, String key) {
         return key.endsWith(BIAS_KEY_SUFFIX);
     }
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/WrapperLayerParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/WrapperLayerParamInitializer.java
@@ -1,0 +1,88 @@
+package org.deeplearning4j.nn.params;
+
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.layers.wrapper.BaseWrapperLayer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.List;
+import java.util.Map;
+
+public class WrapperLayerParamInitializer implements ParamInitializer {
+
+    private static final WrapperLayerParamInitializer INSTANCE = new WrapperLayerParamInitializer();
+
+    public static WrapperLayerParamInitializer getInstance(){
+        return INSTANCE;
+    }
+
+    private WrapperLayerParamInitializer(){
+
+    }
+
+    @Override
+    public int numParams(NeuralNetConfiguration conf) {
+        return numParams(conf.getLayer());
+    }
+
+    @Override
+    public int numParams(Layer layer) {
+        Layer l = underlying(layer);
+        return l.initializer().numParams(l);
+    }
+
+    @Override
+    public List<String> paramKeys(Layer layer) {
+        Layer l = underlying(layer);
+        return l.initializer().paramKeys(l);
+    }
+
+    @Override
+    public List<String> weightKeys(Layer layer) {
+        Layer l = underlying(layer);
+        return l.initializer().weightKeys(l);
+    }
+
+    @Override
+    public List<String> biasKeys(Layer layer) {
+        Layer l = underlying(layer);
+        return l.initializer().biasKeys(l);
+    }
+
+    @Override
+    public boolean isWeightParam(Layer layer, String key) {
+        Layer l = underlying(layer);
+        return l.initializer().isWeightParam(layer, key);
+    }
+
+    @Override
+    public boolean isBiasParam(Layer layer, String key) {
+        Layer l = underlying(layer);
+        return l.initializer().isBiasParam(layer, key);
+    }
+
+    @Override
+    public Map<String, INDArray> init(NeuralNetConfiguration conf, INDArray paramsView, boolean initializeParams) {
+        Layer orig = conf.getLayer();
+        Layer l = underlying(conf.getLayer());
+        conf.setLayer(l);
+        Map<String,INDArray> m = l.initializer().init(conf, paramsView, initializeParams);
+        conf.setLayer(orig);
+        return m;
+    }
+
+    @Override
+    public Map<String, INDArray> getGradientsFromFlattened(NeuralNetConfiguration conf, INDArray gradientView) {
+        Layer orig = conf.getLayer();
+        Layer l = underlying(conf.getLayer());
+        conf.setLayer(l);
+        Map<String,INDArray> m = l.initializer().getGradientsFromFlattened(conf, gradientView);
+        conf.setLayer(orig);
+        return m;
+    }
+
+    private Layer underlying(Layer layer){
+        return ((BaseWrapperLayer)layer).getUnderlying();
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
@@ -168,7 +168,13 @@ public class TimeSeriesUtils {
         return out;
     }
 
-
+    /**
+     * Extract out the last time steps (2d array from 3d array input) accounting for the mask layer, if present.
+     *
+     * @param pullFrom Input time series array (rank 3) to pull the last time steps from
+     * @param mask     Mask array (rank 2). May be null
+     * @return         2d array of the last time steps
+     */
     public static Pair<INDArray,int[]> pullLastTimeSteps(INDArray pullFrom, INDArray mask){
         //Then: work out, from the mask array, which time step of activations we want, extract activations
         //Also: record where they came from (so we can do errors later)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
@@ -23,8 +23,11 @@ import org.nd4j.linalg.api.ops.CustomOp;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.BooleanIndexing;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.indexing.conditions.Conditions;
+import org.nd4j.linalg.primitives.Pair;
 
 import java.util.Arrays;
 
@@ -165,4 +168,33 @@ public class TimeSeriesUtils {
         return out;
     }
 
+
+    public static Pair<INDArray,int[]> pullLastTimeSteps(INDArray pullFrom, INDArray mask){
+        //Then: work out, from the mask array, which time step of activations we want, extract activations
+        //Also: record where they came from (so we can do errors later)
+        int[] fwdPassTimeSteps;
+        INDArray out;
+        if (mask == null) {
+            //No mask array -> extract same (last) column for all
+            int lastTS = pullFrom.size(2) - 1;
+            out = pullFrom.get(NDArrayIndex.all(), NDArrayIndex.all(), NDArrayIndex.point(lastTS));
+            fwdPassTimeSteps = null; //Null -> last time step for all examples
+        } else {
+            int[] outShape = new int[] {pullFrom.size(0), pullFrom.size(1)};
+            out = Nd4j.create(outShape);
+
+            //Want the index of the last non-zero entry in the mask array
+            INDArray lastStepArr = BooleanIndexing.lastIndex(mask, Conditions.epsNotEquals(0.0), 1);
+            fwdPassTimeSteps = lastStepArr.data().asInt();
+
+            //Now, get and assign the corresponding subsets of 3d activations:
+            for (int i = 0; i < fwdPassTimeSteps.length; i++) {
+                //TODO can optimize using reshape + pullRows
+                out.putRow(i, pullFrom.get(NDArrayIndex.point(i), NDArrayIndex.all(),
+                        NDArrayIndex.point(fwdPassTimeSteps[i])));
+            }
+        }
+
+        return new Pair<>(out, fwdPassTimeSteps);
+    }
 }


### PR DESCRIPTION
Wrapper layer that extracts out the last time step (accounting for masks) of the activations of the underlying RNN layer.
Mainly implemented for Keras import (return_sequences = false config for RNNs).