### PR TITLE
PI tweaks

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -428,6 +428,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         if (initCalled)
             return;
 
+        if (configuration.getTrainingWorkspaceMode() == null)
+            configuration.setTrainingWorkspaceMode(WorkspaceMode.NONE);
+
+        if (configuration.getInferenceWorkspaceMode() == null)
+            configuration.setInferenceWorkspaceMode(WorkspaceMode.NONE);
+
+        if (configuration.getCacheMode() == null)
+            configuration.setCacheMode(CacheMode.NONE);
+
         OneTimeLogger.info(log, "Starting ComputationGraph with WorkspaceModes set to [training: {}; inference: {}], cacheMode set to [{}]",
                 configuration.getTrainingWorkspaceMode(), configuration.getInferenceWorkspaceMode(), configuration.getCacheMode());
 

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -514,6 +514,15 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         if (initCalled)
             return;
 
+        if (layerWiseConfigurations.getTrainingWorkspaceMode() == null)
+            layerWiseConfigurations.setTrainingWorkspaceMode(WorkspaceMode.NONE);
+
+        if (layerWiseConfigurations.getInferenceWorkspaceMode() == null)
+            layerWiseConfigurations.setInferenceWorkspaceMode(WorkspaceMode.NONE);
+
+        if (layerWiseConfigurations.getCacheMode() == null)
+            layerWiseConfigurations.setCacheMode(CacheMode.NONE);
+
         OneTimeLogger.info(log, "Starting MultiLayerNetwork with WorkspaceModes set to [training: {}; inference: {}], cacheMode set to [{}]",
                 layerWiseConfigurations.getTrainingWorkspaceMode(),
                 layerWiseConfigurations.getInferenceWorkspaceMode(),

--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/ParallelInferenceTest.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/test/java/org/deeplearning4j/parallelism/ParallelInferenceTest.java
@@ -408,6 +408,8 @@ public class ParallelInferenceTest {
                 }
 
                 testParallelInference(inf, arrs, exp);
+
+                inf.shutdown();
             }
         }
     }
@@ -457,6 +459,8 @@ public class ParallelInferenceTest {
                     exp.add(out);
                 }
                 testParallelInference(inf, arrs, exp);
+
+                inf.shutdown();
             }
         }
     }
@@ -512,6 +516,8 @@ public class ParallelInferenceTest {
                 }
 
                 testParallelInference(inf, arrs, exp);
+
+                inf.shutdown();
             }
         }
     }
@@ -564,6 +570,8 @@ public class ParallelInferenceTest {
                     exp.add(out);
                 }
                 testParallelInference(inf, arrs, exp);
+
+                inf.shutdown();
             }
         }
     }
@@ -616,6 +624,8 @@ public class ParallelInferenceTest {
 
                 actOk = inf.output(inOk);
                 assertEquals(expOk, actOk);
+
+                inf.shutdown();
             }
         }
     }
@@ -689,6 +699,8 @@ public class ParallelInferenceTest {
                     }
 
                     testParallelInference(inf, in, inMasks, exp);
+
+                    inf.shutdown();
                 }
             }
         }
@@ -733,6 +745,7 @@ public class ParallelInferenceTest {
                 }
 
                 testParallelInferenceMulti(inf, in, null, exp);
+                inf.shutdown();
             }
         }
 


### PR DESCRIPTION
***WIP; DO NOT MERGE;***

This PR fixes few minor issues in ParallelInference tests:
- PI.shutdown() method added, to destroy all worker threads (and release corresponding resources)
- MNL/CG workspaces/cache modes validation on init