### PR TITLE
Remove five redundant DataSetPreProcessor casts.

### DIFF
--- a/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/test/TestDataSetIterator.java
+++ b/deeplearning4j-core/src/main/java/org/deeplearning4j/datasets/test/TestDataSetIterator.java
@@ -111,8 +111,8 @@ public class TestDataSetIterator implements DataSetIterator {
     }
 
     @Override
-    public void setPreProcessor(org.nd4j.linalg.dataset.api.DataSetPreProcessor preProcessor) {
-        this.preProcessor = (DataSetPreProcessor) preProcessor;
+    public void setPreProcessor(DataSetPreProcessor preProcessor) {
+        this.preProcessor = preProcessor;
     }
 
     @Override

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/iterator/Word2VecDataSetIterator.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/iterator/Word2VecDataSetIterator.java
@@ -255,8 +255,8 @@ public class Word2VecDataSetIterator implements DataSetIterator {
     }
 
     @Override
-    public void setPreProcessor(org.nd4j.linalg.dataset.api.DataSetPreProcessor preProcessor) {
-        this.preProcessor = (DataSetPreProcessor) preProcessor;
+    public void setPreProcessor(DataSetPreProcessor preProcessor) {
+        this.preProcessor = preProcessor;
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/BaseDatasetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/BaseDatasetIterator.java
@@ -129,7 +129,7 @@ public class BaseDatasetIterator implements DataSetIterator {
 
     @Override
     public void setPreProcessor(DataSetPreProcessor preProcessor) {
-        this.preProcessor = (DataSetPreProcessor) preProcessor;
+        this.preProcessor = preProcessor;
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/SamplingDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/SamplingDataSetIterator.java
@@ -120,7 +120,7 @@ public class SamplingDataSetIterator implements DataSetIterator {
 
     @Override
     public void setPreProcessor(DataSetPreProcessor preProcessor) {
-        this.preProcessor = (DataSetPreProcessor) preProcessor;
+        this.preProcessor = preProcessor;
     }
 
     @Override

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/impl/ListDataSetIterator.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/datasets/iterator/impl/ListDataSetIterator.java
@@ -120,7 +120,7 @@ public class ListDataSetIterator<T extends DataSet> implements DataSetIterator {
 
     @Override
     public void setPreProcessor(DataSetPreProcessor preProcessor) {
-        this.preProcessor = (DataSetPreProcessor) preProcessor;
+        this.preProcessor = preProcessor;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removes seemingly redundant casts, to avoid code reader confusion.

## How was this patch tested?

Ran `mvn install -DskipTests=true` locally.