### PR TITLE
Add FileDataSetIterator and FileMultiDataSetIterator

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/TestFileIterators.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/datasets/iterator/TestFileIterators.java
@@ -1,0 +1,153 @@
+package org.deeplearning4j.datasets.iterator;
+
+import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.datasets.iterator.file.FileDataSetIterator;
+import org.deeplearning4j.datasets.iterator.file.FileMultiDataSetIterator;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.MultiDataSet;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestFileIterators extends BaseDL4JTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testFileDataSetIterator() throws Exception {
+        folder.create();
+        File f = folder.newFolder();
+
+        DataSet d1 = new DataSet(Nd4j.linspace(1, 10, 10).transpose(),
+                Nd4j.linspace(101, 110, 10).transpose());
+        DataSet d2 = new DataSet(Nd4j.linspace(11, 20, 10).transpose(),
+                Nd4j.linspace(111, 120, 10).transpose());
+        DataSet d3 = new DataSet(Nd4j.linspace(21, 30, 10).transpose(),
+                Nd4j.linspace(121, 130, 10).transpose());
+
+        d1.save(new File(f, "d1.bin"));
+        File f2 = new File(f, "subdir/d2.bin");
+        f2.getParentFile().mkdir();
+        d2.save(f2);
+        d3.save(new File(f, "d3.otherExt"));
+
+        List<DataSet> exp = Arrays.asList(d1, d3, d2);  //
+        DataSetIterator iter = new FileDataSetIterator(f, true, null, -1, (String[]) null);
+        List<DataSet> act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+
+        //Test with extension filtering:
+        exp = Arrays.asList(d1, d2);
+        iter = new FileDataSetIterator(f, true, null, -1, "bin");
+        act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+
+        //Test non-recursive
+        exp = Arrays.asList(d1, d3);
+        iter = new FileDataSetIterator(f, false, null, -1, (String[]) null);
+        act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+
+
+        //Test batch size != saved size
+        f = folder.newFolder();
+        d1.save(new File(f, "d1.bin"));
+        d2.save(new File(f, "d2.bin"));
+        d3.save(new File(f, "d3.bin"));
+        exp = Arrays.asList(
+                new DataSet(Nd4j.linspace(1, 15, 15).transpose(),
+                        Nd4j.linspace(101, 115, 15).transpose()),
+                new DataSet(Nd4j.linspace(16, 30, 15).transpose(),
+                        Nd4j.linspace(116, 130, 15).transpose()));
+        iter = new FileDataSetIterator(f, true, null, 15, (String[]) null);
+        act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+    }
+
+    @Test
+    public void testFileMultiDataSetIterator() throws Exception {
+        folder.create();
+        File f = folder.newFolder();
+
+        MultiDataSet d1 = new org.nd4j.linalg.dataset.MultiDataSet(Nd4j.linspace(1, 10, 10).transpose(),
+                Nd4j.linspace(101, 110, 10).transpose());
+        MultiDataSet d2 = new org.nd4j.linalg.dataset.MultiDataSet(Nd4j.linspace(11, 20, 10).transpose(),
+                Nd4j.linspace(111, 120, 10).transpose());
+        MultiDataSet d3 = new org.nd4j.linalg.dataset.MultiDataSet(Nd4j.linspace(21, 30, 10).transpose(),
+                Nd4j.linspace(121, 130, 10).transpose());
+
+        d1.save(new File(f, "d1.bin"));
+        File f2 = new File(f, "subdir/d2.bin");
+        f2.getParentFile().mkdir();
+        d2.save(f2);
+        d3.save(new File(f, "d3.otherExt"));
+
+        List<MultiDataSet> exp = Arrays.asList(d1, d3, d2);  //
+        MultiDataSetIterator iter = new FileMultiDataSetIterator(f, true, null, -1, (String[]) null);
+        List<MultiDataSet> act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+
+        //Test with extension filtering:
+        exp = Arrays.asList(d1, d2);
+        iter = new FileMultiDataSetIterator(f, true, null, -1, "bin");
+        act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+
+        //Test non-recursive
+        exp = Arrays.asList(d1, d3);
+        iter = new FileMultiDataSetIterator(f, false, null, -1, (String[]) null);
+        act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+
+
+        //Test batch size != saved size
+        f = folder.newFolder();
+        d1.save(new File(f, "d1.bin"));
+        d2.save(new File(f, "d2.bin"));
+        d3.save(new File(f, "d3.bin"));
+        exp = Arrays.<MultiDataSet>asList(
+                new org.nd4j.linalg.dataset.MultiDataSet(Nd4j.linspace(1, 15, 15).transpose(),
+                        Nd4j.linspace(101, 115, 15).transpose()),
+                new org.nd4j.linalg.dataset.MultiDataSet(Nd4j.linspace(16, 30, 15).transpose(),
+                        Nd4j.linspace(116, 130, 15).transpose()));
+        iter = new FileMultiDataSetIterator(f, true, null, 15, (String[]) null);
+        act = new ArrayList<>();
+        while (iter.hasNext()) {
+            act.add(iter.next());
+        }
+        assertEquals(exp, act);
+    }
+
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/BaseFileIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/BaseFileIterator.java
@@ -1,0 +1,159 @@
+package org.deeplearning4j.datasets.iterator.file;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.io.FileUtils;
+import org.deeplearning4j.util.MathUtils;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.collection.CompactHeapStringList;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public abstract class BaseFileIterator<T,P> implements Iterator<T> {
+
+    protected final List<String> list;
+    protected final int batchSize;
+    protected final Random rng;
+
+    protected int[] order;
+    protected int position;
+
+    private T partialStored;
+    @Getter @Setter private P preProcessor;
+
+
+    protected BaseFileIterator(File rootDir, int batchSize, String... validExtensions){
+        this(rootDir, true, new Random(), -1, validExtensions);
+    }
+
+    protected BaseFileIterator(File rootDir, boolean recursive, Random rng, int batchSize, String... validExtensions){
+        this.batchSize = batchSize;
+        this.rng = rng;
+
+        list = new CompactHeapStringList();
+        Collection<File> c = FileUtils.listFiles(rootDir, validExtensions, recursive);
+        if(c.isEmpty()){
+            throw new IllegalStateException("Root directory is null " + (validExtensions != null ? " (or all files rejected by extension filter)" : ""));
+        }
+        for(File f : c){
+            list.add(f.getPath());
+        }
+
+        if(rng != null){
+            order = new int[list.size()];
+            for( int i=0; i<order.length; i++ ){
+                order[i] = i;
+            }
+            MathUtils.shuffleArray(order, rng);
+        }
+    }
+
+    @Override
+    public boolean hasNext(){
+        return position < list.size();
+    }
+
+    @Override
+    public T next(){
+        if(!hasNext()){
+            throw new NoSuchElementException("No next element");
+        }
+        int nextIdx = (order == null ? order[position++] : position++);
+
+        T next = load(new File(list.get(nextIdx)));
+        if(batchSize < 0){
+            //Don't recombine, return as-is
+            return next;
+        }
+
+        if(partialStored == null && sizeOf(next) == batchSize){
+            return next;
+        }
+
+        int exampleCount = 0;
+        List<T> toMerge = new ArrayList<>();
+        if(partialStored != null){
+            toMerge.add(partialStored);
+            exampleCount += sizeOf(partialStored);
+            partialStored = null;
+        }
+
+        while(exampleCount < batchSize && hasNext()){
+            nextIdx = (order == null ? order[position++] : position++);
+            next = load(new File(list.get(nextIdx)));
+            exampleCount += sizeOf(next);
+            toMerge.add(next);
+        }
+
+        return mergeAndStoreRemainder(toMerge);
+    }
+
+    @Override
+    public void remove(){
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    protected T mergeAndStoreRemainder(List<T> toMerge){
+        //Could be smaller or larger
+        List<T> correctNum = new ArrayList<>();
+        List<T> remainder = new ArrayList<>();
+        int soFar = 0;
+        for(T t : toMerge){
+            int size = sizeOf(t);
+
+            if(soFar + size <= batchSize ) {
+                correctNum.add(t);
+                soFar += size;
+            } else if(soFar < batchSize){
+                //Split and add some
+                List<T> split = split(t);
+                for(T t2 : split){
+                    if(soFar < batchSize){
+                        correctNum.add(t2);
+                        soFar += sizeOf(t2);
+                    } else {
+                        remainder.add(t2);
+                    }
+                }
+            } else {
+                //Don't need any of this
+                remainder.add(t);
+            }
+        }
+
+        T ret = merge(correctNum);
+        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()){
+            this.partialStored = merge(remainder);
+        }
+
+        return ret;
+    }
+
+
+    public void reset(){
+        position = 0;
+        if(rng != null){
+            MathUtils.shuffleArray(order, rng);
+        }
+    }
+
+    public boolean resetSupported(){
+        return true;
+    }
+
+    public boolean asyncSupported(){
+        return true;
+    }
+
+
+    protected abstract T load(File f);
+
+    protected abstract int sizeOf(T of);
+
+    protected abstract List<T> split(T toSplit);
+
+    protected abstract T merge(List<T> toMerge);
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/BaseFileIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/BaseFileIterator.java
@@ -9,10 +9,16 @@ import org.nd4j.linalg.collection.CompactHeapStringList;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 
-public abstract class BaseFileIterator<T,P> implements Iterator<T> {
+/**
+ * Base class for loading DataSet objects from file
+ *
+ * @param <T> Type of dataset
+ * @param <P> Type of preprocessor
+ * @author Alex Black
+ */
+public abstract class BaseFileIterator<T, P> implements Iterator<T> {
 
     protected final List<String> list;
     protected final int batchSize;
@@ -22,29 +28,31 @@ public abstract class BaseFileIterator<T,P> implements Iterator<T> {
     protected int position;
 
     private T partialStored;
-    @Getter @Setter private P preProcessor;
+    @Getter
+    @Setter
+    protected P preProcessor;
 
 
-    protected BaseFileIterator(File rootDir, int batchSize, String... validExtensions){
+    protected BaseFileIterator(File rootDir, int batchSize, String... validExtensions) {
         this(rootDir, true, new Random(), -1, validExtensions);
     }
 
-    protected BaseFileIterator(File rootDir, boolean recursive, Random rng, int batchSize, String... validExtensions){
+    protected BaseFileIterator(File rootDir, boolean recursive, Random rng, int batchSize, String... validExtensions) {
         this.batchSize = batchSize;
         this.rng = rng;
 
         list = new CompactHeapStringList();
         Collection<File> c = FileUtils.listFiles(rootDir, validExtensions, recursive);
-        if(c.isEmpty()){
+        if (c.isEmpty()) {
             throw new IllegalStateException("Root directory is null " + (validExtensions != null ? " (or all files rejected by extension filter)" : ""));
         }
-        for(File f : c){
+        for (File f : c) {
             list.add(f.getPath());
         }
 
-        if(rng != null){
+        if (rng != null) {
             order = new int[list.size()];
-            for( int i=0; i<order.length; i++ ){
+            for (int i = 0; i < order.length; i++) {
                 order[i] = i;
             }
             MathUtils.shuffleArray(order, rng);
@@ -52,66 +60,71 @@ public abstract class BaseFileIterator<T,P> implements Iterator<T> {
     }
 
     @Override
-    public boolean hasNext(){
+    public boolean hasNext() {
         return position < list.size();
     }
 
     @Override
-    public T next(){
-        if(!hasNext()){
+    public T next() {
+        if (!hasNext()) {
             throw new NoSuchElementException("No next element");
         }
         int nextIdx = (order == null ? order[position++] : position++);
 
         T next = load(new File(list.get(nextIdx)));
-        if(batchSize < 0){
+        if (batchSize <= 0) {
             //Don't recombine, return as-is
             return next;
         }
 
-        if(partialStored == null && sizeOf(next) == batchSize){
+        if (partialStored == null && sizeOf(next) == batchSize) {
             return next;
         }
 
         int exampleCount = 0;
         List<T> toMerge = new ArrayList<>();
-        if(partialStored != null){
+        if (partialStored != null) {
             toMerge.add(partialStored);
             exampleCount += sizeOf(partialStored);
             partialStored = null;
         }
 
-        while(exampleCount < batchSize && hasNext()){
+        while (exampleCount < batchSize && hasNext()) {
             nextIdx = (order == null ? order[position++] : position++);
             next = load(new File(list.get(nextIdx)));
             exampleCount += sizeOf(next);
             toMerge.add(next);
         }
 
-        return mergeAndStoreRemainder(toMerge);
+        T ret = mergeAndStoreRemainder(toMerge);
+        applyPreprocessor(ret);
+        return ret;
     }
 
     @Override
-    public void remove(){
+    public void remove() {
         throw new UnsupportedOperationException("Not supported");
     }
 
-    protected T mergeAndStoreRemainder(List<T> toMerge){
+    protected T mergeAndStoreRemainder(List<T> toMerge) {
         //Could be smaller or larger
         List<T> correctNum = new ArrayList<>();
         List<T> remainder = new ArrayList<>();
         int soFar = 0;
-        for(T t : toMerge){
+        for (T t : toMerge) {
             int size = sizeOf(t);
 
-            if(soFar + size <= batchSize ) {
+            if (soFar + size <= batchSize) {
                 correctNum.add(t);
                 soFar += size;
-            } else if(soFar < batchSize){
+            } else if (soFar < batchSize) {
                 //Split and add some
                 List<T> split = split(t);
-                for(T t2 : split){
-                    if(soFar < batchSize){
+                if (rng != null) {
+                    Collections.shuffle(split, rng);
+                }
+                for (T t2 : split) {
+                    if (soFar < batchSize) {
                         correctNum.add(t2);
                         soFar += sizeOf(t2);
                     } else {
@@ -125,7 +138,7 @@ public abstract class BaseFileIterator<T,P> implements Iterator<T> {
         }
 
         T ret = merge(correctNum);
-        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()){
+        try (MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
             this.partialStored = merge(remainder);
         }
 
@@ -133,18 +146,18 @@ public abstract class BaseFileIterator<T,P> implements Iterator<T> {
     }
 
 
-    public void reset(){
+    public void reset() {
         position = 0;
-        if(rng != null){
+        if (rng != null) {
             MathUtils.shuffleArray(order, rng);
         }
     }
 
-    public boolean resetSupported(){
+    public boolean resetSupported() {
         return true;
     }
 
-    public boolean asyncSupported(){
+    public boolean asyncSupported() {
         return true;
     }
 
@@ -156,4 +169,6 @@ public abstract class BaseFileIterator<T,P> implements Iterator<T> {
     protected abstract List<T> split(T toSplit);
 
     protected abstract T merge(List<T> toMerge);
+
+    protected abstract void applyPreprocessor(T toPreProcess);
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileDataSetIterator.java
@@ -8,34 +8,87 @@ import java.io.File;
 import java.util.List;
 import java.util.Random;
 
-public class FileDataSetIterator extends BaseFileIterator<DataSet,DataSetPreProcessor> implements DataSetIterator {
+/**
+ * Iterate over a directory (and optionally subdirectories) containing a number of {@link DataSet} objects that have
+ * previously been saved to files with {@link DataSet#save(File)}.<br>
+ * This iterator supports the following (optional) features, depending on the constructor used:<br>
+ * - Recursive listing of all files (i.e., include files in subdirectories)<br>
+ * - Filtering based on a set of file extensions (if null, no filtering - assume all files are saved DataSet objects)<br>
+ * - Randomization of iteration order (default enabled, if a {@link Random} instance is provided<br>
+ * - Combining and splitting of DataSets (disabled by default, or if batchSize == -1. If enabled, DataSet objects will
+ * be split or combined as required to ensure the specified minibatch size is returned. In other words, the saved
+ * DataSet objects can have a different number of examples vs. those returned by the iterator.<br>
+ *
+ * @author Alex BLack
+ */
+public class FileDataSetIterator extends BaseFileIterator<DataSet, DataSetPreProcessor> implements DataSetIterator {
 
     /**
-     * Create a FileDataSetIterator with the following default settings:
-     * - Recursive: files in subdirectories are included
-     * - Randomization: order of examples is randomized with a random RNG seed
-     * - Batch size: default (as in the stored DataSets - no splitting/combining)
-     * - File extensions: no filtering - all files in directory are assumed to be a DataSet
+     * Create a FileDataSetIterator with the following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     * - Batch size: default (as in the stored DataSets - no splitting/combining)<br>
+     * - File extensions: no filtering - all files in directory are assumed to be a DataSet<br>
      *
-     * @param rootDir Root directory containing the D
+     * @param rootDir Root directory containing the DataSet objects
      */
-    public FileDataSetIterator(File rootDir){
-        this(rootDir, true, new Random(), -1, (String[])null);
+    public FileDataSetIterator(File rootDir) {
+        this(rootDir, true, new Random(), -1, (String[]) null);
     }
 
-    public FileDataSetIterator(File rootDir, int batchSize){
-        this(rootDir, batchSize, (String[])null);
+    /**
+     * Create a FileDataSetIterator with the specified batch size, and the following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     * - File extensions: no filtering - all files in directory are assumed to be a DataSet<br>
+     *
+     * @param rootDir   Root directory containing the saved DataSet objects
+     * @param batchSize Batch size. If > 0, DataSets will be split/recombined as required. If <= 0, DataSets will
+     *                  simply be loaded and returned unmodified
+     */
+    public FileDataSetIterator(File rootDir, int batchSize) {
+        this(rootDir, batchSize, (String[]) null);
     }
 
-    public FileDataSetIterator(File rootDir, String... validExtensions){
+    /**
+     * Create a FileDataSetIterator with filtering based on file extensions, and the following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     * - Batch size: default (as in the stored DataSets - no splitting/combining)<br>
+     *
+     * @param rootDir         Root directory containing the saved DataSet objects
+     * @param validExtensions May be null. If non-null, only files with one of the specified extensions will be used
+     */
+    public FileDataSetIterator(File rootDir, String... validExtensions) {
         super(rootDir, -1, validExtensions);
     }
 
-    public FileDataSetIterator(File rootDir, int batchSize, String... validExtensions){
+    /**
+     * Create a FileDataSetIterator with the specified batch size, filtering based on file extensions, and the
+     * following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     *
+     * @param rootDir         Root directory containing the saved DataSet objects
+     * @param batchSize       Batch size. If > 0, DataSets will be split/recombined as required. If <= 0, DataSets will
+     *                        simply be loaded and returned unmodified
+     * @param validExtensions May be null. If non-null, only files with one of the specified extensions will be used
+     */
+    public FileDataSetIterator(File rootDir, int batchSize, String... validExtensions) {
         super(rootDir, batchSize, validExtensions);
     }
 
-    public FileDataSetIterator(File rootDir, boolean recursive, Random rng, int batchSize, String... validExtensions){
+    /**
+     * Create a FileDataSetIterator with all settings specified
+     *
+     * @param rootDir         Root directory containing the saved DataSet objects
+     * @param recursive       If true: include files in subdirectories
+     * @param rng             May be null. If non-null, use this to randomize order
+     * @param batchSize       Batch size. If > 0, DataSets will be split/recombined as required. If <= 0, DataSets will
+     *                        simply be loaded and returned unmodified
+     * @param validExtensions May be null. If non-null, only files with one of the specified extensions will be used
+     */
+    public FileDataSetIterator(File rootDir, boolean recursive, Random rng, int batchSize, String... validExtensions) {
         super(rootDir, recursive, rng, batchSize, validExtensions);
     }
 
@@ -59,6 +112,13 @@ public class FileDataSetIterator extends BaseFileIterator<DataSet,DataSetPreProc
     @Override
     protected DataSet merge(List<DataSet> toMerge) {
         return DataSet.merge(toMerge);
+    }
+
+    @Override
+    protected void applyPreprocessor(DataSet toPreProcess) {
+        if (preProcessor != null) {
+            preProcessor.preProcess(toPreProcess);
+        }
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileDataSetIterator.java
@@ -1,0 +1,103 @@
+package org.deeplearning4j.datasets.iterator.file;
+
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+
+import java.io.File;
+import java.util.List;
+import java.util.Random;
+
+public class FileDataSetIterator extends BaseFileIterator<DataSet,DataSetPreProcessor> implements DataSetIterator {
+
+    /**
+     * Create a FileDataSetIterator with the following default settings:
+     * - Recursive: files in subdirectories are included
+     * - Randomization: order of examples is randomized with a random RNG seed
+     * - Batch size: default (as in the stored DataSets - no splitting/combining)
+     * - File extensions: no filtering - all files in directory are assumed to be a DataSet
+     *
+     * @param rootDir Root directory containing the D
+     */
+    public FileDataSetIterator(File rootDir){
+        this(rootDir, true, new Random(), -1, (String[])null);
+    }
+
+    public FileDataSetIterator(File rootDir, int batchSize){
+        this(rootDir, batchSize, (String[])null);
+    }
+
+    public FileDataSetIterator(File rootDir, String... validExtensions){
+        super(rootDir, -1, validExtensions);
+    }
+
+    public FileDataSetIterator(File rootDir, int batchSize, String... validExtensions){
+        super(rootDir, batchSize, validExtensions);
+    }
+
+    public FileDataSetIterator(File rootDir, boolean recursive, Random rng, int batchSize, String... validExtensions){
+        super(rootDir, recursive, rng, batchSize, validExtensions);
+    }
+
+    @Override
+    protected DataSet load(File f) {
+        DataSet ds = new DataSet();
+        ds.load(f);
+        return ds;
+    }
+
+    @Override
+    protected int sizeOf(DataSet of) {
+        return of.numExamples();
+    }
+
+    @Override
+    protected List<DataSet> split(DataSet toSplit) {
+        return toSplit.asList();
+    }
+
+    @Override
+    protected DataSet merge(List<DataSet> toMerge) {
+        return DataSet.merge(toMerge);
+    }
+
+    @Override
+    public DataSet next(int num) {
+        throw new UnsupportedOperationException("Not supported for this iterator");
+    }
+
+    @Override
+    public int totalExamples() {
+        throw new UnsupportedOperationException("Not supported for this iterator");
+    }
+
+    @Override
+    public int inputColumns() {
+        throw new UnsupportedOperationException("Not supported for this iterator");
+    }
+
+    @Override
+    public int totalOutcomes() {
+        throw new UnsupportedOperationException("Not supported for this iterator");
+    }
+
+    @Override
+    public int batch() {
+        return batchSize;
+    }
+
+    @Override
+    public int cursor() {
+        return position;
+    }
+
+    @Override
+    public int numExamples() {
+        throw new UnsupportedOperationException("Not supported for this iterator");
+    }
+
+    @Override
+    public List<String> getLabels() {
+        throw new UnsupportedOperationException("Not supported for this iterator");
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileMultiDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileMultiDataSetIterator.java
@@ -1,0 +1,39 @@
+package org.deeplearning4j.datasets.iterator.file;
+
+import org.nd4j.linalg.dataset.api.MultiDataSet;
+import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileMultiDataSetIterator extends BaseFileIterator<MultiDataSet, MultiDataSetPreProcessor> {
+
+
+    protected FileMultiDataSetIterator(File rootDir, String... validExtensions) {
+        super(rootDir, validExtensions);
+    }
+
+    @Override
+    protected MultiDataSet load(File f) throws IOException {
+        MultiDataSet mds = new org.nd4j.linalg.dataset.MultiDataSet();
+        mds.load(f);
+        return mds;
+    }
+
+    @Override
+    protected int sizeOf(MultiDataSet of) {
+        return of.getFeatures(0).size(0);
+    }
+
+    @Override
+    protected List<MultiDataSet> split(MultiDataSet toSplit) {
+        return toSplit.asList();
+    }
+
+    @Override
+    public MultiDataSet merge(List<MultiDataSet> toMerge){
+        return org.nd4j.linalg.dataset.MultiDataSet.merge(toMerge);
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileMultiDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileMultiDataSetIterator.java
@@ -5,20 +5,102 @@ import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
+/**
+ * Iterate over a directory (and optionally subdirectories) containing a number of {@link MultiDataSet} objects that have
+ * previously been saved to files with {@link MultiDataSet#save(File)}.<br>
+ * This iterator supports the following (optional) features, depending on the constructor used:<br>
+ * - Recursive listing of all files (i.e., include files in subdirectories)<br>
+ * - Filtering based on a set of file extensions (if null, no filtering - assume all files are saved MultiDataSet objects)<br>
+ * - Randomization of iteration order (default enabled, if a {@link Random} instance is provided<br>
+ * - Combining and splitting of MultiDataSets (disabled by default, or if batchSize == -1. If enabled, MultiDataSet
+ * objects will be split or combined as required to ensure the specified minibatch size is returned. In other words, the
+ * saved MultiDataSet objects can have a different number of examples vs. those returned by the iterator.<br>
+ *
+ * @author Alex BLack
+ */
 public class FileMultiDataSetIterator extends BaseFileIterator<MultiDataSet, MultiDataSetPreProcessor> {
 
 
-    protected FileMultiDataSetIterator(File rootDir, String... validExtensions) {
-        super(rootDir, validExtensions);
+    /**
+     * Create a FileMultiDataSetIterator with the following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     * - Batch size: default (as in the stored DataSets - no splitting/combining)<br>
+     * - File extensions: no filtering - all files in directory are assumed to be a DataSet<br>
+     *
+     * @param rootDir Root directory containing the DataSet objects
+     */
+    public FileMultiDataSetIterator(File rootDir) {
+        this(rootDir, true, new Random(), -1, (String[]) null);
+    }
+
+    /**
+     * Create a FileMultiDataSetIterator with the specified batch size, and the following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     * - File extensions: no filtering - all files in directory are assumed to be a DataSet<br>
+     *
+     * @param rootDir   Root directory containing the saved DataSet objects
+     * @param batchSize Batch size. If > 0, DataSets will be split/recombined as required. If <= 0, DataSets will
+     *                  simply be loaded and returned unmodified
+     */
+    public FileMultiDataSetIterator(File rootDir, int batchSize) {
+        this(rootDir, batchSize, (String[]) null);
+    }
+
+    /**
+     * Create a FileMultiDataSetIterator with filtering based on file extensions, and the following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     * - Batch size: default (as in the stored DataSets - no splitting/combining)<br>
+     *
+     * @param rootDir         Root directory containing the saved DataSet objects
+     * @param validExtensions May be null. If non-null, only files with one of the specified extensions will be used
+     */
+    public FileMultiDataSetIterator(File rootDir, String... validExtensions) {
+        super(rootDir, -1, validExtensions);
+    }
+
+    /**
+     * Create a FileMultiDataSetIterator with the specified batch size, filtering based on file extensions, and the
+     * following default settings:<br>
+     * - Recursive: files in subdirectories are included<br>
+     * - Randomization: order of examples is randomized with a random RNG seed<br>
+     *
+     * @param rootDir         Root directory containing the saved DataSet objects
+     * @param batchSize       Batch size. If > 0, DataSets will be split/recombined as required. If <= 0, DataSets will
+     *                        simply be loaded and returned unmodified
+     * @param validExtensions May be null. If non-null, only files with one of the specified extensions will be used
+     */
+    public FileMultiDataSetIterator(File rootDir, int batchSize, String... validExtensions) {
+        super(rootDir, batchSize, validExtensions);
+    }
+
+    /**
+     * Create a FileMultiDataSetIterator with all settings specified
+     *
+     * @param rootDir         Root directory containing the saved DataSet objects
+     * @param recursive       If true: include files in subdirectories
+     * @param rng             May be null. If non-null, use this to randomize order
+     * @param batchSize       Batch size. If > 0, DataSets will be split/recombined as required. If <= 0, DataSets will
+     *                        simply be loaded and returned unmodified
+     * @param validExtensions May be null. If non-null, only files with one of the specified extensions will be used
+     */
+    public FileMultiDataSetIterator(File rootDir, boolean recursive, Random rng, int batchSize, String... validExtensions) {
+        super(rootDir, recursive, rng, batchSize, validExtensions);
     }
 
     @Override
-    protected MultiDataSet load(File f) throws IOException {
+    protected MultiDataSet load(File f) {
         MultiDataSet mds = new org.nd4j.linalg.dataset.MultiDataSet();
-        mds.load(f);
+        try {
+            mds.load(f);
+        } catch (IOException e) {
+            throw new RuntimeException("Error loading MultiDataSet from file: " + f, e);
+        }
         return mds;
     }
 
@@ -33,7 +115,14 @@ public class FileMultiDataSetIterator extends BaseFileIterator<MultiDataSet, Mul
     }
 
     @Override
-    public MultiDataSet merge(List<MultiDataSet> toMerge){
+    public MultiDataSet merge(List<MultiDataSet> toMerge) {
         return org.nd4j.linalg.dataset.MultiDataSet.merge(toMerge);
+    }
+
+    @Override
+    protected void applyPreprocessor(MultiDataSet toPreProcess) {
+        if (preProcessor != null) {
+            preProcessor.preProcess(toPreProcess);
+        }
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileMultiDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileMultiDataSetIterator.java
@@ -2,6 +2,7 @@ package org.deeplearning4j.datasets.iterator.file;
 
 import org.nd4j.linalg.dataset.api.MultiDataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
+import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,7 +22,7 @@ import java.util.Random;
  *
  * @author Alex BLack
  */
-public class FileMultiDataSetIterator extends BaseFileIterator<MultiDataSet, MultiDataSetPreProcessor> {
+public class FileMultiDataSetIterator extends BaseFileIterator<MultiDataSet, MultiDataSetPreProcessor> implements MultiDataSetIterator {
 
 
     /**
@@ -124,5 +125,10 @@ public class FileMultiDataSetIterator extends BaseFileIterator<MultiDataSet, Mul
         if (preProcessor != null) {
             preProcessor.preProcess(toPreProcess);
         }
+    }
+
+    @Override
+    public MultiDataSet next(int num) {
+        throw new UnsupportedOperationException("Not supported for this iterator");
     }
 }


### PR DESCRIPTION
Basically versions of ExistingMinibatchDataSetIterator that supports:
- MultiDataSet
- Splitting/combining (Multi)DataSets
- Randomization
- Automatically inferring files to load (i.e., not based on fixed numbered pattern)
- Filtering and recursive, etc