### PR TITLE
Fixed label mask index in computeGradientAndScore

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1396,7 +1396,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                 if (vertexLayer instanceof FrozenLayerWithBackprop) {
                     vertexLayer = ((FrozenLayerWithBackprop) vertexLayer).getInsideLayer();
                 }
-                vertexLayer.setMaskArray((labelMaskArrays == null) ? null : labelMaskArrays[outNum++]);
+                vertexLayer.setMaskArray((labelMaskArrays == null) ? null : labelMaskArrays[outNum]);
 
                 try(MemoryWorkspace ws = workspaceMgr.notifyScopeEntered(ArrayType.FF_WORKING_MEM)) {
                     score += ((IOutputLayer) vertexLayer).computeScore(l1, l2, true, workspaceMgr);


### PR DESCRIPTION
I am using a `ComputationGraph` configuration with two outputs and a `MultiDataSetIterator` with two outputs and two output masks. During training, `computeGradientAndScore()` fails because the mask is accessed with a wrong index (2 instead of 1). 

```
14.06.18 11:50:30 [main] WARN  o.d.e.t.BaseEarlyStoppingTrainer:118 Early stopping training terminated due to exception at epoch 0, iteration 0
java.lang.ArrayIndexOutOfBoundsException: 2
	at org.deeplearning4j.nn.graph.ComputationGraph.computeGradientAndScore(ComputationGraph.java:1335) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.nn.graph.ComputationGraph.computeGradientAndScore(ComputationGraph.java:1280) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.optimize.solvers.BaseOptimizer.gradientAndScore(BaseOptimizer.java:178) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.optimize.solvers.StochasticGradientDescent.optimize(StochasticGradientDescent.java:60) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.optimize.Solver.optimize(Solver.java:54) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.nn.graph.ComputationGraph.fit(ComputationGraph.java:1104) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.nn.graph.ComputationGraph.fit(ComputationGraph.java:985) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.earlystopping.trainer.EarlyStoppingGraphTrainer.fit(EarlyStoppingGraphTrainer.java:80) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
	at org.deeplearning4j.earlystopping.trainer.BaseEarlyStoppingTrainer.fit(BaseEarlyStoppingTrainer.java:116) ~[deeplearning4j-nn-1.0.0-beta.jar:na]
```

In `computeGradientAndScore()`, `outNum` is incremented twice in the case of multiple output masks (line 1399 and 1408). This is an easy fix that corrects this error with no side effects, because `outNum` is solely used to access output masks.