### PR TITLE
Minor updates to match ND4J DataSet changes

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/layer/IterativeReduceFlatMap.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/layer/IterativeReduceFlatMap.java
@@ -84,7 +84,7 @@ class IterativeReduceFlatMapAdapter implements FlatMapFunctionAdapter<Iterator<D
             collect.add(dataSetIterator.next());
         }
 
-        DataSet data = DataSet.merge(collect, false);
+        DataSet data = DataSet.merge(collect);
         log.debug("Training on " + data.labelCounts());
         NeuralNetConfiguration conf = NeuralNetConfiguration.fromJson(json);
         int numParams = conf.getLayer().initializer().numParams(conf);

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/BaseSparkTest.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/BaseSparkTest.java
@@ -105,7 +105,7 @@ public abstract class BaseSparkTest implements Serializable {
         }
         list.iterator();
 
-        data = new DataSet().merge(list);
+        data = DataSet.merge(list);
         return sc.parallelize(list);
     }
 


### PR DESCRIPTION
To match: https://github.com/deeplearning4j/nd4j/pull/2678
Now-removed deprecated method was still used in one location.