### PR TITLE
Update dependencies in pom.xml files

### DIFF
--- a/deeplearning4j-core/pom.xml
+++ b/deeplearning4j-core/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.8</version>
+            <version>${commons-compress.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/deeplearning4j-nn/pom.xml
+++ b/deeplearning4j-nn/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.8</version>
+            <version>${commons-compress.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <javacpp.version>1.4.1</javacpp.version>
         <javacpp-presets.version>1.4.1</javacpp-presets.version>
         <hadoop.version>2.2.0</hadoop.version>
+        <commons-compress.version>1.16.1</commons-compress.version>
         <commonsmath.version>3.4.1</commonsmath.version>
         <commonslang.version>3.4</commonslang.version>
         <commonsio.version>2.4</commonsio.version>


### PR DESCRIPTION
Probably fixes https://github.com/deeplearning4j/deeplearning4j/issues/4330

## What changes were proposed in this pull request?

Update dependencies that don't match ND4J and DataVec.

## How was this patch tested?

Build passes and `mvn dependency:tree -Dverbose` on dl4j-examples don't show these conflicting dependencies anymore.
