### PR TITLE
PerformanceListener params names are not unified

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/PerformanceListener.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/PerformanceListener.java
@@ -146,44 +146,44 @@ public class PerformanceListener implements IterationListener {
         /**
          * This method defines, if iteration number should be reported together with other data
          *
-         * @param reallyReport
+         * @param reportIteration
          * @return
          */
-        public Builder reportIteration(boolean reallyReport) {
-            this.reportIteration = reallyReport;
+        public Builder reportIteration(boolean reportIteration) {
+            this.reportIteration = reportIteration;
             return this;
         }
 
         /**
          * This method defines, if time per iteration should be reported together with other data
          *
-         * @param reallyReport
+         * @param reportTime
          * @return
          */
-        public Builder reportTime(boolean reallyReport) {
-            this.reportTime = reallyReport;
+        public Builder reportTime(boolean reportTime) {
+            this.reportTime = reportTime;
             return this;
         }
 
         /**
          * This method defines, if ETL time per iteration should be reported together with other data
          *
-         * @param reallyReport
+         * @param reportEtl
          * @return
          */
-        public Builder reportETL(boolean reallyReport) {
-            this.reportEtl = reallyReport;
+        public Builder reportETL(boolean reportEtl) {
+            this.reportEtl = reportEtl;
             return this;
         }
 
         /**
          * This method defines, if samples/sec should be reported together with other data
          *
-         * @param reallyReport
+         * @param reportSample
          * @return
          */
-        public Builder reportSample(boolean reallyReport) {
-            this.reportSample = reallyReport;
+        public Builder reportSample(boolean reportSample) {
+            this.reportSample = reportSample;
             return this;
         }
 
@@ -191,22 +191,22 @@ public class PerformanceListener implements IterationListener {
         /**
          * This method defines, if batches/sec should be reported together with other data
          *
-         * @param reallyReport
+         * @param reportBatch
          * @return
          */
-        public Builder reportBatch(boolean reallyReport) {
-            this.reportBatch = reallyReport;
+        public Builder reportBatch(boolean reportBatch) {
+            this.reportBatch = reportBatch;
             return this;
         }
 
         /**
          * This method defines, if score should be reported together with other data
          *
-         * @param reallyReport
+         * @param reportScore
          * @return
          */
-        public Builder reportScore(boolean reallyReport) {
-            this.reportScore = reallyReport;
+        public Builder reportScore(boolean reportScore) {
+            this.reportScore = reportScore;
             return this;
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

PerformanceListener params names are not unified

## How was this patch tested?

Only visual checking.