### PR TITLE
deeplearning4j-modelexport-solr module for use with Apache Solr

### DIFF
--- a/deeplearning4j-modelexport-solr/pom.xml
+++ b/deeplearning4j-modelexport-solr/pom.xml
@@ -1,0 +1,125 @@
+<!--
+  ~ /*
+  ~  * Copyright 2016 Skymind,Inc.
+  ~  *
+  ~  *    Licensed under the Apache License, Version 2.0 (the "License");
+  ~  *    you may not use this file except in compliance with the License.
+  ~  *    You may obtain a copy of the License at
+  ~  *
+  ~  *        http://www.apache.org/licenses/LICENSE-2.0
+  ~  *
+  ~  *    Unless required by applicable law or agreed to in writing, software
+  ~  *    distributed under the License is distributed on an "AS IS" BASIS,
+  ~  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  *    See the License for the specific language governing permissions and
+  ~  *    limitations under the License.
+  ~  */
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <artifactId>deeplearning4j-modelexport-solr</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>deeplearning4j-parent</artifactId>
+        <groupId>org.deeplearning4j</groupId>
+        <version>0.9.2-SNAPSHOT</version>
+    </parent>
+    <packaging>jar</packaging>
+    <properties>
+        <hdf5.version>1.10.1</hdf5.version>
+    </properties>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>-Ddtype=double</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-ltr</artifactId>
+            <version>${lucene-solr.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>          <!-- Version set by deeplearning4j-parent dependency management -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-api</artifactId>
+            <version>${nd4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.deeplearning4j</groupId>
+            <artifactId>deeplearning4j-nn</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>jackson</artifactId>
+            <version>${nd4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <version>${javacpp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bytedeco.javacpp-presets</groupId>
+            <artifactId>hdf5-platform</artifactId>
+            <version>${hdf5.version}-${javacpp-presets.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+        </dependency>
+
+        <!-- For unit tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>          <!-- Version set by deeplearning4j-parent dependency management -->
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId> <!-- Version set by deeplearning4j-parent dependency management -->
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native</artifactId>
+            <version>${nd4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>test-nd4j-native</id>
+        </profile>
+        <profile>
+            <id>test-nd4j-cuda-8.0</id>
+        </profile>
+    </profiles>
+
+</project>

--- a/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ComputationGraphLTRScoringModel.java
+++ b/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ComputationGraphLTRScoringModel.java
@@ -1,0 +1,54 @@
+package org.deeplearning4j.nn.modelexport.solr.ltr.model;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.solr.ltr.feature.Feature;
+import org.apache.solr.ltr.norm.Normalizer;
+import org.deeplearning4j.nn.api.NeuralNetwork;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+// TODO: change 7_2 to 7_3 once that is released
+/**
+ * An <a href="https://lucene.apache.org/solr/7_2_0/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
+ * org.apache.solr.ltr.model.LTRScoringModel</a> that computes scores using a {@link ComputationGraph}.
+ * <p>
+ * Example configuration:
+ * <pre>{
+  "class": "org.deeplearning4j.nn.modelexport.solr.ltr.model.ComputationGraphLTRScoringModel",
+  "name": "myComputationGraph",
+  "features" : [
+    { "name" : "documentRecency", ... },
+    { "name" : "isBook", ... },
+    { "name" : "originalScore", ... }
+  ],
+  "params": {
+    "serializedModelFileName": "mySerializedComputationGraph"
+  }
+}</pre>
+ */
+public class ComputationGraphLTRScoringModel extends NeuralNetworkLTRScoringModel {
+
+  public ComputationGraphLTRScoringModel(String name, List<Feature> features, List<Normalizer> norms, String featureStoreName,
+      List<Feature> allFeatures, Map<String,Object> params) {
+    super(name, features, norms, featureStoreName, allFeatures, params);
+  }
+
+  protected NeuralNetwork restoreNeuralNetwork(InputStream inputStream) throws IOException {
+    return ModelSerializer.restoreComputationGraph(inputStream);
+  }
+
+  @Override
+  public float score(float[] modelFeatureValuesNormalized) {
+    final ComputationGraph computationGraph = (ComputationGraph)neuralNetwork;
+    final INDArray input = Nd4j.create(modelFeatureValuesNormalized);
+    final INDArray[] outputs = computationGraph.output(input);
+    return outputs[0].getFloat(0);
+  }
+
+}

--- a/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/MultiLayerNetworkLTRScoringModel.java
+++ b/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/MultiLayerNetworkLTRScoringModel.java
@@ -1,0 +1,54 @@
+package org.deeplearning4j.nn.modelexport.solr.ltr.model;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.solr.ltr.feature.Feature;
+import org.apache.solr.ltr.norm.Normalizer;
+import org.deeplearning4j.nn.api.NeuralNetwork;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+// TODO: change 7_2 to 7_3 once that is released
+/**
+ * An <a href="https://lucene.apache.org/solr/7_2_0/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
+ * org.apache.solr.ltr.model.LTRScoringModel</a> that computes scores using a {@link MultiLayerNetwork}.
+ * <p>
+ * Example configuration (snippeet):
+ * <pre>{
+  "class": "org.deeplearning4j.nn.modelexport.solr.ltr.model.MultiLayerNetworkLTRScoringModel",
+  "name": "myMultiLayerNetwork",
+  "features" : [
+    { "name" : "documentRecency", ... },
+    { "name" : "isBook", ... },
+    { "name" : "originalScore", ... }
+  ],
+  "params": {
+    "serializedModelFileName": "mySerializedMultiLayerNetwork"
+  }
+}</pre>
+ */
+public class MultiLayerNetworkLTRScoringModel extends NeuralNetworkLTRScoringModel {
+
+  public MultiLayerNetworkLTRScoringModel(String name, List<Feature> features, List<Normalizer> norms, String featureStoreName,
+      List<Feature> allFeatures, Map<String,Object> params) {
+    super(name, features, norms, featureStoreName, allFeatures, params);
+  }
+
+  protected NeuralNetwork restoreNeuralNetwork(InputStream inputStream) throws IOException {
+    return ModelSerializer.restoreMultiLayerNetwork(inputStream);
+  }
+
+  @Override
+  public float score(float[] modelFeatureValuesNormalized) {
+    final MultiLayerNetwork multiLayerNetwork = (MultiLayerNetwork)neuralNetwork;
+    final INDArray input = Nd4j.create(modelFeatureValuesNormalized);
+    final INDArray output = multiLayerNetwork.output(input);
+    return output.getFloat(0);
+  }
+
+}

--- a/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/NeuralNetworkLTRScoringModel.java
+++ b/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/NeuralNetworkLTRScoringModel.java
@@ -1,0 +1,99 @@
+package org.deeplearning4j.nn.modelexport.solr.ltr.model;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Explanation;
+import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.ltr.feature.Feature;
+import org.apache.solr.ltr.model.AdapterModel;
+import org.apache.solr.ltr.model.ModelException;
+import org.apache.solr.ltr.norm.Normalizer;
+import org.deeplearning4j.nn.api.NeuralNetwork;
+
+// TODO: change 7_2 to 7_3 once that is released
+/**
+ * An abstract <a href="https://lucene.apache.org/solr/7_2_0/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
+ * org.apache.solr.ltr.model.LTRScoringModel</a> that computes scores using a {@link NeuralNetwork}.
+ * Concrete classes must implement the {@link #restoreNeuralNetwork(InputStream)} and {@link #score(float[])} methods.
+ * <p>
+ */
+abstract public class NeuralNetworkLTRScoringModel extends AdapterModel {
+
+  private String serializedModelFileName;
+  protected NeuralNetwork neuralNetwork;
+
+  public NeuralNetworkLTRScoringModel(String name, List<Feature> features, List<Normalizer> norms, String featureStoreName,
+      List<Feature> allFeatures, Map<String,Object> params) {
+    super(name, features, norms, featureStoreName, allFeatures, params);
+  }
+
+  public void setSerializedModelFileName(String serializedModelFileName) {
+    this.serializedModelFileName = serializedModelFileName;
+  }
+
+  @Override
+  public void init(SolrResourceLoader solrResourceLoader) throws ModelException {
+    super.init(solrResourceLoader);
+    try {
+      neuralNetwork = restoreNeuralNetwork(openInputStream());
+    } catch (IOException e) {
+      throw new ModelException("Failed to restore model from given file (" + serializedModelFileName + ")", e);
+    }
+    validate();
+  }
+
+  protected InputStream openInputStream() throws IOException {
+    return solrResourceLoader.openResource(serializedModelFileName);
+  }
+
+  abstract protected NeuralNetwork restoreNeuralNetwork(InputStream inputStream) throws IOException;
+
+  @Override
+  protected void validate() throws ModelException {
+    super.validate();
+    if (serializedModelFileName == null) {
+      throw new ModelException("no serializedModelFileName configured for model "+name);
+    }
+    if (neuralNetwork != null) {
+      validateNeuralNetwork();
+    }
+  }
+
+  protected void validateNeuralNetwork() throws ModelException {
+    try {
+      final float[] mockModelFeatureValuesNormalized = new float[features.size()];
+      score(mockModelFeatureValuesNormalized);
+    } catch (Exception exception) {
+      throw new ModelException("score(...) test failed for model "+name, exception);
+    }
+  }
+
+  abstract public float score(float[] modelFeatureValuesNormalized);
+
+  @Override
+  public Explanation explain(LeafReaderContext context, int doc, float finalScore,
+      List<Explanation> featureExplanations) {
+
+    final StringBuilder sb = new StringBuilder();
+
+    sb.append("(name=").append(getName());
+    sb.append(",class=").append(getClass().getSimpleName());
+    sb.append(",featureValues=[");
+    for (int i = 0; i < featureExplanations.size(); i++) {
+      Explanation featureExplain = featureExplanations.get(i);
+      if (i > 0) {
+        sb.append(',');
+      }
+      final String key = features.get(i).getName();
+      sb.append(key).append('=').append(featureExplain.getValue());
+    }
+    sb.append("])");
+
+    return Explanation.match(finalScore, sb.toString());
+  }
+
+}

--- a/deeplearning4j-modelexport-solr/src/test/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ComputationGraphLTRScoringModelTest.java
+++ b/deeplearning4j-modelexport-solr/src/test/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ComputationGraphLTRScoringModelTest.java
@@ -1,0 +1,67 @@
+package org.deeplearning4j.nn.modelexport.solr.ltr.model;
+
+import java.util.List;
+
+import org.apache.solr.ltr.feature.Feature;
+import org.apache.solr.ltr.model.AdapterModel;
+import org.apache.solr.ltr.norm.Normalizer;
+import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.api.NeuralNetwork;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+public class ComputationGraphLTRScoringModelTest extends NeuralNetworkLTRScoringModelTest {
+
+  protected NeuralNetwork buildAndSaveModel(int numFeatures, String serializedModelFileName) throws Exception {
+
+    final ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder()
+        .graphBuilder()
+        .addInputs("inputLayer")
+        .addLayer("outputLayer",
+          new OutputLayer.Builder().nIn(numFeatures).nOut(1).activation(Activation.IDENTITY).build(),
+          "inputLayer")
+        .setOutputs("outputLayer")
+        .build();
+
+    final ComputationGraph model = new ComputationGraph(conf);
+    model.init();
+
+    final float[] floats = new float[numFeatures+1];
+    float base = 1f;
+    for (int ii=0; ii<floats.length; ++ii)
+    {
+      base *= 2;
+      floats[ii] = base;
+    }
+
+    final INDArray params = Nd4j.create(floats);
+    model.setParams(params);
+
+    ModelSerializer.writeModel(model, serializedModelFileName, false);
+    return model;
+  }
+
+  protected NeuralNetwork restoreModel(String serializedModelFileName) throws Exception {
+    return ModelSerializer.restoreComputationGraph(serializedModelFileName);
+  }
+
+  protected AdapterModel newAdapterModel(String name, List<Feature> features, List<Normalizer> norms, String serializedModelFileName) throws Exception {
+    final ComputationGraphLTRScoringModel model = new ComputationGraphLTRScoringModel(
+          name, features, norms, null, null, null);
+    model.setSerializedModelFileName(serializedModelFileName);
+    return model;
+  }
+
+  protected float score(NeuralNetwork neuralNetwork, float[] vals) throws Exception {
+    final INDArray input = Nd4j.create(vals);
+    final INDArray[] output = ((ComputationGraph)neuralNetwork).output(input);
+    return output[0].getFloat(0);
+  }
+
+}

--- a/deeplearning4j-modelexport-solr/src/test/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/MultiLayerNetworkLTRScoringModelTest.java
+++ b/deeplearning4j-modelexport-solr/src/test/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/MultiLayerNetworkLTRScoringModelTest.java
@@ -1,0 +1,63 @@
+package org.deeplearning4j.nn.modelexport.solr.ltr.model;
+
+import java.util.List;
+
+import org.apache.solr.ltr.feature.Feature;
+import org.apache.solr.ltr.model.AdapterModel;
+import org.apache.solr.ltr.norm.Normalizer;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.api.NeuralNetwork;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+public class MultiLayerNetworkLTRScoringModelTest extends NeuralNetworkLTRScoringModelTest {
+
+  protected NeuralNetwork buildAndSaveModel(int numFeatures, String serializedModelFileName) throws Exception {
+
+    final MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+        .list(
+            new OutputLayer.Builder().nIn(numFeatures).nOut(1).activation(Activation.IDENTITY).build()
+            )
+        .build();
+
+    final MultiLayerNetwork model = new MultiLayerNetwork(conf);
+    model.init();
+
+    final float[] floats = new float[numFeatures+1];
+    float base = 1f;
+    for (int ii=0; ii<floats.length; ++ii)
+    {
+      base *= 2;
+      floats[ii] = base;
+    }
+
+    final INDArray params = Nd4j.create(floats);
+    model.setParams(params);
+
+    ModelSerializer.writeModel(model, serializedModelFileName, false);
+    return model;
+  }
+
+  protected NeuralNetwork restoreModel(String serializedModelFileName) throws Exception {
+    return ModelSerializer.restoreMultiLayerNetwork(serializedModelFileName);
+  }
+
+  protected AdapterModel newAdapterModel(String name, List<Feature> features, List<Normalizer> norms, String serializedModelFileName) throws Exception {
+    final NeuralNetworkLTRScoringModel model = new MultiLayerNetworkLTRScoringModel(
+          name, features, norms, null, null, null);
+    model.setSerializedModelFileName(serializedModelFileName);
+    return model;
+  }
+
+  protected float score(NeuralNetwork neuralNetwork, float[] vals) throws Exception {
+    final INDArray input = Nd4j.create(vals);
+    final INDArray output = ((MultiLayerNetwork)neuralNetwork).output(input);
+    return output.getFloat(0);
+  }
+
+}

--- a/deeplearning4j-modelexport-solr/src/test/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/NeuralNetworkLTRScoringModelTest.java
+++ b/deeplearning4j-modelexport-solr/src/test/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/NeuralNetworkLTRScoringModelTest.java
@@ -1,0 +1,152 @@
+package org.deeplearning4j.nn.modelexport.solr.ltr.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.ltr.feature.Feature;
+import org.apache.solr.ltr.feature.FeatureException;
+import org.apache.solr.ltr.model.AdapterModel;
+import org.apache.solr.ltr.model.ModelException;
+import org.apache.solr.ltr.norm.IdentityNormalizer;
+import org.apache.solr.ltr.norm.Normalizer;
+import org.apache.solr.request.SolrQueryRequest;
+import org.deeplearning4j.nn.api.NeuralNetwork;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+abstract public class NeuralNetworkLTRScoringModelTest {
+
+  protected static class DummyFeature extends Feature {
+
+    public DummyFeature(String name) {
+      super(name, Collections.EMPTY_MAP);
+    }
+
+    @Override
+    protected void validate() throws FeatureException {
+    }
+
+    @Override
+    public FeatureWeight createWeight(IndexSearcher searcher, boolean needsScores, SolrQueryRequest request,
+        Query originalQuery, Map<String,String[]> efi) throws IOException {
+      return null;
+    }
+
+    @Override
+    public LinkedHashMap<String,Object> paramsToMap() {
+      return null;
+    }
+
+  };
+
+  protected List<Feature> featuresList(int numFeatures) throws Exception {
+    final ArrayList<Feature> features = new ArrayList<Feature>();
+    for (int ii=1; ii<=numFeatures; ++ii)
+    {
+      features.add(new DummyFeature("dummy"+ii));
+    }
+    return features;
+  }
+
+  protected List<Normalizer> normalizersList(int numNormalizers) throws Exception {
+    final ArrayList<Normalizer> normalizers = new ArrayList<Normalizer>();
+    for (int ii=1; ii<=numNormalizers; ++ii)
+    {
+      normalizers.add(IdentityNormalizer.INSTANCE);
+    }
+    return normalizers;
+  }
+
+  protected List<float[]> floatsList(int numFloats) {
+    final List<float[]> floatsList = new ArrayList<float[]>();
+    final float[] floats0 = new float[numFloats];
+    final float[] floats1 = new float[numFloats];
+    for (int ii=0; ii<numFloats; ++ii) {
+      floats0[ii] = 0f;
+      floats1[ii] = 1f;
+    }
+    floatsList.add(floats0);
+    floatsList.add(floats1);
+    return floatsList;
+  }
+
+  abstract protected NeuralNetwork buildAndSaveModel(int numFeatures, String serializedModelFileName) throws Exception;
+
+  abstract protected NeuralNetwork restoreModel(String serializedModelFileName) throws Exception;
+
+  abstract protected AdapterModel newAdapterModel(String name, List<Feature> features, List<Normalizer> norms, String serializedModelFileName) throws Exception;
+
+  abstract protected float score(NeuralNetwork neuralNetwork, float[] vals) throws Exception;
+
+  @Test
+  public void test() throws Exception {
+
+    final int numFeatures = 3;
+
+    final Path tempDirPath = Files.createTempDirectory(null);
+    final File tempDirFile = tempDirPath.toFile();
+    tempDirFile.deleteOnExit();
+
+    final SolrResourceLoader solrResourceLoader = new SolrResourceLoader(tempDirPath);
+
+    final File tempFile = File.createTempFile("prefix", "suffix", tempDirFile);
+    tempFile.deleteOnExit();
+
+    final String serializedModelFileName = tempFile.getPath();
+
+    final NeuralNetwork originalModel = buildAndSaveModel(numFeatures, serializedModelFileName);
+
+    final NeuralNetwork restoredModel = restoreModel(serializedModelFileName);
+
+    final AdapterModel ltrModel = newAdapterModel("myModel", featuresList(numFeatures), normalizersList(numFeatures), serializedModelFileName);
+    ltrModel.init(solrResourceLoader);
+
+    for (final float[] floats : floatsList(numFeatures)) {
+
+      final float originalScore = score(originalModel, floats);
+      final float restoredScore = score(restoredModel, floats);
+      final float ltrScore = ltrModel.score(floats);
+
+      assertEquals(originalScore, restoredScore, 0f);
+      assertEquals(originalScore, ltrScore, 0f);
+
+      final List<Explanation> explanations = new ArrayList<Explanation>();
+      explanations.add(Explanation.match(floats[0], ""));
+      explanations.add(Explanation.match(floats[1], ""));
+      explanations.add(Explanation.match(floats[2], ""));
+
+      final Explanation explanation = ltrModel.explain(null, 0, ltrScore, explanations);
+      assertEquals(ltrScore+" = (name=myModel"+
+          ",class="+ltrModel.getClass().getSimpleName()+
+          ",featureValues="+
+          "[dummy1="+Float.toString(floats[0])+
+          ",dummy2="+Float.toString(floats[1])+
+          ",dummy3="+Float.toString(floats[2])+
+          "])\n",
+          explanation.toString());
+    }
+
+    final AdapterModel invalidLtrModel = newAdapterModel("invalidModel", featuresList(numFeatures+1), normalizersList(numFeatures+1), serializedModelFileName);
+    try {
+      invalidLtrModel.init(solrResourceLoader);
+      fail("expected to exception from invalid model init");
+    } catch (ModelException me) {
+      assertTrue(me.getMessage().startsWith("score(...) test failed for model "));
+    }
+
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,19 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <!-- start: temporary addition - TODO: remove it -->
+        <repository>
+            <id>apache-nexus-snapshots</id>
+            <name>Apache Nexus Snapshots</name>
+            <url>https://repository.apache.org/content/groups/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <!--   end: temporary addition - TODO: remove it -->
     </repositories>
 
     <prerequisites>
@@ -79,6 +92,7 @@
         <typesafe.config.version>1.3.0</typesafe.config.version>
         <lombok.version>1.16.16</lombok.version>
         <cleartk.version>2.0.0</cleartk.version>
+        <lucene-solr.version>7.3.0-SNAPSHOT</lucene-solr.version> <!-- TODO: change 7.3.0-SNAPSHOT to 7.3.0 once it's released -->
         <json.version>20131018</json.version>
         <google.protobuf.version>2.6.1</google.protobuf.version>
         <failIfNoTests>false</failIfNoTests>
@@ -531,6 +545,7 @@
         <module>deeplearning4j-nlp-parent</module>
         <module>deeplearning4j-nn</module>
         <module>deeplearning4j-modelimport</module>
+        <module>deeplearning4j-modelexport-solr</module>
         <module>deeplearning4j-zoo</module>
         <module>deeplearning4j-nearestneighbors-parent</module>
     </modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Addition of a new deeplearning4j-modelexport-solr module for use with Apache Solr 7.3 (or higher).

1. Train a model in your 'usual' way and on your 'usual' infrastructure.
1. Save a.k.a. serialize the model to a file.
1. Add the deeplearning4j-modelexport-solr jar (and any dependencies) to your Apache Solr installation.
1. Configure Solr, in the 'usual' way, to use the serialized model file e.g. for [Learning To Rank](https://lucene.apache.org/solr/guide/7_3/learning-to-rank.html) purposes.

The idea for this module emerged in [SOLR-11597](https://issues.apache.org/jira/browse/SOLR-11597) and [SOLR-11838](https://issues.apache.org/jira/browse/SOLR-11838). The changes in this pull request require (not-yet-released) Apache Solr 7.3 with the [org.apache.solr.ltr.model.AdapterModel](https://github.com/apache/lucene-solr/blob/master/solr/contrib/ltr/src/java/org/apache/solr/ltr/model/AdapterModel.java) class added in [SOLR-11941](https://issues.apache.org/jira/browse/SOLR-11941).

## How was this patch tested?

`cd deeplearning4j-modelexport-solr ; mvn test`

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [sort of] Relevant tests for your changes are passing.
- [not yet] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).