### PR TITLE
Fix output type return sequences

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLstm.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLstm.java
@@ -194,6 +194,9 @@ public class KerasLstm extends KerasLayer {
             throw new InvalidKerasConfigurationException(
                     "Keras LSTM layer accepts only one input (received " + inputType.length + ")");
         InputPreProcessor preProcessor = getInputPreprocessor(inputType);
+        if (!returnSequences) {
+            return this.layer.getOutputType(-1, preProcessor.getOutputType(inputType[0]));
+        }
         if (preProcessor != null)
             return  preProcessor.getOutputType(inputType[0]);
         else

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLstm.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLstm.java
@@ -27,7 +27,6 @@ import org.deeplearning4j.nn.conf.layers.InputTypeUtil;
 import org.deeplearning4j.nn.conf.layers.LSTM;
 import org.deeplearning4j.nn.conf.layers.Layer;
 import org.deeplearning4j.nn.conf.layers.recurrent.LastTimeStep;
-import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToRnnPreProcessor;
 import org.deeplearning4j.nn.modelimport.keras.KerasLayer;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
@@ -194,11 +193,13 @@ public class KerasLstm extends KerasLayer {
             throw new InvalidKerasConfigurationException(
                     "Keras LSTM layer accepts only one input (received " + inputType.length + ")");
         InputPreProcessor preProcessor = getInputPreprocessor(inputType);
-        if (!returnSequences) {
-            return this.layer.getOutputType(-1, preProcessor.getOutputType(inputType[0]));
+        if (preProcessor != null) {
+            if (returnSequences) {
+                return  preProcessor.getOutputType(inputType[0]);
+            } else {
+                return this.getLSTMLayer().getOutputType(-1, preProcessor.getOutputType(inputType[0]));
+            }
         }
-        if (preProcessor != null)
-            return  preProcessor.getOutputType(inputType[0]);
         else
             return this.getLSTMLayer().getOutputType(-1, inputType[0]);
 

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLSTMTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLSTMTest.java
@@ -18,6 +18,7 @@
 package org.deeplearning4j.nn.modelimport.keras.layers.recurrent;
 
 import org.deeplearning4j.nn.conf.dropout.Dropout;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.LSTM;
 import org.deeplearning4j.nn.conf.layers.recurrent.LastTimeStep;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras1LayerConfiguration;
@@ -99,9 +100,15 @@ public class KerasLSTMTest {
         layerConfig.put(conf.getLAYER_FIELD_CONFIG(), config);
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 
-        LSTM layer = rs ? (LSTM) new KerasLstm(layerConfig).getLSTMLayer() :
-                (LSTM) ((LastTimeStep) new KerasLstm(layerConfig).getLSTMLayer()).getUnderlying();
-
+        LSTM layer;
+        LastTimeStep lts = null;
+        if (rs) {
+            layer =(LSTM) new KerasLstm(layerConfig).getLSTMLayer();
+        }
+        else {
+            lts = (LastTimeStep) new KerasLstm(layerConfig).getLSTMLayer();
+            layer = (LSTM) lts.getUnderlying();
+        }
         assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
         assertEquals(LAYER_NAME, layer.getLayerName());
         assertEquals(INIT_DL4J, layer.getWeightInit());
@@ -110,7 +117,9 @@ public class KerasLSTMTest {
         assertEquals(new Dropout(DROPOUT_DL4J), layer.getIDropout());
         assertEquals(lstmForgetBiasDouble, layer.getForgetGateBiasInit(), 0.0);
         assertEquals(N_OUT, layer.getNOut());
-
+        if (!rs) {
+            assertEquals(lts.getOutputType(-1, InputType.recurrent(N_OUT)), InputType.feedForward(N_OUT));
+        }
 
     }
 }

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLSTMTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/recurrent/KerasLSTMTest.java
@@ -101,12 +101,16 @@ public class KerasLSTMTest {
         layerConfig.put(conf.getLAYER_FIELD_KERAS_VERSION(), kerasVersion);
 
         LSTM layer;
-        LastTimeStep lts = null;
+        LastTimeStep lts;
+        KerasLstm kerasLstm = new KerasLstm(layerConfig);
         if (rs) {
-            layer =(LSTM) new KerasLstm(layerConfig).getLSTMLayer();
-        }
-        else {
-            lts = (LastTimeStep) new KerasLstm(layerConfig).getLSTMLayer();
+            InputType outputType = kerasLstm.getOutputType(InputType.recurrent(1337));
+            assertEquals(outputType, InputType.recurrent(N_OUT));
+            layer = (LSTM) kerasLstm.getLSTMLayer();
+        } else {
+            lts = (LastTimeStep) kerasLstm.getLSTMLayer();
+            InputType outputType = kerasLstm.getOutputType(InputType.feedForward(1337));
+            assertEquals(outputType, InputType.feedForward(N_OUT));
             layer = (LSTM) lts.getUnderlying();
         }
         assertEquals(ACTIVATION_DL4J, layer.getActivationFn().toString());
@@ -117,9 +121,6 @@ public class KerasLSTMTest {
         assertEquals(new Dropout(DROPOUT_DL4J), layer.getIDropout());
         assertEquals(lstmForgetBiasDouble, layer.getForgetGateBiasInit(), 0.0);
         assertEquals(N_OUT, layer.getNOut());
-        if (!rs) {
-            assertEquals(lts.getOutputType(-1, InputType.recurrent(N_OUT)), InputType.feedForward(N_OUT));
-        }
 
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix an issue where keras models including an LSTM layer with return_sequences=False would return a wrong outputType. 
When return_sequences is false, the LSTM is wrapped in a LastTimeStep. So, the output type is no longer recurrent. Thus, we need to call getOutputType on the LastTimeStep layer instead of the preprocesser. 


(Please fill in changes proposed in this fix)

## How was this patch tested?
Modified the existing unit test to account for this behaviour


