### PR TITLE
Make lombok artifact provided in pom.xml files

### DIFF
--- a/deeplearning4j-core/pom.xml
+++ b/deeplearning4j-core/pom.xml
@@ -150,6 +150,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/deeplearning4j-modelimport/pom.xml
+++ b/deeplearning4j-modelimport/pom.xml
@@ -83,6 +83,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- For unit tests -->

--- a/deeplearning4j-nearestneighbors-parent/deeplearning4j-nearestneighbors-model/pom.xml
+++ b/deeplearning4j-nearestneighbors-parent/deeplearning4j-nearestneighbors-model/pom.xml
@@ -22,6 +22,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.nd4j</groupId>

--- a/deeplearning4j-nn/pom.xml
+++ b/deeplearning4j-nn/pom.xml
@@ -21,6 +21,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/pom.xml
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/pom.xml
@@ -36,6 +36,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>

--- a/deeplearning4j-ui-parent/deeplearning4j-ui-components/pom.xml
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui-components/pom.xml
@@ -18,6 +18,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- ND4J Shaded Jackson Dependency -->

--- a/deeplearning4j-ui-parent/deeplearning4j-ui-model/pom.xml
+++ b/deeplearning4j-ui-parent/deeplearning4j-ui-model/pom.xml
@@ -33,6 +33,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- ND4J APIs -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <jackson.version>2.5.1</jackson.version>
         <spark.jackson.version>2.4.4</spark.jackson.version>
         <typesafe.config.version>1.3.0</typesafe.config.version>
-        <lombok.version>1.16.16</lombok.version>
+        <lombok.version>1.16.20</lombok.version>
         <cleartk.version>2.0.0</cleartk.version>
         <json.version>20131018</json.version>
         <google.protobuf.version>2.6.1</google.protobuf.version>
@@ -917,6 +917,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <reporting>


### PR DESCRIPTION
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/4839

## What changes were proposed in this pull request?

Prevent Lombok from leaking to dependent projects, update version, and rearrange dependencies as required because no longer transitive.

## How was this patch tested?

Build passes, running LenetMnistExample from dl4j-examples works, and confirmed manually on it that `mvn dependency:tree` does not contain lombok anymore.