### PR TITLE
importGraph overload

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/graphmapper/BaseGraphMapper.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/graphmapper/BaseGraphMapper.java
@@ -111,6 +111,17 @@ public abstract class BaseGraphMapper<GRAPH_TYPE,NODE_TYPE,ATTR_TYPE,TENSOR_TYPE
         return def;
     }
 
+
+    /**
+     *
+     * @param graphFile
+     * @return
+     */
+    @Override
+    public  SameDiff importGraph(String graphFile) {
+        return importGraph(new File(graphFile));
+    }
+
     /**
      *
      * @param graphFile

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/graphmapper/GraphMapper.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/graphmapper/GraphMapper.java
@@ -384,4 +384,11 @@ public interface GraphMapper<GRAPH_TYPE,NODE_TYPE,ATTR_TYPE,TENSOR_TYPE> {
      */
     SameDiff importGraph(GRAPH_TYPE tfGraph);
 
+    /**
+     * This method converts given TF graph file
+     * @param file
+     * @return
+     */
+    SameDiff importGraph(String graphFile);
+
 }


### PR DESCRIPTION
Add `ImportGraph(String)`  for easy access from jumpy. Some casting issues with other signatures.
