### PR TITLE
Shyrma prelu2

### DIFF
--- a/libnd4j/include/helpers/ShapeUtils.h
+++ b/libnd4j/include/helpers/ShapeUtils.h
@@ -64,7 +64,7 @@ namespace nd4j {
         // check whether 2 arrays have mutually broadcastable shapes
         // shape comparison starts from the end
         static bool areShapesBroadcastable(const NDArray<T> &arr1, const NDArray<T> &arr2);
-        static bool areShapesBroadcastable(Nd4jLong* shapeX, Nd4jLong * shapeY);
+        static bool areShapesBroadcastable(Nd4jLong* shapeX, Nd4jLong* shapeY);
         static bool areShapesBroadcastable(const std::vector<Nd4jLong>& shape1, const std::vector<Nd4jLong>& shape2);
 
         // check the possibility of broadcast operation, if true then return shapeInfo of resulting array

--- a/libnd4j/include/ops/declarable/generic/activations/prelu.cpp
+++ b/libnd4j/include/ops/declarable/generic/activations/prelu.cpp
@@ -69,7 +69,7 @@ CONFIGURABLE_OP_IMPL(prelu, 2, 1, true, 0, 0) {
 
     helpers::prelu(*input, *alpha, *output);
 
-    if(alpha != INPUT_VARIABLE(1))
+    if(alphaShape != expectedAlphaShape)
         delete alpha;
     
     return Status::OK();
@@ -85,12 +85,45 @@ CONFIGURABLE_OP_IMPL(prelu_bp, 3, 2, true, 0, 0) {
     
     NDArray<T>* dLdI = OUTPUT_VARIABLE(0);
     NDArray<T>* dLdA = OUTPUT_VARIABLE(1);
+
+    std::vector<int> sharedAxes = *block.getIArguments();
     
-    auto derivI = LAMBDA_TTT(i, a, grO) {if (i < static_cast<T>(0)) return a * grO; else return grO; };
-    auto derivA = LAMBDA_TTT(i, a, grO) {if (i < static_cast<T>(0)) return i * grO; else return static_cast<T>(0); };
-        
-    input->applyTriplewiseLambda(alpha, dLdO, derivI, dLdI);
-    input->applyTriplewiseLambda(alpha, dLdO, derivA, dLdA);    
+    const int inputRank     = input->rankOf();
+    const int alphaRank     = alpha->rankOf();
+    const int numSharedAxes = sharedAxes.size();            // can be zero as well
+    const Nd4jLong inputLen = input->lengthOf();
+    const Nd4jLong alphaLen = alpha->lengthOf();
+    const std::vector<Nd4jLong> inputShape = input->getShapeAsVector();
+    const std::vector<Nd4jLong> alphaShape = alpha->getShapeAsVector();
+
+    //***** input validation *****//
+    std::vector<Nd4jLong> expectedAlphaShape(&inputShape[1], &inputShape[inputRank]);
+
+    REQUIRE_TRUE(inputRank > 1, 0, "PRELU_BP OP: wrong rank of input array, expected rank should be > 1, but got %i instead !", inputRank);   
+    
+    for(int i = 0; i < numSharedAxes; ++i) {
+        if(sharedAxes[i] <= 0)
+            sharedAxes[i] += inputRank - 1;
+        REQUIRE_TRUE(1 <= sharedAxes[i] && sharedAxes[i] <= inputRank - 1, 0, "PRELU_BP OP: wrong axis value %i in sharedAxes at position %i, axis value must be within range [1, input_rank-1] !", sharedAxes[i], i);            
+        expectedAlphaShape[sharedAxes[i] - 1] = 1;
+    }
+
+    const Nd4jLong expectedAlphaLen = std::accumulate(expectedAlphaShape.begin(), expectedAlphaShape.end(), 1, std::multiplies<T>());        
+
+    REQUIRE_TRUE(alphaLen == expectedAlphaLen, 0, "PRELU_BP OP: wrong shape of alpha array, expected is %s, but got %s instead !", ShapeUtils<T>::shapeAsString(expectedAlphaShape).c_str(), ShapeUtils<T>::shapeAsString(alphaShape).c_str());   
+    // ***** end of validation ***** //
+    
+    if(alphaShape != expectedAlphaShape) {
+        alpha = alpha->reshape(alpha->ordering(), expectedAlphaShape);
+        dLdA  = dLdA->reshape(dLdA->ordering(), expectedAlphaShape);
+    }
+
+    helpers::preluBP(*input, *alpha, *dLdO, *dLdI, *dLdA);
+
+    if(alphaShape != expectedAlphaShape) {        
+        delete alpha;
+        delete dLdA;
+    }
     
     return Status::OK();
 }

--- a/libnd4j/include/ops/declarable/helpers/activations.h
+++ b/libnd4j/include/ops/declarable/helpers/activations.h
@@ -39,6 +39,9 @@ namespace helpers {
 	template <typename T>
 	void prelu(const NDArray<T>& input, const NDArray<T>& alpha, NDArray<T>& output);
 
+	template <typename T>
+	void preluBP(const NDArray<T>& input, const NDArray<T>& alpha, const NDArray<T>& dLdO, NDArray<T>& dLdI, NDArray<T>& dLdA);
+
 }
 }
 }

--- a/libnd4j/include/ops/declarable/helpers/activations.h
+++ b/libnd4j/include/ops/declarable/helpers/activations.h
@@ -35,7 +35,9 @@ namespace helpers {
 
 	template <typename T>
 	void softmax(const NDArray<T>& input, NDArray<T>& output, const int dimension);
-	    
+
+	template <typename T>
+	void prelu(const NDArray<T>& input, const NDArray<T>& alpha, NDArray<T>& output);
 
 }
 }

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests9.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests9.cpp
@@ -1424,7 +1424,7 @@ TEST_F(DeclarableOpsTests9, prelu_test10) {
 TEST_F(DeclarableOpsTests9, prelu_test11) {
     
     NDArray<float> x('c', {2, 3, 4, 5});    
-    x.linspace(-50);
+    x.linspace(-50.);
     NDArray<float> alpha('c', {4}, {0.f, -0.5f, 0.5f, -1.f});
     NDArray<float> exp('c', {2, 3, 4, 5}, {0.f,   0.f,   0.f,   0.f,   0.f, 22.5f,  22.f,  21.5f,  21.f,  20.5f, -20.f, -19.5f, -19.f, -18.5f, -18.f, 35.f,  34.f,  33.f,  
                                            32.f,  31.f, 0.f,   0.f,   0.f,   0.f,   0.f, 12.5f,  12.f,  11.5f,  11.f,  10.5f, -10.f,  -9.5f,  -9.f,  -8.5f,  -8.f, 15.f,  
@@ -1449,7 +1449,7 @@ TEST_F(DeclarableOpsTests9, prelu_test11) {
 TEST_F(DeclarableOpsTests9, prelu_test12) {
     
     NDArray<float> x('c', {2, 3, 4, 5});    
-    x.linspace(-50);
+    x.linspace(-50.);
     NDArray<float> alpha('c', {3,5}, {-0.7f, -0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f});
     NDArray<float> exp('c', {2, 3, 4, 5}, {35.f, 29.4f, 24.f, 18.8f, 13.8f, 31.5f, 26.4f, 21.5f, 16.8f, 12.3f, 28.f, 23.4f, 19.f, 14.8f, 10.8f, 24.5f, 20.4f, 16.5f, 12.8f,  
                                            9.3f, 6.f,  2.9f,  0.f, -2.7f, -5.2f, 5.f,  2.4f,  0.f, -2.2f, -4.2f, 4.f,  1.9f,  0.f, -1.7f, -3.2f, 3.f,  1.4f,  0.f, -1.2f, 
@@ -1473,7 +1473,7 @@ TEST_F(DeclarableOpsTests9, prelu_test12) {
 TEST_F(DeclarableOpsTests9, prelu_test13) {
     
     NDArray<float> x('c', {2, 3, 4, 5});    
-    x.linspace(-50);
+    x.linspace(-50.);
     NDArray<float> alpha('c', {5,3}, {-0.7f, -0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f});
     NDArray<float> exp('c', {2, 3, 4, 5}, {35.f, 29.4f, 24.f, 18.8f, 13.8f, 31.5f, 26.4f, 21.5f, 16.8f, 12.3f, 28.f, 23.4f, 19.f, 14.8f, 10.8f, 24.5f, 20.4f, 16.5f, 12.8f,  
                                            9.3f, 6.f,  2.9f,  0.f, -2.7f, -5.2f, 5.f,  2.4f,  0.f, -2.2f, -4.2f, 4.f,  1.9f,  0.f, -1.7f, -3.2f, 3.f,  1.4f,  0.f, -1.2f, 
@@ -1497,7 +1497,7 @@ TEST_F(DeclarableOpsTests9, prelu_test13) {
 TEST_F(DeclarableOpsTests9, prelu_test14) {
     
     NDArray<float> x('c', {2, 3, 4, 5});    
-    x.linspace(-50);
+    x.linspace(-50.);
     NDArray<float> alpha('c', {2,10}, {-0.7f, -0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.f, 1.1f, 1.2f});
     NDArray<float> exp('c', {2, 3, 4, 5}, {35.f,  29.4f,  24.f,  18.8f,  13.8f, 9.f,   4.4f,   0.f,  -4.2f,  -8.2f, -12.f, -15.6f, -19.f, -22.2f, -25.2f, -28.f, -30.6f, 
                                            -33.f,-35.2f, -37.2f, 21.f,  17.4f,  14.f,  10.8f,   7.8f, 5.f,   2.4f,   0.f,  -2.2f,  -4.2f, -6.f,  -7.6f,  -9.f, -10.2f, 
@@ -1559,8 +1559,8 @@ TEST_F(DeclarableOpsTests9, thresholdedrelu_test2) {
 ////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests9, prelu_bp_test1) {
     
-    NDArray<double> x('c', {2, 3, 4},     {-12., -11., -10., -9., -8., -7., -6., -5., -4., -3., -2., -1., 0.5, 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.});    
-    NDArray<double> alpha('c', {2, 3, 4}, {1.2,   1.1,  1., 0.9, 0.8, -0.7, -0.6,-0.5,-0.4,-0.3,-0.2,-0.1, 0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, -0.9, -1.0, -1.1});    
+    NDArray<double> x('c', {2, 3, 4}, {-12., -11., -10., -9., -8., -7., -6., -5., -4., -3., -2., -1., 0.5, 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.});
+    NDArray<double> alpha('c', {3, 4}, {-0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.5, 0.1, 0.2, 0.3, 0.4, 0.5});
     NDArray<double> dLdO('c', {2, 3, 4});
 
     const OpArgsHolder<double> argsHolderFF({&x, &alpha}, {}, {});
@@ -1574,6 +1574,63 @@ TEST_F(DeclarableOpsTests9, prelu_bp_test1) {
     ASSERT_TRUE(isGradCorrect);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_bp_test2) {
+    
+    NDArray<double> x('c', {2, 3, 4}, {-12., -11., -10., -9., -8., -7., -6., -5., -4., -3., -2., -1., 0.5, 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.});    
+    NDArray<double> alpha('c', {4}, {-0.6, 2., 4., -1.});
+    NDArray<double> dLdO('c', {2, 3, 4});
+
+    const OpArgsHolder<double> argsHolderFF({&x, &alpha}, {}, {1});
+    const OpArgsHolder<double> argsHolderBP({&x, &alpha, &dLdO}, {}, {1});
+
+    nd4j::ops::prelu<double> opFF;
+    nd4j::ops::prelu_bp<double> opBP;
+
+    const bool isGradCorrect = GradCheck::checkGrad(opFF, opBP, argsHolderFF, argsHolderBP);
+
+    ASSERT_TRUE(isGradCorrect);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_bp_test3) {
+    
+    NDArray<double> x('c', {2, 3, 2, 5});    
+    x.linspace(-30.);
+    x(30) = 0.5;   // avoid zero, since it is points of discontinuity for prelu
+    NDArray<double> alpha('c', {5,3}, {-0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.5, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7});
+    NDArray<double> dLdO('c', {2, 3, 2, 5});
+
+    const OpArgsHolder<double> argsHolderFF({&x, &alpha}, {}, {-1, 2});
+    const OpArgsHolder<double> argsHolderBP({&x, &alpha, &dLdO}, {}, {-1, 2});
+
+    nd4j::ops::prelu<double> opFF;
+    nd4j::ops::prelu_bp<double> opBP;
+
+    const bool isGradCorrect = GradCheck::checkGrad(opFF, opBP, argsHolderFF, argsHolderBP);
+
+    ASSERT_TRUE(isGradCorrect);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_bp_test4) {
+    
+    NDArray<double> x('c', {2, 3, 4, 5});    
+    x.linspace(-50.);
+    x(50) = 0.5;   // avoid zero, since it is points of discontinuity for prele
+    NDArray<double> alpha('c', {2,10}, {-0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.25, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.1, 1.2});
+    NDArray<double> dLdO('c', {2, 3, 4, 5});
+
+    const OpArgsHolder<double> argsHolderFF({&x, &alpha}, {}, {-2});
+    const OpArgsHolder<double> argsHolderBP({&x, &alpha, &dLdO}, {}, {-2});
+
+    nd4j::ops::prelu<double> opFF;
+    nd4j::ops::prelu_bp<double> opBP;
+
+    const bool isGradCorrect = GradCheck::checkGrad(opFF, opBP, argsHolderFF, argsHolderBP);
+
+    ASSERT_TRUE(isGradCorrect);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests9, thresholdedrelu_bp_test1) {

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests9.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests9.cpp
@@ -1242,8 +1242,8 @@ TEST_F(DeclarableOpsTests9, clipbynorm_bp_test3) {
 TEST_F(DeclarableOpsTests9, prelu_test1) {
     
     NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
-    NDArray<float> alpha('c', {2, 3, 4}, {1.2f, 1.1f, 1.f, 0.9f, 0.8f, -0.7f, -0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, -0.9f, -1.0f, -1.1f});
-    NDArray<float> exp('c', {2, 3, 4}, {-14.4f, -12.1f, -10.f, -8.1f, -6.4f, 4.9f, 3.6f, 2.5f, 1.6f, 0.9f, 0.4f,  0.1f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha('c', {3, 4}, {-0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f});
+    NDArray<float> exp('c', {2, 3, 4}, {7.2f, 5.5f, 4.f, 2.7f, 1.6f, 0.7f, 0.f, -0.5f,-0.8f, -0.9f, -0.8f, -0.5f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
 
     nd4j::ops::prelu<float> op;
 
@@ -1260,13 +1260,255 @@ TEST_F(DeclarableOpsTests9, prelu_test1) {
 ////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests9, prelu_test2) {
     
-    NDArray<float> x('c', {2, 3, 4}, {0.f, -4.f, -10.f, -8.f, 0.f, -9.f, -8.f, 5.f, 6.f, 6.f, 9.f, 6.f, -8.f, 5.f, 10.f, -2.f, 3.f, -7.f, 4.f, -8.f, -4.f, -9.f, -9.f, 3.f});    
-    NDArray<float> alpha('c', {2, 3, 4}, {-9.f, 9.f, 2.f, 3.f, -2.f, -3.f, -9.f, -1.f, -1.f, 9.f, -4.f, 6.f, 0.f, -3.f, 4.f, -6.f, -4.f, 7.f, -1.f, 0.f, -10.f, 8.f, -9.f, 0.f});
-    NDArray<float> exp('c', {2, 3, 4}, {0.f, -36.f, -20.f, -24.f, 0.f, 27.f, 72.f, 5.f, 6.f, 6.f, 9.f, 6.f, 0.f, 5.f, 10.f, 12.f, 3.f, -49.f, 4.f, 0.f,40.f,-72.f, 81.f, 3.f});
+    NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha('c', {3}, {-0.6f, 2.f, 4.f});
+    NDArray<float> exp('c', {2, 3, 4}, {7.2f,  6.6f,   6.f,   5.4f, -16.f, -14.f, -12.f, -10.f, -16.f, -12.f,  -8.f,  -4.f, 0.f,   1.f,   2.f,   3.f, 4.f,   5.f,   6.f,   7.f, 8.f,   9.f,  10.f,  11.f});    
 
     nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {0});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
 
-    auto result = op.execute({&x, &alpha}, {}, {});
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test3) {
+    
+    NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha('c', {3,1}, {-0.6f, 2.f, 4.f});
+    NDArray<float> exp('c', {2, 3, 4}, {7.2f,  6.6f,   6.f,   5.4f, -16.f, -14.f, -12.f, -10.f, -16.f, -12.f,  -8.f,  -4.f, 0.f,   1.f,   2.f,   3.f, 4.f,   5.f,   6.f,   7.f, 8.f,   9.f,  10.f,  11.f});    
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {0});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test4) {
+    
+    NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha('c', {1, 3}, {-0.6f, 2.f, 4.f});
+    NDArray<float> exp('c', {2, 3, 4}, {7.2f,  6.6f,   6.f,   5.4f, -16.f, -14.f, -12.f, -10.f, -16.f, -12.f,  -8.f,  -4.f, 0.f,   1.f,   2.f,   3.f, 4.f,   5.f,   6.f,   7.f, 8.f,   9.f,  10.f,  11.f});    
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {0});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test5) {
+    
+    NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha('c', {4}, {-0.6f, 2.f, 4.f, -1.f});
+    NDArray<float> exp('c', {2, 3, 4}, {7.2f, -22.f, -40.f,   9.f, 4.8f, -14.f, -24.f,   5.f, 2.4f,  -6.f,  -8.f,   1.f, 0.f,   1.f,   2.f,   3.f, 4.f,   5.f,   6.f,   7.f, 8.f,   9.f,  10.f,  11.f});    
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {1});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test6) {
+    
+    NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha('c', {1,1,1}, {-2.});
+    NDArray<float> exp('c', {2, 3, 4}, {24.f, 22.f, 20.f, 18.f, 16.f, 14.f, 12.f, 10.f, 8.f,  6.f,  4.f,  2.f, 0.f,  1.f,  2.f,  3.f, 4.f,  5.f,  6.f,  7.f, 8.f,  9.f, 10.f, 11.f});    
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {1,0});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test7) {
+    
+    NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha(-2.f);
+    NDArray<float> exp('c', {2, 3, 4}, {24.f, 22.f, 20.f, 18.f, 16.f, 14.f, 12.f, 10.f, 8.f,  6.f,  4.f,  2.f, 0.f,  1.f,  2.f,  3.f, 4.f,  5.f,  6.f,  7.f, 8.f,  9.f, 10.f, 11.f});    
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {1,0});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test8) {
+    
+    NDArray<float> x('c', {2, 3, 4}, {-12.f, -11.f, -10.f, -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f});    
+    NDArray<float> alpha(-2.f);
+    NDArray<float> exp('c', {2, 3, 4}, {24.f, 22.f, 20.f, 18.f, 16.f, 14.f, 12.f, 10.f, 8.f,  6.f,  4.f,  2.f, 0.f,  1.f,  2.f,  3.f, 4.f,  5.f,  6.f,  7.f, 8.f,  9.f, 10.f, 11.f});    
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {1,0,1,0,1,0});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test9) {
+    
+    NDArray<float> x('c', {2, 4}, {-4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f});    
+    NDArray<float> alpha(-2.f);
+    NDArray<float> exp('c', {2, 4}, {8.f, 6.f, 4.f, 2.f,0.f, 1.f, 2.f, 3.f});
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {0});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test10) {
+    
+    NDArray<float> x('c', {2, 4}, {-4.f, -3.f, -2.f, -1.f, 0.f, 1.f, 2.f, 3.f});    
+    NDArray<float> alpha(-2.f);
+    NDArray<float> exp('c', {2, 4}, {8.f, 6.f, 4.f, 2.f,0.f, 1.f, 2.f, 3.f});
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {1});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test11) {
+    
+    NDArray<float> x('c', {2, 3, 4, 5});    
+    x.linspace(-50);
+    NDArray<float> alpha('c', {4}, {0.f, -0.5f, 0.5f, -1.f});
+    NDArray<float> exp('c', {2, 3, 4, 5}, {0.f,   0.f,   0.f,   0.f,   0.f, 22.5f,  22.f,  21.5f,  21.f,  20.5f, -20.f, -19.5f, -19.f, -18.5f, -18.f, 35.f,  34.f,  33.f,  
+                                           32.f,  31.f, 0.f,   0.f,   0.f,   0.f,   0.f, 12.5f,  12.f,  11.5f,  11.f,  10.5f, -10.f,  -9.5f,  -9.f,  -8.5f,  -8.f, 15.f,  
+                                           14.f,  13.f,  12.f,  11.f, 0.f,   0.f,   0.f,   0.f,   0.f, 2.5f,   2.f,   1.5f,   1.f,   0.5f, 0.f,   1.f,   2.f,   3.f,   4.f, 
+                                           5.f,   6.f,   7.f,   8.f,   9.f, 10.f,  11.f,  12.f,  13.f,  14.f, 15.f,  16.f,  17.f,  18.f,  19.f, 20.f,  21.f,  22.f,  23.f,  
+                                           24.f, 25.f,  26.f,  27.f,  28.f,  29.f, 30.f,  31.f,  32.f,  33.f,  34.f, 35.f,  36.f,  37.f,  38.f,  39.f, 40.f,  41.f,  42.f,  
+                                           43.f,  44.f, 45.f,  46.f,  47.f,  48.f,  49.f, 50.f,  51.f,  52.f,  53.f,  54.f, 55.f,  56.f,  57.f,  58.f,  59.f, 60.f,  61.f,  
+                                           62.f,  63.f,  64.f, 65.f,  66.f,  67.f,  68.f,  69.f});
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {1,3});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test12) {
+    
+    NDArray<float> x('c', {2, 3, 4, 5});    
+    x.linspace(-50);
+    NDArray<float> alpha('c', {3,5}, {-0.7f, -0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f});
+    NDArray<float> exp('c', {2, 3, 4, 5}, {35.f, 29.4f, 24.f, 18.8f, 13.8f, 31.5f, 26.4f, 21.5f, 16.8f, 12.3f, 28.f, 23.4f, 19.f, 14.8f, 10.8f, 24.5f, 20.4f, 16.5f, 12.8f,  
+                                           9.3f, 6.f,  2.9f,  0.f, -2.7f, -5.2f, 5.f,  2.4f,  0.f, -2.2f, -4.2f, 4.f,  1.9f,  0.f, -1.7f, -3.2f, 3.f,  1.4f,  0.f, -1.2f, 
+                                           -2.2f, -3.f, -3.6f, -4.f, -4.2f, -4.2f, -1.5f, -1.6f, -1.5f, -1.2f, -0.7f, 0.f,  1.f,  2.f,  3.f,  4.f, 5.f,  6.f,  7.f,  8.f,  
+                                           9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 
+                                           31.f, 32.f, 33.f, 34.f, 35.f, 36.f, 37.f, 38.f, 39.f, 40.f, 41.f, 42.f, 43.f, 44.f, 45.f, 46.f, 47.f, 48.f, 49.f, 50.f, 51.f, 52.f, 
+                                           53.f, 54.f, 55.f, 56.f, 57.f, 58.f, 59.f, 60.f, 61.f, 62.f, 63.f, 64.f, 65.f, 66.f, 67.f, 68.f, 69.f});
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {-1, 2});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test13) {
+    
+    NDArray<float> x('c', {2, 3, 4, 5});    
+    x.linspace(-50);
+    NDArray<float> alpha('c', {5,3}, {-0.7f, -0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f});
+    NDArray<float> exp('c', {2, 3, 4, 5}, {35.f, 29.4f, 24.f, 18.8f, 13.8f, 31.5f, 26.4f, 21.5f, 16.8f, 12.3f, 28.f, 23.4f, 19.f, 14.8f, 10.8f, 24.5f, 20.4f, 16.5f, 12.8f,  
+                                           9.3f, 6.f,  2.9f,  0.f, -2.7f, -5.2f, 5.f,  2.4f,  0.f, -2.2f, -4.2f, 4.f,  1.9f,  0.f, -1.7f, -3.2f, 3.f,  1.4f,  0.f, -1.2f, 
+                                           -2.2f, -3.f, -3.6f, -4.f, -4.2f, -4.2f, -1.5f, -1.6f, -1.5f, -1.2f, -0.7f, 0.f,  1.f,  2.f,  3.f,  4.f, 5.f,  6.f,  7.f,  8.f,  
+                                           9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 
+                                           31.f, 32.f, 33.f, 34.f, 35.f, 36.f, 37.f, 38.f, 39.f, 40.f, 41.f, 42.f, 43.f, 44.f, 45.f, 46.f, 47.f, 48.f, 49.f, 50.f, 51.f, 52.f, 
+                                           53.f, 54.f, 55.f, 56.f, 57.f, 58.f, 59.f, 60.f, 61.f, 62.f, 63.f, 64.f, 65.f, 66.f, 67.f, 68.f, 69.f});
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {-1, 2});
+    ASSERT_EQ(ND4J_STATUS_OK, result->status());
+    auto output = result->at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+
+    delete result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests9, prelu_test14) {
+    
+    NDArray<float> x('c', {2, 3, 4, 5});    
+    x.linspace(-50);
+    NDArray<float> alpha('c', {2,10}, {-0.7f, -0.6f, -0.5f, -0.4f, -0.3f, -0.2f, -0.1f, 0.f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.f, 1.1f, 1.2f});
+    NDArray<float> exp('c', {2, 3, 4, 5}, {35.f,  29.4f,  24.f,  18.8f,  13.8f, 9.f,   4.4f,   0.f,  -4.2f,  -8.2f, -12.f, -15.6f, -19.f, -22.2f, -25.2f, -28.f, -30.6f, 
+                                           -33.f,-35.2f, -37.2f, 21.f,  17.4f,  14.f,  10.8f,   7.8f, 5.f,   2.4f,   0.f,  -2.2f,  -4.2f, -6.f,  -7.6f,  -9.f, -10.2f, 
+                                           -11.2f, -12.f, -12.6f, -13.f, -13.2f, -13.2f, 7.f,   5.4f,   4.f,   2.8f,   1.8f, 1.f,   0.4f,   0.f,  -0.2f,  -0.2f, 0.f,   
+                                           1.f,   2.f,   3.f,   4.f, 5.f,   6.f,   7.f,   8.f,   9.f, 10.f,  11.f,  12.f,  13.f,  14.f, 15.f,  16.f,  17.f,  18.f,  
+                                           19.f, 20.f,  21.f,  22.f,  23.f,  24.f, 25.f,  26.f,  27.f,  28.f,  29.f, 30.f,  31.f,  32.f,  33.f,  34.f, 35.f,  36.f,  
+                                           37.f,  38.f,  39.f, 40.f,  41.f,  42.f,  43.f,  44.f, 45.f,  46.f,  47.f,  48.f,  49.f, 50.f,  51.f,  52.f,  53.f,  54.f, 
+                                           55.f,  56.f,  57.f,  58.f,  59.f, 60.f,  61.f,  62.f,  63.f,  64.f, 65.f,  66.f,  67.f,  68.f,  69.f});
+
+    nd4j::ops::prelu<float> op;
+    auto result = op.execute({&x, &alpha}, {}, {-2});
     ASSERT_EQ(ND4J_STATUS_OK, result->status());
     auto output = result->at(0);
 


### PR DESCRIPTION
- provide required additional functionality in prelu op, namely add possibility of passing shared_axes parameter which defines axes along which to share learnable parameters for the activation function 
- add more corresponding tests