### PR TITLE
[WIP] Mask zero activations for RNNs

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -35,6 +35,7 @@ import org.deeplearning4j.nn.conf.layers.recurrent.SimpleRnn;
 import org.deeplearning4j.nn.conf.layers.util.MaskLayer;
 import org.deeplearning4j.nn.conf.layers.variational.VariationalAutoencoder;
 import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.nn.layers.recurrent.MaskZeroLayer;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.learning.config.IUpdater;
@@ -80,7 +81,8 @@ import java.util.*;
                 @JsonSubTypes.Type(value = Bidirectional.class, name = "Bidirectional"),
                 @JsonSubTypes.Type(value = SimpleRnn.class, name = "SimpleRnn"),
                 @JsonSubTypes.Type(value = ElementWiseMultiplicationLayer.class, name = "ElementWiseMult"),
-                @JsonSubTypes.Type(value = MaskLayer.class, name = "MaskLayer")}
+                @JsonSubTypes.Type(value = MaskLayer.class, name = "MaskLayer"),
+                @JsonSubTypes.Type(value = MaskZeroLayer.class, name = "MaskZeroLayer")}
 )
 @Data
 @NoArgsConstructor

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTM.java
@@ -183,7 +183,7 @@ public class LSTM extends BaseRecurrentLayer<org.deeplearning4j.nn.conf.layers.L
         FwdPassReturn fwd = LSTMHelpers.activateHelper(this, this.conf, this.layerConf().getGateActivationFn(),
                         this.input, recurrentWeights, inputWeights, biases, training, prevOutputActivations,
                         prevMemCellState, (training && cacheMode != CacheMode.NONE) || forBackprop, true,
-                        LSTMParamInitializer.INPUT_WEIGHT_KEY, null, false, helper,
+                        LSTMParamInitializer.INPUT_WEIGHT_KEY, maskArray, false, helper,
                         forBackprop ? cacheMode : CacheMode.NONE);
 
         if (training && cacheMode != CacheMode.NONE) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
@@ -9,7 +9,16 @@ import org.nd4j.linalg.primitives.Pair;
 
 import lombok.NonNull;
 
+/**
+ *
+ * Masks timesteps with 0 activation. Assumes that the input shape is [batch_size, input_size, timesteps].
+ */
 public class MaskZeroLayer extends BaseWrapperLayer {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -7369482676002469854L;
 
     public MaskZeroLayer(@NonNull Layer underlying){
         super(underlying);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
@@ -54,15 +54,13 @@ public class MaskZeroLayer extends BaseWrapperLayer {
     @Override
     public INDArray activate(TrainingMode training) {
         INDArray input = input();
-        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
-        underlying.setMaskArray(mask);
+        setMaskFromInput(input);
         return underlying.activate(training);
     }
 
     @Override
     public INDArray activate(INDArray input, TrainingMode training) {
-        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
-        underlying.setMaskArray(mask);
+        setMaskFromInput(input);
         return underlying.activate(input, training);
     }
 
@@ -74,31 +72,32 @@ public class MaskZeroLayer extends BaseWrapperLayer {
     @Override
     public INDArray activate(boolean training) {
         INDArray input = input();
-        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
-        underlying.setMaskArray(mask);
+        setMaskFromInput(input);
         return underlying.activate(training);
     }
 
     @Override
     public INDArray activate(INDArray input, boolean training) {
-        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
-        underlying.setMaskArray(mask);
+        setMaskFromInput(input);
         return underlying.activate(input, training);
     }
 
     @Override
     public INDArray activate() {
         INDArray input = input();
-        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
-        underlying.setMaskArray(mask);
+        setMaskFromInput(input);
         return underlying.activate();
     }
 
     @Override
     public INDArray activate(INDArray input) {
+        setMaskFromInput(input);
+        return underlying.activate(input);
+    }
+
+    private void setMaskFromInput(INDArray input) {
         INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
         underlying.setMaskArray(mask);
-        return underlying.activate(input);
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
@@ -1,0 +1,104 @@
+package org.deeplearning4j.nn.layers.recurrent;
+
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.wrapper.BaseWrapperLayer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.primitives.Pair;
+
+import lombok.NonNull;
+
+public class MaskZeroLayer extends BaseWrapperLayer {
+
+    public MaskZeroLayer(@NonNull Layer underlying){
+        super(underlying);
+    }
+
+    @Override
+    public void migrateInput() {
+        underlying.migrateInput();
+    }
+
+
+    @Override
+    public Type type() {
+        return Type.RECURRENT;
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon) {
+        return underlying.backpropGradient(epsilon);
+    }
+
+
+    @Override
+    public INDArray preOutput(INDArray x) {
+        return underlying.preOutput(x);
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x, TrainingMode training) {
+        return underlying.preOutput(x, training);
+    }
+
+    @Override
+    public INDArray activate(TrainingMode training) {
+        INDArray input = input();
+        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
+        underlying.setMaskArray(mask);
+        return underlying.activate(training);
+    }
+
+    @Override
+    public INDArray activate(INDArray input, TrainingMode training) {
+        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
+        underlying.setMaskArray(mask);
+        return underlying.activate(input, training);
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x, boolean training) {
+        return underlying.activate(x, training);
+    }
+
+    @Override
+    public INDArray activate(boolean training) {
+        INDArray input = input();
+        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
+        underlying.setMaskArray(mask);
+        return underlying.activate(training);
+    }
+
+    @Override
+    public INDArray activate(INDArray input, boolean training) {
+        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
+        underlying.setMaskArray(mask);
+        return underlying.activate(input, training);
+    }
+
+    @Override
+    public INDArray activate() {
+        INDArray input = input();
+        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
+        underlying.setMaskArray(mask);
+        return underlying.activate();
+    }
+
+    @Override
+    public INDArray activate(INDArray input) {
+        INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
+        underlying.setMaskArray(mask);
+        return underlying.activate(input);
+    }
+
+    @Override
+    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState, int minibatchSize) {
+        underlying.feedForwardMaskArray(maskArray, currentMaskState, minibatchSize);
+
+        //Input: 2d mask array, for masking a time series. After extracting out the last time step, we no longer need the mask array
+        return new Pair<>(null, currentMaskState);
+    }
+
+
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayer.java
@@ -1,5 +1,7 @@
 package org.deeplearning4j.nn.layers.recurrent;
 
+import java.util.Arrays;
+
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.MaskState;
 import org.deeplearning4j.nn.gradient.Gradient;
@@ -12,6 +14,7 @@ import lombok.NonNull;
 /**
  *
  * Masks timesteps with 0 activation. Assumes that the input shape is [batch_size, input_size, timesteps].
+   @author Martin Boyanov mboyanov@gmail.com
  */
 public class MaskZeroLayer extends BaseWrapperLayer {
 
@@ -96,8 +99,16 @@ public class MaskZeroLayer extends BaseWrapperLayer {
     }
 
     private void setMaskFromInput(INDArray input) {
+        if (input.rank() != 3) {
+            throw new IllegalArgumentException("Expected input of shape [batch_size, timestep_input_size, timestep], got shape "+Arrays.toString(input.shape()) + " instead");
+        }
         INDArray mask = input.eq(0).sum(1).neq(input.shape()[1]);
         underlying.setMaskArray(mask);
+    }
+
+    @Override
+    public int numParams() {
+        return underlying.numParams();
     }
 
     @Override

--- a/deeplearning4j-nn/src/test/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayerTest.java
+++ b/deeplearning4j-nn/src/test/java/org/deeplearning4j/nn/layers/recurrent/MaskZeroLayerTest.java
@@ -1,0 +1,65 @@
+package org.deeplearning4j.nn.layers.recurrent;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.optimize.api.IterationListener;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+
+public class MaskZeroLayerTest {
+
+  @Test
+  public void activate() {
+
+      //GIVEN two examples where some of the timesteps are zero.
+      INDArray ex1 = Nd4j.create(new double[][] {
+          new double[] { 0, 3, 5},
+          new double[] {0, 0, 2}
+      });
+      INDArray ex2 = Nd4j.create(new double[][] {
+          new double[] { 0, 0, 2},
+          new double[] {0, 0, 2}
+      });
+
+      // A LSTM which adds one for every non-zero timestep
+      org.deeplearning4j.nn.conf.layers.LSTM underlying = new org.deeplearning4j.nn.conf.layers.LSTM.Builder()
+              .activation(Activation.IDENTITY)
+              .gateActivationFunction(Activation.IDENTITY)
+              .nIn(2)
+              .nOut(1)
+              .build();
+      NeuralNetConfiguration conf = new NeuralNetConfiguration();
+      conf.setLayer(underlying);
+      INDArray params = Nd4j.zeros(new int[] {16});
+
+      //Set the biases to 1.
+      for (int i = 12;i < 16; i++) {
+          params.putScalar(i, 1.0);
+      }
+      Layer lstm = underlying.instantiate(conf, Collections.<IterationListener>emptyList(), 0, params, false);
+      MaskZeroLayer l = new MaskZeroLayer(lstm);
+      INDArray input = Nd4j.create( Arrays.asList(ex1, ex2), new int[] {2, 2, 3});
+      //WHEN
+      INDArray out = l.activate(input);
+
+      //THEN output should only be incremented for the non-zero timesteps
+      INDArray firstExampleOutput = out.getRow(0);
+      INDArray secondExampleOutput = out.getRow(1);
+
+      assertEquals(firstExampleOutput.getDouble(0), 0.0, 1e-6);
+      assertEquals(firstExampleOutput.getDouble(1), 1.0, 1e-6);
+      assertEquals(firstExampleOutput.getDouble(2), 2.0, 1e-6);
+
+      assertEquals(secondExampleOutput.getDouble(0), 0.0, 1e-6);
+      assertEquals(secondExampleOutput.getDouble(1), 0.0, 1e-6);
+      assertEquals(secondExampleOutput.getDouble(2), 1.0, 1e-6);
+
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
The proposed wrapper looks at the activations of the input and sets the mask to zero for a given timestep if the input activation is zero. 
The idea is to replicate the mask_zero=True behaviour emerging from the Keras Embedding layer, but it should also be applicable in DL4J as a whole.

 
## How was this patch tested?
For now, it has only been tested manually by importing a keras embedding -> keras lstm -> output model and checking in the debugger that the hidden memory state is not updated for the zero timesteps.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
Not yet
- [ ] Relevant tests for your changes are passing.
Haven't run them yet
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
