### PR TITLE
Add validation function for Spark DataSets/MultiDataSets

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -89,7 +89,7 @@ public class SparkUtils {
                     boolean equals;
                     INDArray deserialized;
                     try {
-                        deserialized = si.deserialize(bb, null);
+                        deserialized = (INDArray) si.deserialize(bb, null);
                         //Equals method may fail on malformed INDArrays, hence should be within the try-catch
                         equals = Nd4j.linspace(1, 5, 5).equals(deserialized);
                     } catch (Exception e) {
@@ -482,10 +482,23 @@ public class SparkUtils {
      * @throws IOException If error occurs getting directory contents
      */
     public static JavaRDD<String> listPaths(JavaSparkContext sc, String path) throws IOException {
+        return listPaths(sc, path, false);
+    }
+
+    /**
+     * List of the files in the given directory (path), as a {@code JavaRDD<String>}
+     *
+     * @param sc        Spark context
+     * @param path      Path to list files in
+     * @param recursive Whether to walk the directory tree recursively (i.e., include subdirectories)
+     * @return Paths in the directory
+     * @throws IOException If error occurs getting directory contents
+     */
+    public static JavaRDD<String> listPaths(JavaSparkContext sc, String path, boolean recursive) throws IOException {
         List<String> paths = new ArrayList<>();
         Configuration config = new Configuration();
         FileSystem hdfs = FileSystem.get(URI.create(path), config);
-        RemoteIterator<LocatedFileStatus> fileIter = hdfs.listFiles(new org.apache.hadoop.fs.Path(path), false);
+        RemoteIterator<LocatedFileStatus> fileIter = hdfs.listFiles(new org.apache.hadoop.fs.Path(path), recursive);
 
         while (fileIter.hasNext()) {
             String filePath = fileIter.next().getPath().toString();

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
@@ -4,10 +4,12 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.deeplearning4j.spark.util.SparkUtils;
+import org.deeplearning4j.spark.util.data.validation.ValidateMultiDataSetFn;
 import org.deeplearning4j.spark.util.data.validation.ValidationResultReduceFn;
-import org.deeplearning4j.spark.util.data.validation.dataset.ValidateDataSetFn;
+import org.deeplearning4j.spark.util.data.validation.ValidateDataSetFn;
 
 import java.io.IOException;
+import java.util.List;
 
 public class SparkDataValidation {
 
@@ -30,7 +32,28 @@ public class SparkDataValidation {
         return results.reduce(new ValidationResultReduceFn());
     }
 
+    public ValidationResult validateMultiDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+                                                  int numFeatureArrays, int numLabelArrays,
+                                                  List<int[]> featuresShape, List<int[]> labelsShape){
+        return validateMultiDataSets(new JavaSparkContext(sc), path, recursive, deleteInvalid, numFeatureArrays, numLabelArrays,
+                featuresShape, labelsShape);
+    }
 
+    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+                                                  int numFeatureArrays, int numLabelArrays,
+                                                  List<int[]> featuresShape, List<int[]> labelsShape){
+        JavaRDD<String> paths;
+        try {
+            paths = SparkUtils.listPaths(sc, path, recursive);
+        } catch (IOException e) {
+            throw new RuntimeException("Error listing paths in directory", e);
+        }
+
+        JavaRDD<ValidationResult> results = paths.map(new ValidateMultiDataSetFn(deleteInvalid, numFeatureArrays, numLabelArrays,
+                featuresShape, labelsShape));
+
+        return results.reduce(new ValidationResultReduceFn());
+    }
 
 
 }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
@@ -9,17 +9,91 @@ import org.deeplearning4j.spark.util.data.validation.ValidationResultReduceFn;
 import org.deeplearning4j.spark.util.data.validation.ValidateDataSetFn;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 
+/**
+ * Utilities for validating DataSets and MultiDataSets saved (usually) in a HDFS directory.
+ *
+ * @author Alex Black
+ */
 public class SparkDataValidation {
 
-    private SparkDataValidation(){ }
+    private SparkDataValidation() {
+    }
 
-    public ValidationResult validateDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid, int[] featuresShape, int[] labelsShape){
+    /**
+     * Validate DataSet objects saved to the specified directory on HDFS by attempting to load them and checking their
+     * contents. Assumes DataSets were saved using {@link org.nd4j.linalg.dataset.DataSet#save(OutputStream)}.<br>
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc   Spark context
+     * @param path HDFS path of the directory containing the saved DataSet objects
+     * @return Results of the validation
+     */
+    public ValidationResult validateDataSets(JavaSparkContext sc, String path) {
+        return validateDataSets(sc, path, true, false, null, null);
+    }
+
+    /**
+     * Validate DataSet objects saved to the specified directory on HDFS by attempting to load them and checking their
+     * contents. Assumes DataSets were saved using {@link org.nd4j.linalg.dataset.DataSet#save(OutputStream)}.<br>
+     * This method (optionally) additionally validates the arrays using the specified shapes for the features and labels.
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc            Spark context
+     * @param path          HDFS path of the directory containing the saved DataSet objects
+     * @param featuresShape May be null. If non-null: feature arrays must match the specified shape, for all values with
+     *                      shape > 0. For example, if featuresShape = {-1,10} then the features must be rank 2,
+     *                      can have any size for the first dimension, but must have size 10 for the second dimension.
+     * @param labelsShape   As per featuresShape, but for the labels instead
+     * @return Results of the validation
+     */
+    public ValidationResult validateDataSets(JavaSparkContext sc, String path, int[] featuresShape, int[] labelsShape) {
+        return validateDataSets(sc, path, true, false, featuresShape, labelsShape);
+    }
+
+    /**
+     * Validate DataSet objects - <b>and delete any invalid DataSets</b> - that have been previously saved to the
+     * specified directory on HDFS by attempting to load them and checking their contents. Assumes DataSets were saved
+     * using {@link org.nd4j.linalg.dataset.DataSet#save(OutputStream)}.<br>
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc   Spark context
+     * @param path HDFS path of the directory containing the saved DataSet objects
+     * @return Results of the validation/deletion
+     */
+    public ValidationResult deleteInvalidDataSets(JavaSparkContext sc, String path) {
+        return validateDataSets(sc, path, true, true, null, null);
+    }
+
+    /**
+     * Validate DataSet objects - <b>and delete any invalid DataSets</b> - that have been previously saved to the
+     * specified directory on HDFS by attempting to load them and checking their contents. Assumes DataSets were saved
+     * using {@link org.nd4j.linalg.dataset.DataSet#save(OutputStream)}.<br>
+     * This method (optionally) additionally validates the arrays using the specified shapes for the features and labels.
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc            Spark context
+     * @param path          HDFS path of the directory containing the saved DataSet objects
+     * @param featuresShape May be null. If non-null: feature arrays must match the specified shape, for all values with
+     *                      shape > 0. For example, if featuresShape = {-1,10} then the features must be rank 2,
+     *                      can have any size for the first dimension, but must have size 10 for the second dimension.
+     * @param labelsShape   As per featuresShape, but for the labels instead
+     * @return Results of the validation
+     */
+    public ValidationResult deleteInvalidDataSets(JavaSparkContext sc, String path, int[] featuresShape, int[] labelsShape) {
+        return validateDataSets(sc, path, true, true, featuresShape, labelsShape);
+    }
+
+
+    protected ValidationResult validateDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+                                                int[] featuresShape, int[] labelsShape) {
         return validateDataSets(new JavaSparkContext(sc), path, recursive, deleteInvalid, featuresShape, labelsShape);
     }
 
-    public ValidationResult validateDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid, int[] featuresShape, int[] labelsShape){
+    protected ValidationResult validateDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+                                                int[] featuresShape, int[] labelsShape) {
         JavaRDD<String> paths;
         try {
             paths = SparkUtils.listPaths(sc, path, recursive);
@@ -32,16 +106,121 @@ public class SparkDataValidation {
         return results.reduce(new ValidationResultReduceFn());
     }
 
-    public ValidationResult validateMultiDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
-                                                  int numFeatureArrays, int numLabelArrays,
-                                                  List<int[]> featuresShape, List<int[]> labelsShape){
+
+    /**
+     * Validate MultiDataSet objects saved to the specified directory on HDFS by attempting to load them and checking their
+     * contents. Assumes MultiDataSets were saved using {@link org.nd4j.linalg.dataset.MultiDataSet#save(OutputStream)}.<br>
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc   Spark context
+     * @param path HDFS path of the directory containing the saved DataSet objects
+     * @return Results of the validation
+     */
+    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path) {
+        return validateMultiDataSets(sc, path, true, false, -1, -1, null, null);
+    }
+
+    /**
+     * Validate MultiDataSet objects saved to the specified directory on HDFS by attempting to load them and checking their
+     * contents. Assumes MultiDataSets were saved using {@link org.nd4j.linalg.dataset.MultiDataSet#save(OutputStream)}.<br>
+     * This method additionally validates that the expected number of feature/labels arrays are present in all MultiDataSet
+     * objects<br>
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc               Spark context
+     * @param path             HDFS path of the directory containing the saved DataSet objects
+     * @param numFeatureArrays Number of feature arrays that are expected for the MultiDataSet (set -1 to not check)
+     * @param numLabelArrays   Number of labels arrays that are expected for the MultiDataSet (set -1 to not check)
+     * @return Results of the validation
+     */
+    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, int numFeatureArrays, int numLabelArrays) {
+        return validateMultiDataSets(sc, path, true, false, numFeatureArrays, numLabelArrays, null, null);
+    }
+
+
+    /**
+     * Validate MultiDataSet objects saved to the specified directory on HDFS by attempting to load them and checking their
+     * contents. Assumes MultiDataSets were saved using {@link org.nd4j.linalg.dataset.MultiDataSet#save(OutputStream)}.<br>
+     * This method (optionally) additionally validates the arrays using the specified shapes for the features and labels.
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc            Spark context
+     * @param path          HDFS path of the directory containing the saved DataSet objects
+     * @param featuresShape May be null. If non-null: feature arrays must match the specified shapes, for all values with
+     *                      shape > 0. For example, if featuresShape = {{-1,10}} then there must be 1 features array,
+     *                      features array 0 must be rank 2, can have any size for the first dimension, but must have
+     *                      size 10 for the second dimension.
+     * @param labelsShape   As per featuresShape, but for the labels instead
+     * @return Results of the validation
+     */
+    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, List<int[]> featuresShape, List<int[]> labelsShape) {
+        return validateMultiDataSets(sc, path, true, false, (featuresShape == null ? -1 : featuresShape.size()),
+                (labelsShape == null ? -1 : labelsShape.size()), featuresShape, labelsShape);
+    }
+
+    /**
+     * Validate MultiDataSet objects - <b>and delete any invalid MultiDataSets</b> - that have been previously saved to the
+     * specified directory on HDFS by attempting to load them and checking their contents. Assumes MultiDataSets were saved
+     * using {@link org.nd4j.linalg.dataset.MultiDataSet#save(OutputStream)}.<br>
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc   Spark context
+     * @param path HDFS path of the directory containing the saved DataSet objects
+     * @return Results of the validation/deletion
+     */
+    public ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path) {
+        return validateDataSets(sc, path, true, true, null, null);
+    }
+
+    /**
+     * Validate MultiDataSet objects - <b>and delete any invalid MultiDataSets</b> - that have been previously saved
+     * to the specified directory on HDFS by attempting to load them and checking their contents. Assumes MultiDataSets
+     * were saved using {@link org.nd4j.linalg.dataset.MultiDataSet#save(OutputStream)}.<br>
+     * This method (optionally) additionally validates the arrays using the specified shapes for the features and labels,
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc            Spark context
+     * @param path          HDFS path of the directory containing the saved DataSet objects
+     * @param featuresShape May be null. If non-null: feature arrays must match the specified shapes, for all values with
+     *                      shape > 0. For example, if featuresShape = {{-1,10}} then there must be 1 features array,
+     *                      features array 0 must be rank 2, can have any size for the first dimension, but must have
+     *                      size 10 for the second dimension.
+     * @param labelsShape   As per featuresShape, but for the labels instead
+     * @return Results of the validation
+     */
+    public ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path, List<int[]> featuresShape,
+                                                       List<int[]> labelsShape) {
+        return validateMultiDataSets(sc, path, true, true, (featuresShape == null ? -1 : featuresShape.size()),
+                (labelsShape == null ? -1 : labelsShape.size()), featuresShape, labelsShape);
+    }
+
+    /**
+     * Validate MultiDataSet objects - <b>and delete any invalid MultiDataSets</b> - that have been previously saved
+     * to the specified directory on HDFS by attempting to load them and checking their contents. Assumes MultiDataSets
+     * were saved using {@link org.nd4j.linalg.dataset.MultiDataSet#save(OutputStream)}.<br>
+     * This method (optionally) additionally validates the arrays using the specified shapes for the features and labels.
+     * Note: this method will also consider all files in subdirectories (i.e., is recursive).
+     *
+     * @param sc               Spark context
+     * @param path             HDFS path of the directory containing the saved DataSet objects
+     * @param numFeatureArrays Number of feature arrays that are expected for the MultiDataSet (set -1 to not check)
+     * @param numLabelArrays   Number of labels arrays that are expected for the MultiDataSet (set -1 to not check)
+     * @return Results of the validation
+     */
+    public ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path, int numFeatureArrays, int numLabelArrays) {
+        return validateMultiDataSets(sc, path, true, true, numFeatureArrays, numLabelArrays, null, null);
+    }
+
+    protected ValidationResult validateMultiDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+                                                     int numFeatureArrays, int numLabelArrays,
+                                                     List<int[]> featuresShape, List<int[]> labelsShape) {
         return validateMultiDataSets(new JavaSparkContext(sc), path, recursive, deleteInvalid, numFeatureArrays, numLabelArrays,
                 featuresShape, labelsShape);
     }
 
-    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
-                                                  int numFeatureArrays, int numLabelArrays,
-                                                  List<int[]> featuresShape, List<int[]> labelsShape){
+    protected ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+                                                     int numFeatureArrays, int numLabelArrays,
+                                                     List<int[]> featuresShape, List<int[]> labelsShape) {
         JavaRDD<String> paths;
         try {
             paths = SparkUtils.listPaths(sc, path, recursive);

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
@@ -1,0 +1,36 @@
+package org.deeplearning4j.spark.util.data;
+
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.deeplearning4j.spark.util.SparkUtils;
+import org.deeplearning4j.spark.util.data.validation.ValidationResultReduceFn;
+import org.deeplearning4j.spark.util.data.validation.dataset.ValidateDataSetFn;
+
+import java.io.IOException;
+
+public class SparkDataValidation {
+
+    private SparkDataValidation(){ }
+
+    public ValidationResult validateDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid, int[] featuresShape, int[] labelsShape){
+        return validateDataSets(new JavaSparkContext(sc), path, recursive, deleteInvalid, featuresShape, labelsShape);
+    }
+
+    public ValidationResult validateDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid, int[] featuresShape, int[] labelsShape){
+        JavaRDD<String> paths;
+        try {
+            paths = SparkUtils.listPaths(sc, path, recursive);
+        } catch (IOException e) {
+            throw new RuntimeException("Error listing paths in directory", e);
+        }
+
+        JavaRDD<ValidationResult> results = paths.map(new ValidateDataSetFn(deleteInvalid, featuresShape, labelsShape));
+
+        return results.reduce(new ValidationResultReduceFn());
+    }
+
+
+
+
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/SparkDataValidation.java
@@ -31,7 +31,7 @@ public class SparkDataValidation {
      * @param path HDFS path of the directory containing the saved DataSet objects
      * @return Results of the validation
      */
-    public ValidationResult validateDataSets(JavaSparkContext sc, String path) {
+    public static ValidationResult validateDataSets(JavaSparkContext sc, String path) {
         return validateDataSets(sc, path, true, false, null, null);
     }
 
@@ -49,7 +49,7 @@ public class SparkDataValidation {
      * @param labelsShape   As per featuresShape, but for the labels instead
      * @return Results of the validation
      */
-    public ValidationResult validateDataSets(JavaSparkContext sc, String path, int[] featuresShape, int[] labelsShape) {
+    public static ValidationResult validateDataSets(JavaSparkContext sc, String path, int[] featuresShape, int[] labelsShape) {
         return validateDataSets(sc, path, true, false, featuresShape, labelsShape);
     }
 
@@ -63,7 +63,7 @@ public class SparkDataValidation {
      * @param path HDFS path of the directory containing the saved DataSet objects
      * @return Results of the validation/deletion
      */
-    public ValidationResult deleteInvalidDataSets(JavaSparkContext sc, String path) {
+    public static ValidationResult deleteInvalidDataSets(JavaSparkContext sc, String path) {
         return validateDataSets(sc, path, true, true, null, null);
     }
 
@@ -82,17 +82,17 @@ public class SparkDataValidation {
      * @param labelsShape   As per featuresShape, but for the labels instead
      * @return Results of the validation
      */
-    public ValidationResult deleteInvalidDataSets(JavaSparkContext sc, String path, int[] featuresShape, int[] labelsShape) {
+    public static ValidationResult deleteInvalidDataSets(JavaSparkContext sc, String path, int[] featuresShape, int[] labelsShape) {
         return validateDataSets(sc, path, true, true, featuresShape, labelsShape);
     }
 
 
-    protected ValidationResult validateDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+    protected static ValidationResult validateDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
                                                 int[] featuresShape, int[] labelsShape) {
         return validateDataSets(new JavaSparkContext(sc), path, recursive, deleteInvalid, featuresShape, labelsShape);
     }
 
-    protected ValidationResult validateDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+    protected static ValidationResult validateDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
                                                 int[] featuresShape, int[] labelsShape) {
         JavaRDD<String> paths;
         try {
@@ -116,7 +116,7 @@ public class SparkDataValidation {
      * @param path HDFS path of the directory containing the saved DataSet objects
      * @return Results of the validation
      */
-    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path) {
+    public static ValidationResult validateMultiDataSets(JavaSparkContext sc, String path) {
         return validateMultiDataSets(sc, path, true, false, -1, -1, null, null);
     }
 
@@ -133,7 +133,7 @@ public class SparkDataValidation {
      * @param numLabelArrays   Number of labels arrays that are expected for the MultiDataSet (set -1 to not check)
      * @return Results of the validation
      */
-    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, int numFeatureArrays, int numLabelArrays) {
+    public static ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, int numFeatureArrays, int numLabelArrays) {
         return validateMultiDataSets(sc, path, true, false, numFeatureArrays, numLabelArrays, null, null);
     }
 
@@ -153,7 +153,7 @@ public class SparkDataValidation {
      * @param labelsShape   As per featuresShape, but for the labels instead
      * @return Results of the validation
      */
-    public ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, List<int[]> featuresShape, List<int[]> labelsShape) {
+    public static ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, List<int[]> featuresShape, List<int[]> labelsShape) {
         return validateMultiDataSets(sc, path, true, false, (featuresShape == null ? -1 : featuresShape.size()),
                 (labelsShape == null ? -1 : labelsShape.size()), featuresShape, labelsShape);
     }
@@ -168,8 +168,8 @@ public class SparkDataValidation {
      * @param path HDFS path of the directory containing the saved DataSet objects
      * @return Results of the validation/deletion
      */
-    public ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path) {
-        return validateDataSets(sc, path, true, true, null, null);
+    public static ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path) {
+        return validateMultiDataSets(sc, path, true, true, -1, -1, null, null);
     }
 
     /**
@@ -188,7 +188,7 @@ public class SparkDataValidation {
      * @param labelsShape   As per featuresShape, but for the labels instead
      * @return Results of the validation
      */
-    public ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path, List<int[]> featuresShape,
+    public static ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path, List<int[]> featuresShape,
                                                        List<int[]> labelsShape) {
         return validateMultiDataSets(sc, path, true, true, (featuresShape == null ? -1 : featuresShape.size()),
                 (labelsShape == null ? -1 : labelsShape.size()), featuresShape, labelsShape);
@@ -207,18 +207,18 @@ public class SparkDataValidation {
      * @param numLabelArrays   Number of labels arrays that are expected for the MultiDataSet (set -1 to not check)
      * @return Results of the validation
      */
-    public ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path, int numFeatureArrays, int numLabelArrays) {
+    public static ValidationResult deleteInvalidMultiDataSets(JavaSparkContext sc, String path, int numFeatureArrays, int numLabelArrays) {
         return validateMultiDataSets(sc, path, true, true, numFeatureArrays, numLabelArrays, null, null);
     }
 
-    protected ValidationResult validateMultiDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+    protected static ValidationResult validateMultiDataSets(SparkContext sc, String path, boolean recursive, boolean deleteInvalid,
                                                      int numFeatureArrays, int numLabelArrays,
                                                      List<int[]> featuresShape, List<int[]> labelsShape) {
         return validateMultiDataSets(new JavaSparkContext(sc), path, recursive, deleteInvalid, numFeatureArrays, numLabelArrays,
                 featuresShape, labelsShape);
     }
 
-    protected ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
+    protected static ValidationResult validateMultiDataSets(JavaSparkContext sc, String path, boolean recursive, boolean deleteInvalid,
                                                      int numFeatureArrays, int numLabelArrays,
                                                      List<int[]> featuresShape, List<int[]> labelsShape) {
         JavaRDD<String> paths;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/ValidationResult.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/ValidationResult.java
@@ -1,0 +1,40 @@
+package org.deeplearning4j.spark.util.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ValidationResult {
+    private long countTotal;
+    private long countMissingFile;
+    private long countTotalValid;
+    private long countTotalInvalid;
+    private long countLoadingFailure;
+    private long countMissingFeatures;
+    private long countMissingLabels;
+    private long countInvalidFeatures;
+    private long countInvalidLabels;
+    private long countInvalidDeleted;
+
+    public ValidationResult add(ValidationResult o){
+        if(o == null){
+            return this;
+        }
+
+        countTotal += o.countTotal;
+        countMissingFile += o.countMissingFile;
+        countTotalValid += o.countTotalValid;
+        countTotalInvalid += o.countTotalInvalid;
+        countLoadingFailure += o.countLoadingFailure;
+        countMissingFeatures += o.countMissingFeatures;
+        countMissingLabels += o.countMissingLabels;
+        countInvalidFeatures += o.countInvalidFeatures;
+        countInvalidLabels += o.countInvalidLabels;
+        countInvalidDeleted += o.countInvalidDeleted;
+
+        return this;
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/ValidationResult.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/ValidationResult.java
@@ -4,6 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Result for validation of DataSet and MultiDataSets. See {@link SparkDataValidation} for more details
+ *
+ * @author Alex Black
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Data

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/ValidationResult.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/ValidationResult.java
@@ -1,8 +1,11 @@
 package org.deeplearning4j.spark.util.data;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
 
 /**
  * Result for validation of DataSet and MultiDataSets. See {@link SparkDataValidation} for more details
@@ -12,7 +15,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class ValidationResult {
+@Builder
+public class ValidationResult implements Serializable {
     private long countTotal;
     private long countMissingFile;
     private long countTotalValid;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateDataSetFn.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateDataSetFn.java
@@ -44,6 +44,11 @@ public class ValidateDataSetFn implements Function<String, ValidationResult> {
         DataSet ds = new DataSet();
         Path p = new Path(path);
 
+        if(fileSystem.isDirectory(p)){
+            ret.setCountTotal(0);
+            return ret;
+        }
+
         if (!fileSystem.exists(p)) {
             ret.setCountMissingFile(1);
             return ret;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateDataSetFn.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateDataSetFn.java
@@ -1,0 +1,121 @@
+package org.deeplearning4j.spark.util.data.validation;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.function.Function;
+import org.deeplearning4j.spark.util.data.ValidationResult;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class ValidateDataSetFn implements Function<String, ValidationResult> {
+    public static final int BUFFER_SIZE = 4194304; //4 MB
+
+    private final boolean deleteInvalid;
+    private final int[] featuresShape;
+    private final int[] labelsShape;
+    private transient FileSystem fileSystem;
+
+    public ValidateDataSetFn(boolean deleteInvalid, int[] featuresShape, int[] labelsShape) {
+        this.deleteInvalid = deleteInvalid;
+        this.featuresShape = featuresShape;
+        this.labelsShape = labelsShape;
+    }
+
+    @Override
+    public ValidationResult call(String path) throws Exception {
+        if (fileSystem == null) {
+            try {
+                fileSystem = FileSystem.get(new URI(path), new Configuration());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        ValidationResult ret = new ValidationResult();
+        ret.setCountTotal(1);
+
+        boolean shouldDelete = false;
+        boolean loadSuccessful = false;
+        DataSet ds = new DataSet();
+        Path p = new Path(path);
+
+        if (!fileSystem.exists(p)) {
+            ret.setCountMissingFile(1);
+            return ret;
+        }
+
+        try (FSDataInputStream inputStream = fileSystem.open(p, BUFFER_SIZE)) {
+            ds.load(inputStream);
+            loadSuccessful = true;
+        } catch (Throwable t) {
+            shouldDelete = deleteInvalid;
+            ret.setCountLoadingFailure(1);
+        }
+
+
+        boolean isValid = loadSuccessful;
+        if (loadSuccessful) {
+            //Validate
+            if (ds.getFeatures() == null) {
+                ret.setCountMissingFeatures(1);
+                isValid = false;
+            } else {
+                if(featuresShape != null && !validateArrayShape(featuresShape, ds.getFeatures())){
+                    ret.setCountInvalidFeatures(1);
+                    isValid = false;
+                }
+            }
+
+            if(ds.getLabels() == null){
+                ret.setCountMissingLabels(1);
+                isValid = false;
+            } else {
+                if(labelsShape != null && !validateArrayShape(labelsShape, ds.getLabelsMaskArray())){
+                    ret.setCountInvalidLabels(1);
+                    isValid = false;
+                }
+            }
+
+            if(!isValid && deleteInvalid){
+                shouldDelete = true;
+            }
+        }
+
+        if (isValid) {
+            ret.setCountTotalValid(1);
+        } else {
+            ret.setCountTotalInvalid(1);
+        }
+
+        if (shouldDelete) {
+            fileSystem.delete(p, false);
+            ret.setCountInvalidDeleted(1);
+        }
+
+        return ret;
+    }
+
+    protected static boolean validateArrayShape(int[] featuresShape, INDArray array){
+        if(featuresShape == null){
+            return true;
+        }
+
+        if(featuresShape.length != array.rank()){
+            return false;
+        } else {
+            for( int i=0; i<featuresShape.length; i++ ){
+                if(featuresShape[i] <= 0)
+                    continue;
+                if(featuresShape[i] != array.size(i)){
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateMultiDataSetFn.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateMultiDataSetFn.java
@@ -50,6 +50,11 @@ public class ValidateMultiDataSetFn implements Function<String, ValidationResult
         MultiDataSet ds = new MultiDataSet();
         Path p = new Path(path);
 
+        if(fileSystem.isDirectory(p)){
+            ret.setCountTotal(0);
+            return ret;
+        }
+
         if (!fileSystem.exists(p)) {
             ret.setCountMissingFile(1);
             return ret;

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateMultiDataSetFn.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidateMultiDataSetFn.java
@@ -14,6 +14,12 @@ import java.util.List;
 
 import static org.deeplearning4j.spark.util.data.validation.ValidateDataSetFn.validateArrayShape;
 
+/**
+ * Function used to validate MultiDataSets on HDFS - see {@link org.deeplearning4j.spark.util.data.SparkDataValidation} for
+ * further details
+ *
+ * @author Alex Black
+ */
 public class ValidateMultiDataSetFn implements Function<String, ValidationResult> {
     public static final int BUFFER_SIZE = 4194304; //4 MB
 
@@ -133,7 +139,8 @@ public class ValidateMultiDataSetFn implements Function<String, ValidationResult
             return false;
 
         for( int i=0; i<shapes.size(); i++ ){
-            validateArrayShape(shapes.get(i), arr[i]);
+            if(!validateArrayShape(shapes.get(i), arr[i]))
+                return false;
         }
         return true;
     }

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidationResultReduceFn.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/ValidationResultReduceFn.java
@@ -1,0 +1,11 @@
+package org.deeplearning4j.spark.util.data.validation;
+
+import org.apache.spark.api.java.function.Function2;
+import org.deeplearning4j.spark.util.data.ValidationResult;
+
+public class ValidationResultReduceFn implements Function2<ValidationResult, ValidationResult, ValidationResult> {
+    @Override
+    public ValidationResult call(ValidationResult v1, ValidationResult v2) throws Exception {
+        return v1.add(v2);
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/dataset/ValidateDataSetFn.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/data/validation/dataset/ValidateDataSetFn.java
@@ -1,0 +1,117 @@
+package org.deeplearning4j.spark.util.data.validation.dataset;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.api.java.function.Function;
+import org.deeplearning4j.spark.util.data.ValidationResult;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class ValidateDataSetFn implements Function<String, ValidationResult> {
+    public static final int BUFFER_SIZE = 4194304; //4 MB
+
+    private final boolean deleteInvalid;
+    private final int[] featuresShape;
+    private final int[] labelsShape;
+    private transient FileSystem fileSystem;
+
+    public ValidateDataSetFn(boolean deleteInvalid, int[] featuresShape, int[] labelsShape) {
+        this.deleteInvalid = deleteInvalid;
+        this.featuresShape = featuresShape;
+        this.labelsShape = labelsShape;
+    }
+
+    @Override
+    public ValidationResult call(String path) throws Exception {
+        if (fileSystem == null) {
+            try {
+                fileSystem = FileSystem.get(new URI(path), new Configuration());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        ValidationResult ret = new ValidationResult();
+        ret.setCountTotal(1);
+
+        boolean shouldDelete = false;
+        boolean loadSuccessful = false;
+        DataSet ds = new DataSet();
+        Path p = new Path(path);
+
+        if (!fileSystem.exists(p)) {
+            ret.setCountMissingFile(1);
+            return ret;
+        }
+
+        try (FSDataInputStream inputStream = fileSystem.open(p, BUFFER_SIZE)) {
+            ds.load(inputStream);
+            loadSuccessful = true;
+        } catch (Throwable t) {
+            shouldDelete = deleteInvalid;
+            ret.setCountLoadingFailure(1);
+        }
+
+
+        boolean isValid = loadSuccessful;
+        if (loadSuccessful) {
+            //Validate
+            if (ds.getFeatures() == null) {
+                ret.setCountMissingFeatures(1);
+                isValid = false;
+            } else {
+                if(featuresShape != null && !validateArrayShape(featuresShape, ds.getFeatures())){
+                    ret.setCountInvalidFeatures(1);
+                    isValid = false;
+                }
+            }
+
+            if(ds.getLabels() == null){
+                ret.setCountMissingLabels(1);
+                isValid = false;
+            } else {
+                if(labelsShape != null && !validateArrayShape(labelsShape, ds.getLabelsMaskArray())){
+                    ret.setCountInvalidLabels(1);
+                    isValid = false;
+                }
+            }
+
+            if(!isValid && deleteInvalid){
+                shouldDelete = true;
+            }
+        }
+
+        if (isValid) {
+            ret.setCountTotalValid(1);
+        } else {
+            ret.setCountTotalInvalid(1);
+        }
+
+        if (shouldDelete) {
+            fileSystem.delete(p, false);
+            ret.setCountInvalidDeleted(1);
+        }
+
+        return ret;
+    }
+
+    private static boolean validateArrayShape(int[] featuresShape, INDArray array){
+        if(featuresShape.length != array.rank()){
+            return false;
+        } else {
+            for( int i=0; i<featuresShape.length; i++ ){
+                if(featuresShape[i] <= 0)
+                    continue;
+                if(featuresShape[i] != array.size(i)){
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestValidation.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestValidation.java
@@ -1,0 +1,181 @@
+package org.deeplearning4j.spark.util;
+
+import org.apache.commons.io.FileUtils;
+import org.deeplearning4j.spark.BaseSparkTest;
+import org.deeplearning4j.spark.util.data.SparkDataValidation;
+import org.deeplearning4j.spark.util.data.ValidationResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.MultiDataSet;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestValidation extends BaseSparkTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Override
+    public int numExecutors(){
+        return 1;
+    }
+
+    @Test
+    public void testDataSetValidation() throws Exception {
+
+        File f = folder.newFolder();
+
+        for( int i=0; i<3; i++ ) {
+            DataSet ds = new DataSet(Nd4j.create(10), Nd4j.create(10));
+            ds.save(new File(f, i + ".bin"));
+        }
+
+        ValidationResult r = SparkDataValidation.validateDataSets(sc, f.toURI().toString());
+        ValidationResult exp = ValidationResult.builder()
+                .countTotal(3)
+                .countTotalValid(3)
+                .build();
+        assertEquals(exp, r);
+
+        //Add a DataSet that is corrupt (can't be loaded)
+        File f3 = new File(f, "3.bin");
+        FileUtils.writeStringToFile(f3, "This isn't a DataSet!");
+        r = SparkDataValidation.validateDataSets(sc, f.toURI().toString());
+        exp = ValidationResult.builder()
+                .countTotal(4)
+                .countTotalValid(3)
+                .countTotalInvalid(1)
+                .countLoadingFailure(1)
+                .build();
+        assertEquals(exp, r);
+        f3.delete();
+
+
+        //Add a DataSet with missing features:
+        new DataSet(null, Nd4j.create(10)).save(f3);
+
+        r = SparkDataValidation.validateDataSets(sc, f.toURI().toString());
+        exp = ValidationResult.builder()
+                .countTotal(4)
+                .countTotalValid(3)
+                .countTotalInvalid(1)
+                .countMissingFeatures(1)
+                .build();
+        assertEquals(exp, r);
+
+        r = SparkDataValidation.deleteInvalidDataSets(sc, f.toURI().toString());
+        exp.setCountInvalidDeleted(1);
+        assertEquals(exp, r);
+        assertFalse(f3.exists());
+        for( int i=0; i<3; i++ ){
+            assertTrue(new File(f,i + ".bin").exists());
+        }
+
+        //Add DataSet with incorrect labels shape:
+        new DataSet(Nd4j.create(10), Nd4j.create(20)).save(f3);
+        r = SparkDataValidation.validateDataSets(sc, f.toURI().toString(), new int[]{-1,10}, new int[]{-1,10});
+        exp = ValidationResult.builder()
+                .countTotal(4)
+                .countTotalValid(3)
+                .countTotalInvalid(1)
+                .countInvalidLabels(1)
+                .build();
+
+        assertEquals(exp, r);
+    }
+
+    @Test
+    public void testMultiDataSetValidation() throws Exception {
+
+        File f = folder.newFolder();
+
+        for( int i=0; i<3; i++ ) {
+            MultiDataSet ds = new MultiDataSet(Nd4j.create(10), Nd4j.create(10));
+            ds.save(new File(f, i + ".bin"));
+        }
+
+        ValidationResult r = SparkDataValidation.validateMultiDataSets(sc, f.toURI().toString());
+        ValidationResult exp = ValidationResult.builder()
+                .countTotal(3)
+                .countTotalValid(3)
+                .build();
+        assertEquals(exp, r);
+
+        //Add a MultiDataSet that is corrupt (can't be loaded)
+        File f3 = new File(f, "3.bin");
+        FileUtils.writeStringToFile(f3, "This isn't a MultiDataSet!");
+        r = SparkDataValidation.validateMultiDataSets(sc, f.toURI().toString());
+        exp = ValidationResult.builder()
+                .countTotal(4)
+                .countTotalValid(3)
+                .countTotalInvalid(1)
+                .countLoadingFailure(1)
+                .build();
+        assertEquals(exp, r);
+        f3.delete();
+
+
+        //Add a MultiDataSet with missing features:
+        new MultiDataSet(null, Nd4j.create(10)).save(f3);
+
+        r = SparkDataValidation.validateMultiDataSets(sc, f.toURI().toString());
+        exp = ValidationResult.builder()
+                .countTotal(4)
+                .countTotalValid(3)
+                .countTotalInvalid(1)
+                .countMissingFeatures(1)
+                .build();
+        assertEquals(exp, r);
+
+        r = SparkDataValidation.deleteInvalidMultiDataSets(sc, f.toURI().toString());
+        exp.setCountInvalidDeleted(1);
+        assertEquals(exp, r);
+        assertFalse(f3.exists());
+        for( int i=0; i<3; i++ ){
+            assertTrue(new File(f,i + ".bin").exists());
+        }
+
+        //Add MultiDataSet with incorrect labels shape:
+        new MultiDataSet(Nd4j.create(10), Nd4j.create(20)).save(f3);
+        r = SparkDataValidation.validateMultiDataSets(sc, f.toURI().toString(), Arrays.asList(new int[]{-1,10}),
+                Arrays.asList(new int[]{-1,10}));
+        exp = ValidationResult.builder()
+                .countTotal(4)
+                .countTotalValid(3)
+                .countTotalInvalid(1)
+                .countInvalidLabels(1)
+                .build();
+        f3.delete();
+        assertEquals(exp, r);
+
+        //Add a MultiDataSet with incorrect number of feature arrays:
+        new MultiDataSet(new INDArray[]{Nd4j.create(10), Nd4j.create(10)},
+                new INDArray[]{Nd4j.create(10)}).save(f3);
+        r = SparkDataValidation.validateMultiDataSets(sc, f.toURI().toString(), Arrays.asList(new int[]{-1,10}),
+                Arrays.asList(new int[]{-1,10}));
+        exp = ValidationResult.builder()
+                .countTotal(4)
+                .countTotalValid(3)
+                .countTotalInvalid(1)
+                .countInvalidFeatures(1)
+                .build();
+        assertEquals(exp, r);
+
+
+        r = SparkDataValidation.deleteInvalidMultiDataSets(sc, f.toURI().toString(), Arrays.asList(new int[]{-1,10}),
+                Arrays.asList(new int[]{-1,10}));
+        exp.setCountInvalidDeleted(1);
+        assertEquals(exp, r);
+        assertFalse(f3.exists());
+    }
+
+}

--- a/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestValidation.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestValidation.java
@@ -24,11 +24,6 @@ public class TestValidation extends BaseSparkTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @Override
-    public int numExecutors(){
-        return 1;
-    }
-
     @Test
     public void testDataSetValidation() throws Exception {
 


### PR DESCRIPTION
Basically validates the DataSet or MultiDataSets saved on HDFS.

I required this functionality for debugging with a client; figured I might as well formalize it and add it to DL4J generally.

See also: https://github.com/deeplearning4j/deeplearning4j/issues/4805