### PR TITLE
Improve Arbiter data usability

### DIFF
--- a/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/TaskCreator.java
+++ b/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/TaskCreator.java
@@ -17,11 +17,13 @@
 package org.deeplearning4j.arbiter.optimize.api;
 
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
 import org.deeplearning4j.arbiter.optimize.api.score.ScoreFunction;
 import org.deeplearning4j.arbiter.optimize.runner.IOptimizationRunner;
 import org.deeplearning4j.arbiter.optimize.runner.listener.StatusListener;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 
 /**
@@ -41,6 +43,20 @@ public interface TaskCreator {
      * @param statusListeners Status listeners, that can be used for callbacks (to UI, for example)
      * @return A callable that returns an OptimizationResult, once optimization is complete
      */
+    @Deprecated
     Callable<OptimizationResult> create(Candidate candidate, DataProvider dataProvider, ScoreFunction scoreFunction,
                                         List<StatusListener> statusListeners, IOptimizationRunner runner);
+
+    /**
+     * Generate a callable that can be executed to conduct the training of this model (given the model configuration)
+     *
+     * @param candidate            Candidate (model) configuration to be trained
+     * @param dataSource           Data source
+     * @param dataSourceProperties Properties (may be null) for the data source
+     * @param scoreFunction        Score function to be used to evaluate the model
+     * @param statusListeners      Status listeners, that can be used for callbacks (to UI, for example)
+     * @return A callable that returns an OptimizationResult, once optimization is complete
+     */
+    Callable<OptimizationResult> create(Candidate candidate, Class<? extends DataSource> dataSource, Properties dataSourceProperties,
+                                        ScoreFunction scoreFunction, List<StatusListener> statusListeners, IOptimizationRunner runner);
 }

--- a/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/data/DataProvider.java
+++ b/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/data/DataProvider.java
@@ -24,9 +24,11 @@ import java.util.Map;
 
 /**
  * DataProvider interface abstracts out the providing of data
+ * @deprecated Use {@link DataSource}
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@Deprecated
 public interface DataProvider extends Serializable {
 
     /**

--- a/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/data/DataSource.java
+++ b/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/data/DataSource.java
@@ -1,0 +1,41 @@
+package org.deeplearning4j.arbiter.optimize.api.data;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+/**
+ * DataSource: defines where the data should come from for training and testing.
+ * Note that implementations must have a no-argument contsructor
+ *
+ * @author Alex Black
+ */
+public interface DataSource extends Serializable {
+
+    /**
+     * Configure the current data source with the specified properties
+     * Note: These properties are fixed for the training instance, and are optionally provided by the user
+     * at the configuration stage.
+     * The properties could be anything - and are usually specific to each DataSource implementation.
+     * For example, values such as batch size could be set using these properties
+     * @param properties Properties to apply to the data source instance
+     */
+    void configure(Properties properties);
+
+    /**
+     * Get test data to be used for the optimization. Usually a DataSetIterator or MultiDataSetIterator
+     */
+    Object trainData();
+
+    /**
+     * Get test data to be used for the optimization. Usually a DataSetIterator or MultiDataSetIterator
+     */
+    Object testData();
+
+    /**
+     * The type of data returned by {@link #trainData()} and {@link #testData()}.
+     * Usually DataSetIterator or MultiDataSetIterator
+     * @return Class of the objects returned by trainData and testData
+     */
+    Class<?> getDataType();
+
+}

--- a/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/score/ScoreFunction.java
+++ b/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/score/ScoreFunction.java
@@ -17,12 +17,14 @@
 package org.deeplearning4j.arbiter.optimize.api.score;
 
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
 import org.nd4j.shade.jackson.annotation.JsonInclude;
 import org.nd4j.shade.jackson.annotation.JsonTypeInfo;
 
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * ScoreFunction defines the objective of hyperparameter optimization.
@@ -43,6 +45,16 @@ public interface ScoreFunction extends Serializable {
      * @return Calculated score
      */
     double score(Object model, DataProvider dataProvider, Map<String, Object> dataParameters);
+
+    /**
+     * Calculate and return the score, for the given model and data provider
+     *
+     * @param model                Model to score
+     * @param dataSource           Data source
+     * @param dataSourceProperties data source properties
+     * @return Calculated score
+     */
+    double score(Object model, Class<? extends DataSource> dataSource, Properties dataSourceProperties);
 
     /**
      * Should this score function be minimized or maximized?

--- a/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/config/OptimizationConfiguration.java
+++ b/arbiter/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/config/OptimizationConfiguration.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.arbiter.optimize.config;
 import lombok.*;
 import org.deeplearning4j.arbiter.optimize.api.CandidateGenerator;
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
 import org.deeplearning4j.arbiter.optimize.api.saving.ResultSaver;
 import org.deeplearning4j.arbiter.optimize.api.score.ScoreFunction;
 import org.deeplearning4j.arbiter.optimize.api.termination.TerminationCondition;
@@ -28,8 +29,10 @@ import org.nd4j.shade.jackson.core.JsonProcessingException;
 import org.nd4j.shade.jackson.databind.annotation.JsonSerialize;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
 /**
  * OptimizationConfiguration ties together all of the various
@@ -45,6 +48,10 @@ import java.util.List;
 public class OptimizationConfiguration {
     @JsonSerialize
     private DataProvider dataProvider;
+    @JsonSerialize
+    private Class<? extends DataSource> dataSource;
+    @JsonSerialize
+    private Properties dataSourceProperties;
     @JsonSerialize
     private CandidateGenerator candidateGenerator;
     @JsonSerialize
@@ -63,6 +70,8 @@ public class OptimizationConfiguration {
 
     private OptimizationConfiguration(Builder builder) {
         this.dataProvider = builder.dataProvider;
+        this.dataSource = builder.dataSource;
+        this.dataSourceProperties = builder.dataSourceProperties;
         this.candidateGenerator = builder.candidateGenerator;
         this.resultSaver = builder.resultSaver;
         this.scoreFunction = builder.scoreFunction;
@@ -74,19 +83,46 @@ public class OptimizationConfiguration {
 
         //Validate the configuration: data types, score types, etc
         //TODO
+
+        //Validate that the dataSource has a no-arg constructor
+        if(dataSource != null){
+            try{
+                dataSource.getConstructor();
+            } catch (NoSuchMethodException e){
+                throw new IllegalStateException("Data source class " + dataSource.getName() + " does not have a public no-argument constructor");
+            }
+        }
     }
 
     public static class Builder {
 
         private DataProvider dataProvider;
+        private Class<? extends DataSource> dataSource;
+        private Properties dataSourceProperties;
         private CandidateGenerator candidateGenerator;
         private ResultSaver resultSaver;
         private ScoreFunction scoreFunction;
         private List<TerminationCondition> terminationConditions;
         private Long rngSeed;
 
+        /**
+         * @deprecated Use {@link #dataSource(Class, Properties)}
+         */
+        @Deprecated
         public Builder dataProvider(DataProvider dataProvider) {
             this.dataProvider = dataProvider;
+            return this;
+        }
+
+        /**
+         * DataSource: defines where the data should come from for training and testing.
+         * Note that implementations must have a no-argument contsructor
+         * @param dataSource           Class for the data source
+         * @param dataSourceProperties May be null. Properties for configuring the data source
+         */
+        public Builder dataSource(Class<? extends DataSource> dataSource, Properties dataSourceProperties){
+            this.dataSource = dataSource;
+            this.dataSourceProperties = dataSourceProperties;
             return this;
         }
 

--- a/arbiter/arbiter-core/src/test/java/org/deeplearning4j/arbiter/optimize/TestGridSearch.java
+++ b/arbiter/arbiter-core/src/test/java/org/deeplearning4j/arbiter/optimize/TestGridSearch.java
@@ -21,6 +21,7 @@ import lombok.Data;
 import org.deeplearning4j.arbiter.optimize.api.*;
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
 import org.deeplearning4j.arbiter.optimize.api.data.DataSetIteratorFactoryProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
 import org.deeplearning4j.arbiter.optimize.api.score.ScoreFunction;
 import org.deeplearning4j.arbiter.optimize.generator.GridSearchCandidateGenerator;
 import org.deeplearning4j.arbiter.optimize.parameter.continuous.ContinuousParameterSpace;
@@ -173,6 +174,11 @@ public class TestGridSearch {
         }
 
         @Override
+        public double score(Object model, Class<? extends DataSource> dataSource, Properties dataSourceProperties) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public boolean minimize() {
             return true;
         }
@@ -200,7 +206,7 @@ public class TestGridSearch {
 
                     BraninConfig candidate = (BraninConfig) c.getValue();
 
-                    double score = scoreFunction.score(candidate, null, null);
+                    double score = scoreFunction.score(candidate, null, (Map)null);
                     System.out.println(candidate.getX1() + "\t" + candidate.getX2() + "\t" + score);
 
                     Thread.sleep(20);
@@ -217,6 +223,11 @@ public class TestGridSearch {
                     return new OptimizationResult(c, score, c.getIndex(), null, ci, null);
                 }
             };
+        }
+
+        @Override
+        public Callable<OptimizationResult> create(Candidate candidate, Class<? extends DataSource> dataSource, Properties dataSourceProperties, ScoreFunction scoreFunction, List<StatusListener> statusListeners, IOptimizationRunner runner) {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/scoring/impl/RegressionScoreFunction.java
+++ b/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/scoring/impl/RegressionScoreFunction.java
@@ -17,6 +17,7 @@
 package org.deeplearning4j.arbiter.scoring.impl;
 
 import lombok.*;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
 import org.deeplearning4j.arbiter.scoring.RegressionValue;
 import org.deeplearning4j.arbiter.scoring.util.ScoreUtil;
 import org.deeplearning4j.datasets.iterator.MultiDataSetWrapperIterator;
@@ -25,6 +26,8 @@ import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
+
+import java.util.Properties;
 
 /**
  * Score function for regression (including multi-label regression) for a MultiLayerNetwork or ComputationGraph

--- a/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/task/ComputationGraphTaskCreator.java
+++ b/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/task/ComputationGraphTaskCreator.java
@@ -234,7 +234,11 @@ public class ComputationGraphTaskCreator implements TaskCreator {
 
             Double score = null;
             if (net != null) {
-                score = scoreFunction.score(net, dataProvider, candidate.getDataParameters());
+                if(dataSource != null){
+                    score = scoreFunction.score(net, dataSource, dataSourceProperties);
+                } else {
+                    score = scoreFunction.score(net, dataProvider, candidate.getDataParameters());
+                }
                 ci.setScore(score);
             }
 

--- a/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/task/ComputationGraphTaskCreator.java
+++ b/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/task/ComputationGraphTaskCreator.java
@@ -28,6 +28,7 @@ import org.deeplearning4j.arbiter.optimize.api.Candidate;
 import org.deeplearning4j.arbiter.optimize.api.OptimizationResult;
 import org.deeplearning4j.arbiter.optimize.api.TaskCreator;
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
 import org.deeplearning4j.arbiter.optimize.api.evaluation.ModelEvaluator;
 import org.deeplearning4j.arbiter.optimize.api.saving.ResultReference;
 import org.deeplearning4j.arbiter.optimize.api.saving.ResultSaver;
@@ -50,6 +51,7 @@ import org.nd4j.linalg.function.BiFunction;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 
 /**
@@ -80,11 +82,20 @@ public class ComputationGraphTaskCreator implements TaskCreator {
                 taskListener, runner);
     }
 
+    @Override
+    public Callable<OptimizationResult> create(Candidate candidate, Class<? extends DataSource> dataSource, Properties dataSourceProperties,
+                                               ScoreFunction scoreFunction, List<StatusListener> statusListeners, IOptimizationRunner runner) {
+        return new GraphLearningTask(candidate, dataSource, dataSourceProperties, scoreFunction, modelEvaluator, statusListeners,
+                taskListener, runner);
+    }
+
     @AllArgsConstructor
     private static class GraphLearningTask implements Callable<OptimizationResult> {
 
         private Candidate candidate;
         private DataProvider dataProvider;
+        private Class<? extends DataSource> dataSource;
+        private Properties dataSourceProperties;
         private ScoreFunction scoreFunction;
         private ModelEvaluator modelEvaluator;
         private List<StatusListener> listeners;
@@ -98,6 +109,19 @@ public class ComputationGraphTaskCreator implements TaskCreator {
                                  TaskListener taskListener, IOptimizationRunner runner) {
             this.candidate = candidate;
             this.dataProvider = dataProvider;
+            this.scoreFunction = scoreFunction;
+            this.modelEvaluator = modelEvaluator;
+            this.listeners = listeners;
+            this.taskListener = taskListener;
+            this.runner = runner;
+        }
+
+        public GraphLearningTask(Candidate candidate, Class<? extends DataSource> dataSource, Properties dataSourceProperties,
+                                 ScoreFunction scoreFunction, ModelEvaluator modelEvaluator, List<StatusListener> listeners,
+                                 TaskListener taskListener, IOptimizationRunner runner) {
+            this.candidate = candidate;
+            this.dataSource = dataSource;
+            this.dataSourceProperties = dataSourceProperties;
             this.scoreFunction = scoreFunction;
             this.modelEvaluator = modelEvaluator;
             this.listeners = listeners;
@@ -162,7 +186,15 @@ public class ComputationGraphTaskCreator implements TaskCreator {
             }
 
             //For DataSetIterator: wraps in a MultiDataSetIterator, hence method can be used for both
-            MultiDataSetIterator iterator = ScoreUtil.getMultiIterator(dataProvider.trainData(candidate.getDataParameters()));
+            MultiDataSetIterator iterator;
+            if(dataSource != null){
+                DataSource dsInstance = dataSource.newInstance();
+                if(dataSourceProperties != null)
+                    dsInstance.configure(dataSourceProperties);
+                iterator = ScoreUtil.getMultiIterator(dsInstance.trainData());
+            } else {
+                iterator = ScoreUtil.getMultiIterator(dataProvider.trainData(candidate.getDataParameters()));
+            }
 
 
             EarlyStoppingConfiguration<ComputationGraph> esConfig =

--- a/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/computationgraph/TestGraphLocalExecution.java
+++ b/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/computationgraph/TestGraphLocalExecution.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.arbiter.computationgraph;
 
+import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.arbiter.ComputationGraphSpace;
 import org.deeplearning4j.arbiter.conf.updater.AdamSpace;
 import org.deeplearning4j.arbiter.conf.updater.SgdSpace;
@@ -23,9 +24,12 @@ import org.deeplearning4j.arbiter.evaluator.multilayer.ClassificationEvaluator;
 import org.deeplearning4j.arbiter.layers.DenseLayerSpace;
 import org.deeplearning4j.arbiter.layers.OutputLayerSpace;
 import org.deeplearning4j.arbiter.multilayernetwork.MnistDataSetIteratorFactory;
+import org.deeplearning4j.arbiter.multilayernetwork.TestDL4JLocalExecution;
 import org.deeplearning4j.arbiter.optimize.api.CandidateGenerator;
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
 import org.deeplearning4j.arbiter.optimize.api.data.DataSetIteratorFactoryProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
+import org.deeplearning4j.arbiter.optimize.api.saving.ResultReference;
 import org.deeplearning4j.arbiter.optimize.api.score.ScoreFunction;
 import org.deeplearning4j.arbiter.optimize.api.termination.MaxCandidatesCondition;
 import org.deeplearning4j.arbiter.optimize.api.termination.MaxTimeCondition;
@@ -38,6 +42,7 @@ import org.deeplearning4j.arbiter.optimize.runner.IOptimizationRunner;
 import org.deeplearning4j.arbiter.optimize.runner.LocalOptimizationRunner;
 import org.deeplearning4j.arbiter.saver.local.FileModelSaver;
 import org.deeplearning4j.arbiter.scoring.ScoreFunctions;
+import org.deeplearning4j.arbiter.scoring.impl.TestSetLossScoreFunction;
 import org.deeplearning4j.arbiter.task.ComputationGraphTaskCreator;
 import org.deeplearning4j.arbiter.util.TestDataFactoryProviderMnist;
 import org.deeplearning4j.datasets.iterator.MultiDataSetWrapperIterator;
@@ -54,7 +59,9 @@ import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.dataset.api.iterator.MultiDataSetIterator;
@@ -66,14 +73,90 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-
+@Slf4j
 public class TestGraphLocalExecution {
+
+    @Rule
+    public TemporaryFolder testDir = new TemporaryFolder();
+
+    @Test
+    public void testLocalExecutionDataSources() throws Exception {
+
+        for( int dataApproach = 0; dataApproach<3; dataApproach++ ) {
+            log.info("////////////////// Starting Test: {} ///////////////////", dataApproach);
+
+            //Define: network config (hyperparameter space)
+            ComputationGraphSpace mls = new ComputationGraphSpace.Builder()
+                    .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                    .updater(new SgdSpace(new ContinuousParameterSpace(0.0001, 0.1)))
+                    .l2(new ContinuousParameterSpace(0.0001, 0.01))
+                    .addInputs("in")
+                    .addLayer("0",
+                            new DenseLayerSpace.Builder().nIn(784).nOut(new IntegerParameterSpace(10, 20))
+                                    .activation(new DiscreteParameterSpace<>(Activation.RELU,
+                                            Activation.TANH))
+                                    .build(), "in") //1-2 identical layers (except nIn)
+                    .addLayer("1", new OutputLayerSpace.Builder().nOut(10).activation(Activation.SOFTMAX)
+                            .lossFunction(LossFunctions.LossFunction.MCXENT).build(), "0")
+                    .setOutputs("1")
+                    .setInputTypes(InputType.feedForward(784))
+                    .numEpochs(3).pretrain(false).backprop(true).build();
+
+            DataProvider dp = null;
+            Class<? extends DataSource> ds = null;
+            Properties dsP = null;
+            CandidateGenerator candidateGenerator;
+
+            if(dataApproach == 0){
+                ds = TestDL4JLocalExecution.MnistDataSource.class;
+                dsP = new Properties();
+                dsP.setProperty("minibatch", "8");
+                candidateGenerator = new RandomSearchGenerator(mls);
+            } else if(dataApproach == 1) {
+                //DataProvider approach
+                dp = new TestDL4JLocalExecution.MnistDataProvider();
+                candidateGenerator = new RandomSearchGenerator(mls);
+            } else {
+                //Factory approach
+                Map<String, Object> commands = new HashMap<>();
+                commands.put(DataSetIteratorFactoryProvider.FACTORY_KEY, TestDataFactoryProviderMnist.class.getCanonicalName());
+
+                candidateGenerator = new RandomSearchGenerator(mls, commands);
+                dp = new DataSetIteratorFactoryProvider();
+            }
+
+            File f = testDir.newFolder();
+            File modelSave = new File(f, "modelSaveDir");
+
+            OptimizationConfiguration configuration = new OptimizationConfiguration.Builder()
+                    .candidateGenerator(candidateGenerator)
+                    .dataProvider(dp)
+                    .dataSource(ds, dsP)
+                    .modelSaver(new FileModelSaver(modelSave))
+                    .scoreFunction(new TestSetLossScoreFunction())
+                    .terminationConditions(new MaxTimeCondition(2, TimeUnit.MINUTES),
+                            new MaxCandidatesCondition(5))
+                    .build();
+
+            IOptimizationRunner runner = new LocalOptimizationRunner(configuration,new ComputationGraphTaskCreator(new ClassificationEvaluator()));
+
+            runner.execute();
+
+            List<ResultReference> results = runner.getResults();
+            assertEquals(5, results.size());
+
+            System.out.println("----- COMPLETE - " + results.size() + " results -----");
+        }
+    }
+
 
     @Test
     public void testLocalExecution() throws Exception {

--- a/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/json/TestJson.java
+++ b/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/json/TestJson.java
@@ -28,6 +28,7 @@ import org.deeplearning4j.arbiter.optimize.api.CandidateGenerator;
 import org.deeplearning4j.arbiter.optimize.api.ParameterSpace;
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
 import org.deeplearning4j.arbiter.optimize.api.data.DataSetIteratorFactoryProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
 import org.deeplearning4j.arbiter.optimize.api.score.ScoreFunction;
 import org.deeplearning4j.arbiter.optimize.api.termination.MaxCandidatesCondition;
 import org.deeplearning4j.arbiter.optimize.api.termination.MaxTimeCondition;
@@ -42,22 +43,30 @@ import org.deeplearning4j.arbiter.scoring.ScoreFunctions;
 import org.deeplearning4j.arbiter.scoring.impl.TestSetLossScoreFunction;
 import org.deeplearning4j.arbiter.util.TestDataFactoryProviderMnist;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.earlystopping.EarlyStoppingConfiguration;
 import org.deeplearning4j.earlystopping.saver.InMemoryModelSaver;
+import org.deeplearning4j.earlystopping.scorecalc.ClassificationScoreCalculator;
 import org.deeplearning4j.earlystopping.scorecalc.DataSetLossCalculatorCG;
+import org.deeplearning4j.earlystopping.scorecalc.base.BaseIEvaluationScoreCalculator;
 import org.deeplearning4j.earlystopping.termination.MaxEpochsTerminationCondition;
+import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.eval.IEvaluation;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.junit.Test;
 import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Created by Alex on 14/02/2017.
@@ -137,6 +146,52 @@ public class TestJson {
     }
 
     @Test
+    public void testOptimizationFromJsonDataSource() {
+        for(boolean withProperties : new boolean[]{false, true}) {
+            //Define: network config (hyperparameter space)
+            ComputationGraphSpace cgs = new ComputationGraphSpace.Builder()
+                    .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                    .updater(new AdaMaxSpace(new ContinuousParameterSpace(0.0001, 0.1)))
+                    .l2(new ContinuousParameterSpace(0.0001, 0.01)).addInputs("in")
+                    .setInputTypes(InputType.feedForward(4))
+                    .addLayer("first",
+                            new DenseLayerSpace.Builder().nIn(4).nOut(new IntegerParameterSpace(2, 10))
+                                    .activation(new DiscreteParameterSpace<>(Activation.RELU,
+                                            Activation.TANH))
+                                    .build(),
+                            "in") //1-2 identical layers (except nIn)
+                    .addLayer("out", new OutputLayerSpace.Builder().nOut(3).activation(Activation.SOFTMAX)
+                            .lossFunction(LossFunctions.LossFunction.MCXENT).build(), "first")
+                    .setOutputs("out").pretrain(false).backprop(true).build();
+
+            //Define configuration:
+            Map<String, Object> commands = new HashMap<>();
+            commands.put(DataSetIteratorFactoryProvider.FACTORY_KEY, TestDataFactoryProviderMnist.class.getCanonicalName());
+
+            CandidateGenerator candidateGenerator = new RandomSearchGenerator(cgs, commands);
+
+            Properties p = new Properties();
+            p.setProperty("minibatch", "16");
+
+            OptimizationConfiguration configuration =
+                    new OptimizationConfiguration.Builder().candidateGenerator(candidateGenerator)
+                            .dataSource(MnistDataSource.class, (withProperties ? p : null))
+                            .scoreFunction(new TestSetLossScoreFunction())
+                            .terminationConditions(new MaxTimeCondition(2, TimeUnit.MINUTES),
+                                    new MaxCandidatesCondition(100))
+                            .build();
+
+            String json = configuration.toJson();
+            OptimizationConfiguration loadConf = OptimizationConfiguration.fromJson(json);
+            assertEquals(configuration, loadConf);
+            assertNotNull(loadConf.getDataSource());
+            if(withProperties){
+                assertNotNull(loadConf.getDataSourceProperties());
+            }
+        }
+    }
+
+    @Test
     public void testComputationGraphSpaceJson() {
         ParameterSpace<Integer> p = new IntegerParameterSpace(10, 100);
         ComputationGraphSpace cgs =
@@ -170,6 +225,43 @@ public class TestJson {
             ScoreFunction fromJson = JsonMapper.getMapper().readValue(json, ScoreFunction.class);
 
             assertEquals(sc, fromJson);
+        }
+    }
+
+
+    public static class MnistDataSource implements DataSource {
+        private int minibatch;
+
+        public MnistDataSource(){
+
+        }
+
+        @Override
+        public void configure(Properties properties) {
+            this.minibatch = Integer.parseInt(properties.getProperty("minibatch", "16"));
+        }
+
+        @Override
+        public Object trainData() {
+            try {
+                return new MnistDataSetIterator(minibatch, true, 12345);
+            } catch (Exception e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Object testData() {
+            try {
+                return new MnistDataSetIterator(minibatch, true, 12345);
+            } catch (Exception e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Class<?> getDataType() {
+            return DataSetIterator.class;
         }
     }
 }

--- a/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/MNISTOptimizationTest.java
+++ b/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/MNISTOptimizationTest.java
@@ -110,7 +110,8 @@ public class MNISTOptimizationTest {
             throw new RuntimeException();
 
         OptimizationConfiguration configuration = new OptimizationConfiguration.Builder()
-                        .candidateGenerator(candidateGenerator).dataProvider(dataProvider)
+                        .candidateGenerator(candidateGenerator)
+                        .dataProvider(dataProvider)
                         .modelSaver(new FileModelSaver(modelSavePath)).scoreFunction(new TestSetLossScoreFunction(true))
                         .terminationConditions(new MaxTimeCondition(120, TimeUnit.MINUTES),
                                         new MaxCandidatesCondition(100))

--- a/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestDL4JLocalExecution.java
+++ b/arbiter/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestDL4JLocalExecution.java
@@ -27,6 +27,8 @@ import org.deeplearning4j.arbiter.optimize.api.Candidate;
 import org.deeplearning4j.arbiter.optimize.api.CandidateGenerator;
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
 import org.deeplearning4j.arbiter.optimize.api.data.DataSetIteratorFactoryProvider;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
+import org.deeplearning4j.arbiter.optimize.api.saving.ResultReference;
 import org.deeplearning4j.arbiter.optimize.api.termination.MaxCandidatesCondition;
 import org.deeplearning4j.arbiter.optimize.api.termination.MaxTimeCondition;
 import org.deeplearning4j.arbiter.optimize.generator.GridSearchCandidateGenerator;
@@ -41,7 +43,9 @@ import org.deeplearning4j.arbiter.saver.local.FileModelSaver;
 import org.deeplearning4j.arbiter.scoring.impl.TestSetLossScoreFunction;
 import org.deeplearning4j.arbiter.task.MultiLayerNetworkTaskCreator;
 import org.deeplearning4j.arbiter.util.TestDataFactoryProviderMnist;
+import org.deeplearning4j.datasets.iterator.EarlyTerminationDataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.earlystopping.EarlyStoppingConfiguration;
 import org.deeplearning4j.earlystopping.saver.InMemoryModelSaver;
 import org.deeplearning4j.earlystopping.scorecalc.DataSetLossCalculator;
@@ -50,71 +54,158 @@ import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 public class TestDL4JLocalExecution {
 
+    @Rule
+    public TemporaryFolder testDir = new TemporaryFolder();
 
     @Test
-    @org.junit.Ignore
     public void testLocalExecution() throws Exception {
 
-        //Define: network config (hyperparameter space)
-        MultiLayerSpace mls = new MultiLayerSpace.Builder()
-                        .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
-                        .updater(new SgdSpace(new ContinuousParameterSpace(0.0001, 0.1)))
-                        .l2(new ContinuousParameterSpace(0.0001, 0.01))
-                        .addLayer(
-                                        new DenseLayerSpace.Builder().nIn(4).nOut(new IntegerParameterSpace(2, 10))
-                                                        .activation(new DiscreteParameterSpace<>(Activation.RELU,
-                                                                        Activation.TANH))
-                                                        .build(),
-                                        new IntegerParameterSpace(1, 2), true) //1-2 identical layers (except nIn)
-                        .addLayer(new OutputLayerSpace.Builder().nOut(3).activation(Activation.SOFTMAX)
-                                        .lossFunction(LossFunctions.LossFunction.MCXENT).build())
-                        .numEpochs(3).pretrain(false).backprop(true).build();
+        for( int dataApproach = 0; dataApproach<3; dataApproach++ ) {
+            log.info("////////////////// Starting Test: {} ///////////////////", dataApproach);
 
-        //Define configuration:
-        Map<String, Object> commands = new HashMap<>();
-        commands.put(DataSetIteratorFactoryProvider.FACTORY_KEY, TestDataFactoryProviderMnist.class.getCanonicalName());
+            //Define: network config (hyperparameter space)
+            MultiLayerSpace mls = new MultiLayerSpace.Builder()
+                    .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+                    .updater(new SgdSpace(new ContinuousParameterSpace(0.0001, 0.1)))
+                    .l2(new ContinuousParameterSpace(0.0001, 0.01))
+                    .addLayer(
+                            new DenseLayerSpace.Builder().nIn(784).nOut(new IntegerParameterSpace(10, 20))
+                                    .activation(new DiscreteParameterSpace<>(Activation.RELU,
+                                            Activation.TANH))
+                                    .build()) //1-2 identical layers (except nIn)
+                    .addLayer(new OutputLayerSpace.Builder().nOut(10).activation(Activation.SOFTMAX)
+                            .lossFunction(LossFunctions.LossFunction.MCXENT).build())
+                    .numEpochs(3).pretrain(false).backprop(true).build();
 
-        CandidateGenerator candidateGenerator = new RandomSearchGenerator(mls, commands);
-        DataProvider dataProvider = new DataSetIteratorFactoryProvider();
+            DataProvider dp = null;
+            Class<? extends DataSource> ds = null;
+            Properties dsP = null;
+            CandidateGenerator candidateGenerator;
 
+            if(dataApproach == 0){
+                ds = MnistDataSource.class;
+                dsP = new Properties();
+                dsP.setProperty("minibatch", "8");
+                candidateGenerator = new RandomSearchGenerator(mls);
+            } else if(dataApproach == 1) {
+                //DataProvider approach
+                dp = new MnistDataProvider();
+                candidateGenerator = new RandomSearchGenerator(mls);
+            } else {
+                //Factory approach
+                Map<String, Object> commands = new HashMap<>();
+                commands.put(DataSetIteratorFactoryProvider.FACTORY_KEY, TestDataFactoryProviderMnist.class.getCanonicalName());
 
-        //        String modelSavePath = FilenameUtils.concat(System.getProperty("java.io.tmpdir"),"ArbiterDL4JTest/");
-        String modelSavePath = new File(System.getProperty("java.io.tmpdir"), "ArbiterDL4JTest/").getAbsolutePath();
+                candidateGenerator = new RandomSearchGenerator(mls, commands);
+                dp = new DataSetIteratorFactoryProvider();
+            }
 
-        File f = new File(modelSavePath);
-        if (f.exists())
-            f.delete();
-        f.mkdir();
-        f.deleteOnExit();
-        if (!f.exists())
-            throw new RuntimeException();
+            File f = testDir.newFolder();
+            File modelSave = new File(f, "modelSaveDir");
 
-        OptimizationConfiguration configuration = new OptimizationConfiguration.Builder()
-                        .candidateGenerator(candidateGenerator).dataProvider(dataProvider)
-                        .modelSaver(new FileModelSaver(modelSavePath)).scoreFunction(new TestSetLossScoreFunction())
-                        .terminationConditions(new MaxTimeCondition(2, TimeUnit.MINUTES),
-                                        new MaxCandidatesCondition(100))
-                        .build();
+            OptimizationConfiguration configuration = new OptimizationConfiguration.Builder()
+                    .candidateGenerator(candidateGenerator)
+                    .dataProvider(dp)
+                    .dataSource(ds, dsP)
+                    .modelSaver(new FileModelSaver(modelSave))
+                    .scoreFunction(new TestSetLossScoreFunction())
+                    .terminationConditions(new MaxTimeCondition(2, TimeUnit.MINUTES),
+                            new MaxCandidatesCondition(5))
+                    .build();
 
-        IOptimizationRunner runner = new LocalOptimizationRunner(configuration,
-                        new MultiLayerNetworkTaskCreator(new ClassificationEvaluator()));
+            IOptimizationRunner runner = new LocalOptimizationRunner(configuration,
+                    new MultiLayerNetworkTaskCreator(new ClassificationEvaluator()));
 
-        runner.execute();
+            runner.execute();
 
+            List<ResultReference> results = runner.getResults();
+            assertEquals(5, results.size());
 
-        System.out.println("----- COMPLETE -----");
+            System.out.println("----- COMPLETE - " + results.size() + " results -----");
+        }
+    }
+
+    public static class MnistDataSource implements DataSource {
+        private int minibatch;
+
+        public MnistDataSource(){
+
+        }
+
+        @Override
+        public void configure(Properties properties) {
+            this.minibatch = Integer.parseInt(properties.getProperty("minibatch", "16"));
+        }
+
+        @Override
+        public Object trainData() {
+            try {
+                return new EarlyTerminationDataSetIterator(new MnistDataSetIterator(minibatch, true, 12345), 3);
+            } catch (Exception e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Object testData() {
+            try {
+                return new EarlyTerminationDataSetIterator(new MnistDataSetIterator(minibatch, true, 12345), 3);
+            } catch (Exception e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Class<?> getDataType() {
+            return DataSetIterator.class;
+        }
+    }
+
+    public static class MnistDataProvider implements DataProvider {
+        private int minibatch = 8;
+
+        @Override
+        public Object trainData(Map<String, Object> dataParameters) {
+            try {
+                return new EarlyTerminationDataSetIterator(new MnistDataSetIterator(minibatch, true, 12345), 3);
+            } catch (Exception e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Object testData(Map<String, Object> dataParameters) {
+            try {
+                return new EarlyTerminationDataSetIterator(new MnistDataSetIterator(minibatch, true, 12345), 3);
+            } catch (Exception e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Class<?> getDataType() {
+            return DataSetIterator.class;
+        }
     }
 
     @Test


### PR DESCRIPTION
Users can now provide a DataSource - which (unlike DataProvider) doesn't require JSON serializability, Jackson annotations, etc.
Existing DataProvider functionality still works, but has been deprecated.

Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/5164