### PR TITLE
set output even though an exception happens

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
@@ -337,8 +337,7 @@ public class ParallelInference {
                             INDArray output = null;
                             try {
                                 output = ((MultiLayerNetwork) replicatedModel).output(request.getInput()[0]);
-                            }
-                            catch (Exception e) {
+                            } catch (Exception e) {
                                 // do nothing
                             }
                             request.setOutput(output);

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
@@ -334,7 +334,13 @@ public class ParallelInference {
                             INDArray[] output = ((ComputationGraph) replicatedModel).output(false, request.getInput());
                             request.setOutput(output);
                         } else if (replicatedModel instanceof MultiLayerNetwork) {
-                            INDArray output = ((MultiLayerNetwork) replicatedModel).output(request.getInput()[0]);
+                            INDArray output = null;
+                            try {
+                                output = ((MultiLayerNetwork) replicatedModel).output(request.getInput()[0]);
+                            }
+                            catch (Exception e) {
+                                // do nothing
+                            }
                             request.setOutput(output);
                         }
 


### PR DESCRIPTION
## The InferenceWorker will set the output even though an exception happens

When an exception happened when executing the statement `output = ((MultiLayerNetwork) replicatedModel).output(request.getInput()[0])` ,  the `InferenceWorker` will not call  the method  `request.setOutput(output)`. Then `observer.waitTillDone()` will wait all the time.

## How was this patch tested?

This code was tested manually.

## Quick checklist