### PR TITLE
ND4J: Move nd4j-native test dependencies into profiles

### DIFF
--- a/jumpy/pom.xml
+++ b/jumpy/pom.xml
@@ -81,6 +81,38 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <forceCreation>true</forceCreation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>empty-javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${basedir}/javadoc</classesDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>empty-sources-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>sources</classifier>
+                            <classesDirectory>${basedir}/src</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nd4j/nd4j-jdbc/nd4j-jdbc-hsql/pom.xml
+++ b/nd4j/nd4j-jdbc/nd4j-jdbc-hsql/pom.xml
@@ -60,6 +60,7 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
             <dependencies>
                 <dependency>
                     <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-jdbc/nd4j-jdbc-hsql/pom.xml
+++ b/nd4j/nd4j-jdbc/nd4j-jdbc-hsql/pom.xml
@@ -40,12 +40,6 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-dbutils</groupId>
             <artifactId>commons-dbutils</artifactId>
             <version>${commons-db.version}</version>
@@ -66,6 +60,14 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-client/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-client/pom.xml
@@ -98,6 +98,7 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
             <dependencies>
                 <dependency>
                     <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-client/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-client/pom.xml
@@ -83,19 +83,6 @@
         </dependency>
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <classifier>${javacpp.platform}</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
             <artifactId>nd4j-parameter-server</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -111,6 +98,21 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <classifier>${javacpp.platform}</classifier>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/pom.xml
@@ -31,12 +31,6 @@
     <dependencies>
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
             <artifactId>nd4j-parameter-server-client</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -60,6 +54,14 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-node/pom.xml
@@ -54,6 +54,7 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
             <dependencies>
                 <dependency>
                     <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server/pom.xml
@@ -90,6 +90,7 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
             <dependencies>
                 <dependency>
                     <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server/pom.xml
@@ -82,19 +82,6 @@
 
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <classifier>${javacpp.platform}</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
             <artifactId>nd4j-aeron</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -103,6 +90,21 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <classifier>${javacpp.platform}</classifier>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/nd4j/nd4j-serde/nd4j-aeron/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-aeron/pom.xml
@@ -49,6 +49,7 @@
     </profile>
     <profile>
       <id>testresources</id>
+      <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
       <dependencies>
         <dependency>
           <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-serde/nd4j-aeron/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-aeron/pom.xml
@@ -49,17 +49,19 @@
     </profile>
     <profile>
       <id>testresources</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.nd4j</groupId>
+          <artifactId>nd4j-native</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 
 
   <dependencies>
-    <dependency>
-      <groupId>org.nd4j</groupId>
-      <artifactId>nd4j-native</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.nd4j</groupId>
       <artifactId>nd4j-api</artifactId>

--- a/nd4j/nd4j-serde/nd4j-arrow/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-arrow/pom.xml
@@ -105,6 +105,7 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
             <dependencies>
                 <dependency>
                     <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-serde/nd4j-arrow/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-arrow/pom.xml
@@ -37,12 +37,6 @@
         </dependency>
         <dependency>
             <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.nd4j</groupId>
             <artifactId>nd4j-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -111,6 +105,14 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/nd4j/nd4j-serde/nd4j-gson/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-gson/pom.xml
@@ -44,13 +44,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
           <version>${junit.version}</version>
@@ -61,6 +54,14 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 

--- a/nd4j/nd4j-serde/nd4j-gson/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-gson/pom.xml
@@ -54,6 +54,7 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
             <dependencies>
                 <dependency>
                     <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-serde/nd4j-kryo/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-kryo/pom.xml
@@ -90,6 +90,7 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <!-- Put nd4j-native in profile so that CUDA-only builds succeed -->
             <dependencies>
                 <dependency>
                     <groupId>org.nd4j</groupId>

--- a/nd4j/nd4j-serde/nd4j-kryo/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-kryo/pom.xml
@@ -80,13 +80,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.nd4j</groupId>
-            <artifactId>nd4j-native</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
           <version>${junit.version}</version>
@@ -97,6 +90,14 @@
     <profiles>
         <profile>
             <id>testresources</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,88 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <id>agibsonccc</id>
+            <name>Adam Gibson</name>
+            <email>adam@skymind.io</email>
+        </developer>
+        <developer>
+            <id>chrisvnicholson</id>
+            <name>Chris Nicholson</name>
+            <email>chris@skymind.io</email>
+        </developer>
+        <developer>
+            <id>jpatanooga</id>
+            <name>Josh Patterson</name>
+        </developer>
+        <developer>
+            <id>AlexDBlack</id>
+            <name>Alex Black</name>
+        </developer>
+        <developer>
+            <id>nyghtowl</id>
+            <name>Melanie Warrick</name>
+        </developer>
+        <developer>
+            <id>raver119</id>
+            <name>raver119</name>
+        </developer>
+        <developer>
+            <id>saudet</id>
+            <name>Samuel Audet</name>
+        </developer>
+        <developer>
+            <id>eraly</id>
+            <name>Susan Eraly</name>
+        </developer>
+        <developer>
+            <id>kepricon</id>
+            <name>Daehyun Kim</name>
+        </developer>
+        <developer>
+            <id>turambar</id>
+            <name>Dave kale</name>
+        </developer>
+        <!--current & previous core contributers and company developers-->
+        <developer>
+            <id>rubenfiszel</id>
+            <name>Ruben Fiszel</name>
+        </developer>
+        <developer>
+            <id>smarthi</id>
+            <name>Suneel Marthi</name>
+        </developer>
+        <developer>
+            <id>taisukeoe</id>
+            <name>Taisuke Oe</name>
+        </developer>
+        <developer>
+            <id>treo</id>
+            <name>Paul Dubs</name>
+        </developer>
+        <developer>
+            <id>EronWright</id>
+            <name>Eron Wright</name>
+        </developer>
+        <developer>
+            <id>jyt109</id>
+            <name>Jeffrey Tang</name>
+        </developer>
+        <developer>
+            <id>sonaliii</id>
+            <name>Sonali Dayal</name>
+        </developer>
+        <developer>
+            <id>emmjaykay</id>
+            <name>emmjaykay</name>
+        </developer>
+        <developer>
+            <id>crockpotveggies</id>
+            <name>Justin Long</name>
+        </developer>
+    </developers>
+
     <modules>
         <module>libnd4j</module>
         <module>nd4j</module>


### PR DESCRIPTION
To fix build issues when building for the CUDA backend only.

`mvn -nsu dependency:tree -Dmaven.test.skip` and `mvn -nsu dependency:tree -Ptestresources` relieves the changes to be effective.