### PR TITLE
Keras: optional input shape (for no-top models)

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
@@ -90,7 +90,7 @@ public class KerasModel {
             throws UnsupportedKerasConfigurationException, IOException, InvalidKerasConfigurationException {
         this(modelBuilder.getModelJson(), modelBuilder.getModelYaml(), modelBuilder.getWeightsArchive(),
                 modelBuilder.getWeightsRoot(), modelBuilder.getTrainingJson(), modelBuilder.getTrainingArchive(),
-                modelBuilder.isEnforceTrainingConfig());
+                modelBuilder.isEnforceTrainingConfig(), modelBuilder.getInputShape());
     }
 
     /**
@@ -108,7 +108,8 @@ public class KerasModel {
      * @throws UnsupportedKerasConfigurationException Unsupported Keras config
      */
     protected KerasModel(String modelJson, String modelYaml, Hdf5Archive weightsArchive, String weightsRoot,
-                         String trainingJson, Hdf5Archive trainingArchive, boolean enforceTrainingConfig)
+                         String trainingJson, Hdf5Archive trainingArchive, boolean enforceTrainingConfig,
+                         int[] inputShape)
             throws IOException, InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
 
         Map<String, Object> modelConfig = KerasModelUtils.parseModelConfig(modelJson, modelYaml);
@@ -161,7 +162,7 @@ public class KerasModel {
             importTrainingConfiguration(trainingJson);
 
         /* Infer output types for each layer. */
-        inferOutputTypes(null);
+        inferOutputTypes(inputShape);
 
         /* Store weights in layers. */
         if (weightsArchive != null)

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
@@ -161,7 +161,7 @@ public class KerasModel {
             importTrainingConfiguration(trainingJson);
 
         /* Infer output types for each layer. */
-        inferOutputTypes();
+        inferOutputTypes(null);
 
         /* Store weights in layers. */
         if (weightsArchive != null)
@@ -245,12 +245,15 @@ public class KerasModel {
      * Helper method called from constructor. Infers and records output type
      * for every layer.
      */
-    void inferOutputTypes()
+    void inferOutputTypes(int[] inputShape)
             throws InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
         this.outputTypes = new HashMap<>();
         for (KerasLayer layer : this.layersOrdered) {
             InputType outputType;
             if (layer instanceof KerasInput) {
+                if (inputShape != null) {
+                    layer.inputShape =inputShape;
+                }
                 outputType = layer.getOutputType();
                 this.truncatedBPTT = ((KerasInput) layer).getTruncatedBptt();
             } else {

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModelImport.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModelImport.java
@@ -94,6 +94,27 @@ public class KerasModelImport {
      * Load Keras (Functional API) Model saved using model.save_model(...).
      *
      * @param modelHdf5Filename     path to HDF5 archive storing Keras Model
+     * @param inputShape            optional input shape for models that come without such (e.g. notop = false models)
+     * @param enforceTrainingConfig whether to enforce training configuration options
+     * @return ComputationGraph
+     * @throws IOException                            IO exception
+     * @throws InvalidKerasConfigurationException     Invalid Keras config
+     * @throws UnsupportedKerasConfigurationException Unsupported Keras config
+     * @see ComputationGraph
+     */
+    public static ComputationGraph importKerasModelAndWeights(String modelHdf5Filename, int[] inputShape,
+                                                              boolean enforceTrainingConfig)
+            throws IOException, UnsupportedKerasConfigurationException, InvalidKerasConfigurationException {
+        KerasModel kerasModel = new KerasModel().modelBuilder.modelHdf5Filename(modelHdf5Filename)
+                .enforceTrainingConfig(enforceTrainingConfig).inputShape(inputShape).buildModel();
+        return kerasModel.getComputationGraph();
+    }
+
+
+    /**
+     * Load Keras (Functional API) Model saved using model.save_model(...).
+     *
+     * @param modelHdf5Filename     path to HDF5 archive storing Keras Model
      * @param enforceTrainingConfig whether to enforce training configuration options
      * @return ComputationGraph
      * @throws IOException                            IO exception
@@ -123,6 +144,25 @@ public class KerasModelImport {
         KerasModel kerasModel = new KerasModel().modelBuilder().modelHdf5Filename(modelHdf5Filename)
                 .enforceTrainingConfig(true).buildModel();
         return kerasModel.getComputationGraph();
+    }
+
+    /**
+     * Load Keras Sequential model saved using model.save_model(...).
+     *
+     * @param modelHdf5Filename     path to HDF5 archive storing Keras Sequential model
+     * @param inputShape            optional input shape for models that come without such (e.g. notop = false models)
+     * @param enforceTrainingConfig whether to enforce training configuration options
+     * @return MultiLayerNetwork
+     * @throws IOException IO exception
+     * @see MultiLayerNetwork
+     */
+    public static MultiLayerNetwork importKerasSequentialModelAndWeights(String modelHdf5Filename,
+                                                                         int[] inputShape,
+                                                                         boolean enforceTrainingConfig)
+            throws IOException, InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
+        KerasSequentialModel kerasModel = new KerasSequentialModel().modelBuilder().modelHdf5Filename(modelHdf5Filename)
+                .enforceTrainingConfig(enforceTrainingConfig).inputShape(inputShape).buildSequential();
+        return kerasModel.getMultiLayerNetwork();
     }
 
     /**

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
@@ -126,7 +126,7 @@ public class KerasSequentialModel extends KerasModel {
             importTrainingConfiguration(trainingJson);
 
         /* Infer output types for each layer. */
-        inferOutputTypes();
+        inferOutputTypes(null);
 
         /* Store weights in layers. */
         if (weightsArchive != null)

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasSequentialModel.java
@@ -59,7 +59,7 @@ public class KerasSequentialModel extends KerasModel {
             throws UnsupportedKerasConfigurationException, IOException, InvalidKerasConfigurationException {
         this(modelBuilder.getModelJson(), modelBuilder.getModelYaml(), modelBuilder.getWeightsArchive(),
                 modelBuilder.getWeightsRoot(), modelBuilder.getTrainingJson(), modelBuilder.getTrainingArchive(),
-                modelBuilder.isEnforceTrainingConfig());
+                modelBuilder.isEnforceTrainingConfig(), modelBuilder.getInputShape());
     }
 
     /**
@@ -75,7 +75,8 @@ public class KerasSequentialModel extends KerasModel {
      * @throws IOException I/O exception
      */
     public KerasSequentialModel(String modelJson, String modelYaml, Hdf5Archive weightsArchive, String weightsRoot,
-                                String trainingJson, Hdf5Archive trainingArchive, boolean enforceTrainingConfig)
+                                String trainingJson, Hdf5Archive trainingArchive, boolean enforceTrainingConfig,
+                                int[] inputShape)
             throws IOException, InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
 
         Map<String, Object> modelConfig = KerasModelUtils.parseModelConfig(modelJson, modelYaml);
@@ -103,8 +104,8 @@ public class KerasSequentialModel extends KerasModel {
             inputLayer = this.layersOrdered.get(0);
         } else {
             /* Add placeholder input layer and update lists of input and output layers. */
-            int[] inputShape = this.layersOrdered.get(0).getInputShape();
-            inputLayer = new KerasInput("input1", inputShape);
+            int[] firstLayerInputShape = this.layersOrdered.get(0).getInputShape();
+            inputLayer = new KerasInput("input1", firstLayerInputShape);
             inputLayer.setDimOrder(this.layersOrdered.get(0).getDimOrder());
             this.layers.put(inputLayer.getLayerName(), inputLayer);
             this.layersOrdered.add(0, inputLayer);
@@ -126,7 +127,7 @@ public class KerasSequentialModel extends KerasModel {
             importTrainingConfiguration(trainingJson);
 
         /* Infer output types for each layer. */
-        inferOutputTypes(null);
+        inferOutputTypes(inputShape);
 
         /* Store weights in layers. */
         if (weightsArchive != null)

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelBuilder.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelBuilder.java
@@ -28,6 +28,7 @@ public class KerasModelBuilder implements Cloneable, Closeable {
     protected Hdf5Archive trainingArchive = null;
     protected boolean enforceTrainingConfig = false;
     protected KerasModelConfiguration config;
+    protected int[] inputShape = null;
 
 
     public KerasModelBuilder(KerasModelConfiguration config) {
@@ -48,6 +49,11 @@ public class KerasModelBuilder implements Cloneable, Closeable {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         IOUtils.copy(modelJsonInputStream, byteArrayOutputStream);
         this.modelJson = new String(byteArrayOutputStream.toByteArray());
+        return this;
+    }
+
+    public KerasModelBuilder inputShape(int[] inputShape) {
+        this.inputShape = inputShape;
         return this;
     }
 
@@ -125,16 +131,16 @@ public class KerasModelBuilder implements Cloneable, Closeable {
 
     public KerasModel buildModel()
             throws IOException, InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
-        KerasModel m = new KerasModel(this);
+        KerasModel model = new KerasModel(this);
         close();
-        return m;
+        return model;
     }
 
     public KerasSequentialModel buildSequential()
             throws IOException, InvalidKerasConfigurationException, UnsupportedKerasConfigurationException {
-        KerasSequentialModel m = new KerasSequentialModel(this);
+        KerasSequentialModel sequentialModel = new KerasSequentialModel(this);
         close();
-        return m;
+        return sequentialModel;
     }
 
     @Override public void close() {

--- a/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasModelEndToEndTest.java
+++ b/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasModelEndToEndTest.java
@@ -331,11 +331,16 @@ public class KerasModelEndToEndTest {
     @Test
     @Ignore
     public void importXception() throws Exception {
-        ComputationGraph graph = importFunctionalModelH5Test("modelimport/keras/examples/xception/xception_tf_keras_2.h5");
+        int[] inputShape = new int[]{299, 299, 3};
+        ComputationGraph graph = importFunctionalModelH5Test(
+                "modelimport/keras/examples/xception/xception_tf_keras_2.h5", inputShape);
     }
 
-
     private ComputationGraph importFunctionalModelH5Test(String modelPath) throws Exception {
+        return importFunctionalModelH5Test(modelPath, null);
+    }
+
+    private ComputationGraph importFunctionalModelH5Test(String modelPath, int[] inputShape) throws Exception {
         ClassPathResource modelResource =
                 new ClassPathResource(modelPath,
                         KerasModelEndToEndTest.class.getClassLoader());
@@ -343,11 +348,19 @@ public class KerasModelEndToEndTest {
         Files.copy(modelResource.getInputStream(), modelFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         KerasModelBuilder builder = new KerasModel().modelBuilder().modelHdf5Filename(modelFile.getAbsolutePath())
                 .enforceTrainingConfig(false);
+        if (inputShape != null) {
+            builder.inputShape(inputShape);
+        }
         KerasModel model = builder.buildModel();
         return model.getComputationGraph();
     }
 
     private void importSequentialModelH5Test(String modelPath) throws Exception {
+        importSequentialModelH5Test(modelPath, null);
+    }
+
+
+    private void importSequentialModelH5Test(String modelPath, int[] inputShape) throws Exception {
         ClassPathResource modelResource =
                 new ClassPathResource(modelPath,
                         KerasModelEndToEndTest.class.getClassLoader());
@@ -355,6 +368,9 @@ public class KerasModelEndToEndTest {
         Files.copy(modelResource.getInputStream(), modelFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         KerasModelBuilder builder = new KerasModel().modelBuilder().modelHdf5Filename(modelFile.getAbsolutePath())
                 .enforceTrainingConfig(false);
+        if (inputShape != null) {
+            builder.inputShape(inputShape);
+        }
         KerasSequentialModel model = builder.buildSequential();
         model.getMultiLayerNetwork();
     }


### PR DESCRIPTION
Models, especially Keras applications like ResNet etc., can come without input shape, e.g. when `include_top=False` in applications. For this case we can now optionally provide input shape info in all relevant places.  