### PR TITLE
Tests and fixes for ParallelInference

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -56,6 +56,10 @@ public class GlobalPoolingLayer extends Layer {
         this.layerName = builder.layerName;
     }
 
+    public GlobalPoolingLayer(PoolingType poolingType){
+        this(new GlobalPoolingLayer.Builder().poolingType(poolingType));
+    }
+
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
@@ -421,6 +421,10 @@ public class ParallelInference {
             return setInput(observer, new INDArray[]{input}, null);
         }
 
+        protected InferenceObservable setInput(@NonNull Observer observer, INDArray... input){
+            return setInput(observer, input, null);
+        }
+
         protected InferenceObservable setInput(@NonNull Observer observer, INDArray[] input, INDArray[] inputMask) {
             synchronized (locker) {
                 boolean isNew = false;

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
@@ -336,19 +336,27 @@ public class ParallelInference {
                         if (replicatedModel instanceof ComputationGraph) {
                             List<INDArray[]> batches = request.getInputBatches();
                             List<INDArray[]> out = new ArrayList<>(batches.size());
-                            for( INDArray[] inBatch : batches ) {
-                                INDArray[] output = ((ComputationGraph) replicatedModel).output(false, inBatch);
-                                out.add(output);
+                            try {
+                                for (INDArray[] inBatch : batches) {
+                                    INDArray[] output = ((ComputationGraph) replicatedModel).output(false, inBatch);
+                                    out.add(output);
+                                }
+                                request.setOutputBatches(out);
+                            } catch (Exception e){
+                                request.setOutputException(e);
                             }
-                            request.setOutputBatches(out);
                         } else if (replicatedModel instanceof MultiLayerNetwork) {
                             List<INDArray[]> batches = request.getInputBatches();
                             List<INDArray[]> out = new ArrayList<>(batches.size());
-                            for( INDArray[] inBatch : batches ) {
-                                INDArray output = ((MultiLayerNetwork) replicatedModel).output(inBatch[0]);
-                                out.add(new INDArray[]{output});
+                            try {
+                                for (INDArray[] inBatch : batches) {
+                                    INDArray output = ((MultiLayerNetwork) replicatedModel).output(inBatch[0]);
+                                    out.add(new INDArray[]{output});
+                                }
+                                request.setOutputBatches(out);
+                            } catch (Exception e){
+                                request.setOutputException(e);
                             }
-                            request.setOutputBatches(out);
                         }
 
 

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
@@ -2,6 +2,7 @@ package org.deeplearning4j.parallelism.inference;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
 
+import java.util.List;
 import java.util.Observer;
 
 /**
@@ -9,11 +10,11 @@ import java.util.Observer;
  */
 public interface InferenceObservable {
 
-    INDArray[] getInput();
+    List<INDArray[]> getInputBatches();
 
-    void setInput(INDArray... input);
+    void addInput(INDArray... input);
 
-    void setOutput(INDArray... output);
+    void setOutputBatches(List<INDArray[]> output);
 
     void addObserver(Observer observer);
 

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
@@ -21,6 +21,8 @@ public interface InferenceObservable {
      */
     List<Pair<INDArray[],INDArray[]>> getInputBatches();
 
+    void addInput(INDArray... input);
+
     void addInput(INDArray[] input, INDArray[] inputMasks);
 
     void setOutputBatches(List<INDArray[]> output);

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.parallelism.inference;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.primitives.Pair;
 
 import java.util.List;
 import java.util.Observer;
@@ -10,9 +11,17 @@ import java.util.Observer;
  */
 public interface InferenceObservable {
 
-    List<INDArray[]> getInputBatches();
+    /**
+     * Get input batches - and their associated input mask arrays, if any<br>
+     * Note that usually the returned list will be of size 1 - however, in the batched case, not all inputs
+     * can actually be batched (variable size inputs to fully convolutional net, for example). In these "can't batch"
+     * cases, multiple input batches will be returned, to be processed
+     *
+     * @return List of pairs of input arrays and input mask arrays. Input mask arrays may be null.
+     */
+    List<Pair<INDArray[],INDArray[]>> getInputBatches();
 
-    void addInput(INDArray... input);
+    void addInput(INDArray[] input, INDArray[] inputMasks);
 
     void setOutputBatches(List<INDArray[]> output);
 

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/InferenceObservable.java
@@ -16,6 +16,8 @@ public interface InferenceObservable {
 
     void setOutputBatches(List<INDArray[]> output);
 
+    void setOutputException(Exception e);
+
     void addObserver(Observer observer);
 
     INDArray[] getOutput();

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
@@ -20,8 +20,8 @@ public class BasicInferenceObservable extends Observable implements InferenceObs
     private INDArray[] input;
     @Getter
     private long id;
-    @Getter
     private INDArray[] output;
+    protected Exception exception;
 
 
     public BasicInferenceObservable(INDArray... inputs) {
@@ -45,5 +45,28 @@ public class BasicInferenceObservable extends Observable implements InferenceObs
     @Override
     public List<INDArray[]> getInputBatches(){
         return Collections.singletonList(input);
+    }
+
+    @Override
+    public void setOutputException(Exception exception){
+        this.exception = exception;
+        this.setChanged();
+        notifyObservers();
+    }
+
+    @Override
+    public INDArray[] getOutput(){
+        checkOutputException();
+        return output;
+    }
+
+    protected void checkOutputException(){
+        if(exception != null){
+            if(exception instanceof RuntimeException){
+                throw (RuntimeException)exception;
+            } else {
+                throw new RuntimeException("Exception encountered while getting output: " + exception.getMessage(), exception);
+            }
+        }
     }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
@@ -36,6 +36,11 @@ public class BasicInferenceObservable extends Observable implements InferenceObs
     }
 
     @Override
+    public void addInput(@NonNull INDArray... input){
+        addInput(input, null);
+    }
+
+    @Override
     public void addInput(@NonNull INDArray[] input, INDArray[] inputMasks) {
         this.input = input;
         this.inputMasks = inputMasks;

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
@@ -17,7 +17,6 @@ import java.util.Observable;
  */
 @Slf4j
 public class BasicInferenceObservable extends Observable implements InferenceObservable {
-    @Getter
     private INDArray[] input;
     private INDArray[] inputMasks;
     @Getter

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.parallelism.inference.InferenceObservable;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.primitives.Pair;
 
 import java.util.Collections;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.Observable;
 public class BasicInferenceObservable extends Observable implements InferenceObservable {
     @Getter
     private INDArray[] input;
+    private INDArray[] inputMasks;
     @Getter
     private long id;
     private INDArray[] output;
@@ -25,13 +27,19 @@ public class BasicInferenceObservable extends Observable implements InferenceObs
 
 
     public BasicInferenceObservable(INDArray... inputs) {
+        this(inputs, null);
+    }
+
+    public BasicInferenceObservable(INDArray[] inputs, INDArray[] inputMasks){
         super();
         this.input = inputs;
+        this.inputMasks = inputMasks;
     }
 
     @Override
-    public void addInput(@NonNull INDArray... input) {
+    public void addInput(@NonNull INDArray[] input, INDArray[] inputMasks) {
         this.input = input;
+        this.inputMasks = inputMasks;
     }
 
     @Override
@@ -43,8 +51,8 @@ public class BasicInferenceObservable extends Observable implements InferenceObs
     }
 
     @Override
-    public List<INDArray[]> getInputBatches(){
-        return Collections.singletonList(input);
+    public List<Pair<INDArray[],INDArray[]>> getInputBatches(){
+        return Collections.singletonList(new Pair<>(input, inputMasks));
     }
 
     @Override

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BasicInferenceObservable.java
@@ -1,10 +1,14 @@
 package org.deeplearning4j.parallelism.inference.observers;
 
+import com.google.common.base.Preconditions;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.parallelism.inference.InferenceObservable;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Observable;
 
 /**
@@ -26,13 +30,20 @@ public class BasicInferenceObservable extends Observable implements InferenceObs
     }
 
     @Override
-    public void setInput(INDArray... input) {
+    public void addInput(@NonNull INDArray... input) {
         this.input = input;
     }
 
-    public void setOutput(INDArray... output) {
-        this.output = output;
+    @Override
+    public void setOutputBatches(@NonNull List<INDArray[]> output) {
+        Preconditions.checkArgument(output.size() == 1, "Expected size 1 output: got size " + output.size());
+        this.output = output.get(0);
         this.setChanged();
         notifyObservers();
+    }
+
+    @Override
+    public List<INDArray[]> getInputBatches(){
+        return Collections.singletonList(input);
     }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservable.java
@@ -197,8 +197,7 @@ public class BatchedInferenceObservable extends BasicInferenceObservable impleme
     @Override
     public INDArray[] getOutput() {
         // basically we should take care of splits here: each client should get its own part of output, wrt order number
-
-        int pos = position.get();
+        checkOutputException();
         return outputs.get(position.get());
     }
 }

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservable.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservable.java
@@ -90,6 +90,9 @@ public class BatchedInferenceObservable extends BasicInferenceObservable impleme
                     if(inputMasks.get(i) != null) {
                         if(fMasksToMerge == null){
                             fMasksToMerge = new INDArray[countToMerge][0];
+                            for( int j=0; j<countToMerge; j++ ){
+                                fMasksToMerge[j] = null;
+                            }
                         }
                         fMasksToMerge[fPos] = inputMasks.get(i);
                     }

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/ParallelInferenceTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/ParallelInferenceTest.java
@@ -173,9 +173,10 @@ public class ParallelInferenceTest {
 
         assertTrue(observable1 == observable2);
 
-        List<INDArray[]> l = observable1.getInputBatches();
+        List<Pair<INDArray[],INDArray[]>> l = observable1.getInputBatches();
         assertEquals(1, l.size());
-        INDArray[] input = l.get(0);
+        INDArray[] input = l.get(0).getFirst();
+        assertNull(l.get(0).getSecond());
 
         assertEquals(1, input.length);
         assertArrayEquals(new int[] {2, 100}, input[0].shape());
@@ -201,9 +202,10 @@ public class ParallelInferenceTest {
         assertTrue(observable1 == observable2);
         assertTrue(observable1 != observable3);
 
-        List<INDArray[]> l = observable1.getInputBatches();
+        List<Pair<INDArray[],INDArray[]>> l = observable1.getInputBatches();
         assertEquals(1, l.size());
-        INDArray[] input = l.get(0);
+        INDArray[] input = l.get(0).getFirst();
+        assertNull(l.get(0).getSecond());
 
         assertEquals(1.0f, input[0].tensorAlongDimension(0, 1).meanNumber().floatValue(), 0.001);
         assertEquals(2.0f, input[0].tensorAlongDimension(1, 1).meanNumber().floatValue(), 0.001);
@@ -211,7 +213,8 @@ public class ParallelInferenceTest {
 
         l = observable3.getInputBatches();
         assertEquals(1, l.size());
-        input = l.get(0);
+        input = l.get(0).getFirst();
+        assertNull(l.get(0).getSecond());
         assertEquals(3.0f, input[0].tensorAlongDimension(0, 1).meanNumber().floatValue(), 0.001);
     }
 

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/ParallelInferenceTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/ParallelInferenceTest.java
@@ -28,10 +28,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.Pair;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -176,7 +173,9 @@ public class ParallelInferenceTest {
 
         assertTrue(observable1 == observable2);
 
-        INDArray[] input = observable1.getInput();
+        List<INDArray[]> l = observable1.getInputBatches();
+        assertEquals(1, l.size());
+        INDArray[] input = l.get(0);
 
         assertEquals(1, input.length);
         assertArrayEquals(new int[] {2, 100}, input[0].shape());
@@ -202,12 +201,17 @@ public class ParallelInferenceTest {
         assertTrue(observable1 == observable2);
         assertTrue(observable1 != observable3);
 
-        INDArray[] input = observable1.getInput();
+        List<INDArray[]> l = observable1.getInputBatches();
+        assertEquals(1, l.size());
+        INDArray[] input = l.get(0);
 
         assertEquals(1.0f, input[0].tensorAlongDimension(0, 1).meanNumber().floatValue(), 0.001);
         assertEquals(2.0f, input[0].tensorAlongDimension(1, 1).meanNumber().floatValue(), 0.001);
 
-        input = observable3.getInput();
+
+        l = observable3.getInputBatches();
+        assertEquals(1, l.size());
+        input = l.get(0);
         assertEquals(3.0f, input[0].tensorAlongDimension(0, 1).meanNumber().floatValue(), 0.001);
     }
 
@@ -228,7 +232,7 @@ public class ParallelInferenceTest {
         for (int i = 0; i < bigOutput.rows(); i++)
             bigOutput.getRow(i).assign((float) i);
 
-        observable3.setOutput(bigOutput);
+        observable3.setOutputBatches(Collections.singletonList(new INDArray[]{bigOutput}));
         INDArray out = null;
 
         observable3.setPosition(0);
@@ -436,6 +440,14 @@ public class ParallelInferenceTest {
         for( int i=0; i<in.size(); i++ ){
             INDArray e = exp.get(i);
             INDArray a = act[i];
+
+//            float[] fe = e.dup().data().asFloat();
+//            float[] fa = a.dup().data().asFloat();
+//            System.out.println(Arrays.toString(fe));
+//            System.out.println(Arrays.toString(fa));
+//            assertArrayEquals(fe, fa, 1e-8f);
+//            System.out.println(Arrays.toString(e.shape()) + " vs " + Arrays.toString(a.shape()));
+//            assertArrayEquals(e.shape(), a.shape());
 
             assertEquals(e, a);
         }

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservableTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservableTest.java
@@ -53,14 +53,14 @@ public class BatchedInferenceObservableTest {
         BatchedInferenceObservable observable = new BatchedInferenceObservable();
 
         for (int i = 0; i < 32; i++) {
-            observable.addInput(new INDArray[]{Nd4j.create(3, 72, 72).assign(i)}, null);
+            observable.addInput(new INDArray[]{Nd4j.create(1,3, 72, 72).assign(i)}, null);
         }
 
         assertEquals(1, observable.getInputBatches().size());
 
         INDArray array = observable.getInputBatches().get(0).getFirst()[0];
-        assertEquals(3, array.rank());
-        assertEquals(32, array.shape()[0]);
+        assertEquals(4, array.rank());
+        assertEquals(32, array.size(0));
 
         log.info("Array shape: {}", Arrays.toString(array.shapeInfoDataBuffer().asInt()));
 

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservableTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservableTest.java
@@ -30,7 +30,7 @@ public class BatchedInferenceObservableTest {
         BatchedInferenceObservable observable = new BatchedInferenceObservable();
 
         for (int i = 0; i < 32; i++) {
-            observable.addInput(Nd4j.create(100).assign(i));
+            observable.addInput(new INDArray[]{Nd4j.create(100).assign(i)}, null);
         }
 
         assertEquals(1, observable.getInput().length);
@@ -51,7 +51,7 @@ public class BatchedInferenceObservableTest {
         BatchedInferenceObservable observable = new BatchedInferenceObservable();
 
         for (int i = 0; i < 32; i++) {
-            observable.addInput(Nd4j.create(3, 72, 72).assign(i));
+            observable.addInput(new INDArray[]{Nd4j.create(3, 72, 72).assign(i)}, null);
         }
 
         assertEquals(1, observable.getInput().length);
@@ -72,7 +72,7 @@ public class BatchedInferenceObservableTest {
         BatchedInferenceObservable observable = new BatchedInferenceObservable();
 
         for (int i = 0; i < 32; i++) {
-            observable.addInput(Nd4j.create(3, 72, 72).assign(i), Nd4j.create(100, 100).assign(100 + i));
+            observable.addInput(new INDArray[]{Nd4j.create(3, 72, 72).assign(i), Nd4j.create(100, 100).assign(100 + i)}, null);
         }
 
         assertEquals(2, observable.getInput().length);

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservableTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservableTest.java
@@ -8,6 +8,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -29,7 +30,7 @@ public class BatchedInferenceObservableTest {
         BatchedInferenceObservable observable = new BatchedInferenceObservable();
 
         for (int i = 0; i < 32; i++) {
-            observable.setInput(Nd4j.create(100).assign(i));
+            observable.addInput(Nd4j.create(100).assign(i));
         }
 
         assertEquals(1, observable.getInput().length);
@@ -50,7 +51,7 @@ public class BatchedInferenceObservableTest {
         BatchedInferenceObservable observable = new BatchedInferenceObservable();
 
         for (int i = 0; i < 32; i++) {
-            observable.setInput(Nd4j.create(3, 72, 72).assign(i));
+            observable.addInput(Nd4j.create(3, 72, 72).assign(i));
         }
 
         assertEquals(1, observable.getInput().length);
@@ -71,7 +72,7 @@ public class BatchedInferenceObservableTest {
         BatchedInferenceObservable observable = new BatchedInferenceObservable();
 
         for (int i = 0; i < 32; i++) {
-            observable.setInput(Nd4j.create(3, 72, 72).assign(i), Nd4j.create(100, 100).assign(100 + i));
+            observable.addInput(Nd4j.create(3, 72, 72).assign(i), Nd4j.create(100, 100).assign(100 + i));
         }
 
         assertEquals(2, observable.getInput().length);
@@ -101,7 +102,7 @@ public class BatchedInferenceObservableTest {
         }
 
         observable.setCounter(32);
-        observable.setOutput(output0, output1);
+        observable.setOutputBatches(Collections.singletonList(new INDArray[]{output0, output1}));
 
         List<INDArray[]> outputs = observable.getOutputs();
 


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/4813

What specifically this adds/fixes:
- Support for different size inputs (time series lengths, CNN sizes) when in batched mode
- Support for 'pre-batched' inputs (i.e., if the user passes in a minibatch size > 1, they get the same minibatch size back out)
- Exceptions that occur during net output are now propagated to ParallelInference.output() calls (previously: could block indefinitely)
- Adds output method overloads that support input mask arrays
- Fixes some issues (edge cases) with how inputs were batched together and split

Note: with regard to batching different size input arrays - currently this just processes them separately.
This certainly isn't ideal for performance, but at least it works robustly - I'll leave it at that for now, given the limited time before the planned release.
