### PR TITLE
Remove five IterationListener's unused private 'invoked' member

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ComposableIterationListener.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ComposableIterationListener.java
@@ -31,7 +31,6 @@ import java.util.Collection;
  */
 public class ComposableIterationListener implements IterationListener {
     private Collection<IterationListener> listeners = new ArrayList<>();
-    private boolean invoked = false;
 
     public ComposableIterationListener(IterationListener... iterationListener) {
         listeners.addAll(Arrays.asList(iterationListener));

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ParamAndGradientIterationListener.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ParamAndGradientIterationListener.java
@@ -31,8 +31,6 @@ public class ParamAndGradientIterationListener implements IterationListener {
     private static final int MAX_WRITE_FAILURE_MESSAGES = 10;
     private static final Logger logger = LoggerFactory.getLogger(ParamAndGradientIterationListener.class);
 
-    private boolean invoked = false;
-
     private int iterations;
     private long totalIterationCount = 0;
     private boolean printMean = true;

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ScoreIterationListener.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ScoreIterationListener.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 public class ScoreIterationListener implements IterationListener {
     private int printIterations = 10;
     private static final Logger log = LoggerFactory.getLogger(ScoreIterationListener.class);
-    private boolean invoked = false;
 
     /**
      * @param printIterations    frequency with which to print scores (i.e., every printIterations parameter updates)

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/TimeIterationListener.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/TimeIterationListener.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class TimeIterationListener implements IterationListener {
 
     private static final long serialVersionUID = 1L;
-    private boolean invoked;
     private long start;
     private int iterationCount;
     private AtomicLong iterationCounter = new AtomicLong(0);

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/EarlyStoppingParallelTrainer.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/EarlyStoppingParallelTrainer.java
@@ -314,7 +314,6 @@ public class EarlyStoppingParallelTrainer<T extends Model> implements IEarlyStop
      */
     private class AveragingIterationListener<T extends Model> implements IterationListener {
         private final Logger log = LoggerFactory.getLogger(AveragingIterationListener.class);
-        private boolean invoked = false;
         private IterationTerminationCondition terminationReason = null;
         private EarlyStoppingParallelTrainer<T> trainer;
 


### PR DESCRIPTION
These private members appear to be unused (assuming no strange access via introspection, reflection or something) and so could be removed for clarity.