### PR TITLE
Fix SubsamplingLayer backprop to do 'exclude padding' during backprop, same as forward

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -191,7 +191,6 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
 
         INDArray col2d = col6d.reshape('c', miniBatch * inDepth * outH * outW, kernel[0] * kernel[1]);
 
-
         switch (layerConf().getPoolingType()) {
             case MAX:
                 //Execute im2col, then reshape to 2d. Note rows are in a different order for cOrderStrides true vs false cases
@@ -326,6 +325,7 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                 break;
             case AVG:
                 pt = LegacyPooling2D.Pooling2DType.AVG;
+                extra = 1.0;    //Divide by kH*kW not "number present" to match backward pass
                 break;
             case PNORM:
                 pt = LegacyPooling2D.Pooling2DType.PNORM;


### PR DESCRIPTION

PRs to match:
https://github.com/deeplearning4j/libnd4j/pull/787
https://github.com/deeplearning4j/nd4j/pull/2660

Before:
![image](https://user-images.githubusercontent.com/2360237/36475417-ac05c48a-174e-11e8-9e11-0e6e4abf7642.png)

After: (CPU)
![image](https://user-images.githubusercontent.com/2360237/36475405-9d08257c-174e-11e8-9a78-540fed1409af.png)

After: (CUDA)
![image](https://user-images.githubusercontent.com/2360237/36583230-eaf9963c-18c8-11e8-9379-31d315efb91c.png)


Edit: also fixes failing gradient checks due to subsampling1d - was due to mismatch between forward and backward pass divisor modes (for padding).
