### PR TITLE
DL4J: Add OOM Crash Dump Reporting

### DIFF
--- a/deeplearning4j/deeplearning4j-core/pom.xml
+++ b/deeplearning4j/deeplearning4j-core/pom.xml
@@ -190,7 +190,6 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
-
     </dependencies>
 
     <profiles>

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/optimize/solver/TestOptimizers.java
@@ -14,6 +14,7 @@ import org.deeplearning4j.nn.conf.layers.DenseLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
@@ -1073,6 +1074,11 @@ public class TestOptimizers extends BaseDL4JTest {
         @Override
         public void allowInputModification(boolean allow) {
 
+        }
+
+        @Override
+        public LayerHelper getHelper() {
+            return null;
         }
     }
 }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/CrashReportingUtilTest.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/CrashReportingUtilTest.java
@@ -1,0 +1,117 @@
+package org.deeplearning4j.util;
+
+import org.apache.commons.io.FileUtils;
+import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.datasets.iterator.EarlyTerminationDataSetIterator;
+import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.PoolingType;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.learning.config.NoOp;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CrashReportingUtilTest extends BaseDL4JTest {
+
+    @Rule
+    public TemporaryFolder testDir = new TemporaryFolder();
+
+    @After
+    public void after(){
+        //Reset dir
+        CrashReportingUtil.crashDumpOutputDirectory(null);
+    }
+
+    @Test
+    public void testMLN() throws Exception {
+        File dir = testDir.newFolder();
+        CrashReportingUtil.crashDumpOutputDirectory(dir);
+
+        int kernel = 2;
+        int stride = 1;
+        int padding = 0;
+        PoolingType poolingType = PoolingType.MAX;
+        int inputDepth = 1;
+        int height = 28;
+        int width = 28;
+
+
+        MultiLayerConfiguration conf =
+                new NeuralNetConfiguration.Builder().updater(new NoOp())
+                        .weightInit(WeightInit.DISTRIBUTION)
+                        .dist(new NormalDistribution(0, 1))
+                        .list().layer(0,
+                        new ConvolutionLayer.Builder()
+                                .kernelSize(kernel, kernel)
+                                .stride(stride, stride)
+                                .padding(padding, padding)
+                                .nIn(inputDepth)
+                                .nOut(3).build())
+                        .layer(1, new SubsamplingLayer.Builder(poolingType)
+                                .kernelSize(kernel, kernel)
+                                .stride(stride, stride)
+                                .padding(padding, padding)
+                                .build())
+                        .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                                .activation(Activation.SOFTMAX)
+                                .nOut(10).build())
+                        .setInputType(InputType.convolutionalFlat(height, width,
+                                inputDepth))
+                        .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        //Test net that hasn't been trained yet
+        Exception e = new Exception();
+        CrashReportingUtil.writeMemoryCrashDump(net, e);
+
+        File[] list = dir.listFiles();
+        assertNotNull(list);
+        assertEquals(1, list.length);
+        String str = FileUtils.readFileToString(list[0]);
+//        System.out.println(str);
+        assertTrue(str.contains("Network Information"));
+        assertTrue(str.contains("Layer Helpers"));
+        assertTrue(str.contains("JavaCPP"));
+
+
+        //Train:
+        DataSetIterator iter = new EarlyTerminationDataSetIterator(new MnistDataSetIterator(32, true, 12345), 5);
+        net.fit(iter);
+        dir = testDir.newFolder();
+        CrashReportingUtil.crashDumpOutputDirectory(dir);
+        CrashReportingUtil.writeMemoryCrashDump(net, e);
+
+        list = dir.listFiles();
+        assertNotNull(list);
+        assertEquals(1, list.length);
+        str = FileUtils.readFileToString(list[0]);
+        assertTrue(str.contains("Network Information"));
+        assertTrue(str.contains("Layer Helpers"));
+        assertTrue(str.contains("JavaCPP"));
+
+        System.out.println("///////////////////////////////////////////////////////////");
+        System.out.println(str);
+        System.out.println("///////////////////////////////////////////////////////////");
+
+    }
+
+
+}

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
@@ -49,6 +49,8 @@ import org.nd4j.util.OneTimeLogger;
 import org.nd4j.util.StringUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.bytedeco.javacpp.cuda.CUstream_st;
 import static org.bytedeco.javacpp.cudnn.*;
@@ -651,6 +653,12 @@ public class CudnnConvolutionHelper extends BaseCudnnHelper implements Convoluti
         private INDArray origInput;
         private int[] padding;
         private int[] outSize;
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        //No memory use other than shared, and the structs (which are small)
+        return Collections.emptyMap();
     }
 
 }

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/CudnnSubsamplingHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/CudnnSubsamplingHelper.java
@@ -38,6 +38,9 @@ import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.nn.workspace.ArrayType;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.bytedeco.javacpp.cuda.CUstream_st;
 import static org.bytedeco.javacpp.cudnn.*;
 import static org.deeplearning4j.nn.layers.convolution.CudnnConvolutionHelper.getCudnnForwardArgs;
@@ -260,6 +263,12 @@ public class CudnnSubsamplingHelper extends BaseCudnnHelper implements Subsampli
             context.syncOldStream();
 
         return reduced;
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        //No persistent memory use other than the structs (which are small)
+        return Collections.emptyMap();
     }
 
 }

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnBatchNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnBatchNormalizationHelper.java
@@ -40,6 +40,10 @@ import org.nd4j.linalg.jcublas.context.CudaContext;
 import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.util.ArrayUtil;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.bytedeco.javacpp.cuda.CUstream_st;
 import static org.bytedeco.javacpp.cudnn.*;
 
@@ -290,5 +294,14 @@ public class CudnnBatchNormalizationHelper extends BaseCudnnHelper implements Ba
         }
 
         return activations;
+    }
+
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        Map<String,Long> memUse = new HashMap<>();
+        memUse.put("meanCache", meanCache.capacity());
+        memUse.put("varCache", varCache.capacity());
+        return memUse;
     }
 }

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnLocalResponseNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnLocalResponseNormalizationHelper.java
@@ -37,6 +37,9 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.nn.workspace.ArrayType;
 import org.nd4j.linalg.util.ArrayUtil;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.bytedeco.javacpp.cuda.CUstream_st;
 import static org.bytedeco.javacpp.cudnn.*;
 
@@ -219,4 +222,9 @@ public class CudnnLocalResponseNormalizationHelper extends BaseCudnnHelper imple
         return activations;
     }
 
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        //No persistent memory use other than the structs (which are small)
+        return Collections.emptyMap();
+    }
 }

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/recurrent/CudnnLSTMHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/recurrent/CudnnLSTMHelper.java
@@ -39,6 +39,8 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.nn.workspace.ArrayType;
 import org.nd4j.util.StringUtils;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.bytedeco.javacpp.cuda.*;
@@ -633,5 +635,14 @@ public class CudnnLSTMHelper extends BaseCudnnHelper implements LSTMHelper {
         toReturn.prevMemCell = prevMemCell;
 
         return toReturn;
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        Map<String,Long> memUse = new HashMap<>();
+        memUse.put("stateStace", stateSpace.capacity());
+        memUse.put("reserveSpace", reserveSpace.capacity());
+        memUse.put("weightsSpace", weightsSpace.capacity());
+        return memUse;
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/pom.xml
+++ b/deeplearning4j/deeplearning4j-nn/pom.xml
@@ -69,6 +69,13 @@
             <version>${threadly.version}</version>
         </dependency>
 
+        <!-- oshi: Used for collecting system information for memory crash dump reporting -->
+        <dependency>
+            <groupId>com.github.oshi</groupId>
+            <artifactId>oshi-core</artifactId>
+            <version>${oshi.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/deeplearning4j/deeplearning4j-nn/pom.xml
+++ b/deeplearning4j/deeplearning4j-nn/pom.xml
@@ -40,6 +40,11 @@
         </dependency>
         <dependency>
             <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native-api</artifactId>
+            <version>${nd4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.nd4j</groupId>
             <artifactId>nd4j-common</artifactId>
             <version>${nd4j.version}</version>
         </dependency>

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/Layer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/Layer.java
@@ -21,6 +21,7 @@ package org.deeplearning4j.nn.api;
 
 import org.deeplearning4j.nn.conf.CacheMode;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -250,4 +251,9 @@ public interface Layer extends Serializable, Cloneable, Model {
      * @return New mask array after this layer, along with the new mask state.
      */
     Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState, int minibatchSize);
+
+    /**
+     * @return Get the layer helper, if any
+     */
+    LayerHelper getHelper();
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -52,7 +52,7 @@ import org.deeplearning4j.optimize.Solver;
 import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.optimize.solvers.accumulation.GradientsAccumulator;
-import org.deeplearning4j.util.CrashUtils;
+import org.deeplearning4j.util.CrashReportingUtil;
 import org.deeplearning4j.util.ModelSerializer;
 import org.deeplearning4j.util.NetworkUtils;
 import org.nd4j.base.Preconditions;
@@ -799,7 +799,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try{
             pretrainHelper(iter);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -849,7 +849,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try{
             pretrainLayerHelper(layerName, iter);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1143,7 +1143,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try{
             fitHelper(inputs, labels, featureMaskArrays, labelMaskArrays);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1493,7 +1493,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerTillIndex, null,
                     input, inputMaskArrays, labelMaskArrays, clearInputs);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1525,7 +1525,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, graphVertexIndexOfLayer,
                 null, inputs, inputMaskArrays, labelMaskArrays, true);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1579,7 +1579,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, vertices.length - 1,
                     null, input, inputMaskArrays, labelMaskArrays, clearInputs);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1604,7 +1604,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, vertices.length - 1,
                     null, inputs, inputMaskArrays, labelMaskArrays, true);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1705,7 +1705,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             clearLayersStates();
             return out;
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1754,7 +1754,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try {
             return outputOfLayersDetached(train, FwdPassType.STANDARD, getOutputLayerIndices(), input, null, null, clearInputs, detachedInputs);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2358,7 +2358,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             calcBackpropGradients(true, configuration.getBackpropType() == BackpropType.TruncatedBPTT, epsilons);
             return gradient;
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2869,7 +2869,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try{
             return scoreHelper(dataSet, training);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2965,7 +2965,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try{
             return scoreExamplesHelper(dataSet, addRegularizationTerms);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -3329,7 +3329,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try{
             return rnnTimeStepHelper(inputs);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -3907,7 +3907,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         try{
             return doEvaluationHelper(iterator, evaluations);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -4016,6 +4016,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * Will also give information about frozen layers/vertices, if any.
      *
      * @return Summary as a string
+     * @see #memoryInfo(int, InputType...)
      */
     public String summary() {
         return summary(null);
@@ -4030,6 +4031,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * Will also give information about frozen layers/vertices, if any.
      *
      * @return Summary as a string
+     * @see #memoryInfo(int, InputType...)
      */
     public String summary(InputType... inputTypes) {
 
@@ -4149,6 +4151,22 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         ret += "\n";
 
         return ret;
+    }
+
+    /**
+     * Generate information regarding memory use for the network, for the given input types and minibatch size.
+     * Note that when using workspaces or CuDNN, the network should be trained for some iterations so that the memory
+     * workspaces have time to initialize. Without this, the memory requirements during training may be underestimated.
+     *
+     * Note also that this is the same information that is generated during an OOM crash when training or performing
+     * inference.
+     *
+     * @param minibatch    Minibatch size to estimate memory for
+     * @param inputTypes   Input types to the network
+     * @return A String with information about network memory use information
+     */
+    public String memoryInfo(int minibatch, InputType... inputTypes){
+        return CrashReportingUtil.generateMemoryStatus(this, minibatch, inputTypes);
     }
 
     /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -52,6 +52,7 @@ import org.deeplearning4j.optimize.Solver;
 import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.optimize.solvers.accumulation.GradientsAccumulator;
+import org.deeplearning4j.util.CrashUtils;
 import org.deeplearning4j.util.ModelSerializer;
 import org.deeplearning4j.util.NetworkUtils;
 import org.nd4j.base.Preconditions;
@@ -108,6 +109,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
     private boolean initDone = false;
     protected boolean clearTbpttState = true;  //Mainly for unit testing (should be enabled otherwise)
     //Workspaces for CUDNN. Pass to LayerWorkspaceMgr for re-use in cudnn helpers
+    @Getter
     protected transient Map<String,Pointer> helperWorkspaces = new HashMap<>();
 
     /**
@@ -794,6 +796,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * Pretrain network with multiple inputs and/or outputs
      */
     public void pretrain(MultiDataSetIterator iter) {
+        try{
+            pretrainHelper(iter);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
+
+    private void pretrainHelper(MultiDataSetIterator iter){
         if (!configuration.isPretrain())
             return;
         if (flattenedGradients == null) {
@@ -835,6 +846,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * @param iter      Training data
      */
     public void pretrainLayer(String layerName, MultiDataSetIterator iter) {
+        try{
+            pretrainLayerHelper(layerName, iter);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
+
+    private void pretrainLayerHelper(String layerName, MultiDataSetIterator iter){
         if (!configuration.isPretrain())
             return;
         if (flattenedGradients == null) {
@@ -1120,6 +1140,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * @param labelMaskArrays   Mas arrays for the labels/outputs. Typically used for RNN training. May be null.
      */
     public void fit(INDArray[] inputs, INDArray[] labels, INDArray[] featureMaskArrays, INDArray[] labelMaskArrays) {
+        try{
+            fitHelper(inputs, labels, featureMaskArrays, labelMaskArrays);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
+
+    private void fitHelper(INDArray[] inputs, INDArray[] labels, INDArray[] featureMaskArrays, INDArray[] labelMaskArrays) {
         if (numParams() == 0) {
             return; //Edge case: net with no params: fitting is a no-op
         }
@@ -1424,8 +1453,6 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
     }
 
 
-
-
     /**
      * Conduct forward pass using a single input array. Note that this method can only be used with ComputationGraphs
      * with a single input array.
@@ -1462,8 +1489,13 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      */
     public Map<String, INDArray> feedForward(INDArray[] input, int layerTillIndex,boolean train, boolean clearInputs) {
         setInputs(input);
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerTillIndex, null,
-                input, inputMaskArrays, labelMaskArrays, clearInputs);
+        try {
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerTillIndex, null,
+                    input, inputMaskArrays, labelMaskArrays, clearInputs);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
 
@@ -1489,8 +1521,13 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      */
     public Map<String, INDArray> feedForward(boolean train,int layerTillIndex) {
         int graphVertexIndexOfLayer = layers[layerTillIndex].getIndex();
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, graphVertexIndexOfLayer,
+        try{
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, graphVertexIndexOfLayer,
                 null, inputs, inputMaskArrays, labelMaskArrays, true);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
 
@@ -1538,8 +1575,13 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      */
     public Map<String, INDArray> feedForward(INDArray[] input, boolean train, boolean clearInputs){
         setInputs(input);
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false,  vertices.length-1,
-                null, input, inputMaskArrays, labelMaskArrays, clearInputs);
+        try {
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, vertices.length - 1,
+                    null, input, inputMaskArrays, labelMaskArrays, clearInputs);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /**
@@ -1558,8 +1600,13 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * @return A map of activations for each layer (not each GraphVertex). Keys = layer name, values = layer activations
      */
     public Map<String, INDArray> feedForward(boolean train) {
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false,  vertices.length-1,
-                null, inputs, inputMaskArrays, labelMaskArrays, true);
+        try {
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, vertices.length - 1,
+                    null, inputs, inputMaskArrays, labelMaskArrays, true);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /**
@@ -1651,11 +1698,16 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * @return           Network output activations
      */
     public INDArray[] output(boolean train, @NonNull INDArray[] input, INDArray[] inputMasks, INDArray[] labelMasks){
-        setLayerMaskArrays(inputMasks, labelMasks);
-        INDArray[] out = outputOfLayersDetached(train, FwdPassType.STANDARD, getOutputLayerIndices(), input, inputMasks, labelMasks, true, false);
-        clearLayerMaskArrays();
-        clearLayersStates();
-        return out;
+        try {
+            setLayerMaskArrays(inputMasks, labelMasks);
+            INDArray[] out = outputOfLayersDetached(train, FwdPassType.STANDARD, getOutputLayerIndices(), input, inputMasks, labelMasks, true, false);
+            clearLayerMaskArrays();
+            clearLayersStates();
+            return out;
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /**
@@ -1699,7 +1751,12 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      */
     public INDArray[] output(boolean train, boolean clearInputs, INDArray... input){
         boolean detachedInputs = !clearInputs;  //If !clearInputs, then inputs should be detached (otherwise: will be out of scope)
-        return outputOfLayersDetached(train, FwdPassType.STANDARD, getOutputLayerIndices(), input, null, null, clearInputs, detachedInputs);
+        try {
+            return outputOfLayersDetached(train, FwdPassType.STANDARD, getOutputLayerIndices(), input, null, null, clearInputs, detachedInputs);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /**
@@ -1773,20 +1830,6 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                     vertexName + " - class: " + clazz + ") - array is defined in incorrect workspace", e);
         }
     }
-
-
-    /**
-     * FF - inference/test time, returning all array activations detached from any workspace.
-     * Note that no workspace should be active externally when calling this method
-     * Also:
-     * - Clear the inputs to each layer, unless clearLayers == false
-     *
-     * @param layerIndex
-     * @param features
-     * @param fMask
-     * @param storeLastForTBPTT ONLY used when fwdPassType == FwdPassType.RNN_ACTIVATE_WITH_STORED_STATE
-     * @return
-     */
 
     /**
      * Feed-forward through the network - returning all array activations detached from any workspace.
@@ -2311,8 +2354,13 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                     "Invalid input: must have epsilons length equal to number of output arrays");
 
 
-        calcBackpropGradients(true, configuration.getBackpropType() == BackpropType.TruncatedBPTT, epsilons);
-        return gradient;
+        try {
+            calcBackpropGradients(true, configuration.getBackpropType() == BackpropType.TruncatedBPTT, epsilons);
+            return gradient;
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /**
@@ -2706,14 +2754,26 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
     }
 
     /**
-     * Get the ComputationGraphUpdater for the network
+     * Get the ComputationGraphUpdater for the network. Creates one on demand, if required
      */
     public ComputationGraphUpdater getUpdater() {
-        if (solver == null) {
+        return getUpdater(true);
+    }
+
+    /**
+     * Get the ComputationGraphUpdater for this network
+     * @param initializeIfAbsent If true: create the updater if one is absent. False: return null if absent.
+     * @return Updater
+     */
+    public ComputationGraphUpdater getUpdater(boolean initializeIfAbsent){
+        if (solver == null && initializeIfAbsent) {
             solver = new Solver.Builder().configure(conf()).listeners(getListeners()).model(this).build();
             solver.getOptimizer().setUpdaterComputationGraph(new ComputationGraphUpdater(this));
         }
-        return solver.getOptimizer().getComputationGraphUpdater();
+        if(solver != null) {
+            return solver.getOptimizer().getComputationGraphUpdater();
+        }
+        return null;
     }
 
     /**
@@ -2806,6 +2866,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * @return the score for the given input,label pairs
      */
     public double score(MultiDataSet dataSet, boolean training) {
+        try{
+            return scoreHelper(dataSet, training);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
+
+    private double scoreHelper(MultiDataSet dataSet, boolean training){
         LayerWorkspaceMgr mgr;
         WorkspaceMode wsm = (training ? configuration.getTrainingWorkspaceMode() : configuration.getInferenceWorkspaceMode());
         if(wsm == WorkspaceMode.NONE){
@@ -2893,6 +2962,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * @return An INDArray (column vector) of size input.numRows(); the ith entry is the score (loss value) of the ith example
      */
     public INDArray scoreExamples(MultiDataSet dataSet, boolean addRegularizationTerms) {
+        try{
+            return scoreExamplesHelper(dataSet, addRegularizationTerms);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
+
+    private INDArray scoreExamplesHelper(MultiDataSet dataSet, boolean addRegularizationTerms){
         LayerWorkspaceMgr mgr;
         if(configuration.getInferenceWorkspaceMode() == WorkspaceMode.NONE){
             mgr = LayerWorkspaceMgr.noWorkspaces();
@@ -3248,9 +3326,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * Otherwise output is 3d [miniBatchSize,outputSize,inputTimeSeriesLength] when using RnnOutputLayer (or unmodified otherwise).
      */
     public INDArray[] rnnTimeStep(INDArray... inputs) {
+        try{
+            return rnnTimeStepHelper(inputs);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
 
-//        this.inputs = inputs;
-        //Idea: if 2d in, want 2d out
+    private INDArray[] rnnTimeStepHelper(INDArray... inputs){
         boolean inputIs2d = true;
         for (INDArray i : inputs) {
             if (i.rank() != 2) {
@@ -3820,6 +3904,15 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      * @return The input IEvaluation instance, after performing evaluation on the test data
      */
     public <T extends IEvaluation> T[] doEvaluation(MultiDataSetIterator iterator, T... evaluations) {
+        try{
+            return doEvaluationHelper(iterator, evaluations);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
+
+    private <T extends IEvaluation> T[] doEvaluationHelper(MultiDataSetIterator iterator, T... evaluations){
         if (layers == null || !(getOutputLayer(0) instanceof IOutputLayer)) {
             throw new IllegalStateException("Cannot evaluate network with no output layer");
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/AbstractLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/AbstractLayer.java
@@ -444,4 +444,10 @@ public abstract class AbstractLayer<LayerConfT extends org.deeplearning4j.nn.con
     public void allowInputModification(boolean allow){
         inputModificationAllowed = allow;
     }
+
+    @Override
+    public LayerHelper getHelper() {
+        //Layers with helpers should override this method!
+        return null;
+    }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/LayerHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/LayerHelper.java
@@ -1,0 +1,20 @@
+package org.deeplearning4j.nn.layers;
+
+import java.util.Map;
+
+public interface LayerHelper {
+
+    /**
+     * Return the currently allocated memory for the helper.<br>
+     * (a) Excludes: any shared memory used by multiple helpers/layers<br>
+     * (b) Excludes any temporary memory
+     * (c) Includes all memory that persists for longer than the helper method<br>
+     * This is mainly used for debugging and reporting purposes. Returns a map:<br>
+     * Key: The name of the type of memory<br>
+     * Value: The amount of memory<br>
+     *
+     * @return Map of memory, may be null if none is used.
+     */
+    Map<String,Long> helperMemoryUse();
+
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
@@ -23,6 +23,7 @@ import org.deeplearning4j.nn.conf.layers.ConvolutionLayer.BwdDataAlgo;
 import org.deeplearning4j.nn.conf.layers.ConvolutionLayer.BwdFilterAlgo;
 import org.deeplearning4j.nn.conf.layers.ConvolutionLayer.FwdAlgo;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.nd4j.linalg.activations.IActivation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.primitives.Pair;
@@ -33,7 +34,7 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
  *
  * @author saudet
  */
-public interface ConvolutionHelper {
+public interface ConvolutionHelper extends LayerHelper {
     boolean checkSupported();
 
     Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray delta, int[] kernel,

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -27,6 +27,7 @@ import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.layers.BaseLayer;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.activations.IActivation;
@@ -435,6 +436,11 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
     @Override
     public boolean isPretrainLayer() {
         return false;
+    }
+
+    @Override
+    public LayerHelper getHelper() {
+        return helper;
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingHelper.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.nn.layers.convolution.subsampling;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.layers.PoolingType;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
@@ -29,7 +30,7 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
  *
  * @author saudet
  */
-public interface SubsamplingHelper {
+public interface SubsamplingHelper extends LayerHelper {
     boolean checkSupported();
 
     Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, int[] kernel, int[] strides, int[] pad,

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -27,6 +27,7 @@ import org.deeplearning4j.nn.conf.layers.PoolingType;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.AbstractLayer;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
@@ -394,6 +395,11 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
     @Override
     public void clearNoiseWeightParams() {
         //no op
+    }
+
+    @Override
+    public LayerHelper getHelper() {
+        return helper;
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -7,6 +7,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.BaseLayer;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.nn.params.BatchNormalizationParamInitializer;
 import org.deeplearning4j.nn.workspace.ArrayType;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
@@ -432,6 +433,11 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
     @Override
     public boolean isPretrainLayer() {
         return false;
+    }
+
+    @Override
+    public LayerHelper getHelper() {
+        return helper;
     }
 
     public long[] getShape(INDArray x) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalizationHelper.java
@@ -18,6 +18,7 @@
 package org.deeplearning4j.nn.layers.normalization;
 
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
@@ -27,7 +28,7 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
  *
  * @author saudet
  */
-public interface BatchNormalizationHelper {
+public interface BatchNormalizationHelper extends LayerHelper {
     boolean checkSupported(double eps);
 
     Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, int[] shape, INDArray gamma,

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
@@ -6,6 +6,7 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.AbstractLayer;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.OldMulOp;
 import org.nd4j.linalg.factory.Nd4j;
@@ -236,6 +237,11 @@ public class LocalResponseNormalization
     @Override
     public void clearNoiseWeightParams() {
         //No op
+    }
+
+    @Override
+    public LayerHelper getHelper() {
+        return helper;
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalizationHelper.java
@@ -18,6 +18,7 @@
 package org.deeplearning4j.nn.layers.normalization;
 
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
@@ -27,7 +28,7 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
  *
  * @author saudet
  */
-public interface LocalResponseNormalizationHelper {
+public interface LocalResponseNormalizationHelper extends LayerHelper {
     boolean checkSupported(double k, double n, double alpha, double beta);
 
     Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, double k, double n, double alpha,

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/recurrent/LSTMHelper.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.nn.layers.recurrent;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.nd4j.linalg.activations.IActivation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.primitives.Pair;
@@ -32,7 +33,7 @@ import java.util.Map;
  *
  * @author saudet
  */
-public interface LSTMHelper {
+public interface LSTMHelper extends LayerHelper {
     boolean checkSupported(IActivation gateActivationFn, IActivation activationFn, boolean hasPeepholeConnections);
 
     Pair<Gradient, INDArray> backpropGradient(final NeuralNetConfiguration conf, final IActivation gateActivationFn,

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/variational/VariationalAutoencoder.java
@@ -11,6 +11,7 @@ import org.deeplearning4j.nn.conf.layers.variational.LossFunctionWrapper;
 import org.deeplearning4j.nn.conf.layers.variational.ReconstructionDistribution;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.nn.params.VariationalAutoencoderParamInitializer;
 import org.deeplearning4j.nn.workspace.ArrayType;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
@@ -901,6 +902,11 @@ public class VariationalAutoencoder implements Layer {
 
 
         throw new UnsupportedOperationException("Not yet implemented " + layerId());
+    }
+
+    @Override
+    public LayerHelper getHelper() {
+        return null;
     }
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/wrapper/BaseWrapperLayer.java
@@ -7,6 +7,7 @@ import org.deeplearning4j.nn.api.MaskState;
 import org.deeplearning4j.nn.conf.CacheMode;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.TrainingListener;
@@ -325,5 +326,10 @@ public abstract class BaseWrapperLayer implements Layer {
     @Override
     public void allowInputModification(boolean allow) {
         underlying.allowInputModification(allow);
+    }
+
+    @Override
+    public LayerHelper getHelper() {
+        return underlying.getHelper();
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -2925,11 +2925,18 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @return Updater for MultiLayerNetwork
      */
     public synchronized Updater getUpdater() {
-        if (solver == null) {
+        return getUpdater(true);
+    }
+
+    public synchronized Updater getUpdater(boolean initializeIfReq) {
+        if (solver == null && initializeIfReq) {
             solver = new Solver.Builder().configure(conf()).listeners(getListeners()).model(this).build();
             solver.getOptimizer().setUpdater(UpdaterCreator.getUpdater(this));
         }
-        return solver.getOptimizer().getUpdater();
+        if(solver != null) {
+            return solver.getOptimizer().getUpdater();
+        }
+        return null;
     }
 
     /** Set the updater for the MultiLayerNetwork */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -54,6 +54,7 @@ import org.deeplearning4j.optimize.Solver;
 import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.optimize.solvers.accumulation.GradientsAccumulator;
+import org.deeplearning4j.util.CrashUtils;
 import org.deeplearning4j.util.ModelSerializer;
 import org.deeplearning4j.util.NetworkUtils;
 import org.nd4j.base.Preconditions;
@@ -756,8 +757,13 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @return the list of activations for each layer
      */
     public List<INDArray> feedForward(boolean train) {
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layers.length-1,
-                input, mask, null, true);
+        try {
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layers.length-1,
+                    input, mask, null, true);
+        } catch (OutOfMemoryError e) {
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /**
@@ -772,7 +778,12 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @return Activations from feed-forward
      */
     public List<INDArray> feedForward(boolean train, boolean clearInputs){
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layers.length-1, input, mask, null, clearInputs);
+        try{
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layers.length-1, input, mask, null, clearInputs);
+        } catch (OutOfMemoryError e) {
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /** Compute the activations from the input to the specified layer.<br>
@@ -785,7 +796,12 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @return list of activations.
      */
     public List<INDArray> feedForwardToLayer(int layerNum, INDArray input) {
-        return ffToLayerActivationsDetached(false, FwdPassType.STANDARD, false, layerNum, input, mask, null, true);
+        try{
+            return ffToLayerActivationsDetached(false, FwdPassType.STANDARD, false, layerNum, input, mask, null, true);
+        } catch (OutOfMemoryError e) {
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /** Compute the activations from the input to the specified layer.<br>
@@ -799,8 +815,13 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @return list of activations.
      */
     public List<INDArray> feedForwardToLayer(int layerNum, INDArray input, boolean train) {
-        int layerVertexIdx = layers[layerNum].getIndex();
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerVertexIdx, input, mask, null, true);
+        try {
+            int layerVertexIdx = layers[layerNum].getIndex();
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerVertexIdx, input, mask, null, true);
+        } catch (OutOfMemoryError e) {
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /** Compute the activations from the input to the specified layer, using the currently set input for the network.<br>
@@ -813,7 +834,12 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @return list of activations.
      */
     public List<INDArray> feedForwardToLayer(int layerNum, boolean train) {
-        return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerNum, input, mask, null, true);
+        try {
+            return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerNum, input, mask, null, true);
+        } catch (OutOfMemoryError e) {
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
 
@@ -2022,6 +2048,15 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * @param labelsMask The mask array for the labels (used for variable length time series, etc). May be null.
      */
     public void fit(INDArray features, INDArray labels, INDArray featuresMask, INDArray labelsMask) {
+        try{
+            fitHelper(features, labels, featuresMask, labelsMask);
+        } catch (OutOfMemoryError e){
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
+    }
+
+    private void fitHelper(INDArray features, INDArray labels, INDArray featuresMask, INDArray labelsMask){
         if(numParams() == 0){
             //No op: can't fit a network with 0 parameters
             return;
@@ -2133,7 +2168,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * [0.5, 0.5] or some other probability distribution summing to one
      */
     public INDArray output(INDArray input, boolean train) {
-        return outputOfLayerDetached(train, FwdPassType.STANDARD,layers.length-1, input, null, null);
+        return output(input, train, null, null);
     }
 
     /** Calculate the output of the network, with masking arrays. The masking arrays are used in situations such
@@ -2141,7 +2176,12 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * of varying lengths within the same minibatch.
      */
     public INDArray output(INDArray input, boolean train, INDArray featuresMask, INDArray labelsMask) {
-        return outputOfLayerDetached(train, FwdPassType.STANDARD, layers.length-1, input, featuresMask, labelsMask);
+        try {
+            return outputOfLayerDetached(train, FwdPassType.STANDARD, layers.length - 1, input, featuresMask, labelsMask);
+        } catch (OutOfMemoryError e) {
+            CrashUtils.writeMemoryCrashDump(this, e);
+            throw e;
+        }
     }
 
     /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -46,6 +46,7 @@ import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.layers.FrozenLayer;
 import org.deeplearning4j.nn.layers.FrozenLayerWithBackprop;
 import org.deeplearning4j.nn.layers.recurrent.BidirectionalLayer;
+import org.deeplearning4j.nn.layers.LayerHelper;
 import org.deeplearning4j.nn.updater.MultiLayerUpdater;
 import org.deeplearning4j.nn.updater.UpdaterCreator;
 import org.deeplearning4j.nn.workspace.ArrayType;
@@ -2788,6 +2789,11 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         }
 
         return new Pair<>(maskArray, currentMaskState);
+    }
+
+    @Override
+    public LayerHelper getHelper() {
+        throw new UnsupportedOperationException("Not supported");
     }
 
     //==========

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -3362,6 +3362,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * Columns are LayerIndex with layer type, nIn, nOut, Total number of parameters and the Shapes of the parameters
      * Will also give information about frozen layers, if any.
      * @return Summary as a string
+     * @see #memoryInfo(int, InputType)
      */
     public String summary() {
         return summary(null);
@@ -3373,6 +3374,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      * Columns are LayerIndex with layer type, nIn, nOut, Total number of parameters, Shapes of the parameters, Input activation shape, Output activation shape
      * Will also give information about frozen layers, if any.
      * @return Summary as a string
+     * @see #memoryInfo(int, InputType)
      */
     public String summary(InputType inputType) {
         String ret = "\n";
@@ -3455,6 +3457,22 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         ret += StringUtils.repeat("=", 250);
         ret += "\n";
         return ret;
+    }
+
+    /**
+     * Generate information regarding memory use for the network, for the given input type and minibatch size.
+     * Note that when using workspaces or CuDNN, the network should be trained for some iterations so that the memory
+     * workspaces have time to initialize. Without this, the memory requirements during training may be underestimated.
+     *
+     * Note also that this is the same information that is generated during an OOM crash when training or performing
+     * inference.
+     *
+     * @param minibatch    Minibatch size to estimate memory for
+     * @param inputType    Input type to the network
+     * @return A String with information about network memory use information
+     */
+    public String memoryInfo(int minibatch, InputType inputType){
+        return CrashReportingUtil.generateMemoryStatus(this, minibatch, inputType);
     }
 
     /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -55,7 +55,7 @@ import org.deeplearning4j.optimize.Solver;
 import org.deeplearning4j.optimize.api.ConvexOptimizer;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.optimize.solvers.accumulation.GradientsAccumulator;
-import org.deeplearning4j.util.CrashUtils;
+import org.deeplearning4j.util.CrashReportingUtil;
 import org.deeplearning4j.util.ModelSerializer;
 import org.deeplearning4j.util.NetworkUtils;
 import org.nd4j.base.Preconditions;
@@ -743,7 +743,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
             }
             return res;
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -768,7 +768,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layers.length-1,
                     input, mask, null, true);
         } catch (OutOfMemoryError e) {
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -788,7 +788,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layers.length-1, input, mask, null, clearInputs);
         } catch (OutOfMemoryError e) {
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -806,7 +806,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             return ffToLayerActivationsDetached(false, FwdPassType.STANDARD, false, layerNum, input, mask, null, true);
         } catch (OutOfMemoryError e) {
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -826,7 +826,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
             int layerVertexIdx = layers[layerNum].getIndex();
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerVertexIdx, input, mask, null, true);
         } catch (OutOfMemoryError e) {
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -844,7 +844,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try {
             return ffToLayerActivationsDetached(train, FwdPassType.STANDARD, false, layerNum, input, mask, null, true);
         } catch (OutOfMemoryError e) {
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1441,7 +1441,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             fitHelper(iterator);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -1559,7 +1559,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             return calculateGradientsHelper(features, label, fMask, labelMask);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2077,7 +2077,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             fitHelper(features, labels, featuresMask, labelsMask);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2205,7 +2205,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try {
             return outputOfLayerDetached(train, FwdPassType.STANDARD, layers.length - 1, input, featuresMask, labelsMask);
         } catch (OutOfMemoryError e) {
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2374,7 +2374,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             return scoreHelper(data, training);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2448,7 +2448,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             return scoreExamplesHelper(data, addRegularizationTerms);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -2956,7 +2956,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
             }
             return out;
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }
@@ -3170,7 +3170,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         try{
             return doEvaluationHelper(iterator, evaluations);
         } catch (OutOfMemoryError e){
-            CrashUtils.writeMemoryCrashDump(this, e);
+            CrashReportingUtil.writeMemoryCrashDump(this, e);
             throw e;
         }
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ScoreIterationListener.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/optimize/listeners/ScoreIterationListener.java
@@ -54,4 +54,9 @@ public class ScoreIterationListener extends BaseTrainingListener implements Seri
             log.info("Score at iteration {} is {}", iteration, score);
         }
     }
+
+    @Override
+    public String toString(){
+        return "ScoreIterationListener(" + printIterations + ")";
+    }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
@@ -131,7 +131,7 @@ public class CrashReportingUtil {
         log.error(">>> Out of Memory Exception Detected. Memory crash dump written to: {}", f.getAbsolutePath());
         log.warn("Memory crash dump reporting can be disabled with CrashUtil.crashDumpsEnabled(false) or using system " +
                 "property -D" + CRASH_DUMP_ENABLED_PROPERTY + "=false");
-        log.warn("Memory crash dump reporting output location CrashUtil.crashDumpOutputDirectory(File) or using system " +
+        log.warn("Memory crash dump reporting output location can be set with CrashUtil.crashDumpOutputDirectory(File) or using system " +
                 "property -D" + CRASH_DUMP_OUTPUT_DIRECTORY_PROPERTY + "=<path>");
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
@@ -1,5 +1,7 @@
 package org.deeplearning4j.util;
 
+import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -42,13 +44,29 @@ import java.util.*;
 import static org.deeplearning4j.nn.conf.inputs.InputType.inferInputType;
 import static org.deeplearning4j.nn.conf.inputs.InputType.inferInputTypes;
 
+/**
+ * A utility for generating crash reports when an out of memory error occurs.
+ *
+ * @author Alex Black
+ */
 @Slf4j
 public class CrashReportingUtil {
 
+    /**
+     * System property that can be used to enable or disable memory crash reporting. Memory crash reporting is
+     * enabled by default.
+     */
     public static final String CRASH_DUMP_ENABLED_PROPERTY = "org.deeplearning4j.crash.reporting.enabled";
+
+    /**
+     * System property that can be use to customize the output directory for memory crash reporting. By default,
+     * the current working directory will be used
+     */
     public static final String CRASH_DUMP_OUTPUT_DIRECTORY_PROPERTY = "org.deeplearning4j.crash.reporting.directory";
 
+    @Getter
     private static boolean crashDumpsEnabled = true;
+    @Getter
     private static File crashDumpRootDirectory;
 
     static {
@@ -76,11 +94,20 @@ public class CrashReportingUtil {
 
     private CrashReportingUtil(){ }
 
-
+    /**
+     * Method that can be used to enable or disable memory crash reporting. Memory crash reporting is enabled by default.
+     */
     public static void crashDumpsEnabled(boolean enabled){
         crashDumpsEnabled = enabled;
     }
 
+    /**
+     * Method that can be use to customize the output directory for memory crash reporting. By default,
+     * the current working directory will be used.
+     *
+     * @param rootDir Root directory to use for crash reporting. If null is passed, the current working directory
+     *                will be used
+     */
     public static void crashDumpOutputDirectory(File rootDir){
         if(rootDir == null){
             String userDir = System.getProperty("user.dir");
@@ -93,8 +120,15 @@ public class CrashReportingUtil {
         crashDumpRootDirectory = rootDir;
     }
 
-
-    public static void writeMemoryCrashDump(Model net, Throwable e){
+    /**
+     * Generate and write the crash dump to the crash dump root directory (by default, the working directory).
+     * Naming convention for crash dump files: "dl4j-memory-crash-dump-<timestamp>_<thread-id>.txt"
+     *
+     *
+     * @param net   Net to generate the crash dump for. May not be null
+     * @param e     Throwable/exception. Stack trace will be included in the network output
+     */
+    public static void writeMemoryCrashDump(@NonNull Model net, @NonNull Throwable e){
         if(!crashDumpsEnabled){
             return;
         }
@@ -139,6 +173,14 @@ public class CrashReportingUtil {
     }
 
     private static final String FORMAT = "%-40s%s";
+
+    /**
+     * Generate memory/system report as a String, for the specified network.
+     * Includes informatioun about the system, memory configuration, network, etc.
+     *
+     * @param net   Net to generate the report for
+     * @return Report as a String
+     */
     public static String generateMemoryStatus(Model net){
         MultiLayerNetwork mln = null;
         ComputationGraph cg = null;
@@ -297,9 +339,7 @@ public class CrashReportingUtil {
                 sb.append(f("Listener " + (lCount++), tl));
             }
         }
-
-
-
+        
         return sb.toString();
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
@@ -338,12 +338,18 @@ public class CrashReportingUtil {
         String procName = sys.getHardware().getProcessor().getName();
         long totalMem = sys.getHardware().getMemory().getTotal();
 
+        sb.append(f("Operating System", os.getManufacturer() + " " + os.getFamily() + " " + os.getVersion().getVersion()));
+        sb.append(f("CPU", procName));
+        sb.append(f("CPU Cores - Physical", sys.getHardware().getProcessor().getPhysicalProcessorCount()));
+        sb.append(f("CPU Cores - Logical", sys.getHardware().getProcessor().getLogicalProcessorCount()));
+        sb.append(fBytes("Total System Memory", totalMem));
+
         NativeOps nativeOps = NativeOpsHolder.getInstance().getDeviceNativeOps();
         int nDevices = nativeOps.getAvailableDevices();
         if (nDevices > 0) {
             sb.append(f("Number of GPUs Detected", nDevices));
             //Name CC, Total memory, current memory, free memory
-            String fGpu = "  %-30s %-5s %16s %16s %16s";
+            String fGpu = "  %-30s %-5s %24s %24s %24s";
             sb.append(String.format(fGpu, "Name", "CC", "Total Memory", "Used Memory", "Free Memory")).append("\n");
             for (int i = 0; i < nDevices; i++) {
                 try {
@@ -363,12 +369,6 @@ public class CrashReportingUtil {
                 }
             }
         }
-
-        sb.append(f("Operating System", os.getManufacturer() + " " + os.getFamily() + " " + os.getVersion().getVersion()));
-        sb.append(f("CPU", procName));
-        sb.append(f("CPU Cores - Physical", sys.getHardware().getProcessor().getPhysicalProcessorCount()));
-        sb.append(f("CPU Cores - Logical", sys.getHardware().getProcessor().getLogicalProcessorCount()));
-        sb.append(fBytes("Total System Memory", totalMem));
 
         sb.append("\n----- ND4J Environment Information -----\n");
         sb.append(f("Data Type", Nd4j.dataType()));

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashReportingUtil.java
@@ -343,7 +343,7 @@ public class CrashReportingUtil {
         if (nDevices > 0) {
             sb.append(f("Number of GPUs Detected", nDevices));
             //Name CC, Total memory, current memory, free memory
-            String fGpu = "  %-30s %-5s %16 %16 %16";
+            String fGpu = "  %-30s %-5s %16s %16s %16s";
             sb.append(String.format(fGpu, "Name", "CC", "Total Memory", "Used Memory", "Free Memory")).append("\n");
             for (int i = 0; i < nDevices; i++) {
                 try {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/CrashUtils.java
@@ -1,0 +1,278 @@
+package org.deeplearning4j.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.bytedeco.javacpp.Pointer;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.updater.MultiLayerUpdater;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.primitives.Pair;
+import org.nd4j.linalg.util.ArrayUtil;
+import org.nd4j.util.StringUtils;
+import org.nd4j.versioncheck.VersionCheck;
+import org.nd4j.versioncheck.VersionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+@Slf4j
+public class CrashUtils {
+
+    private CrashUtils(){ }
+
+
+    public static void writeMemoryCrashDump(MultiLayerNetwork net, Throwable e){
+        long now = System.currentTimeMillis();
+        File f = new File("dl4j-memory-crash-dump-" + now + ".txt");
+        StringBuilder sb = new StringBuilder();
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        sb.append("OOM Exception Encountered\nTimestamp: ")
+                .append(sdf.format(now)).append("\n\n");
+
+        sb.append("Stack Trace:\n")
+                .append(ExceptionUtils.getStackTrace(e));
+
+        try{
+            sb.append("\n\n").append(generateMemoryStatus(net));
+        } catch (Throwable t){
+            sb.append("<Error generating network memory status information section>")
+                    .append(ExceptionUtils.getStackTrace(t));
+        }
+
+        String toWrite = sb.toString();
+        try{
+            FileUtils.writeStringToFile(f, toWrite);
+        } catch (IOException e2){
+            log.error("Error writing memory crash dump information to disk: {}", f.getAbsolutePath(), e2);
+        }
+
+        log.warn(">>> Memory crash dump written to: {}", f.getAbsolutePath());
+    }
+
+    private static final String FORMAT = "%-40s%s";
+    public static String generateMemoryStatus(MultiLayerNetwork net){
+        StringBuilder sb = genericMemoryStatus();
+        String format = "%40s%s";
+
+        int bytesPerElement;
+        switch (Nd4j.dataType()){
+            case DOUBLE:
+                bytesPerElement = 8;
+                break;
+            case FLOAT:
+                bytesPerElement = 4;
+                break;
+            case HALF:
+                bytesPerElement = 2;
+                break;
+            default:
+                bytesPerElement = 0;    //TODO
+        }
+
+        sb.append("----- Workspace Information -----\n");
+        List<MemoryWorkspace> allWs = Nd4j.getWorkspaceManager().getAllWorkspacesForCurrentThread();
+        sb.append(f("Workspaces: # for current thread", allWs.size()));
+        //sb.append(f("Workspaces: # for all threads", allWs.size()));      //TODO
+        sb.append("Current thread workspaces:\n");
+        //Name, open, size, currently allocated
+        String wsFormat = "  %-30s%-20s%-20s";
+        sb.append(String.format(wsFormat, "Name", "State", "Size")).append("\n");
+        long totalWsSize = 0;
+        for(MemoryWorkspace ws : allWs){
+            totalWsSize += ws.getCurrentSize();
+            sb.append(String.format(wsFormat, ws.getId(),
+                    (ws.isScopeActive() ? "OPEN" : "CLOSED"),
+                    fBytes(ws.getCurrentSize()))).append("\n");
+        }
+        sb.append(fBytes("Workspaces total size", totalWsSize));
+
+        long sumMem = 0;
+        long nParams = net.params().length();
+        sb.append("\n----- Network Information -----\n")
+                .append(f("Network # Parameters", nParams))
+                .append(fBytes("Parameter Memory", bytesPerElement * nParams));
+        if(net.getFlattenedGradients() == null){
+            sb.append(f("Parameter Gradients Memory", "<not allocated>"));
+        } else {
+            sumMem += (net.getFlattenedGradients().length() * bytesPerElement);
+            sb.append(fBytes("Parameter Gradients Memory", bytesPerElement * net.getFlattenedGradients().length()));
+        }
+        MultiLayerUpdater u = (MultiLayerUpdater) net.getUpdater(false);
+        if(u == null){
+            sb.append(f("Updater","<not initialized>"));
+        } else {
+            INDArray stateArr = u.getStateViewArray();
+            long stateArrLength = (stateArr == null ? 0 : stateArr.length());
+            sb.append(f("Updater Number of Elements", stateArrLength));
+            sb.append(fBytes("Updater Memory", stateArrLength * bytesPerElement));
+            sumMem += stateArrLength * bytesPerElement;
+        }
+        sb.append(fBytes("Params + Gradient + Updater Memory", sumMem));
+        sb.append(f("Workspace Mode: Training", net.getLayerWiseConfigurations().getTrainingWorkspaceMode()));
+        sb.append(f("Workspace Mode: Inference", net.getLayerWiseConfigurations().getInferenceWorkspaceMode()));
+        appendLayerInformation(sb, net.getLayers());
+
+        appendActivationShapes(net, sb, bytesPerElement);
+
+        return sb.toString();
+    }
+
+    private static String f(String s1, Object o){
+        return String.format(FORMAT, s1, (o == null ? "null" : o.toString())) + "\n";
+    }
+
+    private static String fBytes(long bytes){
+        String s = StringUtils.TraditionalBinaryPrefix.long2String(bytes, "B", 2);
+        if(bytes >= 1024){
+            s += " (" + bytes + ")";
+        }
+        return s;
+    }
+
+    private static String fBytes(String s1, long bytes){
+        String s = fBytes(bytes);
+        return f(s1, s);
+    }
+
+    private static StringBuilder genericMemoryStatus(){
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("========== Memory Information ==========\n");
+        sb.append("----- Version Information -----\n");
+        Pair<String,String> pair = inferVersion();
+        sb.append(f("Deeplearning4j Version", (pair.getFirst() == null ? "<could not determine>" : pair.getFirst())));
+        sb.append(f("Deeplearning4j CUDA", (pair.getSecond() == null ? "<not present>" : pair.getSecond())));
+
+        sb.append("\n----- Memory - System Information -----\n");
+
+        long xmx = Runtime.getRuntime().maxMemory();
+        long jvmTotal = Runtime.getRuntime().totalMemory();
+        long javacppMaxPhys = Pointer.maxPhysicalBytes();
+        long javacppMaxBytes = Pointer.maxBytes();
+        long javacppCurrPhys = Pointer.physicalBytes();
+        long javacppCurrBytes = Pointer.totalBytes();
+        sb.append(fBytes("JVM Memory: XMX", xmx))
+                .append(fBytes("JVM Memory: current", jvmTotal))
+                .append(fBytes("JavaCPP Memory: Max Bytes", javacppMaxBytes))
+                .append(fBytes("JavaCPP Memory: Max Physical", javacppMaxPhys))
+                .append(fBytes("JavaCPP Memory: Current Bytes", javacppCurrBytes))
+                .append(fBytes("JavaCPP Memory: Current Physical", javacppCurrPhys));
+        boolean periodicGcEnabled = Nd4j.getMemoryManager().isPeriodicGcActive();
+        long autoGcWindow = Nd4j.getMemoryManager().getAutoGcWindow();
+        sb.append(f("Periodic GC Enabled", periodicGcEnabled));
+        if(periodicGcEnabled){
+            sb.append(f("Periodic GC Frequency", autoGcWindow + " ms"));
+        }
+
+
+        sb.append("\n----- ND4J Environment Information -----\n");
+        sb.append(f("Data Type", Nd4j.dataType()));
+        Properties p = Nd4j.getExecutioner().getEnvironmentInformation();
+        for(String s : p.stringPropertyNames()){
+            sb.append(f(s, p.get(s)));
+        }
+
+        return sb;
+    }
+
+    private static void appendLayerInformation(StringBuilder sb, org.deeplearning4j.nn.api.Layer[] layers){
+        Map<String,Integer> layerClasses = new HashMap<>();
+        for(org.deeplearning4j.nn.api.Layer l : layers){
+            if(!layerClasses.containsKey(l.getClass().getSimpleName())){
+                layerClasses.put(l.getClass().getSimpleName(), 0);
+            }
+            layerClasses.put(l.getClass().getSimpleName(), layerClasses.get(l.getClass().getSimpleName()) + 1);
+        }
+
+        List<String> l = new ArrayList<>(layerClasses.keySet());
+        Collections.sort(l);
+        sb.append(f("Number of Layers", layers.length));
+        sb.append("Layer Counts\n");
+        for(String s : l){
+            sb.append("  ").append(f(s, layerClasses.get(s)));
+        }
+    }
+
+    private static void appendActivationShapes(MultiLayerNetwork net, StringBuilder sb, int bytesPerElement){
+        INDArray input = net.getInput();
+        if(input == null){
+            return;
+        }
+        if(input.rank() < 2 || input.rank() > 4){
+            //TODO 3d CNN support
+            return;
+        }
+
+        sb.append("\n----- Network Activations: Inferred Activation Shapes -----\n");
+        InputType inputType = null;
+        switch (input.rank()){
+            case 2:
+                inputType = InputType.feedForward(input.size(1));
+                break;
+            case 3:
+                inputType = InputType.recurrent(input.size(1), input.size(2));
+                break;
+            case 4:
+                inputType = InputType.convolutional(input.size(2), input.size(3), input.size(1));
+                break;
+        }
+
+        sb.append(f("Current Minibatch Size", input.size(0)));
+        sb.append(f("Current Input Shape", Arrays.toString(input.shape())));
+        List<InputType> inputTypes = net.getLayerWiseConfigurations().getLayerActivationTypes(inputType);
+        String format = "%-3s %-20s %-20s %-42s %-20s %-12s %-12s";
+        sb.append(String.format(format, "Idx", "Name", "Layer Type", "Activations Type", "Activations Shape",
+                "# Elements", "Memory")).append("\n");
+        org.deeplearning4j.nn.api.Layer[] layers = net.getLayers();
+        long totalActivationBytes = 0;
+        long last = 0;
+        for( int i=0; i<inputTypes.size(); i++ ){
+            long[] shape = inputTypes.get(i).getShape(true);
+            if(shape[0] <= 0){
+                shape[0] = input.size(0);
+            }
+            long numElements = ArrayUtil.prodLong(shape);
+            long bytes = numElements*bytesPerElement;
+            totalActivationBytes += bytes;
+            sb.append(String.format(format, String.valueOf(i), layers[i].conf().getLayer().getLayerName(), layers[i].getClass().getSimpleName(),
+                    inputTypes.get(i), Arrays.toString(shape), String.valueOf(numElements), fBytes(bytes))).append("\n");
+            last = bytes;
+        }
+        sb.append(fBytes("Total Activations Memory", totalActivationBytes));
+
+        //Exclude output layer, include input
+        long totalActivationGradMem = totalActivationBytes - last + (ArrayUtil.prodLong(input.shape()) * bytesPerElement);
+        sb.append(fBytes("Total Activation Gradient Memory", totalActivationGradMem));
+
+    }
+
+    public static Pair<String,String> inferVersion(){
+        List<VersionInfo> vi = VersionCheck.getVersionInfos();
+
+        String dl4jVersion = null;
+        String dl4jCudaArtifact = null;
+        for(VersionInfo v : vi){
+            if("org.deeplearning4j".equals(v.getGroupId()) && "deeplearning4j-core".equals(v.getArtifactId())){
+                String version = v.getBuildVersion();
+                if(version.contains("SNAPSHOT")){
+                    dl4jVersion = version + " (" + v.getCommitIdAbbrev() + ")";
+                }
+                dl4jVersion = version;
+            } else if("org.deeplearning4j".equals(v.getGroupId()) && v.getArtifactId() != null && v.getArtifactId().contains("deeplearning4j-cuda")){
+                dl4jCudaArtifact = v.getArtifactId();
+            }
+
+        }
+
+        return new Pair<>(dl4jVersion, dl4jCudaArtifact);
+    }
+
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/NetworkUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/NetworkUtils.java
@@ -1,31 +1,21 @@
 package org.deeplearning4j.util;
 
-import org.bytedeco.javacpp.Pointer;
+import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.BaseLayer;
 import org.deeplearning4j.nn.conf.layers.Layer;
 import org.deeplearning4j.nn.graph.ComputationGraph;
-import org.deeplearning4j.nn.layers.AbstractLayer;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.updater.MultiLayerUpdater;
 import org.deeplearning4j.nn.updater.graph.ComputationGraphUpdater;
-import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.IUpdater;
-import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.schedule.ISchedule;
-import org.nd4j.linalg.util.ArrayUtil;
-import org.nd4j.util.StringUtils;
-import org.nd4j.versioncheck.VersionCheck;
-import org.nd4j.versioncheck.VersionInfo;
 
-import java.util.*;
-
+@Slf4j
 public class NetworkUtils {
 
     private NetworkUtils() {
@@ -264,227 +254,5 @@ public class NetworkUtils {
         net.setUpdater(null);
         ComputationGraphUpdater u = net.getUpdater();
         u.setStateViewArray(origUpdaterState);
-    }
-
-
-
-    private static final String FORMAT = "%-40s%s";
-
-    public static String generateMemoryStatus(MultiLayerNetwork net){
-        StringBuilder sb = genericMemoryStatus();
-        String format = "%40s%s";
-
-        int bytesPerElement;
-        switch (Nd4j.dataType()){
-            case DOUBLE:
-                bytesPerElement = 8;
-                break;
-            case FLOAT:
-                bytesPerElement = 4;
-                break;
-            case HALF:
-                bytesPerElement = 2;
-                break;
-            default:
-                bytesPerElement = 0;    //TODO
-        }
-
-        sb.append("----- Workspace Information -----\n");
-        List<MemoryWorkspace> allWs = Nd4j.getWorkspaceManager().getAllWorkspacesForCurrentThread();
-        sb.append(f("Workspaces: # for current thread", allWs.size()));
-        //sb.append(f("Workspaces: # for all threads", allWs.size()));      //TODO
-        sb.append("Current thread workspaces:\n");
-        //Name, open, size, currently allocated
-        String wsFormat = "  %-30s%-20s%-20s";
-        sb.append(String.format(wsFormat, "Name", "State", "Size")).append("\n");
-        long totalWsSize = 0;
-        for(MemoryWorkspace ws : allWs){
-            totalWsSize += ws.getCurrentSize();
-            sb.append(String.format(wsFormat, ws.getId(),
-                    (ws.isScopeActive() ? "OPEN" : "CLOSED"),
-                    fBytes(ws.getCurrentSize()))).append("\n");
-        }
-        sb.append(fBytes("Workspaces total size", totalWsSize));
-
-        long sumMem = 0;
-        long nParams = net.params().length();
-        sb.append("\n----- Network Information -----\n")
-                .append(f("Network # Parameters", nParams))
-                .append(fBytes("Parameter Memory", bytesPerElement * nParams));
-        if(net.getFlattenedGradients() == null){
-            sb.append(f("Parameter Gradients Memory", "<not allocated>"));
-        } else {
-            sumMem += (net.getFlattenedGradients().length() * bytesPerElement);
-            sb.append(fBytes("Parameter Gradients Memory", bytesPerElement * net.getFlattenedGradients().length()));
-        }
-        MultiLayerUpdater u = (MultiLayerUpdater) net.getUpdater(false);
-        if(u == null){
-            sb.append(f("Updater","<not initialized>"));
-        } else {
-            INDArray stateArr = u.getStateViewArray();
-            long stateArrLength = (stateArr == null ? 0 : stateArr.length());
-            sb.append(f("Updater Number of Elements", stateArrLength));
-            sb.append(fBytes("Updater Memory", stateArrLength * bytesPerElement));
-            sumMem += stateArrLength * bytesPerElement;
-        }
-        sb.append(fBytes("Params + Gradient + Updater Memory", sumMem));
-        sb.append(f("Workspace Mode: Training", net.getLayerWiseConfigurations().getTrainingWorkspaceMode()));
-        sb.append(f("Workspace Mode: Inference", net.getLayerWiseConfigurations().getInferenceWorkspaceMode()));
-        appendLayerInformation(sb, net.getLayers());
-
-        appendActivationShapes(net, sb, bytesPerElement);
-
-        return sb.toString();
-    }
-
-    private static String f(String s1, Object o){
-        return String.format(FORMAT, s1, (o == null ? "null" : o.toString())) + "\n";
-    }
-
-    private static String fBytes(long bytes){
-        String s = StringUtils.TraditionalBinaryPrefix.long2String(bytes, "B", 2);
-        if(bytes >= 1024){
-            s += " (" + bytes + ")";
-        }
-        return s;
-    }
-
-    private static String fBytes(String s1, long bytes){
-        String s = fBytes(bytes);
-        return f(s1, s);
-    }
-
-    private static StringBuilder genericMemoryStatus(){
-
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("========== Memory Information ==========\n");
-        sb.append("----- Version Information -----\n");
-        Pair<String,String> pair = inferVersion();
-        sb.append(f("Deeplearning4j Version", (pair.getFirst() == null ? "<could not determine>" : pair.getFirst())));
-        sb.append(f("Deeplearning4j CUDA", (pair.getSecond() == null ? "<not present>" : pair.getSecond())));
-
-        sb.append("\n----- Memory - System Information -----\n");
-
-        long xmx = Runtime.getRuntime().maxMemory();
-        long jvmTotal = Runtime.getRuntime().totalMemory();
-        long javacppMaxPhys = Pointer.maxPhysicalBytes();
-        long javacppMaxBytes = Pointer.maxBytes();
-        long javacppCurrPhys = Pointer.physicalBytes();
-        long javacppCurrBytes = Pointer.totalBytes();
-        sb.append(fBytes("JVM Memory: XMX", xmx))
-                .append(fBytes("JVM Memory: current", jvmTotal))
-                .append(fBytes("JavaCPP Memory: Max Bytes", javacppMaxBytes))
-                .append(fBytes("JavaCPP Memory: Max Physical", javacppMaxPhys))
-                .append(fBytes("JavaCPP Memory: Current Bytes", javacppCurrBytes))
-                .append(fBytes("JavaCPP Memory: Current Physical", javacppCurrPhys));
-        boolean periodicGcEnabled = Nd4j.getMemoryManager().isPeriodicGcActive();
-        long autoGcWindow = Nd4j.getMemoryManager().getAutoGcWindow();
-        sb.append(f("Periodic GC Enabled", periodicGcEnabled));
-        if(periodicGcEnabled){
-            sb.append(f("Periodic GC Frequency", autoGcWindow + " ms"));
-        }
-
-
-        sb.append("\n----- ND4J Environment Information -----\n");
-        sb.append(f("Data Type", Nd4j.dataType()));
-        Properties p = Nd4j.getExecutioner().getEnvironmentInformation();
-        for(String s : p.stringPropertyNames()){
-            sb.append(f(s, p.get(s)));
-        }
-
-        return sb;
-    }
-
-    private static void appendLayerInformation(StringBuilder sb, org.deeplearning4j.nn.api.Layer[] layers){
-        Map<String,Integer> layerClasses = new HashMap<>();
-        for(org.deeplearning4j.nn.api.Layer l : layers){
-            if(!layerClasses.containsKey(l.getClass().getSimpleName())){
-                layerClasses.put(l.getClass().getSimpleName(), 0);
-            }
-            layerClasses.put(l.getClass().getSimpleName(), layerClasses.get(l.getClass().getSimpleName()) + 1);
-        }
-
-        List<String> l = new ArrayList<>(layerClasses.keySet());
-        Collections.sort(l);
-        sb.append(f("Number of Layers", layers.length));
-        sb.append("Layer Counts\n");
-        for(String s : l){
-            sb.append("  ").append(f(s, layerClasses.get(s)));
-        }
-    }
-
-    private static void appendActivationShapes(MultiLayerNetwork net, StringBuilder sb, int bytesPerElement){
-        INDArray input = net.getInput();
-        if(input == null){
-            return;
-        }
-        if(input.rank() < 2 || input.rank() > 4){
-            //TODO 3d CNN support
-            return;
-        }
-
-        sb.append("\n----- Network Activations: Inferred Activation Shapes -----\n");
-        InputType inputType = null;
-        switch (input.rank()){
-            case 2:
-                inputType = InputType.feedForward(input.size(1));
-                break;
-            case 3:
-                inputType = InputType.recurrent(input.size(1), input.size(2));
-                break;
-            case 4:
-                inputType = InputType.convolutional(input.size(2), input.size(3), input.size(1));
-                break;
-        }
-
-        sb.append(f("Current Minibatch Size", input.size(0)));
-        sb.append(f("Current Input Shape", Arrays.toString(input.shape())));
-        List<InputType> inputTypes = net.getLayerWiseConfigurations().getLayerActivationTypes(inputType);
-        String format = "%-3s %-20s %-20s %-42s %-20s %-12s %-12s";
-        sb.append(String.format(format, "Idx", "Name", "Layer Type", "Activations Type", "Activations Shape",
-                "# Elements", "Memory")).append("\n");
-        org.deeplearning4j.nn.api.Layer[] layers = net.getLayers();
-        long totalActivationBytes = 0;
-        long last = 0;
-        for( int i=0; i<inputTypes.size(); i++ ){
-            long[] shape = inputTypes.get(i).getShape(true);
-            if(shape[0] <= 0){
-                shape[0] = input.size(0);
-            }
-            long numElements = ArrayUtil.prodLong(shape);
-            long bytes = numElements*bytesPerElement;
-            totalActivationBytes += bytes;
-            sb.append(String.format(format, String.valueOf(i), layers[i].conf().getLayer().getLayerName(), layers[i].getClass().getSimpleName(),
-                    inputTypes.get(i), Arrays.toString(shape), String.valueOf(numElements), fBytes(bytes))).append("\n");
-            last = bytes;
-        }
-        sb.append(fBytes("Total Activations Memory", totalActivationBytes));
-
-        //Exclude output layer, include input
-        long totalActivationGradMem = totalActivationBytes - last + (ArrayUtil.prodLong(input.shape()) * bytesPerElement);
-        sb.append(fBytes("Total Activation Gradient Memory", totalActivationGradMem));
-
-    }
-
-    public static Pair<String,String> inferVersion(){
-        List<VersionInfo> vi = VersionCheck.getVersionInfos();
-
-        String dl4jVersion = null;
-        String dl4jCudaArtifact = null;
-        for(VersionInfo v : vi){
-            if("org.deeplearning4j".equals(v.getGroupId()) && "deeplearning4j-core".equals(v.getArtifactId())){
-                String version = v.getBuildVersion();
-                if(version.contains("SNAPSHOT")){
-                    dl4jVersion = version + " (" + v.getCommitIdAbbrev() + ")";
-                }
-                dl4jVersion = version;
-            } else if("org.deeplearning4j".equals(v.getGroupId()) && v.getArtifactId() != null && v.getArtifactId().contains("deeplearning4j-cuda")){
-                dl4jCudaArtifact = v.getArtifactId();
-            }
-
-        }
-
-        return new Pair<>(dl4jVersion, dl4jCudaArtifact);
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/NetworkUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/NetworkUtils.java
@@ -1,9 +1,11 @@
 package org.deeplearning4j.util;
 
+import org.bytedeco.javacpp.Pointer;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.BaseLayer;
 import org.deeplearning4j.nn.conf.layers.Layer;
 import org.deeplearning4j.nn.graph.ComputationGraph;
@@ -11,9 +13,18 @@ import org.deeplearning4j.nn.layers.AbstractLayer;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.updater.MultiLayerUpdater;
 import org.deeplearning4j.nn.updater.graph.ComputationGraphUpdater;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.IUpdater;
+import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.schedule.ISchedule;
+import org.nd4j.linalg.util.ArrayUtil;
+import org.nd4j.util.StringUtils;
+import org.nd4j.versioncheck.VersionCheck;
+import org.nd4j.versioncheck.VersionInfo;
+
+import java.util.*;
 
 public class NetworkUtils {
 
@@ -253,5 +264,227 @@ public class NetworkUtils {
         net.setUpdater(null);
         ComputationGraphUpdater u = net.getUpdater();
         u.setStateViewArray(origUpdaterState);
+    }
+
+
+
+    private static final String FORMAT = "%-40s%s";
+
+    public static String generateMemoryStatus(MultiLayerNetwork net){
+        StringBuilder sb = genericMemoryStatus();
+        String format = "%40s%s";
+
+        int bytesPerElement;
+        switch (Nd4j.dataType()){
+            case DOUBLE:
+                bytesPerElement = 8;
+                break;
+            case FLOAT:
+                bytesPerElement = 4;
+                break;
+            case HALF:
+                bytesPerElement = 2;
+                break;
+            default:
+                bytesPerElement = 0;    //TODO
+        }
+
+        sb.append("----- Workspace Information -----\n");
+        List<MemoryWorkspace> allWs = Nd4j.getWorkspaceManager().getAllWorkspacesForCurrentThread();
+        sb.append(f("Workspaces: # for current thread", allWs.size()));
+        //sb.append(f("Workspaces: # for all threads", allWs.size()));      //TODO
+        sb.append("Current thread workspaces:\n");
+        //Name, open, size, currently allocated
+        String wsFormat = "  %-30s%-20s%-20s";
+        sb.append(String.format(wsFormat, "Name", "State", "Size")).append("\n");
+        long totalWsSize = 0;
+        for(MemoryWorkspace ws : allWs){
+            totalWsSize += ws.getCurrentSize();
+            sb.append(String.format(wsFormat, ws.getId(),
+                    (ws.isScopeActive() ? "OPEN" : "CLOSED"),
+                    fBytes(ws.getCurrentSize()))).append("\n");
+        }
+        sb.append(fBytes("Workspaces total size", totalWsSize));
+
+        long sumMem = 0;
+        long nParams = net.params().length();
+        sb.append("\n----- Network Information -----\n")
+                .append(f("Network # Parameters", nParams))
+                .append(fBytes("Parameter Memory", bytesPerElement * nParams));
+        if(net.getFlattenedGradients() == null){
+            sb.append(f("Parameter Gradients Memory", "<not allocated>"));
+        } else {
+            sumMem += (net.getFlattenedGradients().length() * bytesPerElement);
+            sb.append(fBytes("Parameter Gradients Memory", bytesPerElement * net.getFlattenedGradients().length()));
+        }
+        MultiLayerUpdater u = (MultiLayerUpdater) net.getUpdater(false);
+        if(u == null){
+            sb.append(f("Updater","<not initialized>"));
+        } else {
+            INDArray stateArr = u.getStateViewArray();
+            long stateArrLength = (stateArr == null ? 0 : stateArr.length());
+            sb.append(f("Updater Number of Elements", stateArrLength));
+            sb.append(fBytes("Updater Memory", stateArrLength * bytesPerElement));
+            sumMem += stateArrLength * bytesPerElement;
+        }
+        sb.append(fBytes("Params + Gradient + Updater Memory", sumMem));
+        sb.append(f("Workspace Mode: Training", net.getLayerWiseConfigurations().getTrainingWorkspaceMode()));
+        sb.append(f("Workspace Mode: Inference", net.getLayerWiseConfigurations().getInferenceWorkspaceMode()));
+        appendLayerInformation(sb, net.getLayers());
+
+        appendActivationShapes(net, sb, bytesPerElement);
+
+        return sb.toString();
+    }
+
+    private static String f(String s1, Object o){
+        return String.format(FORMAT, s1, (o == null ? "null" : o.toString())) + "\n";
+    }
+
+    private static String fBytes(long bytes){
+        String s = StringUtils.TraditionalBinaryPrefix.long2String(bytes, "B", 2);
+        if(bytes >= 1024){
+            s += " (" + bytes + ")";
+        }
+        return s;
+    }
+
+    private static String fBytes(String s1, long bytes){
+        String s = fBytes(bytes);
+        return f(s1, s);
+    }
+
+    private static StringBuilder genericMemoryStatus(){
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("========== Memory Information ==========\n");
+        sb.append("----- Version Information -----\n");
+        Pair<String,String> pair = inferVersion();
+        sb.append(f("Deeplearning4j Version", (pair.getFirst() == null ? "<could not determine>" : pair.getFirst())));
+        sb.append(f("Deeplearning4j CUDA", (pair.getSecond() == null ? "<not present>" : pair.getSecond())));
+
+        sb.append("\n----- Memory - System Information -----\n");
+
+        long xmx = Runtime.getRuntime().maxMemory();
+        long jvmTotal = Runtime.getRuntime().totalMemory();
+        long javacppMaxPhys = Pointer.maxPhysicalBytes();
+        long javacppMaxBytes = Pointer.maxBytes();
+        long javacppCurrPhys = Pointer.physicalBytes();
+        long javacppCurrBytes = Pointer.totalBytes();
+        sb.append(fBytes("JVM Memory: XMX", xmx))
+                .append(fBytes("JVM Memory: current", jvmTotal))
+                .append(fBytes("JavaCPP Memory: Max Bytes", javacppMaxBytes))
+                .append(fBytes("JavaCPP Memory: Max Physical", javacppMaxPhys))
+                .append(fBytes("JavaCPP Memory: Current Bytes", javacppCurrBytes))
+                .append(fBytes("JavaCPP Memory: Current Physical", javacppCurrPhys));
+        boolean periodicGcEnabled = Nd4j.getMemoryManager().isPeriodicGcActive();
+        long autoGcWindow = Nd4j.getMemoryManager().getAutoGcWindow();
+        sb.append(f("Periodic GC Enabled", periodicGcEnabled));
+        if(periodicGcEnabled){
+            sb.append(f("Periodic GC Frequency", autoGcWindow + " ms"));
+        }
+
+
+        sb.append("\n----- ND4J Environment Information -----\n");
+        sb.append(f("Data Type", Nd4j.dataType()));
+        Properties p = Nd4j.getExecutioner().getEnvironmentInformation();
+        for(String s : p.stringPropertyNames()){
+            sb.append(f(s, p.get(s)));
+        }
+
+        return sb;
+    }
+
+    private static void appendLayerInformation(StringBuilder sb, org.deeplearning4j.nn.api.Layer[] layers){
+        Map<String,Integer> layerClasses = new HashMap<>();
+        for(org.deeplearning4j.nn.api.Layer l : layers){
+            if(!layerClasses.containsKey(l.getClass().getSimpleName())){
+                layerClasses.put(l.getClass().getSimpleName(), 0);
+            }
+            layerClasses.put(l.getClass().getSimpleName(), layerClasses.get(l.getClass().getSimpleName()) + 1);
+        }
+
+        List<String> l = new ArrayList<>(layerClasses.keySet());
+        Collections.sort(l);
+        sb.append(f("Number of Layers", layers.length));
+        sb.append("Layer Counts\n");
+        for(String s : l){
+            sb.append("  ").append(f(s, layerClasses.get(s)));
+        }
+    }
+
+    private static void appendActivationShapes(MultiLayerNetwork net, StringBuilder sb, int bytesPerElement){
+        INDArray input = net.getInput();
+        if(input == null){
+            return;
+        }
+        if(input.rank() < 2 || input.rank() > 4){
+            //TODO 3d CNN support
+            return;
+        }
+
+        sb.append("\n----- Network Activations: Inferred Activation Shapes -----\n");
+        InputType inputType = null;
+        switch (input.rank()){
+            case 2:
+                inputType = InputType.feedForward(input.size(1));
+                break;
+            case 3:
+                inputType = InputType.recurrent(input.size(1), input.size(2));
+                break;
+            case 4:
+                inputType = InputType.convolutional(input.size(2), input.size(3), input.size(1));
+                break;
+        }
+
+        sb.append(f("Current Minibatch Size", input.size(0)));
+        sb.append(f("Current Input Shape", Arrays.toString(input.shape())));
+        List<InputType> inputTypes = net.getLayerWiseConfigurations().getLayerActivationTypes(inputType);
+        String format = "%-3s %-20s %-20s %-42s %-20s %-12s %-12s";
+        sb.append(String.format(format, "Idx", "Name", "Layer Type", "Activations Type", "Activations Shape",
+                "# Elements", "Memory")).append("\n");
+        org.deeplearning4j.nn.api.Layer[] layers = net.getLayers();
+        long totalActivationBytes = 0;
+        long last = 0;
+        for( int i=0; i<inputTypes.size(); i++ ){
+            long[] shape = inputTypes.get(i).getShape(true);
+            if(shape[0] <= 0){
+                shape[0] = input.size(0);
+            }
+            long numElements = ArrayUtil.prodLong(shape);
+            long bytes = numElements*bytesPerElement;
+            totalActivationBytes += bytes;
+            sb.append(String.format(format, String.valueOf(i), layers[i].conf().getLayer().getLayerName(), layers[i].getClass().getSimpleName(),
+                    inputTypes.get(i), Arrays.toString(shape), String.valueOf(numElements), fBytes(bytes))).append("\n");
+            last = bytes;
+        }
+        sb.append(fBytes("Total Activations Memory", totalActivationBytes));
+
+        //Exclude output layer, include input
+        long totalActivationGradMem = totalActivationBytes - last + (ArrayUtil.prodLong(input.shape()) * bytesPerElement);
+        sb.append(fBytes("Total Activation Gradient Memory", totalActivationGradMem));
+
+    }
+
+    public static Pair<String,String> inferVersion(){
+        List<VersionInfo> vi = VersionCheck.getVersionInfos();
+
+        String dl4jVersion = null;
+        String dl4jCudaArtifact = null;
+        for(VersionInfo v : vi){
+            if("org.deeplearning4j".equals(v.getGroupId()) && "deeplearning4j-core".equals(v.getArtifactId())){
+                String version = v.getBuildVersion();
+                if(version.contains("SNAPSHOT")){
+                    dl4jVersion = version + " (" + v.getCommitIdAbbrev() + ")";
+                }
+                dl4jVersion = version;
+            } else if("org.deeplearning4j".equals(v.getGroupId()) && v.getArtifactId() != null && v.getArtifactId().contains("deeplearning4j-cuda")){
+                dl4jCudaArtifact = v.getArtifactId();
+            }
+
+        }
+
+        return new Pair<>(dl4jVersion, dl4jCudaArtifact);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/5535

The basic idea: when DL4J (MLN and CG specifically) OOMs during training or inference, write an info dump to aid in understanding why, debugging and improving memory config and/or network config.


Output (real-world ResNet50 OOM)
https://gist.github.com/AlexDBlack/c605a01dd20300e753dadd7296df6252

Logged on OOM:
(Note this will by default be written to the current working directory (path here is for unit test))
```
o.d.u.CrashReportingUtil - >>> Out of Memory Exception Detected. Memory crash dump written to: C:\Users\Alex\AppData\Local\Temp\junit7109276185443170604\junit1948375717567978708\dl4j-memory-crash-dump-1528686384749_1.txt
o.d.u.CrashReportingUtil - Memory crash dump reporting can be disabled with CrashUtil.crashDumpsEnabled(false) or using system property -Dorg.deeplearning4j.crash.reporting.enabled=false
o.d.u.CrashReportingUtil - Memory crash dump reporting output location CrashUtil.crashDumpOutputDirectory(File) or using system property -Dorg.deeplearning4j.crash.reporting.directory=<path>
```

Remaining improvements I want to make - but I think I will merge it now, and do a second pass at a later date.
1. Where appropriate, add memory use info for async iterator (maybe unnecessary with (3))
2. Add basic information/explanation to crash dump; add link to DL4J memory page
3. Add info about workspaces used in other threads
