### PR TITLE
Optimize summarized array formatting.

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/string/NDArrayStrings.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/string/NDArrayStrings.java
@@ -151,14 +151,15 @@ public class NDArrayStrings {
             offset++;
             StringBuilder sb = new StringBuilder();
             sb.append("[");
-            for (int i = 0; i < arr.slices(); i++) {
-                if (summarize && i > 2 && i < arr.slices() - 3) {
-                    if (i == 3) {
-                        sb.append(" ...");
-                        sb.append(newLineSep + " \n");
-                        sb.append(StringUtils.repeat("\n", rank - 2));
-                        sb.append(StringUtils.repeat(" ", offset));
-                    }
+            long nSlices = arr.slices();
+            for (int i = 0; i < nSlices; i++) {
+                if (summarize && i > 2 && i < nSlices - 3) {
+                    sb.append(" ...");
+                    sb.append(newLineSep).append(" \n");
+                    sb.append(StringUtils.repeat("\n", rank - 2));
+                    sb.append(StringUtils.repeat(" ", offset));
+                    // immediately jump to the last slices so we only print ellipsis once
+                    i = Math.max(i, (int) nSlices - 4);
                 } else {
                     if (arr.rank() == 3 && arr.slice(i).isRowVector()) sb.append("[");
                     //hack fix for slice issue with 'f' order
@@ -170,9 +171,9 @@ public class NDArrayStrings {
                     else {
                         sb.append(format(arr.slice(i), offset, summarize));
                     }
-                    if (i != arr.slices() - 1) {
+                    if (i != nSlices - 1) {
                         if (arr.rank() == 3 && arr.slice(i).isRowVector()) sb.append("]");
-                        sb.append(newLineSep + " \n");
+                        sb.append(newLineSep).append(" \n");
                         sb.append(StringUtils.repeat("\n", rank - 2));
                         sb.append(StringUtils.repeat(" ", offset));
                     } else {
@@ -188,12 +189,15 @@ public class NDArrayStrings {
     private String vectorToString(INDArray arr, boolean summarize) {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
-        for (int i = 0; i < arr.length(); i++) {
+        long l = arr.length();
+        for (int i = 0; i <l; i++) {
             if (arr instanceof IComplexNDArray) {
                 sb.append(((IComplexNDArray) arr).getComplex(i).toString());
             } else {
-                if (summarize && i > 2 && i < arr.length() - 3) {
-                    if (i == 3) sb.append("  ...");
+                if (summarize && i > 2 && i < l - 3) {
+                    sb.append("  ...");
+                    // immediately jump to the last elements so we only print ellipsis once
+                    i = Math.max(i, (int) l - 4);
                 } else {
                     double arrElement = arr.getDouble(i);
                     if (!dontOverrideFormat && ((Math.abs(arrElement) < this.minToPrintWithoutSwitching && arrElement!= 0) || (Math.abs(arrElement) >= this.maxToPrintWithoutSwitching))) {
@@ -213,8 +217,8 @@ public class NDArrayStrings {
                     }
                 }
             }
-            if (i < arr.length() - 1) {
-                if (!summarize || i < 2 || i > arr.length() - 3 || (summarize && arr.length() == 6)) {
+            if (i < l - 1) {
+                if (!summarize || i < 2 || i > l - 3 || (summarize && l == 6)) {
                     sb.append(colSep);
                 }
             }


### PR DESCRIPTION
Dear Maintainers, please accept this PR that optimizes formatting of large arrays.

Currently, there are a couple of issues with the formatting of large NDArrays.

- INDArray.slices() is called _at least_ once per element in the array. This operation is *not* zero cost.
- When summarizing, all elements between `[4, array.length() - 3]` are looped over without being used for anything, but still causes evaluation of 2 if statements pr iteration.

Poor `INDArray.toString` performance is a major issue when using a debugger that automatically shows the local variable scope and their `toString` output.
Effectively, this means I cannot debug when working with very large arrays.

This PR fixes the 2 issues describe above by:

- setting the result of `array.slice()` to a variable that is reused in the loop.
- Jumping directly from element 4 to element l - 4 rather than looping over the unused elements in between.
