### PR TITLE
Fix memory corruption when using Hdf5Archive

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelBuilder.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelBuilder.java
@@ -11,6 +11,7 @@ import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfig
 import org.nd4j.shade.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -18,7 +19,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 @Data
-public class KerasModelBuilder implements Cloneable {
+public class KerasModelBuilder implements Cloneable, Closeable {
     protected String modelJson = null;
     protected String modelYaml = null;
     protected String trainingJson = null;
@@ -81,28 +82,33 @@ public class KerasModelBuilder implements Cloneable {
 
     public KerasModelBuilder modelHdf5Filename(String modelHdf5Filename)
             throws UnsupportedKerasConfigurationException, InvalidKerasConfigurationException, IOException {
-        this.weightsArchive = this.trainingArchive = new Hdf5Archive(modelHdf5Filename);
-        this.weightsRoot = config.getTrainingWeightsRoot();
-        if (!this.weightsArchive.hasAttribute(config.getTrainingModelConfigAttribute()))
-            throw new InvalidKerasConfigurationException(
-                    "Model configuration attribute missing from " + modelHdf5Filename + " archive.");
-        String initialModelJson = this.weightsArchive.readAttributeAsJson(
-                config.getTrainingModelConfigAttribute());
+        try {
+            this.weightsArchive = this.trainingArchive = new Hdf5Archive(modelHdf5Filename);
+            this.weightsRoot = config.getTrainingWeightsRoot();
+            if (!this.weightsArchive.hasAttribute(config.getTrainingModelConfigAttribute()))
+                throw new InvalidKerasConfigurationException(
+                        "Model configuration attribute missing from " + modelHdf5Filename + " archive.");
+            String initialModelJson = this.weightsArchive.readAttributeAsJson(
+                    config.getTrainingModelConfigAttribute());
 
-        String kerasVersion = this.weightsArchive.readAttributeAsFixedLengthString(
-                config.getFieldKerasVersion(), 5);
-        Map<String, Object> modelMapper = KerasModelUtils.parseJsonString(initialModelJson);
-        modelMapper.put(config.getFieldKerasVersion(), kerasVersion);
+            String kerasVersion = this.weightsArchive.readAttributeAsFixedLengthString(
+                    config.getFieldKerasVersion(), 5);
+            Map<String, Object> modelMapper = KerasModelUtils.parseJsonString(initialModelJson);
+            modelMapper.put(config.getFieldKerasVersion(), kerasVersion);
 
-        int majorKerasVersion = Character.getNumericValue(kerasVersion.charAt(0));
-        if (majorKerasVersion == 2) {
-            String backend = this.weightsArchive.readAttributeAsString(config.getFieldBackend());
-            modelMapper.put(config.getFieldBackend(), backend);
+            int majorKerasVersion = Character.getNumericValue(kerasVersion.charAt(0));
+            if (majorKerasVersion == 2) {
+                String backend = this.weightsArchive.readAttributeAsString(config.getFieldBackend());
+                modelMapper.put(config.getFieldBackend(), backend);
+            }
+
+            this.modelJson = new ObjectMapper().writeValueAsString(modelMapper);
+            if (this.trainingArchive.hasAttribute(config.getTrainingTrainingConfigAttribute()))
+                this.trainingJson = this.trainingArchive.readAttributeAsJson(config.getTrainingTrainingConfigAttribute());
+        } catch (Throwable t) {
+            close();
+            throw t;
         }
-
-        this.modelJson = new ObjectMapper().writeValueAsString(modelMapper);
-        if (this.trainingArchive.hasAttribute(config.getTrainingTrainingConfigAttribute()))
-            this.trainingJson = this.trainingArchive.readAttributeAsJson(config.getTrainingTrainingConfigAttribute());
         return this;
     }
 
@@ -119,11 +125,26 @@ public class KerasModelBuilder implements Cloneable {
 
     public KerasModel buildModel()
             throws IOException, InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
-        return new KerasModel(this);
+        KerasModel m = new KerasModel(this);
+        close();
+        return m;
     }
 
     public KerasSequentialModel buildSequential()
             throws IOException, InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
-        return new KerasSequentialModel(this);
+        KerasSequentialModel m = new KerasSequentialModel(this);
+        close();
+        return m;
+    }
+
+    @Override public void close() {
+        if (trainingArchive != null && trainingArchive != weightsArchive) {
+            trainingArchive.close();
+            trainingArchive = null;
+        }
+        if (weightsArchive != null) {
+            weightsArchive.close();
+            weightsArchive = null;
+        }
     }
 }

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasModelEndToEndTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasModelEndToEndTest.java
@@ -249,7 +249,10 @@ public class KerasModelEndToEndTest {
      */
     @Test
     public void importWganDiscriminator() throws Exception {
-        importSequentialModelH5Test("modelimport/keras/examples/gans/wgan_discriminator.h5");
+        for (int i = 0; i < 100; i++) {
+            // run a few times to make sure HDF5 doesn't crash
+            importSequentialModelH5Test("modelimport/keras/examples/gans/wgan_discriminator.h5");
+        }
     }
 
     @Test
@@ -298,7 +301,7 @@ public class KerasModelEndToEndTest {
                         KerasModelEndToEndTest.class.getClassLoader());
         File outputsFile = File.createTempFile(TEMP_OUTPUTS_FILENAME, H5_EXTENSION);
         Files.copy(outputsResource.getInputStream(), outputsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        Hdf5Archive outputsArchive = new Hdf5Archive(outputsFile.getAbsolutePath());
+        try (Hdf5Archive outputsArchive = new Hdf5Archive(outputsFile.getAbsolutePath())) {
 
         if (checkPredictions) {
             INDArray input = getInputs(outputsArchive, tfOrdering)[0];
@@ -343,6 +346,7 @@ public class KerasModelEndToEndTest {
                 throw new RuntimeException("Cannot gradient check 4d output array");
             }
             checkGradients(model, input, testLabels);
+        }
         }
     }
 


### PR DESCRIPTION
Fixes issue #4769

## What changes were proposed in this pull request?

Makes sure all HDF5 objects are deallocated in the proper order to keep it happy.

## How was this patch tested?

Slightly updated unit tests pass without crashing. I actually let importWganDiscriminator() run for 10000 iterations without problems, but reduced it to 100 for this PR so it does not take too much time to run.