### PR TITLE
Fix for transposed PCA on CUDA

### DIFF
--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java
@@ -624,10 +624,13 @@ public class JcublasLapack extends BaseLapack {
 		int tmp1 = N ;
 		N = M ;
 		M = tmp1 ;
+        byte tmp2 = jobu;
+        jobu = jobvt;
+        jobvt = tmp2;
 
 		a = A.transpose().dup('f') ;
-		u = VT.dup('f') ;
-		vt = U.dup('f') ;
+		u = (VT == null) ? null : VT.transpose().dup('f');
+        vt = (U == null) ? null : U.transpose().dup('f');
 	} else {
 	        // cuda requires column ordering - we'll register a warning in case
        	 	if (A.ordering() == 'c')
@@ -675,8 +678,8 @@ public class JcublasLapack extends BaseLapack {
             // Do the actual decomp
             stat = cusolverDnSgesvd(solverDn, jobu, jobvt, M, N, (FloatPointer) xAPointer.getDevicePointer(), M,
                             new CudaPointer(allocator.getPointer(S, ctx)).asFloatPointer(),
-                            U == null ? null : new CudaPointer(allocator.getPointer(u, ctx)).asFloatPointer(), M,
-                            VT == null ? null : new CudaPointer(allocator.getPointer(vt, ctx)).asFloatPointer(), N,
+                            u == null ? null : new CudaPointer(allocator.getPointer(u, ctx)).asFloatPointer(), M,
+                            vt == null ? null : new CudaPointer(allocator.getPointer(vt, ctx)).asFloatPointer(), N,
                             new CudaPointer(workspace).asFloatPointer(), worksize,
                             new CudaPointer(allocator.getPointer(rwork, ctx)).asFloatPointer(),
                             new CudaPointer(allocator.getPointer(INFO, ctx)).asIntPointer());
@@ -687,21 +690,23 @@ public class JcublasLapack extends BaseLapack {
         allocator.registerAction(ctx, INFO);
         allocator.registerAction(ctx, S);
 
-	if (U != null)
-            	allocator.registerAction(ctx, u);
-	if (VT != null)
-		allocator.registerAction(ctx, vt);
+        if (u != null)
+            allocator.registerAction(ctx, u);
+        if (vt != null)
+            allocator.registerAction(ctx, vt);
 
-	// if we transposed A then swap & transpose U & V'
-	if( hadToTransposeA ) {
-		U.assign(vt.transpose());
-		VT.assign(u.transpose());
-	} else {
-		if (u != U)
-			U.assign(u);
-		if (vt != VT)
-			VT.assign(vt);
-	}
+        // if we transposed A then swap & transpose U & V'
+        if( hadToTransposeA ) {
+            if (vt != null)
+                U.assign(vt.transpose());
+            if (u != null)
+                VT.assign(u.transpose());
+        } else {
+            if (u != U)
+                U.assign(u);
+            if (vt != VT)
+                VT.assign(vt);
+        }
     }
 
 
@@ -725,10 +730,13 @@ public class JcublasLapack extends BaseLapack {
 		int tmp1 = N ;
 		N = M ;
 		M = tmp1 ;
+        byte tmp2 = jobu;
+        jobu = jobvt;
+        jobvt = tmp2;
 
 		a = A.transpose().dup('f') ;
-		u = VT.dup('f') ;
-		vt = U.dup('f') ;
+		u = (VT == null) ? null : VT.transpose().dup('f');
+        vt = (U == null) ? null : U.transpose().dup('f');
 	} else {
 	        // cuda requires column ordering - we'll register a warning in case
        	 	if (A.ordering() == 'c')
@@ -781,8 +789,8 @@ public class JcublasLapack extends BaseLapack {
             // Do the actual decomp
             stat = cusolverDnDgesvd(solverDn, jobu, jobvt, M, N, (DoublePointer) xAPointer.getDevicePointer(), M,
                             new CudaPointer(allocator.getPointer(S, ctx)).asDoublePointer(),
-                            U == null ? null : new CudaPointer(allocator.getPointer(u, ctx)).asDoublePointer(), M,
-                            VT == null ? null : new CudaPointer(allocator.getPointer(vt, ctx)).asDoublePointer(), N,
+                            u == null ? null : new CudaPointer(allocator.getPointer(u, ctx)).asDoublePointer(), M,
+                            vt == null ? null : new CudaPointer(allocator.getPointer(vt, ctx)).asDoublePointer(), N,
                             new CudaPointer(workspace).asDoublePointer(), worksize,
                             new CudaPointer(allocator.getPointer(rwork, ctx)).asDoublePointer(),
                             new CudaPointer(allocator.getPointer(INFO, ctx)).asIntPointer());
@@ -795,22 +803,24 @@ public class JcublasLapack extends BaseLapack {
         allocator.registerAction(ctx, S);
         allocator.registerAction(ctx, a);
 
-        if (U != null)
+        if (u != null)
             allocator.registerAction(ctx, u);
 
-        if (VT != null)
+        if (vt != null)
             allocator.registerAction(ctx, vt);
 
-	// if we transposed A then swap & transpose U & V'
-	if( hadToTransposeA ) {
-		U.assign(vt.transpose());
-		VT.assign(u.transpose());
-	} else {
-		if (u != U)
-			U.assign(u);
-		if (vt != VT)
-			VT.assign(vt);
-	}
+        // if we transposed A then swap & transpose U & V'
+        if( hadToTransposeA ) {
+            if (vt != null)
+                U.assign(vt.transpose());
+            if (u != null)
+                VT.assign(u.transpose());
+        } else {
+            if (u != U)
+                U.assign(u);
+            if (vt != VT)
+                VT.assign(vt);
+        }
     }
 
     public int ssyev( char _jobz, char _uplo, int N, INDArray A, INDArray R ) {

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dimensionalityreduction/TestPCA.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dimensionalityreduction/TestPCA.java
@@ -61,7 +61,29 @@ public class TestPCA extends BaseNd4jTest {
             assertEquals("Reconstructed matrix is very different from the original.", 0.0, Diff.getDouble(i), 1.0);
         }
     }
+    
+    @Test
+    public void testFactorSVDTransposed() {
+        int m = 4;
+        int n = 13;
 
+        double f[] = new double[] {7, 1, 11, 11, 7, 11, 3, 1, 2, 21, 1, 11, 10, 26, 29, 56, 31, 52, 55, 71, 31, 54, 47,
+                        40, 66, 68, 6, 15, 8, 8, 6, 9, 17, 22, 18, 4, 23, 9, 8, 60, 52, 20, 47, 33, 22, 6, 44, 22, 26,
+                        34, 12, 12};
+
+        INDArray A = Nd4j.create(f, new int[] {m, n}, 'f');
+
+        INDArray A1 = A.dup('f');
+        INDArray factor = org.nd4j.linalg.dimensionalityreduction.PCA.pca_factor(A1, 3, true);
+        A1 = A.subiRowVector(A.mean(0));
+
+        INDArray reduced = A1.mmul(factor);
+        INDArray reconstructed = reduced.mmul(factor.transpose());
+        INDArray diff = reconstructed.sub(A1);
+        for (int i = 0; i < m * n; i++) {
+            assertEquals("Reconstructed matrix is very different from the original.", 0.0, diff.getDouble(i), 1.0);
+        }
+    }
 
     @Test
     public void testFactorVariance() {


### PR DESCRIPTION
In [JcublasLapack](https://github.com/deeplearning4j/deeplearning4j/blob/152a425b93700db27deb1f9be45fd78c2b13ef09/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java#L615) implementation, singular value decomposition is being calculated on transposed matrices in some cases:
```
        // we should transpose & adjust outputs if M<N
	// cuda has a limitation, but it's OK we know
	// 	A = U S V'
	// transpose multiply rules give us ...
	// 	A' = V S' U'
```

However, [PCA](https://github.com/deeplearning4j/deeplearning4j/blob/152a425b93700db27deb1f9be45fd78c2b13ef09/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/PCA.java#L187) calls this function with `U = null`:
```
        // Note - we don't care about U 
        Nd4j.getBlasWrapper().lapack().gesvd(A, s, null, VT);
```

This leads to to a `NullPointerException` in [line 630](https://github.com/deeplearning4j/deeplearning4j/blob/152a425b93700db27deb1f9be45fd78c2b13ef09/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/blas/JcublasLapack.java#L630) if `M<N`:
```
		vt = U.dup('f') ;
```

This PR adds a UnitTest for this case and fix for the SVD implementation in JCublas backend. With CPU backend, everything looks good.