### PR TITLE
get rid of jcpp shapeInfo calls

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -111,7 +111,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     protected transient boolean compressed = false;
 
     // this field holds jvm copy of shapeInfo
-    protected long[] javaShapeInformation;
+    protected transient JvmShapeInfo jvmShapeInfo;
+
 
 
     //Precalculate these arrays (like [3,2,1,0], [2,1,0], [1,0], [0] etc) for use in TAD, to avoid creating same int[]s over and over
@@ -1063,7 +1064,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     private void setShapeInformation(Pair<DataBuffer, long[]> shapeInfo) {
         this.shapeInformation = shapeInfo.getFirst();
-        this.javaShapeInformation = shapeInfo.getSecond();
+        this.jvmShapeInfo = new JvmShapeInfo(shapeInfo.getSecond());
     }
 
 
@@ -1181,10 +1182,10 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
         long length = length();
 
-        if (dimension >= Shape.rank(javaShapeInformation)) {
-            if (length / size(Shape.rank(javaShapeInformation) - 1) >= Integer.MAX_VALUE)
+        if (dimension >= jvmShapeInfo.rank) {
+            if (length / size(jvmShapeInfo.rank - 1) >= Integer.MAX_VALUE)
                 throw new IllegalArgumentException("Vectors along dimension can not be >= Integer.MAX_VALUE");
-            return (int) (length / size(Shape.rank(javaShapeInformation) - 1));
+            return (int) (length / size(jvmShapeInfo.rank - 1));
         }
         if (length / size(dimension) >= Integer.MAX_VALUE)
             throw new IllegalArgumentException("Vectors along dimension can not be >= Integer.MAX_VALUE");
@@ -1201,10 +1202,10 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     public INDArray vectorAlongDimension(int index, int dimension) {
         if (dimension < 0)
-            dimension = Shape.rank(javaShapeInformation) + dimension;
+            dimension = jvmShapeInfo.getRank() + dimension;
 
         //return the whole thing
-        if (dimension == Shape.rank(javaShapeInformation) - 1 && size(dimension) == 1 && rank() > 2
+        if (dimension == jvmShapeInfo.getRank() - 1 && size(dimension) == 1 && rank() > 2
                 || rank() > 2 && dimension == 0 && size(dimension) == 1) {
             return this;
         }
@@ -1516,7 +1517,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             return putScalar(indexes[0], indexes[1], indexes[2], indexes[3], value);
         } else {
             autoProcessScalarCall();
-            long offset = Shape.getOffset(javaShapeInformation, indexes);
+            long offset = Shape.getOffset(jvmShapeInfo.javaShapeInformation, indexes);
             data.put(offset, value);
         }
         return this;
@@ -1542,7 +1543,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             return putScalar(indexes[0], indexes[1], indexes[2], indexes[3], value);
         } else {
             autoProcessScalarCall();
-            long offset = Shape.getOffset(javaShapeInformation, indexes);
+            long offset = Shape.getOffset(jvmShapeInfo.javaShapeInformation, indexes);
             data.put(offset, value);
         }
         return this;
@@ -1560,7 +1561,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
         if (rank() > 2)
             throw new IllegalStateException("Cannot use putScalar(int,int,double) on a rank " + rank() + " INDArray");
-        long offset = Shape.getOffsetUnsafe(javaShapeInformation, row, col);
+        long offset = Shape.getOffsetUnsafe(jvmShapeInfo.javaShapeInformation, row, col);
         data.put(offset, value);
         return this;
     }
@@ -1574,16 +1575,16 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             throw new IllegalStateException(
                     "Cannot use putScalar(int,int,int,double) on a rank " + rank() + " INDArray");
         long offset = 0; // Shape.getOffsetUnsafe(javaShapeInformation, dim0, dim1, dim2);
-        long size_0 = javaShapeInformation[1];
-        long size_1 = javaShapeInformation[1 + 1];
-        long size_2 = javaShapeInformation[1 + 2];
+        long size_0 = jvmShapeInfo.javaShapeInformation[1];
+        long size_1 = jvmShapeInfo.javaShapeInformation[1 + 1];
+        long size_2 = jvmShapeInfo.javaShapeInformation[1 + 2];
 
         if (size_0 != 1)
-            offset += dim0 * javaShapeInformation[1 + 0 + 3];
+            offset += dim0 * jvmShapeInfo.javaShapeInformation[1 + 0 + 3];
         if (size_1 != 1)
-            offset += dim1 * javaShapeInformation[1 + 1 + 3];
+            offset += dim1 * jvmShapeInfo.javaShapeInformation[1 + 1 + 3];
         if (size_2 != 1)
-            offset += dim2 * javaShapeInformation[1 + 2 + 3];
+            offset += dim2 * jvmShapeInfo.javaShapeInformation[1 + 2 + 3];
 
         data.put(offset, value);
         return this;
@@ -1597,7 +1598,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (rank() != 4)
             throw new IllegalStateException(
                     "Cannot use putScalar(int,int,int,int,double) on a rank " + rank() + " INDArray");
-        long offset = Shape.getOffsetUnsafe(javaShapeInformation, dim0, dim1, dim2, dim3);
+        long offset = Shape.getOffsetUnsafe(jvmShapeInfo.javaShapeInformation, dim0, dim1, dim2, dim3);
         data.put(offset, value);
         return this;
     }
@@ -2031,13 +2032,13 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (isEmpty())
             return false;
 
-        if (Shape.rank(javaShapeInformation) == 0) {
+        if (jvmShapeInfo.rank == 0) {
             return true;
-        } else if (Shape.rank(javaShapeInformation) > 2) {
+        } else if (jvmShapeInfo.rank > 2) {
             return false;
-        } else if (Shape.rank(javaShapeInformation) == 1) {
-            return shapeOf().getInt(0) == 1;
-        } else if (Shape.rank(javaShapeInformation) == 2) {
+        } else if (jvmShapeInfo.rank == 1) {
+            return shape()[0] == 1;
+        } else if (jvmShapeInfo.rank == 2) {
             return shape()[0] == 1 && shape()[1] == 1 || length() == 1;
         }
 
@@ -2588,8 +2589,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             And it's possible to be not a view, and have non-empty originalBuffer
          */
         // length/data.length can be different in case of Threshold conversion
-        return Shape.offset(javaShapeInformation) > 0
-                || (length() < data().length() && data.dataType() != DataBuffer.Type.INT)
+        return Shape.offset(jvmShapeInfo.javaShapeInformation) > 0
+                || (length() < data().length() && data.dataType() != DataBuffer.Type.LONG)
                 || data().originalDataBuffer() != null;
     }
 
@@ -2682,7 +2683,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         long[] dotProductOffsets = offsets;
         int[] dotProductStride = stride;
 
-        long offset = Shape.offset(javaShapeInformation) + NDArrayIndex.offset(dotProductStride, dotProductOffsets);
+        long offset = Shape.offset(jvmShapeInfo.javaShapeInformation) + NDArrayIndex.offset(dotProductStride, dotProductOffsets);
         if (offset >= data().length())
             offset = ArrayUtil.sumLong(offsets);
 
@@ -2749,7 +2750,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (i < 0)
             i += this.length();
 
-        long idx = this.isVector() ? i : Shape.getOffset(this.javaShapeInformation, Shape.ind2subC(this.shape(), i));
+        long idx = this.isVector() ? i : Shape.getOffset(jvmShapeInfo.javaShapeInformation, Shape.ind2subC(this.shape(), i));
         val buffer = Nd4j.createBuffer(this.data(), idx, 1);
         val shape = Nd4j.getShapeInfoProvider().createShapeInformation(new long[0], new long[0],0,1,'c');
         return Nd4j.createArrayFromShapeBuffer(buffer, shape);
@@ -3198,10 +3199,10 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public int stride(int dimension) {
-        int rank = Shape.rank(javaShapeInformation);
+        int rank = jvmShapeInfo.rank;
         if (dimension < 0)
-            return strideOf().getInt(dimension + rank);
-        return strideOf().getInt(dimension);
+            return (int) stride()[dimension + rank];
+        return (int) stride()[dimension];
     }
 
     @Override
@@ -4172,12 +4173,12 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Deprecated
     public long linearIndex(long i) {
         long idx = i;
-        for (int j = 0; j < Shape.rank(javaShapeInformation) - 1; j++) {
+        for (int j = 0; j < jvmShapeInfo.rank - 1; j++) {
             if (size((int) i) == 1)
                 continue;
             idx += i * stride(j);
         }
-        return Shape.offset(javaShapeInformation) + (idx);
+        return Shape.offset(jvmShapeInfo.javaShapeInformation) + (idx);
     }
 
 
@@ -4201,7 +4202,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (slice >= slices)
             throw new IllegalArgumentException("Illegal slice " + slice);
 
-        if (Shape.rank(javaShapeInformation) == 0 || isVector()) {
+        if (jvmShapeInfo.rank == 0 || isVector()) {
             if (slice == 0 || isVector()) {
                 return createScalarForIndex(slice, true);
             }
@@ -4278,7 +4279,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (slice >= slices)
             throw new IllegalArgumentException("Illegal slice " + slice);
 
-        if (Shape.rank(javaShapeInformation) == 0) {
+        if (jvmShapeInfo.rank == 0) {
             if (slice == 0)
                 return createScalarForIndex(slice, true);
             else
@@ -4314,7 +4315,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             if (indexes[i] < 0)
                 indexes[i] += this.size(i);
         }
-        long idx = Shape.getOffset(this.javaShapeInformation, indexes);
+        long idx = Shape.getOffset(jvmShapeInfo.javaShapeInformation, indexes);
         val buffer = Nd4j.createBuffer(this.data(), idx, 1);
         val shape = Nd4j.getShapeInfoProvider().createShapeInformation(new long[0], new long[0],0,1,'c');
         return Nd4j.createArrayFromShapeBuffer(buffer, shape);
@@ -4330,7 +4331,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 indexes[i] += this.size(i);
         }
 
-        long idx = Shape.getOffset(this.javaShapeInformation, indexes);
+        long idx = Shape.getOffset(jvmShapeInfo.javaShapeInformation, indexes);
         val buffer = Nd4j.createBuffer(this.data(), idx, 1);
         val shape = Nd4j.getShapeInfoProvider().createShapeInformation(new long[0], new long[0],0,1,'c');
         return Nd4j.createArrayFromShapeBuffer(buffer, shape);
@@ -4704,8 +4705,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 Shape.stride(shapeInformation)) : " Other array should have been stride: "
                 + Shape.toString(Shape.stride(shapeInformation)) + " but was "
                 + Arrays.toString(other.stride());
-        assert Shape.offset(javaShapeInformation) == other.offset() : "Offset of this array is "
-                + Shape.offset(javaShapeInformation) + " but other was " + other.offset();
+        assert Shape.offset(jvmShapeInfo.javaShapeInformation) == other.offset() : "Offset of this array is "
+                + Shape.offset(jvmShapeInfo.javaShapeInformation) + " but other was " + other.offset();
 
     }
 
@@ -5288,7 +5289,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      * @return the shape of this matrix
      */
     public long[] shape() {
-        return Shape.shape(javaShapeInformation);
+        return jvmShapeInfo.shape;
     }
 
     /**
@@ -5309,7 +5310,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public long[] stride() {
-        return Shape.stride(javaShapeInformation);
+        return jvmShapeInfo.stride;
     }
 
 
@@ -5323,7 +5324,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public char ordering() {
-        return Shape.order(javaShapeInformation);
+        return jvmShapeInfo.order;
     }
 
     /**
@@ -5335,6 +5336,9 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public long size(int dimension) {
+        if (dimension < 0)
+            dimension += jvmShapeInfo.rank;
+
         if (isScalar()) {
             if (dimension == 0 || dimension == 1 || dimension < 0)
                 return length();
@@ -5342,22 +5346,16 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 throw new IllegalArgumentException("Illegal dimension for scalar " + dimension);
         }
 
-        if (dimension < 0) {
-            return shapeOf().getInt(dimension + Shape.rank(javaShapeInformation));
-        }
-
         if (dimension >= rank())
             throw new IllegalArgumentException("Invalid size: cannot get size of dimension " + dimension + " for rank "
                     + rank() + " NDArray (array shape: " + Arrays.toString(this.shape()) + ")");
 
-        val _shapeInfo = shapeInfoDataBuffer();
-        val _shape = shapeOf();
-        return shapeOf().getInt(dimension);
+        return jvmShapeInfo.shape[dimension];
     }
 
     @Override
     public int rank() {
-        return Shape.rank(javaShapeInformation);
+        return jvmShapeInfo.rank;
     }
 
     /**
@@ -5367,7 +5365,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public long length() {
-        return Shape.length(javaShapeInformation);
+        return jvmShapeInfo.length;
     }
 
     /**
@@ -5378,7 +5376,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     @Deprecated
     public long lengthLong() {
-        return Shape.length(javaShapeInformation);
+        return jvmShapeInfo.length;
     }
 
     @Override
@@ -5399,7 +5397,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
         boolean compatible = true;
         int count = shape.length - 1;
-        int thisCount = Shape.rank(javaShapeInformation) - 1;
+        int thisCount = jvmShapeInfo.rank - 1;
         for (int i = shape.length - 1; i > 0; i--) {
             if (count < 0 || thisCount < 0)
                 break;
@@ -5520,7 +5518,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     public INDArray dimShuffle(Object[] rearrange, long[] newOrder, boolean[] broadCastable) {
         Nd4j.getCompressor().autoDecompress(this);
 
-        if (broadCastable.length != Shape.rank(javaShapeInformation))
+        if (broadCastable.length != jvmShapeInfo.rank)
             throw new IllegalArgumentException(
                     "The broadcastable dimensions must be the same length as the current shape");
 
@@ -5630,7 +5628,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             return dup();
         boolean alreadyInOrder = true;
         //IntBuffer shapeInfo = shapeInfo();
-        int rank = Shape.rank(javaShapeInformation);
+        int rank = jvmShapeInfo.rank;
         for (int i = 0; i < rank; i++) {
             if (rearrange[i] != i) {
                 alreadyInOrder = false;
@@ -5663,7 +5661,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     public INDArray permutei(int... rearrange) {
         boolean alreadyInOrder = true;
         val shapeInfo = shapeInfo();
-        int rank = Shape.rank(javaShapeInformation);
+        int rank = jvmShapeInfo.rank;
         for (int i = 0; i < rank; i++) {
             if (rearrange[i] != i) {
                 alreadyInOrder = false;
@@ -5739,7 +5737,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
 
     protected void checkArrangeArray(int[] arr) {
-        assert arr.length == Shape.rank(javaShapeInformation) : "Invalid rearrangement: number of arrangement != shape";
+        assert arr.length == jvmShapeInfo.rank : "Invalid rearrangement: number of arrangement != shape";
         for (int i = 0; i < arr.length; i++) {
             if (arr[i] >= arr.length)
                 throw new IllegalArgumentException("The specified dimensions can't be swapped. Given element " + i
@@ -5769,7 +5767,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public boolean isVector() {
-        if (Shape.rank(javaShapeInformation) == 1)
+        if (jvmShapeInfo.rank == 1)
             return true;
 
         return isRowVector() || isColumnVector();
@@ -6597,6 +6595,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public boolean isEmpty() {
-        return ArrayOptionsHelper.arrayType(javaShapeInformation) == ArrayType.EMPTY;
+        return ArrayOptionsHelper.arrayType(jvmShapeInfo.javaShapeInformation) == ArrayType.EMPTY;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/JvmShapeInfo.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/JvmShapeInfo.java
@@ -1,0 +1,28 @@
+package org.nd4j.linalg.api.ndarray;
+
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.nd4j.linalg.api.shape.Shape;
+
+public class JvmShapeInfo {
+    @Getter protected long[] javaShapeInformation;
+    @Getter protected long[] shape;
+    @Getter protected long[] stride;
+    @Getter protected long length;
+    @Getter protected long ews;
+    @Getter protected long extras;
+    @Getter protected char order;
+    @Getter protected int rank;
+
+    public JvmShapeInfo(@NonNull long[] javaShapeInformation) {
+        this.javaShapeInformation = javaShapeInformation;
+        this.shape = Shape.shape(javaShapeInformation);
+        this.stride = Shape.stride(javaShapeInformation);
+        this.length = Shape.length(javaShapeInformation);
+        this.ews = Shape.elementWiseStride(javaShapeInformation);
+        this.extras = Shape.extras(javaShapeInformation);
+        this.order = Shape.order(javaShapeInformation);
+        this.rank = Shape.rank(javaShapeInformation);
+    }
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/Shape.java
@@ -2974,6 +2974,10 @@ public class Shape {
         return ret;
     }
 
+    public static long extras(long[] buffer) {
+        return options(buffer);
+    }
+
     /**
      * Get the offset for the buffer
      *
@@ -3032,6 +3036,18 @@ public class Shape {
     public static int elementWiseStride(IntBuffer buffer) {
         int length2 = shapeInfoLength(buffer.get(0));
         return buffer.get(length2 - 2);
+    }
+
+    /**
+     * Get the element wise stride for the
+     * shape info buffer
+     * @param buffer the buffer to get the element
+     *               wise stride from
+     * @return the element wise stride for the buffer
+     */
+    public static long elementWiseStride(long[] buffer) {
+        int length2 = shapeInfoLength(buffer);
+        return buffer[length2 - 2];
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
@@ -31,6 +31,7 @@ import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.BaseNDArray;
 import org.nd4j.linalg.api.ndarray.BaseNDArrayProxy;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ndarray.JvmShapeInfo;
 import org.nd4j.linalg.api.ops.executioner.GridExecutioner;
 import org.nd4j.linalg.api.ops.performance.PerformanceTracker;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
@@ -58,7 +59,7 @@ public class JCublasNDArray extends BaseNDArray {
 
 
     public JCublasNDArray(DataBuffer buffer, CudaLongDataBuffer shapeInfo, long[] javaShapeInfo) {
-        this.javaShapeInformation = javaShapeInfo;
+        this.jvmShapeInfo = new JvmShapeInfo(javaShapeInfo);
         this.shapeInformation = shapeInfo;
         this.data = buffer;
     }
@@ -515,7 +516,7 @@ public class JCublasNDArray extends BaseNDArray {
      */
     public void setShapeInfoDataBuffer(DataBuffer buffer) {
         this.shapeInformation = buffer;
-        this.javaShapeInformation = shapeInformation.asLong();
+        this.jvmShapeInfo = new JvmShapeInfo(shapeInformation.asLong());
     }
 
     private Object writeReplace() throws java.io.ObjectStreamException {

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/NDArray.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/NDArray.java
@@ -29,6 +29,7 @@ import org.nd4j.linalg.api.buffer.LongBuffer;
 import org.nd4j.linalg.api.ndarray.BaseNDArray;
 import org.nd4j.linalg.api.ndarray.BaseNDArrayProxy;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ndarray.JvmShapeInfo;
 import org.nd4j.linalg.api.ops.performance.PerformanceTracker;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.memory.MemcpyDirection;
@@ -66,7 +67,7 @@ public class NDArray extends BaseNDArray {
 
 
     public NDArray(DataBuffer buffer, LongBuffer shapeInfo, long[] javaShapeInfo) {
-        this.javaShapeInformation = javaShapeInfo;
+        this.jvmShapeInfo = new JvmShapeInfo(javaShapeInfo);
         this.shapeInformation = shapeInfo;
         this.data = buffer;
     }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
@@ -25,6 +25,7 @@ import lombok.val;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 import org.apache.commons.math3.util.FastMath;
+import org.nd4j.linalg.api.blas.params.GemmParams;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.executioner.GridExecutioner;
@@ -6668,6 +6669,31 @@ public class Nd4jTestsC extends BaseNd4jTest {
         assertEquals(exp, array);
     }
 
+    @Test
+    public void testSomething_1() {
+        val arrayX = Nd4j.create(128, 128, 'f');
+        val arrayY = Nd4j.create(128, 128, 'f');
+        val arrayZ = Nd4j.create(128, 128, 'f');
+
+        int iterations = 10000;
+        // warmup
+        for (int e = 0; e < 1000; e++)
+            arrayX.addi(arrayY);
+
+        for (int e = 0; e < iterations; e++) {
+            val c = new GemmParams(arrayX, arrayY, arrayZ);
+        }
+
+        val tS = System.nanoTime();
+        for (int e = 0; e < iterations; e++) {
+            //val c = new GemmParams(arrayX, arrayY, arrayZ);
+            arrayX.mmuli(arrayY, arrayZ);
+        }
+
+        val tE = System.nanoTime();
+
+        log.info("Average time: {}", ((tE - tS) / iterations));
+    }
 
     ///////////////////////////////////////////////////////
     protected static void fillJvmArray3D(float[][][] arr) {


### PR DESCRIPTION
This PR removes databuffer jcpp backed calls for shape information: ranks, lengths, columns, rows, sizes, strides etc. They are replaced with jvm shapeinfo structure. initialized once.