### PR TITLE
Use long[] arrays for shape in sparse ndarrays

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
@@ -27,7 +27,6 @@ import org.nd4j.linalg.indexing.conditions.Condition;
 import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.util.LinAlgExceptions;
 
-import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -326,14 +325,14 @@ public abstract class BaseSparseNDArray implements ISparseNDArray {
         return length;
     }
 
-    protected void init(int[] shape) {
+    protected void init(long[] shape) {
 
         if (shape.length == 1) {
             rows = 1;
-            columns = shape[0];
+            columns = (int) shape[0];
         } else if (this.shape().length == 2) {
-            rows = shape[0];
-            columns = shape[1];
+            rows = (int) shape[0];
+            columns = (int) shape[1];
         }
         rank = shape.length;
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArrayCOO.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArrayCOO.java
@@ -42,7 +42,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
     protected transient volatile boolean isSorted = false;
 
 
-    public BaseSparseNDArrayCOO(double[] values, int[][] indices, int[] shape) {
+    public BaseSparseNDArrayCOO(double[] values, int[][] indices, long[] shape) {
 
         checkNotNull(values);
         checkNotNull(indices);
@@ -84,7 +84,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
 
     }
 
-    public BaseSparseNDArrayCOO(DataBuffer values, DataBuffer indices, int[] shape) {
+    public BaseSparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] shape) {
         checkArgument(values.length() * shape.length == indices.length());
 
         this.values = Nd4j.createBuffer(values, 0, values.length());
@@ -100,7 +100,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
 
     }
 
-    public BaseSparseNDArrayCOO(float[] values, int[][] indices, int[] shape) {
+    public BaseSparseNDArrayCOO(float[] values, int[][] indices, long[] shape) {
         checkArgument(values.length == indices.length);
         checkArgument(values.length == 0 || indices[0].length == shape.length);
 
@@ -116,7 +116,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
                         hiddenDimension, rank());
     }
 
-    public BaseSparseNDArrayCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape) {
+    public BaseSparseNDArrayCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape) {
         this.values = Nd4j.createBuffer(values, 0, values.length());
         this.indices = indices;
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape));
@@ -127,7 +127,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
     }
 
     public BaseSparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags,
-                    int[] hiddenDimensions, int underlyingRank, int[] shape) {
+                                int[] hiddenDimensions, int underlyingRank, long[] shape) {
         this(values, indices, Nd4j.getSparseInfoProvider().createSparseInformation(flags, sparseOffsets,
                         hiddenDimensions, underlyingRank), shape);
     }
@@ -510,7 +510,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
             throw new IllegalStateException("Invalid index found of zero length");
 
         // FIXME: LONG
-        int[] shape = LongUtils.toInts(resolution.getShapes());
+        long[] shape = resolution.getShapes();
         int numSpecifiedIndex = 0;
 
         for (int i = 0; i < indexes.length; i++)
@@ -886,7 +886,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
     @Override
     public INDArray subArray(ShapeOffsetResolution resolution) {
         long[] offsets = resolution.getOffsets();
-        int[] shape = LongUtils.toInts(resolution.getShapes());
+        long[] shape = resolution.getShapes();
         int[] stride = LongUtils.toInts(resolution.getStrides());
         int[] flags = resolution.getFixed();
         flags = updateFlags(flags, shape);
@@ -987,7 +987,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
     * @param viewFlags the Fixed array calculate within the view
     * @param newShape the shape of the view
     * */
-    private int[] updateFlags(int[] viewFlags, int[] newShape) {
+    private int[] updateFlags(int[] viewFlags, long[] newShape) {
         // Check if flags is well-formed
         int count = 0;
         for (int i = 0; i < viewFlags.length; i++) {
@@ -1019,7 +1019,7 @@ public class BaseSparseNDArrayCOO extends BaseSparseNDArray {
         return extendedFlags;
     }
 
-    private INDArray create(DataBuffer values, DataBuffer indices, DataBuffer sparseInfo, int[] newShape) {
+    private INDArray create(DataBuffer values, DataBuffer indices, DataBuffer sparseInfo, long[] newShape) {
         return Nd4j.createSparseCOO(values, indices, sparseInfo, newShape);
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArrayCSR.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArrayCSR.java
@@ -31,12 +31,12 @@ public abstract class BaseSparseNDArrayCSR extends BaseSparseNDArray {
      * @param columnsPointers Element i of the integer array columns is the number of the column in A that contains the i-th value
      *                in the values array.
      * @param pointerB Element j of this integer array gives the index of the element in the values array that is first
-     *                 non-zero element in a row j of A. Note that this index is equal to pointerB(j) - pointerB(1)+1 .
+ *                 non-zero element in a row j of A. Note that this index is equal to pointerB(j) - pointerB(1)+1 .
      * @param pointerE An integer array that contains row indices, such that pointerE(j)-pointerB(1) is the index of the
-     *                 element in the values array that is last non-zero element in a row j of A.
+*                 element in the values array that is last non-zero element in a row j of A.
      * @param shape Shape of the matrix A
      */
-    public BaseSparseNDArrayCSR(double[] data, int[] columnsPointers, int[] pointerB, int[] pointerE, int[] shape) {
+    public BaseSparseNDArrayCSR(double[] data, int[] columnsPointers, int[] pointerB, int[] pointerE, long[] shape) {
         checkArgument(data.length == columnsPointers.length);
         checkArgument(pointerB.length == pointerE.length);
         // TODO
@@ -57,11 +57,11 @@ public abstract class BaseSparseNDArrayCSR extends BaseSparseNDArray {
 
     }
 
-    public BaseSparseNDArrayCSR(float[] data, int[] columnsPointers, int[] pointerB, int[] pointerE, int[] shape) {
+    public BaseSparseNDArrayCSR(float[] data, int[] columnsPointers, int[] pointerB, int[] pointerE, long[] shape) {
         this(Nd4j.createBuffer(data), columnsPointers, pointerB, pointerE, shape);
     }
 
-    public BaseSparseNDArrayCSR(DataBuffer data, int[] columnsPointers, int[] pointerB, int[] pointerE, int[] shape) {
+    public BaseSparseNDArrayCSR(DataBuffer data, int[] columnsPointers, int[] pointerB, int[] pointerE, long[] shape) {
         checkArgument(pointerB.length == pointerE.length);
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape));
         init(shape);
@@ -230,7 +230,7 @@ public abstract class BaseSparseNDArrayCSR extends BaseSparseNDArray {
     public INDArray subArray(ShapeOffsetResolution resolution) {
 
         long[] offsets = resolution.getOffsets();
-        int[] shape = LongUtils.toInts(resolution.getShapes());
+        long[] shape = resolution.getShapes();
 
 
         List<Integer> accuColumns = new ArrayList<>();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
@@ -31,7 +31,6 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 
 import java.io.File;
-import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -1928,21 +1927,21 @@ public interface NDArrayFactory {
 
     // =========== Sparse methods ===========
 
-    INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape);
+    INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape);
 
-    INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape);
+    INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape);
 
-    INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, int[] shape);
+    INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, long[] shape);
 
-    INDArray createSparseCOO(double[] values, int[][] indices, int[] shape);
+    INDArray createSparseCOO(double[] values, int[][] indices, long[] shape);
 
-    INDArray createSparseCOO(float[] values, int[][] indices, int[] shape);
+    INDArray createSparseCOO(float[] values, int[][] indices, long[] shape);
 
-    INDArray createSparseCOO(DataBuffer values, DataBuffer indices, int[] shape);
+    INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] shape);
 
-    INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape);
+    INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape);
 
     INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags,
-                    int[] hiddenDimensions, int underlyingRank, int[] shape);
+                             int[] hiddenDimensions, int underlyingRank, long[] shape);
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -58,7 +58,6 @@ import org.nd4j.linalg.api.ops.executioner.DefaultOpExecutioner;
 import org.nd4j.linalg.api.ops.executioner.OpExecutioner;
 import org.nd4j.linalg.api.ops.factory.DefaultOpFactory;
 import org.nd4j.linalg.api.ops.factory.OpFactory;
-import org.nd4j.linalg.api.ops.impl.controlflow.Select;
 import org.nd4j.linalg.api.ops.impl.indexaccum.IMax;
 import org.nd4j.linalg.api.ops.impl.shape.Diag;
 import org.nd4j.linalg.api.ops.impl.transforms.OldReverse;
@@ -84,7 +83,6 @@ import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4jBackend.NoAvailableBackendException;
 import org.nd4j.linalg.memory.BasicMemoryManager;
 import org.nd4j.linalg.memory.MemoryManager;
-import org.nd4j.linalg.ops.transforms.Transforms;
 import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.string.NDArrayStrings;
 import org.nd4j.linalg.util.ArrayUtil;
@@ -5747,7 +5745,7 @@ public class Nd4j {
      * @param shape
      * @return a INDArray
      * */
-    public static INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public static INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCSR(data, columns, pointerB, pointerE, shape);
 
         return matrix;
@@ -5761,7 +5759,7 @@ public class Nd4j {
      * @param shape
      * @return a INDArray
      * */
-    public static INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public static INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCSR(data, columns, pointerB, pointerE, shape);
 
         return matrix;
@@ -5776,23 +5774,18 @@ public class Nd4j {
      * @return a INDArray
      * */
     public static INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE,
-                                           int[] shape) {
+                                           long[] shape) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCSR(data, columns, pointerB, pointerE, shape);
 
         return matrix;
     }
-
+    /**
+     * @param data
+     * @param indices
+     * @param shape
+     * @return a INDArray
+     * */
     public static INDArray createSparseCOO(double[] data, int[][] indices, long[] shape) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * @param data
-     * @param indices
-     * @param shape
-     * @return a INDArray
-     * */
-    public static INDArray createSparseCOO(double[] data, int[][] indices, int[] shape) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCOO(data, indices, shape);
 
         return matrix;
@@ -5804,7 +5797,7 @@ public class Nd4j {
      * @param shape
      * @return a INDArray
      * */
-    public static INDArray createSparseCOO(float[] data, int[][] indices, int[] shape) {
+    public static INDArray createSparseCOO(float[] data, int[][] indices, long[] shape) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCOO(data, indices, shape);
 
         return matrix;
@@ -5816,7 +5809,7 @@ public class Nd4j {
      * @param shape
      * @return a INDArray
      * */
-    public static INDArray createSparseCOO(DataBuffer data, DataBuffer indices, int[] shape) {
+    public static INDArray createSparseCOO(DataBuffer data, DataBuffer indices, long[] shape) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCOO(data, indices, shape);
 
         return matrix;
@@ -5830,7 +5823,7 @@ public class Nd4j {
      * @return a INDArray
      * */
     public static INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation,
-                                           int[] shape) {
+                                           long[] shape) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCOO(values, indices, sparseInformation, shape);
         return matrix;
     }
@@ -5840,13 +5833,13 @@ public class Nd4j {
      * @param indices a DataBuffer with the indexes of the values
      * @param sparseOffsets the sparse
      * @param flags an array that define the inactive dimension
+     * @param shape
      * @param hiddenDimensions an array containing the position of the hidden dimensions
      * @param underlyingRank the rank of the original ndarray
-     * @param shape
      * @return a INDArray
      * */
     public static INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags,
-                                           int[] shape, int[] hiddenDimensions, int underlyingRank) {
+                                           long[] shape, int[] hiddenDimensions, int underlyingRank) {
         INDArray matrix = SPARSE_INSTANCE.createSparseCOO(values, indices, sparseOffsets, flags, hiddenDimensions,
                 underlyingRank, shape);
         return matrix;

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -1846,42 +1846,42 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     @Override
-    public INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(double[] values, int[][] indices, int[] shape) {
+    public INDArray createSparseCOO(double[] values, int[][] indices, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(float[] values, int[][] indices, int[] shape) {
+    public INDArray createSparseCOO(float[] values, int[][] indices, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, long[] shape) {
         throw new UnsupportedOperationException();
     }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayCOO.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayCOO.java
@@ -8,23 +8,23 @@ import org.nd4j.linalg.api.ndarray.BaseSparseNDArrayCOO;
  */
 public class JCusparseNDArrayCOO extends BaseSparseNDArrayCOO {
 
-    public JCusparseNDArrayCOO(double[] values, int[][] indices, int[] shape) {
+    public JCusparseNDArrayCOO(double[] values, int[][] indices, long[] shape) {
         super(values, indices, shape);
     }
 
-    public JCusparseNDArrayCOO(DataBuffer values, DataBuffer indices, int[] shape) {
+    public JCusparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] shape) {
         super(values, indices, shape);
     }
 
-    public JCusparseNDArrayCOO(float[] values, int[][] indices, int[] shape) {
+    public JCusparseNDArrayCOO(float[] values, int[][] indices, long[] shape) {
         super(values, indices, shape);
     }
 
-    public JCusparseNDArrayCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape) {
+    public JCusparseNDArrayCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape) {
         super(values, indices, sparseInformation, shape);
     }
 
-    public JCusparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, int[] shape) {
+    public JCusparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, long[] shape) {
         super(values, indices, sparseOffsets, flags, hiddenDimensions, underlyingRank, shape);
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayFactory.java
@@ -501,42 +501,42 @@ public class JCusparseNDArrayFactory extends BaseSparseNDArrayFactory{
     }
 
     @Override
-    public ISparseNDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public ISparseNDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         return new JcusparseNDArrayCSR(data, columns, pointerB, pointerE, shape);
     }
 
     @Override
-    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(double[] values, int[][] indices, int[] shape) {
+    public INDArray createSparseCOO(double[] values, int[][] indices, long[] shape) {
         return new JCusparseNDArrayCOO(values, indices, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(float[] values, int[][] indices, int[] shape) {
+    public INDArray createSparseCOO(float[] values, int[][] indices, long[] shape) {
         return new JCusparseNDArrayCOO(values, indices, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] shape) {
         return new JCusparseNDArrayCOO(values, indices, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape) {
         return new JCusparseNDArrayCOO(values, indices, sparseInformation, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, long[] shape) {
         return new JCusparseNDArrayCOO(values, indices, sparseOffsets, flags, hiddenDimensions, underlyingRank, shape);
     }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JcusparseNDArrayCSR.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JcusparseNDArrayCSR.java
@@ -10,7 +10,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  */
 public class JcusparseNDArrayCSR extends BaseSparseNDArrayCSR {
 
-    public JcusparseNDArrayCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public JcusparseNDArrayCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         super(data, columns, pointerB, pointerE, shape);
     }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -1439,43 +1439,43 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
     }
 
     @Override
-    public INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(double[] values, int[][] indices, int[] shape) {
+    public INDArray createSparseCOO(double[] values, int[][] indices, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(float[] values, int[][] indices, int[] shape) {
+    public INDArray createSparseCOO(float[] values, int[][] indices, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape) {
         throw new UnsupportedOperationException();
     }
 
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, long[] shape) {
         throw new UnsupportedOperationException();
     }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuSparseNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuSparseNDArrayFactory.java
@@ -35,40 +35,40 @@ public class CpuSparseNDArrayFactory extends BaseSparseNDArrayFactory {
     public CpuSparseNDArrayFactory(){}
 
     @Override
-    public INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape){
+    public INDArray createSparseCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape){
         return new SparseNDArrayCSR(data, columns, pointerB, pointerE, shape);
     }
     @Override
-    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape){
+    public INDArray createSparseCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape){
         return new SparseNDArrayCSR(data, columns, pointerB, pointerE, shape);
     }
     @Override
-    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, int[] shape){
+    public INDArray createSparseCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, long[] shape){
         return new SparseNDArrayCSR(data, columns, pointerB, pointerE, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(double[] values, int[][] indices, int[] shape){
+    public INDArray createSparseCOO(double[] values, int[][] indices, long[] shape){
         return new SparseNDArrayCOO(values, indices, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(float[] values, int[][] indices, int[] shape){
+    public INDArray createSparseCOO(float[] values, int[][] indices, long[] shape){
         return new SparseNDArrayCOO(values, indices, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, int[] shape){
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] shape){
         return new SparseNDArrayCOO(values, indices, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, long[] shape) {
         return new SparseNDArrayCOO(values, indices, sparseOffsets, flags, hiddenDimensions, underlyingRank, shape);
     }
 
     @Override
-    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape) {
+    public INDArray createSparseCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape) {
         return new SparseNDArrayCOO(values, indices, sparseInformation, shape);
     }
     //  TODO ->

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/SparseNDArrayCOO.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/SparseNDArrayCOO.java
@@ -7,23 +7,23 @@ import org.nd4j.linalg.api.ndarray.BaseSparseNDArrayCOO;
  * @author Audrey Loeffel
  */
 public class SparseNDArrayCOO extends BaseSparseNDArrayCOO {
-    public SparseNDArrayCOO(double[] values, int[][] indices, int[] shape){
+    public SparseNDArrayCOO(double[] values, int[][] indices, long[] shape){
         super(values, indices, shape);
     }
 
-    public SparseNDArrayCOO(DataBuffer values, DataBuffer indices, int[] shape){
+    public SparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] shape){
         super(values, indices, shape);
     }
 
-    public SparseNDArrayCOO(float[] values, int[][] indices, int[] shape) {
+    public SparseNDArrayCOO(float[] values, int[][] indices, long[] shape) {
         super(values, indices, shape);
     }
 
-    public SparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, int[] shape){
+    public SparseNDArrayCOO(DataBuffer values, DataBuffer indices, long[] sparseOffsets, int[] flags, int[] hiddenDimensions, int underlyingRank, long[] shape){
         super(values, indices, sparseOffsets, flags, hiddenDimensions, underlyingRank, shape);
     }
 
-    public SparseNDArrayCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, int[] shape) {
+    public SparseNDArrayCOO(DataBuffer values, DataBuffer indices, DataBuffer sparseInformation, long[] shape) {
         super(values, indices, sparseInformation, shape);
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/SparseNDArrayCSR.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/SparseNDArrayCSR.java
@@ -26,17 +26,17 @@ public class SparseNDArrayCSR extends BaseSparseNDArrayCSR {
  * @param pointerE An integer array that contains row indices, such that pointerE(j)-pointerB(1) is the index of the
  *                 element in the values array that is last non-zero element in a row j of A.
  * @param shape Shape of the matrix A
-*/
-    public SparseNDArrayCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+ */
+    public SparseNDArrayCSR(double[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
 
         super(data, columns, pointerB, pointerE, shape);
     }
-    public SparseNDArrayCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public SparseNDArrayCSR(float[] data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
 
         super(data, columns, pointerB, pointerE, shape);
     }
 
-    public SparseNDArrayCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, int[] shape) {
+    public SparseNDArrayCSR(DataBuffer data, int[] columns, int[] pointerB, int[] pointerE, long[] shape) {
 
         super(data, columns, pointerB, pointerE, shape);
     }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/SparseNDArrayCOOTest.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/SparseNDArrayCOOTest.java
@@ -35,14 +35,14 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldPutScalar() {
-        INDArray sparse = Nd4j.createSparseCOO(new double[] {1, 2}, new int[][] {{0, 0}, {0, 2}}, new int[] {1, 3});
+        INDArray sparse = Nd4j.createSparseCOO(new double[] {1, 2}, new int[][] {{0, 0}, {0, 2}}, new long[] {1, 3});
         sparse.putScalar(1, 3);
 
     }
 
     @Test
     public void shouldntPutZero() {
-        INDArray sparse = Nd4j.createSparseCOO(new double[] {1, 2}, new int[][] {{0, 0}, {0, 2}}, new int[] {1, 3});
+        INDArray sparse = Nd4j.createSparseCOO(new double[] {1, 2}, new int[][] {{0, 0}, {0, 2}}, new long[] {1, 3});
         int oldNNZ = sparse.nnz();
         sparse.putScalar(1, 0);
         assertArrayEquals(new int[] {0, 2}, sparse.getVectorCoordinates().asInt());
@@ -52,7 +52,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldRemoveZero() {
-        INDArray sparse = Nd4j.createSparseCOO(new double[] {1, 2}, new int[][] {{0, 0}, {0, 2}}, new int[] {1, 3});
+        INDArray sparse = Nd4j.createSparseCOO(new double[] {1, 2}, new int[][] {{0, 0}, {0, 2}}, new long[] {1, 3});
         sparse.putScalar(0, 0);
         assertArrayEquals(new int[] {2}, sparse.getVectorCoordinates().asInt());
     }
@@ -67,7 +67,7 @@ public class SparseNDArrayCOOTest {
         // test with sparse :
         double[] values = {1, 2, 3, 4};
         int[][] indices = {{0, 3}, {1, 2}, {2, 1}, {3, 4}};
-        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new int[] {5, 5});
+        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new long[] {5, 5});
 
         // subarray in the top right corner
         BaseSparseNDArrayCOO sparseView = (BaseSparseNDArrayCOO) sparseNDArray.get(NDArrayIndex.interval(0, 2),
@@ -85,7 +85,7 @@ public class SparseNDArrayCOOTest {
 
         double[] values = {1, 2, 3, 4};
         int[][] indices = {{0, 3}, {1, 2}, {2, 1}, {3, 4}};
-        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new int[] {5, 5});
+        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new long[] {5, 5});
 
         BaseSparseNDArrayCOO sparseView = (BaseSparseNDArrayCOO) sparseNDArray.get(NDArrayIndex.interval(2, 5),
                         NDArrayIndex.interval(0, 2));
@@ -101,7 +101,7 @@ public class SparseNDArrayCOOTest {
 
         double[] values = {1, 2, 3, 4};
         int[][] indices = {{0, 3}, {1, 2}, {2, 1}, {3, 4}};
-        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new int[] {5, 5});
+        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new long[] {5, 5});
         BaseSparseNDArrayCOO sparseView = (BaseSparseNDArrayCOO) sparseNDArray.get(NDArrayIndex.interval(0, 2),
                         NDArrayIndex.interval(2, 5));
         assertEquals(2, sparseView.nnz());
@@ -115,7 +115,7 @@ public class SparseNDArrayCOOTest {
     public void shouldTakeViewInTheMiddle() {
         double[] values = {1, 2, 3, 4};
         int[][] indices = {{0, 3}, {1, 2}, {2, 1}, {3, 4}};
-        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new int[] {5, 5});
+        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new long[] {5, 5});
         BaseSparseNDArrayCOO sparseView = (BaseSparseNDArrayCOO) sparseNDArray.get(NDArrayIndex.interval(1, 3),
                         NDArrayIndex.interval(1, 3));
         assertEquals(2, sparseView.nnz());
@@ -129,7 +129,7 @@ public class SparseNDArrayCOOTest {
     public void shouldGetFirstColumn() {
         double[] values = {1, 2, 3, 4};
         int[][] indices = {{0, 3}, {1, 2}, {2, 1}, {3, 4}};
-        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new int[] {5, 5});
+        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new long[] {5, 5});
         BaseSparseNDArrayCOO sparseView =
                         (BaseSparseNDArrayCOO) sparseNDArray.get(NDArrayIndex.all(), NDArrayIndex.point(0));
         assertEquals(0, sparseView.nnz());
@@ -141,7 +141,7 @@ public class SparseNDArrayCOOTest {
     public void shouldGetRowInTheMiddle() {
         double[] values = {1, 2, 3, 4};
         int[][] indices = {{0, 3}, {1, 2}, {2, 1}, {3, 4}};
-        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new int[] {5, 5});
+        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new long[] {5, 5});
         BaseSparseNDArrayCOO sparseView =
                         (BaseSparseNDArrayCOO) sparseNDArray.get(NDArrayIndex.point(2), NDArrayIndex.all());
         assertEquals(1, sparseView.nnz());
@@ -155,7 +155,7 @@ public class SparseNDArrayCOOTest {
     public void shouldGetScalar() {
         double[] values = {1, 2, 3, 4};
         int[][] indices = {{0, 3}, {1, 2}, {2, 1}, {3, 4}};
-        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new int[] {5, 5});
+        INDArray sparseNDArray = Nd4j.createSparseCOO(values, indices, new long[] {5, 5});
         BaseSparseNDArrayCOO sparseView =
                         (BaseSparseNDArrayCOO) sparseNDArray.get(NDArrayIndex.point(2), NDArrayIndex.point(1));
         assertEquals(1, sparseView.nnz());
@@ -166,7 +166,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldTakeView3dimensionArray() {
-        int[] shape = new int[] {2, 2, 2};
+        long[] shape = new long[] {2, 2, 2};
         double[] values = new double[] {2, 1, 4, 3};
         int[][] indices = new int[][] {{0, 0, 0}, {1, 0, 1}, {1, 1, 0}, {1, 1, 1}};
 
@@ -183,7 +183,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldTakeViewOfView() {
-        int[] shape = new int[] {2, 2, 2};
+        long[] shape = new long[] {2, 2, 2};
         double[] values = new double[] {2, 1, 4, 3};
         int[][] indices = new int[][] {{0, 0, 0}, {1, 0, 1}, {1, 1, 0}, {1, 1, 1}};
 
@@ -199,7 +199,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldTakeViewOfView2() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 1}, {3, 1, 0}};
@@ -217,7 +217,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldGetWithSpecifiedIndexes() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 1}, {3, 1, 0}};
@@ -231,7 +231,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldGetWithSpecifiedIndexes2() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 2}, {3, 1, 0}};
@@ -257,7 +257,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void newAxisWithSparseArray() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 2}, {3, 1, 0}};
@@ -269,7 +269,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void nestedSparseViewWithNewAxis() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 2}, {3, 1, 0}};
@@ -335,7 +335,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldTranslateViewIndexesToOriginal() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 2}, {3, 1, 0}};
@@ -350,7 +350,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldTranslateViewIndexesToOriginal2() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 2}, {3, 1, 0}};
@@ -363,7 +363,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldTranslateViewIndexesToOriginal3() {
-        int[] shape = new int[] {4, 2, 3, 3};
+        long[] shape = new long[] {4, 2, 3, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2, 0}, {0, 1, 1, 1}, {1, 0, 0, 0}, {1, 0, 1, 0}, {1, 1, 2, 1},
                         {2, 0, 1, 0}, {2, 1, 2, 0}, {3, 0, 2, 1}, {3, 1, 0, 1}};
@@ -377,7 +377,7 @@ public class SparseNDArrayCOOTest {
     @Test
     public void shouldTranslateViewWithPrependNewAxis() {
         // TODO FIX get view with a new prepend axis
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 2}, {3, 1, 0}};
@@ -397,7 +397,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void shouldSortCOOIndices() {
-        int[] shape = new int[] {4, 3, 3};
+        long[] shape = new long[] {4, 3, 3};
         double[] values = new double[] {1};
         int[][] indices = new int[][] {{0, 0, 0}};
         INDArray original = Nd4j.createSparseCOO(values, indices, shape);
@@ -545,7 +545,7 @@ public class SparseNDArrayCOOTest {
 
     @Test
     public void binarySearch() {
-        int[] shape = new int[] {4, 2, 3};
+        long[] shape = new long[] {4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 2}, {0, 1, 1}, {1, 0, 0}, {1, 0, 1}, {1, 1, 2}, {2, 0, 1}, {2, 1, 2},
                         {3, 0, 2}, {3, 1, 0}};
@@ -568,7 +568,7 @@ public class SparseNDArrayCOOTest {
     @Test
     public void tryToFindABugWithHiddenDim(){
 
-        int[] shape = new int[] {1, 4, 2, 3};
+        long[] shape = new long[] {1, 4, 2, 3};
         double[] values = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
         int[][] indices = new int[][] {{0, 0, 0, 2}, {0, 0, 1, 1}, {0, 1, 0, 0}, {0, 1, 0, 1}, {0, 1, 1, 2}, {0, 2, 0, 1}, {0, 2, 1, 2},
                 {0, 3, 0, 2}, {0, 3, 1, 0}};

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/SparseNDArrayCSRTest.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/SparseNDArrayCSRTest.java
@@ -30,7 +30,7 @@ public class SparseNDArrayCSRTest {
     private int[] columns = {0, 1, 3, 0, 1, 2, 3, 4, 0, 2, 3, 1, 4};
     private int[] pointerB = {0, 3, 5, 8, 11};
     private int[] pointerE = {3, 5, 8, 11, 13};
-    private int[] shape = {5, 5};
+    private long[] shape = {5, 5};
 
 
     @Test
@@ -57,7 +57,7 @@ public class SparseNDArrayCSRTest {
             double[] expectedColumns = {0, 1, 3, 0, 1, 1, 2, 3, 4, 0, 2, 3, 1, 4};
             int[] expectedPointerB = {0, 3, 5, 9, 12};
             int[] expectedPointerE = {3, 5, 9, 12, 14};
-            int[] expectedShape = {5, 5};
+            long[] expectedShape = {5, 5};
 
 
             assertArrayEquals(expectedValues, sparseCSRArray.getDoubleValues(), 0);
@@ -104,7 +104,7 @@ public class SparseNDArrayCSRTest {
             double[] expectedColumns = {0, 1, 3, 0, 1, 2, 3, 4, 0, 2, 3, 1, 4};
             int[] expectedPointerB = {0, 3, 5, 8, 11};
             int[] expectedPointerE = {3, 5, 8, 11, 13};
-            int[] expectedShape = {5, 5};
+            long[] expectedShape = {5, 5};
 
             assertArrayEquals(expectedValues, sparseCSRArray.getDoubleValues(), 0);
             assertArrayEquals(expectedColumns, sparseCSRArray.getColumns(), 0);

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/blas/SparseCOOLevel1Test.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/blas/SparseCOOLevel1Test.java
@@ -22,7 +22,7 @@ public class SparseCOOLevel1Test extends BaseNd4jTest {
     // vector = [1, 2, 0, 4]
     private double[] data = {1, 2, 4};
     private int[][] indexes = new int[][] {{0, 0}, {0, 1}, {0, 3}};
-    private int[] shape = {1, 4};
+    private long[] shape = {1, 4};
 
     public SparseCOOLevel1Test(Nd4jBackend backend) {
         super(backend);
@@ -91,7 +91,7 @@ public class SparseCOOLevel1Test extends BaseNd4jTest {
 
         //System.out.println("indexes: " + ((BaseSparseNDArray) sparseVec).getVectorCoordinates().toString());
         INDArray expectedSparseVec = Nd4j.createSparseCSR(new double[] {3, 6, 6, 12}, new int[] {0, 1, 2, 3},
-                        new int[] {0}, new int[] {4}, new int[] {1, 4});
+                        new int[] {0}, new int[] {4}, new long[] {1, 4});
         INDArray expectedVec = Nd4j.create(new double[] {-1, -2, 3, -4});
         assertEquals(getFailureMessage(), expectedSparseVec.data(), sparseVec.data());
 
@@ -120,7 +120,7 @@ public class SparseCOOLevel1Test extends BaseNd4jTest {
         Nd4j.getBlasWrapper().level1().rot(vec.length(), sparseVec, vec, 1, 2);
 
         INDArray expectedSparseVec = Nd4j.createSparseCSR(new double[] {3, 6, 9, 12}, new int[] {0, 1, 2, 3},
-                        new int[] {0}, new int[] {4}, new int[] {1, 4});
+                        new int[] {0}, new int[] {4}, new long[] {1, 4});
         INDArray expectedVec = Nd4j.create(new double[] {-1, -2, -3, -4});
         assertEquals(getFailureMessage(), expectedSparseVec.data(), sparseVec.data());
         assertEquals(getFailureMessage(), expectedVec, vec);

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/blas/SparseCOOLevel2Test.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/blas/SparseCOOLevel2Test.java
@@ -22,7 +22,7 @@ public class SparseCOOLevel2Test extends BaseNd4jTest {
     // matrix = [[1, 2], [0, 0]]
     private double[] data = {1, 2};
     private int[][] indexes = new int[][] {{0, 0}, {0, 1}};
-    private int[] shape = {2, 2};
+    private long[] shape = {2, 2};
 
     public SparseCOOLevel2Test(Nd4jBackend backend) {
         super(backend);

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/blas/SparseCSRLevel1Test.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/api/blas/SparseCSRLevel1Test.java
@@ -23,7 +23,7 @@ public class SparseCSRLevel1Test extends BaseNd4jTest {
     private int[] col = {0, 1, 3};
     private int[] pointerB = {0};
     private int[] pointerE = {4};
-    private int[] shape = {1, 4};
+    private long[] shape = {1, 4};
 
     public SparseCSRLevel1Test(Nd4jBackend backend) {
         super(backend);
@@ -92,7 +92,7 @@ public class SparseCSRLevel1Test extends BaseNd4jTest {
 
         //System.out.println("indexes: " + ((BaseSparseNDArray) sparseVec).getVectorCoordinates().toString());
         INDArray expectedSparseVec = Nd4j.createSparseCSR(new double[] {3, 6, 6, 12}, new int[] {0, 1, 2, 3},
-                        new int[] {0}, new int[] {4}, new int[] {1, 4});
+                        new int[] {0}, new int[] {4}, new long[] {1, 4});
         INDArray expectedVec = Nd4j.create(new double[] {-1, -2, 3, -4});
         assertEquals(getFailureMessage(), expectedSparseVec.data(), sparseVec.data());
 
@@ -121,7 +121,7 @@ public class SparseCSRLevel1Test extends BaseNd4jTest {
         Nd4j.getBlasWrapper().level1().rot(vec.length(), sparseVec, vec, 1, 2);
 
         INDArray expectedSparseVec = Nd4j.createSparseCSR(new double[] {3, 6, 9, 12}, new int[] {0, 1, 2, 3},
-                        new int[] {0}, new int[] {4}, new int[] {1, 4});
+                        new int[] {0}, new int[] {4}, new long[] {1, 4});
         INDArray expectedVec = Nd4j.create(new double[] {-1, -2, -3, -4});
         assertEquals(getFailureMessage(), expectedSparseVec.data(), sparseVec.data());
         assertEquals(getFailureMessage(), expectedVec, vec);


### PR DESCRIPTION
Dear Maintainers, please accept this PR that brings shape for INDSparseArray inline with INDArray by using long[] for shape.

Please comment whether other attributes of INDSparseArray implementers should also be changed from int[] to long[]