### PR TITLE
Add distributionManagement for root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,4 +63,28 @@
         <module>jumpy</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <id>sonatype-nexus</id>
+            <activation>
+                <property>
+                    <name>local.software.repository</name>
+                    <value>sonatype</value>
+                </property>
+            </activation>
+            <distributionManagement>
+                <repository>
+                    <id>sonatype-nexus-releases</id>
+                    <name>Nexus Release Repository</name>
+                    <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>sonatype-nexus-snapshots</id>
+                    <name>Sonatype Nexus snapshot repository</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Add `distributionManagement` tag to be able to deploy snapshot artifacts to oss sonatype nexus.