### PR TITLE
ND4J: Remove references to RawIndexer not available on Android

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/compression/CompressedDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/compression/CompressedDataBuffer.java
@@ -70,7 +70,7 @@ public class CompressedDataBuffer extends BaseDataBuffer {
         out.writeInt((int) compressionDescriptor.getCompressedLength());
         out.writeUTF(Type.COMPRESSED.name());
         // at this moment we don't care about mimics anymore
-        //ByteRawIndexer indexer = new ByteRawIndexer((BytePointer) pointer);
+        //ByteIndexer indexer = ByteIndexer.create((BytePointer) pointer);
         out.writeUTF(compressionDescriptor.getCompressionAlgorithm());
         out.writeLong(compressionDescriptor.getCompressedLength());
         out.writeLong(compressionDescriptor.getOriginalLength());

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
@@ -21,7 +21,7 @@ import lombok.val;
 import org.bytedeco.javacpp.*;
 import org.bytedeco.javacpp.indexer.DoubleIndexer;
 import org.bytedeco.javacpp.indexer.FloatIndexer;
-import org.bytedeco.javacpp.indexer.LongRawIndexer;
+import org.bytedeco.javacpp.indexer.LongIndexer;
 import org.nd4j.linalg.api.blas.*;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
@@ -20,7 +20,7 @@ import lombok.val;
 import org.bytedeco.javacpp.*;
 import org.bytedeco.javacpp.indexer.DoubleIndexer;
 import org.bytedeco.javacpp.indexer.FloatIndexer;
-import org.bytedeco.javacpp.indexer.LongRawIndexer;
+import org.bytedeco.javacpp.indexer.LongIndexer;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.performance.PerformanceTracker;
@@ -120,7 +120,7 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
                 newPointer,
                 DataBuffer.Type.LONG,
                 length,
-                LongRawIndexer.create(newPointer));
+                LongIndexer.create(newPointer));
 
         dataPointer.position(0);
         dataPointer.limit(dataBufferElementSize * Shape.length(shapeBuffer));
@@ -190,7 +190,7 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
                 newPointer,
                 DataBuffer.Type.LONG,
                 length,
-                LongRawIndexer.create(newPointer));
+                LongIndexer.create(newPointer));
 
         dataPointer.position(0);
         dataPointer.limit(dataBufferElementSize * Shape.length(shapeBuffer));

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -899,9 +899,9 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
                 this.type = t;
 
                 this.pointer = new CudaPointer(allocationPoint.getPointers().getHostPointer(), length).asLongPointer();
-                indexer = LongRawIndexer.create((LongPointer) pointer);
+                indexer = LongIndexer.create((LongPointer) pointer);
 
-                LongRawIndexer Lindexer = (LongRawIndexer) indexer;
+                LongIndexer Lindexer = (LongIndexer) indexer;
 
                 for (long i = 0; i < length(); i++) {
                     if (t == Type.LONG)

--- a/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -1037,7 +1037,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
         } else if (dataType() == Type.INT) {
             return ((IntIndexer) indexer).get(offset() + i);
         } else if (dataType() == Type.LONG) {
-                return ((LongRawIndexer) indexer).get(offset() + i);
+                return ((LongIndexer) indexer).get(offset() + i);
         } else {
             return ((DoubleIndexer) indexer).get(offset() + i);
         }
@@ -1085,7 +1085,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
         } else if (dataType() == Type.INT) {
             return ((IntIndexer) indexer).get(offset() + i);
         } else if (dataType() == Type.LONG) {
-            return ((LongRawIndexer) indexer).get(offset() + i);
+            return ((LongIndexer) indexer).get(offset() + i);
         } else if (dataType() == Type.HALF) {
             return ((HalfIndexer) indexer).get(offset() + i);
         } else {
@@ -1120,7 +1120,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
     public void pointerIndexerByGlobalType(Type currentType) {
         if (currentType == Type.LONG) {
             pointer = new LongPointer(length());
-            setIndexer(LongRawIndexer.create((LongPointer) pointer));
+            setIndexer(LongIndexer.create((LongPointer) pointer));
             type = Type.LONG;
         } else if (currentType == Type.INT) {
             pointer = new IntPointer(length());
@@ -1163,7 +1163,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
         } else if (dataType() == Type.INT) {
             ((IntIndexer) indexer).put(offset() + i, (int) element);
         } else if (dataType() == Type.LONG) {
-            ((LongRawIndexer) indexer).put(offset() + i, (long) element);
+            ((LongIndexer) indexer).put(offset() + i, (long) element);
         } else {
             ((FloatIndexer) indexer).put(offset() + i, element);
         }
@@ -1182,7 +1182,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
         } else if (dataType() == Type.INT) {
             ((IntIndexer) indexer).put(offset() + i, (int) element);
         } else if (dataType() == Type.LONG) {
-            ((LongRawIndexer) indexer).put(offset() + i, (long) element);
+            ((LongIndexer) indexer).put(offset() + i, (long) element);
         } else if (dataType() == Type.HALF) {
             ((HalfIndexer) indexer).put(offset() + i, (float) element);
         } else {
@@ -1200,7 +1200,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
         } else if (dataType() == Type.INT) {
             ((IntIndexer) indexer).put(offset() + i, element);
         } else if (dataType() == Type.LONG) {
-            ((LongRawIndexer) indexer).put(offset() + i, element);
+            ((LongIndexer) indexer).put(offset() + i, element);
         } else {
             ((FloatIndexer) indexer).put(offset() + i, element);
         }
@@ -1216,7 +1216,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
         } else if (dataType() == Type.INT) {
             ((IntIndexer) indexer).put(offset() + i, (int) element);
         } else if (dataType() == Type.LONG) {
-            ((LongRawIndexer) indexer).put(offset() + i, element);
+            ((LongIndexer) indexer).put(offset() + i, element);
         } else {
             ((FloatIndexer) indexer).put(offset() + i, (float) element);
         }


### PR DESCRIPTION
This causes issues on Android when loading models, see issue #6150.