### PR TITLE
Add SameDiff Layer

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/samediff/SameDiffTest1.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/samediff/SameDiffTest1.java
@@ -1,0 +1,145 @@
+package org.deeplearning4j.samediff;
+
+import org.junit.Test;
+import org.nd4j.autodiff.samediff.SDGraph;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.ops.transforms.Transforms;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SameDiffTest1 {
+
+    @Test
+    public void test1() {
+
+        SameDiff sd = SameDiff.create();
+
+        SDVariable input = sd.var("input", new int[]{3,4});
+        SDVariable weights = sd.var("weights", new int[]{4,5});
+        SDVariable bias = sd.var("bias", new int[]{1,5});
+
+        SDVariable mmul = sd.mmul("mmul", input, weights);
+        SDVariable z = mmul.add("z", bias);
+        SDVariable out = sd.sigmoid("out", z);
+
+        SDGraph g = sd.graph();
+        System.out.println(g);
+
+        System.out.println(out);
+
+
+        INDArray iInput = Nd4j.rand(3,4);
+        INDArray iWeights = Nd4j.rand(4,5);
+        INDArray iBias = Nd4j.rand(1,5);
+
+        INDArray iZ = iInput.mmul(iWeights).addiRowVector(iBias);
+        INDArray iOut = Transforms.sigmoid(iZ, true);
+
+        Map<String,INDArray> values = new HashMap<>();
+        values.put("input", iInput);
+        values.put("weights", iWeights);
+        values.put("bias", iBias);
+
+        INDArray[] outAct = sd.eval(values);
+
+        System.out.println();
+    }
+
+
+    @Test
+    public void test2() {
+
+        SameDiff sd = SameDiff.create();
+
+        SDVariable input = sd.var("input", new int[]{3,4});
+        SDVariable weights = sd.var("weights", new int[]{4,5});
+        SDVariable bias = sd.var("bias", new int[]{1,5});
+
+        SDVariable mmul = sd.mmul("mmul", input, weights);
+        SDVariable z = mmul.add("z", bias);
+        SDVariable out = sd.sigmoid("out", z);
+
+        SDGraph g = sd.graph();
+        System.out.println(g);
+
+        System.out.println(out);
+
+
+        INDArray iInput = Nd4j.rand(3,4);
+        INDArray iWeights = Nd4j.rand(4,5);
+        INDArray iBias = Nd4j.rand(1,5);
+
+        INDArray iZ = iInput.mmul(iWeights).addiRowVector(iBias);
+        INDArray iOut = Transforms.sigmoid(iZ, true);
+
+        Map<String,INDArray> values = new HashMap<>();
+        values.put("input", iInput);
+        values.put("weights", iWeights);
+        values.put("bias", iBias);
+
+        INDArray[] outAct = sd.eval(values);
+
+        System.out.println();
+    }
+
+    @Test
+    public void test3() {
+
+        SameDiff sd = SameDiff.create();
+
+        INDArray iInput = Nd4j.rand(3,4);
+        INDArray iWeights = Nd4j.rand(4,5);
+        INDArray iBias = Nd4j.rand(1,5);
+
+        SDVariable input = sd.var("input", iInput);
+        SDVariable weights = sd.var("weights", iWeights);
+        SDVariable bias = sd.var("bias", iBias);
+
+        SDVariable mmul = sd.mmul("mmul", input, weights);
+        SDVariable z = mmul.add("z", bias);
+        SDVariable out = sd.sigmoid("out", z);
+
+
+        INDArray outAct = sd.execAndEndResult();
+
+
+
+        INDArray iZ = iInput.mmul(iWeights).addiRowVector(iBias);
+        INDArray iOut = Transforms.sigmoid(iZ, true);
+
+        Map<String,INDArray> values = new HashMap<>();
+        values.put("input", iInput);
+        values.put("weights", iWeights);
+        values.put("bias", iBias);
+
+        System.out.println();
+    }
+
+
+    @Test
+    public void test4() {
+
+        SameDiff sd = SameDiff.create();
+
+        INDArray iInput = Nd4j.rand(3,4);
+        INDArray iWeights = Nd4j.rand(4,5);
+        INDArray iBias = Nd4j.rand(1,5);
+
+        SDVariable input = sd.var("input", iInput);
+        SDVariable weights = sd.var("weights", iWeights);
+        SDVariable bias = sd.var("bias", iBias);
+
+        SDVariable mmul = sd.mmul("mmul", input, weights);
+        SDVariable z = mmul.add("z", bias);
+        SDVariable out = sd.sigmoid("out", z);
+
+
+        INDArray outArr = out.eval();
+
+        System.out.println(outArr);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/BaseSameDiffLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/BaseSameDiffLayer.java
@@ -54,7 +54,9 @@ public abstract class BaseSameDiffLayer extends Layer {
 
     public abstract List<String> biasKeys();
 
-    public abstract void defineLayer(SameDiff sameDiff, SDVariable layerInput, Map<String,INDArray> paramTable);
+    public abstract Map<String,int[]> paramShapes();
+
+    public abstract void defineLayer(SameDiff sameDiff, SDVariable layerInput, Map<String,SDVariable> paramTable);
 
     //==================================================================================================================
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/BaseSameDiffLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/BaseSameDiffLayer.java
@@ -1,0 +1,161 @@
+package org.deeplearning4j.nn.conf.layers.samediff;
+
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.nn.params.SameDiffParamInitializer;
+import org.deeplearning4j.optimize.api.IterationListener;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.learning.config.IUpdater;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public abstract class BaseSameDiffLayer extends Layer {
+
+    protected double l1;
+    protected double l2;
+    protected double l1Bias;
+    protected double l2Bias;
+    protected IUpdater updater;
+    protected IUpdater biasUpdater;
+
+
+    private List<String> paramKeys;
+
+    protected BaseSameDiffLayer(Builder builder){
+        super(builder);
+        this.l1 = builder.l1;
+        this.l2 = builder.l2;
+        this.l1Bias = builder.l1Bias;
+        this.l2Bias = builder.l2Bias;
+        this.updater = builder.updater;
+        this.biasUpdater = builder.biasUpdater;
+    }
+
+    @Override
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<IterationListener> iterationListeners,
+                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        return null;
+    }
+
+    @Override
+    public ParamInitializer initializer() {
+        return SameDiffParamInitializer.getInstance();
+    }
+
+    @Override
+    public abstract InputType getOutputType(int layerIndex, InputType inputType);
+
+    @Override
+    public abstract void setNIn(InputType inputType, boolean override);
+
+    @Override
+    public abstract InputPreProcessor getPreProcessorForInputType(InputType inputType);
+
+    public abstract List<String> weightKeys();
+
+    public abstract List<String> biasKeys();
+
+    @Override
+    public double getL1ByParam(String paramName) {
+        return (initializer().isWeightParam(this, paramName) ? l1 :  l1Bias);
+    }
+
+    @Override
+    public double getL2ByParam(String paramName) {
+        return (initializer().isWeightParam(this, paramName) ? l2 :  l2Bias);
+    }
+
+    @Override
+    public boolean isPretrainParam(String paramName) {
+        return false;
+    }
+
+    @Override
+    public LayerMemoryReport getMemoryReport(InputType inputType) {
+        return new LayerMemoryReport(); //TODO
+    }
+
+    public List<String> paramKeys(){
+        if(paramKeys == null){
+            List<String> pk = new ArrayList<>();
+            pk.addAll(weightKeys());
+            pk.addAll(biasKeys());
+            paramKeys = pk;
+        }
+        return paramKeys;
+    }
+
+
+    public static abstract class Builder<T extends Builder<T>> extends Layer.Builder<T> {
+
+        protected double l1 = Double.NaN;
+        protected double l2 = Double.NaN;
+        protected double l1Bias = Double.NaN;
+        protected double l2Bias = Double.NaN;
+        protected IUpdater updater = null;
+        protected IUpdater biasUpdater = null;
+
+        /**
+         * L1 regularization coefficient (weights only). Use {@link #l1Bias(double)} to configure the l1 regularization
+         * coefficient for the bias.
+         */
+        public T l1(double l1) {
+            this.l1 = l1;
+            return (T) this;
+        }
+
+        /**
+         * L2 regularization coefficient (weights only). Use {@link #l2Bias(double)} to configure the l2 regularization
+         * coefficient for the bias.
+         */
+        public T l2(double l2) {
+            this.l2 = l2;
+            return (T) this;
+        }
+
+        /**
+         * L1 regularization coefficient for the bias. Default: 0. See also {@link #l1(double)}
+         */
+        public T l1Bias(double l1Bias) {
+            this.l1Bias = l1Bias;
+            return (T) this;
+        }
+
+        /**
+         * L2 regularization coefficient for the bias. Default: 0. See also {@link #l2(double)}
+         */
+        public T l2Bias(double l2Bias) {
+            this.l2Bias = l2Bias;
+            return (T) this;
+        }
+
+        /**
+         * Gradient updater. For example, {@link org.nd4j.linalg.learning.config.Adam}
+         * or {@link org.nd4j.linalg.learning.config.Nesterovs}
+         *
+         * @param updater Updater to use
+         */
+        public T updater(IUpdater updater) {
+            this.updater = updater;
+            return (T) this;
+        }
+
+        /**
+         * Gradient updater configuration, for the biases only. If not set, biases will use the updater as
+         * set by {@link #updater(IUpdater)}
+         *
+         * @param biasUpdater Updater to use for bias parameters
+         */
+        public T biasUpdater(IUpdater biasUpdater){
+            this.biasUpdater = biasUpdater;
+            return (T) this;
+        }
+
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/samediff/SameDiffLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/samediff/SameDiffLayer.java
@@ -14,6 +14,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.Pair;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class SameDiffLayer extends AbstractLayer<BaseSameDiffLayer> {
@@ -121,6 +122,12 @@ public class SameDiffLayer extends AbstractLayer<BaseSameDiffLayer> {
         int[] inputShape = input.shape().clone();
         inputShape[0] = -1;
         SDVariable inputVar = sameDiff.var(INPUT_KEY, inputShape);     //TODO WHAT ABOUT VARIABLE SIZES?
-        layerConf().defineLayer(sameDiff, inputVar, p);
+        Map<String,int[]> paramShapes = layerConf().paramShapes();
+        Map<String,SDVariable> params = new LinkedHashMap<>();
+        for(String s : layerConf().paramKeys()){
+            int[] ps = paramShapes.get(s);
+            params.put(s, sameDiff.var(s, ps));
+        }
+        layerConf().defineLayer(sameDiff, inputVar, params);
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/samediff/SameDiffLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/samediff/SameDiffLayer.java
@@ -1,0 +1,126 @@
+package org.deeplearning4j.nn.layers.samediff;
+
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.samediff.BaseSameDiffLayer;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.AbstractLayer;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SameDiffLayer extends AbstractLayer<BaseSameDiffLayer> {
+
+    private static final String INPUT_KEY = "input";
+
+    protected SameDiff sameDiff;
+    protected String outputKey;
+
+
+    public SameDiffLayer(NeuralNetConfiguration conf){
+        super(conf);
+    }
+
+
+
+    @Override
+    public Layer clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPretrainLayer() {
+        return false;
+    }
+
+    @Override
+    public void clearNoiseWeightParams() {
+        //TODO - properly support noise weight...
+    }
+
+    @Override
+    public INDArray activate(boolean training) {
+        if(sameDiff == null){
+            doInit();
+        }
+
+        SameDiff sd = sameDiff.getFunction(outputKey);
+        //Build map:
+        Map<String, INDArray> map = new HashMap<>(paramTable());
+        map.put(INPUT_KEY, input);
+
+        try(MemoryWorkspace ws = Nd4j.getWorkspaceManager().scopeOutOfWorkspaces()) {
+            return sd.execAndEndResult();
+        }
+    }
+
+    @Override
+    public INDArray preOutput(boolean training) {
+        return activate(training);
+    }
+
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon) {
+        Gradient g = new DefaultGradient();
+
+        SameDiff sd = sameDiff.getFunction(outputKey);
+        INDArray dLdIn;
+        try(MemoryWorkspace ws = Nd4j.getWorkspaceManager().scopeOutOfWorkspaces()){
+            sd.execBackwards();
+            for(String s : layerConf().paramKeys() ){
+                INDArray pg = sd.grad(s).getArr();
+                g.gradientForVariable().put(s, pg);
+            }
+
+            dLdIn = sd.grad(INPUT_KEY).getArr();
+        }
+
+        return new Pair<>(g, dLdIn);
+    }
+
+    @Override
+    public double calcL2(boolean backpropParamsOnly) {
+        double l2Sum = 0.0;
+        for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
+            double l2 = conf.getL2ByParam(entry.getKey());
+            if (l2 > 0) {
+                double norm2 = getParam(entry.getKey()).norm2Number().doubleValue();
+                l2Sum += 0.5 * l2 * norm2 * norm2;
+            }
+        }
+
+        return l2Sum;
+    }
+
+    @Override
+    public double calcL1(boolean backpropParamsOnly) {
+        double l1Sum = 0.0;
+        for (Map.Entry<String, INDArray> entry : paramTable().entrySet()) {
+            double l1 = conf.getL1ByParam(entry.getKey());
+            if (l1 > 0) {
+                double norm1 = getParam(entry.getKey()).norm1Number().doubleValue();
+                l1Sum += l1 * norm1;
+            }
+        }
+
+        return l1Sum;
+    }
+
+    protected void doInit(){
+        sameDiff = SameDiff.create();
+        Map<String,INDArray > p = paramTable();
+
+        int[] inputShape = input.shape().clone();
+        inputShape[0] = -1;
+        SDVariable inputVar = sameDiff.var(INPUT_KEY, inputShape);     //TODO WHAT ABOUT VARIABLE SIZES?
+        layerConf().defineLayer(sameDiff, inputVar, p);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SameDiffParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SameDiffParamInitializer.java
@@ -3,10 +3,17 @@ package org.deeplearning4j.nn.params;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.layers.samediff.BaseSameDiffLayer;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.util.ArrayUtil;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
+import static org.nd4j.linalg.indexing.NDArrayIndex.point;
 
 public class SameDiffParamInitializer implements ParamInitializer {
 
@@ -18,46 +25,77 @@ public class SameDiffParamInitializer implements ParamInitializer {
 
     @Override
     public int numParams(NeuralNetConfiguration conf) {
-        return 0;
+        return numParams(conf.getLayer());
     }
 
     @Override
     public int numParams(Layer layer) {
-        return 0;
+        BaseSameDiffLayer sd = (BaseSameDiffLayer)layer;
+        Map<String,int[]> m = sd.paramShapes();
+        int n = 0;
+        for(int[] arr : m.values()){
+            n += ArrayUtil.prod(arr);
+        }
+        return n;
     }
 
     @Override
     public List<String> paramKeys(Layer layer) {
-        return null;
+        BaseSameDiffLayer sd = (BaseSameDiffLayer)layer;
+        return sd.paramKeys();
     }
 
     @Override
     public List<String> weightKeys(Layer layer) {
-        return null;
+        BaseSameDiffLayer sd = (BaseSameDiffLayer)layer;
+        return sd.weightKeys();
     }
 
     @Override
     public List<String> biasKeys(Layer layer) {
-        return null;
+        BaseSameDiffLayer sd = (BaseSameDiffLayer)layer;
+        return sd.biasKeys();
     }
 
     @Override
     public boolean isWeightParam(Layer layer, String key) {
-        return false;
+        return weightKeys(layer).contains(key);
     }
 
     @Override
     public boolean isBiasParam(Layer layer, String key) {
-        return false;
+        return biasKeys(layer).contains(key);
     }
 
     @Override
     public Map<String, INDArray> init(NeuralNetConfiguration conf, INDArray paramsView, boolean initializeParams) {
-        return null;
+        BaseSameDiffLayer sd = (BaseSameDiffLayer) conf.getLayer();
+        Map<String,INDArray> out = subsetAndReshape(sd.paramKeys(), sd.paramShapes(), paramsView);
+        if(initializeParams){
+            //TODO
+            throw new RuntimeException("Parameter initialization not yet implemented");
+        }
+        return out;
     }
 
     @Override
     public Map<String, INDArray> getGradientsFromFlattened(NeuralNetConfiguration conf, INDArray gradientView) {
-        return null;
+        BaseSameDiffLayer sd = (BaseSameDiffLayer) conf.getLayer();
+        return subsetAndReshape(sd.paramKeys(), sd.paramShapes(), gradientView);
+    }
+
+    private Map<String,INDArray> subsetAndReshape(List<String> params, Map<String,int[]> paramShapes, INDArray view){
+        Map<String,INDArray> out = new LinkedHashMap<>();
+        int soFar = 0;
+        for(String s : params){
+            int[] sh = paramShapes.get(s);
+            int length = ArrayUtil.prod(sh);
+            INDArray sub = view.get(point(0), interval(soFar, soFar + length));
+            if(!Arrays.equals(sub.shape(), sh)){
+                sub = sub.reshape('c', sh); //TODO initialization order
+            }
+            out.put(s, sub);
+        }
+        return out;
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SameDiffParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/SameDiffParamInitializer.java
@@ -1,0 +1,63 @@
+package org.deeplearning4j.nn.params;
+
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.List;
+import java.util.Map;
+
+public class SameDiffParamInitializer implements ParamInitializer {
+
+    private static final SameDiffParamInitializer INSTANCE = new SameDiffParamInitializer();
+
+    public static SameDiffParamInitializer getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public int numParams(NeuralNetConfiguration conf) {
+        return 0;
+    }
+
+    @Override
+    public int numParams(Layer layer) {
+        return 0;
+    }
+
+    @Override
+    public List<String> paramKeys(Layer layer) {
+        return null;
+    }
+
+    @Override
+    public List<String> weightKeys(Layer layer) {
+        return null;
+    }
+
+    @Override
+    public List<String> biasKeys(Layer layer) {
+        return null;
+    }
+
+    @Override
+    public boolean isWeightParam(Layer layer, String key) {
+        return false;
+    }
+
+    @Override
+    public boolean isBiasParam(Layer layer, String key) {
+        return false;
+    }
+
+    @Override
+    public Map<String, INDArray> init(NeuralNetConfiguration conf, INDArray paramsView, boolean initializeParams) {
+        return null;
+    }
+
+    @Override
+    public Map<String, INDArray> getGradientsFromFlattened(NeuralNetConfiguration conf, INDArray gradientView) {
+        return null;
+    }
+}


### PR DESCRIPTION
***WIP DO NOT MERGE***
Still a long way to go here. Needs lots of testing.

Adds SameDiff layer. In summary, to add a SameDiff layer:
- Users extend BaseSameDiffLayer (i.e., the config class), which has methods to return the graph, parameter names and shapes, etc.
- Unlike 'vanilla' DL4J/ND4J layers: users will *not usually* need to implement a Layer implementation class or a parameter initializer (just the config class above)


For now, I'm focusing on the single layer only case (i.e., no building large SameDiff graph across multiple layers). However, I'm keeping this in mind with the API so it can be added later.