### PR TITLE
More SameDiff Op Fixes

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/NoBiasGradientCheckTests.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/gradientcheck/NoBiasGradientCheckTests.java
@@ -112,14 +112,12 @@ public class NoBiasGradientCheckTests extends BaseDL4JTest {
 
         int nIn = 5;
         int nOut = 3;
+        int tsLength = 3;
         int layerSize = 6;
 
         for (int minibatch : new int[]{1, 4}) {
-            INDArray input = Nd4j.rand(minibatch, nIn);
-            INDArray labels = Nd4j.zeros(minibatch, nOut);
-            for (int i = 0; i < minibatch; i++) {
-                labels.putScalar(i, i % nOut, 1.0);
-            }
+            INDArray input = Nd4j.rand(new int[]{minibatch, nIn, tsLength});
+            INDArray labels = TestUtils.randomOneHotTimeSeries(minibatch, nOut, tsLength);
 
             for (boolean rnnOutHasBias : new boolean[]{true, false}) {
 

--- a/libnd4j/include/ops/declarable/headers/convo.h
+++ b/libnd4j/include/ops/declarable/headers/convo.h
@@ -186,6 +186,7 @@ namespace nd4j {
          */
         #if NOT_EXCLUDED(OP_im2col)
         DECLARE_CUSTOM_OP(im2col, 1, 1, false, 0, 9);
+		DECLARE_CUSTOM_OP(im2col_bp, 2, 1, false, 0, 9);
         #endif
 
         /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -386,6 +386,10 @@ public class DifferentialFunctionFactory {
         return new Im2col(sameDiff(), input, config).outputVariable();
     }
 
+    public SDVariable im2ColBp(SDVariable im2colInput, SDVariable gradientAtOutput, Conv2DConfig config){
+        return new Im2colBp(sameDiff(), im2colInput, gradientAtOutput, config).outputVariable();
+    }
+
     public SDVariable col2Im(SDVariable input, Conv2DConfig config){
         return new Col2Im(sameDiff(), input, config).outputVariable();
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -23,6 +23,7 @@ import org.nd4j.linalg.api.ops.impl.scatter.*;
 import org.nd4j.linalg.api.ops.impl.shape.*;
 import org.nd4j.linalg.api.ops.impl.shape.Stack;
 import org.nd4j.linalg.api.ops.impl.shape.bp.SliceBp;
+import org.nd4j.linalg.api.ops.impl.shape.bp.StridedSliceBp;
 import org.nd4j.linalg.api.ops.impl.transforms.*;
 import org.nd4j.linalg.api.ops.impl.transforms.SoftMaxDerivative;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.*;
@@ -1841,6 +1842,12 @@ public class DifferentialFunctionFactory {
     public SDVariable stridedSlice(SDVariable in, long[] begin, long[] end, long[] strides, int beginMask,
                                    int endMask, int ellipsisMask, int newAxisMask, int shrinkAxisMask) {
         return new StridedSlice(sameDiff(), in, begin, end, strides, beginMask, endMask, ellipsisMask,
+                newAxisMask, shrinkAxisMask).outputVariable();
+    }
+
+    public SDVariable stridedSliceBp(SDVariable in, SDVariable grad, long[] begin, long[] end, long[] strides, int beginMask,
+                                   int endMask, int ellipsisMask, int newAxisMask, int shrinkAxisMask) {
+        return new StridedSliceBp(sameDiff(), in, grad, begin, end, strides, beginMask, endMask, ellipsisMask,
                 newAxisMask, shrinkAxisMask).outputVariable();
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -13,6 +13,7 @@ import org.nd4j.linalg.api.ops.impl.accum.Min;
 import org.nd4j.linalg.api.ops.impl.accum.bp.*;
 import org.nd4j.linalg.api.ops.impl.accum.distances.*;
 import org.nd4j.linalg.api.ops.impl.broadcast.BiasAdd;
+import org.nd4j.linalg.api.ops.impl.broadcast.BiasAddGrad;
 import org.nd4j.linalg.api.ops.impl.indexaccum.*;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.*;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.config.*;
@@ -583,6 +584,10 @@ public class DifferentialFunctionFactory {
 
     public SDVariable biasAdd(SDVariable input, SDVariable bias) {
         return new BiasAdd(sameDiff(), input, bias).outputVariable();
+    }
+
+    public SDVariable[] biasAddBp(SDVariable input, SDVariable bias, SDVariable grad) {
+        return new BiasAddGrad(sameDiff(), input, bias, grad).outputVariables();
     }
 
     public SDVariable norm1(SDVariable i_x, boolean keepDims, int... dimensions) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -566,8 +566,24 @@ public class DifferentialFunctionFactory {
         return new LastIndex(sameDiff(), in, condition, keepDims, dimensions).outputVariable();
     }
 
-    public SDVariable matchCondition(SDVariable in, Condition condition){
+    /**
+     * Returns a count of the number of elements that satisfy the condition
+     * @param in        Input
+     * @param condition Condition
+     * @return          Number of elements that the condition is satisfied for
+     */
+    public SDVariable matchConditionCount(SDVariable in, Condition condition){
         return new MatchCondition(sameDiff(), in, condition).outputVariable();
+    }
+
+    /**
+     * Returns a boolean mask of equal shape to the input, where the condition is satisfied
+     * @param in        Input
+     * @param condition Condition
+     * @return          Boolean mask
+     */
+    public SDVariable matchCondition(SDVariable in, Condition condition){
+        return new MatchConditionTransform(sameDiff(), in, condition).outputVariable();
     }
 
     public SDVariable cumsum(SDVariable in, SDVariable axis, boolean exclusive, boolean reverse) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -22,6 +22,7 @@ import org.nd4j.linalg.api.ops.impl.scalar.comparison.*;
 import org.nd4j.linalg.api.ops.impl.scatter.*;
 import org.nd4j.linalg.api.ops.impl.shape.*;
 import org.nd4j.linalg.api.ops.impl.shape.Stack;
+import org.nd4j.linalg.api.ops.impl.shape.bp.SliceBp;
 import org.nd4j.linalg.api.ops.impl.transforms.*;
 import org.nd4j.linalg.api.ops.impl.transforms.SoftMaxDerivative;
 import org.nd4j.linalg.api.ops.impl.transforms.arithmetic.*;
@@ -1816,6 +1817,10 @@ public class DifferentialFunctionFactory {
 
     public SDVariable slice(SDVariable input, int[] begin, int[] size) {
         return new Slice(sameDiff(), input, begin, size).outputVariable();
+    }
+
+    public SDVariable sliceBp(SDVariable input, SDVariable gradient, int[] begin, int[] size) {
+        return new SliceBp(sameDiff(), input, gradient, begin, size).outputVariable();
     }
 
     public SDVariable stridedSlice(SDVariable input, int[] begin, int[] end, int[] strides) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -3625,11 +3625,44 @@ public class SameDiff {
         return updateVariableNameAndReference(ret, name);
     }
 
-    public SDVariable matchCondition(SDVariable in, Condition condition) {
+    /**
+     * Returns a count of the number of elements that satisfy the condition
+     * @param in        Input
+     * @param condition Condition
+     * @return          Number of elements that the condition is satisfied for
+     */
+    public SDVariable matchConditionCount(SDVariable in, Condition condition) {
+        return matchConditionCount(null, in, condition);
+    }
+
+    /**
+     * Returns a count of the number of elements that satisfy the condition
+     * @param in        Input
+     * @param condition Condition
+     * @return          Number of elements that the condition is satisfied for
+     */
+    public SDVariable matchConditionCount(String name, SDVariable in, Condition condition) {
+        SDVariable ret = f().matchConditionCount(in, condition);
+        return updateVariableNameAndReference(ret, name);
+    }
+
+    /**
+     * Returns a boolean mask of equal shape to the input, where the condition is satisfied
+     * @param in        Input
+     * @param condition Condition
+     * @return          Boolean mask
+     */
+    public SDVariable matchCondition(SDVariable in, Condition condition){
         return matchCondition(null, in, condition);
     }
 
-    public SDVariable matchCondition(String name, SDVariable in, Condition condition) {
+    /**
+     * Returns a boolean mask of equal shape to the input, where the condition is satisfied
+     * @param in        Input
+     * @param condition Condition
+     * @return          Boolean mask
+     */
+    public SDVariable matchCondition(String name, SDVariable in, Condition condition){
         SDVariable ret = f().matchCondition(in, condition);
         return updateVariableNameAndReference(ret, name);
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
@@ -477,6 +477,11 @@ public class DynamicCustomOp extends DifferentialFunction implements CustomOp {
         if (outputShapes != null)
             return outputShapes;
 
+        if (descriptor == null) {
+            throw new IllegalStateException("Could not find descriptor for op: " + opName()
+                    + (DynamicCustomOp.class == this.getClass() ? "" : " - class: " + getClass().getName()));
+        }
+
 
         //not fully initialized: missing integer args
         if (descriptor.getNumIArgs() >= 0 && numIArguments() < descriptor.getNumIArgs()) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/MatchCondition.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/MatchCondition.java
@@ -27,6 +27,7 @@ import org.nd4j.linalg.api.ops.BaseAccumulation;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.conditions.Condition;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,6 @@ public class MatchCondition extends BaseAccumulation {
         this.compare = condition.getValue();
         this.mode = condition.condtionNum();
         this.eps = Nd4j.EPS_THRESHOLD;
-
         this.extraArgs = new Object[] {compare, eps, (double) mode};
     }
 
@@ -100,7 +100,7 @@ public class MatchCondition extends BaseAccumulation {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        return null;
+        return Collections.singletonList(sameDiff.zerosLike(arg()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/ZeroFraction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/accum/ZeroFraction.java
@@ -27,6 +27,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseAccumulation;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -56,6 +57,11 @@ public class ZeroFraction extends DynamicCustomOp {
     @Override
     public String tensorflowName() {
         throw new NoOpNameFoundException("No tf name found for shape " + opName());
+    }
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> grad){
+        return Collections.singletonList(sameDiff.zerosLike(arg()));
     }
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/broadcast/BiasAdd.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/broadcast/BiasAdd.java
@@ -10,11 +10,11 @@ import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
 import org.tensorflow.framework.NodeDef;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+/**
+ * Bias addition gradient operation.
+ */
 @NoArgsConstructor
 public class BiasAdd extends DynamicCustomOp {
 
@@ -58,5 +58,10 @@ public class BiasAdd extends DynamicCustomOp {
     @Override
     public String tensorflowName() {
         return "BiasAdd";
+    }
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> gradient){
+        return Arrays.asList(f().biasAddBp(arg(0), arg(1), gradient.get(0)));
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/broadcast/BiasAddGrad.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/broadcast/BiasAddGrad.java
@@ -5,29 +5,17 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseBroadcastOp;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
 
 import java.util.List;
 
-public class BiasAddGrad extends BaseBroadcastOp {
-    public BiasAddGrad(SameDiff sameDiff, SDVariable i_v1, SDVariable i_v2, int[] dimension) {
-        super(sameDiff, i_v1, i_v2, dimension);
-    }
+public class BiasAddGrad extends DynamicCustomOp {
 
-    public BiasAddGrad(SameDiff sameDiff, SDVariable i_v1, SDVariable i_v2, boolean inPlace, int[] dimension) {
-        super(sameDiff, i_v1, i_v2, inPlace, dimension);
-    }
-
-    public BiasAddGrad(SameDiff sameDiff, SDVariable i_v1, SDVariable i_v2, int[] dimension, Object[] extraArgs) {
-        super(sameDiff, i_v1, i_v2, dimension, extraArgs);
+    public BiasAddGrad(SameDiff sameDiff, SDVariable input, SDVariable bias, SDVariable gradient) {
+        super(null, sameDiff, new SDVariable[]{input, bias, gradient});
     }
 
     public BiasAddGrad() {}
-
-    public BiasAddGrad(INDArray x, INDArray y, INDArray z, int... dimension) {
-        super(x, y, z, dimension);
-    }
-
-
 
     @Override
     public int opNum() {
@@ -43,7 +31,7 @@ public class BiasAddGrad extends BaseBroadcastOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        return null;
+        throw new UnsupportedOperationException("Differentiation not supported for op " + getClass().getSimpleName());
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Conv3DDerivative.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Conv3DDerivative.java
@@ -54,4 +54,15 @@ public class Conv3DDerivative extends Conv3D {
         throw new UnsupportedOperationException("Unable to differentiate from a derivative op");
     }
 
+    @Override
+    public int getNumOutputs(){
+        //Fwd inputs: input, weight, optional bias
+        //Bwd inputs: input, input grad, weight, optional bias
+        if(args().length == 4){
+            return 3;   //Includes bias
+        } else {
+            return 2;   //No bias - only input + weight grads
+        }
+    }
+
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/DeConv2DDerivative.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/DeConv2DDerivative.java
@@ -47,4 +47,12 @@ public class DeConv2DDerivative extends DeConv2D {
 
     }
 
+    @Override
+    public int getNumOutputs(){
+        //Inputs: in, weights, optional bias, gradOut                      3 req, 1 optional
+        //Outputs: gradAtInput, gradW, optional gradB                      2 req, 1 optional
+        SDVariable[] args = args();
+        return args.length - 1;
+    }
+
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Im2colBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Im2colBp.java
@@ -16,29 +16,23 @@ import java.util.Map;
 /**
  * Im2col operation
  */
-public class Im2col extends DynamicCustomOp {
+public class Im2colBp extends DynamicCustomOp {
 
     protected Conv2DConfig conv2DConfig;
 
-    @Builder(builderMethodName = "builder")
-    public Im2col(SameDiff sameDiff, SDVariable[] inputFunctions, INDArray[] inputArrays, INDArray[] outputs, Conv2DConfig conv2DConfig) {
-        super(null, inputArrays, outputs);
-        if (sameDiff != null) {
-            this.sameDiff = sameDiff;
-        }
-
+    public Im2colBp(SameDiff sameDiff, SDVariable i2cInput, SDVariable gradAtOutput, Conv2DConfig conv2DConfig) {
+        super(null, sameDiff,new SDVariable[]{i2cInput, gradAtOutput});
         this.conv2DConfig = conv2DConfig;
-
         addArgs();
     }
 
-    public Im2col(SameDiff sd, SDVariable input, Conv2DConfig config){
+    public Im2colBp(SameDiff sd, SDVariable input, Conv2DConfig config){
         super(null, sd, new SDVariable[]{input});
         this.conv2DConfig = config;
         addArgs();
     }
 
-    public Im2col() {}
+    public Im2colBp() {}
 
     protected void addArgs() {
         addIArgument(conv2DConfig.getKH());
@@ -50,7 +44,6 @@ public class Im2col extends DynamicCustomOp {
         addIArgument(conv2DConfig.getDH());
         addIArgument(conv2DConfig.getDW());
         addIArgument(ArrayUtil.fromBoolean(conv2DConfig.isSameMode()));
-
     }
 
 
@@ -61,11 +54,11 @@ public class Im2col extends DynamicCustomOp {
 
     @Override
     public String opName() {
-        return "im2col";
+        return "im2col_bp";
     }
 
     @Override
-    public List<SDVariable> doDiff(List<SDVariable> grad) {
-        return Collections.singletonList(f().im2ColBp(arg(), grad.get(0), conv2DConfig));
+    public List<SDVariable> doDiff(List<SDVariable> f1) {
+        throw new UnsupportedOperationException("Differentiation not supported for this op: " + getClass().getSimpleName());
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/LocalResponseNormalization.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/LocalResponseNormalization.java
@@ -157,19 +157,14 @@ public class LocalResponseNormalization extends DynamicCustomOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        List<SDVariable> ret = new ArrayList<>();
-        List<SDVariable> inputs = new ArrayList<>();
-        inputs.addAll(Arrays.asList(args()));
-        inputs.add(f1.get(0));
-        LocalResponseNormalizationDerivative localResponseNormalizationDerivative = LocalResponseNormalizationDerivative.derivativeBuilder()
+        SDVariable[] gradFnInputs = new SDVariable[]{arg(), f1.get(0)};
+        LocalResponseNormalizationDerivative lrnGrad = LocalResponseNormalizationDerivative.derivativeBuilder()
                 .inPlace(inPlace)
                 .sameDiff(sameDiff)
-                .inputFunctions(inputs.toArray(new SDVariable[inputs.size()]))
+                .inputFunctions(gradFnInputs)
                 .config(config)
                 .build();
-        ret.addAll(Arrays.asList(localResponseNormalizationDerivative.outputVariables()));
-
-        return ret;
+        return Collections.singletonList(lrnGrad.outputVariable());
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling3D.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Pooling3D.java
@@ -90,6 +90,8 @@ public class Pooling3D extends DynamicCustomOp {
         addIArgument(config.getDD());
         addIArgument(config.getDW());
         addIArgument(config.getDH());
+        addIArgument(config.isCeilingMode() ? 1 : 0);       //Ceiling mode == same mode???
+        addIArgument(config.isNCDHW() ? 1 : 0);
 
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/SConv2D.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/SConv2D.java
@@ -11,6 +11,7 @@ import org.nd4j.linalg.api.ops.impl.layers.convolution.config.Conv2DConfig;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -34,15 +35,21 @@ public class SConv2D extends Conv2D {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        List<SDVariable> ret = new ArrayList<>();
+        //Args at libnd4j level: in, gradAtOut, wD, wP, bias
+        //Args for SConv2d libnd4j: input, wD, wP, bias
         List<SDVariable> inputs = new ArrayList<>();
-        inputs.addAll(Arrays.asList(args()));
+        inputs.add(arg(0));
         inputs.add(f1.get(0));
+        SDVariable[] args = args();
+        for( int i=1; i<args.length; i++ ){ //Skip input, already added
+            inputs.add(args[i]);
+        }
         SConv2DDerivative conv2DDerivative = SConv2DDerivative.sDerviativeBuilder()
                 .conv2DConfig(config)
                 .inputFunctions(inputs.toArray(new SDVariable[inputs.size()]))
+                .sameDiff(sameDiff)
                 .build();
-        ret.addAll(Arrays.asList(conv2DDerivative.outputVariables()));
+        List<SDVariable> ret = Arrays.asList(conv2DDerivative.outputVariables());
         return ret;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/SConv2DDerivative.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/SConv2DDerivative.java
@@ -15,8 +15,7 @@ import java.util.List;
  * SConv2DDerivative operation
  */
 @Slf4j
-public class
-SConv2DDerivative extends SConv2D {
+public class SConv2DDerivative extends SConv2D {
 
     @Builder(builderMethodName = "sDerviativeBuilder")
     public SConv2DDerivative(SameDiff sameDiff, SDVariable[] inputFunctions, INDArray[] inputArrays, INDArray[] outputs, Conv2DConfig conv2DConfig) {
@@ -48,6 +47,14 @@ SConv2DDerivative extends SConv2D {
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
         throw new UnsupportedOperationException("Unable to take derivative of derivative.");
+    }
+
+    @Override
+    public int getNumOutputs(){
+        //Inputs: in, gradAtOutput, weightsDepth, optional weightsPoint, optional weightsBias       3 req, 2 optional
+        //Outputs: gradAtInput, gradWD, optional gradWP, optional gradB                             2 req, 2 optional
+        SDVariable[] args = args();
+        return args.length - 1;
     }
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/config/Pooling3DConfig.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/config/Pooling3DConfig.java
@@ -16,6 +16,7 @@ public class Pooling3DConfig extends BaseConvolutionConfig {
     private long dD, dW, dH; // dilation
     private Pooling3D.Pooling3DType type;
     private boolean ceilingMode;
+    @Builder.Default private boolean isNCDHW = true;
 
     public Map<String, Object> toProperties() {
         Map<String, Object> ret = new LinkedHashMap<>();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Slice.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Slice.java
@@ -33,9 +33,7 @@ import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
 import org.tensorflow.framework.NodeDef;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Slice function
@@ -169,9 +167,7 @@ public class Slice extends DynamicCustomOp {
     }
 
     @Override
-    public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        //TODO need to implement backprop ops for slice: https://github.com/deeplearning4j/libnd4j/issues/710
-        throw new UnsupportedOperationException("Not yet implemented/supported");
+    public List<SDVariable> doDiff(List<SDVariable> grad) {
+        return Collections.singletonList(f().sliceBp(arg(), grad.get(0), begin, size));
     }
-
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/StridedSlice.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/StridedSlice.java
@@ -277,7 +277,8 @@ public class StridedSlice extends DynamicCustomOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> i_v) {
-        throw new UnsupportedOperationException("Not yet supported/implemented");
+        return Collections.singletonList(f().stridedSliceBp(arg(), i_v.get(0), begin, end, strides, beginMask, endMask,
+                ellipsisMask, newAxisMask, shrinkAxisMask));
     }
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/bp/SliceBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/bp/SliceBp.java
@@ -38,9 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Slice function
+ * Slice backprop function
  *
- * @author Adam Gibson
+ * @author Alex Black
  */
 @Slf4j
 public class SliceBp extends DynamicCustomOp {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/bp/SliceBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/bp/SliceBp.java
@@ -1,0 +1,79 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.shape.bp;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.imports.descriptors.properties.PropertyMapping;
+import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
+import org.tensorflow.framework.AttrValue;
+import org.tensorflow.framework.GraphDef;
+import org.tensorflow.framework.NodeDef;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Slice function
+ *
+ * @author Adam Gibson
+ */
+@Slf4j
+public class SliceBp extends DynamicCustomOp {
+
+    private int[] begin;
+    private int[] size;
+
+    public SliceBp() {}
+
+    public SliceBp(SameDiff sameDiff, @NonNull SDVariable input, @NonNull SDVariable gradient, @NonNull int[] begin, @NonNull int[] size){
+        super(null, sameDiff, new SDVariable[]{input, gradient});
+        this.begin = begin;
+        this.size = size;
+        addIArgument(begin);
+        addIArgument(size);
+    }
+
+
+    @Override
+    public String opName() {
+        return "slice_bp";
+    }
+
+
+    @Override
+    public void assertValidForExecution() {
+        if (numInputArguments() != 2 && numInputArguments() != 4) {
+            throw new ND4JIllegalStateException("Num input arguments must be 2 or 4.");
+        }
+    }
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> i_v) {
+        throw new UnsupportedOperationException("Differentiation not supported for backprop op: " + getClass().getSimpleName());
+    }
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/bp/StridedSliceBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/bp/StridedSliceBp.java
@@ -1,0 +1,109 @@
+/*-
+ *
+ *  * Copyright 2015 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ *
+ */
+
+package org.nd4j.linalg.api.ops.impl.shape.bp;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.imports.descriptors.properties.PropertyMapping;
+import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
+import org.nd4j.linalg.util.ArrayUtil;
+import org.tensorflow.framework.AttrValue;
+import org.tensorflow.framework.GraphDef;
+import org.tensorflow.framework.NodeDef;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strided Slice backprop function
+ *
+ * @author Alex Black
+ */
+@Slf4j
+public class StridedSliceBp extends DynamicCustomOp {
+    private long[] begin;
+    private long[] end;
+    private long[] strides;
+    private int beginMask;
+    private int endMask;
+    private int ellipsisMask;
+    private int newAxisMask;
+    private int shrinkAxisMask;
+
+    public StridedSliceBp() {}
+
+    public StridedSliceBp(SameDiff sameDiff, @NonNull SDVariable in, @NonNull SDVariable grad, @NonNull long[] begin, @NonNull long[] end, @NonNull long[] strides,
+                          int beginMask, int endMask, int ellipsisMask, int newAxisMask, int shrinkAxisMask){
+        super(null, sameDiff, new SDVariable[]{in, grad});
+        this.begin = begin;
+        this.end = end;
+        this.strides = strides;
+        this.beginMask = beginMask;
+        this.endMask = endMask;
+        this.ellipsisMask = ellipsisMask;
+        this.newAxisMask = newAxisMask;
+        this.shrinkAxisMask = shrinkAxisMask;
+
+        //https://github.com/deeplearning4j/libnd4j/blob/master/include/ops/declarable/generic/parity_ops/strided_slice.cpp#L279
+        addArguments();
+    }
+
+    private void addArguments(){
+        addIArgument(beginMask);
+        addIArgument(ellipsisMask);
+        addIArgument(endMask);
+        addIArgument(newAxisMask);
+        addIArgument(shrinkAxisMask);
+        addIArgument(begin);
+        addIArgument(end);
+        addIArgument(strides);
+    }
+
+
+    @Override
+    public String opName() {
+        return "strided_slice_bp";
+    }
+
+
+    @Override
+    public void assertValidForExecution() {
+        if(numInputArguments() != 2 && numInputArguments() != 4) {
+            throw new ND4JIllegalStateException("Num input arguments must be 2 or 4.");
+        }
+
+        if(numIArguments() < 5) {
+            throw new ND4JIllegalStateException("Number of integer arguments must >= 5");
+        }
+    }
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> i_v) {
+        throw new UnsupportedOperationException("Differentation not supported for backprop function: " + getClass().getSimpleName());
+    }
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/MatchConditionTransform.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/MatchConditionTransform.java
@@ -29,6 +29,7 @@ import org.nd4j.linalg.api.ops.BaseTransformOp;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.conditions.Condition;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,29 +39,18 @@ import java.util.List;
  */
 public class MatchConditionTransform extends BaseTransformOp {
 
+    private Condition condition;
     private double compare;
     private double eps;
     private int mode;
 
-    public MatchConditionTransform(SameDiff sameDiff, SDVariable i_v, boolean inPlace, double compare, double eps, int mode) {
-        super(sameDiff, i_v, inPlace);
-        this.compare = compare;
-        this.eps = eps;
-        this.mode = mode;
-    }
-
-    public MatchConditionTransform(SameDiff sameDiff, SDVariable i_v, long[] shape, boolean inPlace, Object[] extraArgs, double compare, double eps, int mode) {
-        super(sameDiff, i_v, shape, inPlace, extraArgs);
-        this.compare = compare;
-        this.eps = eps;
-        this.mode = mode;
-    }
-
-    public MatchConditionTransform(SameDiff sameDiff, SDVariable i_v, Object[] extraArgs, double compare, double eps, int mode) {
-        super(sameDiff, i_v, extraArgs);
-        this.compare = compare;
-        this.eps = eps;
-        this.mode = mode;
+    public MatchConditionTransform(SameDiff sameDiff, SDVariable in, Condition condition) {
+        super(sameDiff, in, false);
+        this.condition = condition;
+        this.compare = condition.getValue();
+        this.mode = condition.condtionNum();
+        this.eps = Nd4j.EPS_THRESHOLD;
+        this.extraArgs = new Object[] {compare, eps, (double) mode};
     }
 
     public MatchConditionTransform() {}
@@ -113,6 +103,6 @@ public class MatchConditionTransform extends BaseTransformOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {
-        return null;
+        return Collections.singletonList(sameDiff.zerosLike(arg()));
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/custom/RandomNormal.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/custom/RandomNormal.java
@@ -8,6 +8,9 @@ import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.ArrayUtil;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Random normal distribution
  *
@@ -38,5 +41,10 @@ public class RandomNormal extends DynamicCustomOp {
     @Override
     public String tensorflowName() {
         throw new NoOpNameFoundException("Not TF op name set for " + getClass().getSimpleName());
+    }
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> grad){
+        return Collections.singletonList(sameDiff.zerosLike(arg()));
     }
 }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LayerOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LayerOpValidation.java
@@ -654,17 +654,17 @@ public class LayerOpValidation extends BaseOpValidation {
         SDVariable out = sd.sconv2d(vars, c);
         out = sd.tanh("out", out);
 
-//        INDArray outArr = sd.execAndEndResult();
-//        //Expected output size: out = (in - k + 2*p)/s + 1 = (28-2+0)/1+1 = 27
-//        val outShape = outArr.shape();
-//        assertArrayEquals(new long[]{mb, nOut, 27, 27}, outShape);
+        INDArray outArr = sd.execAndEndResult();
+        //Expected output size: out = (in - k + 2*p)/s + 1 = (28-2+0)/1+1 = 27
+        val outShape = outArr.shape();
+        assertArrayEquals(new long[]{mb, nOut, 27, 27}, outShape);
 
         SDVariable loss = out.std(true);
 
-        System.out.println(sd.summary());
-        System.out.println("--------------------------");
-        sd.createGradFunction();
-        System.out.println(sd.getFunction("grad").summary());
+//        System.out.println(sd.summary());
+//        System.out.println("--------------------------");
+//        sd.createGradFunction();
+//        System.out.println(sd.getFunction("grad").summary());
 
         //Gradient check:
         TestCase tc = new TestCase(sd);
@@ -676,19 +676,19 @@ public class LayerOpValidation extends BaseOpValidation {
     public void testDeconv2dBasic() {
         OpValidationSuite.ignoreFailing();
 
-        int nIn = 3;
-        int nOut = 4;
+        int nIn = 2;
+        int nOut = 3;
         int kH = 2;
         int kW = 2;
 
-        int mb = 3;
+        int mb = 2;
         int imgH = 28;
         int imgW = 28;
 
         SameDiff sd = SameDiff.create();
-        INDArray wArr = Nd4j.create(nOut, nIn, kH, kW);
-        INDArray bArr = Nd4j.create(1, nOut);
-        INDArray inArr = Nd4j.create(mb, nIn, imgH, imgW);
+        INDArray wArr = Nd4j.rand(new int[]{nIn, nOut, kH, kW}); //Libnd4j expected weights format: [chIn, chOut, kH, kW] - NCHW
+        INDArray bArr = Nd4j.rand(new long[]{nOut});
+        INDArray inArr = Nd4j.rand(new long[]{mb, nIn, imgH, imgW});
 
         SDVariable in = sd.var("in", inArr);
         SDVariable w = sd.var("W", wArr);
@@ -711,6 +711,12 @@ public class LayerOpValidation extends BaseOpValidation {
         //Expected output size: out = (in + k + 2*p)/ s - 1 = (28 + 2+0)/1 - 1 = 29
         val outShape = outArr.shape();
         assertArrayEquals(new long[]{mb, nOut, 29, 29}, outShape);
+
+        SDVariable loss = out.std(true);
+        //Gradient check:
+        TestCase tc = new TestCase(sd);
+        String err = OpValidation.validate(tc);
+        assertNull(err);
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LayerOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LayerOpValidation.java
@@ -1,5 +1,6 @@
 package org.nd4j.autodiff.opvalidation;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Test;
 import org.nd4j.autodiff.OpValidationSuite;
@@ -22,6 +23,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
+@Slf4j
 public class LayerOpValidation extends BaseOpValidation {
     public LayerOpValidation(Nd4jBackend backend) {
         super(backend);
@@ -130,7 +132,7 @@ public class LayerOpValidation extends BaseOpValidation {
 
         Nd4j.getRandom().setSeed(12345);
 
-        int[][] inputSizes = new int[][]{{1, 3, 8, 8}, {3, 6, 12, 12}};
+        int[][] inputSizes = new int[][]{{1, 3, 8, 8}}; //, {3, 6, 12, 12}};
 
         List<String> failed = new ArrayList<>();
 
@@ -236,7 +238,7 @@ public class LayerOpValidation extends BaseOpValidation {
                         break;
                     case 7:
                         //LRN
-                        msg = "7 - LRN with NHWC - input" + Arrays.toString(inSizeNCHW);
+                        msg = "7 - LRN with NCHW - input" + Arrays.toString(inSizeNCHW);
                         inSize = inSizeNCHW;
                         in = sd.var("in", inSize);
                         out = sd.localResponseNormalization(in, LocalResponseNormalizationConfig.builder()
@@ -255,6 +257,7 @@ public class LayerOpValidation extends BaseOpValidation {
                 in.setArray(inArr);
                 SDVariable loss = sd.standardDeviation("loss", out, true);
 
+                log.info("Starting test: " + msg);
                 TestCase tc = new TestCase(sd);
                 String error = OpValidation.validate(tc);
                 if (error != null) {
@@ -554,7 +557,9 @@ public class LayerOpValidation extends BaseOpValidation {
                     in.setArray(inArr);
                     SDVariable loss = sd.standardDeviation("loss", out, true);
 
+                    log.info("Starting test: " + msg);
                     TestCase tc = new TestCase(sd);
+                    tc.testName(msg);
                     String error = OpValidation.validate(tc);
                     if (error != null) {
                         failed.add(name);

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LayerOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LayerOpValidation.java
@@ -96,8 +96,8 @@ public class LayerOpValidation extends BaseOpValidation {
         for (boolean rank1Bias : new boolean[]{false, true}) {
 
             SameDiff sameDiff = SameDiff.create();
-            INDArray input = Nd4j.rand(new long[]{2, 4});
-            INDArray b = Nd4j.rand(rank1Bias ? new long[]{4} : new long[]{1, 4});
+            INDArray input = Nd4j.linspace(1,8,8).reshape(new long[]{2, 4});
+            INDArray b = Nd4j.linspace(1,4,4).reshape(rank1Bias ? new long[]{4} : new long[]{1, 4}).divi(4);
 
             SDVariable sdInput = sameDiff.var("input", input);
             SDVariable sdBias = sameDiff.var("bias", b);
@@ -105,7 +105,7 @@ public class LayerOpValidation extends BaseOpValidation {
             SDVariable res = sameDiff.biasAdd(sdInput, sdBias);
             SDVariable loss = sameDiff.standardDeviation(res, true);
 
-            INDArray exp = input.addiRowVector(b);
+            INDArray exp = input.addRowVector(b);
 
             TestCase tc = new TestCase(sameDiff)
                     .gradientCheck(true)

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/MiscOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/MiscOpValidation.java
@@ -308,9 +308,6 @@ public class MiscOpValidation extends BaseOpValidation {
 
     @Test
     public void testScatterOpGradients() {
-        OpValidationSuite.ignoreFailing();
-
-
         List<String> failed = new ArrayList<>();
 
         for (int i = 0; i < 5; i++) {
@@ -381,8 +378,9 @@ public class MiscOpValidation extends BaseOpValidation {
             SDVariable loss = sd.sum(scatter);  //.standardDeviation(scatter, true);  //.sum(scatter);  //TODO stdev might be better here as gradients are non-symmetrical...
             sd.execAndEndResult();
 
-            TestCase tc = new TestCase(sd);
-            tc.expected(scatter, exp);
+            TestCase tc = new TestCase(sd)
+                    .expected(scatter, exp)
+                    .gradCheckSkipVariables(indices.getVarName());
 
             String error = OpValidation.validate(tc);
             if(error != null){

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/MiscOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/MiscOpValidation.java
@@ -527,7 +527,7 @@ public class MiscOpValidation extends BaseOpValidation {
 
 
     @Test
-    public void testMmulGradient() {
+    public void testMmulGradientManual() {
         SameDiff sameDiff = SameDiff.create();
         INDArray sumInput = Nd4j.linspace(1, 4, 4).reshape(2, 2);
         Map<String, INDArray> inputs = new HashMap<>();
@@ -571,6 +571,64 @@ public class MiscOpValidation extends BaseOpValidation {
 
         assertEquals(xGradAssertion, gradWrtX.getArr());
         assertEquals(yGradAssertion, gradWrtY.getArr());
+    }
+
+    @Test
+    public void testMmulGradients(){
+
+        int[] aShape = new int[]{2,3};
+        int[] bShape = new int[]{3,4};
+        List<String> failed = new ArrayList<>();
+
+        for( char aOrder : new char[]{'c', 'f'}) {
+            for (char bOrder : new char[]{'c', 'f'}) {
+                for (boolean transposeA : new boolean[]{false, true}) {
+                    for (boolean transposeB : new boolean[]{false, true}) {
+                        for (boolean transposeResult : new boolean[]{false, true}) {    //https://github.com/deeplearning4j/deeplearning4j/issues/5648
+                            Nd4j.getRandom().setSeed(12345);
+
+                            INDArray aArr = Nd4j.rand(t(transposeA, aShape)).dup(aOrder);
+                            INDArray bArr = Nd4j.rand(t(transposeB, bShape)).dup(bOrder);
+
+                            SameDiff sd = SameDiff.create();
+                            SDVariable a = sd.var("a", aArr);
+                            SDVariable b = sd.var("b", bArr);
+
+                            MMulTranspose mt = MMulTranspose.builder()
+                                    .transposeA(transposeA)
+                                    .transposeB(transposeB)
+                                    .transposeResult(transposeResult)
+                                    .build();
+
+                            SDVariable mmul = sd.mmul(a, b, mt);
+
+                            INDArray exp = (transposeA ? aArr.transpose() : aArr);
+                            exp = exp.mmul(transposeB ? bArr.transpose() : bArr);
+                            exp = (transposeResult ? exp.transpose() : exp);
+
+                            SDVariable loss = mmul.std(true);
+
+                            String name = aOrder + "," + bOrder + ",tA=" + transposeA + ",tB=" + transposeB +
+                                    ",tRes=" + transposeResult;
+                            TestCase tc = new TestCase(sd).testName(name)
+                                    .expected(mmul, exp);
+
+                            String err = OpValidation.validate(tc, true);
+                            if(err != null)
+                                failed.add(err);
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(failed.toString(), 0, failed.size());
+    }
+
+    private static int[] t(boolean transpose, int[] orig){
+        if(!transpose)
+            return orig;
+        return new int[]{orig[1], orig[0]};
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ReductionOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ReductionOpValidation.java
@@ -90,9 +90,11 @@ public class ReductionOpValidation extends BaseOpValidation {
             SDVariable nonZero = sd.countNonZero(input);
             SDVariable zero = sd.countZero(input);
 
+            SDVariable loss = nonZero.add(zero).std(true);
+
             String error = OpValidation.validate(new TestCase(sd)
-                    .expectedOutput(nonZero.getVarName(), Nd4j.trueScalar(2.0))
-                    .expectedOutput(zero.getVarName(), Nd4j.trueScalar(2.0))
+                    .expectedOutput(nonZero.getVarName(), Nd4j.trueScalar(i == 0 ? 2.0 : 4.0))
+                    .expectedOutput(zero.getVarName(), Nd4j.trueScalar(i == 0 ? 2.0 : 0.0))
                     .gradientCheck(i != 0)
             );
             if(error != null)
@@ -124,7 +126,7 @@ public class ReductionOpValidation extends BaseOpValidation {
             SDVariable zeroFraction = sd.zeroFraction(input);
 
             String error = OpValidation.validate(new TestCase(sd)
-                    .expectedOutput(zeroFraction.getVarName(), Nd4j.trueScalar(0.5))
+                    .expectedOutput(zeroFraction.getVarName(), Nd4j.trueScalar(i == 0 ? 0.5 : 0.0))
                     .gradientCheck(i != 0)
             );
             if(error != null)

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
@@ -663,7 +663,7 @@ public class ShapeOpValidation extends BaseOpValidation {
                     //for gradient check, need to combine to single scalar output...
                     SDVariable merged = sd.mergeAvg(unstacked);
 
-                    if (ArrayUtil.prodLong(stackedShape) == 1) {
+                    if (ArrayUtil.prodLong(stackedShape) == 1 || ArrayUtil.prodLong(shape) == 1) {
                         SDVariable loss = sd.sum("loss", merged);
                     } else {
                         SDVariable loss = sd.standardDeviation("loss", merged, true);
@@ -685,7 +685,7 @@ public class ShapeOpValidation extends BaseOpValidation {
                     }
                     String error = OpValidation.validate(tc, true);
                     if(error != null){
-                        failed.add(name);
+                        failed.add(error);
                     }
                 }
             }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
@@ -322,11 +322,11 @@ public class ShapeOpValidation extends BaseOpValidation {
         //Order here: original shape, begin, size
         List<Triple<int[], int[], int[]>> testCases = new ArrayList<>();
         testCases.add(new Triple<>(new int[]{3, 4}, new int[]{0, 0}, new int[]{3, 4}));
-        testCases.add(new Triple<>(new int[]{3, 4}, new int[]{1, 1}, new int[]{3, 4}));
-        testCases.add(new Triple<>(new int[]{3, 4}, new int[]{1, 2}, new int[]{2, 3}));
+        testCases.add(new Triple<>(new int[]{3, 4}, new int[]{1, 1}, new int[]{2, 1}));
+        testCases.add(new Triple<>(new int[]{3, 4}, new int[]{1, 2}, new int[]{2, 2}));
         testCases.add(new Triple<>(new int[]{3, 4, 5}, new int[]{0, 0, 0}, new int[]{3, 4, 5}));
         testCases.add(new Triple<>(new int[]{3, 4, 5}, new int[]{1, 1, 1}, new int[]{2, 3, 4}));
-        testCases.add(new Triple<>(new int[]{3, 4, 5}, new int[]{1, 0, 2}, new int[]{3, 3, 4}));
+        testCases.add(new Triple<>(new int[]{3, 4, 5}, new int[]{1, 0, 2}, new int[]{3, 3, 2}));
 
         List<String> failed = new ArrayList<>();
 
@@ -345,10 +345,10 @@ public class ShapeOpValidation extends BaseOpValidation {
             String msg = "i=" + i + ": inShape=" + Arrays.toString(os) + ", begin=" + Arrays.toString(b) + ", end=" + Arrays.toString(e);
             log.info("Starting test: " + msg);
 
-            TestCase tc = new TestCase(sd);
-            String error = OpValidation.validate(tc);
+            TestCase tc = new TestCase(sd).testName(msg);
+            String error = OpValidation.validate(tc, true);
             if(error != null){
-                failed.add(name);
+                failed.add(error);
             }
         }
 

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
@@ -405,7 +405,6 @@ public class ShapeOpValidation extends BaseOpValidation {
         testCases.add(SSCase.builder().shape(3, 4).begin(-999, 0).end(3, 4).strides(1, 1).beginMask(1).build());
         testCases.add(SSCase.builder().shape(3, 4).begin(1, 1).end(3, -999).strides(1, 1).endMask(1 << 1).build());
         testCases.add(SSCase.builder().shape(3, 4).begin(-999, 0).end(-999, 4).strides(1, 1).beginMask(1).endMask(1).build());
-        testCases.add(SSCase.builder().shape(3, 4).begin(-999, 0, 0).end(-999, 3, 4).strides(1, 1).newAxisMask(1).build());
 
         testCases.add(SSCase.builder().shape(3, 4, 5).begin(0, 0, 0).end(3, 4, 5).strides(1, 1, 1).build());
         testCases.add(SSCase.builder().shape(3, 4, 5).begin(1, 2, 3).end(3, 4, 5).strides(1, 1, 1).build());
@@ -433,9 +432,10 @@ public class ShapeOpValidation extends BaseOpValidation {
             log.info("Starting test: " + msg);
 
             TestCase tc = new TestCase(sd);
-            String error = OpValidation.validate(tc);
+            tc.testName(msg);
+            String error = OpValidation.validate(tc, true);
             if(error != null){
-                failed.add(name);
+                failed.add(error);
             }
         }
         assertEquals(failed.toString(), 0, failed.size());

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/TransformOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/TransformOpValidation.java
@@ -1221,10 +1221,9 @@ public class TransformOpValidation extends BaseOpValidation {
 
     @Test
     public void testReplaceWhereScalar(){
-        OpValidationSuite.ignoreFailing();
-        fail(); //JVM crash
         for(Condition c : new Condition[]{Conditions.lessThan(0.5), Conditions.greaterThan(0.5), Conditions.equals(0.5)}){
 
+            log.info("Testing condition: " + c.getClass().getName());
             INDArray inArr = Nd4j.rand(3,4);
             SameDiff sd = SameDiff.create();
             SDVariable in = sd.var("in", inArr);
@@ -1244,8 +1243,6 @@ public class TransformOpValidation extends BaseOpValidation {
 
     @Test
     public void testReplaceWhereArray(){
-        OpValidationSuite.ignoreFailing();
-        fail(); //JVM crash
         for(Condition c : new Condition[]{Conditions.lessThan(0.5), Conditions.greaterThan(0.5), Conditions.equals(0.5)}){
 
             INDArray inArr = Nd4j.rand(3,4);


### PR DESCRIPTION
This should be good to go - can be merged if CI is happy with it...

Fixes ops (and/or their gradients/tests):
* BiasAdd
* SConv2D
* Deconv2d
* Pooling3d
* Adds im2col backprop op (mainly for shape function - can't use col2im as backprop as we need the output shape as input to the shape function...)
* mmul fixes (not fully working due to transposeResult issue, but better)
* conv3d fixes
* matchCondition (CompareAndReplace/Set)
* Slice and strided slice
(plus a few other minor things)