### PR TITLE
Remove duplicate GEMM call

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -3775,15 +3775,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 Nd4j.getBlasWrapper().level3().gemm(BlasBufferUtil.getCharForTranspose(result),
                         BlasBufferUtil.getCharForTranspose(this), BlasBufferUtil.getCharForTranspose(temp), 1.0,
                         this, other, 0.0, temp);
-                Nd4j.getBlasWrapper().level3().gemm(
-                        BlasBufferUtil.getCharForTranspose(result),
-                        BlasBufferUtil.getCharForTranspose(this),
-                        BlasBufferUtil.getCharForTranspose(temp),
-                        1.0,
-                        this,
-                        other,
-                        0.0,
-                        temp);
             }
 
             result.assign(temp);


### PR DESCRIPTION
For some reason there was a duplicate GEMM call within `.mmuli`. Looks like that may have been a copy and paste error.