### PR TITLE
Update logic for libnd4j tests

### DIFF
--- a/libnd4j/tests_cpu/run_tests.sh
+++ b/libnd4j/tests_cpu/run_tests.sh
@@ -5,10 +5,6 @@ set -exo pipefail
 IS_RELEASE='true'
 OSARCH=$(arch)
 
-if [ -f /opt/rh/devtoolset-7/enable ]; then
-    source /opt/rh/devtoolset-7/enable
-fi
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
     export CC=$(ls -1 /usr/local/bin/gcc-? | head -n 1)
     export CXX=$(ls -1 /usr/local/bin/g++-? | head -n 1)
@@ -41,10 +37,4 @@ else
     ../buildnativeoperations.sh -t -b release
 fi
 
-if [[ -f /etc/redhat-release && "$OSARCH" == "x86_64" && "$IS_RELEASE" == "false" ]]; then
-    # sudo is used as workaround for LeakSanitizer that requires root permissions on CentOS
-    sudo bash -c '../blasbuild/cpu/tests_cpu/layers_tests/runtests --gtest_output="xml:../target/surefire-reports/TEST-results.xml"'
-    sudo chown -R "${USER:-jenkins}":"${USER:-jenkins}" ../target
-else
-    ../blasbuild/cpu/tests_cpu/layers_tests/runtests --gtest_output="xml:../target/surefire-reports/TEST-results.xml"
-fi
+../blasbuild/cpu/tests_cpu/layers_tests/runtests --gtest_output="xml:../target/surefire-reports/TEST-results.xml"


### PR DESCRIPTION
- Remove sudo;

- Remove source /opt/rh/devtoolset-7/enable, because of new logic for tests.




