### PR TITLE
nd4j: facilitate deallocator thread identification (for test purposes)

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java
@@ -238,13 +238,16 @@ public abstract class BasicWorkspaceManager implements MemoryWorkspaceManager {
     }
 
 
+    @Deprecated // For test use within the github.com/deeplearning4j/deeplearning4j repo only.
+    public static final String WorkspaceDeallocatorThreadName = "Workspace deallocator thread";
+
     protected class WorkspaceDeallocatorThread extends Thread implements Runnable {
         private final ReferenceQueue<MemoryWorkspace> queue;
 
         protected WorkspaceDeallocatorThread(ReferenceQueue<MemoryWorkspace> queue) {
             this.queue = queue;
             this.setDaemon(true);
-            this.setName("Workspace deallocator thread");
+            this.setName(WorkspaceDeallocatorThreadName);
         }
 
         @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/rng/deallocator/NativeRandomDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/rng/deallocator/NativeRandomDeallocator.java
@@ -54,6 +54,9 @@ public class NativeRandomDeallocator {
     }
 
 
+    @Deprecated // For test use within the github.com/deeplearning4j/deeplearning4j repo only.
+    public static final String DeallocatorThreadNamePrefix = "NativeRandomDeallocator thread ";
+
     /**
      * This class provides garbage collection for NativeRandom state memory. It's not too big amount of memory used, but we don't want any leaks.
      *
@@ -66,7 +69,7 @@ public class NativeRandomDeallocator {
                         Map<Long, GarbageStateReference> referenceMap) {
             this.queue = queue;
             this.referenceMap = referenceMap;
-            this.setName("NativeRandomDeallocator thread " + threadId);
+            this.setName(DeallocatorThreadNamePrefix + threadId);
             this.setDaemon(true);
         }
 


### PR DESCRIPTION
An assumption:

* Sometimes tests have no control over the cleanup of certain private deallocator threads e.g. [BasicWorkspaceManager.WorkspaceDeallocatorThread](https://github.com/deeplearning4j/deeplearning4j/blob/master/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/memory/provider/BasicWorkspaceManager.java) and [NativeRandomDeallocator.DeallocatorThread](https://github.com/deeplearning4j/deeplearning4j/blob/master/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/rng/deallocator/NativeRandomDeallocator.java) in [nd4j/nd4j-backends](https://github.com/deeplearning4j/deeplearning4j/tree/master/nd4j/nd4j-backends).

A problem:

* Some tests may wish to use something like [randomizedtesting](https://github.com/randomizedtesting/randomizedtesting)'s [ThreadLeakControl.checkThreadLeaks](https://github.com/randomizedtesting/randomizedtesting/blob/master/randomized-runner/src/main/java/com/carrotsearch/randomizedtesting/ThreadLeakControl.java) to test for leaked threads in the code under test.
* But how to distinguish genuinely leaked threads from threads known-to-be-lingering?

A proposed solution:

* Provide a way to identify the known-to-be-lingering threads.
* Use the `ThreadLeakFilters` annotation to filter out such threads.

An example:

* `TupleStreamDataSetIteratorTest` in https://github.com/deeplearning4j/deeplearning4j/pull/4876