### PR TITLE
libnd4j: Consolidate builds of libraries and tests

### DIFF
--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -63,6 +63,7 @@
     </developers>
 
     <properties>
+        <libnd4j.build>release</libnd4j.build>
         <libnd4j.chip>cpu</libnd4j.chip>
         <libnd4j.platform>${javacpp.platform}</libnd4j.platform>
         <libnd4j.extension>${javacpp.platform.extension}</libnd4j.extension>
@@ -70,7 +71,7 @@
         <libnd4j.compute></libnd4j.compute>
         <libnd4j.classifier>${libnd4j.platform}</libnd4j.classifier>
         <libnd4j.tests.phase>test</libnd4j.tests.phase>
-        <libnd4j.test.is.release.build>true</libnd4j.test.is.release.build>
+<!--        <libnd4j.test.is.release.build>true</libnd4j.test.is.release.build>-->
     </properties>
 
     <build>
@@ -102,6 +103,8 @@
                             <buildCommand>
                                 <program>bash</program>
                                 <argument>${project.basedir}/buildnativeoperations.sh</argument>
+                                <argument>--build-type</argument>
+                                <argument>${libnd4j.build}</argument>
                                 <argument>--chip</argument>
                                 <argument>${libnd4j.chip}</argument>
                                 <argument>--platform</argument>
@@ -112,6 +115,7 @@
                                 <argument>${libnd4j.cuda}</argument>
                                 <argument>--compute</argument>
                                 <argument>${libnd4j.compute}</argument>
+                                <argument>${libnd4j.tests}</argument>
                             </buildCommand>
                             <workingDirectory>${project.basedir}</workingDirectory>
                         </configuration>

--- a/libnd4j/tests_cpu/run_tests.sh
+++ b/libnd4j/tests_cpu/run_tests.sh
@@ -19,39 +19,39 @@
 
 set -exo pipefail
 
-IS_RELEASE='true'
-OSARCH=$(arch)
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    export CC=$(ls -1 /usr/local/bin/gcc-? | head -n 1)
-    export CXX=$(ls -1 /usr/local/bin/g++-? | head -n 1)
-elif [[ "$OSTYPE" == "linux-gnu" ]]; then
-    export CC=$(which gcc)
-    export CXX=$(which g++)
-fi
-
-parse_commandline ()
-{
-	while test $# -gt 0
-	do
-		_key="$1"
-		case "$_key" in
-			--release=*)
-				IS_RELEASE="${_key##--release=}"
-				;;
-			*)
-				;;
-		esac
-		shift
-	done
-}
-
-parse_commandline "$@"
-
-if [[ "$IS_RELEASE" == "false" ]]; then
-    ../buildnativeoperations.sh -t -b debug
-else
-    ../buildnativeoperations.sh -t -b release
-fi
+#IS_RELEASE='true'
+#OSARCH=$(arch)
+#
+#if [[ "$OSTYPE" == "darwin"* ]]; then
+#    export CC=$(ls -1 /usr/local/bin/gcc-? | head -n 1)
+#    export CXX=$(ls -1 /usr/local/bin/g++-? | head -n 1)
+#elif [[ "$OSTYPE" == "linux-gnu" ]]; then
+#    export CC=$(which gcc)
+#    export CXX=$(which g++)
+#fi
+#
+#parse_commandline ()
+#{
+#	while test $# -gt 0
+#	do
+#		_key="$1"
+#		case "$_key" in
+#			--release=*)
+#				IS_RELEASE="${_key##--release=}"
+#				;;
+#			*)
+#				;;
+#		esac
+#		shift
+#	done
+#}
+#
+#parse_commandline "$@"
+#
+#if [[ "$IS_RELEASE" == "false" ]]; then
+#    ../buildnativeoperations.sh -t -b debug
+#else
+#    ../buildnativeoperations.sh -t -b release
+#fi
 
 ../blasbuild/cpu/tests_cpu/layers_tests/runtests --gtest_output="xml:../target/surefire-reports/TEST-results.xml"

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,9 @@
         <scalafmt.version>1.3.0</scalafmt.version>
         <scalacheck.version>1.13.5</scalacheck.version>
 
+        <libnd4j.tests>--tests</libnd4j.tests>
+        <libnd4j.test.skip>false</libnd4j.test.skip>
+        <skipBackendChoice>false</skipBackendChoice>
         <skipTestResourceEnforcement>false
         </skipTestResourceEnforcement> <!-- Test resource profile must be enabled unless using -DskipTests etc -->
     </properties>
@@ -491,17 +494,6 @@
         </profile>
         <!-- This controls skipping the test backend choice enforcement below -->
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <libnd4j.test.skip>false</libnd4j.test.skip>
-                <skipBackendChoice>false</skipBackendChoice>
-                <skipTestResourceEnforcement>false</skipTestResourceEnforcement>
-            </properties>
-        </profile>
-        <profile>
             <id>skipTestCompileAndRun</id>
             <activation>
                 <property>
@@ -510,6 +502,7 @@
                 </property>
             </activation>
             <properties>
+                <libnd4j.tests></libnd4j.tests>
                 <libnd4j.test.skip>true</libnd4j.test.skip>
                 <skipBackendChoice>true</skipBackendChoice>
                 <skipTestResourceEnforcement>true</skipTestResourceEnforcement>
@@ -523,6 +516,7 @@
                 </property>
             </activation>
             <properties>
+                <libnd4j.tests></libnd4j.tests>
                 <libnd4j.test.skip>true</libnd4j.test.skip>
                 <skipBackendChoice>true</skipBackendChoice>
                 <skipTestResourceEnforcement>true</skipTestResourceEnforcement>


### PR DESCRIPTION
To run the buildnativeoperations.sh script properly from run_tests.sh, we would need a way to pass all the build options. This is an issue in the pom.xml file, where we call run_tests.sh after buildnativeoperations.sh, effectively voiding all our build options (avx512, etc).

So, this patch removes the call to the buildnativeoperations.sh script from run_tests.sh, and builds the tests as part of the main build in Maven's lifecycle. Also, the `libnd4j.test.is.release.build` property is now ignored and replaced by the simpler `libnd4j.build` property.