### PR TITLE
Fixed support of loading binary Google model

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
@@ -2630,7 +2630,7 @@ public class WordVectorSerializer {
                 log.debug("Trying BinaryReader...");
                 vocabCache = new AbstractCache.Builder<VocabWord>().build();
                 storage.clear();
-                try (Reader reader = new BinaryReader(file)) {
+                try (BinaryReader reader = new BinaryReader(file)) {
                     while (reader.hasNext()) {
                         Pair<VocabWord, float[]> pair = reader.next();
                         VocabWord word = pair.getFirst();
@@ -2639,7 +2639,7 @@ public class WordVectorSerializer {
 
                         vocabCache.addToken(word);
                         vocabCache.addWordToIndex(word.getIndex(), word.getLabel());
-
+                        reader.readByte();
                         Nd4j.getMemoryManager().invokeGcOccasionally();
                     }
                 } catch (Exception ez) {
@@ -2712,6 +2712,14 @@ public class WordVectorSerializer {
                 }
 
                 return Pair.makePair(element, vector);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public byte readByte() {
+            try {
+                return stream.readByte();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
loadStaticModel() used to crash because it doesn't read the return line. That is, after reading the first word with its vector, it does a readString(), and the return line is read as a new empty word.