### PR TITLE
Add dependency on MKL-DNN and use its version of MKL by default

### DIFF
--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-platform/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-platform/pom.xml
@@ -25,6 +25,11 @@
             <version>${mkl.version}-${javacpp-presets.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.bytedeco.javacpp-presets</groupId>
+            <artifactId>mkl-dnn-platform</artifactId>
+            <version>${mkl-dnn.version}-${javacpp-presets.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>${nd4j.backend}</artifactId>
             <version>${project.version}</version>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -52,6 +52,17 @@
 <!--            <version>${mkl.version}-${javacpp-presets.version}</version>-->
 <!--            <classifier>${dependency.platform}</classifier>-->
 <!--        </dependency>-->
+        <dependency>
+            <groupId>org.bytedeco.javacpp-presets</groupId>
+            <artifactId>mkl-dnn</artifactId>
+            <version>${mkl-dnn.version}-${javacpp-presets.version}</version>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.bytedeco.javacpp-presets</groupId>-->
+<!--            <artifactId>mkl-dnn</artifactId>-->
+<!--            <version>${mkl-dnn.version}-${javacpp-presets.version}</version>-->
+<!--            <classifier>${dependency.platform}</classifier>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -91,6 +91,13 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
 
     @Override
     public void createBlas() {
+        String lib = System.getProperty("org.bytedeco.javacpp.openblas.load",
+                     System.getProperty("org.bytedeco.javacpp.openblas_nolapack.load", "")).toLowerCase();
+        if (lib.trim().length() == 0) {
+            // try to load by default the LAPACK-less version of MKL bundled with MKL-DNN
+            System.setProperty("org.bytedeco.javacpp.openblas_nolapack.load", "mklml");
+        }
+
         blas = new CpuBlas();
 
         // TODO: add batched gemm here

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuBlas.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuBlas.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.mkl_rt;
 import org.nd4j.nativeblas.Nd4jBlas;
 
-import static org.bytedeco.javacpp.openblas.*;
+import static org.bytedeco.javacpp.openblas_nolapack.*;
 
 /**
  * Implementation of Nd4jBlas with OpenBLAS/MKL

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLevel1.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLevel1.java
@@ -13,7 +13,7 @@ import org.nd4j.linalg.api.ops.impl.accum.Dot;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.nativeblas.Nd4jBlas;
 
-import static org.bytedeco.javacpp.openblas.*;
+import static org.bytedeco.javacpp.openblas_nolapack.*;
 
 
 /**

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLevel2.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLevel2.java
@@ -11,7 +11,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.nativeblas.Nd4jBlas;
 
-import static org.bytedeco.javacpp.openblas.*;
+import static org.bytedeco.javacpp.openblas_nolapack.*;
 import static org.nd4j.linalg.cpu.nativecpu.blas.CpuBlas.*;
 
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLevel3.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/blas/CpuLevel3.java
@@ -12,7 +12,7 @@ import org.nd4j.linalg.api.ops.aggregates.impl.AggregateGEMM;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.nativeblas.Nd4jBlas;
 
-import static org.bytedeco.javacpp.openblas.*;
+import static org.bytedeco.javacpp.openblas_nolapack.*;
 import static org.nd4j.linalg.cpu.nativecpu.blas.CpuBlas.*;
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
         <javacv.version>1.4.2-SNAPSHOT</javacv.version>
         <openblas.version>0.3.0</openblas.version>
         <mkl.version>2018.3</mkl.version>
+        <mkl-dnn.version>0.14</mkl-dnn.version>
         <opencv.version>3.4.1</opencv.version>
         <ffmpeg.version>4.0</ffmpeg.version>
         <leptonica.version>1.76.0</leptonica.version>


### PR DESCRIPTION
Fixes #5508 since with this we'll be bundling a free version of MKL sourced from the archives here:
https://github.com/intel/mkl-dnn/releases

It's still possible to use full MKL by setting the "org.bytedeco.javacpp.openblas.load" property to "mkl_rt".

Tested manually on LenetMnistExample and works fine.