### PR TITLE
Remove unused lucene.version pom.xml property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <typesafe.config.version>1.3.0</typesafe.config.version>
         <lombok.version>1.16.16</lombok.version>
         <cleartk.version>2.0.0</cleartk.version>
-        <lucene.version>5.3.1</lucene.version>
         <json.version>20131018</json.version>
         <google.protobuf.version>2.6.1</google.protobuf.version>
         <failIfNoTests>false</failIfNoTests>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This property appears to be unused. If however it is actually used indirectly somehow somewhere then perhaps we could add a comment about that and/or mention that/why this specific older version is used instead of one of the newer versions: https://lucene.apache.org/solr/community.html#about-versions

## How was this patch tested?

Ran `git grep lucene` on the repo to try and find use of the property (and found none).
