### PR TITLE
Add gcc/g++ path workaround for libnd4j tests on linux

### DIFF
--- a/libnd4j/tests_cpu/run_tests.sh
+++ b/libnd4j/tests_cpu/run_tests.sh
@@ -12,6 +12,9 @@ fi
 if [[ "$OSTYPE" == "darwin"* ]]; then
     export CC=$(ls -1 /usr/local/bin/gcc-? | head -n 1)
     export CXX=$(ls -1 /usr/local/bin/g++-? | head -n 1)
+elif [[ "$OSTYPE" == "linux-gnu" ]]; then
+    export CC=$(which gcc)
+    export CXX=$(which g++)
 fi
 
 parse_commandline ()


### PR DESCRIPTION
This changes have been requested by libnd4j team as temp workaround for tests run.