### PR TITLE
[WIP] DL4J: Javadoc pass

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/constraint/NonNegativeConstraint.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/constraint/NonNegativeConstraint.java
@@ -23,7 +23,7 @@ import org.nd4j.linalg.indexing.BooleanIndexing;
 import org.nd4j.linalg.indexing.conditions.Conditions;
 
 /**
- * Constrain the weights to be non-negative
+ * Constrain the parameters to be non-negative. All values less than zero will be set to 0.0
  *
  * @author Alex Black
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/BinomialDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/BinomialDistribution.java
@@ -20,8 +20,7 @@ import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A binomial distribution.
- * This is based on the interface from apache commons math.
+ * A binomial distribution, with 2 parameters: number of trials, and probability of success
  *
  * @author Adam Gibson
  *

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/ConstantDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/ConstantDistribution.java
@@ -16,13 +16,17 @@
 
 package org.deeplearning4j.nn.conf.distribution;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * Constant distribution.
+ * Constant distribution: a "distribution" where all values are set to the specified constant
  *
  */
+@Data
+@EqualsAndHashCode(callSuper = false)
 public class ConstantDistribution extends Distribution {
 
     private double value;
@@ -35,38 +39,6 @@ public class ConstantDistribution extends Distribution {
     @JsonCreator
     public ConstantDistribution(@JsonProperty("value") double value) {
         this.value = value;
-    }
-
-    public double getValue() {
-        return value;
-    }
-
-    public void setValue(double value) {
-        this.value = value;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(value);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ConstantDistribution other = (ConstantDistribution) obj;
-        if (Double.doubleToLongBits(value) != Double.doubleToLongBits(other.value))
-            return false;
-        return true;
     }
 
     public String toString() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/Distributions.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/Distributions.java
@@ -19,7 +19,7 @@ package org.deeplearning4j.nn.conf.distribution;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
- * Static method for instantiating an nd4j distribution from a configuration object.
+ * Static methods for instantiating an nd4j distribution from a DL4J distribution configuration object.
  *
  */
 public class Distributions {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/GaussianDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/GaussianDistribution.java
@@ -20,9 +20,11 @@ import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A normal distribution.
+ * A normal (Gaussian) distribution, with two parameters: mean and standard deviation
+ *
+ * @deprecated Use {@link NormalDistribution} which is identical to this implementation
  */
-
+@Deprecated
 public class GaussianDistribution extends NormalDistribution {
 
     /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/LogNormalDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/LogNormalDistribution.java
@@ -16,13 +16,19 @@
 
 package org.deeplearning4j.nn.conf.distribution;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A log-normal distribution.
+ * A log-normal distribution, with two parameters: mean and standard deviation.
+ * Note: the mean and standard deviation are for the logarithm of the values.
+ * Put another way: if X~LogN(M,S), then mean(log(X))=M, and stdev(log(X))=S
  *
  */
+@EqualsAndHashCode(callSuper = false)
+@Data
 public class LogNormalDistribution extends Distribution {
 
     private double mean, std;
@@ -38,50 +44,6 @@ public class LogNormalDistribution extends Distribution {
     public LogNormalDistribution(@JsonProperty("mean") double mean, @JsonProperty("std") double std) {
         this.mean = mean;
         this.std = std;
-    }
-
-    public double getMean() {
-        return mean;
-    }
-
-    public void setMean(double mean) {
-        this.mean = mean;
-    }
-
-    public double getStd() {
-        return std;
-    }
-
-    public void setStd(double std) {
-        this.std = std;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(mean);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        temp = Double.doubleToLongBits(std);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LogNormalDistribution other = (LogNormalDistribution) obj;
-        if (Double.doubleToLongBits(mean) != Double.doubleToLongBits(other.mean))
-            return false;
-        if (Double.doubleToLongBits(std) != Double.doubleToLongBits(other.std))
-            return false;
-        return true;
     }
 
     public String toString() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/NormalDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/NormalDistribution.java
@@ -16,13 +16,17 @@
 
 package org.deeplearning4j.nn.conf.distribution;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A normal distribution.
+ * A normal (Gaussian) distribution, with two parameters: mean and standard deviation
  *
  */
+@EqualsAndHashCode(callSuper = false)
+@Data
 public class NormalDistribution extends Distribution {
 
     private double mean, std;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/OrthogonalDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/OrthogonalDistribution.java
@@ -16,13 +16,18 @@
 
 package org.deeplearning4j.nn.conf.distribution;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * Orthogonal distribution.
+ * Orthogonal distribution, with gain parameter.<br>
+ * See <a href="http://arxiv.org/abs/1312.6120">http://arxiv.org/abs/1312.6120</a> for details
  *
  */
+@EqualsAndHashCode(callSuper = false)
+@Data
 public class OrthogonalDistribution extends Distribution {
 
     private double gain;
@@ -36,38 +41,6 @@ public class OrthogonalDistribution extends Distribution {
     @JsonCreator
     public OrthogonalDistribution(@JsonProperty("gain") double gain) {
         this.gain = gain;
-    }
-
-    public double getGain() {
-        return gain;
-    }
-
-    public void setGain(double gain) {
-        this.gain = gain;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(gain);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        OrthogonalDistribution other = (OrthogonalDistribution) obj;
-        if (Double.doubleToLongBits(gain) != Double.doubleToLongBits(other.gain))
-            return false;
-        return true;
     }
 
     public String toString() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/TruncatedNormalDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/TruncatedNormalDistribution.java
@@ -16,13 +16,18 @@
 
 package org.deeplearning4j.nn.conf.distribution;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A truncated normal distribution.
- *
+ * A truncated normal distribution, with 2 parameters: mean and standard deviation<br>
+ * This distribution is a standard normal/Gaussian distribtion, however values are "truncated" in the sense that any
+ * values that fall outside the range [mean - 2 * stdev, mean + 2 * stdev] are re-sampled.
  */
+@EqualsAndHashCode(callSuper = false)
+@Data
 public class TruncatedNormalDistribution extends Distribution {
 
     private double mean, std;
@@ -38,50 +43,6 @@ public class TruncatedNormalDistribution extends Distribution {
     public TruncatedNormalDistribution(@JsonProperty("mean") double mean, @JsonProperty("std") double std) {
         this.mean = mean;
         this.std = std;
-    }
-
-    public double getMean() {
-        return mean;
-    }
-
-    public void setMean(double mean) {
-        this.mean = mean;
-    }
-
-    public double getStd() {
-        return std;
-    }
-
-    public void setStd(double std) {
-        this.std = std;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(mean);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        temp = Double.doubleToLongBits(std);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        TruncatedNormalDistribution other = (TruncatedNormalDistribution) obj;
-        if (Double.doubleToLongBits(mean) != Double.doubleToLongBits(other.mean))
-            return false;
-        if (Double.doubleToLongBits(std) != Double.doubleToLongBits(other.std))
-            return false;
-        return true;
     }
 
     public String toString() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/UniformDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/distribution/UniformDistribution.java
@@ -16,15 +16,19 @@
 
 package org.deeplearning4j.nn.conf.distribution;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.math3.exception.NumberIsTooLargeException;
 import org.apache.commons.math3.exception.util.LocalizedFormats;
 import org.nd4j.shade.jackson.annotation.JsonCreator;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A uniform distribution.
+ * A uniform distribution, with two parameters: lower and upper - i.e., U(lower,upper)
  *
  */
+@EqualsAndHashCode(callSuper = false)
+@Data
 public class UniformDistribution extends Distribution {
 
     private double upper, lower;
@@ -48,51 +52,7 @@ public class UniformDistribution extends Distribution {
         this.upper = upper;
     }
 
-    public double getUpper() {
-        return upper;
-    }
-
-    public void setUpper(double upper) {
-        this.upper = upper;
-    }
-
-    public double getLower() {
-        return lower;
-    }
-
-    public void setLower(double lower) {
-        this.lower = lower;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        long temp;
-        temp = Double.doubleToLongBits(lower);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        temp = Double.doubleToLongBits(upper);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        UniformDistribution other = (UniformDistribution) obj;
-        if (Double.doubleToLongBits(lower) != Double.doubleToLongBits(other.lower))
-            return false;
-        if (Double.doubleToLongBits(upper) != Double.doubleToLongBits(other.upper))
-            return false;
-        return true;
-    }
-
     public String toString() {
-        return "UniformDistribution{" + "lower=" + lower + ", upper=" + upper + '}';
+        return "UniformDistribution(lower=" + lower + ", upper=" + upper + ")";
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/dropout/DropoutHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/dropout/DropoutHelper.java
@@ -16,15 +16,34 @@
 
 package org.deeplearning4j.nn.conf.dropout;
 
-import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
+/**
+ * A helper interface for native dropout implementations
+ *
+ * @author Alex Black
+ */
 public interface DropoutHelper {
 
+    /**
+     * @return Check if this dropout helper is supported in the current environment
+     */
     boolean checkSupported();
 
+    /**
+     * Apply the dropout during forward pass
+     * @param inputActivations       Input activations (pre dropout)
+     * @param resultArray            Output activations (post dropout). May be same as (or different to) input array
+     * @param dropoutInputRetainProb Probability of retaining an activation
+     */
     void applyDropout(INDArray inputActivations, INDArray resultArray, double dropoutInputRetainProb);
 
+    /**
+     * Perform backpropagation. Note that the same dropout mask should be used for backprop as was used during the last
+     * call to {@link #applyDropout(INDArray, INDArray, double)}
+     * @param gradAtOutput Gradient at output (from perspective of forward pass)
+     * @param gradAtInput  Result array - gradient at input. May be same as (or different to) gradient at input
+     */
     void backprop(INDArray gradAtOutput, INDArray gradAtInput);
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/dropout/SpatialDropout.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/dropout/SpatialDropout.java
@@ -32,12 +32,15 @@ import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * Spatial dropout: can only be applied to 4D (convolutional) activations.
- * Dropout mask is generated along the depth dimension, and is applied to each x/y location in an image.<br>
+ * Spatial dropout: can only be applied to 3D (time series), 4D (convolutional 2D) or 5D (convolutional 3D) activations.
+ * Dropout mask is generated along the depth dimension, and is applied to:<br>
+ * For 3D/time series/sequence input: each step in the sequence<br>
+ * For 4D (CNN 2D) input: each x/y location in an image.<br>
+ * For 5D (CNN 3D) input: each x/y/z location in a volume<br>
  * Note that the dropout mask is generated independently for each example: i.e., a dropout mask of shape [minibatch, channels]
  * is generated and applied to activations of shape [minibatch, channels, height, width]
  * <p>
- * Reference: Efficient Object Localization Using Convolutional Networks: https://arxiv.org/abs/1411.4280
+ * Reference: Efficient Object Localization Using Convolutional Networks: <a href="https://arxiv.org/abs/1411.4280">https://arxiv.org/abs/1411.4280</a>
  *
  * @author Alex Black
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ElementWiseVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ElementWiseVertex.java
@@ -28,14 +28,19 @@ import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
  * An ElementWiseVertex is used to combine the activations of two or more layer in an element-wise manner<br>
- * For example, the activations may be combined by addition, subtraction or multiplication or by selecting the maximum.
- * Addition, Average, Max and Product may use an arbitrary number of input arrays. Note that in the case of subtraction, only two inputs may be used.
+ * For example, the activations may be combined by addition, subtraction, multiplication (product), average or by
+ * selecting the maximum.<br>
+ * Addition, Average, Max and Product may use an arbitrary number of input arrays. Note that in the case of subtraction,
+ * only two inputs may be used.
  *
  * @author Alex Black
  */
 @Data
 public class ElementWiseVertex extends GraphVertex {
 
+    /**
+     * @param op The operation to perform on the inputs
+     */
     public ElementWiseVertex(@JsonProperty("op") Op op) {
         this.op = op;
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/FrozenVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/FrozenVertex.java
@@ -31,9 +31,12 @@ import org.nd4j.linalg.learning.config.NoOp;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * FrozenVertex is used for the purposes of transfer learning
- * A frozen layers wraps another DL4J GraphVertex within it.
+ * FrozenVertex is used for the purposes of transfer learning.<br>
+ * A frozen vertex wraps another DL4J GraphVertex within it.
  * During backprop, the FrozenVertex is skipped, and any parameters are not be updated.
+ * Usually users will typically not create FrozenVertex instances directly - they are usually used in the process of performing
+ * transfer learning
+ *
  * @author Alex Black
  */
 @Data

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/GraphVertex.java
@@ -31,8 +31,8 @@ import org.nd4j.shade.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 
 /**
- * A GraphVertex is a vertex in the computation graph. It may contain Layer, or define some arbitrary forward/backward pass
- * behaviour based on the inputs
+ * A GraphVertex is a vertex in the computation graph type of neural network. It may contain Layer, or define some
+ * arbitrary forward/backward pass behaviour based on the inputs. GraphVertex instances may also have trainable parameters.
  *
  * @author Alex Black
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/L2NormalizeVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/L2NormalizeVertex.java
@@ -27,10 +27,11 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * L2NormalizeVertex performs L2 normalization on a single input.
+ * L2NormalizeVertex performs L2 normalization on a single input, along the specified dimensions.
+ * L2 normalization is defined as: out = in / l2Norm(in)<br>
  *
  * Can be configured to normalize a single dimension, or normalize across
- * all dimensions except zero by leaving dimension blank or setting it to -1.
+ * all dimensions except dimensions zero (i.e., the minibatch dimension) by leaving dimension blank or setting it to -1.
  *
  * @author Justin Long (crockpotveggies)
  * @author Alex Black (AlexDBlack)

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/L2Vertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/L2Vertex.java
@@ -26,7 +26,11 @@ import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
- * L2Vertex calculates the L2 least squares error of two inputs.
+ * L2Vertex calculates the L2 (Euclidean) least squares error of two inputs, on a per-example basis.
+ * It outputs a single value for each input - i.e., for input [minibatch,X] it outputs shape [minibatch,1]
+ * where each value {@code out[i,0] = l2Distance(in1[i,...], in2[i,...])}<br>
+ * Note however than epsilon value (1e-8 by default) will be added to inputs to avoid the gradient being undefined
+ * for all zero inputs
  *
  * For example, in Triplet Embedding you can input an anchor and a pos/neg class and use two parallel
  * L2 vertices to calculate two real numbers which can be fed into a LossLayer to calculate TripletLoss.
@@ -36,10 +40,16 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 public class L2Vertex extends GraphVertex {
     protected double eps;
 
+    /**
+     * Constructor with default epsilon value of 1e-8
+     */
     public L2Vertex() {
         this.eps = 1e-8;
     }
 
+    /**
+     * @param eps Epsilon value to add to inputs (to avoid all zeros input and hence undefined gradients)
+     */
     public L2Vertex(double eps) {
         this.eps = eps;
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/MergeVertex.java
@@ -27,11 +27,11 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 
 /** A MergeVertex is used to combine the activations of two or more layers/GraphVertex by means of concatenation/merging.<br>
  * Exactly how this is done depends on the type of input.<br>
- * For 2d (feed forward layer) inputs: MergeVertex([numExamples,layerSize1],[numExamples,layerSize2]) -> [numExamples,layerSize1 + layerSize2]<br>
- * For 3d (time series) inputs: MergeVertex([numExamples,layerSize1,timeSeriesLength],[numExamples,layerSize2,timeSeriesLength])
- *      -> [numExamples,layerSize1 + layerSize2,timeSeriesLength]<br>
- * For 4d (convolutional) inputs: MergeVertex([numExamples,depth1,width,height],[numExamples,depth2,width,height])
- *      -> [numExamples,depth1 + depth2,width,height]<br>
+ * For 2d (feed forward layer) inputs: {@code MergeVertex([numExamples,layerSize1],[numExamples,layerSize2]) -> [numExamples,layerSize1 + layerSize2]}<br>
+ * For 3d (time series) inputs: {@code MergeVertex([numExamples,layerSize1,timeSeriesLength],[numExamples,layerSize2,timeSeriesLength])
+ *      -> [numExamples,layerSize1 + layerSize2,timeSeriesLength]}<br>
+ * For 4d (convolutional) inputs: {@code MergeVertex([numExamples,depth1,width,height],[numExamples,depth2,width,height])
+ *      -> [numExamples,depth1 + depth2,width,height]}<br>
  * @author Alex Black
  */
 public class MergeVertex extends GraphVertex {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/PoolHelperVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/PoolHelperVertex.java
@@ -27,7 +27,8 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
  * Removes the first column and row from an input. This is to fix inconsistencies from ZeroPadding
- * layers in imported models from Caffe. See https://gist.github.com/joelouismarino/a2ede9ab3928f999575423b9887abd14.
+ * layers in imported models from Caffe.<br>
+ * See <a href="https://gist.github.com/joelouismarino/a2ede9ab3928f999575423b9887abd14">https://gist.github.com/joelouismarino/a2ede9ab3928f999575423b9887abd14</a>.
  *
  * @author Justin Long (crockpotveggies)
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/PreprocessorVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/PreprocessorVertex.java
@@ -27,8 +27,10 @@ import org.deeplearning4j.nn.conf.memory.MemoryReport;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
-/** PreprocessorVertex is a simple adaptor class that allows a {@link InputPreProcessor} to be used in a ComputationGraph
+/**
+ * PreprocessorVertex is a simple adaptor class that allows a {@link InputPreProcessor} to be used in a ComputationGraph
  * GraphVertex, without it being associated with a layer.
+ *
  * @author Alex Black
  */
 @NoArgsConstructor
@@ -78,16 +80,8 @@ public class PreprocessorVertex extends GraphVertex {
 
     @Override
     public org.deeplearning4j.nn.graph.vertex.GraphVertex instantiate(ComputationGraph graph, String name, int idx,
-                    INDArray paramsView, boolean initializeParams) {
+                                                                      INDArray paramsView, boolean initializeParams) {
         return new org.deeplearning4j.nn.graph.vertex.impl.PreprocessorVertex(graph, name, idx, preProcessor);
-    }
-
-    @Override
-    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
-        if (vertexInputs.length != 1)
-            throw new InvalidInputTypeException("Invalid input: Preprocessor vertex expects " + "exactly one input");
-
-        return preProcessor.getOutputType(vertexInputs[0]);
     }
 
     @Override
@@ -96,8 +90,16 @@ public class PreprocessorVertex extends GraphVertex {
 
         InputType outputType = getOutputType(-1, inputTypes);
         return new LayerMemoryReport.Builder(null, PreprocessorVertex.class, inputTypes[0], outputType)
-                        .standardMemory(0, 0) //No params
-                        .workingMemory(0, 0, 0, 0).cacheMemory(0, 0) //No caching
-                        .build();
+                .standardMemory(0, 0) //No params
+                .workingMemory(0, 0, 0, 0).cacheMemory(0, 0) //No caching
+                .build();
+    }
+
+    @Override
+    public InputType getOutputType(int layerIndex, InputType... vertexInputs) throws InvalidInputTypeException {
+        if (vertexInputs.length != 1)
+            throw new InvalidInputTypeException("Invalid input: Preprocessor vertex expects " + "exactly one input");
+
+        return preProcessor.getOutputType(vertexInputs[0]);
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ReshapeVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ReshapeVertex.java
@@ -22,6 +22,7 @@ import org.deeplearning4j.nn.conf.inputs.InvalidInputTypeException;
 import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
 import org.deeplearning4j.nn.conf.memory.MemoryReport;
 import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.nd4j.base.Preconditions;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
@@ -43,12 +44,22 @@ public class ReshapeVertex extends GraphVertex {
     protected int[] newShape;
     protected int[] maskShape;
 
+    /**
+     * Reshape with the default reshape order of 'c'
+     * @param newShape New shape for activations
+     */
     public ReshapeVertex(int... newShape){
         this(DEFAULT_RESHAPE_ORDER, newShape, null);
     }
 
+    /**
+     * @param reshapeOrder Order (must be 'c' or 'f') for the activations
+     * @param newShape     New shape
+     * @param maskShape    Mask shape
+     */
     public ReshapeVertex(@JsonProperty("reshapeOrder") char reshapeOrder, @JsonProperty("newShape") int[] newShape,
                          @JsonProperty("maskShape") int[] maskShape) {
+        Preconditions.checkState(reshapeOrder == 'c' || reshapeOrder == 'f', "Reshape order must be 'c' or 'f'. Got: '%s'", String.valueOf(reshapeOrder));
         this.reshapeOrder = reshapeOrder;
         this.newShape = newShape;
         this.maskShape = maskShape;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ScaleVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ScaleVertex.java
@@ -26,15 +26,18 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A ScaleVertex is used to scale the size of activations of a single layer<br>
- * For example, ResNet activations can be scaled in repeating blocks to keep variance
- * under control.
+ * A ScaleVertex is used to scale the size of activations of a single layer: this is simply multiplication by a
+ * fixed scalar value<br>
+ * For example, ResNet activations can be scaled in repeating blocks to keep variance under control.
  *
  * @author Justin Long (@crockpotveggies)
  */
 @Data
 public class ScaleVertex extends GraphVertex {
 
+    /**
+     * @param scaleFactor The scaling factor to multiply input activations by
+     */
     public ScaleVertex(@JsonProperty("scaleFactor") double scaleFactor) {
         this.scaleFactor = scaleFactor;
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ShiftVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/ShiftVertex.java
@@ -29,18 +29,19 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
 
 /**
- * A ShiftVertex is used to shift the activations of a single layer<br>
+ * A ShiftVertex is used to shift the activations of a single layer. It is addition of a scalar value.<br>
  * One could use it to add a bias or as part of some other calculation.
  * For example, Highway Layers need them in two places. One, it's often
  * useful to have the gate weights have a large negative bias. (Of course
  * for this, we could just initialize the biases that way.)
  * But, _also_ it needs to do this:
- * (1-sigmoid(weight * input + bias)) (*) input + sigmoid(weight * input + bias) (*) activation(w2 * input + bias) ((*) is hadamard product)
- * So, here, we could have
- * 1. a DenseLayer that does the sigmoid
- * 2. a ScaleVertex(-1) and
- * 3. a ShiftVertex(1)
- * to accomplish that.
+ * {@code (1-sigmoid(weight * input + bias)) (*) input + sigmoid(weight * input + bias) (*) activation(w2 * input + bias) ((*) is hadamard product)}
+ * <br>
+ * So, here, we could have:<br>
+ * 1. a DenseLayer that does the sigmoid<br>
+ * 2. a ScaleVertex(-1) and<br>
+ * 3. a ShiftVertex(1)<br>
+ * to accomplish that.<br>
  *
  * @author Binesh Bannerjee (binesh_binesh@hotmail.com, @bnsh on gitter)
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/StackVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/StackVertex.java
@@ -26,9 +26,10 @@ import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 /**
- * StackVertex allows for stacking of inputs so that they may be forwarded through
- * a network. This is useful for cases such as Triplet Embedding, where shared parameters
- * are not supported by the network.
+ * StackVertex allows for stacking of inputs so that they may be forwarded through a network.
+ * This is useful for cases such as Triplet Embedding, where shared parameters are not supported by the network.
+ * Note that stacking occurs along dimension 0: so if 2 inputs both have shape {@code [mb,x]}, the the output
+ * after stacking has shape {@code [2*mb,x]}. Can be used for
  *
  * @author Justin Long (crockpotveggies)
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/SubsetVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/graph/SubsetVertex.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
  * For example, a subset of the activations out of a layer.<br>
  * Note that this subset is specifying by means of an interval of the original activations.
  * For example, to get the first 10 activations of a layer (or, first 10 features out of a CNN layer) use
- * new SubsetVertex(0,9).<br>
+ * {@code new SubsetVertex(0,9)}<br>
  * In the case of convolutional (4d) activations, this is done along channels.
  *
  * @author Alex Black

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/inputs/InvalidInputTypeException.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/inputs/InvalidInputTypeException.java
@@ -17,7 +17,8 @@
 package org.deeplearning4j.nn.conf.inputs;
 
 
-/** InvalidInputTypeException: Thrown if the GraphVertex cannot handle the type of input provided.
+/**
+ * InvalidInputTypeException: Thrown if the GraphVertex cannot handle the type of input provided.
  */
 public class InvalidInputTypeException extends RuntimeException {
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
@@ -61,6 +61,9 @@ public class Cropping1D extends NoParamLayer {
         this(new Builder(cropTop, cropBottom));
     }
 
+    /**
+     * @param cropping Cropping as a length 2 array, with values {@code [cropTop, cropBottom]}
+     */
     public Cropping1D(int[] cropping) {
         this(new Builder(cropping));
     }
@@ -117,7 +120,7 @@ public class Cropping1D extends NoParamLayer {
         }
 
         /**
-         * @param cropping Cropping amount for top/bottom(in that order). Must be length 1 or 2 array.
+         * @param cropping Cropping amount for top/bottom (in that order). Must be length 1 or 2 array.
          */
         public Builder(@NonNull int[] cropping) {
             Preconditions.checkArgument(cropping.length == 2 || cropping.length == 1,

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
@@ -68,6 +68,10 @@ public class Cropping2D extends NoParamLayer {
         this(new Builder(cropTop, cropBottom, cropLeft, cropRight));
     }
 
+    /**
+     * @param cropping Cropping as either a length 2 array, with values {@code [cropTopBottom, cropLeftRight]},
+     *                 or as a length 4 array, with values {@code [cropTop, cropBottom, cropLeft, cropRight]}
+     */
     public Cropping2D(int[] cropping) {
         this(new Builder(cropping));
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
@@ -75,6 +75,10 @@ public class Cropping3D extends NoParamLayer {
         this(new Builder(cropLeftD, cropRightD, cropLeftH, cropRightH, cropLeftW, cropRightW));
     }
 
+    /**
+     * @param cropping Cropping as either a length 3 array, with values {@code [cropDepth, cropHeight, cropWidth]},
+     *                 or as a length 4 array, with values {@code [cropLeftDepth, cropRightDepth, cropLeftHeight, cropRightHeight, cropLeftWidth, cropRightWidth]}
+     */
     public Cropping3D(int[] cropping) {
         this(new Builder(cropping));
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 
 /**
- * Elementwise multiplication layer with weights: implements out = activationFn(input .* w + b) where:<br>
+ * Elementwise multiplication layer with weights: implements {@code out = activationFn(input .* w + b)} where:<br>
  * - w is a learnable weight vector of length nOut<br>
  * - ".*" is element-wise multiplication<br>
  * - b is a bias vector<br>

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
@@ -36,9 +36,15 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Created by Alex on 10/07/2017.
+ * FrozenLayer is used for the purposes of transfer learning.<br>
+ * A frozen layer wraps another DL4J Layer within it.
+ * During backprop, the FrozenLayer is skipped, and any parameters are not be updated.
+ * Usually users will typically not create FrozenLayer instances directly - they are usually used in the process of performing
+ * transfer learning
+ *
+ * @author Alex Black
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class FrozenLayer extends Layer {
 
     @Getter

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
@@ -41,7 +41,8 @@ import java.util.List;
 /**
  * Frozen layer freezes parameters of the layer it wraps, but allows the backpropagation to continue.
  * 
- * Created by Ugljesa Jovanovic (jovanovic.ugljesa@gmail.com) on 06/05/2018.
+ * @author Ugljesa Jovanovic (jovanovic.ugljesa@gmail.com) on 06/05/2018.
+ * @see FrozenLayer
  */
 @Data
 public class FrozenLayerWithBackprop extends BaseWrapperLayer {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
@@ -41,20 +41,34 @@ import java.util.Map;
 
 /**
  * Output (loss) layer for YOLOv2 object detection model, based on the papers:
- * YOLO9000: Better, Faster, Stronger - Redmon & Farhadi (2016) - https://arxiv.org/abs/1612.08242<br>
+ * YOLO9000: Better, Faster, Stronger - Redmon & Farhadi (2016) - <a href="https://arxiv.org/abs/1612.08242">https://arxiv.org/abs/1612.08242</a><br>
  * and<br>
  * You Only Look Once: Unified, Real-Time Object Detection - Redmon et al. (2016) -
- * http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf<br>
- *
+ * <a href="http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf">http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf</a>
+ * <br>
  * This loss function implementation is based on the YOLOv2 version of the paper. However, note that it doesn't
  * currently support simultaneous training on both detection and classification datasets as described in the
- * YOlO9000 paper.
+ * YOlO9000 paper.<br>
  *
  * Note: Input activations to the Yolo2OutputLayer should have shape: [minibatch, b*(5+c), H, W], where:<br>
- * b = number of bounding boxes (determined by config)<br>
+ * b = number of bounding boxes (determined by config - see papers for details)<br>
  * c = number of classes<br>
  * H = output/label height<br>
  * W = output/label width<br>
+ * <br>
+ * Important: In practice, this means that the last convolutional layer before your Yolo2OutputLayer should have output
+ * depth of b*(5+c). Thus if you change the number of bounding boxes, or change the number of object classes,
+ * the number of channels (nOut of the last convolution layer) needs to also change.
+ * <br>
+ * Label format: [minibatch, 4+C, H, W]<br>
+ * Order for labels depth: [x1,y1,x2,y2,(class labels)]<br>
+ * x1 = box top left position<br>
+ * y1 = as above, y axis<br>
+ * x2 = box bottom right position<br>
+ * y2 = as above y axis<br>
+ * Note: labels are represented as a multiple of grid size - for a 13x13 grid, (0,0) is top left, (13,13) is bottom right<br>
+ * Note also that mask arrays are not required - this implementation infers the presence or absence of objects in each grid
+ * cell from the class labels (which should be 1-hot if an object is present, or all 0s otherwise).
  *
  * @author Alex Black
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
@@ -27,7 +27,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import java.util.Collection;
 
 /**
- * LastTimeStep is a "wrapper" layer: it wraps any RNN layer, and extracts out the last time step during forward pass,
+ * LastTimeStep is a "wrapper" layer: it wraps any RNN (or CNN1D) layer, and extracts out the last time step during forward pass,
  * and returns it as a row vector (per example). That is, for 3d (time series) input (with shape [minibatch, layerSize,
  * timeSeriesLength]), we take the last time step and return it as a 2d array with shape [minibatch, layerSize].<br>
  * Note that the last time step operation takes into account any mask arrays, if present: thus, variable length time

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
@@ -33,9 +33,11 @@ import java.util.Map;
 
 /**
  * Simple RNN - aka "vanilla" RNN is the simplest type of recurrent neural network layer.
- * It implements out_t = activationFn( in_t * inWeight + out_(t-1) * recurrentWeights + bias).
+ * It implements {@code out_t = activationFn( in_t * inWeight + out_(t-1) * recurrentWeights + bias)}.
  *
- * Note that other architectures (LSTM, etc) are usually more effective, especially for longer time series
+ * Note that other architectures (LSTM, etc) are usually much more effective, especially for longer time series;
+ * however SimpleRnn is very fast to compute, and hence may be considered where the length of the temporal dependencies
+ * in the dataset are only a few steps long.
  *
  * @author Alex Black
  */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/objdetect/Yolo2OutputLayer.java
@@ -53,10 +53,10 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.*;
 
 /**
  * Output (loss) layer for YOLOv2 object detection model, based on the papers:
- * YOLO9000: Better, Faster, Stronger - Redmon & Farhadi (2016) - https://arxiv.org/abs/1612.08242<br>
+ * YOLO9000: Better, Faster, Stronger - Redmon & Farhadi (2016) - <a href="https://arxiv.org/abs/1612.08242">https://arxiv.org/abs/1612.08242</a><br>
  * and<br>
  * You Only Look Once: Unified, Real-Time Object Detection - Redmon et al. (2016) -
- * http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf<br>
+ * <a href="http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf">http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf</a>
  * <br>
  * This loss function implementation is based on the YOLOv2 version of the paper. However, note that it doesn't
  * currently support simultaneous training on both detection and classification datasets as described in the


### PR DESCRIPTION
Now that we are relying on javadoc for our autogen docs, it's even more important that the javadoc is complete and high quality.

Also fixes up a number of formatting issues in the javadoc - mainly links (making them proper ```<a href="...">...</a>``` format) and code (making them ```{@code ...}``` format).

Also cleans up some stuff I noted in the process.