### PR TITLE
Serialization fix for bidirectional layer wrapper

### DIFF
--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/TestUtils.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/TestUtils.java
@@ -1,6 +1,8 @@
 package org.deeplearning4j;
 
 import org.apache.commons.compress.utils.IOUtils;
+import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.util.ModelSerializer;
@@ -17,42 +19,74 @@ public class TestUtils {
 
     public static MultiLayerNetwork testModelSerialization(MultiLayerNetwork net){
 
+        MultiLayerNetwork restored;
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ModelSerializer.writeModel(net, baos, true);
             byte[] bytes = baos.toByteArray();
 
             ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-            MultiLayerNetwork restored = ModelSerializer.restoreMultiLayerNetwork(bais, true);
+            restored = ModelSerializer.restoreMultiLayerNetwork(bais, true);
 
             assertEquals(net.getLayerWiseConfigurations(), restored.getLayerWiseConfigurations());
             assertEquals(net.params(), restored.params());
-
-            return restored;
         } catch (IOException e){
             //Should never happen
             throw new RuntimeException(e);
         }
+
+        //Also check the MultiLayerConfiguration is serializable (required by Spark etc)
+        MultiLayerConfiguration conf = net.getLayerWiseConfigurations();
+        serializeDeserializeJava(conf);
+
+        return restored;
     }
 
     public static ComputationGraph testModelSerialization(ComputationGraph net){
 
+        ComputationGraph restored;
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ModelSerializer.writeModel(net, baos, true);
             byte[] bytes = baos.toByteArray();
 
             ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-            ComputationGraph restored = ModelSerializer.restoreComputationGraph(bais, true);
+            restored = ModelSerializer.restoreComputationGraph(bais, true);
 
             assertEquals(net.getConfiguration(), restored.getConfiguration());
             assertEquals(net.params(), restored.params());
-
-            return restored;
         } catch (IOException e){
             //Should never happen
             throw new RuntimeException(e);
         }
+
+        //Also check the ComputationGraphConfiguration is serializable (required by Spark etc)
+        ComputationGraphConfiguration conf = net.getConfiguration();
+        serializeDeserializeJava(conf);
+
+        return restored;
+    }
+
+    private static <T> T serializeDeserializeJava(T object){
+        byte[] bytes;
+        try(ByteArrayOutputStream baos = new ByteArrayOutputStream(); ObjectOutputStream oos = new ObjectOutputStream(baos)){
+            oos.writeObject(object);
+            oos.close();
+            bytes = baos.toByteArray();
+        } catch (IOException e){
+            //Should never happen
+            throw new RuntimeException(e);
+        }
+
+        T out;
+        try(ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))){
+            out = (T)ois.readObject();
+        } catch (IOException | ClassNotFoundException e){
+            throw new RuntimeException(e);
+        }
+
+        assertEquals(object, out);
+        return out;
     }
 
     public static INDArray randomOneHot(int examples, int nOut){

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/BNGradientCheckTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/BNGradientCheckTest.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
@@ -78,6 +79,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
         assertTrue(gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 
     @Test

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/BNGradientCheckTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/BNGradientCheckTest.java
@@ -119,6 +119,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
         assertTrue(gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 
     @Test
@@ -213,6 +214,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                         assertTrue(gradOK);
+                        TestUtils.testModelSerialization(mln);
                     }
                 }
             }
@@ -311,6 +313,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                         assertTrue(gradOK);
+                        TestUtils.testModelSerialization(mln);
                     }
                 }
             }
@@ -350,6 +353,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
         assertTrue(gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 
     @Test
@@ -389,6 +393,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
         assertTrue(gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 
     @Test
@@ -425,6 +430,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                         new INDArray[] {labels});
 
         assertTrue(gradOK);
+        TestUtils.testModelSerialization(net);
     }
 
 
@@ -519,6 +525,7 @@ public class BNGradientCheckTest extends BaseDL4JTest {
                                         new INDArray[] {input}, new INDArray[] {labels});
 
                         assertTrue(gradOK);
+                        TestUtils.testModelSerialization(net);
                     }
                 }
             }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/CNN1DGradientCheckTest.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/CNN1DGradientCheckTest.java
@@ -187,6 +187,7 @@ public class CNN1DGradientCheckTest extends BaseDL4JTest {
                                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                         assertTrue(msg, gradOK);
+                        TestUtils.testModelSerialization(net);
                     }
                 }
             }
@@ -262,6 +263,7 @@ public class CNN1DGradientCheckTest extends BaseDL4JTest {
                                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                         assertTrue(msg, gradOK);
+                        TestUtils.testModelSerialization(net);
                     }
                 }
             }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GlobalPoolingGradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GlobalPoolingGradientCheckTests.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -94,7 +95,7 @@ public class GlobalPoolingGradientCheckTests extends BaseDL4JTest {
                                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                 assertTrue(gradOK);
-
+                TestUtils.testModelSerialization(mln);
             }
         }
     }
@@ -151,7 +152,7 @@ public class GlobalPoolingGradientCheckTests extends BaseDL4JTest {
                                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                 assertTrue(gradOK);
-
+                TestUtils.testModelSerialization(mln);
             }
         }
     }
@@ -221,6 +222,7 @@ public class GlobalPoolingGradientCheckTests extends BaseDL4JTest {
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, featuresMask, null);
 
             assertTrue(gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 
@@ -301,6 +303,7 @@ public class GlobalPoolingGradientCheckTests extends BaseDL4JTest {
                                     DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, inputMask, null);
 
                     assertTrue(gradOK);
+                    TestUtils.testModelSerialization(mln);
                 }
             }
         }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTests.java
@@ -115,6 +115,7 @@ public class GradientCheckTests extends BaseDL4JTest {
         String msg = "testMinibatchApplication() - activationFn=" + afn + ", lossFn=" + lf
                 + ", outputActivation=" + outputActivation + ", doLearningFirst=" + doLearningFirst;
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 
 
@@ -195,6 +196,7 @@ public class GradientCheckTests extends BaseDL4JTest {
                     String msg = "testGradMLP2LayerIrisSimple() - activationFn=" + afn + ", lossFn=" + lf
                                     + ", outputActivation=" + outputActivation + ", doLearningFirst=" + doLearningFirst;
                     assertTrue(msg, gradOK);
+                    TestUtils.testModelSerialization(mln);
                 }
             }
         }
@@ -290,6 +292,7 @@ public class GradientCheckTests extends BaseDL4JTest {
                                         + ", outputActivation=" + outputActivation + ", doLearningFirst="
                                         + doLearningFirst + ", l2=" + l2 + ", l1=" + l1;
                         assertTrue(msg, gradOK);
+                        TestUtils.testModelSerialization(mln);
                     }
                 }
             }
@@ -334,6 +337,7 @@ public class GradientCheckTests extends BaseDL4JTest {
 
         String msg = "testEmbeddingLayerSimple";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 
     @Test
@@ -420,6 +424,7 @@ public class GradientCheckTests extends BaseDL4JTest {
                         boolean gradOK = GradientCheckUtil.checkGradients(mln, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
                                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
                         assertTrue(msg, gradOK);
+                        TestUtils.testModelSerialization(mln);
                     }
                 }
             }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTestsComputationGraph.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTestsComputationGraph.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
@@ -93,6 +94,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testBasicIris()";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -143,6 +145,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testBasicIrisWithMerging()";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -199,6 +202,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
             String msg = "testBasicIrisWithElementWiseVertex(op=" + op + ")";
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -258,6 +262,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
             String msg = "testBasicIrisWithElementWiseVertex(op=" + op + ")";
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -304,6 +309,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testCnnDepthMerge()";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -365,6 +371,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testLSTMWithMerging()";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -405,6 +412,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testLSTMWithSubset()";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -456,6 +464,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                         PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, new INDArray[] {input}, new INDArray[] {labels});
 
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -509,6 +518,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testLSTMWithDuplicateToTimeSeries()";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -572,6 +582,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                 PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, new INDArray[] {input}, new INDArray[] {labels});
 
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
     @Test
@@ -614,6 +625,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {out});
 
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -653,6 +665,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {out});
 
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -697,6 +710,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, new INDArray[] {out});
 
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -747,6 +761,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {out});
 
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -815,6 +830,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testBasicIrisTripletStackingL2Loss()";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(graph);
     }
 
 
@@ -874,6 +890,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                                 new INDArray[] {labels});
 
                 assertTrue(msg, gradOK);
+                TestUtils.testModelSerialization(graph);
             }
         }
     }
@@ -937,6 +954,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, example, labels);
 
                 assertTrue(msg, gradOK);
+                TestUtils.testModelSerialization(net);
             }
         }
     }
@@ -985,6 +1003,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {labels});
 
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -1042,6 +1061,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {labels1, labels2});
 
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -1099,6 +1119,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {labels1, labels2});
 
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -1163,6 +1184,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {labels1, labels2}, new INDArray[] {inMask1, inMask2}, null);
 
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -1218,6 +1240,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, new INDArray[] {in1, in2},
                             new INDArray[] {labels1, labels2});
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -1260,6 +1283,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {labels1});
 
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -1308,6 +1332,7 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
                             new INDArray[] {labels1});
 
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(graph);
         }
     }
 
@@ -1345,5 +1370,6 @@ public class GradientCheckTestsComputationGraph extends BaseDL4JTest {
 
         String msg = "testGraphEmbeddingLayerSimple";
         assertTrue(msg, gradOK);
+        TestUtils.testModelSerialization(cg);
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTestsMasking.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/GradientCheckTestsMasking.java
@@ -130,6 +130,7 @@ public class GradientCheckTestsMasking extends BaseDL4JTest {
                 String msg = "gradientCheckMaskingOutputSimple() - timeSeriesLength=" + timeSeriesLength
                                 + ", miniBatchSize=" + 1;
                 assertTrue(msg, gradOK);
+                TestUtils.testModelSerialization(mln);
             }
         }
     }
@@ -187,6 +188,7 @@ public class GradientCheckTestsMasking extends BaseDL4JTest {
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, mask, mask);
 
             assertTrue(gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 
@@ -265,6 +267,7 @@ public class GradientCheckTestsMasking extends BaseDL4JTest {
                                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, features, labels, null, labelMask);
 
                 assertTrue(msg, gradOK);
+                TestUtils.testModelSerialization(net);
             }
         }
     }
@@ -380,6 +383,7 @@ public class GradientCheckTestsMasking extends BaseDL4JTest {
                                 new INDArray[] {features}, new INDArray[] {labels}, null, new INDArray[]{labelMask}, null);
 
                 assertTrue(msg + " (compgraph)", gradOK);
+                TestUtils.testModelSerialization(graph);
             }
         }
     }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/LRNGradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/LRNGradientCheckTests.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
@@ -75,6 +76,7 @@ public class LRNGradientCheckTests extends BaseDL4JTest {
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
         assertTrue(gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/LSTMGradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/LSTMGradientCheckTests.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.Updater;
@@ -115,6 +116,7 @@ public class LSTMGradientCheckTests extends BaseDL4JTest {
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
             assertTrue(testName, gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 
@@ -202,6 +204,7 @@ public class LSTMGradientCheckTests extends BaseDL4JTest {
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                 assertTrue(testName, gradOK);
+                TestUtils.testModelSerialization(mln);
             }
         }
     }
@@ -263,6 +266,7 @@ public class LSTMGradientCheckTests extends BaseDL4JTest {
                 boolean gradOK = GradientCheckUtil.checkGradients(mln, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
                                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
                 assertTrue(msg, gradOK);
+                TestUtils.testModelSerialization(mln);
             }
         }
     }
@@ -356,6 +360,7 @@ public class LSTMGradientCheckTests extends BaseDL4JTest {
                     String msg = "testGradientGravesLSTMFull() - activationFn=" + afn + ", lossFn=" + lf
                                     + ", outputActivation=" + outputActivation + ", l2=" + l2 + ", l1=" + l1;
                     assertTrue(msg, gradOK);
+                    TestUtils.testModelSerialization(mln);
                 }
             }
         }
@@ -411,6 +416,7 @@ public class LSTMGradientCheckTests extends BaseDL4JTest {
             String msg = "testGradientGravesLSTMEdgeCases() - timeSeriesLength=" + timeSeriesLength[i]
                             + ", miniBatchSize=" + miniBatchSize[i];
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 
@@ -464,5 +470,6 @@ public class LSTMGradientCheckTests extends BaseDL4JTest {
         boolean gradOK = GradientCheckUtil.checkGradients(mln, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
         assertTrue(gradOK);
+        TestUtils.testModelSerialization(mln);
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/LossFunctionGradientCheck.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/LossFunctionGradientCheck.java
@@ -2,6 +2,7 @@ package org.deeplearning4j.gradientcheck;
 
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -181,6 +182,7 @@ public class LossFunctionGradientCheck extends BaseDL4JTest {
                 }
 
                 System.out.println("\n\n");
+                TestUtils.testModelSerialization(net);
             }
         }
 
@@ -343,6 +345,7 @@ public class LossFunctionGradientCheck extends BaseDL4JTest {
                 }
 
                 System.out.println("\n\n");
+                TestUtils.testModelSerialization(net);
             }
         }
 

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/OutputLayerGradientChecks.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/OutputLayerGradientChecks.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -117,6 +118,7 @@ public class OutputLayerGradientChecks extends BaseDL4JTest {
                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, null, labelMask);
 
                 assertTrue(testName, gradOK);
+                TestUtils.testModelSerialization(mln);
             }
         }
     }
@@ -222,6 +224,7 @@ public class OutputLayerGradientChecks extends BaseDL4JTest {
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels, null, labelMask);
 
                     assertTrue(testName, gradOK);
+                    TestUtils.testModelSerialization(mln);
                 }
             }
         }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
@@ -176,6 +176,7 @@ public class RnnGradientChecks extends BaseDL4JTest {
                                 boolean gradOK = GradientCheckUtil.checkGradients(net, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
                                         DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, in, labels, inMask, null);
                                 assertTrue(gradOK);
+                                TestUtils.testModelSerialization(net);
                             }
                         }
                     }
@@ -246,6 +247,7 @@ public class RnnGradientChecks extends BaseDL4JTest {
                     boolean gradOK = GradientCheckUtil.checkGradients(net, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, in, labels, inMask, null);
                     assertTrue(name, gradOK);
+                    TestUtils.testModelSerialization(net);
                 }
             }
         }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/RnnGradientChecks.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.WorkspaceMode;
@@ -102,6 +103,9 @@ public class RnnGradientChecks extends BaseDL4JTest {
                         boolean gradOK = GradientCheckUtil.checkGradients(net, DEFAULT_EPS, DEFAULT_MAX_REL_ERROR,
                                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, in, labels, inMask, null);
                         assertTrue(gradOK);
+
+
+                        TestUtils.testModelSerialization(net);
                     }
                 }
             }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/VaeGradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/VaeGradientCheckTests.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.gradientcheck;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.TestUtils;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
@@ -115,6 +116,7 @@ public class VaeGradientCheckTests extends BaseDL4JTest {
                     DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input,
                     labels);
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 
@@ -190,6 +192,7 @@ public class VaeGradientCheckTests extends BaseDL4JTest {
                     RETURN_ON_FIRST_FAILURE, input, 12345);
 
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 
@@ -276,6 +279,7 @@ public class VaeGradientCheckTests extends BaseDL4JTest {
                     data, 12345);
 
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 
@@ -318,6 +322,7 @@ public class VaeGradientCheckTests extends BaseDL4JTest {
                     features, 12345);
 
             assertTrue(msg, gradOK);
+            TestUtils.testModelSerialization(mln);
         }
     }
 }

--- a/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/YoloGradientCheckTests.java
+++ b/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/YoloGradientCheckTests.java
@@ -3,6 +3,7 @@ package org.deeplearning4j.gradientcheck;
 import org.apache.commons.io.IOUtils;
 import org.datavec.api.records.reader.RecordReader;
 import org.datavec.api.split.FileSplit;
+import org.deeplearning4j.TestUtils;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.nd4j.linalg.io.ClassPathResource;
@@ -115,6 +116,7 @@ public class YoloGradientCheckTests extends BaseDL4JTest {
                             DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, input, labels);
 
                     assertTrue(msg, gradOK);
+                    TestUtils.testModelSerialization(net);
                 }
             }
         }
@@ -222,5 +224,6 @@ public class YoloGradientCheckTests extends BaseDL4JTest {
                 DEFAULT_MIN_ABS_ERROR, PRINT_RESULTS, RETURN_ON_FIRST_FAILURE, f, l);
 
         assertTrue(ok);
+        TestUtils.testModelSerialization(net);
     }
 }

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
@@ -35,7 +35,7 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.point;
  */
 @NoArgsConstructor
 @Data
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"initializer"})
 @JsonIgnoreProperties({"initializer"})
 public class Bidirectional extends Layer {
 
@@ -55,7 +55,7 @@ public class Bidirectional extends Layer {
     private Layer fwd;
     private Layer bwd;
     private Mode mode;
-    private BidirectionalParamInitializer initializer;
+    private transient BidirectionalParamInitializer initializer;
 
     private Bidirectional(Bidirectional.Builder builder) {
         super(builder);

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDLayerParams.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDLayerParams.java
@@ -10,6 +10,7 @@ import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 import org.nd4j.shade.jackson.annotation.JsonTypeInfo;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -20,7 +21,7 @@ import java.util.*;
 @JsonIgnoreProperties({"paramsList", "weightParamsList", "biasParamsList"})
 @NoArgsConstructor
 @Data
-public class SDLayerParams {
+public class SDLayerParams implements Serializable {
 
     private Map<String,int[]> weightParams = new LinkedHashMap<>();
     private Map<String,int[]> biasParams = new LinkedHashMap<>();

--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/BidirectionalParamInitializer.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/params/BidirectionalParamInitializer.java
@@ -92,6 +92,8 @@ public class BidirectionalParamInitializer implements ParamInitializer {
         INDArray forwardView = paramsView.get(point(0), interval(0, n));
         INDArray backwardView = paramsView.get(point(0), interval(n, 2*n));
 
+        conf.clearVariables();
+
         NeuralNetConfiguration c1 = conf.clone();
         NeuralNetConfiguration c2 = conf.clone();
         c1.setLayer(underlying);


### PR DESCRIPTION
Just waiting on full test suite to run before merging.

Also adds additional model/config serialization checks to those gradient checks that don't already have them.