### PR TITLE
GCC 4.9 issue

### DIFF
--- a/libnd4j/include/array/DataTypeConversions.h
+++ b/libnd4j/include/array/DataTypeConversions.h
@@ -29,7 +29,8 @@ namespace nd4j {
 
 #if __GNUC__ <= 4
                             if (!canKeep)
-                                throw std::runtime_error("Can't swap bytes with GCC 4.x");
+                                for (Nd4jLong e = 0; e < length; e++)
+                                    buffer[e] = BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
                             else
                                 for (Nd4jLong e = 0; e < length; e++)
                                     buffer[e] = static_cast<T>(tmp[e]);
@@ -49,7 +50,8 @@ namespace nd4j {
 
 #if __GNUC__ <= 4
                             if (!canKeep)
-                                throw std::runtime_error("Can't swap bytes with GCC 4.x");
+                                for (Nd4jLong e = 0; e < length; e++)
+                                    buffer[e] = BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
                             else
                                 for (Nd4jLong e = 0; e < length; e++)
                                     buffer[e] = static_cast<T>(tmp[e]);
@@ -70,7 +72,8 @@ namespace nd4j {
 
 #if __GNUC__ <= 4
                             if (!canKeep)
-                                throw std::runtime_error("Can't swap bytes with GCC 4.x");
+                                for (Nd4jLong e = 0; e < length; e++)
+                                    buffer[e] = BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
                             else
                                 for (Nd4jLong e = 0; e < length; e++)
                                     buffer[e] = static_cast<T>(tmp[e]);

--- a/libnd4j/include/array/DataTypeConversions.h
+++ b/libnd4j/include/array/DataTypeConversions.h
@@ -22,32 +22,44 @@ namespace nd4j {
 
             switch (dataType) {
                 case DataType_FLOAT: {
-                        auto tmp = (float *) src;
+                        if (std::is_same<T, float>::value && canKeep) {
+                            memcpy(buffer, src, length * sizeof(T));
+                        } else {
+                            auto tmp = reinterpret_cast<float *>(src);
 
-                        //#pragma omp parallel for simd schedule(guided)
-                        for (Nd4jLong e = 0; e < length; e++) {
-                            buffer[e] = canKeep ? (T) tmp[e] : BitwiseUtils::swap_bytes<T>((T) tmp[e]);
+                            //#pragma omp parallel for simd schedule(guided)
+                            for (Nd4jLong e = 0; e < length; e++)
+                                buffer[e] = canKeep ? static_cast<T>(tmp[e]) : BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
                         }
                     }
                     break;
                 case DataType_DOUBLE: {
-                        auto tmp = (double *) src;
+                        if (std::is_same<T, double>::value && canKeep) {
+                            memcpy(buffer, src, length * sizeof(T));
+                        } else {
+                            auto tmp = reinterpret_cast<double *>(src);
 
-                        //#pragma omp parallel for simd schedule(guided)
-                        for (Nd4jLong e = 0; e < length; e++)
-                            buffer[e] = canKeep ? (T) tmp[e] : BitwiseUtils::swap_bytes<T>((T) tmp[e]);
+                            //#pragma omp parallel for simd schedule(guided)
+                            for (Nd4jLong e = 0; e < length; e++)
+                                buffer[e] = canKeep ? static_cast<T>(tmp[e]) : BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
+                        }
                     }
                     break;
                 case DataType_HALF: {
-                        auto tmp = (float16 *) src;
 
-                        //#pragma omp parallel for simd schedule(guided)
-                        for (Nd4jLong e = 0; e < length; e++)
-                            buffer[e] = canKeep ? (T) tmp[e] : BitwiseUtils::swap_bytes<T>((T) tmp[e]);
+                        if (std::is_same<T, float16>::value && canKeep) {
+                            memcpy(buffer, src, length * sizeof(T));
+                        } else {
+                            auto tmp = reinterpret_cast<float16 *>(src);
+
+                            //#pragma omp parallel for simd schedule(guided)
+                            for (Nd4jLong e = 0; e < length; e++)
+                                buffer[e] = canKeep ? static_cast<T>(tmp[e]) : BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
+                        }
                     }
                     break;
                 default: {
-                    nd4j_printf("Unsupported DataType requested: [%i]\n", (int) dataType);
+                    nd4j_printf("Unsupported DataType requested: [%i]\n", static_cast<int>(dataType));
                     throw "Unsupported DataType";
                 }
             }

--- a/libnd4j/include/array/DataTypeConversions.h
+++ b/libnd4j/include/array/DataTypeConversions.h
@@ -27,9 +27,17 @@ namespace nd4j {
                         } else {
                             auto tmp = reinterpret_cast<float *>(src);
 
+#if __GNUC__ <= 4
+                            if (!canKeep)
+                                throw std::runtime_error("Can't swap bytes with GCC 4.x");
+                            else
+                                for (Nd4jLong e = 0; e < length; e++)
+                                    buffer[e] = static_cast<T>(tmp[e]);
+#else
                             //#pragma omp parallel for simd schedule(guided)
                             for (Nd4jLong e = 0; e < length; e++)
                                 buffer[e] = canKeep ? static_cast<T>(tmp[e]) : BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
+#endif
                         }
                     }
                     break;
@@ -39,9 +47,17 @@ namespace nd4j {
                         } else {
                             auto tmp = reinterpret_cast<double *>(src);
 
+#if __GNUC__ <= 4
+                            if (!canKeep)
+                                throw std::runtime_error("Can't swap bytes with GCC 4.x");
+                            else
+                                for (Nd4jLong e = 0; e < length; e++)
+                                    buffer[e] = static_cast<T>(tmp[e]);
+#else
                             //#pragma omp parallel for simd schedule(guided)
                             for (Nd4jLong e = 0; e < length; e++)
                                 buffer[e] = canKeep ? static_cast<T>(tmp[e]) : BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
+#endif
                         }
                     }
                     break;
@@ -52,9 +68,17 @@ namespace nd4j {
                         } else {
                             auto tmp = reinterpret_cast<float16 *>(src);
 
+#if __GNUC__ <= 4
+                            if (!canKeep)
+                                throw std::runtime_error("Can't swap bytes with GCC 4.x");
+                            else
+                                for (Nd4jLong e = 0; e < length; e++)
+                                    buffer[e] = static_cast<T>(tmp[e]);
+#else
                             //#pragma omp parallel for simd schedule(guided)
                             for (Nd4jLong e = 0; e < length; e++)
                                 buffer[e] = canKeep ? static_cast<T>(tmp[e]) : BitwiseUtils::swap_bytes<T>(static_cast<T>(tmp[e]));
+#endif
                         }
                     }
                     break;


### PR DESCRIPTION
This PR fixes issue related to tests crash when libnd4j built with GCC 4.9 on CentOS