### PR TITLE
Update versions of OpenBLAS, MKL-DNN, OpenCV, and TensorFlow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,16 +186,16 @@
         <javacpp.version>1.4.2-SNAPSHOT</javacpp.version>
         <javacpp-presets.version>1.4.2-SNAPSHOT</javacpp-presets.version>
         <javacv.version>1.4.2-SNAPSHOT</javacv.version>
-        <openblas.version>0.3.2.dev</openblas.version>
+        <openblas.version>0.3.0</openblas.version>
         <mkl.version>2018.3</mkl.version>
-        <mkl-dnn.version>0.14</mkl-dnn.version>
-        <opencv.version>3.4.1</opencv.version>
+        <mkl-dnn.version>0.15</mkl-dnn.version>
+        <opencv.version>3.4.2</opencv.version>
         <ffmpeg.version>4.0.1</ffmpeg.version>
         <leptonica.version>1.76.0</leptonica.version>
         <hdf5.version>1.10.2</hdf5.version>
         <ale.version>0.6.0</ale.version>
-        <tensorflow.version>1.9.0-rc2</tensorflow.version>
-        <tensorflow.javacpp.version>${tensorflow.version}-1.4.2-SNAPSHOT</tensorflow.javacpp.version>
+        <tensorflow.version>1.9.0</tensorflow.version>
+        <tensorflow.javacpp.version>${tensorflow.version}-${javacpp-presets.version}</tensorflow.javacpp.version>
 
         <commons-compress.version>1.16.1</commons-compress.version>
         <commonsmath.version>3.4.1</commonsmath.version>


### PR DESCRIPTION
Note: Here we are reverting to OpenBLAS 0.3.0 as it's the last known working version for now.