### PR TITLE
Evaluation: Properly handle no-arg binary metrics for binary case

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalTest.java
@@ -72,16 +72,6 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
  */
 public class EvalTest extends BaseDL4JTest {
 
-    @Before
-    public void before(){
-        Nd4j.getExecutioner().setProfilingMode(OpExecutioner.ProfilingMode.SCOPE_PANIC);
-    }
-
-    @After
-    public void after(){
-        Nd4j.getExecutioner().setProfilingMode(OpExecutioner.ProfilingMode.DISABLED);
-    }
-
 
     @Test
     public void testEval() {
@@ -1093,4 +1083,99 @@ public class EvalTest extends BaseDL4JTest {
         net.evaluate(testData);
     }
 
+
+    @Test
+    public void testEvalBinaryMetrics(){
+
+        Evaluation ePosClass1_nOut2 = new Evaluation(2, 1);
+        Evaluation ePosClass0_nOut2 = new Evaluation(2, 0);
+        Evaluation ePosClass1_nOut1 = new Evaluation(2, 1);
+        Evaluation ePosClass0_nOut1 = new Evaluation(2, 0);
+
+        Evaluation[] evals = new Evaluation[]{ePosClass1_nOut2, ePosClass0_nOut2, ePosClass1_nOut1, ePosClass0_nOut1};
+        int[] posClass = {1,0,1,0};
+
+
+        //Correct, actual positive class -> TP
+        INDArray p1_1 = Nd4j.create(new double[]{0.3, 0.7});
+        INDArray l1_1 = Nd4j.create(new double[]{0,1});
+        INDArray p1_0 = Nd4j.create(new double[]{0.7, 0.3});
+        INDArray l1_0 = Nd4j.create(new double[]{1,0});
+
+        //Incorrect, actual positive class -> FN
+        INDArray p2_1 = Nd4j.create(new double[]{0.6, 0.4});
+        INDArray l2_1 = Nd4j.create(new double[]{0,1});
+        INDArray p2_0 = Nd4j.create(new double[]{0.4, 0.6});
+        INDArray l2_0 = Nd4j.create(new double[]{1,0});
+
+        //Correct, actual negative class -> TN
+        INDArray p3_1 = Nd4j.create(new double[]{0.8, 0.2});
+        INDArray l3_1 = Nd4j.create(new double[]{1,0});
+        INDArray p3_0 = Nd4j.create(new double[]{0.2, 0.8});
+        INDArray l3_0 = Nd4j.create(new double[]{0,1});
+
+        //Incorrect, actual negative class -> FP
+        INDArray p4_1 = Nd4j.create(new double[]{0.45, 0.55});
+        INDArray l4_1 = Nd4j.create(new double[]{1,0});
+        INDArray p4_0 = Nd4j.create(new double[]{0.55, 0.45});
+        INDArray l4_0 = Nd4j.create(new double[]{0,1});
+
+        int tp = 7;
+        int fn = 5;
+        int tn = 3;
+        int fp = 1;
+        for( int i=0; i<tp; i++ ) {
+            ePosClass1_nOut2.eval(l1_1, p1_1);
+            ePosClass1_nOut1.eval(l1_1.getColumn(1), p1_1.getColumn(1));
+            ePosClass0_nOut2.eval(l1_0, p1_0);
+            ePosClass0_nOut1.eval(l1_0.getColumn(1), p1_0.getColumn(1));    //label 0 = instance of positive class
+        }
+        for( int i=0; i<fn; i++ ){
+            ePosClass1_nOut2.eval(l2_1, p2_1);
+            ePosClass1_nOut1.eval(l2_1.getColumn(1), p2_1.getColumn(1));
+            ePosClass0_nOut2.eval(l2_0, p2_0);
+            ePosClass0_nOut1.eval(l2_0.getColumn(1), p2_0.getColumn(1));
+        }
+        for( int i=0; i<tn; i++ ) {
+            ePosClass1_nOut2.eval(l3_1, p3_1);
+            ePosClass1_nOut1.eval(l3_1.getColumn(1), p3_1.getColumn(1));
+            ePosClass0_nOut2.eval(l3_0, p3_0);
+            ePosClass0_nOut1.eval(l3_0.getColumn(1), p3_0.getColumn(1));
+        }
+        for( int i=0; i<fp; i++ ){
+            ePosClass1_nOut2.eval(l4_1, p4_1);
+            ePosClass1_nOut1.eval(l4_1.getColumn(1), p4_1.getColumn(1));
+            ePosClass0_nOut2.eval(l4_0, p4_0);
+            ePosClass0_nOut1.eval(l4_0.getColumn(1), p4_0.getColumn(1));
+        }
+
+        for( int i=0; i<evals.length; i++ ){
+            int positiveClass = posClass[i];
+            String m = String.valueOf(i);
+            int tpAct = evals[i].truePositives().get(positiveClass);
+            int tnAct = evals[i].trueNegatives().get(positiveClass);
+            int fpAct = evals[i].falsePositives().get(positiveClass);
+            int fnAct = evals[i].falseNegatives().get(positiveClass);
+
+            //System.out.println(evals[i].stats());
+
+            assertEquals(m, tp, tpAct);
+            assertEquals(m, tn, tnAct);
+            assertEquals(m, fp, fpAct);
+            assertEquals(m, fn, fnAct);
+        }
+
+        double acc = (tp+tn) / (double)(tp+fn+tn+fp);
+        double rec = tp / (double)(tp+fn);
+        double prec = tp / (double)(tp+fp);
+        double f1 = 2 * (prec * rec) / (prec + rec);
+
+        for( int i=0; i<evals.length; i++ ){
+            String m = String.valueOf(i);
+            assertEquals(m, acc, evals[i].accuracy(), 1e-5);
+            assertEquals(m, prec, evals[i].precision(), 1e-5);
+            assertEquals(m, rec, evals[i].recall(), 1e-5);
+            assertEquals(m, f1, evals[i].f1(), 1e-5);
+        }
+    }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/eval/EvalTest.java
@@ -1091,9 +1091,11 @@ public class EvalTest extends BaseDL4JTest {
         Evaluation ePosClass0_nOut2 = new Evaluation(2, 0);
         Evaluation ePosClass1_nOut1 = new Evaluation(2, 1);
         Evaluation ePosClass0_nOut1 = new Evaluation(2, 0);
+        Evaluation ePosClassNull_nOut2 = new Evaluation(2, null);
+        Evaluation ePosClassNull_nOut1 = new Evaluation(2, null);
 
         Evaluation[] evals = new Evaluation[]{ePosClass1_nOut2, ePosClass0_nOut2, ePosClass1_nOut1, ePosClass0_nOut1};
-        int[] posClass = {1,0,1,0};
+        int[] posClass = {1,0,1,0,-1,-1};
 
 
         //Correct, actual positive class -> TP
@@ -1129,27 +1131,39 @@ public class EvalTest extends BaseDL4JTest {
             ePosClass1_nOut1.eval(l1_1.getColumn(1), p1_1.getColumn(1));
             ePosClass0_nOut2.eval(l1_0, p1_0);
             ePosClass0_nOut1.eval(l1_0.getColumn(1), p1_0.getColumn(1));    //label 0 = instance of positive class
+
+            ePosClassNull_nOut2.eval(l1_1, p1_1);
+            ePosClassNull_nOut1.eval(l1_0.getColumn(0), p1_0.getColumn(0));
         }
         for( int i=0; i<fn; i++ ){
             ePosClass1_nOut2.eval(l2_1, p2_1);
             ePosClass1_nOut1.eval(l2_1.getColumn(1), p2_1.getColumn(1));
             ePosClass0_nOut2.eval(l2_0, p2_0);
             ePosClass0_nOut1.eval(l2_0.getColumn(1), p2_0.getColumn(1));
+
+            ePosClassNull_nOut2.eval(l2_1, p2_1);
+            ePosClassNull_nOut1.eval(l2_0.getColumn(0), p2_0.getColumn(0));
         }
         for( int i=0; i<tn; i++ ) {
             ePosClass1_nOut2.eval(l3_1, p3_1);
             ePosClass1_nOut1.eval(l3_1.getColumn(1), p3_1.getColumn(1));
             ePosClass0_nOut2.eval(l3_0, p3_0);
             ePosClass0_nOut1.eval(l3_0.getColumn(1), p3_0.getColumn(1));
+
+            ePosClassNull_nOut2.eval(l3_1, p3_1);
+            ePosClassNull_nOut1.eval(l3_0.getColumn(0), p3_0.getColumn(0));
         }
         for( int i=0; i<fp; i++ ){
             ePosClass1_nOut2.eval(l4_1, p4_1);
             ePosClass1_nOut1.eval(l4_1.getColumn(1), p4_1.getColumn(1));
             ePosClass0_nOut2.eval(l4_0, p4_0);
             ePosClass0_nOut1.eval(l4_0.getColumn(1), p4_0.getColumn(1));
+
+            ePosClassNull_nOut2.eval(l4_1, p4_1);
+            ePosClassNull_nOut1.eval(l4_0.getColumn(0), p4_0.getColumn(0));
         }
 
-        for( int i=0; i<evals.length; i++ ){
+        for( int i=0; i<4; i++ ){
             int positiveClass = posClass[i];
             String m = String.valueOf(i);
             int tpAct = evals[i].truePositives().get(positiveClass);
@@ -1177,5 +1191,16 @@ public class EvalTest extends BaseDL4JTest {
             assertEquals(m, rec, evals[i].recall(), 1e-5);
             assertEquals(m, f1, evals[i].f1(), 1e-5);
         }
+
+        //Also check macro-averaged versions (null positive class):
+        assertEquals(acc, ePosClassNull_nOut2.accuracy(), 1e-6);
+        assertEquals(ePosClass1_nOut2.recall(EvaluationAveraging.Macro), ePosClassNull_nOut2.recall(), 1e-6);
+        assertEquals(ePosClass1_nOut2.precision(EvaluationAveraging.Macro), ePosClassNull_nOut2.precision(), 1e-6);
+        assertEquals(ePosClass1_nOut2.f1(EvaluationAveraging.Macro), ePosClassNull_nOut2.f1(), 1e-6);
+
+        assertEquals(acc, ePosClassNull_nOut1.accuracy(), 1e-6);
+        assertEquals(ePosClass1_nOut2.recall(EvaluationAveraging.Macro), ePosClassNull_nOut1.recall(), 1e-6);
+        assertEquals(ePosClass1_nOut2.precision(EvaluationAveraging.Macro), ePosClassNull_nOut1.precision(), 1e-6);
+        assertEquals(ePosClass1_nOut2.f1(EvaluationAveraging.Macro), ePosClassNull_nOut1.f1(), 1e-6);
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/Evaluation.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/eval/Evaluation.java
@@ -18,8 +18,10 @@
 
 package org.deeplearning4j.eval;
 
+import com.google.common.base.Preconditions;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.eval.meta.Prediction;
@@ -53,8 +55,22 @@ import java.util.*;
  *   argmax / 0.5)<br>
  * - Custom cost array, using {@link #Evaluation(INDArray)} or {@link #Evaluation(List, INDArray)} for multi-class <br>
  * <br>
+ * Note: Care should be taken when using the Evaluation class for binary classification metrics such as F1, precision,
+ * recall, etc. There are a number of cases to consider:<br>
+ * 1. For binary classification (1 or 2 network outputs)<br>
+ *    a) Default behaviour: class 1 is assumed as the positive class. Consequently, no-arg methods such as {@link #f1()},
+ *       {@link #precision()}, {@link #recall()} etc will report the binary metric for class 1 only<br>
+ *    b) To set class 0 as the positive class instead of class 1 (the default), use {@link #Evaluation(int, Integer)} or
+ *       {@link #Evaluation(double, Integer)} or {@link #setBinaryPositiveClass(Integer)}. Then, {@link #f1()},
+ *       {@link #precision()}, {@link #recall()} etc will report the binary metric for class 0 only.<br>
+ *    c) To use macro-averaged metrics over both classes for binary classification (uncommon and usually not advisable)
+ *       specify 'null' as the argument (instead of 0 or 1) as per (b) above<br>
+ * 2. For multi-class classification, binary metric methods such as {@link #f1()}, {@link #precision()}, {@link #recall()}
+ *    will report macro-average (of the one-vs-all) binary metrics. Note that you can specify micro vs. macro averaging
+ *    using {@link #f1(EvaluationAveraging)} and similar methods<br>
+ * <br>
  * Note that setting a custom binary decision threshold is only possible for the binary case (1 or 2 outputs) and cannot
- * be used if the number of classes exceeds 2. Predictions with probablity > threshold are considered to be class 1,
+ * be used if the number of classes exceeds 2. Predictions with probability > threshold are considered to be class 1,
  * and are considered class 0 otherwise.<br>
  * <br>
  * Cost arrays (a row vector, of size equal to the number of outputs) modify the evaluation process: instead of simply
@@ -76,6 +92,7 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
     //What to output from the precision/recall function when we encounter an edge case
     protected static final double DEFAULT_EDGE_VALUE = 0.0;
 
+    protected Integer binaryPositiveClass = 1;  //Used *only* for binary classification; default value here to 1 for legacy JSON loading
     protected final int topN;
     protected int topNCorrectCount = 0;
     protected int topNTotalCount = 0; //Could use topNCountCorrect / (double)getNumRowCounter() - except for eval(int,int), hence separate counters
@@ -101,16 +118,35 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
     // Empty constructor
     public Evaluation() {
         this.topN = 1;
+        this.binaryPositiveClass = 1;
     }
 
     /**
-     * The number of classes to account
-     * for in the evaluation
+     * The number of classes to account for in the evaluation
      * @param numClasses the number of classes to account for in the evaluation
      */
     public Evaluation(int numClasses) {
-        this(createLabels(numClasses), 1);
+        this(numClasses, (numClasses == 2 ? 1 : null));
     }
+
+    /**
+     * Constructor for specifying the number of classes, and optionally the positive class for binary classification.
+     * See Evaluation javadoc for more details on evaluation in the binary case
+     *
+     * @param numClasses          The number of classes for the evaluation. Must be 2, if binaryPositiveClass is non-null
+     * @param binaryPositiveClass If non-null, the positive class (0 or 1).
+     */
+    public Evaluation(int numClasses, Integer binaryPositiveClass){
+        this(createLabels(numClasses), 1);
+        if(binaryPositiveClass != null){
+            Preconditions.checkArgument(binaryPositiveClass == 0 || binaryPositiveClass == 1,
+                    "Only 0 and 1 are valid inputs for binaryPositiveClass; got " + binaryPositiveClass);
+            Preconditions.checkArgument(numClasses == 2, "Cannot set binaryPositiveClass argument " +
+                    "when number of classes is not equal to 2 (got: numClasses=" + numClasses + ")");
+        }
+        this.binaryPositiveClass = binaryPositiveClass;
+    }
+
 
     /**
      * The labels to include with the evaluation.
@@ -148,17 +184,39 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
             createConfusion(labels.size());
         }
         this.topN = topN;
+        if(labels != null && labels.size() == 2){
+            this.binaryPositiveClass = 1;
+        }
     }
 
     /**
      * Create an evaluation instance with a custom binary decision threshold. Note that binary decision thresholds can
-     * only be used with binary classifiers.
+     * only be used with binary classifiers.<br>
+     * Defaults to class 1 for the positive class - see class javadoc, and use {@link #Evaluation(double, Integer)} to
+     * change this.
      *
      * @param binaryDecisionThreshold Decision threshold to use for binary predictions
      */
     public Evaluation(double binaryDecisionThreshold) {
+        this(binaryDecisionThreshold, 1);
+    }
+
+    /**
+     * Create an evaluation instance with a custom binary decision threshold. Note that binary decision thresholds can
+     * only be used with binary classifiers.<br>
+     * This constructor also allows the user to specify the positive class for binary classification. See class javadoc
+     * for more details.
+     *
+     * @param binaryDecisionThreshold Decision threshold to use for binary predictions
+     */
+    public Evaluation(double binaryDecisionThreshold, @NonNull Integer binaryPositiveClass) {
+        if(binaryPositiveClass != null){
+            Preconditions.checkArgument(binaryPositiveClass == 0 || binaryPositiveClass == 1,
+                    "Only 0 and 1 are valid inputs for binaryPositiveClass; got " + binaryPositiveClass);
+        }
         this.binaryDecisionThreshold = binaryDecisionThreshold;
         this.topN = 1;
+        this.binaryPositiveClass = binaryPositiveClass;
     }
 
     /**
@@ -191,6 +249,13 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
         this.labelsList = labels;
         this.costArray = costArray;
         this.topN = 1;
+    }
+
+    protected int numClasses(){
+        if(labelsList != null){
+            return labelsList.size();
+        }
+        return confusion().getClasses().size();
     }
 
     @Override
@@ -499,6 +564,10 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
         }
     }
 
+    /**
+     * Report the classification statistics as a String
+     * @return Classification statistics as a String
+     */
     public String stats() {
         return stats(false);
     }
@@ -590,9 +659,16 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
                 builder.append("es");
             builder.append(" excluded from average)");
         }
-        if (nClasses > 2) {
+        if (nClasses > 2 || binaryPositiveClass == null) {
             builder.append("\nPrecision, recall & F1: macro-averaged (equally weighted avg. of ").append(nClasses)
                             .append(" classes)");
+        }
+        if(nClasses == 2 && binaryPositiveClass != null){
+            builder.append("\nPrecision, recall & F1: reported for positive class (class ").append(binaryPositiveClass);
+            if(labelsList != null){
+                builder.append(" - \"").append(labelsList.get(binaryPositiveClass)).append("\"");
+            }
+            builder.append(") only");
         }
         if (binaryDecisionThreshold != null) {
             builder.append("\nBinary decision threshold: ").append(binaryDecisionThreshold);
@@ -635,7 +711,7 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
     }
 
     /**
-     * Returns the precision for a given label
+     * Returns the precision for a given class label
      *
      * @param classLabel the label
      * @return the precision for the label
@@ -658,13 +734,20 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
     }
 
     /**
-     * Precision based on guesses so far
-     * Takes into account all known classes and outputs average precision across all of them.
-     * i.e., is macro-averaged precision, equivalent to {@code precision(EvaluationAveraging.Macro)}
+     * Precision based on guesses so far.<br>
+     * Note: value returned will differ depending on number of classes and settings.<br>
+     * 1. For binary classification, if the positive class is set (via default value of 1, via constructor,
+     *    or via {@link #setBinaryPositiveClass(Integer)}), the returned value will be for the specified positive class
+     *    only.<br>
+     * 2. For the multi-class case, or when {@link #getBinaryPositiveClass()} is null, the returned value is macro-averaged
+     *    across all classes. i.e., is macro-averaged precision, equivalent to {@code precision(EvaluationAveraging.Macro)}<br>
      *
      * @return the total precision based on guesses so far
      */
     public double precision() {
+        if(binaryPositiveClass != null && numClasses() == 2){
+            return precision(binaryPositiveClass);
+        }
         return precision(EvaluationAveraging.Macro);
     }
 
@@ -798,12 +881,20 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
     }
 
     /**
-     * Recall based on guesses so far
-     * Takes into account all known classes and outputs average recall across all of them
+     * Recall based on guesses so far<br>
+     * Note: value returned will differ depending on number of classes and settings.<br>
+     * 1. For binary classification, if the positive class is set (via default value of 1, via constructor,
+     *    or via {@link #setBinaryPositiveClass(Integer)}), the returned value will be for the specified positive class
+     *    only.<br>
+     * 2. For the multi-class case, or when {@link #getBinaryPositiveClass()} is null, the returned value is macro-averaged
+     *    across all classes. i.e., is macro-averaged recall, equivalent to {@code recall(EvaluationAveraging.Macro)}<br>
      *
      * @return the recall for the outcomes
      */
     public double recall() {
+        if(binaryPositiveClass != null && numClasses() == 2){
+            return recall(binaryPositiveClass);
+        }
         return recall(EvaluationAveraging.Macro);
     }
 
@@ -870,12 +961,21 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
     }
 
     /**
-     * False positive rate based on guesses so far
-     * Takes into account all known classes and outputs average fpr across all of them
+     * False positive rate based on guesses so far<br>
+     * Note: value returned will differ depending on number of classes and settings.<br>
+     * 1. For binary classification, if the positive class is set (via default value of 1, via constructor,
+     *    or via {@link #setBinaryPositiveClass(Integer)}), the returned value will be for the specified positive class
+     *    only.<br>
+     * 2. For the multi-class case, or when {@link #getBinaryPositiveClass()} is null, the returned value is macro-averaged
+     *    across all classes. i.e., is macro-averaged false positive rate, equivalent to
+     *    {@code falsePositiveRate(EvaluationAveraging.Macro)}<br>
      *
      * @return the fpr for the outcomes
      */
     public double falsePositiveRate() {
+        if(binaryPositiveClass != null && numClasses() == 2){
+            return falsePositiveRate(binaryPositiveClass);
+        }
         return falsePositiveRate(EvaluationAveraging.Macro);
     }
 
@@ -933,11 +1033,20 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
 
     /**
      * False negative rate based on guesses so far
-     * Takes into account all known classes and outputs average fnr across all of them
+     * Note: value returned will differ depending on number of classes and settings.<br>
+     * 1. For binary classification, if the positive class is set (via default value of 1, via constructor,
+     *    or via {@link #setBinaryPositiveClass(Integer)}), the returned value will be for the specified positive class
+     *    only.<br>
+     * 2. For the multi-class case, or when {@link #getBinaryPositiveClass()} is null, the returned value is macro-averaged
+     *    across all classes. i.e., is macro-averaged false negative rate, equivalent to
+     *    {@code falseNegativeRate(EvaluationAveraging.Macro)}<br>
      *
      * @return the fnr for the outcomes
      */
     public double falseNegativeRate() {
+        if(binaryPositiveClass != null && numClasses() == 2){
+            return falseNegativeRate(binaryPositiveClass);
+        }
         return falseNegativeRate(EvaluationAveraging.Macro);
     }
 
@@ -971,11 +1080,20 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
 
     /**
      * False Alarm Rate (FAR) reflects rate of misclassified to classified records
-     * http://ro.ecu.edu.au/cgi/viewcontent.cgi?article=1058&context=isw
+     * http://ro.ecu.edu.au/cgi/viewcontent.cgi?article=1058&context=isw<br>
+     * Note: value returned will differ depending on number of classes and settings.<br>
+     * 1. For binary classification, if the positive class is set (via default value of 1, via constructor,
+     *    or via {@link #setBinaryPositiveClass(Integer)}), the returned value will be for the specified positive class
+     *    only.<br>
+     * 2. For the multi-class case, or when {@link #getBinaryPositiveClass()} is null, the returned value is macro-averaged
+     *    across all classes. i.e., is macro-averaged false alarm rate)
      *
      * @return the fpr for the outcomes
      */
     public double falseAlarmRate() {
+        if(binaryPositiveClass != null && numClasses() == 2){
+            return (falsePositiveRate(binaryPositiveClass) + falseNegativeRate(binaryPositiveClass)) / 2.0;
+        }
         return (falsePositiveRate() + falseNegativeRate()) / 2.0;
     }
 
@@ -1022,16 +1140,26 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
     }
 
     /**
-     * Calculate the (macro) average F1 score across all classes
-     *
-     * TP: true positive
-     * FP: False Positive
-     * FN: False Negative
-     * F1 score: 2 * TP / (2TP + FP + FN)
+     * Calculate the F1 score<br>
+     * F1 score is defined as:<br>
+     * TP: true positive<br>
+     * FP: False Positive<br>
+     * FN: False Negative<br>
+     * F1 score: 2 * TP / (2TP + FP + FN)<br>
+     * <br>
+     * Note: value returned will differ depending on number of classes and settings.<br>
+     * 1. For binary classification, if the positive class is set (via default value of 1, via constructor,
+     *    or via {@link #setBinaryPositiveClass(Integer)}), the returned value will be for the specified positive class
+     *    only.<br>
+     * 2. For the multi-class case, or when {@link #getBinaryPositiveClass()} is null, the returned value is macro-averaged
+     *    across all classes. i.e., is macro-averaged f1, equivalent to {@code f1(EvaluationAveraging.Macro)}<br>
      *
      * @return the f1 score or harmonic mean of precision and recall based on current guesses
      */
     public double f1() {
+        if(binaryPositiveClass != null && numClasses() == 2){
+            return f1(binaryPositiveClass);
+        }
         return f1(EvaluationAveraging.Macro);
     }
 
@@ -1209,9 +1337,6 @@ public class Evaluation extends BaseEvaluation<Evaluation> {
             throw new UnsupportedOperationException("Unknown averaging approach: " + averaging);
         }
     }
-
-
-    // Access counter methods
 
     /**
      * True positives: correctly rejected


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/4759

Previously: Evaluation.f1(), .precision(), .recall() etc returned the macro-averaged values for the non-binary case. Macro-averaging makes sense for the multi-class case, but not the binary case.
The no-arg methods (f1() etc) now report the binary metric that would be expected.

Javadoc and stats() method now also make it clear exactly what is being reported for the binary vs. non-binary cases.

```
Predictions labeled as 0 classified by model as 0: 3 times
Predictions labeled as 0 classified by model as 1: 1 times
Predictions labeled as 1 classified by model as 0: 5 times
Predictions labeled as 1 classified by model as 1: 7 times


==========================Scores========================================
 # of classes:    2
 Accuracy:        0.6250
 Precision:       0.6250
 Recall:          0.6667
 F1 Score:        0.7000
Precision, recall & F1: reported for positive class (class 1 - "1") only
========================================================================
```