### PR TITLE
Add maven enforcer ban for lombok as compile scope dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,11 @@
                                     <version>3.3</version>
                                     <message>Please install maven 3.3 or higher</message>
                                 </requireMavenVersion>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>org.projectlombok:*:*:*:compile</exclude>
+                                    </excludes>
+                                </bannedDependencies>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
I've tested this: it picks up compile scope lombok (build fails when present) but allows provided scope (i.e., full build with this passes).