### PR TITLE
deeplearning4j-modelexport-solr: upgrade to Apache Lucene/Solr 7.4.0

### DIFF
--- a/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
+++ b/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
@@ -22,7 +22,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
- * An <a href="https://lucene.apache.org/solr/7_3_0/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
+ * An <a href="https://lucene.apache.org/solr/7_4_0/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
  * org.apache.solr.ltr.model.LTRScoringModel</a> that computes scores using a {@link MultiLayerNetwork} or
  * {@link ComputationGraph} model.
  * <p>
@@ -42,7 +42,7 @@ import org.nd4j.linalg.factory.Nd4j;
  * <p>
  * Apache Solr Reference Guide:
  * <ul>
- * <li> <a href="https://lucene.apache.org/solr/guide/7_3/learning-to-rank.html">Learning To Rank</a>
+ * <li> <a href="https://lucene.apache.org/solr/guide/7_4/learning-to-rank.html">Learning To Rank</a>
  * </ul>
  */
 public class ScoringModel extends AdapterModel {

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <typesafe.config.version>1.3.0</typesafe.config.version>
         <lombok.version>1.16.20</lombok.version>
         <cleartk.version>2.0.0</cleartk.version>
-        <lucene-solr.version>7.3.0</lucene-solr.version>
+        <lucene-solr.version>7.4.0</lucene-solr.version>
         <json.version>20131018</json.version>
         <google.protobuf.version>2.6.1</google.protobuf.version>
         <failIfNoTests>false</failIfNoTests>


### PR DESCRIPTION
http://lucene.apache.org/core/7_4_0/changes/Changes.html

http://lucene.apache.org/solr/7_4_0/changes/Changes.html