### PR TITLE
FileDataSetIterator - Make getLabels method not throw UnsupportedOperationException

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/file/FileDataSetIterator.java
@@ -1,5 +1,7 @@
 package org.deeplearning4j.datasets.iterator.file;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
@@ -22,6 +24,10 @@ import java.util.Random;
  * @author Alex BLack
  */
 public class FileDataSetIterator extends BaseFileIterator<DataSet, DataSetPreProcessor> implements DataSetIterator {
+
+    @Getter
+    @Setter
+    private List<String> labels;
 
     /**
      * Create a FileDataSetIterator with the following default settings:<br>
@@ -153,11 +159,6 @@ public class FileDataSetIterator extends BaseFileIterator<DataSet, DataSetPrePro
 
     @Override
     public int numExamples() {
-        throw new UnsupportedOperationException("Not supported for this iterator");
-    }
-
-    @Override
-    public List<String> getLabels() {
         throw new UnsupportedOperationException("Not supported for this iterator");
     }
 }


### PR DESCRIPTION
getLabels is actually called in some evaluation methods, so can't/shouldn't throw an exception.
https://github.com/deeplearning4j/deeplearning4j/blob/f9c10b7267df380fe2571c947563f9d831290645/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java#L3199