### PR TITLE
#2031: Update Gradle instructions to correct scope

### DIFF
--- a/buildtools.md
+++ b/buildtools.md
@@ -39,7 +39,7 @@ You can use Deeplearning4j with SBT by adding the following to your build.sbt:
 
 You can use Deeplearning4j with Gradle by adding the following to your build.gradle in the dependencies block:
 
-    provided "org.deeplearning4j:deeplearning4j-core:${FIND THE VERSION FROM OUR EXAMPLES http://github.com/deeplearning4j/dl4j-examples}"
+    compile "org.deeplearning4j:deeplearning4j-core:${FIND THE VERSION FROM OUR EXAMPLES http://github.com/deeplearning4j/dl4j-examples}"
 
 ## Leiningen
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated the Gradle build instructions to use `compile` instead of `provided` when declaring the dependency. There is no such thing as `provided` in a Gradle build unless the user has manually declared and wired up this configuration to tasks or applied and plugin that does similar.

Attention was called to this issue by a question in the [Gradle Forums](https://discuss.gradle.org/t/build-file-for-deeplearning4j/25358).

## How was this patch tested?

Verified a standard Gradle build can use the updated documentation as shown without an error.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [X] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
