### PR TITLE
Make collectTrainingStats configurable in SharedTrainingMaster Builder

### DIFF
--- a/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
@@ -1212,7 +1212,7 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
 
         public SharedTrainingMaster build() {
             SharedTrainingMaster master = new SharedTrainingMaster(voidConfiguration, numWorkers, rddTrainingApproach,
-                            storageLevel, true, repartitionStrategy, repartition, threshold, minThreshold,
+                            storageLevel, collectTrainingStats, repartitionStrategy, repartition, threshold, minThreshold,
                             thresholdStep, stepTrigger, stepDelay, shakeFrequency, batchSize, debugLongerIterations,
                             numWorkersPerNode);
             if (transport != null)

--- a/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
+++ b/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
@@ -432,7 +432,8 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
             try {
                 String sparkIp = InetAddress.getByName(System.getenv("SPARK_PUBLIC_DNS")).getHostAddress();
                 voidConfiguration.setControllerAddress(sparkIp);
-            } catch(UnknownHostException e) { }
+            } catch (UnknownHostException e) {
+            }
         }
 
         // next step - is to get ip address that matches specific network mask
@@ -1212,9 +1213,9 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
 
         public SharedTrainingMaster build() {
             SharedTrainingMaster master = new SharedTrainingMaster(voidConfiguration, numWorkers, rddTrainingApproach,
-                            storageLevel, collectTrainingStats, repartitionStrategy, repartition, threshold, minThreshold,
-                            thresholdStep, stepTrigger, stepDelay, shakeFrequency, batchSize, debugLongerIterations,
-                            numWorkersPerNode);
+                            storageLevel, collectTrainingStats, repartitionStrategy, repartition, threshold,
+                            minThreshold, thresholdStep, stepTrigger, stepDelay, shakeFrequency, batchSize,
+                            debugLongerIterations, numWorkersPerNode);
             if (transport != null)
                 master.transport = this.transport;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using `SharedTrainingMaster.Builder()`, there is no possibility to disable the collect of training stats. There is a `setCollectTrainingStats(boolean)` available on the `Builder` but it's not taken later during the `build()`. This PR aims to fix it.

## How was this patch tested?

`cd deeplearning4j-scaleout ; mvn test`

## Quick checklist

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
- [x] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
