### PR TITLE
Changed DataSet.merge signature

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -140,7 +140,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      * @param data the data to merge
      * @return a single dataset
      */
-    public static DataSet merge(List<DataSet> data) {
+    public static DataSet merge(List<? extends org.nd4j.linalg.dataset.api.DataSet> data) {
         if (data.isEmpty())
             throw new IllegalArgumentException("Unable to merge empty dataset");
 
@@ -148,7 +148,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
         boolean anyFeaturesPreset = false;
         boolean anyLabelsPreset = false;
         boolean first = true;
-        for(DataSet ds : data){
+        for(org.nd4j.linalg.dataset.api.DataSet ds : data){
             if(ds.isEmpty()){
                 continue;
             }
@@ -171,7 +171,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
         INDArray[] featuresMasksToMerge = null;
         INDArray[] labelsMasksToMerge = null;
         int count = 0;
-        for (DataSet ds : data) {
+        for (org.nd4j.linalg.dataset.api.DataSet ds : data) {
             if(ds.isEmpty())
                 continue;
             featuresToMerge[count] = ds.getFeatures();
@@ -209,7 +209,7 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
         DataSet dataset = new DataSet(featuresOut, labelsOut, featuresMaskOut, labelsMaskOut);
 
         List<Serializable> meta = null;
-        for (DataSet ds : data) {
+        for (org.nd4j.linalg.dataset.api.DataSet ds : data) {
             if (ds.getExampleMetaData() == null || ds.getExampleMetaData().size() != ds.numExamples()) {
                 meta = null;
                 break;


### PR DESCRIPTION
This small PR addresses an immediate problem I had : getRange returns an api.DataSet, which is logical since getRange is inherited from api.DataSet interface. But DataSet.merge only takes a list of DataSet.
So no way to merge a dataset obtained from getRange without cast.

However, there is a deeper design problem : api.DataSet references DataSet, which ruins the point of having a separate interface. I think one of the two following actions must be taken:
1) Replace DataSet with api.DataSet anywhere in api.DataSet, and in signatures of methods in DataSet implementing an interface method. There will be an issue with the whole interface currently implementing Iterable<DataSet>. Maybe this must be removed. Implementing Iterable<? extends api.DataSet> is not possible. implementing Iterable<api.DataSet> would not be very consistent. Renaming DataSet with something like MemoryDataSet or some name that evokes what is specific to this class WRT other possible implementations would be good too and less confusing.
2) Decide that an api.DataSet is always implemented by DataSet (which is necessarily the case right now) or a subclass and merge them.

These remarks about the api/implementation split hold for DataSet, but may hold for others, I didn't check.