### PR TITLE
Fixed support of loading the binary Google model

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
@@ -2705,11 +2705,12 @@ public class WordVectorSerializer {
                 VocabWord element = new VocabWord(1.0, word);
                 element.setIndex(idxCounter.getAndIncrement());
 
-
                 float[] vector = new float[vectorLength];
                 for (int i = 0; i < vectorLength; i++) {
                     vector[i] = readFloat(stream);
                 }
+
+                stream.readByte();
 
                 return Pair.makePair(element, vector);
             } catch (Exception e) {


### PR DESCRIPTION
After reading the word String and the floats, we need to skip the return line. Otherwise that return line is read as a new empty String, crashing the loader.