### PR TITLE
Fix NativeImageLoader on Android

### DIFF
--- a/datavec/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/BaseImageLoader.java
+++ b/datavec/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/BaseImageLoader.java
@@ -39,6 +39,10 @@ public abstract class BaseImageLoader implements Serializable {
 
     protected static final Logger log = LoggerFactory.getLogger(BaseImageLoader.class);
 
+    public enum MultiPageMode {
+        MINIBATCH, CHANNELS, FIRST
+    }
+
     public static final File BASE_DIR = new File(System.getProperty("user.home"));
     public static final String[] ALLOWED_FORMATS = {"tif", "jpg", "png", "jpeg", "bmp", "JPEG", "JPG", "TIF", "PNG"};
     protected Random rng = new Random(System.currentTimeMillis());
@@ -48,7 +52,7 @@ public abstract class BaseImageLoader implements Serializable {
     protected long channels = -1;
     protected boolean centerCropIfNeeded = false;
     protected ImageTransform imageTransform = null;
-    protected NativeImageLoader.MultiPageMode multiPageMode = null;
+    protected MultiPageMode multiPageMode = null;
 
     public String[] getAllowedFormats() {
         return ALLOWED_FORMATS;

--- a/datavec/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
+++ b/datavec/datavec-data/datavec-data-image/src/test/java/org/datavec/image/loader/TestNativeImageLoader.java
@@ -36,6 +36,7 @@ import java.util.Random;
 import static org.bytedeco.javacpp.lept.*;
 import static org.bytedeco.javacpp.opencv_core.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -108,8 +109,7 @@ public class TestNativeImageLoader {
         NativeImageLoader loader5 = new NativeImageLoader(h4, w4, ch4, NativeImageLoader.MultiPageMode.FIRST);
         INDArray array6 = null;
         try {
-            array6 = loader5.asMatrix(
-						new ClassPathResource(path2MitosisFile).getFile());
+            array6 = loader5.asMatrix(new ClassPathResource(path2MitosisFile).getFile());
         } catch (IOException e) {
             e.printStackTrace();
             fail();
@@ -122,6 +122,7 @@ public class TestNativeImageLoader {
 
         int ch5 = 4, pages1 = 1;
         NativeImageLoader loader6 = new NativeImageLoader(h4, w4, 1, NativeImageLoader.MultiPageMode.CHANNELS);
+        loader6.direct = false; // simulate conditions under Android
         INDArray array7 = null;
         try {
             array7 = loader6.asMatrix(
@@ -139,8 +140,7 @@ public class TestNativeImageLoader {
         NativeImageLoader loader7 = new NativeImageLoader(h4, w4, ch6, NativeImageLoader.MultiPageMode.MINIBATCH);
         INDArray array8 = null;
         try {
-            array8 = loader7.asMatrix(
-                  new ClassPathResource(path2MitosisFile).getFile());
+            array8 = loader7.asMatrix(new ClassPathResource(path2MitosisFile).getFile());
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -163,24 +163,29 @@ public class TestNativeImageLoader {
         assertEquals(2, array1.rank());
         assertEquals(1, array1.rows());
         assertEquals(h1 * w1 * ch1, array1.columns());
+        assertNotEquals(0.0, array1.sum().getDouble(0), 0.0);
 
         INDArray array2 = loader1.asRowVector(img2);
         assertEquals(2, array2.rank());
         assertEquals(1, array2.rows());
         assertEquals(h1 * w1 * ch1, array2.columns());
+        assertNotEquals(0.0, array2.sum().getDouble(0), 0.0);
 
         int w2 = 103, h2 = 68, ch2 = 4;
         NativeImageLoader loader2 = new NativeImageLoader(h2, w2, ch2);
+        loader2.direct = false; // simulate conditions under Android
 
         INDArray array3 = loader2.asRowVector(img1);
         assertEquals(2, array3.rank());
         assertEquals(1, array3.rows());
         assertEquals(h2 * w2 * ch2, array3.columns());
+        assertNotEquals(0.0, array3.sum().getDouble(0), 0.0);
 
         INDArray array4 = loader2.asRowVector(img2);
         assertEquals(2, array4.rank());
         assertEquals(1, array4.rows());
         assertEquals(h2 * w2 * ch2, array4.columns());
+        assertNotEquals(0.0, array4.sum().getDouble(0), 0.0);
     }
 
     @Test
@@ -197,6 +202,7 @@ public class TestNativeImageLoader {
         assertEquals(1, array1.size(1));
         assertEquals(h1, array1.size(2));
         assertEquals(w1, array1.size(3));
+        assertNotEquals(0.0, array1.sum().getDouble(0), 0.0);
 
         INDArray array2 = loader1.asMatrix(img2);
         assertEquals(4, array2.rank());
@@ -204,9 +210,11 @@ public class TestNativeImageLoader {
         assertEquals(1, array2.size(1));
         assertEquals(h1, array2.size(2));
         assertEquals(w1, array2.size(3));
+        assertNotEquals(0.0, array2.sum().getDouble(0), 0.0);
 
         int w2 = 111, h2 = 66, ch2 = 3;
         NativeImageLoader loader2 = new NativeImageLoader(h2, w2, ch2);
+        loader2.direct = false; // simulate conditions under Android
 
         INDArray array3 = loader2.asMatrix(img1);
         assertEquals(4, array3.rank());
@@ -214,6 +222,7 @@ public class TestNativeImageLoader {
         assertEquals(3, array3.size(1));
         assertEquals(h2, array3.size(2));
         assertEquals(w2, array3.size(3));
+        assertNotEquals(0.0, array3.sum().getDouble(0), 0.0);
 
         INDArray array4 = loader2.asMatrix(img2);
         assertEquals(4, array4.rank());
@@ -221,6 +230,7 @@ public class TestNativeImageLoader {
         assertEquals(3, array4.size(1));
         assertEquals(h2, array4.size(2));
         assertEquals(w2, array4.size(3));
+        assertNotEquals(0.0, array4.sum().getDouble(0), 0.0);
 
         int w3 = 123, h3 = 77, ch3 = 3;
         NativeImageLoader loader3 = new NativeImageLoader(h3, w3, ch3);
@@ -233,12 +243,14 @@ public class TestNativeImageLoader {
         assertEquals(3, array5.size(1));
         assertEquals(h3, array5.size(2));
         assertEquals(w3, array5.size(3));
+        assertNotEquals(0.0, array5.sum().getDouble(0), 0.0);
 
         Mat mat = loader3.asMat(array5);
         assertEquals(w3, mat.cols());
         assertEquals(h3, mat.rows());
         assertEquals(ch3, mat.channels());
         assertTrue(mat.type() == CV_32FC(ch3) || mat.type() == CV_64FC(ch3));
+        assertNotEquals(0.0, sumElems(mat).get(), 0.0);
 
         Frame frame = loader3.asFrame(array5, Frame.DEPTH_UBYTE);
         assertEquals(w3, frame.imageWidth);
@@ -251,12 +263,14 @@ public class TestNativeImageLoader {
         assertEquals(array1, loader4.asMatrix(img12));
 
         NativeImageLoader loader5 = new NativeImageLoader(0, 0, 0);
+        loader5.direct = false; // simulate conditions under Android
         INDArray array7 = loader5.asMatrix(f3);
         assertEquals(4, array7.rank());
         assertEquals(1, array7.size(0));
         assertEquals(3, array7.size(1));
         assertEquals(32, array7.size(2));
         assertEquals(32, array7.size(3));
+        assertNotEquals(0.0, array7.sum().getDouble(0), 0.0);
     }
 
     @Test
@@ -271,24 +285,29 @@ public class TestNativeImageLoader {
         assertEquals(h1, scaled1.rows());
         assertEquals(w1, scaled1.cols());
         assertEquals(img1.channels(), scaled1.channels());
+        assertNotEquals(0.0, sumElems(scaled1).get(), 0.0);
 
         Mat scaled2 = loader1.scalingIfNeed(img2);
         assertEquals(h1, scaled2.rows());
         assertEquals(w1, scaled2.cols());
         assertEquals(img2.channels(), scaled2.channels());
+        assertNotEquals(0.0, sumElems(scaled2).get(), 0.0);
 
         int w2 = 70, h2 = 120, ch2 = 3;
         NativeImageLoader loader2 = new NativeImageLoader(h2, w2, ch2);
+        loader2.direct = false; // simulate conditions under Android
 
         Mat scaled3 = loader2.scalingIfNeed(img1);
         assertEquals(h2, scaled3.rows());
         assertEquals(w2, scaled3.cols());
         assertEquals(img1.channels(), scaled3.channels());
+        assertNotEquals(0.0, sumElems(scaled3).get(), 0.0);
 
         Mat scaled4 = loader2.scalingIfNeed(img2);
         assertEquals(h2, scaled4.rows());
         assertEquals(w2, scaled4.cols());
         assertEquals(img2.channels(), scaled4.channels());
+        assertNotEquals(0.0, sumElems(scaled4).get(), 0.0);
     }
 
     @Test
@@ -305,11 +324,13 @@ public class TestNativeImageLoader {
         assertEquals(85, cropped1.rows());
         assertEquals(60, cropped1.cols());
         assertEquals(img1.channels(), cropped1.channels());
+        assertNotEquals(0.0, sumElems(cropped1).get(), 0.0);
 
         Mat cropped2 = loader.centerCropIfNeeded(img2);
         assertEquals(70, cropped2.rows());
         assertEquals(95, cropped2.cols());
         assertEquals(img2.channels(), cropped2.channels());
+        assertNotEquals(0.0, sumElems(cropped2).get(), 0.0);
     }
 
 
@@ -365,6 +386,7 @@ public class TestNativeImageLoader {
         assertEquals(1, array1.size(1));
         assertEquals(h1, array1.size(2));
         assertEquals(w1, array1.size(3));
+        assertNotEquals(0.0, array1.sum().getDouble(0), 0.0);
     }
 
     @Test


### PR DESCRIPTION
Makes sure to write back changes with `Indexer.release()` when not using direct indexers, as on Android.

I also updated the unit tests to also use non-direct indexers, and they pass only after the changes.

/cc @jrmerwin @johanvos 