### PR TITLE
Fix for obtaining own IP by master and nodes in shared training

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/pw/SharedTrainingWrapper.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/pw/SharedTrainingWrapper.java
@@ -218,7 +218,7 @@ public class SharedTrainingWrapper {
 
                     // we should introduce ourselves to controller
                     // FIXME: if localIP is null - use original ip discovery available in VoidParameterServer
-                    String localIP = System.getenv("SPARK_PUBLIC_DNS");
+                    String localIP = null;
 
                     // picking IP address based on network mask
                     if (localIP == null && voidConfiguration.getNetworkMask() != null) {

--- a/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
@@ -45,6 +45,8 @@ import org.nd4j.shade.jackson.core.JsonProcessingException;
 import org.nd4j.shade.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -426,8 +428,12 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
                             : graph.getSparkContext().defaultParallelism();
 
         // set current box as controller, if field is unset - switch to next stop
-        if (voidConfiguration.getControllerAddress() == null)
-            voidConfiguration.setControllerAddress(System.getenv("SPARK_PUBLIC_DNS"));
+        if (voidConfiguration.getControllerAddress() == null) {
+            try {
+                String sparkIp = InetAddress.getByName(System.getenv("SPARK_PUBLIC_DNS")).getHostAddress();
+                voidConfiguration.setControllerAddress(sparkIp);
+            } catch(UnknownHostException e) { }
+        }
 
         // next step - is to get ip address that matches specific network mask
         if (voidConfiguration.getControllerAddress() == null && voidConfiguration.getNetworkMask() != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Parameter Server master now translates SPARK_PUBLIC_DNS to IP if it's just hostname.

## How was this patch tested?

Ran MNIST parameter server example after building this and analogous nd4j change with expected result
