### PR TITLE
Fix build errors occuring with JDK 9

### DIFF
--- a/arbiter/arbiter-ui/pom.xml
+++ b/arbiter/arbiter-ui/pom.xml
@@ -188,7 +188,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <scalaVersion>2.11.7</scalaVersion>
+                    <scalaVersion>${scala.version}</scalaVersion>
                 </configuration>
             </plugin>
 

--- a/arbiter/pom.xml
+++ b/arbiter/pom.xml
@@ -220,10 +220,10 @@
                     <artifactId>scala-maven-plugin</artifactId>
                     <version>${maven-scala-plugin.version}</version>
                     <configuration>
-                        <scalaVersion>2.11.7</scalaVersion>
                         <args>
                             <arg>-deprecation</arg>
                             <arg>-explaintypes</arg>
+                            <arg>-nobootcp</arg>
                         </args>
                     </configuration>
                     <executions>

--- a/datavec/datavec-hadoop/pom.xml
+++ b/datavec/datavec-hadoop/pom.xml
@@ -86,6 +86,10 @@
                     <artifactId>jsr305</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>

--- a/datavec/pom.xml
+++ b/datavec/pom.xml
@@ -246,8 +246,9 @@
                         <rule>DuplicateDep</rule>
                         <rule>RedundantDepVersion</rule>
                         <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
                         <rule>VersionProp</rule>
-                        <rule>DotVersionProperty</rule>
+                        <rule>DotVersionProperty</rule> -->
                     </onlyRunRules>
                     <xmlOutputFile>${project.build.directory}/maven-lint-result.xml</xmlOutputFile>
                 </configuration>

--- a/deeplearning4j/deeplearning4j-modelexport-solr/pom.xml
+++ b/deeplearning4j/deeplearning4j-modelexport-solr/pom.xml
@@ -140,12 +140,30 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-annotations</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-auth</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -162,6 +180,10 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
@@ -176,6 +198,10 @@
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>

--- a/deeplearning4j/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/pom.xml
@@ -101,6 +101,12 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-explaintypes</arg>
+                        <arg>-nobootcp</arg>
+                    </args>
                     <jvmArgs>
                         <jvmArg>-Xms128m</jvmArg>
                         <jvmArg>-Xmx512m</jvmArg>

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
@@ -302,6 +302,13 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                </configuration>
+            </plugin>
 
             <!-- Build helper plugin: used to add the multiple independent source directories (Java, Scala, HTML templates) -->
             <plugin>

--- a/deeplearning4j/deeplearning4j-ui-parent/pom.xml
+++ b/deeplearning4j/deeplearning4j-ui-parent/pom.xml
@@ -38,10 +38,10 @@
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>${maven-scala-plugin.version}</version>
                 <configuration>
-                    <scalaVersion>2.11.8</scalaVersion>
                     <args>
                         <arg>-deprecation</arg>
                         <arg>-explaintypes</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                 </configuration>
                 <executions>

--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -255,8 +255,9 @@
                     <onlyRunRules>
                         <rule>DuplicateDep</rule>
                         <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
                         <rule>VersionProp</rule>
-                        <rule>DotVersionProperty</rule>
+                        <rule>DotVersionProperty</rule> -->
                     </onlyRunRules>
                     <xmlOutputFile>${project.build.directory}/maven-lint-result.xml</xmlOutputFile>
                 </configuration>

--- a/gym-java-client/pom.xml
+++ b/gym-java-client/pom.xml
@@ -205,8 +205,9 @@
                         <rule>DuplicateDep</rule>
                         <rule>RedundantDepVersion</rule>
                         <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
                         <rule>VersionProp</rule>
-                        <rule>DotVersionProperty</rule>
+                        <rule>DotVersionProperty</rule> -->
                     </onlyRunRules>
                 </configuration>
                 <executions>

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -157,11 +157,6 @@
         mentioning java-shaded as the type for why we use this instead of google's (mainly due ot other systems packaging
         their own older protobuf versions-->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.os72</groupId>
             <artifactId>protobuf-java-shaded-351</artifactId>
             <version>0.9</version>
@@ -210,13 +205,6 @@
             <groupId>org.nd4j</groupId>
             <artifactId>jackson</artifactId>
             <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -43,7 +43,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
@@ -165,7 +164,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>libnd4j-checks</id>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -142,7 +142,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <environmentVariables>
                         <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}:${user.dir}:${libnd4jhome}/blasbuild/cpu/blas/</LD_LIBRARY_PATH>
@@ -262,7 +261,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>libnd4j-checks</id>

--- a/nd4j/nd4j-backends/nd4j-tests-tensorflow/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-tests-tensorflow/pom.xml
@@ -45,7 +45,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>test</phase>

--- a/nd4j/nd4j-backends/nd4j-tests/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-tests/pom.xml
@@ -41,7 +41,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/nd4j/nd4j-buffer/pom.xml
+++ b/nd4j/nd4j-buffer/pom.xml
@@ -138,12 +138,5 @@
             <artifactId>javacpp</artifactId>
             <version>${javacpp.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/nd4j/nd4j-common/pom.xml
+++ b/nd4j/nd4j-common/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
@@ -109,20 +108,12 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>${commons-codec.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nd4j/nd4j-jdbc/nd4j-jdbc-mysql/pom.xml
+++ b/nd4j/nd4j-jdbc/nd4j-jdbc-mysql/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>${junit.version}</version>
           <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-rocksdb-storage/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-rocksdb-storage/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>${junit.version}</version>
           <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-status/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-status/pom.xml
@@ -158,7 +158,6 @@
         <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>${junit.version}</version>
           <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameterserver-model/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameterserver-model/pom.xml
@@ -32,15 +32,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-
     <profiles>
         <profile>
             <id>testresources</id>

--- a/nd4j/nd4j-serde/nd4j-aeron/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-aeron/pom.xml
@@ -76,7 +76,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/nd4j/nd4j-serde/nd4j-arrow/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-arrow/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -44,11 +43,6 @@
             <groupId>com.carrotsearch</groupId>
             <artifactId>hppc</artifactId>
             <version>${hppc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/nd4j/nd4j-serde/nd4j-gson/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-gson/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>${junit.version}</version>
           <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nd4j/nd4j-serde/nd4j-kryo/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-kryo/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>${junit.version}</version>
           <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nd4j/nd4j-uberjar/pom.xml
+++ b/nd4j/nd4j-uberjar/pom.xml
@@ -69,7 +69,6 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-enforcer-plugin</artifactId>
-              <version>1.4.1</version>
               <executions>
                 <execution>
                   <phase>package</phase>

--- a/nd4j/pom.xml
+++ b/nd4j/pom.xml
@@ -212,7 +212,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--  <plugin>
+            <plugin>
                 <groupId>com.lewisd</groupId>
                 <artifactId>lint-maven-plugin</artifactId>
                 <version>0.0.11</version>
@@ -222,8 +222,9 @@
                     <rule>DuplicateDep</rule>
                     <rule>RedundantDepVersion</rule>
                     <rule>RedundantPluginVersion</rule>
+                    <!-- Rules incompatible with Java 9
                     <rule>VersionProp</rule>
-                    <rule>DotVersionProperty</rule>
+                    <rule>DotVersionProperty</rule> -->
                   </onlyRunRules>
                 </configuration>
                 <executions>
@@ -235,7 +236,7 @@
                     </goals>
                   </execution>
                 </executions>
-              </plugin>-->
+              </plugin>
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
 
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
@@ -429,6 +429,23 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <doclint>none</doclint>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>s3-repo</id>
             <activation>

--- a/rl4j/pom.xml
+++ b/rl4j/pom.xml
@@ -151,8 +151,9 @@
                         <rule>DuplicateDep</rule>
                         <rule>RedundantDepVersion</rule>
                         <rule>RedundantPluginVersion</rule>
+                        <!-- Rules incompatible with Java 9
                         <rule>VersionProp</rule>
-                        <rule>DotVersionProperty</rule>
+                        <rule>DotVersionProperty</rule> -->
                     </onlyRunRules>
                     <xmlOutputFile>${project.build.directory}/maven-lint-result.xml</xmlOutputFile>
                 </configuration>

--- a/scalnet/pom.xml
+++ b/scalnet/pom.xml
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${maven-scala-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -165,6 +165,11 @@
                 </executions>
                 <configuration>
                     <scalaVersion>${scala.version}</scalaVersion>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-explaintypes</arg>
+                        <arg>-nobootcp</arg>
+                    </args>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
With this, all modules build with Java 9 as well as Java 8, and most unit tests pass with Java 9 as well.