### PR TITLE
Ensure topological sort is consistent on all platforms for deserialized nets

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -1589,7 +1589,7 @@ public class TestComputationGraphNetwork extends BaseDL4JTest {
 
             assertArrayEquals(origOrder, loadedOrder);
 
-            INDArray[] out5 = g.output(in);
+            INDArray[] out5 = g2.output(in);
             assertArrayEquals(out1, out5);
         }
     }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -53,9 +53,7 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.*;
 
@@ -1493,5 +1491,96 @@ public class TestComputationGraphNetwork extends BaseDL4JTest {
 
         assertEquals(exp, actBuilder);
         assertEquals(exp, actConf);
+    }
+
+
+
+
+    @Test
+    public void testTopoSortSaving(){
+
+        ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder()
+                .graphBuilder()
+                .addInputs("in1", "in2")
+                .addLayer("l0", new DenseLayer.Builder().nIn(10).nOut(10).build(), "in1")
+                .addLayer("l1", new DenseLayer.Builder().nIn(20).nOut(10).build(), "in1", "in2")
+                .addLayer("l2", new DenseLayer.Builder().nIn(10).nOut(10).build(), "in2")
+                .addLayer("l3", new DenseLayer.Builder().nIn(10).nOut(10).build(), "l0")
+                .addLayer("l4", new DenseLayer.Builder().nIn(10).nOut(10).build(), "l1")
+                .addLayer("l5", new DenseLayer.Builder().nIn(10).nOut(10).build(), "l2")
+                .addLayer("l6", new OutputLayer.Builder().nIn(20).nOut(10).build(), "l3", "l5")
+                .addLayer("l7", new OutputLayer.Builder().nIn(10).nOut(10).build(), "l4")
+                .setOutputs("l6", "l7")
+                .build();
+
+        INDArray[] in = new INDArray[]{
+                Nd4j.rand(3, 10),
+                Nd4j.rand(3, 10)};
+
+        ComputationGraph cg = new ComputationGraph(conf);
+        cg.init();
+        int[] order = cg.topologicalSortOrder();
+        INDArray[] out1 = cg.output(in);
+
+        //Check it's the same after loading:
+        System.out.println("-----------");
+        ComputationGraph cg2 = TestUtils.testModelSerialization(cg);
+        int[] order2 = cg2.topologicalSortOrder();
+        assertArrayEquals(order, order2);
+
+        INDArray[] out2 = cg2.output(in);
+        assertArrayEquals(out1, out2);
+
+        //Delete the topological order, ensure it gets recreated properly:
+        ComputationGraphConfiguration conf3 = cg2.getConfiguration().clone();
+        conf3.setTopologicalOrder(null);
+        conf3.setTopologicalOrderStr(null);
+        ComputationGraph cg3 = new ComputationGraph(conf3);
+        cg3.init();
+        cg3.setParams(cg2.params());
+
+        int[] order3 = cg3.topologicalSortOrder();
+        INDArray[] out3 = cg3.output(in);
+        assertArrayEquals(order, order3);
+        assertArrayEquals(out1, out3);
+
+
+//        //Now, change the order, and ensure the net is the same... note that we can do [l0, l1, l2] in any order
+//
+//        List<List<String>> someValidOrders = new ArrayList<>();
+//        List<int[]> someValidOrderIdxs = new ArrayList<>();
+//        someValidOrders.add(Arrays.asList("in1", "in2", "l0", "l1", "l2", "l3", "l4", "l5", "l6", "l7"));
+//        someValidOrderIdxs.add(new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+//        someValidOrders.add(Arrays.asList("in1", "in2", "l1", "l0", "l2", "l3", "l4", "l5", "l6", "l7"));
+//        someValidOrderIdxs.add(new int[]{0, 1, 3, 2, 4, 5, 6, 7, 8, 9});
+//        someValidOrders.add(Arrays.asList("in1", "in2", "l2", "l1", "l0", "l3", "l4", "l5", "l6", "l7"));
+//        someValidOrderIdxs.add(new int[]{0, 1, 4, 3, 2, 5, 6, 7, 8, 9});
+//        someValidOrders.add(Arrays.asList("in1", "in2", "l2", "l5", "l0", "l1", "l3", "l4", "l7", "l6"));
+//        someValidOrderIdxs.add(new int[]{0, 1, 4, 7, 2, 3, 5, 6, 9, 8});
+//
+//        for( int i=0; i<someValidOrders.size(); i++ ){
+//            List<String> l = someValidOrders.get(i);
+//            int[] arr = someValidOrderIdxs.get(i);
+//
+//            ComputationGraphConfiguration conf2 = conf.clone();
+//            conf2.setTopologicalOrderStr(l);
+//            conf2.setTopologicalOrder(arr);
+//
+//            ComputationGraph g = new ComputationGraph(conf2);
+//            g.setParamTable(cg.paramTable());
+//            g.init();
+//            int[] origOrder = g.topologicalSortOrder();
+//
+//            INDArray[] out4 = g.output(in);
+//            assertArrayEquals(out1, out4);
+//
+//            ComputationGraph g2 = TestUtils.testModelSerialization(g);
+//            int[] loadedOrder = g2.topologicalSortOrder();
+//
+//            assertArrayEquals(origOrder, loadedOrder);
+//
+//            INDArray[] out5 = g.output(in);
+//            assertArrayEquals(out1, out5);
+//        }
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ComputationGraphConfiguration.java
@@ -101,6 +101,8 @@ public class ComputationGraphConfiguration implements Serializable, Cloneable {
     //Counter for the number of epochs completed so far. Used for per-epoch schedules
     protected int epochCount = 0;
 
+    protected int[] topologicalOrder;
+    protected List<String> topologicalOrderStr;
 
     /**
      * @return JSON representation of configuration

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -155,7 +155,9 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * (and hence also backward pass, which is the opposite to this) is conducted in the network.
      */
     protected int[] topologicalOrder;
-
+    /**
+     * Topological sort and vertex index/name + name/index mapping
+     */
     protected GraphIndices graphIndices;
 
     /**
@@ -1081,6 +1083,14 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         return calculateIndices().getTopologicalSortOrder();
     }
 
+    /**
+     * Calculate the indices needed for the network:<br>
+     * (a) topological sort order<br>
+     * (b) Map: vertex index -> vertex name<br>
+     * (c) Map: vertex name -> vertex index<br>
+     *
+     * @return Calculated indices
+     */
     public GraphIndices calculateIndices(){
         if(graphIndices != null)
             return graphIndices;
@@ -1203,13 +1213,12 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                                 + "\")");
         }
 
-        //Store:
-
+        //Store: the topological sort order in the configuraation... this is to ensure that when the config is
+        // deserialized, it has exactly the same topological sort order on all platforms
         List<String> s = new ArrayList<>(out.length);
         for( int idx : out){
             s.add(vertexNamesMap.get(idx));
         }
-
         configuration.setTopologicalOrder(out);
         configuration.setTopologicalOrderStr(s);
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -430,7 +430,6 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
 //        }
 
         //First: build topological ordering, based on configuration. Used for forward pass, backprop and order of parameters/gradients
-//        topologicalOrder = topologicalSortOrder();
         Indexes indexes = calculateIndexes();
         topologicalOrder = indexes.getTopologicalSortOrder();
 
@@ -462,11 +461,11 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         for (; i < configuration.getNetworkInputs().size(); i++) {
             numParamsForVertex[i] = 0; //No parameters for input vertices
         }
-        for (Map.Entry<String, org.deeplearning4j.nn.conf.graph.GraphVertex> nodeEntry : configVertexMap.entrySet()) {
-            org.deeplearning4j.nn.conf.graph.GraphVertex n = nodeEntry.getValue();
+        for(; i<topologicalOrder.length; i++ ){
+            String name = indexes.getIdxToName().get(i);
+            org.deeplearning4j.nn.conf.graph.GraphVertex n = configVertexMap.get(name);
             numParamsForVertex[i] = n.numParams(true);
             numParams += numParamsForVertex[i];
-            i++;
         }
 
         boolean initializeParams;
@@ -516,9 +515,11 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         List<Layer> tempLayerList = new ArrayList<>();
         defaultConfiguration.clearVariables();
         List<String> variables = defaultConfiguration.variables(false);
-        for (Map.Entry<String, org.deeplearning4j.nn.conf.graph.GraphVertex> nodeEntry : configVertexMap.entrySet()) {
-            org.deeplearning4j.nn.conf.graph.GraphVertex n = nodeEntry.getValue();
-            String name = nodeEntry.getKey();
+        i = configuration.getNetworkInputs().size();
+        for(; i<topologicalOrder.length; i++ ){
+            String name = indexes.getIdxToName().get(i);
+            org.deeplearning4j.nn.conf.graph.GraphVertex n = configVertexMap.get(name);
+
             GraphVertex gv = n.instantiate(this, name, vertexNumber, paramsViewForVertex[vertexNumber],
                     initializeParams);
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1100,6 +1100,27 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
 //        if (topologicalOrder != null)
 //            return topologicalOrder;
 
+
+        //Get cached topological sort order from config, if present
+        if(configuration.getTopologicalOrder() != null && configuration.getTopologicalOrderStr() != null){
+            int[] t = configuration.getTopologicalOrder();
+            List<String> s = configuration.getTopologicalOrderStr();
+            Map<String,Integer> m1 = new HashMap<>();
+            Map<Integer,String> m2 = new HashMap<>();
+            for( int i=0; i<t.length; i++ ){
+                m1.put(s.get(i), t[i]);
+                m2.put(t[i], s.get(i));
+            }
+
+            System.out.println("RETURNING CACHED TOPO SORT");
+            return Indexes.builder()
+                    .topologicalSortOrder(t)
+                    .nameToIdx(m1)
+                    .idxToName(m2)
+                    .build();
+        }
+
+
         //https://en.wikipedia.org/wiki/Topological_sorting#Kahn.27s_algorithm
         Map<String, org.deeplearning4j.nn.conf.graph.GraphVertex> nodeMap = configuration.getVertices();
         List<String> networkInputNames = configuration.getNetworkInputs();
@@ -1196,6 +1217,16 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                                 + "cycle includes vertex \"" + vertexNamesMap.get(entry.getKey())
                                 + "\")");
         }
+
+        //Store:
+
+        List<String> s = new ArrayList<>(out.length);
+        for( int idx : out){
+            s.add(vertexNamesMap.get(idx));
+        }
+
+        configuration.setTopologicalOrder(out);
+        configuration.setTopologicalOrderStr(s);
 
 //        return out;
         return Indexes.builder()

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/util/GraphIndices.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/util/GraphIndices.java
@@ -1,0 +1,21 @@
+package org.deeplearning4j.nn.graph.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * Simple helper class for ComputationGraph topological sort
+ *
+ * @author Alex Black
+ */
+@Data
+@AllArgsConstructor
+@Builder
+public class GraphIndices {
+    private int[] topologicalSortOrder;
+    private Map<String,Integer> nameToIdx;
+    private Map<Integer,String> idxToName;
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/util/GraphIndices.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/util/GraphIndices.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import java.util.Map;
 
 /**
- * Simple helper class for ComputationGraph topological sort
+ * Simple helper class for ComputationGraph topological sort and vertex index/name + name/index mapping
  *
  * @author Alex Black
  */


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/4057
Now the topo sort is calculated only once and stored in the configuration.