### PR TITLE
DL4J Spark fixes (Gradient Sharing)

### DIFF
--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/accumulation/SharedTrainingAccumulationFunction.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/accumulation/SharedTrainingAccumulationFunction.java
@@ -8,6 +8,8 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author raver119@gmail.com
@@ -78,11 +80,26 @@ public class SharedTrainingAccumulationFunction implements
                 listenerUpdates.addAll(listenerUpdates2);
         }
 
-
+        Map<String,Integer> minibatchesPerExecutor = new HashMap<>();
+        if(tuple1.getMinibatchesPerExecutor() != null) {
+            for (Map.Entry<String, Integer> e : tuple1.getMinibatchesPerExecutor().entrySet()){
+                minibatchesPerExecutor.put(e.getKey(), e.getValue());
+            }
+        }
+        if(tuple2.getMinibatchesPerExecutor() != null){
+            for (Map.Entry<String, Integer> e : tuple2.getMinibatchesPerExecutor().entrySet()){
+                if(minibatchesPerExecutor.containsKey(e.getKey())){
+                    minibatchesPerExecutor.put(e.getKey(), minibatchesPerExecutor.get(e.getKey()) + e.getValue());
+                } else {
+                    minibatchesPerExecutor.put(e.getKey(), e.getValue());
+                }
+            }
+        }
 
         return SharedTrainingAccumulationTuple.builder().scoreSum(score).updaterStateArray(stateView)
                         .aggregationsCount(aggregationsCount).sparkTrainingStats(stats)
                         .listenerMetaData(listenerMetaData).listenerUpdates(listenerUpdates)
-                        .listenerStaticInfo(listenerStaticInfo).build();
+                        .listenerStaticInfo(listenerStaticInfo)
+                        .minibatchesPerExecutor(minibatchesPerExecutor).build();
     }
 }

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/accumulation/SharedTrainingAccumulationTuple.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/accumulation/SharedTrainingAccumulationTuple.java
@@ -11,6 +11,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * @author raver119@gmail.com
@@ -27,4 +28,5 @@ public class SharedTrainingAccumulationTuple implements Serializable {
     private Collection<StorageMetaData> listenerMetaData;
     private Collection<Persistable> listenerStaticInfo;
     private Collection<Persistable> listenerUpdates;
+    private Map<String,Integer> minibatchesPerExecutor;
 }

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/pw/SharedTrainingWrapper.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/pw/SharedTrainingWrapper.java
@@ -92,11 +92,13 @@ public class SharedTrainingWrapper {
      * @param iterator
      */
     public void attachDS(Iterator<DataSet> iterator) {
+        log.info("Attaching thread...");
+
+        //Count the number of minibatches - used for reporting/debugging purposes
         if(iteratorDataSetCount.get() == null)
             iteratorDataSetCount.set(new AtomicInteger(0));
         AtomicInteger count = iteratorDataSetCount.get();
-
-        log.info("Attaching thread...");
+        count.set(0);
 
         // we're creating our Observable wrapper
         VirtualIterator<DataSet> wrapped = new VirtualIterator<>(new CountingIterator<>(iterator, count));
@@ -118,10 +120,13 @@ public class SharedTrainingWrapper {
      * @param iterator
      */
     public void attachMDS(Iterator<MultiDataSet> iterator) {
+        log.info("Attaching thread...");
+
+        //Count the number of minibatches - used for reporting/debugging purposes
         if(iteratorDataSetCount.get() == null)
             iteratorDataSetCount.set(new AtomicInteger(0));
         AtomicInteger count = iteratorDataSetCount.get();
-        log.info("Attaching thread...");
+        count.set(0);
 
         // we're creating our Observable wrapper
         VirtualIterator<MultiDataSet> wrapped = new VirtualIterator<>(new CountingIterator<>(iterator, count));

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/pw/SharedTrainingWrapper.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/pw/SharedTrainingWrapper.java
@@ -21,6 +21,8 @@ import org.deeplearning4j.spark.parameterserver.networking.messages.SilentIntrod
 import org.deeplearning4j.spark.parameterserver.training.SharedTrainingResult;
 import org.deeplearning4j.spark.parameterserver.training.SharedTrainingWorker;
 import org.deeplearning4j.spark.parameterserver.util.BlockingObserver;
+import org.deeplearning4j.spark.parameterserver.util.CountingIterator;
+import org.deeplearning4j.spark.util.SparkUtils;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSet;
@@ -34,10 +36,12 @@ import org.nd4j.parameterserver.distributed.transport.Transport;
 import org.nd4j.parameterserver.distributed.util.NetworkOrganizer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This class maintains ParallelWrapper instance in Spark environment, and provides primitives for inter-executor
@@ -58,6 +62,7 @@ public class SharedTrainingWrapper {
 
     protected AtomicBoolean isFirst = new AtomicBoolean(false);
 
+    protected ThreadLocal<AtomicInteger> iteratorDataSetCount = new ThreadLocal<>();    //Using AtomicInteger because it's mutable, not because it's atomic
     protected ThreadLocal<BlockingObserver> observer = new ThreadLocal<>();
     protected EncodedGradientsAccumulator accumulator;
     protected Model originalModel;
@@ -87,11 +92,14 @@ public class SharedTrainingWrapper {
      * @param iterator
      */
     public void attachDS(Iterator<DataSet> iterator) {
+        if(iteratorDataSetCount.get() == null)
+            iteratorDataSetCount.set(new AtomicInteger(0));
+        AtomicInteger count = iteratorDataSetCount.get();
 
         log.info("Attaching thread...");
 
         // we're creating our Observable wrapper
-        VirtualIterator<DataSet> wrapped = new VirtualIterator<>(iterator);
+        VirtualIterator<DataSet> wrapped = new VirtualIterator<>(new CountingIterator<>(iterator, count));
 
         // and creating Observer which will be used to monitor progress within iterator
         BlockingObserver obs = new BlockingObserver();
@@ -110,10 +118,13 @@ public class SharedTrainingWrapper {
      * @param iterator
      */
     public void attachMDS(Iterator<MultiDataSet> iterator) {
+        if(iteratorDataSetCount.get() == null)
+            iteratorDataSetCount.set(new AtomicInteger(0));
+        AtomicInteger count = iteratorDataSetCount.get();
         log.info("Attaching thread...");
 
         // we're creating our Observable wrapper
-        VirtualIterator<MultiDataSet> wrapped = new VirtualIterator<>(iterator);
+        VirtualIterator<MultiDataSet> wrapped = new VirtualIterator<>(new CountingIterator<>(iterator, count));
 
         // and creating Observer which will be used to monitor progress within iterator
         BlockingObserver obs = new BlockingObserver();
@@ -341,7 +352,9 @@ public class SharedTrainingWrapper {
             // FIXME: fill stats here
             return SharedTrainingResult.builder().aggregationsCount(1).scoreSum(originalModel.score())
                             .updaterStateArray(updaterState).listenerMetaData(new ArrayList<>())
-                            .listenerStaticInfo(new ArrayList<>()).listenerUpdates(new ArrayList<>()).build();
+                            .listenerStaticInfo(new ArrayList<>()).listenerUpdates(new ArrayList<>())
+                            .minibatchesPerExecutor(Collections.singletonMap(SparkUtils.getSparkExecutorId(), iteratorDataSetCount.get().get()))
+                    .build();
         } else {
             // blocking call right here, all non-master threads will be blocked here
             try {
@@ -351,7 +364,7 @@ public class SharedTrainingWrapper {
                 log.info("Feeder thread done...");
 
                 //  nothing to do here, just give away empty result
-                return new SharedTrainingResult();
+                return SharedTrainingResult.builder().minibatchesPerExecutor(Collections.singletonMap(SparkUtils.getSparkExecutorId(), iteratorDataSetCount.get().get())).build();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 // FIXME: we don't really need to throw it again, it's here only for debugging purposes

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
@@ -943,7 +943,9 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
         protected double stepTrigger = 0.05;
         protected int stepDelay = 50;
         protected int shakeFrequency = 0;
+        @Deprecated
         protected Repartition repartition = Repartition.Always;
+        @Deprecated
         protected RepartitionStrategy repartitionStrategy = RepartitionStrategy.Balanced;
         protected StorageLevel storageLevel = StorageLevel.MEMORY_ONLY_SER();
         protected StorageLevel storageLevelStreams = StorageLevel.MEMORY_ONLY();
@@ -1011,7 +1013,9 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
          * This parameter defines when repartition is applied (if applied)
          * @param repartition
          * @return
+         * @deprecated Use {@link #repartitioner(Repartitioner)}
          */
+        @Deprecated
         public Builder repartitionData(Repartition repartition) {
             this.repartition = repartition;
             return this;
@@ -1023,7 +1027,9 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
          * for details
          *
          * @param repartitionStrategy Repartitioning strategy to use
+         * @deprecated Use {@link #repartitioner(Repartitioner)}
          */
+        @Deprecated
         public Builder repartitionStrategy(RepartitionStrategy repartitionStrategy) {
             this.repartitionStrategy = repartitionStrategy;
             return this;
@@ -1224,11 +1230,24 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
             return this;
         }
 
+        /**
+         * Number of minibatches to asynchronously prefetch when training. Default: 2
+         * @param prefetchNumBatches Number of batches to prefetch
+         */
         public Builder workerPrefetchNumBatches(int prefetchNumBatches){
             this.workerPrefetchNumBatches = prefetchNumBatches;
             return this;
         }
 
+        /**
+         * Repartitioner to use to repartition data before fitting.
+         * DL4J performs a MapPartitions operation for training, hence how the data is partitioned can matter a lot for
+         * performance (specifically, too few partitions can result in poor cluster utilization).
+         * Default is {@link DefaultRepartitioner}
+         *
+         * @param repartitioner Repartitioner to use
+         * @return Repartitioner
+         */
         public Builder repartitioner(Repartitioner repartitioner){
             this.repartitioner = repartitioner;
             return this;

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingMaster.java
@@ -773,8 +773,7 @@ public class SharedTrainingMaster extends BaseTrainingMaster<SharedTrainingResul
         if (collectTrainingStats)
             stats.logRepartitionStart();
 
-        splitData = SparkUtils.repartition(splitData, repartition, repartitionStrategy,
-                        numObjectsEachWorker(rddDataSetNumExamples), numWorkers);
+        splitData = SparkUtils.repartitionEqually(splitData, repartition, numWorkers);
         int nPartitions = splitData.partitions().size();
 
         if (collectTrainingStats && repartition != Repartition.Never)

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingResult.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/training/SharedTrainingResult.java
@@ -13,6 +13,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * @author raver119@gmail.com
@@ -29,9 +30,11 @@ public class SharedTrainingResult extends BaseTrainingResult implements Training
     private Collection<StorageMetaData> listenerMetaData;
     private Collection<Persistable> listenerStaticInfo;
     private Collection<Persistable> listenerUpdates;
+    private Map<String,Integer> minibatchesPerExecutor;
+
 
     @Override
     public void setStats(SparkTrainingStats sparkTrainingStats) {
-
+        setSparkTrainingStats(sparkTrainingStats);
     }
 }

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/util/CountingIterator.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/util/CountingIterator.java
@@ -5,6 +5,12 @@ import lombok.AllArgsConstructor;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * A simple iterator that adds 1 to the specified counter every time next() is called
+ *
+ * @param <T> Type of iterator
+ * @author Alex Black
+ */
 @AllArgsConstructor
 public class CountingIterator<T> implements Iterator<T> {
 

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/util/CountingIterator.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/src/main/java/org/deeplearning4j/spark/parameterserver/util/CountingIterator.java
@@ -1,0 +1,24 @@
+package org.deeplearning4j.spark.parameterserver.util;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@AllArgsConstructor
+public class CountingIterator<T> implements Iterator<T> {
+
+    private final Iterator<T> iter;
+    private final AtomicInteger counter;
+
+    @Override
+    public boolean hasNext() {
+        return iter.hasNext();
+    }
+
+    @Override
+    public T next() {
+        counter.getAndIncrement();
+        return iter.next();
+    }
+}

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/api/Repartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/api/Repartitioner.java
@@ -1,0 +1,11 @@
+package org.deeplearning4j.spark.api;
+
+import org.apache.spark.api.java.JavaRDD;
+
+import java.io.Serializable;
+
+public interface Repartitioner extends Serializable {
+
+    <T> JavaRDD<T> repartition(JavaRDD<T> input, int minObjectsPerPartition, int numExecutors);
+
+}

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/api/Repartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/api/Repartitioner.java
@@ -4,6 +4,12 @@ import org.apache.spark.api.java.JavaRDD;
 
 import java.io.Serializable;
 
+/**
+ * Repartitioner interface: controls how data should be repartitioned before training.
+ * Currently used only in SharedTrainingMaster
+ *
+ * @author Alex Black
+ */
 public interface Repartitioner extends Serializable {
 
     <T> JavaRDD<T> repartition(JavaRDD<T> input, int minObjectsPerPartition, int numExecutors);

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/datavec/RDDMiniBatches.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/datavec/RDDMiniBatches.java
@@ -31,7 +31,7 @@ import java.util.List;
  * @author Adam Gibson
  */
 public class RDDMiniBatches implements Serializable {
-    private int miniBatches = 10;
+    private int miniBatches;
     private JavaRDD<DataSet> toSplitJava;
 
     public RDDMiniBatches(int miniBatches, JavaRDD<DataSet> toSplit) {

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/BalancedPartitioner.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.spark.impl.common.repartition;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.Partitioner;
 
 import java.util.Random;
@@ -14,6 +15,7 @@ import java.util.Random;
  *
  * @author Alex Black
  */
+@Slf4j
 public class BalancedPartitioner extends Partitioner {
     private final int numPartitions; //Total number of partitions
     private final int elementsPerPartition;
@@ -46,6 +48,8 @@ public class BalancedPartitioner extends Partitioner {
             if (outputPartition >= numPartitions) {
                 //Should never happen, unless there's some up-stream problem with calculating elementsPerPartition
                 outputPartition = getRandom().nextInt(numPartitions);
+                log.warn("**** Random partition assigned (1): elementIdx={}, numPartitions={}, elementsPerPartition={}, remainder={}",
+                        elementIdx, numPartitions, elementsPerPartition, remainder);
             }
             return outputPartition;
         } else {
@@ -57,6 +61,8 @@ public class BalancedPartitioner extends Partitioner {
             if (outputPartition >= numPartitions) {
                 //Should never happen, unless there's some up-stream problem with calculating elementsPerPartition
                 outputPartition = getRandom().nextInt(numPartitions);
+                log.warn("**** Random partition assigned (2): elementIdx={}, numPartitions={}, elementsPerPartition={}, remainder={}",
+                        elementIdx, numPartitions, elementsPerPartition, remainder);
             }
             return outputPartition;
         }

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/EqualPartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/common/repartition/EqualPartitioner.java
@@ -1,0 +1,52 @@
+package org.deeplearning4j.spark.impl.common.repartition;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.Partitioner;
+import org.apache.spark.api.java.JavaRDD;
+
+import java.util.Random;
+
+/**
+ * This is a custom partitioner (used in conjunction with {@link JavaRDD#zipWithIndex()} to repartition a RDD.
+ * Unlike a standard .repartition() call (which assigns partitions like [2,3,4,1,2,3,4,1,2,...] for 4 partitions],
+ * this function attempts to keep contiguous elements (i.e., those elements originally in the same partition) together
+ * much more frequently. Furthermore, it is less prone to producing larger or smaller than expected partitions, as
+ * it is entirely deterministic, whereas .repartition() has a degree of randomness (i.e., start index) which can result in
+ * a large degree of variance when the number of elements in the original partitions is small (as is the case generally in DL4J)<br>
+ * Note also that if the number of elements are not a multiple of the number of partitions, an int[] to specify the
+ * locations of these values is used instead.
+ *
+ * @author Alex Black
+ */
+@Slf4j
+@AllArgsConstructor
+public class EqualPartitioner extends Partitioner {
+    private final int numPartitions; //Total number of partitions
+    private final int partitionSizeExRemainder;
+    private final int[] remainderPositions;
+
+    @Override
+    public int numPartitions() {
+        return numPartitions;
+    }
+
+    @Override
+    public int getPartition(Object key) {
+        int elementIdx = key.hashCode();
+
+        //Assign an equal number of elements to each partition, sequentially
+        // For any remainder, use the specified remainder indexes
+
+        //Work out: which partition it belongs to...
+        if(elementIdx < numPartitions * partitionSizeExRemainder){
+            //Standard element
+            return elementIdx / partitionSizeExRemainder;
+        } else {
+            //Is a 'remainder' element
+            int remainderNum = elementIdx % partitionSizeExRemainder;
+            return remainderPositions[remainderNum];
+        }
+    }
+}

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/DefaultRepartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/DefaultRepartitioner.java
@@ -1,0 +1,49 @@
+package org.deeplearning4j.spark.impl.repartitioner;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.deeplearning4j.spark.api.Repartitioner;
+import org.deeplearning4j.spark.impl.common.CountPartitionsFunction;
+import scala.Tuple2;
+
+import java.util.List;
+
+/**
+ * DefaultRepartitioner: Repartition data so that we exactly N objects per partition, up to a maximum of M partitions
+ */
+public class DefaultRepartitioner implements Repartitioner {
+    public static final int DEFAULT_MAX_PARTITIONS = 5000;
+
+    private final int maxPartitions;
+
+    public DefaultRepartitioner(){
+        this(DEFAULT_MAX_PARTITIONS);
+    }
+
+    public DefaultRepartitioner(int maxPartitions){
+        this.maxPartitions = maxPartitions;
+    }
+
+
+    @Override
+    public <T> JavaRDD<T> repartition(JavaRDD<T> rdd, int minObjectsPerPartition, int numExecutors) {
+        //Num executors intentionally not used
+
+        //Count each partition...
+        List<Tuple2<Integer, Integer>> partitionCounts =
+                rdd.mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
+        int totalObjects = 0;
+        for(Tuple2<Integer,Integer> t2 : partitionCounts){
+            totalObjects += t2._2();
+        }
+
+        //Now, we want 'minObjectsPerPartition' in each partition... up to a maximum number of partitions
+        int numPartitions;
+        if(totalObjects / minObjectsPerPartition > maxPartitions){
+            //Need more than the minimum, to avoid exceeding the maximum
+            numPartitions = maxPartitions;
+        } else {
+            numPartitions = (int)Math.ceil(totalObjects / (double)minObjectsPerPartition);
+        }
+        return EqualRepartitioner.repartition(rdd, numPartitions, partitionCounts);
+    }
+}

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/DefaultRepartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/DefaultRepartitioner.java
@@ -8,17 +8,27 @@ import scala.Tuple2;
 import java.util.List;
 
 /**
- * DefaultRepartitioner: Repartition data so that we exactly N objects per partition, up to a maximum of M partitions
+ * DefaultRepartitioner: Repartition data so that we exactly the minimum number of objects per partition, up to a
+ * specified maximum number of partitions partitions
+ *
+ * @author Alex Black
  */
 public class DefaultRepartitioner implements Repartitioner {
     public static final int DEFAULT_MAX_PARTITIONS = 5000;
 
     private final int maxPartitions;
 
+    /**
+     * Create a DefaultRepartitioner with the default maximum number of partitions, {@link #DEFAULT_MAX_PARTITIONS}
+     */
     public DefaultRepartitioner(){
         this(DEFAULT_MAX_PARTITIONS);
     }
 
+    /**
+     *
+     * @param maxPartitions Maximum number of partitions
+     */
     public DefaultRepartitioner(int maxPartitions){
         this.maxPartitions = maxPartitions;
     }

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/EqualRepartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/EqualRepartitioner.java
@@ -13,6 +13,14 @@ import scala.Tuple2;
 import java.util.List;
 import java.util.Random;
 
+/**
+ * Equal repartitioner. Splits the data into numExecutors equal sized partitions.<br>
+ * Note that if the number of objects isn't an exact multiple of the number of executors, the "remainder"
+ * are randomly allocated to one partition without replacement (i.e., the largest partitions will have exactly 1
+ * more object than the smallest partitions)
+ *
+ * @author Alex Black
+ */
 @Slf4j
 public class EqualRepartitioner implements Repartitioner {
     @Override
@@ -53,7 +61,6 @@ public class EqualRepartitioner implements Repartitioner {
         }
 
         if (initialPartitions == numPartitions && !repartitionRequired) {
-            //log.info("Did not repartition - all correct size: initial={}, numPartitions={}", initialPartitions, numExecutors);
             //Don't need to do any repartitioning here - already in the format we want
             return rdd;
         }
@@ -81,14 +88,6 @@ public class EqualRepartitioner implements Repartitioner {
 
         int partitionSizeExRemainder = totalObjects / numPartitions;
         pairIndexed = pairIndexed.partitionBy(new EqualPartitioner(numPartitions, partitionSizeExRemainder, remainderPartitions));
-
-//        //DEBUGGING
-//        List<Tuple2<Integer, Integer>> partitionCounts2 =
-//                rdd.mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
-//        List<Tuple2<Integer, Integer>> partitionCounts3 =
-//                pairIndexed.values().mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
-//        log.info("Partition counts - BEFORE: {}", partitionCounts2);
-//        log.info("Partition counts - AFTER: {}", partitionCounts3);
         return pairIndexed.values();
     }
 }

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/EqualRepartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/EqualRepartitioner.java
@@ -1,0 +1,94 @@
+package org.deeplearning4j.spark.impl.repartitioner;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.deeplearning4j.spark.api.Repartitioner;
+import org.deeplearning4j.spark.impl.common.CountPartitionsFunction;
+import org.deeplearning4j.spark.impl.common.repartition.EqualPartitioner;
+import org.deeplearning4j.spark.util.SparkUtils;
+import org.nd4j.linalg.util.MathUtils;
+import scala.Tuple2;
+
+import java.util.List;
+import java.util.Random;
+
+@Slf4j
+public class EqualRepartitioner implements Repartitioner {
+    @Override
+    public <T> JavaRDD<T> repartition(JavaRDD<T> rdd, int minObjectsPerPartition, int numExecutors) {
+        //minObjectsPerPartition: intentionally not used here
+
+        //Repartition: either always, or origNumPartitions != numWorkers
+
+        //First: count number of elements in each partition. Need to know this so we can work out how to properly index each example,
+        // so we can in turn create properly balanced partitions after repartitioning
+        //Because the objects (DataSets etc) should be small, this should be OK
+
+        //Count each partition...
+        List<Tuple2<Integer, Integer>> partitionCounts =
+                rdd.mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
+        return repartition(rdd, numExecutors, partitionCounts);
+    }
+
+
+    public static <T> JavaRDD<T> repartition(JavaRDD<T> rdd, int numPartitions, List<Tuple2<Integer, Integer>> partitionCounts){
+        int totalObjects = 0;
+        int initialPartitions = partitionCounts.size();
+
+        for (Tuple2<Integer, Integer> t2 : partitionCounts) {
+            totalObjects += t2._2();
+        }
+
+        //Check if already correct
+        int minAllowable = (int)Math.floor(totalObjects / (double) numPartitions);
+        int maxAllowable = (int)Math.ceil(totalObjects / (double) numPartitions);
+
+        boolean repartitionRequired = false;
+        for (Tuple2<Integer, Integer> t2 : partitionCounts) {
+            if(t2._2() < minAllowable || t2._2() > maxAllowable ){
+                repartitionRequired = true;
+                break;
+            }
+        }
+
+        if (initialPartitions == numPartitions && !repartitionRequired) {
+            //log.info("Did not repartition - all correct size: initial={}, numPartitions={}", initialPartitions, numExecutors);
+            //Don't need to do any repartitioning here - already in the format we want
+            return rdd;
+        }
+
+        //Index each element for repartitioning (can only do manual repartitioning on a JavaPairRDD)
+        JavaPairRDD<Integer, T> pairIndexed = SparkUtils.indexedRDD(rdd);
+
+        //Handle remainder.
+        //We'll randomly allocate one of these to a single partition, with no partition getting more than 1 (otherwise, imbalanced)
+        //Given that we don't know exactly how Spark will allocate partitions to workers, we are probably better off doing
+        // this randomly rather than "first N get +1" or "every M get +1" as this could introduce poor load balancing
+        int remainder = totalObjects % numPartitions;
+        int[] remainderPartitions = null;
+        if (remainder > 0) {
+            remainderPartitions = new int[remainder];
+            int[] temp = new int[numPartitions];
+            for( int i=0; i< temp.length; i++ ){
+                temp[i] = i;
+            }
+            MathUtils.shuffleArray(temp, new Random());
+            for( int i=0; i<remainder; i++ ){
+                remainderPartitions[i] = temp[i];
+            }
+        }
+
+        int partitionSizeExRemainder = totalObjects / numPartitions;
+        pairIndexed = pairIndexed.partitionBy(new EqualPartitioner(numPartitions, partitionSizeExRemainder, remainderPartitions));
+
+//        //DEBUGGING
+//        List<Tuple2<Integer, Integer>> partitionCounts2 =
+//                rdd.mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
+//        List<Tuple2<Integer, Integer>> partitionCounts3 =
+//                pairIndexed.values().mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
+//        log.info("Partition counts - BEFORE: {}", partitionCounts2);
+//        log.info("Partition counts - AFTER: {}", partitionCounts3);
+        return pairIndexed.values();
+    }
+}

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/NoOpRepartitioner.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/impl/repartitioner/NoOpRepartitioner.java
@@ -1,0 +1,16 @@
+package org.deeplearning4j.spark.impl.repartitioner;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.deeplearning4j.spark.api.Repartitioner;
+
+/**
+ * No-op repartitioner. Returns the input un-modified
+ *
+ * @author Alex Black
+ */
+public class NoOpRepartitioner implements Repartitioner {
+    @Override
+    public <T> JavaRDD<T> repartition(JavaRDD<T> input, int minObjectsPerPartition, int numExecutors) {
+        return input;
+    }
+}

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -575,7 +575,7 @@ public class SparkUtils {
 
         synchronized (SparkUtils.class){
             //re-check, in case some other thread set it while waiting for lock
-            if(sparkExecutorId == null)
+            if(sparkExecutorId != null)
                 return sparkExecutorId;
 
             String s = System.getProperty("sun.java.command");

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -381,6 +381,7 @@ public class SparkUtils {
                 JavaPairRDD<Integer, T> pairIndexed = indexedRDD(rdd);
 
                 int remainder = (totalObjects - numPartitions * objectsPerPartition) % numPartitions;
+                log.info("Amount to rebalance: numPartitions={}, objectsPerPartition={}, remainder={}", numPartitions, objectsPerPartition, remainder);
                 pairIndexed = pairIndexed
                                 .partitionBy(new BalancedPartitioner(numPartitions, objectsPerPartition, remainder));
 

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -387,7 +387,10 @@ public class SparkUtils {
                 //DEBUGGING
                 List<Tuple2<Integer, Integer>> partitionCounts2 =
                         rdd.mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
-                log.info("Partition counts: {}", partitionCounts2);
+                List<Tuple2<Integer, Integer>> partitionCounts3 =
+                        pairIndexed.values().mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
+                log.info("Partition counts - BEFORE: {}", partitionCounts2);
+                log.info("Partition counts - AFTER: {}", partitionCounts3);
 
                 return pairIndexed.values();
             default:

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/util/SparkUtils.java
@@ -378,7 +378,6 @@ public class SparkUtils {
                 }
 
                 if (initialPartitions == numPartitions && allCorrectSize) {
-                    log.info("Did not repartition - all correct size: initial={}, numPartitions={}", initialPartitions, numPartitions);
                     //Don't need to do any repartitioning here - already in the format we want
                     return rdd;
                 }
@@ -390,15 +389,6 @@ public class SparkUtils {
                 log.info("Amount to rebalance: numPartitions={}, objectsPerPartition={}, remainder={}", numPartitions, objectsPerPartition, remainder);
                 pairIndexed = pairIndexed
                                 .partitionBy(new BalancedPartitioner(numPartitions, objectsPerPartition, remainder));
-
-                //DEBUGGING
-                List<Tuple2<Integer, Integer>> partitionCounts2 =
-                        rdd.mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
-                List<Tuple2<Integer, Integer>> partitionCounts3 =
-                        pairIndexed.values().mapPartitionsWithIndex(new CountPartitionsFunction<T>(), true).collect();
-                log.info("Partition counts - BEFORE: {}", partitionCounts2);
-                log.info("Partition counts - AFTER: {}", partitionCounts3);
-
                 return pairIndexed.values();
             default:
                 throw new RuntimeException("Unknown setting for repartition: " + repartition);

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/datavec/MiniBatchTests.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/datavec/MiniBatchTests.java
@@ -30,6 +30,8 @@ import org.nd4j.linalg.io.ClassPathResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -55,9 +57,11 @@ public class MiniBatchTests extends BaseSparkTest {
         count = points.count();
         assertEquals(300, count);
 
+        points = points.repartition(1);
         JavaRDD<DataSet> miniBatches = new RDDMiniBatches(10, points).miniBatchesJava();
         count = miniBatches.count();
-        assertEquals(30, count);
+        List<DataSet> list = miniBatches.collect();
+        assertEquals(30, count);    //Expect exactly 30 from 1 partition... could be more for multiple input partitions
 
         lines.unpersist();
         points.unpersist();

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestRepartitioning.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/test/java/org/deeplearning4j/spark/util/TestRepartitioning.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.spark.util;
 
+import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.deeplearning4j.spark.BaseSparkTest;
@@ -8,10 +9,12 @@ import org.deeplearning4j.spark.api.RepartitionStrategy;
 import org.deeplearning4j.spark.impl.common.CountPartitionsFunction;
 import org.deeplearning4j.spark.impl.common.repartition.AssignIndexFunction;
 import org.deeplearning4j.spark.impl.common.repartition.MapTupleToPairFlatMap;
+import org.junit.Assert;
 import org.junit.Test;
 import scala.Tuple2;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -24,50 +27,6 @@ import static org.junit.Assert.assertTrue;
  * Created by Alex on 03/07/2016.
  */
 public class TestRepartitioning extends BaseSparkTest {
-
-    public void testAssignIdx() {
-        List<String> list = new ArrayList<>();
-        for (int i = 0; i < 1000; i++) {
-            list.add(String.valueOf(i));
-        }
-
-        JavaRDD<String> rdd = sc.parallelize(list, 10);
-
-        int numPartitions = rdd.getNumPartitions();
-        int objectsPerPartition = 100;
-
-        List<Tuple2<Integer, Integer>> partitionCounts =
-                        rdd.mapPartitionsWithIndex(new CountPartitionsFunction<String>(), true).collect();
-        int totalObjects = 0;
-        int initialPartitions = partitionCounts.size();
-
-        int[] countPerPartition = new int[partitionCounts.size()];
-        int x = 0;
-        for (Tuple2<Integer, Integer> t2 : partitionCounts) {
-            int partitionSize = t2._2();
-            countPerPartition[x++] = partitionSize;
-        }
-
-        int[] elementStartOffsetByPartitions = new int[countPerPartition.length];
-        for (int i = 1; i < elementStartOffsetByPartitions.length; i++) {
-            elementStartOffsetByPartitions[i] = elementStartOffsetByPartitions[i - 1] + countPerPartition[i - 1];
-        }
-
-        JavaRDD<Tuple2<Integer, String>> indexed = rdd
-                        .mapPartitionsWithIndex(new AssignIndexFunction<String>(elementStartOffsetByPartitions), true);
-        JavaPairRDD<Integer, String> pairIndexed =
-                        indexed.mapPartitionsToPair(new MapTupleToPairFlatMap<Integer, String>(), true);
-
-        JavaPairRDD<Integer, String> withIndexes = indexedRDD(rdd);
-
-        List<Integer> pairKeys = pairIndexed.keys().collect();
-        List<Integer> indexedKeys = withIndexes.keys().collect();
-
-        assertTrue(indexedKeys.size() == pairKeys.size());
-        for (int i = 0; i < pairKeys.size(); i++) {
-            assertEquals(pairKeys.get(i), indexedKeys.get(i));
-        }
-    }
 
     @Test
     public void testRepartitioning() {
@@ -144,6 +103,68 @@ public class TestRepartitioning extends BaseSparkTest {
             }
 
             assertEquals(expNumPartitionsWithMore, actNumPartitionsWithMore);
+        }
+    }
+
+    @Test
+    public void testRepartitioning3(){
+
+        //Initial partitions (idx, count) - [(0,29), (1,29), (2,29), (3,34), (4,34), (5,35), (6,34)]
+
+        List<Integer> ints = new ArrayList<>();
+        for( int i=0; i<224; i++ ){
+            ints.add(i);
+        }
+
+        JavaRDD<Integer> rdd = sc.parallelize(ints);
+        JavaPairRDD<Integer,Integer> pRdd = SparkUtils.indexedRDD(rdd);
+        JavaPairRDD<Integer,Integer> initial = pRdd.partitionBy(new Partitioner() {
+            @Override
+            public int getPartition(Object key) {
+                int i = (Integer)key;
+                if(i < 29){
+                    return 0;
+                } else if(i < 29+29){
+                    return 1;
+                } else if(i < 29+29+29){
+                    return 2;
+                } else if(i < 29+29+29+34){
+                    return 3;
+                } else if(i < 29+29+29+34+34){
+                    return 4;
+                } else if(i < 29+29+29+34+34+35){
+                    return 5;
+                } else {
+                    return 6;
+                }
+            }
+            @Override
+            public int numPartitions() {
+                return 7;
+            }
+        });
+
+        List<Tuple2<Integer, Integer>> partitionCounts = initial.values().mapPartitionsWithIndex(new CountPartitionsFunction<Integer>(), true).collect();
+
+        System.out.println(partitionCounts);
+
+        List<Tuple2<Integer,Integer>> initialExpected = Arrays.asList(
+                new Tuple2<>(0,29),
+                new Tuple2<>(1,29),
+                new Tuple2<>(2,29),
+                new Tuple2<>(3,34),
+                new Tuple2<>(4,34),
+                new Tuple2<>(5,35),
+                new Tuple2<>(6,34));
+        Assert.assertEquals(initialExpected, partitionCounts);
+
+
+        JavaRDD<Integer> afterRepartition = SparkUtils.repartitionBalanceIfRequired(initial.values(), Repartition.Always, 2, 112);
+        List<Tuple2<Integer, Integer>> partitionCountsAfter = afterRepartition.mapPartitionsWithIndex(new CountPartitionsFunction<Integer>(), true).collect();
+        System.out.println(partitionCountsAfter);
+
+        for(Tuple2<Integer,Integer> t2 : partitionCountsAfter){
+            assertEquals(2, (int)t2._2());
         }
     }
 


### PR DESCRIPTION
Fixes/improvements for gradinet sharing.

Specifically:
* Bug fix in repartitioning for gradient sharing
* Makes repartitioning more configurable (adds Repartitioner interface)
* Improves repartitioning (new default algorithm allows spark scheduler to do proper load balancing)
* Post training, logs number of minibatches fit for each JVM