### PR TITLE
DL4J Fixes

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingMaskingTests.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingMaskingTests.java
@@ -17,6 +17,7 @@
 package org.deeplearning4j.nn.layers.pooling;
 
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -27,6 +28,7 @@ import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.PoolingType;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.junit.Test;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -36,6 +38,7 @@ import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.nd4j.linalg.learning.config.NoOp;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -372,8 +375,8 @@ public class GlobalPoolingMaskingTests extends BaseDL4JTest {
         for (PoolingType pt : poolingTypes) {
             MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder().weightInit(WeightInit.XAVIER)
                     .convolutionMode(ConvolutionMode.Same).seed(12345L).list()
-                    .layer(0, new ConvolutionLayer.Builder().nIn(depthIn).nOut(depthOut).kernelSize(2, width)
-                            .stride(1, width).activation(Activation.TANH).build())
+                    .layer(0, new ConvolutionLayer.Builder().nIn(depthIn).nOut(depthOut).kernelSize(2, 2)
+                            .stride(1, 1).activation(Activation.TANH).build())
                     .layer(1, new org.deeplearning4j.nn.conf.layers.GlobalPoolingLayer.Builder().poolingType(pt)
                             .build())
                     .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.MCXENT)
@@ -399,6 +402,8 @@ public class GlobalPoolingMaskingTests extends BaseDL4JTest {
             INDArray outMasked = net.output(inToBeMasked);
             net.clearLayerMaskArrays();
 
+            net.setLayerMaskArrays(maskArray, null);
+
             for (int i = 0; i < minibatch; i++) {
                 INDArray subset;
                 if(i == 0){
@@ -407,6 +412,8 @@ public class GlobalPoolingMaskingTests extends BaseDL4JTest {
                     subset = inToBeMasked.get(interval(i, i, true), all(), interval(0,3), interval(0,2));
                 }
 
+                net.clear();
+                net.clearLayerMaskArrays();
                 INDArray outSubset = net.output(subset);
                 INDArray outMaskedSubset = outMasked.getRow(i);
 

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/iterator/CnnSentenceDataSetIterator.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/iterator/CnnSentenceDataSetIterator.java
@@ -65,9 +65,20 @@ public class CnnSentenceDataSetIterator implements DataSetIterator {
         RemoveWord, UseUnknownVector
     }
 
+    /**
+     * Format of features:<br>
+     * CNN1D: For use with 1d convolution layers: Shape [minibatch, vectorSize, sentenceLength]<br>
+     * CNN2D: For use with 2d convolution layers: Shape [minibatch, 1, vectorSize, sentenceLength] or [minibatch, 1, sentenceLength, vectorSize],
+     * depending on the setting for 'sentencesAlongHeight' configuration.
+     */
+    public enum Format {
+        RNN, CNN1D, CNN2D
+    }
+
     private static final String UNKNOWN_WORD_SENTINEL = "UNKNOWN_WORD_SENTINEL";
 
-    private LabeledSentenceProvider sentenceProvider = null;
+    private Format format;
+    private LabeledSentenceProvider sentenceProvider;
     private WordVectors wordVectors;
     private TokenizerFactory tokenizerFactory;
     private UnknownWordHandling unknownWordHandling;
@@ -86,7 +97,8 @@ public class CnnSentenceDataSetIterator implements DataSetIterator {
 
     private Pair<List<String>, String> preLoadedTokens;
 
-    private CnnSentenceDataSetIterator(Builder builder) {
+    protected CnnSentenceDataSetIterator(Builder builder) {
+        this.format = builder.format;
         this.sentenceProvider = builder.sentenceProvider;
         this.wordVectors = builder.wordVectors;
         this.tokenizerFactory = builder.tokenizerFactory;
@@ -124,36 +136,49 @@ public class CnnSentenceDataSetIterator implements DataSetIterator {
      */
     public INDArray loadSingleSentence(String sentence) {
         List<String> tokens = tokenizeSentence(sentence);
-
-        int[] featuresShape = new int[] {1, 1, 0, 0};
-        if (sentencesAlongHeight) {
-            featuresShape[2] = Math.min(maxSentenceLength, tokens.size());
-            featuresShape[3] = wordVectorSize;
+        if(format == Format.CNN1D || format == Format.RNN){
+            int[] featuresShape = new int[] {1, wordVectorSize, Math.min(maxSentenceLength, tokens.size())};
+            INDArray features = Nd4j.create(featuresShape, (format == Format.CNN1D ? 'c' : 'f'));
+            INDArrayIndex[] indices = new INDArrayIndex[3];
+            indices[0] = NDArrayIndex.point(0);
+            for (int i = 0; i < featuresShape[2]; i++) {
+                INDArray vector = getVector(tokens.get(i));
+                indices[1] = NDArrayIndex.all();
+                indices[2] = NDArrayIndex.point(i);
+                features.put(indices, vector);
+            }
+            return features;
         } else {
-            featuresShape[2] = wordVectorSize;
-            featuresShape[3] = Math.min(maxSentenceLength, tokens.size());
-        }
+            int[] featuresShape = new int[] {1, 1, 0, 0};
+            if (sentencesAlongHeight) {
+                featuresShape[2] = Math.min(maxSentenceLength, tokens.size());
+                featuresShape[3] = wordVectorSize;
+            } else {
+                featuresShape[2] = wordVectorSize;
+                featuresShape[3] = Math.min(maxSentenceLength, tokens.size());
+            }
 
-        INDArray features = Nd4j.create(featuresShape);
-        int length = (sentencesAlongHeight ? featuresShape[2] : featuresShape[3]);
-        for (int i = 0; i < length; i++) {
-            INDArray vector = getVector(tokens.get(i));
-
+            INDArray features = Nd4j.create(featuresShape);
+            int length = (sentencesAlongHeight ? featuresShape[2] : featuresShape[3]);
             INDArrayIndex[] indices = new INDArrayIndex[4];
             indices[0] = NDArrayIndex.point(0);
             indices[1] = NDArrayIndex.point(0);
-            if (sentencesAlongHeight) {
-                indices[2] = NDArrayIndex.point(i);
-                indices[3] = NDArrayIndex.all();
-            } else {
-                indices[2] = NDArrayIndex.all();
-                indices[3] = NDArrayIndex.point(i);
+            for (int i = 0; i < length; i++) {
+                INDArray vector = getVector(tokens.get(i));
+
+                if (sentencesAlongHeight) {
+                    indices[2] = NDArrayIndex.point(i);
+                    indices[3] = NDArrayIndex.all();
+                } else {
+                    indices[2] = NDArrayIndex.all();
+                    indices[3] = NDArrayIndex.point(i);
+                }
+
+                features.put(indices, vector);
             }
 
-            features.put(indices, vector);
+            return features;
         }
-
-        return features;
     }
 
     private INDArray getVector(String word) {
@@ -288,50 +313,92 @@ public class CnnSentenceDataSetIterator implements DataSetIterator {
             labels.putScalar(i, labelIdx, 1.0);
         }
 
-        int[] featuresShape = new int[4];
-        featuresShape[0] = currMinibatchSize;
-        featuresShape[1] = 1;
-        if (sentencesAlongHeight) {
-            featuresShape[2] = maxLength;
-            featuresShape[3] = wordVectorSize;
+        INDArray features;
+        INDArray featuresMask = null;
+        if(format == Format.CNN1D || format == Format.RNN){
+            int[] featuresShape = new int[]{currMinibatchSize, wordVectorSize, maxLength};
+            features = Nd4j.create(featuresShape, (format == Format.CNN1D ? 'c' : 'f'));
+
+            INDArrayIndex[] idxs = new INDArrayIndex[3];
+            idxs[1] = NDArrayIndex.all();
+            for (int i = 0; i < currMinibatchSize; i++) {
+                idxs[0] = NDArrayIndex.point(i);
+                List<String> currSentence = tokenizedSentences.get(i).getFirst();
+                for (int j = 0; j < currSentence.size() && j < maxSentenceLength; j++) {
+                    idxs[2] = NDArrayIndex.point(j);
+                    INDArray vector = getVector(currSentence.get(j));
+                    features.put(idxs, vector);
+                }
+            }
+
+            if (minLength != maxLength) {
+                featuresMask = Nd4j.create(currMinibatchSize, maxLength);
+                for (int i = 0; i < currMinibatchSize; i++) {
+                    int sentenceLength = tokenizedSentences.get(i).getFirst().size();
+                    if (sentenceLength >= maxLength) {
+                        featuresMask.getRow(i).assign(1.0);
+                    } else {
+                        featuresMask.get(NDArrayIndex.point(i), NDArrayIndex.interval(0, sentenceLength)).assign(1.0);
+                    }
+                }
+            }
+
         } else {
-            featuresShape[2] = wordVectorSize;
-            featuresShape[3] = maxLength;
-        }
+            int[] featuresShape = new int[4];
+            featuresShape[0] = currMinibatchSize;
+            featuresShape[1] = 1;
+            if (sentencesAlongHeight) {
+                featuresShape[2] = maxLength;
+                featuresShape[3] = wordVectorSize;
+            } else {
+                featuresShape[2] = wordVectorSize;
+                featuresShape[3] = maxLength;
+            }
 
-        INDArray features = Nd4j.create(featuresShape);
-        for (int i = 0; i < currMinibatchSize; i++) {
-            List<String> currSentence = tokenizedSentences.get(i).getFirst();
-
-            for (int j = 0; j < currSentence.size() && j < maxSentenceLength; j++) {
-                INDArray vector = getVector(currSentence.get(j));
-
-                INDArrayIndex[] indices = new INDArrayIndex[4];
-                //TODO REUSE
+            features = Nd4j.create(featuresShape);
+            INDArrayIndex[] indices = new INDArrayIndex[4];
+            indices[1] = NDArrayIndex.point(0);
+            for (int i = 0; i < currMinibatchSize; i++) {
                 indices[0] = NDArrayIndex.point(i);
-                indices[1] = NDArrayIndex.point(0);
-                if (sentencesAlongHeight) {
-                    indices[2] = NDArrayIndex.point(j);
-                    indices[3] = NDArrayIndex.all();
+                List<String> currSentence = tokenizedSentences.get(i).getFirst();
+                for (int j = 0; j < currSentence.size() && j < maxSentenceLength; j++) {
+                    INDArray vector = getVector(currSentence.get(j));
+
+                    if (sentencesAlongHeight) {
+                        indices[2] = NDArrayIndex.point(j);
+                        indices[3] = NDArrayIndex.all();
+                    } else {
+                        indices[2] = NDArrayIndex.all();
+                        indices[3] = NDArrayIndex.point(j);
+                    }
+
+                    features.put(indices, vector);
+                }
+            }
+
+            if (minLength != maxLength) {
+                int idxSeq;
+                if(sentencesAlongHeight){
+                    featuresMask = Nd4j.create(currMinibatchSize, 1, maxLength, 1);
+                    idxSeq = 2;
                 } else {
-                    indices[2] = NDArrayIndex.all();
-                    indices[3] = NDArrayIndex.point(j);
+                    featuresMask = Nd4j.create(currMinibatchSize, 1, 1, maxLength);
+                    idxSeq = 3;
                 }
 
-                features.put(indices, vector);
-            }
-        }
-
-        INDArray featuresMask = null;
-        if (minLength != maxLength) {
-            featuresMask = Nd4j.create(currMinibatchSize, maxLength);
-
-            for (int i = 0; i < currMinibatchSize; i++) {
-                int sentenceLength = tokenizedSentences.get(i).getFirst().size();
-                if (sentenceLength >= maxLength) {
-                    featuresMask.getRow(i).assign(1.0);
-                } else {
-                    featuresMask.get(NDArrayIndex.point(i), NDArrayIndex.interval(0, sentenceLength)).assign(1.0);
+                INDArrayIndex[] idxs = new INDArrayIndex[4];
+                idxs[1] = NDArrayIndex.all();
+                idxs[2] = NDArrayIndex.all();   //One of [2] and [3] will get replaced, depending on sentencesAlongHeight
+                idxs[3] = NDArrayIndex.all();
+                for (int i = 0; i < currMinibatchSize; i++) {
+                    idxs[0] = NDArrayIndex.point(i);
+                    int sentenceLength = tokenizedSentences.get(i).getFirst().size();
+                    if (sentenceLength >= maxLength) {
+                        idxs[idxSeq] = NDArrayIndex.all();
+                    } else {
+                        idxs[idxSeq] = NDArrayIndex.interval(0,sentenceLength);
+                    }
+                    featuresMask.get(idxs).assign(1.0);
                 }
             }
         }
@@ -394,6 +461,7 @@ public class CnnSentenceDataSetIterator implements DataSetIterator {
 
     public static class Builder {
 
+        private Format format;
         private LabeledSentenceProvider sentenceProvider = null;
         private WordVectors wordVectors;
         private TokenizerFactory tokenizerFactory = new DefaultTokenizerFactory();
@@ -403,6 +471,23 @@ public class CnnSentenceDataSetIterator implements DataSetIterator {
         private int minibatchSize = 32;
         private boolean sentencesAlongHeight = true;
         private DataSetPreProcessor dataSetPreProcessor;
+
+        /**
+         * @deprecated Due to old default, that will be changed in the future. Use {@link #Builder(Format)} to specify
+         * the {@link Format} of the activations
+         */
+        @Deprecated
+        public Builder(){
+            //Default for backward compatibility
+            this(Format.CNN2D);
+        }
+
+        /**
+         * @param format The format to use for the features - i.e., for 1D or 2D CNNs
+         */
+        public Builder(@NonNull Format format){
+            this.format = format;
+        }
 
         /**
          * Specify how the (labelled) sentences / documents should be provided

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/iterator/TestCnnSentenceDataSetIterator.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/iterator/TestCnnSentenceDataSetIterator.java
@@ -39,8 +39,6 @@ public class TestCnnSentenceDataSetIterator {
 
     @Test
     public void testSentenceIterator() throws Exception {
-
-
         WordVectors w2v = WordVectorSerializer
                         .readWord2VecModel(new ClassPathResource("word2vec/googleload/sample_vec.bin").getFile());
 
@@ -65,69 +63,145 @@ public class TestCnnSentenceDataSetIterator {
 
         boolean[] alongHeightVals = new boolean[] {true, false};
 
-        for (boolean alongHeight : alongHeightVals) {
+        for(boolean norm : new boolean[]{true, false}) {
+            for (boolean alongHeight : alongHeightVals) {
 
-            INDArray expectedFeatures;
-            if (alongHeight) {
-                expectedFeatures = Nd4j.create(2, 1, maxLength, vectorSize);
-            } else {
-                expectedFeatures = Nd4j.create(2, 1, vectorSize, maxLength);
-            }
-
-            INDArray expectedFeatureMask = Nd4j.create(new double[][] {{1, 1, 1, 1}, {1, 1, 1, 0}});
-
-            for (int i = 0; i < 4; i++) {
+                INDArray expectedFeatures;
                 if (alongHeight) {
-                    expectedFeatures.get(NDArrayIndex.point(0), NDArrayIndex.point(0), NDArrayIndex.point(i),
-                                    NDArrayIndex.all()).assign(w2v.getWordVectorMatrix(s1.get(i)));
+                    expectedFeatures = Nd4j.create(2, 1, maxLength, vectorSize);
                 } else {
-                    expectedFeatures.get(NDArrayIndex.point(0), NDArrayIndex.point(0), NDArrayIndex.all(),
-                                    NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrix(s1.get(i)));
+                    expectedFeatures = Nd4j.create(2, 1, vectorSize, maxLength);
                 }
-            }
 
-            for (int i = 0; i < 3; i++) {
+                int[] fmShape;
+                if(alongHeight){
+                    fmShape = new int[]{2, 1, 4, 1};
+                } else {
+                    fmShape = new int[]{2, 1, 1, 4};
+                }
+                INDArray expectedFeatureMask = Nd4j.create(new double[][]{{1, 1, 1, 1}, {1, 1, 1, 0}}).reshape('c', fmShape);
+
+
+                for (int i = 0; i < 4; i++) {
+                    INDArray v = norm ? w2v.getWordVectorMatrixNormalized(s1.get(i)) : w2v.getWordVectorMatrix(s1.get(i));
+                    if (alongHeight) {
+                        expectedFeatures.get(NDArrayIndex.point(0), NDArrayIndex.point(0), NDArrayIndex.point(i),
+                                NDArrayIndex.all()).assign(v);
+                    } else {
+                        expectedFeatures.get(NDArrayIndex.point(0), NDArrayIndex.point(0), NDArrayIndex.all(),
+                                NDArrayIndex.point(i)).assign(v);
+                    }
+                }
+
+                for (int i = 0; i < 3; i++) {
+                    INDArray v = norm ? w2v.getWordVectorMatrixNormalized(s2.get(i)) : w2v.getWordVectorMatrix(s2.get(i));
+                    if (alongHeight) {
+                        expectedFeatures.get(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.point(i),
+                                NDArrayIndex.all()).assign(v);
+                    } else {
+                        expectedFeatures.get(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.all(),
+                                NDArrayIndex.point(i)).assign(v);
+                    }
+                }
+
+
+                LabeledSentenceProvider p = new CollectionLabeledSentenceProvider(sentences, labelsForSentences, null);
+                CnnSentenceDataSetIterator dsi = new CnnSentenceDataSetIterator.Builder(CnnSentenceDataSetIterator.Format.CNN2D)
+                        .sentenceProvider(p).useNormalizedWordVectors(norm)
+                        .wordVectors(w2v).maxSentenceLength(256).minibatchSize(32).sentencesAlongHeight(alongHeight)
+                        .build();
+
+                //            System.out.println("alongHeight = " + alongHeight);
+                DataSet ds = dsi.next();
+                assertArrayEquals(expectedFeatures.shape(), ds.getFeatures().shape());
+                assertEquals(expectedFeatures, ds.getFeatures());
+                assertEquals(expLabels, ds.getLabels());
+                assertEquals(expectedFeatureMask, ds.getFeaturesMaskArray());
+                assertNull(ds.getLabelsMaskArray());
+
+                INDArray s1F = dsi.loadSingleSentence(sentences.get(0));
+                INDArray s2F = dsi.loadSingleSentence(sentences.get(1));
+                INDArray sub1 = ds.getFeatures().get(NDArrayIndex.interval(0, 0, true), NDArrayIndex.all(),
+                        NDArrayIndex.all(), NDArrayIndex.all());
+                INDArray sub2;
                 if (alongHeight) {
-                    expectedFeatures.get(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.point(i),
-                                    NDArrayIndex.all()).assign(w2v.getWordVectorMatrix(s2.get(i)));
+
+                    sub2 = ds.getFeatures().get(NDArrayIndex.interval(1, 1, true), NDArrayIndex.all(),
+                            NDArrayIndex.interval(0, 3), NDArrayIndex.all());
                 } else {
-                    expectedFeatures.get(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.all(),
-                                    NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrix(s2.get(i)));
+                    sub2 = ds.getFeatures().get(NDArrayIndex.interval(1, 1, true), NDArrayIndex.all(), NDArrayIndex.all(),
+                            NDArrayIndex.interval(0, 3));
                 }
+
+                assertArrayEquals(sub1.shape(), s1F.shape());
+                assertArrayEquals(sub2.shape(), s2F.shape());
+                assertEquals(sub1, s1F);
+                assertEquals(sub2, s2F);
             }
+        }
+    }
 
 
-            LabeledSentenceProvider p = new CollectionLabeledSentenceProvider(sentences, labelsForSentences, null);
-            CnnSentenceDataSetIterator dsi = new CnnSentenceDataSetIterator.Builder().sentenceProvider(p)
-                            .wordVectors(w2v).maxSentenceLength(256).minibatchSize(32).sentencesAlongHeight(alongHeight)
-                            .build();
+    @Test
+    public void testSentenceIteratorCNN1D_RNN() throws Exception {
+        WordVectors w2v = WordVectorSerializer
+                .readWord2VecModel(new ClassPathResource("word2vec/googleload/sample_vec.bin").getFile());
 
-            //            System.out.println("alongHeight = " + alongHeight);
-            DataSet ds = dsi.next();
-            assertArrayEquals(expectedFeatures.shape(), ds.getFeatures().shape());
-            assertEquals(expectedFeatures, ds.getFeatures());
-            assertEquals(expLabels, ds.getLabels());
-            assertEquals(expectedFeatureMask, ds.getFeaturesMaskArray());
-            assertNull(ds.getLabelsMaskArray());
+        int vectorSize = w2v.lookupTable().layerSize();
 
-            INDArray s1F = dsi.loadSingleSentence(sentences.get(0));
-            INDArray s2F = dsi.loadSingleSentence(sentences.get(1));
-            INDArray sub1 = ds.getFeatures().get(NDArrayIndex.interval(0, 0, true), NDArrayIndex.all(),
-                            NDArrayIndex.all(), NDArrayIndex.all());
-            INDArray sub2;
-            if (alongHeight) {
+        List<String> sentences = new ArrayList<>();
+        //First word: all present
+        sentences.add("these balance Database model");
+        sentences.add("into same THISWORDDOESNTEXIST are");
+        int maxLength = 4;
+        List<String> s1 = Arrays.asList("these", "balance", "Database", "model");
+        List<String> s2 = Arrays.asList("into", "same", "are");
 
-                sub2 = ds.getFeatures().get(NDArrayIndex.interval(1, 1, true), NDArrayIndex.all(),
-                                NDArrayIndex.interval(0, 3), NDArrayIndex.all());
-            } else {
-                sub2 = ds.getFeatures().get(NDArrayIndex.interval(1, 1, true), NDArrayIndex.all(), NDArrayIndex.all(),
-                                NDArrayIndex.interval(0, 3));
+        List<String> labelsForSentences = Arrays.asList("Positive", "Negative");
+
+        INDArray expLabels = Nd4j.create(new double[][] {{0, 1}, {1, 0}}); //Order of labels: alphabetic. Positive -> [0,1]
+
+        for(boolean norm : new boolean[]{true, false}) {
+            for(CnnSentenceDataSetIterator.Format f : new CnnSentenceDataSetIterator.Format[]{CnnSentenceDataSetIterator.Format.CNN1D, CnnSentenceDataSetIterator.Format.RNN}){
+
+                INDArray expectedFeatures = Nd4j.create(2, vectorSize, maxLength);
+                int[] fmShape = new int[]{2, 4};
+                INDArray expectedFeatureMask = Nd4j.create(new double[][]{{1, 1, 1, 1}, {1, 1, 1, 0}}).reshape('c', fmShape);
+
+
+                for (int i = 0; i < 4; i++) {
+                    INDArray v = norm ? w2v.getWordVectorMatrixNormalized(s1.get(i)) : w2v.getWordVectorMatrix(s1.get(i));
+                    expectedFeatures.get(NDArrayIndex.point(0), NDArrayIndex.all(),NDArrayIndex.point(i)).assign(v);
+                }
+
+                for (int i = 0; i < 3; i++) {
+                    INDArray v = norm ? w2v.getWordVectorMatrixNormalized(s2.get(i)) : w2v.getWordVectorMatrix(s2.get(i));
+                    expectedFeatures.get(NDArrayIndex.point(1), NDArrayIndex.all(), NDArrayIndex.point(i)).assign(v);
+                }
+
+                LabeledSentenceProvider p = new CollectionLabeledSentenceProvider(sentences, labelsForSentences, null);
+                CnnSentenceDataSetIterator dsi = new CnnSentenceDataSetIterator.Builder(f)
+                        .sentenceProvider(p).useNormalizedWordVectors(norm)
+                        .wordVectors(w2v).maxSentenceLength(256).minibatchSize(32)
+                        .build();
+
+                DataSet ds = dsi.next();
+                assertArrayEquals(expectedFeatures.shape(), ds.getFeatures().shape());
+                assertEquals(expectedFeatures, ds.getFeatures());
+                assertEquals(expLabels, ds.getLabels());
+                assertEquals(expectedFeatureMask, ds.getFeaturesMaskArray());
+                assertNull(ds.getLabelsMaskArray());
+
+                INDArray s1F = dsi.loadSingleSentence(sentences.get(0));
+                INDArray s2F = dsi.loadSingleSentence(sentences.get(1));
+                INDArray sub1 = ds.getFeatures().get(NDArrayIndex.interval(0, 0, true), NDArrayIndex.all(), NDArrayIndex.all());
+                INDArray sub2 = ds.getFeatures().get(NDArrayIndex.interval(1, 1, true), NDArrayIndex.all(), NDArrayIndex.interval(0, 3));
+
+                assertArrayEquals(sub1.shape(), s1F.shape());
+                assertArrayEquals(sub2.shape(), s2F.shape());
+                assertEquals(sub1, s1F);
+                assertEquals(sub2, s2F);
             }
-
-            assertArrayEquals(sub1.shape(), s1F.shape());
-            assertArrayEquals(sub2.shape(), s2F.shape());
-            assertEquals(sub1, s1F);
-            assertEquals(sub2, s2F);
         }
     }
 
@@ -156,7 +230,8 @@ public class TestCnnSentenceDataSetIterator {
 
 
         LabeledSentenceProvider p = new CollectionLabeledSentenceProvider(sentences, labelsForSentences, null);
-        CnnSentenceDataSetIterator dsi = new CnnSentenceDataSetIterator.Builder().sentenceProvider(p).wordVectors(w2v)
+        CnnSentenceDataSetIterator dsi = new CnnSentenceDataSetIterator.Builder(CnnSentenceDataSetIterator.Format.CNN2D).sentenceProvider(p).wordVectors(w2v)
+                        .useNormalizedWordVectors(true)
                         .maxSentenceLength(256).minibatchSize(32).sentencesAlongHeight(false).build();
 
         //            System.out.println("alongHeight = " + alongHeight);
@@ -164,16 +239,16 @@ public class TestCnnSentenceDataSetIterator {
 
         INDArray expectedFeatures = Nd4j.create(2, 1, vectorSize, maxLength);
 
-        INDArray expectedFeatureMask = Nd4j.create(new double[][] {{1, 1, 1, 1}, {1, 1, 1, 0}});
+        INDArray expectedFeatureMask = Nd4j.create(new double[][] {{1, 1, 1, 1}, {1, 1, 1, 0}}).reshape('c', 2, 1, 1, 4);
 
         for (int i = 0; i < 4; i++) {
             expectedFeatures.get(NDArrayIndex.point(0), NDArrayIndex.point(0), NDArrayIndex.all(),
-                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrix(s1.get(i)));
+                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrixNormalized(s1.get(i)));
         }
 
         for (int i = 0; i < 3; i++) {
             expectedFeatures.get(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.all(),
-                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrix(s2.get(i)));
+                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrixNormalized(s2.get(i)));
         }
 
         assertArrayEquals(expectedFeatures.shape(), ds.getFeatures().shape());
@@ -211,7 +286,8 @@ public class TestCnnSentenceDataSetIterator {
 
 
         LabeledSentenceProvider p = new CollectionLabeledSentenceProvider(sentences, labelsForSentences, null);
-        CnnSentenceDataSetIterator dsi = new CnnSentenceDataSetIterator.Builder().sentenceProvider(p).wordVectors(w2v)
+        CnnSentenceDataSetIterator dsi = new CnnSentenceDataSetIterator.Builder(CnnSentenceDataSetIterator.Format.CNN2D).sentenceProvider(p).wordVectors(w2v)
+                        .useNormalizedWordVectors(true)
                         .maxSentenceLength(256).minibatchSize(2).sentencesAlongHeight(false).build();
 
         assertTrue(dsi.hasNext());
@@ -222,16 +298,16 @@ public class TestCnnSentenceDataSetIterator {
 
         INDArray expectedFeatures = Nd4j.create(2, 1, vectorSize, maxLength);
 
-        INDArray expectedFeatureMask = Nd4j.create(new double[][] {{1, 1, 1, 1}, {1, 1, 1, 0}});
+        INDArray expectedFeatureMask = Nd4j.create(new double[][] {{1, 1, 1, 1}, {1, 1, 1, 0}}).reshape('c', 2, 1, 1, 4);
 
         for (int i = 0; i < 4; i++) {
             expectedFeatures.get(NDArrayIndex.point(0), NDArrayIndex.point(0), NDArrayIndex.all(),
-                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrix(s1.get(i)));
+                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrixNormalized(s1.get(i)));
         }
 
         for (int i = 0; i < 3; i++) {
             expectedFeatures.get(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.all(),
-                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrix(s2.get(i)));
+                            NDArrayIndex.point(i)).assign(w2v.getWordVectorMatrixNormalized(s2.get(i)));
         }
 
         assertArrayEquals(expectedFeatures.shape(), ds.getFeatures().shape());

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
@@ -24,6 +24,7 @@ import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.optimize.api.TrainingListener;
+import org.deeplearning4j.util.Convolution1DUtils;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
@@ -82,14 +83,16 @@ public class Convolution1DLayer extends ConvolutionLayer {
                     + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
                     + inputType);
         }
-        long inputTsLength = ((InputType.InputTypeRecurrent) inputType).getTimeSeriesLength();
-        InputType dummyConv = new InputType.InputTypeConvolutional(inputTsLength, inputTsLength, nOut);
-        InputType.InputTypeConvolutional returnConv = (InputType.InputTypeConvolutional)
-                InputTypeUtil.getOutputTypeCnnLayers(dummyConv, kernelSize, stride, padding, dilation,
-                        convolutionMode, nOut, layerIndex, getLayerName(), ConvolutionLayer.class);
-        long outputTsLength = returnConv.getHeight();
-        return InputType.recurrent(nOut, outputTsLength);
-
+        InputType.InputTypeRecurrent it = (InputType.InputTypeRecurrent) inputType;
+        long inputTsLength = it.getTimeSeriesLength();
+        long outLength;
+        if(inputTsLength < 0){
+            //Probably: user did InputType.recurrent(x) without specifying sequence length
+            outLength = -1;
+        } else {
+            outLength = Convolution1DUtils.getOutputSize((int)inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode, dilation[0]);
+        }
+        return InputType.recurrent(nOut, outLength);
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
@@ -24,6 +24,7 @@ import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.optimize.api.TrainingListener;
+import org.deeplearning4j.util.Convolution1DUtils;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
@@ -75,7 +76,16 @@ public class Subsampling1DLayer extends SubsamplingLayer {
             throw new IllegalStateException("Invalid input for Subsampling1D layer (layer name=\"" + getLayerName()
                     + "\"): Expected RNN input, got " + inputType);
         }
-        return inputType;
+        InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent)inputType;
+        long inputTsLength = r.getTimeSeriesLength();
+        int outLength;
+        if(inputTsLength < 0){
+            //Probably: user did InputType.recurrent(x) without specifying sequence length
+            outLength = -1;
+        } else {
+            outLength = Convolution1DUtils.getOutputSize((int)inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode, dilation[0]);
+        }
+        return InputType.recurrent(r.getSize(), outLength);
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
@@ -80,7 +80,10 @@ public class Upsampling1D extends BaseUpsamplingLayer {
                     + inputType);
         }
         InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
-        return InputType.recurrent(recurrent.getSize(), recurrent.getTimeSeriesLength());
+        long outLength = recurrent.getTimeSeriesLength();
+        if(outLength > 0)
+            outLength *= size[0];
+        return InputType.recurrent(recurrent.getSize(), outLength);
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/AbstractLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/AbstractLayer.java
@@ -387,8 +387,7 @@ public abstract class AbstractLayer<LayerConfT extends org.deeplearning4j.nn.con
 
 
     @Override
-    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState,
-                    int minibatchSize) {
+    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState, int minibatchSize) {
         //Most layers: CNN, dense, activation, etc - set mask array, mask state and then leave the mask unmodified
 
         this.maskArray = maskArray;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.nn.layers.convolution;
 
 import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
 import org.deeplearning4j.nn.conf.CacheMode;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -465,6 +466,18 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
     public void setParams(INDArray params) {
         //Override, as base layer does f order parameter flattening by default
         setParams(params, 'c');
+    }
+
+    @Override
+    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState, int minibatchSize) {
+        if (maskArray == null) {
+            //For same mode (with stride 1): output activations size is always same size as input activations size -> mask array is same size
+            return new Pair<>(maskArray, currentMaskState);
+        }
+
+        INDArray outMask = ConvolutionUtils.cnn2dMaskReduction(maskArray, layerConf().getKernelSize(), layerConf().getStride(),
+                layerConf().getPadding(), layerConf().getDilation(), layerConf().getConvolutionMode());
+        return new Pair<>(outMask, currentMaskState);
     }
 
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.nn.layers.convolution.subsampling;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.exception.DL4JInvalidInputException;
 import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.api.MaskState;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.PoolingType;
@@ -447,5 +448,17 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
     @Override
     public void setParams(INDArray params) {
 
+    }
+
+    @Override
+    public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState, int minibatchSize) {
+        if (maskArray == null) {
+            //For same mode (with stride 1): output activations size is always same size as input activations size -> mask array is same size
+            return new Pair<>(maskArray, currentMaskState);
+        }
+
+        INDArray outMask = ConvolutionUtils.cnn2dMaskReduction(maskArray, layerConf().getKernelSize(), layerConf().getStride(),
+                layerConf().getPadding(), layerConf().getDilation(), layerConf().getConvolutionMode());
+        return super.feedForwardMaskArray(outMask, currentMaskState, minibatchSize);
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingLayer.java
@@ -42,13 +42,12 @@ import java.util.Arrays;
  * Global pooling layer - used to do pooling over time for RNNs, and 2d pooling for CNNs.<br>
  * Supports the following {@link PoolingType}s: SUM, AVG, MAX, PNORM<br>
  *
- * Global pooling layer can also handle mask arrays when dealing with variable length inputs. Mask arrays are assumed
- * to be 2d, and are fed forward through the network during training or post-training forward pass:<br>
- * - Time series: mask arrays are shape [miniBatchSize, maxTimeSeriesLength] and contain values 0 or 1 only<br>
- * - CNNs: mask have shape [miniBatchSize, height] or [miniBatchSize, width]. Important: the current implementation assumes
- *   that for CNNs + variable length (masking), the input shape is [miniBatchSize, channels, height, 1] or
- *   [miniBatchSize, channels, 1, width] respectively. This is the case with global pooling in architectures like CNN for
- *   sentence classification.<br>
+ * Global pooling layer can also handle mask arrays when dealing with variable length inputs.<br>
+ * mask arrays are assumed to be 2d, and are fed forward through the network during
+ * training or post-training forward pass:<br>
+ * - Time series (RNNs, 1d CNNs): mask arrays are shape [miniBatchSize, maxTimeSeriesLength] and contain values 0 or 1 only<br>
+ * - CNNs (2d): mask have shape [miniBatchSize, 1, height, 1] or [miniBatchSize, 1, 1, width] or [minibatch, 1, height, width].
+ *   When used activations of shape [minibatch, channels, height, width] the size 1 dimensions are broadcast along the input<br>
  * <p>
  *
  * Behaviour with default settings:<br>
@@ -176,8 +175,8 @@ public class GlobalPoolingLayer extends AbstractLayer<org.deeplearning4j.nn.conf
                                     + "on CNN data. Got 4d activations array (shape "
                                     + Arrays.toString(input.shape()) + ") and " + maskArray.rank()
                                     + "d mask array (shape " + Arrays.toString(maskArray.shape()) + ") "
-                                    + " - 4d masks should have shape [batchSize,1,h,1] or [batchSize,1,w,1]"
-                                    + layerId());
+                                    + " - when used in conjunction with input data of shape [batch,channels,h,w]=" + Arrays.toString(input.shape())
+                                    + " 4d masks should have shape [batchSize,1,h,1] or [batchSize,1,w,1] or [batchSize,1,h,w]" + layerId());
                 }
 
                 reduced2d = MaskedReductionUtil.maskedPoolingConvolution(poolingType, input, maskArray, pNorm);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/Convolution1DUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/Convolution1DUtils.java
@@ -54,6 +54,27 @@ public class Convolution1DUtils {
     /**
      * Get the output size (height) for the given input data and CNN1D configuration
      *
+     * @param inH             Input size (height, or channels).
+     * @param kernel          Kernel size
+     * @param strides         Stride
+     * @param padding         Padding
+     * @param convolutionMode Convolution mode (Same, Strict, Truncate)
+     * @param dilation        Kernel dilation
+     * @return Output size (width)
+     */
+    public static int getOutputSize(int inH, int kernel, int strides, int padding,
+                                    ConvolutionMode convolutionMode, int dilation) {
+        // FIXME: int cast
+        int eKernel = effectiveKernelSize(kernel, dilation);
+        if (convolutionMode == ConvolutionMode.Same) {
+            return (int) Math.ceil(inH / ((double) strides));
+        }
+        return (inH - eKernel + 2 * padding) / strides + 1;
+    }
+
+    /**
+     * Get the output size (height) for the given input data and CNN1D configuration
+     *
      * @param inputData       Input data
      * @param kernel          Kernel size
      * @param strides         Stride

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
@@ -581,6 +581,18 @@ public class ConvolutionUtils {
         return output.reshape('c', in.size(0), outH);
     }
 
+    /**
+     * Reduce a 2d CNN layer mask array (of 0s and 1s) according to the layer configuration. Note that when a CNN layer
+     * changes the shape of the activations (for example, stride > 1) the corresponding mask array needs to change shape
+     * also (as there is a correspondence between the two). This method performs the forward pass for the mask.
+     * @param inMask          Input mask array - rank 4, shape [mb,c,h,1] or [mb,c,w,1] or [mb,c,h,w]
+     * @param kernel          Kernel configuration for the layer
+     * @param stride          Stride
+     * @param padding         Padding
+     * @param dilation        Dilation
+     * @param convolutionMode Convolution mode
+     * @return The mask array corresponding to the network output
+     */
     public static INDArray cnn2dMaskReduction(INDArray inMask, int[] kernel, int[] stride, int[] padding, int[] dilation, ConvolutionMode convolutionMode ){
         //Mask array should be broadcastable with CNN activations. Thus should have shape [mb,x,y,z]
         //where:
@@ -589,10 +601,8 @@ public class ConvolutionUtils {
         // z == 1 OR width
 
         if(inMask.rank() != 4){
-            //TODO BETTER ERROR MESSAGE EXPLAINING FORMAT
-            //TODO ALSO HANDLE LEGACY FORMAT WITH WARNING WHERE POSSIBLE
-            throw new IllegalStateException("Expected rank 4 mask array for CNN activations. Mask arrays for 2D CNN layers " +
-                    "must have shape [mb,1,X,Y] where X = (1 or activationsHeight) and Y = (1 or activationsWidth): " +
+            throw new IllegalStateException("Expected rank 4 mask array for 2D CNN layers. Mask arrays for 2D CNN layers " +
+                    "must have shape [batchSize,channels,X,Y] where X = (1 or activationsHeight) and Y = (1 or activationsWidth): " +
                     "Got rank " + inMask.rank() + " array with shape " + Arrays.toString(inMask.shape()));
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/MaskedReductionUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/MaskedReductionUtil.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.util;
 
+import com.sun.prism.impl.shape.ShapeUtil;
 import org.deeplearning4j.nn.conf.layers.PoolingType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.broadcast.BroadcastAddOp;
@@ -27,6 +28,8 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.BooleanIndexing;
 import org.nd4j.linalg.indexing.conditions.Conditions;
 import org.nd4j.linalg.ops.transforms.Transforms;
+
+import java.util.Arrays;
 
 /**
  *
@@ -173,15 +176,27 @@ public class MaskedReductionUtil {
     }
 
 
-    public static INDArray maskedPoolingConvolution(PoolingType poolingType, INDArray toReduce, INDArray mask,
-                    boolean alongHeight, int pnorm) {
-        // [minibatch, channels, h=1, w=X] or [minibatch, channels, h=X, w=1] data
-        // with a mask array of shape [minibatch, X]
+    public static INDArray maskedPoolingConvolution(PoolingType poolingType, INDArray toReduce, INDArray mask, int pnorm) {
+        if(mask.rank() != 4){
+            //TODO BETTER ERROR MESSAGE EXPLAINING FORMAT
+            //TODO ALSO HANDLE LEGACY FORMAT WITH WARNING WHERE POSSIBLE
+            throw new IllegalStateException("Expected rank 4 mask array: Got array with shape " + Arrays.toString(mask.shape()));
+        }
 
-        //If masking along height: broadcast dimensions are [0,2]
-        //If masking along width: broadcast dimensions are [0,3]
+        // [minibatch, channels, h, w] data with a mask array of shape [minibatch, 1, X, Y]
+        // where X=(1 or inH) and Y=(1 or inW)
 
-        int[] dimensions = (alongHeight ? CNN_DIM_MASK_H : CNN_DIM_MASK_W);
+        //General case: must be equal or 1 on each dimension
+        int[] dimensions = new int[4];
+        int count = 0;
+        for(int i=0; i<4; i++ ){
+            if(toReduce.size(i) == mask.size(i)){
+                dimensions[count++] = i;
+            }
+        }
+        if(count < 4){
+            dimensions = Arrays.copyOfRange(dimensions, 0, count);
+        }
 
         switch (poolingType) {
             case MAX:
@@ -203,7 +218,7 @@ public class MaskedReductionUtil {
                 if (poolingType == PoolingType.SUM) {
                     return summed;
                 }
-                INDArray maskCounts = mask.sum(1);
+                INDArray maskCounts = mask.sum(1,2,3);
                 summed.diviColumnVector(maskCounts);
                 return summed;
 


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/5907
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/5624

Note: This PR makes significant changes to mask arrays for CNN layers.
- Previously: masks were always 2d, [minibatch,H] or [minibatch,W]. And global pooling layer could work only if exactly one of H or W of input was 1
- Now: Masks for CNNs are 4d, in a broadcastable format: ```[mb,d/1, h/1, w/1]```
    - Required to fix #5624 
    - This also allows us to support more sophisticated masking situations: for example, different image sizes in same minibatch for fully convolutional networks (using either Pool+outputLayer, or CnnLossLayer)
- CnnSentenceDataSetIterator now supports Cnn1d/RNN format also (plus has been updated to new 2d CNN mask format)