### PR TITLE
updated to get rid of deprecated datavec components

### DIFF
--- a/deeplearning4j-data/deeplearning4j-datasets/src/main/java/org/deeplearning4j/datasets/fetchers/CacheableExtractableDataSetFetcher.java
+++ b/deeplearning4j-data/deeplearning4j-datasets/src/main/java/org/deeplearning4j/datasets/fetchers/CacheableExtractableDataSetFetcher.java
@@ -2,7 +2,7 @@ package org.deeplearning4j.datasets.fetchers;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
-import org.datavec.api.util.ArchiveUtils;
+import org.nd4j.util.ArchiveUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/iterator/provider/CollectionLabeledSentenceProvider.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/iterator/provider/CollectionLabeledSentenceProvider.java
@@ -1,9 +1,9 @@
 package org.deeplearning4j.iterator.provider;
 
 import lombok.NonNull;
-import org.datavec.api.util.RandomUtils;
 import org.deeplearning4j.iterator.LabeledSentenceProvider;
 import org.nd4j.linalg.primitives.Pair;
+import org.nd4j.linalg.util.MathUtils;
 
 import java.util.*;
 
@@ -46,7 +46,7 @@ public class CollectionLabeledSentenceProvider implements LabeledSentenceProvide
                 order[i] = i;
             }
 
-            RandomUtils.shuffleInPlace(order, rng);
+            MathUtils.shuffleArray(order, rng);
         }
 
         //Collect set of unique labels for all sentences
@@ -78,7 +78,7 @@ public class CollectionLabeledSentenceProvider implements LabeledSentenceProvide
     public void reset() {
         cursor = 0;
         if (rng != null) {
-            RandomUtils.shuffleInPlace(order, rng);
+            MathUtils.shuffleArray(order, rng);
         }
     }
 

--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/iterator/provider/FileLabeledSentenceProvider.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/iterator/provider/FileLabeledSentenceProvider.java
@@ -2,10 +2,10 @@ package org.deeplearning4j.iterator.provider;
 
 import lombok.NonNull;
 import org.apache.commons.io.FileUtils;
-import org.datavec.api.util.RandomUtils;
 import org.deeplearning4j.iterator.LabeledSentenceProvider;
 import org.nd4j.linalg.collection.CompactHeapStringList;
 import org.nd4j.linalg.primitives.Pair;
+import org.nd4j.linalg.util.MathUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,7 +54,8 @@ public class FileLabeledSentenceProvider implements LabeledSentenceProvider {
             for (int i = 0; i < totalCount; i++) {
                 order[i] = i;
             }
-            RandomUtils.shuffleInPlace(order, rng);
+
+            MathUtils.shuffleArray(order, rng);
         }
 
         allLabels = new ArrayList<>(filesByLabel.keySet());
@@ -108,7 +109,7 @@ public class FileLabeledSentenceProvider implements LabeledSentenceProvider {
     public void reset() {
         cursor = 0;
         if (rng != null) {
-            RandomUtils.shuffleInPlace(order, rng);
+            MathUtils.shuffleArray(order, rng);
         }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Depends on: https://github.com/deeplearning4j/DataVec/pull/551
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
