### PR TITLE
ser/de fix for CPU

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -1327,7 +1327,7 @@ public class Shape {
         if (rank > 2 || rank < 1)
             return false;
         else {
-            int len = Shape.length(shapeInfo);
+            long len = Shape.length(shapeInfo);
             DataBuffer shape = Shape.shapeOf(shapeInfo);
             return shape.getInt(0) == len || shape.getInt(1) == len;
         }
@@ -2476,13 +2476,14 @@ public class Shape {
      * @param buffer the buffer to get the rank for
      * @return the rank for the shape buffer
      */
-    public static int length(DataBuffer buffer) {
-        int ret = 1;
+    public static long length(DataBuffer buffer) {
+        long ret = 1;
         val rr = buffer.asLong();
         DataBuffer shape = Shape.shapeOf(buffer);
         int rank = Shape.rank(buffer);
         for (int i = 0; i < rank; i++)
             ret *= shape.getLong(i);
+
         return ret;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2692,7 +2692,7 @@ public class Nd4j {
     public static INDArray read(DataInputStream dis) throws IOException {
         DataBuffer shapeInformation = Nd4j.createBufferDetached(new long[1], DataBuffer.Type.LONG);
         shapeInformation.read(dis);
-        int length = Shape.length(shapeInformation);
+        val length = Shape.length(shapeInformation);
         DataBuffer data = CompressedDataBuffer.readUnknown(dis, length);
         return createArrayFromShapeBuffer(data, shapeInformation);
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/serde/binary/BinarySerde.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/serde/binary/BinarySerde.java
@@ -76,7 +76,8 @@ public class BinarySerde {
         if (type != DataBuffer.Type.COMPRESSED) {
             ByteBuffer slice = byteBuffer.slice();
             //wrap the data buffer for the last bit
-            DataBuffer buff = Nd4j.createBuffer(slice, type, Shape.length(shapeBuff));
+            // FIXME: int cast
+            DataBuffer buff = Nd4j.createBuffer(slice, type, (int) Shape.length(shapeBuff));
             //advance past the data
             int position = byteBuffer.position() + (buff.getElementSize() * (int) buff.length());
             byteBuffer.position(position);

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -904,7 +904,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
                 globalType = Nd4j.dataType();
             }
 
-            if (t != globalType && t != Type.INT && Nd4j.sizeOfDataType(globalType) < Nd4j.sizeOfDataType(t)) {
+            if (t != globalType && (!t.equals(Type.INT) && !t.equals(Type.LONG)) && Nd4j.sizeOfDataType(globalType) < Nd4j.sizeOfDataType(t)) {
                 log.warn("Loading a data stream with opType different from what is set globally. Expect precision loss");
                 if (globalType == Type.INT)
                     log.warn("Int to float/double widening UNSUPPORTED!!!");

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/serde/LargeSerDeTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/serde/LargeSerDeTests.java
@@ -1,0 +1,49 @@
+package org.nd4j.linalg.serde;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
+
+import java.io.*;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Slf4j
+public class LargeSerDeTests extends BaseNd4jTest {
+    public LargeSerDeTests(Nd4jBackend backend) {
+        super(backend);
+    }
+
+    @Test
+    public void testLargeArraySerDe_1() throws Exception {
+        val arrayA = Nd4j.rand(new long[] {1, 135079944});
+        //val arrayA = Nd4j.rand(new long[] {1, 13507});
+
+        val tmpFile = File.createTempFile("sdsds", "sdsd");
+        tmpFile.deleteOnExit();
+
+        try (val fos = new FileOutputStream(tmpFile); val bos = new BufferedOutputStream(fos); val dos = new DataOutputStream(bos)) {
+            Nd4j.write(arrayA, dos);
+        }
+
+
+        try (val fis = new FileInputStream(tmpFile); val bis = new BufferedInputStream(fis); val dis = new DataInputStream(bis)) {
+            val arrayB = Nd4j.read(dis);
+
+            assertArrayEquals(arrayA.shape(), arrayB.shape());
+            assertEquals(arrayA.length(), arrayB.length());
+            assertEquals(arrayA, arrayB);
+        }
+    }
+
+    @Override
+    public char ordering() {
+        return 'c';
+    }
+}

--- a/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -1112,14 +1112,14 @@ public abstract class BaseDataBuffer implements DataBuffer {
         if (globalType == Type.INT || type == Type.INT) {
             int anElement = element.intValue();
             put(i, anElement);
+        } else if (globalType == Type.LONG || type == Type.LONG) {
+            long anElement = element.longValue();
+            put(i, anElement);
         } else if (globalType == Type.FLOAT || globalType == Type.HALF) {
             float anElement = element.floatValue();
             put(i, anElement);
         } else if (globalType == Type.DOUBLE) {
             double anElement = element.doubleValue();
-            put(i, anElement);
-        } else if (globalType == Type.LONG) {
-            long anElement = element.longValue();
             put(i, anElement);
         }
     }
@@ -1411,7 +1411,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
                 else if (DataTypeUtil.getDtypeFromContext() == Type.HALF && currentType != Type.INT)
                     elementSize = 2;
 
-                if (currentType != DataTypeUtil.getDtypeFromContext() && currentType != Type.HALF && currentType != Type.INT
+                if (currentType != DataTypeUtil.getDtypeFromContext() && currentType != Type.HALF && (currentType != Type.INT && currentType != Type.LONG)
                         && !(DataTypeUtil.getDtypeFromContext() == Type.DOUBLE)) {
                     log.warn("Loading a data stream with opType different from what is set globally. Expect precision loss");
                     if (DataTypeUtil.getDtypeFromContext() == Type.INT)


### PR DESCRIPTION
This PR fixes:

1) Issue with ser/de of long arrays on CPU backend
2) Removes undesired spam of dtype change