### PR TITLE
Fix test compilation issue after merging earlier PR

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/WordVectorSerializerTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/WordVectorSerializerTest.java
@@ -112,10 +112,8 @@ public class WordVectorSerializerTest {
                         -0.000591, 0.000099, -0.000843, -0.000563});
         String w1 = "database";
         String w2 = "DBMS";
-        WordVectors vecModel = WordVectorSerializer.loadGoogleModel(
-                        new ClassPathResource("word2vec/googleload/sample_vec.txt").getFile(), false, true);
-        WordVectors vectorsBinary = WordVectorSerializer.loadGoogleModel(
-                        new ClassPathResource("word2vec/googleload/sample_vec.bin").getFile(), true, true);
+        WordVectors vecModel = WordVectorSerializer.readWord2VecModel(new ClassPathResource("word2vec/googleload/sample_vec.txt").getFile());
+        WordVectors vectorsBinary = WordVectorSerializer.readWord2VecModel(new ClassPathResource("word2vec/googleload/sample_vec.bin").getFile());
         INDArray textWeights = vecModel.lookupTable().getWeights();
         INDArray binaryWeights = vectorsBinary.lookupTable().getWeights();
         Collection<String> nearest = vecModel.wordsNearest("database", 10);
@@ -127,7 +125,7 @@ public class WordVectorSerializerTest {
 
     @Test
     public void testLoaderText() throws IOException {
-        WordVectors vec = WordVectorSerializer.loadGoogleModel(textFile, false);
+        WordVectors vec = WordVectorSerializer.readWord2VecModel(textFile);
         assertEquals(vec.vocab().numWords(), 30);
         assertTrue(vec.vocab().hasToken("Morgan_Freeman"));
         assertTrue(vec.vocab().hasToken("JA_Montalbano"));
@@ -135,7 +133,7 @@ public class WordVectorSerializerTest {
 
     @Test
     public void testLoaderStream() throws IOException {
-        WordVectors vec = WordVectorSerializer.loadTxtVectors(new FileInputStream(textFile), true);
+        WordVectors vec = WordVectorSerializer.readWord2VecModel(textFile);
 
         assertEquals(vec.vocab().numWords(), 30);
         assertTrue(vec.vocab().hasToken("Morgan_Freeman"));
@@ -144,7 +142,7 @@ public class WordVectorSerializerTest {
 
     @Test
     public void testLoaderBinary() throws IOException {
-        WordVectors vec = WordVectorSerializer.loadGoogleModel(binaryFile, true);
+        WordVectors vec = WordVectorSerializer.readWord2VecModel(binaryFile);
         assertEquals(vec.vocab().numWords(), 30);
         assertTrue(vec.vocab().hasToken("Morgan_Freeman"));
         assertTrue(vec.vocab().hasToken("JA_Montalbano"));
@@ -159,7 +157,7 @@ public class WordVectorSerializerTest {
     @Test
     @Ignore
     public void testWriteWordVectors() throws IOException {
-        WordVectors vec = WordVectorSerializer.loadGoogleModel(binaryFile, true);
+        WordVectors vec = WordVectorSerializer.readWord2VecModel(binaryFile);
         InMemoryLookupTable lookupTable = (InMemoryLookupTable) vec.lookupTable();
         InMemoryLookupCache lookupCache = (InMemoryLookupCache) vec.vocab();
         WordVectorSerializer.writeWordVectors(lookupTable, lookupCache, pathToWriteto);
@@ -176,7 +174,7 @@ public class WordVectorSerializerTest {
     @Test
     @Ignore
     public void testWriteWordVectorsFromWord2Vec() throws IOException {
-        WordVectors vec = WordVectorSerializer.loadGoogleModel(binaryFile, true);
+        WordVectors vec = WordVectorSerializer.readWord2VecModel(binaryFile, true);
         WordVectorSerializer.writeWordVectors((Word2Vec) vec, pathToWriteto);
 
         WordVectors wordVectors = WordVectorSerializer.loadTxtVectors(new File(pathToWriteto));
@@ -194,7 +192,7 @@ public class WordVectorSerializerTest {
     @Ignore
     public void testFromTableAndVocab() throws IOException {
 
-        WordVectors vec = WordVectorSerializer.loadGoogleModel(textFile, false);
+        WordVectors vec = WordVectorSerializer.readWord2VecModel(textFile);
         InMemoryLookupTable lookupTable = (InMemoryLookupTable) vec.lookupTable();
         InMemoryLookupCache lookupCache = (InMemoryLookupCache) vec.vocab();
 
@@ -571,7 +569,7 @@ public class WordVectorSerializerTest {
 
         logger.info("Executor name: {}", Nd4j.getExecutioner().getClass().getSimpleName());
 
-        WordVectors vectorsLive = WordVectorSerializer.loadGoogleModel(binaryFile, true);
+        WordVectors vectorsLive = WordVectorSerializer.readWord2VecModel(binaryFile);
         WordVectors vectorsStatic = WordVectorSerializer.loadStaticModel(binaryFile);
 
         INDArray arrayLive = vectorsLive.getWordVectorMatrix("Morgan_Freeman");
@@ -690,7 +688,7 @@ public class WordVectorSerializerTest {
 
         logger.info("Executor name: {}", Nd4j.getExecutioner().getClass().getSimpleName());
 
-        WordVectors vectorsLive = WordVectorSerializer.loadGoogleModel(binaryFile, true);
+        WordVectors vectorsLive = WordVectorSerializer.readWord2VecModel(binaryFile);
         WordVectors vectorsStatic = WordVectorSerializer.readWord2VecModel(binaryFile, false);
 
         INDArray arrayLive = vectorsLive.getWordVectorMatrix("Morgan_Freeman");

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTests.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp-uima/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTests.java
@@ -65,7 +65,7 @@ public class Word2VecTests {
     @Before
     public void before() throws Exception {
         File googleModelTextFile = new ClassPathResource("word2vecserialization/google_news_30.txt").getFile();
-        googleModel = WordVectorSerializer.loadGoogleModel(googleModelTextFile, false);
+        googleModel = WordVectorSerializer.readWord2VecModel(googleModelTextFile);
         inputFile = new ClassPathResource("/big/raw_sentences.txt").getFile();
 
         File ptwt = new File(System.getProperty("java.io.tmpdir"), "testing_word2vec_serialization.txt");

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -933,8 +933,7 @@ public class ParagraphVectorsTest {
     @Ignore
     @Test
     public void testGoogleModelForInference() throws Exception {
-        WordVectors googleVectors = WordVectorSerializer.loadGoogleModelNonNormalized(
-                        new File("/ext/GoogleNews-vectors-negative300.bin.gz"), true, false);
+        WordVectors googleVectors = WordVectorSerializer.readWord2VecModel(new File("/ext/GoogleNews-vectors-negative300.bin.gz"));
 
         TokenizerFactory t = new DefaultTokenizerFactory();
         t.setTokenPreProcessor(new CommonPreprocessor());

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTestsSmall.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/word2vec/Word2VecTestsSmall.java
@@ -16,7 +16,7 @@ public class Word2VecTestsSmall {
 
     @Before
     public void setUp() throws Exception {
-        word2vec = WordVectorSerializer.loadGoogleModel(new ClassPathResource("vec.bin").getFile(), true, true);
+        word2vec = WordVectorSerializer.readWord2VecModel(new ClassPathResource("vec.bin").getFile());
     }
 
     @Test


### PR DESCRIPTION
Deprecated methods were removed here: https://github.com/deeplearning4j/deeplearning4j/pull/4680

However, I missed some of the test usages of these deprecated methods.