### PR TITLE
Clean up ND4J environment variables and system properties

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/env/impl/OmpNumThreadsAction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/env/impl/OmpNumThreadsAction.java
@@ -17,6 +17,7 @@
 package org.nd4j.linalg.env.impl;
 
 import lombok.val;
+import org.nd4j.config.ND4JEnvironmentVars;
 import org.nd4j.linalg.api.memory.enums.DebugMode;
 import org.nd4j.linalg.env.EnvironmentalAction;
 import org.nd4j.linalg.factory.Nd4j;
@@ -24,14 +25,14 @@ import org.nd4j.linalg.factory.Nd4j;
 public class OmpNumThreadsAction implements EnvironmentalAction {
     @Override
     public String targetVariable() {
-        return "OMP_NUM_THREADS";
+        return ND4JEnvironmentVars.OMP_NUM_THREADS;
     }
 
     @Override
     public void process(String value) {
         val v = Integer.valueOf(value).intValue();
 
-        val skipper = System.getenv("ND4J_SKIP_BLAS_THREADS");
+        val skipper = System.getenv(ND4JEnvironmentVars.ND4J_SKIP_BLAS_THREADS);
         if (skipper == null) {
             // we infer num threads only if skipper undefined
             Nd4j.setNumThreads(v);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -33,6 +33,7 @@ import org.bytedeco.javacpp.indexer.HalfIndexer;
 import org.bytedeco.javacpp.indexer.Indexer;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.base.Preconditions;
+import org.nd4j.config.ND4JEnvironmentVars;
 import org.nd4j.context.Nd4jContext;
 import org.nd4j.graph.FlatArray;
 import org.nd4j.linalg.api.buffer.DataBuffer;
@@ -7178,7 +7179,7 @@ public class Nd4j {
     }
 
     private boolean isFallback() {
-        String fallback = System.getenv("ND4J_FALLBACK");
+        String fallback = System.getenv(ND4JEnvironmentVars.ND4J_FALLBACK);
         if (fallback == null) {
             return false;
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -34,6 +34,7 @@ import org.bytedeco.javacpp.indexer.Indexer;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.base.Preconditions;
 import org.nd4j.config.ND4JEnvironmentVars;
+import org.nd4j.config.ND4JSystemProperties;
 import org.nd4j.context.Nd4jContext;
 import org.nd4j.graph.FlatArray;
 import org.nd4j.linalg.api.buffer.DataBuffer;
@@ -108,10 +109,11 @@ import java.util.logging.Logger;
 public class Nd4j {
 
     public final static String NUMERICAL_STABILITY = "force.stability";
-    public final static String FFT_OPS = "fft";
     public final static String DATA_BUFFER_OPS = "databufferfactory";
     public final static String CONVOLUTION_OPS = "convops";
-    public final static String DTYPE = "dtype";
+    /**@deprecated Use {@link ND4JSystemProperties#DTYPE}*/
+    @Deprecated
+    public final static String DTYPE = ND4JSystemProperties.DTYPE;
     public final static String BLAS_OPS = "blas.ops";
     public final static String SPARSE_BLAS_OPS = "sparseblas.ops";
     public final static String NATIVE_OPS = "native.ops";
@@ -135,7 +137,9 @@ public class Nd4j {
     public final static String MEMORY_MANAGER = "memorymanager";
     public final static String WORKSPACE_MANAGER = "workspacemanager";
     public final static String RANDOM_PROVIDER = "random";
-    public static final String LOG_INIT_ENV_PROPERTY = "org.nd4j.log.initialization";
+    /**@deprecated Use {@link ND4JSystemProperties#LOG_INITIALIZATION}*/
+    @Deprecated
+    public static final String LOG_INIT_ENV_PROPERTY = ND4JSystemProperties.LOG_INITIALIZATION;
 
     //execution mode for element wise operations
     public static OpExecutioner.ExecutionMode executionMode = OpExecutioner.ExecutionMode.JAVA;
@@ -7007,9 +7011,9 @@ public class Nd4j {
             props = Nd4jContext.getInstance().getConf();
             PropertyParser pp = new PropertyParser(props);
 
-            String otherDtype = pp.toString(DTYPE);
-            dtype = otherDtype.equals("float") ? DataBuffer.Type.FLOAT
-                    : otherDtype.equals("half") ? DataBuffer.Type.HALF : DataBuffer.Type.DOUBLE;
+            String otherDtype = pp.toString(ND4JSystemProperties.DTYPE);
+            dtype = otherDtype.equalsIgnoreCase("float") ? DataBuffer.Type.FLOAT
+                    : otherDtype.equalsIgnoreCase("half") ? DataBuffer.Type.HALF : DataBuffer.Type.DOUBLE;
 
             if (dtype == DataBuffer.Type.HALF && backend.getClass().getName().equals("CpuBackend")) {
                 showAttractiveMessage(getMessageForNativeHalfPrecision());
@@ -7108,7 +7112,7 @@ public class Nd4j {
                 fallbackMode.set(false);
             }
 
-            String logInitProperty = System.getProperty(LOG_INIT_ENV_PROPERTY, "true");
+            String logInitProperty = System.getProperty(ND4JSystemProperties.LOG_INITIALIZATION, "true");
             if(Boolean.parseBoolean(logInitProperty)) {
                 OP_EXECUTIONER_INSTANCE.printEnvironmentInformation();
             }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/versioncheck/VersionCheck.java
@@ -17,6 +17,7 @@
 package org.nd4j.versioncheck;
 
 import lombok.extern.slf4j.Slf4j;
+import org.nd4j.config.ND4JSystemProperties;
 
 import java.io.IOException;
 import java.net.URI;
@@ -37,10 +38,10 @@ import java.util.*;
 public class VersionCheck {
 
     /**
-     * Setting the system property to false will stop ND4J from performing the version check, and logging any
-     * warnings/errors. By default, the version check is unable.
+     * @deprecated Use {@link org.nd4j.config.ND4JSystemProperties#VERSION_CHECK_PROPERTY}
      */
-    public static final String VERSION_CHECK_PROPERTY = "org.nd4j.versioncheck";
+    @Deprecated
+    public static final String VERSION_CHECK_PROPERTY = ND4JSystemProperties.VERSION_CHECK_PROPERTY;
     public static final String GIT_PROPERTY_FILE_SUFFIX = "-git.properties";
 
     private static final String SCALA_210_SUFFIX = "_2.10";
@@ -85,7 +86,7 @@ public class VersionCheck {
      * if necessary.
      */
     public static void checkVersions(){
-        boolean doCheck = Boolean.parseBoolean(System.getProperty(VERSION_CHECK_PROPERTY, "true"));
+        boolean doCheck = Boolean.parseBoolean(System.getProperty(ND4JSystemProperties.VERSION_CHECK_PROPERTY, "true"));
 
         if(!doCheck){
             return;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOpsHolder.java
@@ -19,6 +19,7 @@ package org.nd4j.nativeblas;
 import lombok.Getter;
 import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.Pointer;
+import org.nd4j.config.ND4JEnvironmentVars;
 import org.nd4j.context.Nd4jContext;
 import org.nd4j.linalg.factory.Nd4j;
 import org.slf4j.Logger;
@@ -47,7 +48,7 @@ public class NativeOpsHolder {
 
             deviceNativeOps.initializeDevicesAndFunctions();
             int numThreads;
-            String numThreadsString = System.getenv("OMP_NUM_THREADS");
+            String numThreadsString = System.getenv(ND4JEnvironmentVars.OMP_NUM_THREADS);
             if (numThreadsString != null && !numThreadsString.isEmpty()) {
                 numThreads = Integer.parseInt(numThreadsString);
                 deviceNativeOps.setOmpNumThreads(numThreads);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/Nd4jBlas.java
@@ -20,6 +20,7 @@ package org.nd4j.nativeblas;
 import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.Pointer;
+import org.nd4j.config.ND4JEnvironmentVars;
 import org.nd4j.linalg.api.blas.Blas;
 
 
@@ -35,9 +36,9 @@ public abstract class Nd4jBlas implements Blas {
 
     public Nd4jBlas() {
         int numThreads;
-        String skipper = System.getenv("ND4J_SKIP_BLAS_THREADS");
+        String skipper = System.getenv(ND4JEnvironmentVars.ND4J_SKIP_BLAS_THREADS);
         if (skipper == null || skipper.isEmpty()) {
-            String numThreadsString = System.getenv("OMP_NUM_THREADS");
+            String numThreadsString = System.getenv(ND4JEnvironmentVars.OMP_NUM_THREADS);
             if (numThreadsString != null && !numThreadsString.isEmpty()) {
                 numThreads = Integer.parseInt(numThreadsString);
                 setMaxThreads(numThreads);

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/conf/Configuration.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/conf/Configuration.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.nd4j.config.ND4JEnvironmentVars;
 import org.nd4j.jita.allocator.enums.Aggressiveness;
 import org.nd4j.jita.allocator.enums.AllocationStatus;
 import org.nd4j.linalg.factory.Nd4j;
@@ -209,93 +210,80 @@ public class Configuration implements Serializable {
         this.initialized.compareAndSet(false, true);
     }
 
-    /**
-     * Environment variables for
-     * controlling cuda.
-     */
-    private static final String MAX_BLOCK_SIZE = "ND4J_CUDA_MAX_BLOCK_SIZE";
-    private static final String MIN_BLOCK_SIZE = "ND4J_CUDA_MIN_BLOCK_SIZE";
-    private static final String MAX_GRID_SIZE = "ND4J_CUDA_MAX_GRID_SIZE";
-    private static final String USE_PREALLOCATION = "ND4J_CUDA_USE_PREALLOCATION";
-    private static final String MAX_DEVICE_CACHE = "ND4J_CUDA_MAX_DEVICE_CACHE";
-    private static final String MAX_HOST_CACHE = "ND4J_CUDA_MAX_HOST_CACHE";
-    private static final String MAX_DEVICE_ALLOCATION = "ND4J_CUDA_MAX_DEVICE_ALLOCATION";
-    private static final String FORCE_SINGLE_GPU = "ND4J_CUDA_FORCE_SINGLE_GPU";
-
 
     private void parseEnvironmentVariables() {
 
         // Do not call System.getenv(): Accessing all variables requires higher security privileges
-        if (System.getenv(MAX_BLOCK_SIZE) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_BLOCK_SIZE) != null) {
             try {
-                int var = Integer.parseInt(System.getenv(MAX_BLOCK_SIZE));
+                int var = Integer.parseInt(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_BLOCK_SIZE));
                 setMaximumBlockSize(var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", MAX_BLOCK_SIZE, System.getenv(MAX_BLOCK_SIZE));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_MAX_BLOCK_SIZE, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_BLOCK_SIZE));
             }
         }
 
-        if (System.getenv(MIN_BLOCK_SIZE) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MIN_BLOCK_SIZE) != null) {
             try {
-                int var = Integer.parseInt(System.getenv(MIN_BLOCK_SIZE));
+                int var = Integer.parseInt(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MIN_BLOCK_SIZE));
                 setMinimumBlockSize(var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", MIN_BLOCK_SIZE, System.getenv(MIN_BLOCK_SIZE));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_MIN_BLOCK_SIZE, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MIN_BLOCK_SIZE));
             }
         }
 
-        if (System.getenv(MAX_GRID_SIZE) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_GRID_SIZE) != null) {
             try {
-                int var = Integer.parseInt(System.getenv(MAX_GRID_SIZE));
+                int var = Integer.parseInt(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_GRID_SIZE));
                 setMaximumGridSize(var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", MAX_GRID_SIZE, System.getenv(MAX_GRID_SIZE));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_MAX_GRID_SIZE, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_GRID_SIZE));
             }
         }
 
-        if (System.getenv(FORCE_SINGLE_GPU) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_FORCE_SINGLE_GPU) != null) {
             try {
-                boolean var = Boolean.parseBoolean(System.getenv(FORCE_SINGLE_GPU));
+                boolean var = Boolean.parseBoolean(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_FORCE_SINGLE_GPU));
                 allowMultiGPU(!var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", FORCE_SINGLE_GPU, System.getenv(FORCE_SINGLE_GPU));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_FORCE_SINGLE_GPU, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_FORCE_SINGLE_GPU));
             }
         }
 
-        if (System.getenv(USE_PREALLOCATION) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_USE_PREALLOCATION) != null) {
             try {
-                boolean var = Boolean.parseBoolean(System.getenv(USE_PREALLOCATION));
+                boolean var = Boolean.parseBoolean(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_USE_PREALLOCATION));
                 allowPreallocation(var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", USE_PREALLOCATION, System.getenv(USE_PREALLOCATION));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_USE_PREALLOCATION, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_USE_PREALLOCATION));
             }
         }
 
-        if (System.getenv(MAX_DEVICE_CACHE) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_CACHE) != null) {
             try {
-                long var = Long.parseLong(System.getenv(MAX_DEVICE_CACHE));
+                long var = Long.parseLong(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_CACHE));
                 setMaximumDeviceCache(var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", MAX_DEVICE_CACHE, System.getenv(MAX_DEVICE_CACHE));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_CACHE, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_CACHE));
             }
         }
 
 
-        if (System.getenv(MAX_HOST_CACHE) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_HOST_CACHE) != null) {
             try {
-                long var = Long.parseLong(System.getenv(MAX_HOST_CACHE));
+                long var = Long.parseLong(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_HOST_CACHE));
                 setMaximumHostCache(var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", MAX_HOST_CACHE, System.getenv(MAX_HOST_CACHE));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_MAX_HOST_CACHE, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_HOST_CACHE));
             }
         }
 
-        if (System.getenv(MAX_DEVICE_ALLOCATION) != null) {
+        if (System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_ALLOCATION) != null) {
             try {
-                long var = Long.parseLong(System.getenv(MAX_DEVICE_ALLOCATION));
+                long var = Long.parseLong(System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_ALLOCATION));
                 setMaximumSingleDeviceAllocation(var);
             } catch (Exception e) {
-                log.error("Can't parse {}: [{}]", MAX_DEVICE_ALLOCATION, System.getenv(MAX_DEVICE_ALLOCATION));
+                log.error("Can't parse {}: [{}]", ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_ALLOCATION, System.getenv(ND4JEnvironmentVars.ND4J_CUDA_MAX_DEVICE_ALLOCATION));
             }
         }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuNDArrayFactory.java
@@ -19,6 +19,7 @@ package org.nd4j.linalg.cpu.nativecpu;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.nd4j.config.ND4JSystemProperties;
 import org.nd4j.linalg.api.buffer.LongBuffer;
 import org.nd4j.linalg.api.ops.performance.PerformanceTracker;
 import org.nd4j.linalg.api.shape.options.ArrayOptionsHelper;
@@ -91,11 +92,11 @@ public class CpuNDArrayFactory extends BaseNDArrayFactory {
 
     @Override
     public void createBlas() {
-        String lib = System.getProperty("org.bytedeco.javacpp.openblas.load",
-                     System.getProperty("org.bytedeco.javacpp.openblas_nolapack.load", "")).toLowerCase();
+        String lib = System.getProperty(ND4JSystemProperties.ND4J_CPU_LOAD_OPENBLAS,
+                     System.getProperty(ND4JSystemProperties.ND4J_CPU_LOAD_OPENBLAS_NOLAPACK, "")).toLowerCase();
         if (lib.trim().length() == 0) {
             // try to load by default the LAPACK-less version of MKL bundled with MKL-DNN
-            System.setProperty("org.bytedeco.javacpp.openblas_nolapack.load", "mklml");
+            System.setProperty(ND4JSystemProperties.ND4J_CPU_LOAD_OPENBLAS_NOLAPACK, "mklml");
         }
 
         blas = new CpuBlas();

--- a/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.bytedeco.javacpp.*;
 import org.bytedeco.javacpp.indexer.*;
+import org.nd4j.config.ND4JSystemProperties;
 import org.nd4j.linalg.api.buffer.util.AllocUtil;
 import org.nd4j.linalg.api.buffer.util.DataTypeUtil;
 import org.nd4j.linalg.api.complex.IComplexDouble;
@@ -55,18 +56,17 @@ import org.nd4j.linalg.util.ArrayUtil;
 public abstract class BaseDataBuffer implements DataBuffer {
 
     /**
-     * To specify the maximum number of elements to print when using DataBuffer.toString().
-     * Use -1 to print all elements (i.e., no limit)
+     * @deprecated Use {@link ND4JSystemProperties#DATABUFFER_TO_STRING_MAX_ELEMENTS}
      */
-    public static String TO_STRING_MAX_ELEMENTS = "org.nd4j.databuffer.tostring.maxelements";
+    public static String TO_STRING_MAX_ELEMENTS = ND4JSystemProperties.DATABUFFER_TO_STRING_MAX_ELEMENTS;
     private static int TO_STRING_MAX;
     static {
-        String s = System.getProperty(TO_STRING_MAX_ELEMENTS);
+        String s = System.getProperty(ND4JSystemProperties.DATABUFFER_TO_STRING_MAX_ELEMENTS);
         if(s != null ){
             try {
                 TO_STRING_MAX = Integer.parseInt(s);
             } catch (NumberFormatException e){
-                log.warn("Invalid value for key {}: \"{}\"", TO_STRING_MAX_ELEMENTS, s);
+                log.warn("Invalid value for key {}: \"{}\"", ND4JSystemProperties.DATABUFFER_TO_STRING_MAX_ELEMENTS, s);
                 TO_STRING_MAX = 1000;
             }
         } else {

--- a/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
+++ b/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
@@ -47,17 +47,16 @@ public interface DataBuffer extends Serializable {
 
 
     /**
-     * Direct (off heap) and heap allocation
-     *
-     * Each has their trade offs.
-     *
-     * One allows for storing unlimited array sizes, faster i/o with native
-     * applications
-     *
-     * heap is backed by an array and can be useful depending on the api
+     * Mainly used for backward compatability.
+     * Note that DIRECT and HEAP modes have been deprecated asd should not be used.
      */
     enum AllocationMode {
-        DIRECT, HEAP, JAVACPP,
+
+        @Deprecated
+        DIRECT,
+        @Deprecated
+        HEAP,
+        JAVACPP,
         LONG_SHAPE, // long shapes will be used instead of int
     }
 

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JEnvironmentVars.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JEnvironmentVars.java
@@ -67,4 +67,70 @@ public class ND4JEnvironmentVars {
      * will usually still take effect for native BLAS libraries (MKL, OpenBLAS) even if this property is set
      */
     public static final String ND4J_SKIP_BLAS_THREADS = "ND4J_SKIP_BLAS_THREADS";
+
+
+    /**
+     * Applicability: nd4j-native backend<br>
+     * Description: Whether build-in BLAS matrix multiplication (GEMM) should be used instead of the native BLAS
+     * library such as MKL or OpenBLAS. This can have a noticable performance impact for these ops.
+     * Note that this is typically only useful as a workaround (or test) for bugs in these underlying native libraries,
+     * which are rare (but do occasionally occur on some platforms)
+     */
+    public static final String ND4J_FALLBACK = "ND4J_FALLBACK";
+
+
+    /**
+     * Applicability: nd4j-parameter-server<br>
+     * Usage: A fallback for determining the local IP the parameter server, if other approaches fail to determine the
+     * local IP
+     */
+    public static final String DL4J_VOID_IP = "DL4J_VOID_IP";
+
+    /**
+     * Applicability: nd4j-cuda-xx<br>
+     * Description:
+     */
+    public static final String ND4J_CUDA_MAX_BLOCK_SIZE = "ND4J_CUDA_MAX_BLOCK_SIZE";
+
+    /**
+     * Applicability: nd4j-cuda-xx<br>
+     * Description:
+     */
+    public static final String ND4J_CUDA_MIN_BLOCK_SIZE = "ND4J_CUDA_MIN_BLOCK_SIZE";
+
+    /**
+     * Applicability: nd4j-cuda-xx<br>
+     * Description:
+     */
+    public static final String ND4J_CUDA_MAX_GRID_SIZE = "ND4J_CUDA_MAX_GRID_SIZE";
+
+    /**
+     * Applicability: nd4j-cuda-xx used on multi-GPU systems<br>
+     * Description: If set, only a single GPU will be used by ND4J, even if multiple GPUs are available in the system
+     */
+    public static final String ND4J_CUDA_FORCE_SINGLE_GPU = "ND4J_CUDA_FORCE_SINGLE_GPU";
+
+    /**
+     * Applicability: nd4j-cuda-xx<br>
+     * Description:
+     */
+    public static final String ND4J_CUDA_USE_PREALLOCATION = "ND4J_CUDA_USE_PREALLOCATION";
+
+    /**
+     * Applicability: nd4j-cuda-xx<br>
+     * Description:
+     */
+    public static final String ND4J_CUDA_MAX_DEVICE_CACHE = "ND4J_CUDA_MAX_DEVICE_CACHE";
+
+    /**
+     * Applicability: nd4j-cuda-xx<br>
+     * Description:
+     */
+    public static final String ND4J_CUDA_MAX_HOST_CACHE = "ND4J_CUDA_MAX_HOST_CACHE";
+
+    /**
+     * Applicability: nd4j-cuda-xx<br>
+     * Description:
+     */
+    public static final String ND4J_CUDA_MAX_DEVICE_ALLOCATION = "ND4J_CUDA_MAX_DEVICE_ALLOCATION";
 }

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JEnvironmentVars.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JEnvironmentVars.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.nd4j.config;
+
+public class ND4JEnvironmentVars {
+
+    private ND4JEnvironmentVars(){ }
+
+    /**
+     * Applicability: nd4j-native, when multiple backends are on classpath<br>
+     * Description: Defines the priority that the CPU/Native backend should be loaded (or attempt to be loaded). If this
+     * is set to a higher value than {@link #BACKEND_PRIORITY_GPU} (which has default value 100) the native backend
+     * will be loaded in preference to the CUDA backend, when both are on the classpath. Default value: 0
+     */
+    public static final String BACKEND_PRIORITY_CPU = "BACKEND_PRIORITY_CPU";
+
+    /**
+     * Applicability: nd4j-cuda-xx, when multiple backends are on classpath<br>
+     * Description: Defines the priority that the CUDA (GPU) backend should be loaded (or attempt to be loaded). If this
+     * is set to a higher value than {@link #BACKEND_PRIORITY_CPU} (which has default value 0) the GPU backend
+     * will be loaded in preference to the CUDA backend, when both are on the classpath. Default value: 100 - hence
+     * by default, the CUDA backend will be loaded when both it and the CPU/native backend are on the classpath
+     */
+    public static final String BACKEND_PRIORITY_GPU = "BACKEND_PRIORITY_GPU";
+
+    /**
+     * Applicability: always - but only if an ND4J backend cannot be found/loaded via standard ServiceLoader mechanisms<br>
+     * Description: Set this environment variable to a set fully qualified JAR files to attempt to load before failing on
+     * not loading a backend. JAR files should be semi-colon delimited; i.e., "/some/file.jar;/other/path.jar".
+     * This should rarely be required in practice - for example, only in dynamic class loading/dynamic classpath scenarios<br>
+     * For equivalent system property, see {@link ND4JSystemProperties#DYNAMIC_LOAD_CLASSPATH_PROPERTY} for the equivalent
+     * system property (that will take precidence if both are set)
+     */
+    public static final String BACKEND_DYNAMIC_LOAD_CLASSPATH = "ND4J_DYNAMIC_LOAD_CLASSPATH";
+
+    /**
+     * Applicability: nd4j-native backend<br>
+     * Description: Sets the number of OpenMP parallel threads for ND4J native operations (and also native BLAS libraries
+     * such as Intel MKL and OpenBLAS).
+     * By default, this will be set to the number of physical cores (i.e., excluding hyperthreading cores), which usually
+     * provides optimal performance. Setting this to a larger value than the number of physical cores (for example, equal
+     * to number of logical cores - i.e., setting to 16 on an 8-core + hypethreading processor) - can result in reduced
+     * performance<br>
+     * Note that if you have a significant number of parallel Java threads (for example, Spark or ParallelWrapper), or
+     * you want to keep some cores free for other programs - you may want to reduce this value.
+     * @see #ND4J_SKIP_BLAS_THREADS
+     */
+    public static final String OMP_NUM_THREADS = "OMP_NUM_THREADS";
+
+    /**
+     * Applicability: nd4j-native backend<br>
+     * Description: Skips the setting of the {@link #OMP_NUM_THREADS} property for ND4J ops. Note that this property
+     * will usually still take effect for native BLAS libraries (MKL, OpenBLAS) even if this property is set
+     */
+    public static final String ND4J_SKIP_BLAS_THREADS = "ND4J_SKIP_BLAS_THREADS";
+}

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JEnvironmentVars.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JEnvironmentVars.java
@@ -18,8 +18,6 @@ package org.nd4j.config;
 
 public class ND4JEnvironmentVars {
 
-    private ND4JEnvironmentVars(){ }
-
     /**
      * Applicability: nd4j-native, when multiple backends are on classpath<br>
      * Description: Defines the priority that the CPU/Native backend should be loaded (or attempt to be loaded). If this
@@ -27,7 +25,6 @@ public class ND4JEnvironmentVars {
      * will be loaded in preference to the CUDA backend, when both are on the classpath. Default value: 0
      */
     public static final String BACKEND_PRIORITY_CPU = "BACKEND_PRIORITY_CPU";
-
     /**
      * Applicability: nd4j-cuda-xx, when multiple backends are on classpath<br>
      * Description: Defines the priority that the CUDA (GPU) backend should be loaded (or attempt to be loaded). If this
@@ -36,7 +33,6 @@ public class ND4JEnvironmentVars {
      * by default, the CUDA backend will be loaded when both it and the CPU/native backend are on the classpath
      */
     public static final String BACKEND_PRIORITY_GPU = "BACKEND_PRIORITY_GPU";
-
     /**
      * Applicability: always - but only if an ND4J backend cannot be found/loaded via standard ServiceLoader mechanisms<br>
      * Description: Set this environment variable to a set fully qualified JAR files to attempt to load before failing on
@@ -46,7 +42,6 @@ public class ND4JEnvironmentVars {
      * system property (that will take precidence if both are set)
      */
     public static final String BACKEND_DYNAMIC_LOAD_CLASSPATH = "ND4J_DYNAMIC_LOAD_CLASSPATH";
-
     /**
      * Applicability: nd4j-native backend<br>
      * Description: Sets the number of OpenMP parallel threads for ND4J native operations (and also native BLAS libraries
@@ -57,18 +52,16 @@ public class ND4JEnvironmentVars {
      * performance<br>
      * Note that if you have a significant number of parallel Java threads (for example, Spark or ParallelWrapper), or
      * you want to keep some cores free for other programs - you may want to reduce this value.
+     *
      * @see #ND4J_SKIP_BLAS_THREADS
      */
     public static final String OMP_NUM_THREADS = "OMP_NUM_THREADS";
-
     /**
      * Applicability: nd4j-native backend<br>
      * Description: Skips the setting of the {@link #OMP_NUM_THREADS} property for ND4J ops. Note that this property
      * will usually still take effect for native BLAS libraries (MKL, OpenBLAS) even if this property is set
      */
     public static final String ND4J_SKIP_BLAS_THREADS = "ND4J_SKIP_BLAS_THREADS";
-
-
     /**
      * Applicability: nd4j-native backend<br>
      * Description: Whether build-in BLAS matrix multiplication (GEMM) should be used instead of the native BLAS
@@ -77,60 +70,53 @@ public class ND4JEnvironmentVars {
      * which are rare (but do occasionally occur on some platforms)
      */
     public static final String ND4J_FALLBACK = "ND4J_FALLBACK";
-
-
     /**
      * Applicability: nd4j-parameter-server<br>
      * Usage: A fallback for determining the local IP the parameter server, if other approaches fail to determine the
      * local IP
      */
     public static final String DL4J_VOID_IP = "DL4J_VOID_IP";
-
     /**
      * Applicability: nd4j-cuda-xx<br>
      * Description:
      */
     public static final String ND4J_CUDA_MAX_BLOCK_SIZE = "ND4J_CUDA_MAX_BLOCK_SIZE";
-
     /**
      * Applicability: nd4j-cuda-xx<br>
      * Description:
      */
     public static final String ND4J_CUDA_MIN_BLOCK_SIZE = "ND4J_CUDA_MIN_BLOCK_SIZE";
-
     /**
      * Applicability: nd4j-cuda-xx<br>
      * Description:
      */
     public static final String ND4J_CUDA_MAX_GRID_SIZE = "ND4J_CUDA_MAX_GRID_SIZE";
-
     /**
      * Applicability: nd4j-cuda-xx used on multi-GPU systems<br>
      * Description: If set, only a single GPU will be used by ND4J, even if multiple GPUs are available in the system
      */
     public static final String ND4J_CUDA_FORCE_SINGLE_GPU = "ND4J_CUDA_FORCE_SINGLE_GPU";
-
     /**
      * Applicability: nd4j-cuda-xx<br>
      * Description:
      */
     public static final String ND4J_CUDA_USE_PREALLOCATION = "ND4J_CUDA_USE_PREALLOCATION";
-
     /**
      * Applicability: nd4j-cuda-xx<br>
      * Description:
      */
     public static final String ND4J_CUDA_MAX_DEVICE_CACHE = "ND4J_CUDA_MAX_DEVICE_CACHE";
-
     /**
      * Applicability: nd4j-cuda-xx<br>
      * Description:
      */
     public static final String ND4J_CUDA_MAX_HOST_CACHE = "ND4J_CUDA_MAX_HOST_CACHE";
-
     /**
      * Applicability: nd4j-cuda-xx<br>
      * Description:
      */
     public static final String ND4J_CUDA_MAX_DEVICE_ALLOCATION = "ND4J_CUDA_MAX_DEVICE_ALLOCATION";
+
+    private ND4JEnvironmentVars() {
+    }
 }

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JSystemProperties.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JSystemProperties.java
@@ -18,15 +18,12 @@ package org.nd4j.config;
 
 public class ND4JSystemProperties {
 
-    private ND4JSystemProperties(){ }
-
     /**
      * Applicability: Always<br>
      * Description: Sets the default datatype for ND4J - should be one of "float", "double", "half".
      * ND4J is set to float (32-bit floating point values) by default.
      */
     public static final String DTYPE = "dtype";
-
     /**
      * Applicability: Always<br>
      * Description: By default, ND4J will log some information when the library has completed initialization, such as the
@@ -34,11 +31,25 @@ public class ND4JSystemProperties {
      * initialization information
      */
     public static final String LOG_INITIALIZATION = "org.nd4j.log.initialization";
-
-
-    //TODO ADD JAVACCP MEMORY OPTIONS HERE
-    //(Technically they aren't ND4J system properties, but they are very important)
-
+    /**
+     * Applicability: Always<br>
+     * Description: This system property defines the maximum amount of off-heap memory that can be used.
+     * ND4J uses off-heap memory for storage of all INDArray data. This off-heap memory is a different
+     * pool of memory to the on-heap JVM memory (configured using standard Java Xms/Xmx options).
+     * Default: 2x Java XMX setting
+     *
+     * @see #JAVACPP_MEMORY_MAX_PHYSICAL_BYTES
+     */
+    public static final String JAVACPP_MEMORY_MAX_BYTES = "org.bytedeco.javacpp.maxbytes";
+    /**
+     * Applicability: Always<br>
+     * Description: This system property defines the maximum total amount of memory that the process can use - it is
+     * the sum of both off-heap and on-heap memory. This can be used to provide an upper bound on the maximum amount
+     * of memory (of all types) that ND4J will use
+     *
+     * @see #JAVACPP_MEMORY_MAX_BYTES
+     */
+    public static final String JAVACPP_MEMORY_MAX_PHYSICAL_BYTES = "org.bytedeco.javacpp.maxphysicalbytes";
     /**
      * Applicability: always - but only if an ND4J backend cannot be found/loaded via standard ServiceLoader mechanisms<br>
      * Description: Set this property to a set fully qualified JAR files to attempt to load before failing on
@@ -48,7 +59,6 @@ public class ND4JSystemProperties {
      * system property (the system property will take precidence if both are set)
      */
     public static final String DYNAMIC_LOAD_CLASSPATH_PROPERTY = "org.nd4j.backend.dynamicbackend";
-
     /**
      * Applicability: Always<br>
      * Description Setting the system property to false will stop ND4J from performing the version check, and logging any
@@ -57,8 +67,6 @@ public class ND4JSystemProperties {
      * issues, and should be avoided.
      */
     public static final String VERSION_CHECK_PROPERTY = "org.nd4j.versioncheck";
-
-
     /**
      * Applicability: always<br>
      * Description: Used to specify the maximum number of elements (numbers) to print when using DataBuffer.toString().
@@ -67,12 +75,20 @@ public class ND4JSystemProperties {
      * Default: 1000
      */
     public static final String DATABUFFER_TO_STRING_MAX_ELEMENTS = "org.nd4j.databuffer.tostring.maxelements";
-
-
+    /**
+     * Applicability: nd4j-native backend, when multiple BLAS libraries are available<br>
+     * Description: This system property can be used to control which BLAS library is loaded and used by ND4J.
+     * For example, {@code org.bytedeco.javacpp.openblas.load=mkl_rt} can be used to load a default installation of MKL.
+     * However, MKL is liked with by default (when available) so setting this option explicitly is not usually required.
+     * For more details, see <a href="https://github.com/bytedeco/javacpp-presets/tree/master/openblas#documentation">https://github.com/bytedeco/javacpp-presets/tree/master/openblas#documentation</a>
+     */
     public static final String ND4J_CPU_LOAD_OPENBLAS = "org.bytedeco.javacpp.openblas.load";
-
+    /**
+     * Applicability: nd4j-native backend, when multiple BLAS libraries are available<br>
+     * Description: This system property can be used to control which BLAS library is loaded and used by ND4J.
+     * Similar to {@link #ND4J_CPU_LOAD_OPENBLAS} but when this is set, LAPACK will not be loaded
+     */
     public static final String ND4J_CPU_LOAD_OPENBLAS_NOLAPACK = "org.bytedeco.javacpp.openblas_nolapack.load";
-
     /**
      * Applicability: nd4j-parameter-server, dl4j-spark (gradient sharing training master)<br>
      * Description: Aeros in a high-performance communication library used in distributed computing contexts in some
@@ -85,4 +101,7 @@ public class ND4JSystemProperties {
      * the buffer size will have no effect)
      */
     public static final String AERON_TERM_BUFFER_PROP = "aeron.term.buffer.length";
+
+    private ND4JSystemProperties() {
+    }
 }

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JSystemProperties.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JSystemProperties.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.nd4j.config;
+
+public class ND4JSystemProperties {
+
+    private ND4JSystemProperties(){ }
+
+
+    /**
+     * Applicability: always - but only if an ND4J backend cannot be found/loaded via standard ServiceLoader mechanisms<br>
+     * Description: Set this property to a set fully qualified JAR files to attempt to load before failing on
+     * not loading a backend. JAR files should be semi-colon delimited; i.e., "/some/file.jar;/other/path.jar".
+     * This should rarely be required in practice - for example, only in dynamic class loading/dynamic classpath scenarios<br>
+     * For equivalent system property, see {@link ND4JEnvironmentVars#BACKEND_DYNAMIC_LOAD_CLASSPATH} for the equivalent
+     * system property (the system property will take precidence if both are set)
+     */
+    public static final String DYNAMIC_LOAD_CLASSPATH_PROPERTY = "org.nd4j.backend.dynamicbackend";
+
+
+}

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JSystemProperties.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/config/ND4JSystemProperties.java
@@ -20,6 +20,24 @@ public class ND4JSystemProperties {
 
     private ND4JSystemProperties(){ }
 
+    /**
+     * Applicability: Always<br>
+     * Description: Sets the default datatype for ND4J - should be one of "float", "double", "half".
+     * ND4J is set to float (32-bit floating point values) by default.
+     */
+    public static final String DTYPE = "dtype";
+
+    /**
+     * Applicability: Always<br>
+     * Description: By default, ND4J will log some information when the library has completed initialization, such as the
+     * backend (CPU or CUDA), CPU/Devices, memory etc. This system property can be used to disable the logging of this
+     * initialization information
+     */
+    public static final String LOG_INITIALIZATION = "org.nd4j.log.initialization";
+
+
+    //TODO ADD JAVACCP MEMORY OPTIONS HERE
+    //(Technically they aren't ND4J system properties, but they are very important)
 
     /**
      * Applicability: always - but only if an ND4J backend cannot be found/loaded via standard ServiceLoader mechanisms<br>
@@ -31,5 +49,40 @@ public class ND4JSystemProperties {
      */
     public static final String DYNAMIC_LOAD_CLASSPATH_PROPERTY = "org.nd4j.backend.dynamicbackend";
 
+    /**
+     * Applicability: Always<br>
+     * Description Setting the system property to false will stop ND4J from performing the version check, and logging any
+     * warnings/errors. By default, the version check is enabled.<br>
+     * Note: the version check is there for a reason! Using incompatible versions of ND4J/DL4J etc is likely to cause
+     * issues, and should be avoided.
+     */
+    public static final String VERSION_CHECK_PROPERTY = "org.nd4j.versioncheck";
 
+
+    /**
+     * Applicability: always<br>
+     * Description: Used to specify the maximum number of elements (numbers) to print when using DataBuffer.toString().
+     * Use -1 to print all elements (i.e., no limit). This is usually to avoid expensive toString() calls on buffers
+     * which may have millions of elements - for example, in a debugger<br>
+     * Default: 1000
+     */
+    public static final String DATABUFFER_TO_STRING_MAX_ELEMENTS = "org.nd4j.databuffer.tostring.maxelements";
+
+
+    public static final String ND4J_CPU_LOAD_OPENBLAS = "org.bytedeco.javacpp.openblas.load";
+
+    public static final String ND4J_CPU_LOAD_OPENBLAS_NOLAPACK = "org.bytedeco.javacpp.openblas_nolapack.load";
+
+    /**
+     * Applicability: nd4j-parameter-server, dl4j-spark (gradient sharing training master)<br>
+     * Description: Aeros in a high-performance communication library used in distributed computing contexts in some
+     * places in ND4J and DL4J. This term buffer length determines the maximum message length that can be sent via Aeron
+     * in a single message. It can be increased to avoid exceptions such as {@code Encoded message exceeds maxMessageLength of 2097152},
+     * at the expense of increased memory consumption (memory consumption is a multiple of this). It is specified in bytes
+     * with no unit suffix. Default value: 33554432 (32MB).
+     * <b>IMPORTANT</b>: This value must be an exact power of 2.<br>
+     * Note also the maximum effective size is 128MB (134217728) (due to Aeron internal limits - beyond which increasing
+     * the buffer size will have no effect)
+     */
+    public static final String AERON_TERM_BUFFER_PROP = "aeron.term.buffer.length";
 }

--- a/nd4j/nd4j-context/src/main/java/org/nd4j/linalg/factory/Nd4jBackend.java
+++ b/nd4j/nd4j-context/src/main/java/org/nd4j/linalg/factory/Nd4jBackend.java
@@ -16,6 +16,9 @@
 
 package org.nd4j.linalg.factory;
 
+import lombok.extern.slf4j.Slf4j;
+import org.nd4j.config.ND4JEnvironmentVars;
+import org.nd4j.config.ND4JSystemProperties;
 import org.nd4j.context.Nd4jContext;
 import org.nd4j.linalg.io.Resource;
 import org.slf4j.Logger;
@@ -58,18 +61,26 @@ import java.util.*;
  * @author saudet
  *
  */
+@Slf4j
 public abstract class Nd4jBackend {
 
     public static final int BACKEND_PRIORITY_CPU;
     public static final int BACKEND_PRIORITY_GPU;
-    public final static String DYNAMIC_LOAD_CLASSPATH = "ND4J_DYNAMIC_LOAD_CLASSPATH";
-    public final static String DYNAMIC_LOAD_CLASSPATH_PROPERTY = "org.nd4j.backend.dynamicbackend";
-    private static final Logger log = LoggerFactory.getLogger(Nd4jBackend.class);
+    /**
+     * @deprecated Use {@link ND4JEnvironmentVars#BACKEND_DYNAMIC_LOAD_CLASSPATH}
+     */
+    @Deprecated
+    public final static String DYNAMIC_LOAD_CLASSPATH = ND4JEnvironmentVars.BACKEND_DYNAMIC_LOAD_CLASSPATH;
+    /**
+     * @deprecated Use {@link ND4JSystemProperties#DYNAMIC_LOAD_CLASSPATH_PROPERTY}
+     */
+    @Deprecated
+    public final static String DYNAMIC_LOAD_CLASSPATH_PROPERTY = ND4JSystemProperties.DYNAMIC_LOAD_CLASSPATH_PROPERTY;
     private static boolean triedDynamicLoad = false;
 
     static {
         int n = 0;
-        String s = System.getenv("BACKEND_PRIORITY_CPU");
+        String s = System.getenv(ND4JEnvironmentVars.BACKEND_PRIORITY_CPU);
         if (s != null && s.length() > 0) {
             try {
                 n = Integer.parseInt(s);
@@ -82,7 +93,7 @@ public abstract class Nd4jBackend {
 
     static {
         int n = 100;
-        String s = System.getenv("BACKEND_PRIORITY_GPU");
+        String s = System.getenv(ND4JEnvironmentVars.BACKEND_PRIORITY_GPU);
         if (s != null && s.length() > 0) {
             try {
                 n = Integer.parseInt(s);
@@ -196,11 +207,11 @@ public abstract class Nd4jBackend {
         //ones being dynamically discovered.
         //Note that we prioritize jvm properties first, followed by environment variables.
         String[] jarUris;
-        if (System.getProperties().containsKey(DYNAMIC_LOAD_CLASSPATH_PROPERTY) && !triedDynamicLoad) {
-            jarUris = System.getProperties().getProperty(DYNAMIC_LOAD_CLASSPATH_PROPERTY).split(";");
+        if (System.getProperties().containsKey(ND4JSystemProperties.DYNAMIC_LOAD_CLASSPATH_PROPERTY) && !triedDynamicLoad) {
+            jarUris = System.getProperties().getProperty(ND4JSystemProperties.DYNAMIC_LOAD_CLASSPATH_PROPERTY).split(";");
         // Do not call System.getenv(): Accessing all variables requires higher security privileges
-        } else if (System.getenv(DYNAMIC_LOAD_CLASSPATH) != null && !triedDynamicLoad) {
-            jarUris = System.getenv(DYNAMIC_LOAD_CLASSPATH).split(";");
+        } else if (System.getenv(ND4JEnvironmentVars.BACKEND_DYNAMIC_LOAD_CLASSPATH) != null && !triedDynamicLoad) {
+            jarUris = System.getenv(ND4JEnvironmentVars.BACKEND_DYNAMIC_LOAD_CLASSPATH).split(";");
         }
 
         else

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/src/main/java/org/nd4j/parameterserver/distributed/VoidParameterServer.java
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/src/main/java/org/nd4j/parameterserver/distributed/VoidParameterServer.java
@@ -19,6 +19,7 @@ package org.nd4j.parameterserver.distributed;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.nd4j.config.ND4JEnvironmentVars;
 import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
@@ -360,7 +361,7 @@ public class VoidParameterServer {
 
         // last resort here...
         if (sparkIp == null)
-            sparkIp = System.getenv("DL4J_VOID_IP");
+            sparkIp = System.getenv(ND4JEnvironmentVars.DL4J_VOID_IP);
 
 
         log.info("Got [{}] as sparkIp", sparkIp);

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/src/main/java/org/nd4j/parameterserver/distributed/transport/RoutedTransport.java
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/src/main/java/org/nd4j/parameterserver/distributed/transport/RoutedTransport.java
@@ -26,6 +26,7 @@ import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.nd4j.config.ND4JSystemProperties;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.util.HashUtil;
 import org.nd4j.parameterserver.distributed.conf.VoidConfiguration;
@@ -56,8 +57,6 @@ import static java.lang.System.setProperty;
 @Slf4j
 public class RoutedTransport extends BaseTransport {
 
-    //Apparently buffer requirements are a multiple of this?? https://github.com/akka/akka/issues/21923#issuecomment-264707476
-    private static final String AERON_TERM_BUFFER_PROP = "aeron.term.buffer.length";
     private static final long DEFAULT_TERM_BUFFER_PROP = IntMath.pow(2,25); //32MB
 
     protected List<RemoteConnection> shards = new ArrayList<>();
@@ -84,9 +83,9 @@ public class RoutedTransport extends BaseTransport {
 
         // setting this property to try to increase maxmessage length, not sure if it still works though
         //Term buffer length: must be power of 2 and in range 64kB to 1GB: https://github.com/real-logic/aeron/wiki/Configuration-Options
-        String p = System.getProperty(AERON_TERM_BUFFER_PROP);
+        String p = System.getProperty(ND4JSystemProperties.AERON_TERM_BUFFER_PROP);
         if(p == null){
-            System.setProperty(AERON_TERM_BUFFER_PROP, String.valueOf(DEFAULT_TERM_BUFFER_PROP));
+            System.setProperty(ND4JSystemProperties.AERON_TERM_BUFFER_PROP, String.valueOf(DEFAULT_TERM_BUFFER_PROP));
         }
 
         context = new Aeron.Context().publicationConnectionTimeout(30000000000L).driverTimeoutMs(30000)


### PR DESCRIPTION
Moves primary ND4J system properties and environment variables to dedicated classes (in nd4j-common, so it's available to all modules).