### PR TITLE
Empty dtype

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -6606,4 +6606,26 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     public boolean isEmpty() {
         return Shape.isEmpty(jvmShapeInfo.javaShapeInformation);
     }
+
+
+    @Override
+    public long[] shapeInfoJava() {
+        return jvmShapeInfo.javaShapeInformation;
+    }
+
+    @Override
+    public DataBuffer.Type dataType() {
+        val e = Shape.extras(jvmShapeInfo.javaShapeInformation);
+
+        if (e != 0) {
+            val t = ArrayOptionsHelper.dataType(jvmShapeInfo.javaShapeInformation);
+            if (t != DataBuffer.Type.UNKNOWN)
+                return t;
+        }
+
+        if (data != null)
+            return data.dataType();
+
+        return DataBuffer.Type.UNKNOWN;
+    }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
@@ -2253,5 +2253,13 @@ public abstract class BaseSparseNDArray implements ISparseNDArray {
 
     }
 
+    @Override
+    public long[] shapeInfoJava() {
+        return javaShapeInformation;
+    }
 
+    @Override
+    public DataBuffer.Type dataType() {
+        return data().dataType();
+    }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
@@ -3056,4 +3056,16 @@ public interface INDArray extends Serializable {
      * @return
      */
     boolean isEmpty();
+
+    /**
+     * This method returns shapeInformation as jvm long array
+     * @return
+     */
+    long[] shapeInfoJava();
+
+    /**
+     * This method returns dtype for this INDArray
+     * @return
+     */
+    DataBuffer.Type dataType();
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/LongShapeDescriptor.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/LongShapeDescriptor.java
@@ -72,9 +72,9 @@ public class LongShapeDescriptor {
     public int hashCode() {
         int result = (int) order;
 
-        result = 31 * result + Long.hashCode(offset);
-        result = 31 * result + Long.hashCode(ews);
-        result = 31 * result + Long.hashCode(extras);
+        result = 31 * result + longHashCode(offset);
+        result = 31 * result + longHashCode(ews);
+        result = 31 * result + longHashCode(extras);
         result = 31 * result + Arrays.hashCode(shape);
         result = 31 * result + Arrays.hashCode(stride);
         return result;
@@ -95,6 +95,10 @@ public class LongShapeDescriptor {
         return result;
     }
 
+    private int longHashCode(long v) {
+        // impl from j8
+        return (int)(v ^ (v >>> 32));
+    }
 
     public static LongShapeDescriptor fromShapeDescriptor(@NonNull ShapeDescriptor descriptor) {
         return new LongShapeDescriptor(ArrayUtil.toLongArray(descriptor.getShape()), ArrayUtil.toLongArray(descriptor.getStride()), descriptor.getOffset(), descriptor.getEws(), descriptor.getOrder(), descriptor.getExtras());

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/ShapeDescriptor.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/ShapeDescriptor.java
@@ -68,13 +68,18 @@ public class ShapeDescriptor {
     @Override
     public int hashCode() {
         int result = (int) order;
-        // FIXME: LONG
-        result = 31 * result + Long.hashCode(offset);
-        result = 31 * result + Long.hashCode(extras);
+
+        result = 31 * result + longHashCode(offset);
+        result = 31 * result + longHashCode(extras);
         result = 31 * result + ews;
         result = 31 * result + Arrays.hashCode(shape);
         result = 31 * result + Arrays.hashCode(stride);
         return result;
+    }
+
+    private int longHashCode(long v) {
+        // impl from j8
+        return (int)(v ^ (v >>> 32));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/options/ArrayOptionsHelper.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/options/ArrayOptionsHelper.java
@@ -1,13 +1,20 @@
 package org.nd4j.linalg.api.shape.options;
 
 import lombok.val;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
 
 public class ArrayOptionsHelper {
     public static boolean hasBitSet(long[] shapeInfo, long bit) {
         val opt = Shape.options(shapeInfo);
 
         return hasBitSet(opt, bit);
+    }
+
+    public static void setOptionBit(long[] storage, ArrayType type) {
+        int length = Shape.shapeInfoLength(storage);
+        storage[length - 3] = setOptionBit(storage[length-3], type);
     }
 
     public static boolean hasBitSet(long storage, long bit) {
@@ -27,10 +34,51 @@ public class ArrayOptionsHelper {
             return ArrayType.DENSE;
     }
 
+    public static DataBuffer.Type dataType(long[] shapeInfo) {
+        val opt = Shape.options(shapeInfo);
+        if (hasBitSet(opt, 4))
+            return DataBuffer.Type.COMPRESSED;
+        else if (hasBitSet(opt, 4096))
+            return DataBuffer.Type.HALF;
+        else if (hasBitSet(opt, 16384))
+            return DataBuffer.Type.FLOAT;
+        else if (hasBitSet(opt, 32768))
+            return DataBuffer.Type.DOUBLE;
+        else if (hasBitSet(opt, 262144))
+            return DataBuffer.Type.INT;
+        else if (hasBitSet(opt, 524288))
+            return DataBuffer.Type.LONG;
+        else
+            return DataBuffer.Type.UNKNOWN;
+    }
 
-    public static void setOptionBit(long[] storage, ArrayType type) {
-        int length = Shape.shapeInfoLength(storage);
-        storage[length - 3] = setOptionBit(storage[length-3], type);
+    public static long setOptionBit(long storage, DataBuffer.Type type) {
+        long bit = 0;
+        switch (type) {
+            case HALF:
+                bit = 4096;
+                break;
+            case FLOAT:
+                bit = 16384;
+                break;
+            case DOUBLE:
+                bit = 32768;
+                break;
+            case INT:
+                bit = 262144;
+                break;
+            case LONG:
+                bit = 524288;
+                break;
+            case COMPRESSED:
+                bit = 4;
+                break;
+            case UNKNOWN:
+                throw new UnsupportedOperationException();
+        }
+
+        storage |= bit;
+        return storage;
     }
 
     public static long setOptionBit(long storage, ArrayType type) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
@@ -1359,7 +1359,8 @@ public interface NDArrayFactory {
      */
     INDArray scalar(Number value);
 
-    INDArray empty();
+    INDArray empty(DataBuffer.Type type);
+
     INDArray trueScalar(Number value);
 
     INDArray trueVector(float[] data);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -3975,7 +3975,11 @@ public class Nd4j {
      * @return
      */
     public static INDArray empty() {
-        val ret = INSTANCE.empty();
+        return empty(Nd4j.dataType());
+    }
+
+    public static INDArray empty(DataBuffer.Type type) {
+        val ret = INSTANCE.empty(type);
         logCreationIfNecessary(ret);
         return ret;
     }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -1792,8 +1792,9 @@ public class JCublasNDArrayFactory extends BaseNDArrayFactory {
     }
 
     @Override
-    public INDArray empty() {
+    public INDArray empty(DataBuffer.Type type) {
         long extras  = ArrayOptionsHelper.setOptionBit(0L, ArrayType.EMPTY);
+        extras = ArrayOptionsHelper.setOptionBit(extras, type);
         val shape = Nd4j.getShapeInfoProvider().createShapeInformation(new int[0], new int[0],0,1,'c', extras);
         return new JCublasNDArray(null, (CudaLongDataBuffer) shape.getFirst(), shape.getSecond());
     }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCusparseNDArrayFactory.java
@@ -95,7 +95,7 @@ public class JCusparseNDArrayFactory extends BaseSparseNDArrayFactory{
     }
 
     @Override
-    public INDArray empty() {
+    public INDArray empty(DataBuffer.Type type) {
         throw new IllegalStateException();
     }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -530,8 +530,9 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
     }
 
     @Override
-    public INDArray empty() {
+    public INDArray empty(DataBuffer.Type type) {
         long extras  = ArrayOptionsHelper.setOptionBit(0L, ArrayType.EMPTY);
+        extras = ArrayOptionsHelper.setOptionBit(extras, type);
         val shape = Nd4j.getShapeInfoProvider().createShapeInformation(new int[0], new int[0],0,1,'c', extras);
         return new NDArray(null, (LongBuffer) shape.getFirst(), shape.getSecond());
     }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuSparseNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuSparseNDArrayFactory.java
@@ -625,7 +625,7 @@ public class CpuSparseNDArrayFactory extends BaseSparseNDArrayFactory {
 
 
     @Override
-    public INDArray empty() {
+    public INDArray empty(DataBuffer.Type type) {
         throw new UnsupportedOperationException();
     }
 }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/EmptyTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/EmptyTests.java
@@ -7,12 +7,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.nd4j.linalg.BaseNd4jTest;
 import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.shape.options.ArrayOptionsHelper;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @Slf4j
 @RunWith(Parameterized.class)
@@ -41,8 +40,26 @@ public class EmptyTests extends BaseNd4jTest {
         assertFalse(array.isSparse());
 
         assertFalse(array.isAttached());
+
+        assertEquals(Nd4j.dataType(), array.dataType());
     }
 
+
+    @Test
+    public void testEmptyDtype_1() {
+        val array = Nd4j.empty(DataBuffer.Type.INT);
+
+        assertTrue(array.isEmpty());
+        assertEquals(DataBuffer.Type.INT, array.dataType());
+    }
+
+    @Test
+    public void testEmptyDtype_2() {
+        val array = Nd4j.empty(DataBuffer.Type.LONG);
+
+        assertTrue(array.isEmpty());
+        assertEquals(DataBuffer.Type.LONG, array.dataType());
+    }
 
     @Override
     public char ordering() {


### PR DESCRIPTION
This PR adds following:
- Empty NDArrays now provide dtype information (stored in shapeInfo)
- Long.hashCode removed

