### PR TITLE
accuracy method fixed

### DIFF
--- a/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/reader/impl/BasicModelUtils.java
+++ b/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/reader/impl/BasicModelUtils.java
@@ -133,9 +133,8 @@ public class BasicModelUtils<T extends SequenceElement> implements ModelUtils<T>
                 right.clear();
             } else {
                 String[] split = s.split(" ");
-                String word = split[0];
-                List<String> positive = Arrays.asList(word);
-                List<String> negative = Arrays.asList(split[1], split[2]);
+                List<String> positive = Arrays.asList(split[1], split[2]);
+                List<String> negative = Arrays.asList(split[0]);
                 String predicted = split[3];
                 String w = wordsNearest(positive, negative, 1).iterator().next();
                 if (predicted.equals(w))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Accuracy method works wrong when doing analogy test. The parameters of wordNearest (positive and negative) are incorrect

## How was this patch tested?

I tested for manually. I did analogy test for Google analogy question data sets with Googlenews vector model. Old version result is %0. My result is %46.7

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
