### PR TITLE
Reshape : Use negative ints for order

### DIFF
--- a/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
+++ b/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
@@ -18,14 +18,14 @@ namespace nd4j {
                 auto argumets = block.getIArguments();
                 int argsSize = argumets->size();
 
-                REQUIRE_TRUE(argsSize >= 2, 0, "Reshape arguments should have order and at least 1 dimensions");
-
                 int e = 1;
                 char order = (char) -(*argumets)[0];
                 if (order != 'c' && order != 'f') {
                     order = x->ordering();
                     e = 0;
                 }
+
+                REQUIRE_TRUE(argsSize - e >= 1, 0, "Reshape arguments should at least 1 dimension");
 
                 std::vector<Nd4jLong> shapeNew;
                 

--- a/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
+++ b/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
@@ -21,7 +21,7 @@ namespace nd4j {
                 REQUIRE_TRUE(argsSize >= 2, 0, "Reshape arguments should have order and at least 1 dimensions");
 
                 int e = 1;
-                char order = (char) (*argumets)[0];
+                char order = (char) -(*argumets)[0];
                 if (order != 'c' && order != 'f') {
                     order = x->ordering();
                     e = 0;
@@ -57,7 +57,7 @@ namespace nd4j {
 
                 char order = 'c';
                 if (block.numI() > 0)
-                    order = (char) INT_ARG(0);
+                    order = (char) -INT_ARG(0);
 
                 std::vector<Nd4jLong> shapeNew(s->lengthOf());
                 for (int e = 0; e < (int) s->lengthOf(); e++)
@@ -91,7 +91,7 @@ namespace nd4j {
                 std::vector<int> *arguments = block.getIArguments();
 
                 int e = 1;
-                char order = (char) (*arguments)[0];
+                char order = (char) -(*arguments)[0];
                 if (order != 'c' && order != 'f') {
                     order = shape::order(inp);
                     e = 0;

--- a/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
+++ b/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
@@ -15,11 +15,11 @@ namespace nd4j {
             auto x = INPUT_VARIABLE(0);
 
             if (block.width() == 1) {
-                auto argumets = block.getIArguments();
-                int argsSize = argumets->size();
+                auto arguments = block.getIArguments();
+                int argsSize = arguments->size();
 
                 int e = 1;
-                char order = (char) -(*argumets)[0];
+                char order = (char) -(*arguments)[0];
                 if (order != 'c' && order != 'f') {
                     order = x->ordering();
                     e = 0;
@@ -29,8 +29,8 @@ namespace nd4j {
 
                 std::vector<Nd4jLong> shapeNew;
                 
-                for (; e < (int) argumets->size(); e++)
-                    shapeNew.push_back((int) argumets->at(e));
+                for (; e < (int) arguments->size(); e++)
+                    shapeNew.push_back((int) arguments->at(e));
 
                 auto len = shape::prodLong(shapeNew.data(), shapeNew.size());
                 REQUIRE_TRUE(len == x->lengthOf(), 0, "Reshape: lengths before and after reshape should match, but got %i vs %i", x->lengthOf(), len);

--- a/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
+++ b/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
@@ -10,7 +10,8 @@
 namespace nd4j {
     namespace ops {
         //////////////////////////////////////////////////////////////////////////
-        // here iArgs is a vector with order as first element ({order, dim1, dim2, dim3, ...})
+        // here iArgs is a vector with (optional) negative of order as first element:
+        // ({-order, dim1, dim2, dim3, ...})
         CUSTOM_OP_IMPL(reshape, 1, 1, true, 0, -2) {
             auto x = INPUT_VARIABLE(0);
 
@@ -109,7 +110,7 @@ namespace nd4j {
 
                 int *shape_ = shapeNew.data();
                 for (int i = 0; i < (int) shapeNew.size(); i++) {
-                    if (shapeNew[i] < 0) {
+                    if (shapeNew[i] == -1) {
                         if (numberNegativesOnes >= 1)
                             throw std::runtime_error("Only one dimension can be negative ones");
 
@@ -163,7 +164,7 @@ namespace nd4j {
 
                 auto shape_ = shapeNew.data();
                 for (int i = 0; i < (int) shapeNew.size(); i++) {
-                    if (shapeNew[i] < 0) {
+                    if (shapeNew[i] == -1) {
                         if (numberNegativesOnes >= 1)
                             throw std::runtime_error("Only one dimension can be negative ones");
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
@@ -1423,7 +1423,7 @@ TEST_F(DeclarableOpsTests1, Reshape3) {
     NDArray<float> x('c', {3, 4, 5});
 
     nd4j::ops::reshape<float> op;
-    auto result = op.execute({&x}, {}, {99, 3, 4, 5});
+    auto result = op.execute({&x}, {}, {-99, 3, 4, 5});
 
     ASSERT_EQ(ND4J_STATUS_OK, result->status());
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
@@ -1370,7 +1370,7 @@ TEST_F(DeclarableOpsTests1, Reshape1) {
     Context<float>* block = new Context<float>(1, variableSpace, true);
     block->fillInputs({-1});    
     std::vector<int>* arguments = block->getIArguments();
-    arguments->push_back(y->ordering());
+    arguments->push_back(-y->ordering());
     arguments->push_back(3);
     arguments->push_back(5);
     arguments->push_back(4);
@@ -1401,7 +1401,7 @@ TEST_F(DeclarableOpsTests1, Reshape2) {
     Context<float>* block = new Context<float>(1, variableSpace, false);
     block->fillInputs({-1});    
     std::vector<int>* arguments = block->getIArguments();
-    arguments->push_back(y->ordering());
+    arguments->push_back(-y->ordering());
     arguments->push_back(3);
     arguments->push_back(5);
     arguments->push_back(4);

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests4.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests4.cpp
@@ -336,7 +336,7 @@ TEST_F(DeclarableOpsTests4, Test_Reshape_Again) {
     NDArrayFactory<float>::linspace(1, exp);
 
     nd4j::ops::reshape<float> op;
-    auto result = op.execute({&x}, {}, {99, 4, 3});
+    auto result = op.execute({&x}, {}, {-99, 4, 3});
 
     auto z = result->at(0);
 

--- a/libnd4j/tests_cpu/layers_tests/ScalarTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ScalarTests.cpp
@@ -172,7 +172,7 @@ TEST_F(ScalarTests, Test_Reshape_1) {
     NDArray<float> exp('c', {1, 1, 1}, {2.0f});
 
     nd4j::ops::reshape<float> op;
-    auto result = op.execute({&x}, {}, {99, 1, 1, 1});
+    auto result = op.execute({&x}, {}, {-99, 1, 1, 1});
     ASSERT_EQ(ND4J_STATUS_OK, result->status());
 
     auto z = result->at(0);

--- a/libnd4j/tests_cpu/layers_tests/SingleDimTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/SingleDimTests.cpp
@@ -158,7 +158,7 @@ TEST_F(SingleDimTests, Test_Reshape_1) {
     NDArray<float> exp('c', {3}, {1, 2, 3});
 
     nd4j::ops::reshape<float> op;
-    auto result = op.execute({&x}, {}, {99, 3});
+    auto result = op.execute({&x}, {}, {-99, 3});
     ASSERT_EQ(ND4J_STATUS_OK, result->status());
 
     auto z = result->at(0);
@@ -174,7 +174,7 @@ TEST_F(SingleDimTests, Test_Reshape_2) {
     NDArray<float> exp('c', {1, 3}, {1, 2, 3});
 
     nd4j::ops::reshape<float> op;
-    auto result = op.execute({&x}, {}, {99, 1, 3});
+    auto result = op.execute({&x}, {}, {-99, 1, 3});
     ASSERT_EQ(ND4J_STATUS_OK, result->status());
 
     auto z = result->at(0);


### PR DESCRIPTION
Use `-99`, `-102` instead of `99`, `102` to represent `'c'` and `'f'` respectively.
