### PR TITLE
Remove @AllArgsContructor from TransformProcessRecordReader

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/transform/TransformProcessRecordReader.java
@@ -27,7 +27,6 @@ import java.util.NoSuchElementException;
  *
  * @author Adam Gibson
  */
-@AllArgsConstructor
 public class TransformProcessRecordReader implements RecordReader {
     protected RecordReader recordReader;
     protected TransformProcess transformProcess;


### PR DESCRIPTION
It already has a proper constructor, and there is no reason why someone should be setting a cached record when creating that object.