### PR TITLE
Fixed missing log class declaration

### DIFF
--- a/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/ModelMetaData.java
+++ b/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/ModelMetaData.java
@@ -10,9 +10,16 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ModelMetaData {
-    private int[][] inputShape;
+	private int[][] inputShape;
     private int numOutputs;
     private ZooType zooType;
+    
+    public ModelMetaData(int[][] inputShape, int numOutputs, ZooType zooType) {
+		super();
+		this.inputShape = inputShape;
+		this.numOutputs = numOutputs;
+		this.zooType = zooType;
+	}
 
     /**
      * If number of inputs are greater than 1, this states that the
@@ -22,4 +29,8 @@ public class ModelMetaData {
     public boolean useMDS() {
         return inputShape.length > 1 ? true : false;
     }
+
+	public int[][] getInputShape() {
+		return inputShape;
+	}
 }

--- a/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/ZooModel.java
+++ b/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/ZooModel.java
@@ -1,17 +1,20 @@
 package org.deeplearning4j.zoo;
 
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FileUtils;
-import org.deeplearning4j.nn.api.Model;
-import org.deeplearning4j.nn.graph.ComputationGraph;
-import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
-import org.deeplearning4j.util.ModelSerializer;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.zip.Adler32;
 import java.util.zip.Checksum;
+
+import org.apache.commons.io.FileUtils;
+import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.util.ModelSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A zoo model is instantiable, returns information about itself, and can download
@@ -23,7 +26,8 @@ import java.util.zip.Checksum;
 public abstract class ZooModel<T> implements InstantiableModel {
 
     public static File ROOT_CACHE_DIR = new File(System.getProperty("user.home"), "/.deeplearning4j/");
-
+    private static final Logger log = LoggerFactory.getLogger(ZooModel.class);
+    
     public boolean pretrainedAvailable(PretrainedType pretrainedType) {
         if (pretrainedUrl(pretrainedType) == null)
             return false;

--- a/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/util/ClassPrediction.java
+++ b/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/util/ClassPrediction.java
@@ -13,7 +13,14 @@ import lombok.Data;
 @Data
 public class ClassPrediction {
 
-    private int number;
+    public ClassPrediction(int number, String label, double probability) {
+		super();
+		this.number = number;
+		this.label = label;
+		this.probability = probability;
+	}
+
+	private int number;
     private String label;
     private double probability;
 
@@ -21,4 +28,12 @@ public class ClassPrediction {
     public String toString() {
         return "ClassPrediction(number=" + number + ",label=" + label + ",probability=" + probability + ")";
     }
+
+	public String getLabel() {
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
 }

--- a/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestDownload.java
+++ b/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestDownload.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.nn.conf.WorkspaceMode;
 import org.junit.Test;
 import org.nd4j.linalg.factory.Nd4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +18,7 @@ import java.util.Map;
  */
 @Slf4j
 public class TestDownload {
+	private static final Logger log = LoggerFactory.getLogger(TestDownload.class);
 
     @Test
     public void testDownloadAllModels() throws Exception {

--- a/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestImageNet.java
+++ b/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestImageNet.java
@@ -22,6 +22,8 @@ import org.nd4j.linalg.dataset.api.preprocessor.DataNormalization;
 import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;
 import org.nd4j.linalg.dataset.api.preprocessor.VGG16ImagePreProcessor;
 import org.nd4j.linalg.factory.Nd4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,6 +39,7 @@ import static org.junit.Assert.assertTrue;
  */
 @Slf4j
 public class TestImageNet {
+	private static final Logger log = LoggerFactory.getLogger(TestImageNet.class);
 
     @Test
     public void testImageNetLabels() throws IOException {

--- a/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestInstantiation.java
+++ b/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestInstantiation.java
@@ -18,6 +18,8 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.factory.Nd4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,6 +34,7 @@ import static org.junit.Assert.assertArrayEquals;
  */
 @Slf4j
 public class TestInstantiation {
+	private static final Logger log = LoggerFactory.getLogger(TestInstantiation.class);
 
     @Test
     public void testMultipleCnnTraining() throws Exception {


### PR DESCRIPTION
Signed-off-by: Eduardo Sant'Ana da Silva <eduardo.santanadasilva@gmail.com>

## What changes were proposed in this pull request?

Declaring log variable missing instance that was causing compilation errors.

## How was this patch tested?

It was just a compilation error, the log declaration follows other dl4j log declaration.