### PR TITLE
add feed forward to layer for comp graph

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.nn.graph;
 
+import lombok.val;
 import org.datavec.api.records.reader.RecordReader;
 import org.datavec.api.records.reader.impl.csv.CSVRecordReader;
 import org.datavec.api.split.FileSplit;
@@ -68,6 +69,36 @@ public class TestComputationGraphNetwork {
     private static int getNumParams() {
         //Number of parameters for both iris models
         return (4 * 5 + 5) + (5 * 3 + 3);
+    }
+
+
+    @Test
+    public void testFeedForwardToLayer() {
+
+        ComputationGraphConfiguration configuration = getIrisGraphConfiguration();
+
+        ComputationGraph graph = new ComputationGraph(configuration);
+        graph.init();
+
+        MultiLayerConfiguration mlc = getIrisMLNConfiguration();
+        MultiLayerNetwork net = new MultiLayerNetwork(mlc);
+        net.init();
+
+
+        DataSetIterator iris = new IrisDataSetIterator(150, 150);
+        DataSet ds = iris.next();
+
+        graph.setInput(0, ds.getFeatureMatrix());
+        net.setParams(graph.params());
+        Map<String, INDArray> activations = graph.feedForward(false);
+
+        List<INDArray> feedForward = net.feedForward(ds.getFeatureMatrix());
+        assertEquals(activations.size(),feedForward.size());
+        assertEquals(activations.get("outputLayer"),feedForward.get(feedForward.size() - 1));
+
+        val graphForward = graph.feedForward(ds.getFeatureMatrix(),0,false);
+        val networkForward =  net.feedForwardToLayer(0,ds.getFeatureMatrix(),false);
+        assertEquals(graphForward.get("firstLayer"),networkForward.get(1));
     }
 
     @Test

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1576,6 +1576,14 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
 
         //Do forward pass according to the topological ordering of the network
         for (int i = 0; i < topologicalOrder.length; i++) {
+/*
+            if(layerFeedForwardIdx >= 0 && i > layerFeedForwardIdx + 1) {
+                break;
+            }
+*/
+
+
+
             GraphVertex current = vertices[topologicalOrder[i]];
             try (MemoryWorkspace ws = workspace.notifyScopeEntered()) {
 
@@ -1652,7 +1660,8 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                 }
             }
 
-            if(current.getVertexIndex() == layerFeedForwardIdx) break;
+            if(layerFeedForwardIdx > 0 && current.getVertexIndex() == layerFeedForwardIdx) break;
+
         }
 
         if (!train)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1576,12 +1576,6 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
 
         //Do forward pass according to the topological ordering of the network
         for (int i = 0; i < topologicalOrder.length; i++) {
-            if(layerFeedForwardIdx >= 0 && i > layerFeedForwardIdx + 1) {
-                break;
-            }
-
-
-
             GraphVertex current = vertices[topologicalOrder[i]];
             try (MemoryWorkspace ws = workspace.notifyScopeEntered()) {
 
@@ -1657,6 +1651,8 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                     }
                 }
             }
+
+            if(current.getVertexIndex() == layerFeedForwardIdx) break;
         }
 
         if (!train)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1378,6 +1378,77 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         }
     }
 
+
+
+
+
+
+    /**
+     * Conduct forward pass using a single input array. Note that this method can only be used with ComputationGraphs
+     * with a single input array.
+     *
+     * @param input The input array
+     * @param layerTillIndex the layer to feed forward to
+     * @param train If true: do forward pass at training time
+     * @return A map of activations for each layer (not each GraphVertex). Keys = layer name, values = layer activations
+     */
+    public Map<String, INDArray> feedForward(INDArray input, int layerTillIndex,boolean train) {
+        if (numInputArrays != 1)
+            throw new UnsupportedOperationException("Cannot feedForward with single input for graph network with "
+                    + numInputArrays + " expected inputs");
+        setInput(0, input);
+        return feedForward(train,layerTillIndex);
+    }
+
+
+
+    /**
+     * Conduct forward pass using an array of inputs. This overload allows the forward pass to be conducted, optionally
+     * (not) clearing the layer input arrays.<br>
+     * Note: this method should NOT be used with clearInputs = true, unless you know what you are doing. Specifically:
+     * when using clearInputs=false, in combination with workspaces, the layer input fields may leak outside of the
+     * workspaces in which they were defined - potentially causing a crash. See https://deeplearning4j.org/workspaces
+     * for more details
+     *
+     * @param input An array of ComputationGraph inputs
+     * @param layerTillIndex the index of the layer to feed forward to
+     * @param train If true: do forward pass at training time; false: do forward pass at test time
+     * @param clearInputs If true (default for other methods): clear the inputs of all layers after doing forward
+     *                    pass. False don't clear layer inputs.
+     * @return A map of activations for each layer (not each GraphVertex). Keys = layer name, values = layer activations
+     */
+    public Map<String, INDArray> feedForward(INDArray[] input, int layerTillIndex,boolean train, boolean clearInputs) {
+        setInputs(input);
+        return feedForward(train, false, false, clearInputs,layerTillIndex);
+    }
+
+
+    /**
+     * Conduct forward pass using an array of inputs
+     *
+     * @param input An array of ComputationGraph inputs
+     * @param layerTillIndex the index of the layer to feed forward to
+     * @param train If true: do forward pass at training time; false: do forward pass at test time
+     * @return A map of activations for each layer (not each GraphVertex). Keys = layer name, values = layer activations
+     */
+    public Map<String, INDArray> feedForward(INDArray[] input, int layerTillIndex,boolean train) {
+        return feedForward(input, train, true);
+    }
+
+
+    /**
+     * Conduct forward pass using the stored inputs
+     *
+     * @param train If true: do forward pass at training time; false: do forward pass at test time
+     * @param layerTillIndex the index of the layer to feed forward to
+     * @return A map of activations for each layer (not each GraphVertex). Keys = layer name, values = layer activations
+     */
+    public Map<String, INDArray> feedForward(boolean train,int layerTillIndex) {
+        return feedForward(train, false, false, true,layerTillIndex);
+    }
+
+
+
     /**
      * Conduct forward pass using a single input array. Note that this method can only be used with ComputationGraphs
      * with a single input array.
@@ -1458,6 +1529,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         return feedForward(train, excludeOutputLayers, includeNonLayerVertexActivations, true);
     }
 
+
     /**
      * PLEASE NEVER USE THIS METHOD IF YOU"RE NOT SURE WHAT YOU'll GET
      *
@@ -1469,6 +1541,22 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      */
     protected Map<String, INDArray> feedForward(boolean train, boolean excludeOutputLayers,
                                                 boolean includeNonLayerVertexActivations, boolean publicApi) {
+        return feedForward(train,excludeOutputLayers,includeNonLayerVertexActivations,publicApi,-1);
+    }
+    /**
+     * PLEASE NEVER USE THIS METHOD IF YOU"RE NOT SURE WHAT YOU'll GET
+     *
+     * @param train
+     * @param excludeOutputLayers
+     * @param includeNonLayerVertexActivations
+     * @param publicApi
+     * @return
+     */
+    protected Map<String, INDArray> feedForward(boolean train,
+                                                boolean excludeOutputLayers,
+                                                boolean includeNonLayerVertexActivations,
+                                                boolean publicApi,
+                                                int layerFeedForwardIdx) {
         Map<String, INDArray> layerActivations = new HashMap<>();
 
         MemoryWorkspace workspace;
@@ -1488,6 +1576,12 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
 
         //Do forward pass according to the topological ordering of the network
         for (int i = 0; i < topologicalOrder.length; i++) {
+            if(layerFeedForwardIdx >= 0 && i > layerFeedForwardIdx + 1) {
+                break;
+            }
+
+
+
             GraphVertex current = vertices[topologicalOrder[i]];
             try (MemoryWorkspace ws = workspace.notifyScopeEntered()) {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
Adds feed forward to layer for comp graph.
Test:
https://github.com/deeplearning4j/deeplearning4j/blob/6a6d5044419a6b6cea36333ef7d8f065eae46cfe/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java#L80
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
