### PR TITLE
#4887 Remove ModelSerializer.checkInputStream for now

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java
@@ -813,6 +813,9 @@ public class ModelSerializer {
 
 
     private static void checkInputStream(InputStream inputStream) throws IOException {
+
+        /*
+        //available method can return 0 in some cases: https://github.com/deeplearning4j/deeplearning4j/issues/4887
         int available;
         try{
             //InputStream.available(): A subclass' implementation of this method may choose to throw an IOException
@@ -826,6 +829,7 @@ public class ModelSerializer {
             throw new IOException("Cannot read from stream: stream may have been closed or is attempting to be read from" +
                     "multiple times?");
         }
+        */
     }
 
     private static void checkTempFileFromInputStream(File f) throws IOException {


### PR DESCRIPTION
Quick fix for: https://github.com/deeplearning4j/deeplearning4j/issues/4887

Note that this code was intended to detect bad input streams (no data). But the following method should still catch that:
https://github.com/deeplearning4j/deeplearning4j/blob/988630b1c8cde8da6414ca80d146097c902993fb/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ModelSerializer.java#L831-L837

We may be able to add a buffered stream wrapper, and use the available method again.