### PR TITLE
Frozen layer with backprop implementation

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/FrozenLayerWithBackpropTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/FrozenLayerWithBackpropTest.java
@@ -1,0 +1,612 @@
+package org.deeplearning4j.nn.layers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.graph.MergeVertex;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.transferlearning.FineTuneConfiguration;
+import org.deeplearning4j.nn.transferlearning.TransferLearning;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.learning.config.Sgd;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by Ugljesa Jovanovic (jovanovic.ugljesa@gmail.com) on 06/05/2018.
+ * Reused instantiation tests from {@link FrozenLayerTest}
+ */
+@Slf4j
+public class FrozenLayerWithBackpropTest extends BaseDL4JTest {
+
+    @Test
+    public void testFrozenWithBackpropLayerInstantiation() {
+        //We need to be able to instantitate frozen layers from JSON etc, and have them be the same as if
+        // they were initialized via the builder
+        MultiLayerConfiguration conf1 = new NeuralNetConfiguration.Builder().seed(12345).list()
+                .layer(0, new DenseLayer.Builder().nIn(10).nOut(10).activation(Activation.TANH)
+                        .weightInit(WeightInit.XAVIER).build())
+                .layer(1, new DenseLayer.Builder().nIn(10).nOut(10).activation(Activation.TANH)
+                        .weightInit(WeightInit.XAVIER).build())
+                .layer(2, new OutputLayer.Builder(
+                        LossFunctions.LossFunction.MCXENT).activation(Activation.SOFTMAX).nIn(10)
+                        .nOut(10).build())
+                .build();
+
+        MultiLayerConfiguration conf2 = new NeuralNetConfiguration.Builder().seed(12345).list().layer(0,
+                new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(new DenseLayer.Builder().nIn(10).nOut(10)
+                        .activation(Activation.TANH).weightInit(WeightInit.XAVIER).build()))
+                .layer(1, new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                        new DenseLayer.Builder().nIn(10).nOut(10).activation(Activation.TANH)
+                                .weightInit(WeightInit.XAVIER).build()))
+                .layer(2, new OutputLayer.Builder(
+                        LossFunctions.LossFunction.MCXENT).activation(Activation.SOFTMAX).nIn(10)
+                        .nOut(10).build())
+                .build();
+
+        MultiLayerNetwork net1 = new MultiLayerNetwork(conf1);
+        net1.init();
+        MultiLayerNetwork net2 = new MultiLayerNetwork(conf2);
+        net2.init();
+
+        assertEquals(net1.params(), net2.params());
+
+
+        String json = conf2.toJson();
+        MultiLayerConfiguration fromJson = MultiLayerConfiguration.fromJson(json);
+
+        assertEquals(conf2, fromJson);
+
+        MultiLayerNetwork net3 = new MultiLayerNetwork(fromJson);
+        net3.init();
+
+        INDArray input = Nd4j.rand(10, 10);
+
+        INDArray out2 = net2.output(input);
+        INDArray out3 = net3.output(input);
+
+        assertEquals(out2, out3);
+    }
+
+    @Test
+    public void testFrozenLayerInstantiationCompGraph() {
+
+        //We need to be able to instantitate frozen layers from JSON etc, and have them be the same as if
+        // they were initialized via the builder
+        ComputationGraphConfiguration conf1 = new NeuralNetConfiguration.Builder().seed(12345).graphBuilder()
+                .addInputs("in")
+                .addLayer("0", new DenseLayer.Builder().nIn(10).nOut(10).activation(Activation.TANH)
+                        .weightInit(WeightInit.XAVIER).build(), "in")
+                .addLayer("1", new DenseLayer.Builder().nIn(10).nOut(10).activation(Activation.TANH)
+                        .weightInit(WeightInit.XAVIER).build(), "0")
+                .addLayer("2", new OutputLayer.Builder(
+                                LossFunctions.LossFunction.MCXENT).activation(Activation.SOFTMAX).nIn(10)
+                                .nOut(10).build(),
+                        "1")
+                .setOutputs("2").build();
+
+        ComputationGraphConfiguration conf2 = new NeuralNetConfiguration.Builder().seed(12345).graphBuilder()
+                .addInputs("in")
+                .addLayer("0", new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop.Builder()
+                        .layer(new DenseLayer.Builder().nIn(10).nOut(10).activation(Activation.TANH)
+                                .weightInit(WeightInit.XAVIER).build())
+                        .build(), "in")
+                .addLayer("1", new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop.Builder()
+                        .layer(new DenseLayer.Builder().nIn(10).nOut(10).activation(Activation.TANH)
+                                .weightInit(WeightInit.XAVIER).build())
+                        .build(), "0")
+                .addLayer("2", new OutputLayer.Builder(
+                                LossFunctions.LossFunction.MCXENT).activation(Activation.SOFTMAX).nIn(10)
+                                .nOut(10).build(),
+                        "1")
+                .setOutputs("2").build();
+
+        ComputationGraph net1 = new ComputationGraph(conf1);
+        net1.init();
+        ComputationGraph net2 = new ComputationGraph(conf2);
+        net2.init();
+
+        assertEquals(net1.params(), net2.params());
+
+
+        String json = conf2.toJson();
+        ComputationGraphConfiguration fromJson = ComputationGraphConfiguration.fromJson(json);
+
+        assertEquals(conf2, fromJson);
+
+        ComputationGraph net3 = new ComputationGraph(fromJson);
+        net3.init();
+
+        INDArray input = Nd4j.rand(10, 10);
+
+        INDArray out2 = net2.outputSingle(input);
+        INDArray out3 = net3.outputSingle(input);
+
+        assertEquals(out2, out3);
+    }
+
+    @Test
+    public void testMultiLayerNetworkFrozenLayerParamsAfterBackprop() {
+
+        DataSet randomData = new DataSet(Nd4j.rand(100, 4, 12345), Nd4j.rand(100, 1, 12345));
+
+        MultiLayerConfiguration conf1 = new NeuralNetConfiguration.Builder()
+                .seed(12345)
+                .weightInit(WeightInit.XAVIER)
+                .updater(new Sgd(2))
+                .list()
+                .layer(0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(3)
+                                .build()
+                )
+                .layer(1,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(3)
+                                        .nOut(4)
+                                        .build()
+                        )
+                )
+                .layer(2,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(4)
+                                        .nOut(2)
+                                        .build()
+                        )
+                ).layer(3,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                                        .nIn(2)
+                                        .nOut(1)
+                                        .build()
+                        )
+                )
+                .build();
+
+        MultiLayerNetwork network = new MultiLayerNetwork(conf1);
+        network.init();
+        INDArray unfrozenLayerParams = network.getLayer(0).params().dup();
+        INDArray frozenLayerParams1 = network.getLayer(1).params().dup();
+        INDArray frozenLayerParams2 = network.getLayer(2).params().dup();
+        INDArray frozenOutputLayerParams = network.getLayer(3).params().dup();
+
+        for (int i = 0; i < 100; i++) {
+            network.fit(randomData);
+        }
+
+        assertNotEquals(unfrozenLayerParams, network.getLayer(0).params());
+        assertEquals(frozenLayerParams1, network.getLayer(1).params());
+        assertEquals(frozenLayerParams2, network.getLayer(2).params());
+        assertEquals(frozenOutputLayerParams, network.getLayer(3).params());
+
+    }
+
+    @Test
+    public void testComputationGraphFrozenLayerParamsAfterBackprop() {
+
+        DataSet randomData = new DataSet(Nd4j.rand(100, 4,12345), Nd4j.rand(100, 1, 12345));
+        String frozenBranchName = "B1-";
+        String unfrozenBranchName = "B2-";
+
+        String initialLayer = "initial";
+
+        String frozenBranchUnfrozenLayer0 = frozenBranchName + "0";
+        String frozenBranchFrozenLayer1 = frozenBranchName + "1";
+        String frozenBranchFrozenLayer2 = frozenBranchName + "2";
+        String frozenBranchOutput = frozenBranchName + "Output";
+
+
+        String unfrozenLayer0 = unfrozenBranchName + "0";
+        String unfrozenLayer1 = unfrozenBranchName + "1";
+        String unfrozenBranch2 = unfrozenBranchName + "Output";
+
+        ComputationGraphConfiguration computationGraphConf = new NeuralNetConfiguration.Builder()
+                .updater(new Sgd(2.0))
+                .seed(12345)
+                .graphBuilder()
+                .addInputs("input")
+                .addLayer(initialLayer,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(4)
+                                .build(),
+                        "input"
+                )
+                .addLayer(frozenBranchUnfrozenLayer0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(3)
+                                .build(),
+                        initialLayer
+                )
+                .addLayer(frozenBranchFrozenLayer1,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(3)
+                                        .nOut(4)
+                                        .build()
+                        ),
+                        frozenBranchUnfrozenLayer0
+                )
+                .addLayer(frozenBranchFrozenLayer2,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(4)
+                                        .nOut(2)
+                                        .build()
+                        ),
+                        frozenBranchFrozenLayer1
+                )
+                .addLayer(unfrozenLayer0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(4)
+                                .build(),
+                        initialLayer
+                )
+                .addLayer(unfrozenLayer1,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(2)
+                                .build(),
+                        unfrozenLayer0
+                )
+                .addLayer(unfrozenBranch2,
+                        new DenseLayer.Builder()
+                                .nIn(2)
+                                .nOut(1)
+                                .build(),
+                        unfrozenLayer1
+                )
+                .addVertex("merge",
+                        new MergeVertex(), frozenBranchFrozenLayer2, unfrozenBranch2)
+                .addLayer(frozenBranchOutput,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                                        .nIn(3)
+                                        .nOut(1)
+                                        .build()
+                        ),
+                        "merge"
+                )
+                .setOutputs(frozenBranchOutput)
+                .build();
+
+        ComputationGraph computationGraph = new ComputationGraph(computationGraphConf);
+        computationGraph.init();
+        INDArray unfrozenLayerParams = computationGraph.getLayer(frozenBranchUnfrozenLayer0).params().dup();
+        INDArray frozenLayerParams1 = computationGraph.getLayer(frozenBranchFrozenLayer1).params().dup();
+        INDArray frozenLayerParams2 = computationGraph.getLayer(frozenBranchFrozenLayer2).params().dup();
+        INDArray frozenOutputLayerParams = computationGraph.getLayer(frozenBranchOutput).params().dup();
+
+        for (int i = 0; i < 100; i++) {
+            computationGraph.fit(randomData);
+        }
+
+        assertNotEquals(unfrozenLayerParams, computationGraph.getLayer(frozenBranchUnfrozenLayer0).params());
+        assertEquals(frozenLayerParams1, computationGraph.getLayer(frozenBranchFrozenLayer1).params());
+        assertEquals(frozenLayerParams2, computationGraph.getLayer(frozenBranchFrozenLayer2).params());
+        assertEquals(frozenOutputLayerParams, computationGraph.getLayer(frozenBranchOutput).params());
+
+    }
+
+    /**
+     * Frozen layer should have same results as a layer with Sgd updater with learning rate set to 0
+     */
+    @Test
+    public void testFrozenLayerVsSgd() {
+        DataSet randomData = new DataSet(Nd4j.rand(100, 4, 12345), Nd4j.rand(100, 1, 12345));
+
+        MultiLayerConfiguration confSgd = new NeuralNetConfiguration.Builder()
+                .seed(12345)
+                .weightInit(WeightInit.XAVIER)
+                .updater(new Sgd(2))
+                .list()
+                .layer(0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(3)
+                                .build()
+                )
+                .layer(1,
+                        new DenseLayer.Builder()
+                                .updater(new Sgd(0.0))
+                                .biasUpdater(new Sgd(0.0))
+                                .nIn(3)
+                                .nOut(4)
+                                .build()
+                ).layer(2,
+                        new DenseLayer.Builder()
+                                .updater(new Sgd(0.0))
+                                .biasUpdater(new Sgd(0.0))
+                                .nIn(4)
+                                .nOut(2)
+                                .build()
+
+                ).layer(3,
+                        new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                                .updater(new Sgd(0.0))
+                                .biasUpdater(new Sgd(0.0))
+                                .nIn(2)
+                                .nOut(1)
+                                .build()
+                )
+                .build();
+
+        MultiLayerConfiguration confFrozen = new NeuralNetConfiguration.Builder()
+                .seed(12345)
+                .weightInit(WeightInit.XAVIER)
+                .updater(new Sgd(2))
+                .list()
+                .layer(0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(3)
+                                .build()
+                )
+                .layer(1,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(3)
+                                        .nOut(4)
+                                        .build()
+                        )
+                )
+                .layer(2,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(4)
+                                        .nOut(2)
+                                        .build()
+                        )
+                ).layer(3,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                                        .nIn(2)
+                                        .nOut(1)
+                                        .build()
+                        )
+                )
+                .build();
+        MultiLayerNetwork frozenNetwork = new MultiLayerNetwork(confFrozen);
+        frozenNetwork.init();
+        INDArray unfrozenLayerParams = frozenNetwork.getLayer(0).params().dup();
+        INDArray frozenLayerParams1 = frozenNetwork.getLayer(1).params().dup();
+        INDArray frozenLayerParams2 = frozenNetwork.getLayer(2).params().dup();
+        INDArray frozenOutputLayerParams = frozenNetwork.getLayer(3).params().dup();
+
+        MultiLayerNetwork sgdNetwork = new MultiLayerNetwork(confSgd);
+        sgdNetwork.init();
+        INDArray unfrozenSgdLayerParams = sgdNetwork.getLayer(0).params().dup();
+        INDArray frozenSgdLayerParams1 = sgdNetwork.getLayer(1).params().dup();
+        INDArray frozenSgdLayerParams2 = sgdNetwork.getLayer(2).params().dup();
+        INDArray frozenSgdOutputLayerParams = sgdNetwork.getLayer(3).params().dup();
+
+        for (int i = 0; i < 100; i++) {
+            frozenNetwork.fit(randomData);
+        }
+        for (int i = 0; i < 100; i++) {
+            sgdNetwork.fit(randomData);
+        }
+
+        assertEquals(frozenNetwork.getLayer(0).params(), sgdNetwork.getLayer(0).params());
+        assertEquals(frozenNetwork.getLayer(1).params(), sgdNetwork.getLayer(1).params());
+        assertEquals(frozenNetwork.getLayer(2).params(), sgdNetwork.getLayer(2).params());
+        assertEquals(frozenNetwork.getLayer(3).params(), sgdNetwork.getLayer(3).params());
+
+    }
+
+    @Test
+    public void testComputationGraphVsSgd() {
+
+        DataSet randomData = new DataSet(Nd4j.rand(100, 4, 12345), Nd4j.rand(100, 1, 12345));
+        String frozenBranchName = "B1-";
+        String unfrozenBranchName = "B2-";
+
+        String initialLayer = "initial";
+
+        String frozenBranchUnfrozenLayer0 = frozenBranchName + "0";
+        String frozenBranchFrozenLayer1 = frozenBranchName + "1";
+        String frozenBranchFrozenLayer2 = frozenBranchName + "2";
+        String frozenBranchOutput = frozenBranchName + "Output";
+
+
+        String unfrozenLayer0 = unfrozenBranchName + "0";
+        String unfrozenLayer1 = unfrozenBranchName + "1";
+        String unfrozenBranch2 = unfrozenBranchName + "Output";
+
+        ComputationGraphConfiguration computationGraphConf = new NeuralNetConfiguration.Builder()
+                .updater(new Sgd(2.0))
+                .seed(12345)
+                .graphBuilder()
+                .addInputs("input")
+                .addLayer(initialLayer,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(4)
+                                .build(),
+                        "input"
+                )
+                .addLayer(frozenBranchUnfrozenLayer0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(3)
+                                .build(),
+                        initialLayer
+                )
+                .addLayer(frozenBranchFrozenLayer1,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(3)
+                                        .nOut(4)
+                                        .build()
+                        ),
+                        frozenBranchUnfrozenLayer0
+                )
+                .addLayer(frozenBranchFrozenLayer2,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new DenseLayer.Builder()
+                                        .nIn(4)
+                                        .nOut(2)
+                                        .build()
+                        ),
+                        frozenBranchFrozenLayer1
+                )
+                .addLayer(unfrozenLayer0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(4)
+                                .build(),
+                        initialLayer
+                )
+                .addLayer(unfrozenLayer1,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(2)
+                                .build(),
+                        unfrozenLayer0
+                )
+                .addLayer(unfrozenBranch2,
+                        new DenseLayer.Builder()
+                                .nIn(2)
+                                .nOut(1)
+                                .build(),
+                        unfrozenLayer1
+                )
+                .addVertex("merge",
+                        new MergeVertex(), frozenBranchFrozenLayer2, unfrozenBranch2)
+                .addLayer(frozenBranchOutput,
+                        new org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop(
+                                new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                                        .nIn(3)
+                                        .nOut(1)
+                                        .build()
+                        ),
+                        "merge"
+                )
+                .setOutputs(frozenBranchOutput)
+                .build();
+
+        ComputationGraphConfiguration computationSgdGraphConf = new NeuralNetConfiguration.Builder()
+                .updater(new Sgd(2.0))
+                .seed(12345)
+                .graphBuilder()
+                .addInputs("input")
+                .addLayer(initialLayer,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(4)
+                                .build(),
+                        "input"
+                )
+                .addLayer(frozenBranchUnfrozenLayer0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(3)
+                                .build(),
+                        initialLayer
+                )
+                .addLayer(frozenBranchFrozenLayer1,
+                        new DenseLayer.Builder()
+                                .updater(new Sgd(0.0))
+                                .biasUpdater(new Sgd(0.0))
+                                .nIn(3)
+                                .nOut(4)
+                                .build(),
+                        frozenBranchUnfrozenLayer0
+                )
+                .addLayer(frozenBranchFrozenLayer2,
+                        new DenseLayer.Builder()
+                                .updater(new Sgd(0.0))
+                                .biasUpdater(new Sgd(0.0))
+                                .nIn(4)
+                                .nOut(2)
+                                .build()
+                        ,
+                        frozenBranchFrozenLayer1
+                )
+                .addLayer(unfrozenLayer0,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(4)
+                                .build(),
+                        initialLayer
+                )
+                .addLayer(unfrozenLayer1,
+                        new DenseLayer.Builder()
+                                .nIn(4)
+                                .nOut(2)
+                                .build(),
+                        unfrozenLayer0
+                )
+                .addLayer(unfrozenBranch2,
+                        new DenseLayer.Builder()
+                                .nIn(2)
+                                .nOut(1)
+                                .build(),
+                        unfrozenLayer1
+                )
+                .addVertex("merge",
+                        new MergeVertex(), frozenBranchFrozenLayer2, unfrozenBranch2)
+                .addLayer(frozenBranchOutput,
+                        new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                                .updater(new Sgd(0.0))
+                                .biasUpdater(new Sgd(0.0))
+                                .nIn(3)
+                                .nOut(1)
+                                .build()
+                        ,
+                        "merge"
+                )
+                .setOutputs(frozenBranchOutput)
+                .build();
+
+        ComputationGraph frozenComputationGraph = new ComputationGraph(computationGraphConf);
+        frozenComputationGraph.init();
+        INDArray unfrozenLayerParams = frozenComputationGraph.getLayer(frozenBranchUnfrozenLayer0).params().dup();
+        INDArray frozenLayerParams1 = frozenComputationGraph.getLayer(frozenBranchFrozenLayer1).params().dup();
+        INDArray frozenLayerParams2 = frozenComputationGraph.getLayer(frozenBranchFrozenLayer2).params().dup();
+        INDArray frozenOutputLayerParams = frozenComputationGraph.getLayer(frozenBranchOutput).params().dup();
+
+        ComputationGraph sgdComputationGraph = new ComputationGraph(computationSgdGraphConf);
+        sgdComputationGraph.init();
+        INDArray unfrozenSgdLayerParams = sgdComputationGraph.getLayer(frozenBranchUnfrozenLayer0).params().dup();
+        INDArray frozenSgdLayerParams1 = sgdComputationGraph.getLayer(frozenBranchFrozenLayer1).params().dup();
+        INDArray frozenSgdLayerParams2 = sgdComputationGraph.getLayer(frozenBranchFrozenLayer2).params().dup();
+        INDArray frozenSgdOutputLayerParams = sgdComputationGraph.getLayer(frozenBranchOutput).params().dup();
+
+        for (int i = 0; i < 100; i++) {
+            frozenComputationGraph.fit(randomData);
+        }
+        for (int i = 0; i < 100; i++) {
+            sgdComputationGraph.fit(randomData);
+        }
+
+        assertEquals(frozenComputationGraph.getLayer(frozenBranchUnfrozenLayer0).params(), sgdComputationGraph.getLayer(frozenBranchUnfrozenLayer0).params());
+        assertEquals(frozenComputationGraph.getLayer(frozenBranchFrozenLayer1).params(), sgdComputationGraph.getLayer(frozenBranchFrozenLayer1).params());
+        assertEquals(frozenComputationGraph.getLayer(frozenBranchFrozenLayer2).params(), sgdComputationGraph.getLayer(frozenBranchFrozenLayer2).params());
+        assertEquals(frozenComputationGraph.getLayer(frozenBranchOutput).params(), sgdComputationGraph.getLayer(frozenBranchOutput).params());
+
+    }
+
+
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/NeuralNetConfiguration.java
@@ -29,6 +29,7 @@ import org.deeplearning4j.nn.conf.dropout.Dropout;
 import org.deeplearning4j.nn.conf.dropout.IDropout;
 import org.deeplearning4j.nn.conf.graph.GraphVertex;
 import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop;
 import org.deeplearning4j.nn.conf.layers.variational.ReconstructionDistribution;
 import org.deeplearning4j.nn.conf.serde.JsonMappers;
 import org.deeplearning4j.nn.conf.layers.*;
@@ -1076,6 +1077,10 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
                 configureLayer(((FrozenLayer) layer).getLayer());
             }
 
+            if (layer instanceof FrozenLayerWithBackprop) {
+                configureLayer(((FrozenLayerWithBackprop) layer).getLayer());
+            }
+
             return conf;
         }
 
@@ -1097,6 +1102,10 @@ public class NeuralNetConfiguration implements Serializable, Cloneable {
 
             if (layer instanceof FrozenLayer) {
                 copyConfigToLayer(layerName, ((FrozenLayer) layer).getLayer());
+            }
+
+            if (layer instanceof FrozenLayerWithBackprop) {
+                copyConfigToLayer(layerName, ((FrozenLayerWithBackprop) layer).getLayer());
             }
 
             if (layer instanceof Bidirectional) {

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
@@ -1,0 +1,155 @@
+package org.deeplearning4j.nn.conf.layers.misc;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.api.layers.LayerConstraint;
+import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.nn.params.FrozenLayerParamInitializer;
+import org.deeplearning4j.nn.params.FrozenLayerWithBackpropParamInitializer;
+import org.deeplearning4j.optimize.api.TrainingListener;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.learning.config.IUpdater;
+import org.nd4j.shade.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Frozen layer freezes parameters of the layer it wraps, but allows the backpropagation to continue.
+ * 
+ * Created by Ugljesa Jovanovic (jovanovic.ugljesa@gmail.com) on 06/05/2018.
+ */
+@EqualsAndHashCode
+public class FrozenLayerWithBackprop extends Layer {
+
+    @Getter
+    protected Layer layer;
+
+    private FrozenLayerWithBackprop(Builder builder) {
+        super(builder);
+        this.layer = builder.layer;
+    }
+
+    public FrozenLayerWithBackprop(@JsonProperty("layer") Layer layer) {
+        this.layer = layer;
+    }
+
+    public NeuralNetConfiguration getInnerConf(NeuralNetConfiguration conf) {
+        NeuralNetConfiguration nnc = conf.clone();
+        nnc.setLayer(layer);
+        return nnc;
+    }
+
+    @Override
+    public Layer clone() {
+        FrozenLayerWithBackprop l = (FrozenLayerWithBackprop) super.clone();
+        l.layer = layer.clone();
+        return l;
+    }
+
+    @Override
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
+
+        //Need to be able to instantiate a layer, from a config - for JSON -> net type situations
+        org.deeplearning4j.nn.api.Layer underlying = layer.instantiate(getInnerConf(conf), trainingListeners,
+                        layerIndex, layerParamsView, initializeParams);
+
+        NeuralNetConfiguration nncUnderlying = underlying.conf();
+
+        if (nncUnderlying.variables() != null) {
+            List<String> vars = nncUnderlying.variables(true);
+            nncUnderlying.clearVariables();
+            conf.clearVariables();
+            for (String s : vars) {
+                conf.variables(false).add(s);
+                conf.getL1ByParam().put(s, 0.0);
+                conf.getL2ByParam().put(s, 0.0);
+
+                nncUnderlying.variables(false).add(s);
+                nncUnderlying.getL1ByParam().put(s, 0.0);
+                nncUnderlying.getL2ByParam().put(s, 0.0);
+            }
+        }
+
+        return new org.deeplearning4j.nn.layers.FrozenLayerWithBackprop(underlying);
+    }
+
+    @Override
+    public ParamInitializer initializer() {
+        return FrozenLayerWithBackpropParamInitializer.getInstance();
+    }
+
+    @Override
+    public InputType getOutputType(int layerIndex, InputType inputType) {
+        return layer.getOutputType(layerIndex, inputType);
+    }
+
+    @Override
+    public void setNIn(InputType inputType, boolean override) {
+        layer.setNIn(inputType, override);
+    }
+
+    @Override
+    public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
+        return layer.getPreProcessorForInputType(inputType);
+    }
+
+    @Override
+    public double getL1ByParam(String paramName) {
+        return 0;
+    }
+
+    @Override
+    public double getL2ByParam(String paramName) {
+        return 0;
+    }
+
+    @Override
+    public boolean isPretrainParam(String paramName) {
+        return false;
+    }
+
+    @Override
+    public IUpdater getUpdaterByParam(String paramName) {
+        return null;
+    }
+
+    @Override
+    public LayerMemoryReport getMemoryReport(InputType inputType) {
+        return layer.getMemoryReport(inputType);
+    }
+
+    @Override
+    public void setLayerName(String layerName) {
+        super.setLayerName(layerName);
+        layer.setLayerName(layerName);
+    }
+
+    @Override
+    public void setConstraints(List<LayerConstraint> constraints){
+        this.constraints = constraints;
+        this.layer.setConstraints(constraints);
+    }
+
+    public static class Builder extends Layer.Builder<Builder> {
+        private Layer layer;
+
+        public Builder layer(Layer layer) {
+            this.layer = layer;
+            return this;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public FrozenLayerWithBackprop build() {
+            return new FrozenLayerWithBackprop(this);
+        }
+    }
+}

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/LayerVertex.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/vertex/impl/LayerVertex.java
@@ -31,6 +31,7 @@ import org.deeplearning4j.nn.graph.vertex.BaseGraphVertex;
 import org.deeplearning4j.nn.graph.vertex.VertexIndices;
 import org.deeplearning4j.nn.layers.BaseOutputLayer;
 import org.deeplearning4j.nn.layers.FrozenLayer;
+import org.deeplearning4j.nn.layers.FrozenLayerWithBackprop;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
@@ -217,7 +218,12 @@ public class LayerVertex extends BaseGraphVertex {
             }
         }
 
-        if (!(layer instanceof IOutputLayer)) {
+        Layer resolvedLayer = layer;
+        if (layer instanceof FrozenLayerWithBackprop) {
+            resolvedLayer = ((FrozenLayerWithBackprop) layer).getInsideLayer();
+        }
+
+        if (!(resolvedLayer instanceof IOutputLayer)) {
             if (epsilon == null) {
                 return false;
             }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/FrozenLayerWithBackprop.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/FrozenLayerWithBackprop.java
@@ -1,0 +1,421 @@
+package org.deeplearning4j.nn.layers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
+import org.deeplearning4j.nn.conf.CacheMode;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.BaseLayer;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.params.DefaultParamInitializer;
+import org.deeplearning4j.nn.workspace.ArrayType;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
+import org.deeplearning4j.optimize.api.ConvexOptimizer;
+import org.deeplearning4j.optimize.api.TrainingListener;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.learning.config.Sgd;
+import org.nd4j.linalg.lossfunctions.ILossFunction;
+import org.nd4j.linalg.primitives.Pair;
+import org.nd4j.util.OneTimeLogger;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Frozen layer freezes parameters of the layer it wraps, but allows the backpropagation to continue.
+ *
+ * @author Ugljesa Jovanovic (jovanovic.ugljesa@gmail.com)
+ */
+
+@Slf4j
+public class FrozenLayerWithBackprop implements Layer {
+
+    private Layer insideLayer;
+    private boolean logUpdate = false;
+    private boolean logFit = false;
+    private boolean logTestMode = false;
+    private boolean logGradient = false;
+
+    private Gradient zeroGradient;
+
+    public FrozenLayerWithBackprop(final Layer insideLayer) {
+        this.insideLayer = insideLayer;
+        this.zeroGradient = new DefaultGradient(insideLayer.params());
+    }
+
+    @Override
+    public void setCacheMode(CacheMode mode) {
+        // no-op
+    }
+
+
+
+    protected String layerId() {
+        String name = insideLayer.conf().getLayer().getLayerName();
+        return "(layer name: " + (name == null ? "\"\"" : name) + ", layer index: " + insideLayer.getIndex() + ")";
+    }
+
+    @Override
+    public double calcL2(boolean backpropOnlyParams) {
+        return 0;
+    }
+
+    @Override
+    public double calcL1(boolean backpropOnlyParams) {
+        return 0;
+    }
+
+    @Override
+    public Type type() {
+        return insideLayer.type();
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon, LayerWorkspaceMgr workspaceMgr) {
+        INDArray backpropEpsilon = insideLayer.backpropGradient(epsilon, workspaceMgr).getSecond();
+        //backprop might have already changed the gradient view (like BaseLayer and BaseOutputLayer do)
+        //so we want to put it back to zeroes
+        INDArray gradientView = insideLayer.getGradientsViewArray();
+        INDArray zeroArray = Nd4j.zeros(gradientView.shape());
+        if (!gradientView.equalsWithEps(zeroArray, 0)) {
+            gradientView.assign(zeroArray);
+        }
+        return new Pair<>(zeroGradient, backpropEpsilon);
+    }
+    @Override
+    public INDArray activate(boolean training, LayerWorkspaceMgr workspaceMgr) {
+        logTestMode(training);
+        return insideLayer.activate(false, workspaceMgr);
+    }
+
+    @Override
+    public INDArray activate(INDArray input, boolean training, LayerWorkspaceMgr workspaceMgr) {
+        logTestMode(training);
+        return insideLayer.activate(input, false, workspaceMgr);
+    }
+
+    @Override
+    public Layer transpose() {
+        return new FrozenLayerWithBackprop(insideLayer.transpose());
+    }
+
+    @Override
+    public Layer clone() {
+        OneTimeLogger.info(log, "Frozen layers are cloned as their original versions.");
+        return new FrozenLayerWithBackprop(insideLayer.clone());
+    }
+
+    @Override
+    public Collection<TrainingListener> getListeners() {
+        return insideLayer.getListeners();
+    }
+
+    @Override
+    public void setListeners(TrainingListener... listeners) {
+        insideLayer.setListeners(listeners);
+    }
+
+    /**
+     * This method ADDS additional TrainingListener to existing listeners
+     *
+     * @param listener
+     */
+    @Override
+    public void addListeners(TrainingListener... listener) {
+        insideLayer.addListeners(listener);
+    }
+
+    @Override
+    public void fit() {
+        if (!logFit) {
+            OneTimeLogger.info(log, "Frozen layers cannot be fit. Warning will be issued only once per instance");
+            logFit = true;
+        }
+        //no op
+    }
+
+    @Override
+    public void update(Gradient gradient) {
+        if (!logUpdate) {
+            OneTimeLogger.info(log, "Frozen layers will not be updated. Warning will be issued only once per instance");
+            logUpdate = true;
+        }
+        //no op
+    }
+
+    @Override
+    public void update(INDArray gradient, String paramType) {
+        if (!logUpdate) {
+            OneTimeLogger.info(log, "Frozen layers will not be updated. Warning will be issued only once per instance");
+            logUpdate = true;
+        }
+        //no op
+    }
+
+    @Override
+    public double score() {
+        return insideLayer.score();
+    }
+
+    @Override
+    public void computeGradientAndScore(LayerWorkspaceMgr workspaceMgr) {
+        if (!logGradient) {
+            OneTimeLogger.info(log,
+                            "Gradients for the frozen layer are not set and will therefore will not be updated.Warning will be issued only once per instance");
+            logGradient = true;
+        }
+        insideLayer.score();
+        //no op
+    }
+
+    @Override
+    public void accumulateScore(double accum) {
+        insideLayer.accumulateScore(accum);
+    }
+
+    @Override
+    public INDArray params() {
+        return insideLayer.params().dup();
+    }
+
+    @Override
+    public int numParams() {
+        return insideLayer.numParams();
+    }
+
+    @Override
+    public int numParams(boolean backwards) {
+        return insideLayer.numParams(backwards);
+    }
+
+    @Override
+    public void setParams(INDArray params) {
+        insideLayer.setParams(params);
+    }
+
+    @Override
+    public void setParamsViewArray(INDArray params) {
+        insideLayer.setParamsViewArray(params);
+    }
+
+    @Override
+    public INDArray getGradientsViewArray() {
+        return insideLayer.getGradientsViewArray();
+    }
+
+    @Override
+    public void setBackpropGradientsViewArray(INDArray gradients) {
+        insideLayer.setBackpropGradientsViewArray(gradients);
+        if (!logGradient) {
+            OneTimeLogger.info(log,
+                            "Gradients for the frozen layer are not set and will therefore will not be updated.Warning will be issued only once per instance");
+            logGradient = true;
+        }
+        //no-op
+    }
+
+    @Override
+    public void fit(INDArray data, LayerWorkspaceMgr workspaceMgr) {
+        if (!logFit) {
+            OneTimeLogger.info(log, "Frozen layers cannot be fit, but backpropagation will continue.Warning will be issued only once per instance");
+            logFit = true;
+        }
+    }
+
+    @Override
+    public Gradient gradient() {
+        return insideLayer.gradient();
+    }
+
+    @Override
+    public Pair<Gradient, Double> gradientAndScore() {
+        return insideLayer.gradientAndScore();
+    }
+
+    @Override
+    public int batchSize() {
+        return insideLayer.batchSize();
+    }
+
+    @Override
+    public NeuralNetConfiguration conf() {
+        return insideLayer.conf();
+    }
+
+    @Override
+    public void setConf(NeuralNetConfiguration conf) {
+        insideLayer.setConf(conf);
+    }
+
+    @Override
+    public INDArray input() {
+        return insideLayer.input();
+    }
+
+    @Override
+    public void validateInput() {
+        insideLayer.validateInput();
+    }
+
+    @Override
+    public ConvexOptimizer getOptimizer() {
+        return insideLayer.getOptimizer();
+    }
+
+    @Override
+    public INDArray getParam(String param) {
+        return insideLayer.getParam(param);
+    }
+
+    @Override
+    public void initParams() {
+        insideLayer.initParams();
+    }
+
+    @Override
+    public Map<String, INDArray> paramTable() {
+        return insideLayer.paramTable();
+    }
+
+    @Override
+    public Map<String, INDArray> paramTable(boolean backpropParamsOnly) {
+        return insideLayer.paramTable(backpropParamsOnly);
+    }
+
+    @Override
+    public void setParamTable(Map<String, INDArray> paramTable) {
+        insideLayer.setParamTable(paramTable);
+    }
+
+    @Override
+    public void setParam(String key, INDArray val) {
+        insideLayer.setParam(key, val);
+    }
+
+    @Override
+    public void clear() {
+        insideLayer.clear();
+    }
+
+    @Override
+    public void applyConstraints(int iteration, int epoch) {
+        //No-op
+    }
+
+    /**
+     * Init the model
+     */
+    @Override
+    public void init() {
+
+    }
+
+    @Override
+    public void setListeners(Collection<TrainingListener> listeners) {
+        insideLayer.setListeners(listeners);
+    }
+
+    @Override
+    public void setIndex(int index) {
+        insideLayer.setIndex(index);
+    }
+
+    @Override
+    public int getIndex() {
+        return insideLayer.getIndex();
+    }
+
+    @Override
+    public int getIterationCount() {
+        return insideLayer.getIterationCount();
+    }
+
+    @Override
+    public int getEpochCount() {
+        return insideLayer.getEpochCount();
+    }
+
+    @Override
+    public void setIterationCount(int iterationCount) {
+        insideLayer.setIterationCount(iterationCount);
+    }
+
+    @Override
+    public void setEpochCount(int epochCount) {
+        insideLayer.setEpochCount(epochCount);
+    }
+
+    @Override
+    public void setInput(INDArray input, LayerWorkspaceMgr layerWorkspaceMgr) {
+        insideLayer.setInput(input, layerWorkspaceMgr);
+    }
+
+    @Override
+    public void setInputMiniBatchSize(int size) {
+        insideLayer.setInputMiniBatchSize(size);
+    }
+
+    @Override
+    public int getInputMiniBatchSize() {
+        return insideLayer.getInputMiniBatchSize();
+    }
+
+    @Override
+    public void setMaskArray(INDArray maskArray) {
+        insideLayer.setMaskArray(maskArray);
+    }
+
+    @Override
+    public INDArray getMaskArray() {
+        return insideLayer.getMaskArray();
+    }
+
+    @Override
+    public boolean isPretrainLayer() {
+        return insideLayer.isPretrainLayer();
+    }
+
+    @Override
+    public void clearNoiseWeightParams() {
+        insideLayer.clearNoiseWeightParams();
+    }
+
+    @Override
+    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState,
+                    int minibatchSize) {
+        return insideLayer.feedForwardMaskArray(maskArray, currentMaskState, minibatchSize);
+    }
+
+    public void logTestMode(boolean training) {
+        if (!training)
+            return;
+        if (logTestMode) {
+            return;
+        } else {
+            OneTimeLogger.info(log,
+                            "Frozen layer instance found! Frozen layers are treated as always in test mode. Warning will only be issued once per instance");
+            logTestMode = true;
+        }
+    }
+
+    public void logTestMode(TrainingMode training) {
+        if (training.equals(TrainingMode.TEST))
+            return;
+        if (logTestMode) {
+            return;
+        } else {
+            OneTimeLogger.info(log,
+                            "Frozen layer instance found! Frozen layers are treated as always in test mode. Warning will only be issued once per instance");
+            logTestMode = true;
+        }
+    }
+
+    public Layer getInsideLayer() {
+        return insideLayer;
+    }
+}
+
+

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -41,6 +41,7 @@ import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.layers.FrozenLayer;
+import org.deeplearning4j.nn.layers.FrozenLayerWithBackprop;
 import org.deeplearning4j.nn.updater.MultiLayerUpdater;
 import org.deeplearning4j.nn.updater.UpdaterCreator;
 import org.deeplearning4j.nn.workspace.ArrayType;
@@ -2495,7 +2496,11 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @return
      */
     public Layer getOutputLayer() {
-        return getLayers()[getLayers().length - 1];
+        Layer ret = getLayers()[getLayers().length - 1];
+        if (ret instanceof FrozenLayerWithBackprop) {
+            ret = ((FrozenLayerWithBackprop) ret).getInsideLayer();
+        }
+        return ret;
     }
 
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/FrozenLayerWithBackpropParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/FrozenLayerWithBackpropParamInitializer.java
@@ -1,0 +1,88 @@
+package org.deeplearning4j.nn.params;
+
+import org.deeplearning4j.nn.api.ParamInitializer;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.layers.misc.FrozenLayer;
+import org.deeplearning4j.nn.conf.layers.misc.FrozenLayerWithBackprop;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parameter initializer for {@link FrozenLayer} instances. Relies on underlying layer's param initializer.
+ * This is alost a line for line copy of {@link FrozenLayerParamInitializer}, just uses FrozenLayerWithBackprop instead
+ * of FrozenLayer
+ *
+ * @author Ugljesa Jovanovic
+ */
+public class FrozenLayerWithBackpropParamInitializer implements ParamInitializer {
+
+    private static final FrozenLayerWithBackpropParamInitializer INSTANCE = new FrozenLayerWithBackpropParamInitializer();
+
+    public static FrozenLayerWithBackpropParamInitializer getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public int numParams(NeuralNetConfiguration conf) {
+        return numParams(conf.getLayer());
+    }
+
+    @Override
+    public int numParams(Layer layer) {
+        FrozenLayerWithBackprop fl = (FrozenLayerWithBackprop) layer;
+        ParamInitializer initializer = fl.getLayer().initializer();
+        return initializer.numParams(fl.getLayer());
+    }
+
+    @Override
+    public List<String> paramKeys(Layer layer) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> weightKeys(Layer layer) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> biasKeys(Layer layer) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isWeightParam(Layer layer, String key) {
+        return false;
+    }
+
+    @Override
+    public boolean isBiasParam(Layer layer, String key) {
+        return false;
+    }
+
+    @Override
+    public Map<String, INDArray> init(NeuralNetConfiguration conf, INDArray paramsView, boolean initializeParams) {
+        FrozenLayerWithBackprop fl = (FrozenLayerWithBackprop) conf.getLayer();
+        Layer innerLayer = fl.getLayer();
+        ParamInitializer initializer = innerLayer.initializer();
+        conf.setLayer(innerLayer);
+        Map<String, INDArray> m = initializer.init(conf, paramsView, initializeParams);
+        conf.setLayer(fl);
+
+        return m;
+    }
+
+    @Override
+    public Map<String, INDArray> getGradientsFromFlattened(NeuralNetConfiguration conf, INDArray gradientView) {
+        FrozenLayerWithBackprop fl = (FrozenLayerWithBackprop) conf.getLayer();
+        Layer innerLayer = fl.getLayer();
+        ParamInitializer initializer = innerLayer.initializer();
+        conf.setLayer(innerLayer);
+        Map<String, INDArray> m = initializer.getGradientsFromFlattened(conf, gradientView);
+        conf.setLayer(fl);
+        return m;
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce FrozenLayerWithBackprop which would enable having frozen layers (including output layer) and still train layers that precede the frozen layer. This should be useful for GANs.

This was achieved by letting the backpropGradient() execute, but making sure that the gradients are zeroed out.

This should solve #4760 as well

## How was this patch tested?

Unit test were written making sure that the frozen layers stay frozen, while the unfrozen layers can be trained. SGD updater with learning rate 0.0 was used to confirm that the trained layers are having the correct values as when using FrozenLayerWithBackprop. Test were done both for ComputationGraph and MultiLayerNetwork

The implementation was also used in a (poorly tuned) GAN implementation which provided same results as when using SGD updaters.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
- [x] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).






