### PR TITLE
ModelSerializer stream improvements

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelSerializerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelSerializerTest.java
@@ -357,7 +357,7 @@ public class ModelSerializerTest extends BaseDL4JTest {
         ModelSerializer.addNormalizerToModel(tempFile, norm);
 
         InputStream is = new FileInputStream(tempFile);
-        ModelSerializer.restoreComputationGraph(is):
+        ModelSerializer.restoreComputationGraph(is);
 
         try{
             ModelSerializer.restoreNormalizerFromInputStream(is);
@@ -368,7 +368,7 @@ public class ModelSerializerTest extends BaseDL4JTest {
         }
 
         try{
-            ModelSerializer.restoreMultiLayerNetwork(is);
+            ModelSerializer.restoreComputationGraph(is);
             fail("Expected exception");
         } catch (Exception e){
             String msg = e.getMessage();

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelSerializerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelSerializerTest.java
@@ -18,11 +18,13 @@ import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.Normalizer;
 import org.nd4j.linalg.dataset.api.preprocessor.NormalizerMinMaxScaler;
 import org.nd4j.linalg.dataset.api.preprocessor.NormalizerStandardize;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.Sgd;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.linalg.primitives.Pair;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -330,6 +332,11 @@ public class ModelSerializerTest extends BaseDL4JTest {
             String msg = e.getMessage();
             assertTrue(msg, msg.contains("may have been closed"));
         }
+
+        //Also test reading  both model and normalizer from stream (correctly)
+        Pair<MultiLayerNetwork,Normalizer> pair = ModelSerializer.restoreMultiLayerNetworkAndNormalizer(new FileInputStream(tempFile), true);
+        assertEquals(net.params(), pair.getFirst().params());
+        assertNotNull(pair.getSecond());
     }
 
 
@@ -374,5 +381,10 @@ public class ModelSerializerTest extends BaseDL4JTest {
             String msg = e.getMessage();
             assertTrue(msg, msg.contains("may have been closed"));
         }
+
+        //Also test reading  both model and normalizer from stream (correctly)
+        Pair<ComputationGraph,Normalizer> pair = ModelSerializer.restoreComputationGraphAndNormalizer(new FileInputStream(tempFile), true);
+        assertEquals(net.params(), pair.getFirst().params());
+        assertNotNull(pair.getSecond());
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelSerializerTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelSerializerTest.java
@@ -11,7 +11,9 @@ import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
@@ -25,6 +27,7 @@ import org.nd4j.linalg.lossfunctions.LossFunctions;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 
 import static org.junit.Assert.*;
 
@@ -32,6 +35,9 @@ import static org.junit.Assert.*;
  * @author raver119@gmail.com
  */
 public class ModelSerializerTest extends BaseDL4JTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
     @Test
     public void testWriteMLNModel() throws Exception {
@@ -181,7 +187,6 @@ public class ModelSerializerTest extends BaseDL4JTest {
     @Test
     public void testSaveRestoreNormalizerFromInputStream() throws Exception {
         DataSet dataSet = trivialDataSet();
-
         NormalizerStandardize norm = new NormalizerStandardize();
         norm.fit(dataSet);
 
@@ -283,6 +288,91 @@ public class ModelSerializerTest extends BaseDL4JTest {
         } catch (Exception e){
             String msg = e.getMessage();
             assertTrue(msg, msg.contains("JSON") && msg.contains("restoreMultiLayerNetwork"));
+        }
+    }
+
+    @Test
+    public void testInvalidStreamReuse() throws Exception {
+        int nIn = 5;
+        int nOut = 6;
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder().seed(12345).l1(0.01)
+                .list()
+                .layer(new OutputLayer.Builder().nIn(nIn).nOut(nOut).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        DataSet dataSet = trivialDataSet();
+        NormalizerStandardize norm = new NormalizerStandardize();
+        norm.fit(dataSet);
+
+        File tempFile = tempDir.newFile();
+        ModelSerializer.writeModel(net, tempFile, true);
+        ModelSerializer.addNormalizerToModel(tempFile, norm);
+
+        InputStream is = new FileInputStream(tempFile);
+        ModelSerializer.restoreMultiLayerNetwork(is);
+
+        try{
+            ModelSerializer.restoreNormalizerFromInputStream(is);
+            fail("Expected exception");
+        } catch (Exception e){
+            String msg = e.getMessage();
+            assertTrue(msg, msg.contains("may have been closed"));
+        }
+
+        try{
+            ModelSerializer.restoreMultiLayerNetwork(is);
+            fail("Expected exception");
+        } catch (Exception e){
+            String msg = e.getMessage();
+            assertTrue(msg, msg.contains("may have been closed"));
+        }
+    }
+
+
+    @Test
+    public void testInvalidStreamReuseCG() throws Exception {
+        int nIn = 5;
+        int nOut = 6;
+
+        ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder().seed(12345).l1(0.01)
+                .graphBuilder()
+                .addInputs("in")
+                .layer("0", new OutputLayer.Builder().nIn(nIn).nOut(nOut).build(), "in")
+                .setOutputs("0")
+                .build();
+
+        ComputationGraph net = new ComputationGraph(conf);
+        net.init();
+
+        DataSet dataSet = trivialDataSet();
+        NormalizerStandardize norm = new NormalizerStandardize();
+        norm.fit(dataSet);
+
+        File tempFile = tempDir.newFile();
+        ModelSerializer.writeModel(net, tempFile, true);
+        ModelSerializer.addNormalizerToModel(tempFile, norm);
+
+        InputStream is = new FileInputStream(tempFile);
+        ModelSerializer.restoreComputationGraph(is):
+
+        try{
+            ModelSerializer.restoreNormalizerFromInputStream(is);
+            fail("Expected exception");
+        } catch (Exception e){
+            String msg = e.getMessage();
+            assertTrue(msg, msg.contains("may have been closed"));
+        }
+
+        try{
+            ModelSerializer.restoreMultiLayerNetwork(is);
+            fail("Expected exception");
+        } catch (Exception e){
+            String msg = e.getMessage();
+            assertTrue(msg, msg.contains("may have been closed"));
         }
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
@@ -181,9 +181,6 @@ public class ModelSerializer {
     }
 
 
-
-
-
     /**
      * Load a multi layer network from a file
      *
@@ -325,6 +322,8 @@ public class ModelSerializer {
      */
     public static MultiLayerNetwork restoreMultiLayerNetwork(@NonNull InputStream is, boolean loadUpdater)
             throws IOException {
+        checkInputStream(is);
+
         File tmpFile = null;
         try{
             tmpFile = File.createTempFile("restore", "multiLayer");
@@ -333,6 +332,7 @@ public class ModelSerializer {
             IOUtils.copy(is, bos);
             bos.flush();
             IOUtils.closeQuietly(bos);
+            checkTempFileFromInputStream(tmpFile);
             return restoreMultiLayerNetwork(tmpFile, loadUpdater);
         } finally {
             if(tmpFile != null){
@@ -409,6 +409,8 @@ public class ModelSerializer {
      */
     public static ComputationGraph restoreComputationGraph(@NonNull InputStream is, boolean loadUpdater)
             throws IOException {
+        checkInputStream(is);
+
         File tmpFile = null;
         try{
             tmpFile = File.createTempFile("restore", "compGraph");
@@ -417,6 +419,7 @@ public class ModelSerializer {
             IOUtils.copy(is, bos);
             bos.flush();
             IOUtils.closeQuietly(bos);
+            checkTempFileFromInputStream(tmpFile);
             return restoreComputationGraph(tmpFile, loadUpdater);
         } finally {
             if(tmpFile != null){
@@ -729,6 +732,8 @@ public class ModelSerializer {
      * @return the loaded normalizer
      */
     public static <T extends Normalizer> T restoreNormalizerFromInputStream(InputStream is) throws IOException {
+        checkInputStream(is);
+
         File tmpFile = null;
         try {
             tmpFile = File.createTempFile("restore", "normalizer");
@@ -737,6 +742,7 @@ public class ModelSerializer {
             IOUtils.copy(is, bufferedOutputStream);
             bufferedOutputStream.flush();
             IOUtils.closeQuietly(bufferedOutputStream);
+            checkTempFileFromInputStream(tmpFile);
             return restoreNormalizerFromFile(tmpFile);
         } finally {
             if(tmpFile != null){
@@ -772,6 +778,31 @@ public class ModelSerializer {
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+
+    private static void checkInputStream(InputStream inputStream) throws IOException {
+        int available;
+        try{
+            //InputStream.available(): A subclass' implementation of this method may choose to throw an IOException
+            // if this input stream has been closed by invoking the close() method.
+            available = inputStream.available();
+        } catch (IOException e){
+            throw new IOException("Cannot read from stream: stream may have been closed or is attempting to be read from" +
+                    "multiple times?", e);
+        }
+        if(available <= 0){
+            throw new IOException("Cannot read from stream: stream may have been closed or is attempting to be read from" +
+                    "multiple times?");
+        }
+    }
+
+    private static void checkTempFileFromInputStream(File f) throws IOException {
+        if (f.length() <= 0) {
+            throw new IOException("Error reading from input stream: temporary file is empty after copying entire stream." +
+                    " Stream may have been closed before reading, is attempting to be used multiple times, or does not" +
+                    " point to a model file?");
         }
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
@@ -35,7 +35,6 @@ import java.util.zip.ZipOutputStream;
 @Slf4j
 public class ModelSerializer {
 
-    public static final String OLD_UPDATER_BIN = "updater.bin";
     public static final String UPDATER_BIN = "updaterState.bin";
     public static final String NORMALIZER_BIN = "normalizer.bin";
 
@@ -194,7 +193,6 @@ public class ModelSerializer {
 
         boolean gotConfig = false;
         boolean gotCoefficients = false;
-        boolean gotOldUpdater = false;
         boolean gotUpdaterState = false;
         boolean gotPreProcessor = false;
 
@@ -240,21 +238,6 @@ public class ModelSerializer {
         }
 
         if (loadUpdater) {
-            //This can be removed a few releases after 0.4.1...
-            ZipEntry oldUpdaters = zipFile.getEntry(OLD_UPDATER_BIN);
-            if (oldUpdaters != null) {
-                InputStream stream = zipFile.getInputStream(oldUpdaters);
-                ObjectInputStream ois = new ObjectInputStream(stream);
-
-                try {
-                    updater = (Updater) ois.readObject();
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
-
-                gotOldUpdater = true;
-            }
-
             ZipEntry updaterStateEntry = zipFile.getEntry(UPDATER_BIN);
             if (updaterStateEntry != null) {
                 InputStream stream = zipFile.getInputStream(updaterStateEntry);
@@ -303,8 +286,6 @@ public class ModelSerializer {
 
             if (gotUpdaterState && updaterState != null) {
                 network.getUpdater().setStateViewArray(network, updaterState, false);
-            } else if (gotOldUpdater && updater != null) {
-                network.setUpdater(updater);
             }
             return network;
         } else
@@ -339,7 +320,6 @@ public class ModelSerializer {
                 tmpFile.delete();
             }
         }
-
     }
 
     /**
@@ -462,7 +442,6 @@ public class ModelSerializer {
 
         boolean gotConfig = false;
         boolean gotCoefficients = false;
-        boolean gotOldUpdater = false;
         boolean gotUpdaterState = false;
         boolean gotPreProcessor = false;
 
@@ -509,20 +488,6 @@ public class ModelSerializer {
 
 
         if (loadUpdater) {
-            ZipEntry oldUpdaters = zipFile.getEntry(OLD_UPDATER_BIN);
-            if (oldUpdaters != null) {
-                InputStream stream = zipFile.getInputStream(oldUpdaters);
-                ObjectInputStream ois = new ObjectInputStream(stream);
-
-                try {
-                    updater = (ComputationGraphUpdater) ois.readObject();
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
-
-                gotOldUpdater = true;
-            }
-
             ZipEntry updaterStateEntry = zipFile.getEntry(UPDATER_BIN);
             if (updaterStateEntry != null) {
                 InputStream stream = zipFile.getInputStream(updaterStateEntry);
@@ -576,8 +541,6 @@ public class ModelSerializer {
 
             if (gotUpdaterState && updaterState != null) {
                 cg.getUpdater().setStateViewArray(updaterState);
-            } else if (gotOldUpdater && updater != null) {
-                cg.setUpdater(updater);
             }
             return cg;
         } else


### PR DESCRIPTION
Improvements based on: https://github.com/deeplearning4j/deeplearning4j/issues/4825#issuecomment-375238756

1. Adds checks and informative exceptions for invalid stream usage
2. Improves JavaDoc for stream methods
3. Adds restoreMultiLayerNetworkAndNormalizer and restoreComputationGraphAndNormalizer methods (mainly for restoring both simultaneously from a stream)
4. Cleans up the old/obsolete legacy updater restoration