### PR TITLE
Replace DynamicCustomOp in TimeSeriesUtils for reverse

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/TestVariableLengthTS.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/TestVariableLengthTS.java
@@ -10,9 +10,12 @@ import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToRnnPreProcessor;
 import org.deeplearning4j.nn.conf.preprocessor.RnnToFeedForwardPreProcessor;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.util.TimeSeriesUtils;
 import org.junit.Test;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.CustomOp;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.INDArrayIndex;
@@ -544,5 +547,48 @@ public class TestVariableLengthTS extends BaseDL4JTest {
                 }
             }
         }
+    }
+
+
+    @Test
+    public void testReverse(){
+
+        for(char c : new char[]{'f','c'}) {
+
+            INDArray in = Nd4j.linspace(1, 3 * 5 * 10, 3 * 5 * 10).reshape('f', 3, 5, 10).dup(c);
+            INDArray inMask = Nd4j.linspace(1, 30, 30).reshape('f', 3, 10).dup(c); //Minibatch, TS length
+
+            INDArray inReverseExp = reverseTimeSeries(in);
+            INDArray inMaskReverseExp = Nd4j.create(inMask.shape());
+            for (int i = 0; i < inMask.size(1); i++) {
+                inMaskReverseExp.putColumn(i, inMask.getColumn(inMask.size(1) - i - 1));
+            }
+
+            INDArray inReverse = TimeSeriesUtils.reverseTimeSeries(in);
+            INDArray inMaskReverse = TimeSeriesUtils.reverseTimeSeriesMask(inMask);
+
+            assertEquals(inReverseExp, inReverse);
+            assertEquals(inMaskReverseExp, inMaskReverse);
+        }
+    }
+
+
+
+    /**
+     * CPU ONLY VERSION FOR TESTING
+     */
+    public static INDArray reverseTimeSeries(INDArray in){
+        if(in == null){
+            return null;
+        }
+        INDArray out = Nd4j.createUninitialized(in.shape(), 'f');
+        CustomOp op = DynamicCustomOp.builder("reverse")
+                .addIntegerArguments(new int[]{0,1})
+                .addInputs(in)
+                .addOutputs(out)
+                .callInplace(false)
+                .build();
+        Nd4j.getExecutioner().exec(op);
+        return out;
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
@@ -128,6 +128,23 @@ public class TimeSeriesUtils {
         if(in == null){
             return null;
         }
+
+        if(in.ordering() != 'f' || in.isView() || !Shape.strideDescendingCAscendingF(in)){
+            in = in.dup('f');
+        }
+
+        int[] idxs = new int[in.size(2)];
+        int j=0;
+        for( int i=idxs.length-1; i>=0; i--){
+            idxs[j++] = i;
+        }
+
+        INDArray inReshape = in.reshape('f', in.size(0)*in.size(1), in.size(2));
+
+        INDArray outReshape = Nd4j.pullRows(inReshape, 0, idxs, 'f');
+        return outReshape.reshape('f', in.size(0), in.size(1), in.size(2));
+
+        /*
         INDArray out = Nd4j.createUninitialized(in.shape(), 'f');
         CustomOp op = DynamicCustomOp.builder("reverse")
                 .addIntegerArguments(new int[]{0,1})
@@ -137,6 +154,7 @@ public class TimeSeriesUtils {
                 .build();
         Nd4j.getExecutioner().exec(op);
         return out;
+        */
     }
 
     /**
@@ -156,6 +174,15 @@ public class TimeSeriesUtils {
                     + " with shape " + Arrays.toString(mask.shape()));
         }
 
+        int[] idxs = new int[mask.size(1)];
+        int j=0;
+        for( int i=idxs.length-1; i>=0; i--){
+            idxs[j++] = i;
+        }
+
+        return Nd4j.pullRows(mask, 0, idxs);
+
+        /*
         //Assume input mask is 2d: [minibatch, tsLength]
         INDArray out = Nd4j.createUninitialized(mask.shape(), 'f');
         CustomOp op = DynamicCustomOp.builder("reverse")
@@ -166,6 +193,7 @@ public class TimeSeriesUtils {
                 .build();
         Nd4j.getExecutioner().exec(op);
         return out;
+        */
     }
 
     /**


### PR DESCRIPTION
CPU only dynamic custom op is more of a bottleneck than I had anticipated. This *should* improve performance as it can be executed on GPU...