### PR TITLE
Fix CNN args

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/Deconvolution2DLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/Deconvolution2DLayer.java
@@ -206,11 +206,11 @@ public class Deconvolution2DLayer extends ConvolutionLayer {
         INDArray output = Nd4j.create(miniBatch * outDepth * outH * outW);
         INDArray reshapedOutput = output.reshape('c', miniBatch, outDepth, outH, outW);
 
-        Integer sameMode = (convolutionMode == ConvolutionMode.Same) ? 1 : 0;
+        int sameMode = (convolutionMode == ConvolutionMode.Same) ? 1 : 0;
 
         int[] args = new int[] {
                 kH, kW, strides[0], strides[1],
-                pad[0], pad[1], dilation[0], dilation[1], sameMode
+                pad[0], pad[1], dilation[0], dilation[1], sameMode, 0   //Last arg: 0 for nchw
         };
 
         CustomOp op;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -306,14 +306,14 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                 //                time2 = System.nanoTime();
 
                 Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
-                                convolutionMode == ConvolutionMode.Same, Pooling2D.Pooling2DType.AVG, 0.0, outH, outW,
-                                output);
+                                convolutionMode == ConvolutionMode.Same, Pooling2D.Pooling2DType.AVG, Pooling2D.Divisor.INCLUDE_PADDING,
+                                0.0, outH, outW, output);
 
                 break;
             case MAX:
                 Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
-                                convolutionMode == ConvolutionMode.Same, Pooling2D.Pooling2DType.MAX, 0.0, outH, outW,
-                                output);
+                                convolutionMode == ConvolutionMode.Same, Pooling2D.Pooling2DType.MAX, Pooling2D.Divisor.INCLUDE_PADDING,
+                                0.0, outH, outW, output);
 
                 break;
             case PNORM:
@@ -331,8 +331,8 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                 */
 
                 Convolution.pooling2D(input, kernel[0], kernel[1], strides[0], strides[1], pad[0], pad[1], dilation[0], dilation[1],
-                                convolutionMode == ConvolutionMode.Same, Pooling2D.Pooling2DType.PNORM, (double) pnorm,
-                                outH, outW, output);
+                                convolutionMode == ConvolutionMode.Same, Pooling2D.Pooling2DType.PNORM, Pooling2D.Divisor.INCLUDE_PADDING,
+                                (double) pnorm, outH, outW, output);
 
                 break;
             case NONE:


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/4492

ND4J equivalent: https://github.com/deeplearning4j/nd4j/pull/2502

Note that a few of the gradient checks are not passing:
![image](https://user-images.githubusercontent.com/2360237/34768833-20ecc778-f650-11e7-9eed-8bd7d1481be9.png)

Note that all 3 failing tests use same mode with a pooling layer - which suggests perhaps an issue with the pool 2d args?
  