### PR TITLE
Fix Kuromoji dictionary file download

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/com/atilika/kuromoji/util/KuromojiBinFilesFetcher.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-japanese/src/main/java/com/atilika/kuromoji/util/KuromojiBinFilesFetcher.java
@@ -42,7 +42,7 @@ public class KuromojiBinFilesFetcher {
         binFileList.add(new File(root, "unknownDictionary.bin"));
 
         for (File f : binFileList) {
-            if (f.exists() == false) {
+            if (!f.exists()) {
                 return false;
             }
         }
@@ -51,24 +51,25 @@ public class KuromojiBinFilesFetcher {
 
     public static File downloadAndUntar() throws IOException {
         File rootDir = getKuromojiRoot();
-        if (rootDir.exists()) {
-            throw new IOException("remove exist directory : " + rootDir);
-        } else {
+        File[] files = rootDir.listFiles();
+        if (rootDir.exists() && files != null && files.length > 0) {
+            log.warn("Kuromoji dictionary files exist but failed checks. Deleting and re-downloading.");
+            FileUtils.deleteDirectory(rootDir);
             rootDir.mkdir();
-
-            log.info("Downloading Kuromoji bin files...");
-
-            // download kuromoji bin file from azure blob
-            File tarFile = new File(rootDir, "kuromoji_bin_files.tar.gz");
-            if (!tarFile.isFile()) {
-                FileUtils.copyURLToFile(
-                                new URL("https://dhkuromoji.blob.core.windows.net/kuromoji/kuromoji_bin_files.tar.gz"),
-                                tarFile);
-            }
-            ArchiveUtils.unzipFileTo(tarFile.getAbsolutePath(), rootDir.getAbsolutePath());
         }
 
-        return null;
+        log.info("Downloading Kuromoji bin files...");
+
+        // download kuromoji bin file from azure blob
+        File tarFile = new File(rootDir, "kuromoji_bin_files.tar.gz");
+        if (!tarFile.isFile()) {
+            FileUtils.copyURLToFile(
+                            new URL("https://dhkuromoji.blob.core.windows.net/kuromoji/kuromoji_bin_files.tar.gz"),
+                            tarFile);
+        }
+        ArchiveUtils.unzipFileTo(tarFile.getAbsolutePath(), rootDir.getAbsolutePath());
+
+        return rootDir.getAbsoluteFile();
     }
 
     @Deprecated


### PR DESCRIPTION
The previous logic would bail with an IOException if the directory existed.  DL4JResources.getDirectory helpfully creates the directory that you ask for it so this will fail if you haven't downloaded kuromoji previously.