### PR TITLE
Fix Keras weight bug (closes #5100)

### DIFF
--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/KerasModel.java
@@ -162,7 +162,9 @@ public class KerasModel {
             if (trainingJson != null)
                 importTrainingConfiguration(trainingJson);
             else throw new UnsupportedKerasConfigurationException("If enforceTrainingConfig is true, a training " +
-                    "configuration object (JSON) has to be provided.");
+                    "configuration object has to be provided. Usually the only practical way to do this is to store" +
+                    " your keras model with `model.save('model_path.h5'. If you store model config and weights" +
+                    " separately no training configuration is attached.");
         }
 
         /* Infer output types for each layer. */

--- a/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelBuilder.java
+++ b/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasModelBuilder.java
@@ -118,13 +118,9 @@ public class KerasModelBuilder implements Cloneable, Closeable {
         return this;
     }
 
-    public KerasModelBuilder weightsHdf5Filename(String weightsHdf5Filename)
-            throws InvalidKerasConfigurationException {
+    public KerasModelBuilder weightsHdf5Filename(String weightsHdf5Filename) {
         this.weightsArchive = new Hdf5Archive(weightsHdf5Filename);
         this.weightsRoot = config.getTrainingWeightsRoot();
-        if (!this.weightsArchive.hasAttribute(config.getTrainingModelConfigAttribute()))
-            throw new InvalidKerasConfigurationException(
-                    "Model configuration attribute missing from " + weightsHdf5Filename + " archive.");
         return this;
     }
 


### PR DESCRIPTION
Checks were too tight when users specified only model config json and weights. Also, the error message you get when using `enforceTrainingConfig` true has been clarified.