### PR TITLE
PerformanceListener in build is missing reportEtl setting

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/PerformanceListener.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/PerformanceListener.java
@@ -232,6 +232,7 @@ public class PerformanceListener implements IterationListener {
             listener.reportTime = this.reportTime;
             listener.reportBatch = this.reportBatch;
             listener.reportSample = this.reportSample;
+            listener.reportEtl = this.reportEtl;
 
             return listener;
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

PerformanceListener in build method is missing reportEtl setting

## How was this patch tested?

Only visual checking.

