### PR TITLE
libnd4j: Add MKL-DNN stride support and nd4j::Environment::useMKLDNN setting

### DIFF
--- a/libnd4j/blas/Environment.h
+++ b/libnd4j/blas/Environment.h
@@ -35,6 +35,7 @@ namespace nd4j{
         std::atomic<bool> _debug;
         std::atomic<bool> _profile;
         std::atomic<int> _maxThreads;
+        std::atomic<bool> _useMKLDNN{true};
 
         static Environment* _instance;
 
@@ -59,6 +60,9 @@ namespace nd4j{
 
         int maxThreads();
         void setMaxThreads(int max);
+
+        bool isUseMKLDNN() { return _useMKLDNN.load(); }
+        void setUseMKLDNN(bool useMKLDNN) { _useMKLDNN.store(useMKLDNN); }
     };
 }
 

--- a/libnd4j/include/graph/ContextPrototype.h
+++ b/libnd4j/include/graph/ContextPrototype.h
@@ -22,7 +22,7 @@
 #define ND4J_CONTEXT_PROTOTYPE_H
 
 #include <vector>
-
+#include <Environment.h>
 
 namespace nd4j {
     namespace graph {
@@ -40,7 +40,7 @@ namespace nd4j {
             // opNum for legacy XYZ ops
             int _opNum = -1;
 
-            bool _useMKLDNN = true;
+            bool _useMKLDNN = nd4j::Environment::getInstance()->isUseMKLDNN();
 
         public:
             explicit ContextPrototype(int nodeId = 1, bool inPlace = false);

--- a/libnd4j/include/ops/declarable/generic/convo/conv2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/conv2d.cpp
@@ -64,14 +64,10 @@ CUSTOM_OP_IMPL(conv2d, 2, 1, false, 0, 9) {
         REQUIRE_TRUE(bias->rankOf() <= 2 && oC == bias->lengthOf(), 0, "CUSTOM CONV2D OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, bias->rankOf(), bias->lengthOf());                
 
 #ifdef HAVE_MKLDNN
-    bool areAllStridesDefault = shape::areStridesDefault(input->getShapeInfo()) && shape::areStridesDefault(weights->getShapeInfo()) && shape::areStridesDefault(output->getShapeInfo());
-    if(bias)
-        areAllStridesDefault = areAllStridesDefault && shape::areStridesDefault(bias->getShapeInfo());
-
-    if (areAllStridesDefault && block.isUseMKLDNN() && MKLDNNStream<T>::isSupported()) {
+    if (block.isUseMKLDNN() && MKLDNNStream<T>::isSupported()) {
         if (block.getMKLDNNStream() == nullptr) {
             block.setMKLDNNStream(new MKLDNNStream<T>("conv2d"));
-        }        
+        }
         ConvolutionUtils<T>::mkldnn_conv2d(*block.getMKLDNNStream(), {input, weights, bias}, output, {kH,kW,sH,sW,pH,pW,dH,dW,isSameMode,isNCHW});
     } else {
 #endif

--- a/libnd4j/include/ops/declarable/generic/helpers/impl/convolutions.cpp
+++ b/libnd4j/include/ops/declarable/generic/helpers/impl/convolutions.cpp
@@ -879,53 +879,27 @@ void ConvolutionUtils<T>::mkldnn_conv2d(MKLDNNStream<T> &stream, const std::vect
         auto formatw = mkldnn::memory::format::hwio;
         auto conv_src_md = mkldnn::memory::desc({ conv_src_tz }, type, format);
         auto conv_weights_md = mkldnn::memory::desc({ conv_weights_tz }, type, formatw);
-        auto conv_bias_md = mkldnn::memory::desc({ conv_bias_tz }, type, mkldnn::memory::format::x);        
+        auto conv_bias_md = mkldnn::memory::desc({ conv_bias_tz }, type, mkldnn::memory::format::x);
         auto conv_dst_md = mkldnn::memory::desc({ conv_dst_tz }, type, format);
 
-        // conv_src_md.data.ndims     = 4;
-        // conv_weights_md.data.ndims = 4;
-        // conv_bias_md.data.ndims    = 1;
-        // conv_dst_md.data.ndims     = 4;
+        conv_src_md.data.format = mkldnn_blocked; // overrides "format = isNCHW ? nchw : nhwc"
+        conv_src_md.data.layout_desc.blocking.strides[0][0] = input->stridesOf()[isNCHW ? 0 : 0];
+        conv_src_md.data.layout_desc.blocking.strides[0][1] = input->stridesOf()[isNCHW ? 1 : 3];
+        conv_src_md.data.layout_desc.blocking.strides[0][2] = input->stridesOf()[isNCHW ? 2 : 1];
+        conv_src_md.data.layout_desc.blocking.strides[0][3] = input->stridesOf()[isNCHW ? 3 : 2];
 
-        // conv_src_md.data.dims[0] = bS;
-        // conv_src_md.data.dims[1] = iC;
-        // conv_src_md.data.dims[2] = iH;
-        // conv_src_md.data.dims[3] = iW;
+        conv_weights_md.data.format = mkldnn_blocked; // overrides "formatw = hwio"
+        conv_weights_md.data.layout_desc.blocking.strides[0][0] = weights->stridesOf()[3];
+        conv_weights_md.data.layout_desc.blocking.strides[0][1] = weights->stridesOf()[2];
+        conv_weights_md.data.layout_desc.blocking.strides[0][2] = weights->stridesOf()[0];
+        conv_weights_md.data.layout_desc.blocking.strides[0][3] = weights->stridesOf()[1];
 
-        // conv_weights_md.data.dims[0] = oC;
-        // conv_weights_md.data.dims[1] = iC;
-        // conv_weights_md.data.dims[2] = kH;
-        // conv_weights_md.data.dims[3] = kW;
+        conv_dst_md.data.format = mkldnn_blocked; // overrides "format = isNCHW ? nchw : nhwc"
+        conv_dst_md.data.layout_desc.blocking.strides[0][0] = output->stridesOf()[isNCHW ? 0 : 0];
+        conv_dst_md.data.layout_desc.blocking.strides[0][1] = output->stridesOf()[isNCHW ? 1 : 3];
+        conv_dst_md.data.layout_desc.blocking.strides[0][2] = output->stridesOf()[isNCHW ? 2 : 1];
+        conv_dst_md.data.layout_desc.blocking.strides[0][3] = output->stridesOf()[isNCHW ? 3 : 2];
 
-        // conv_dst_md.data.dims[0] = bS;
-        // conv_dst_md.data.dims[1] = oC;
-        // conv_dst_md.data.dims[2] = oH;
-        // conv_dst_md.data.dims[3] = oW;
-        
-        // conv_bias_md.data.dims[0] = oC;
-
-        // conv_src_md.data.format     = mkldnn_blocked;
-        // conv_weights_md.data.format = mkldnn_blocked;
-        // conv_bias_md.data.format    = mkldnn_blocked;
-        // conv_dst_md.data.format     = mkldnn_blocked;
-
-        // conv_src_md.data.layout_desc.blocking.strides[0][0] = input->stridesOf()[0];
-        // conv_src_md.data.layout_desc.blocking.strides[0][1] = input->stridesOf()[1];
-        // conv_src_md.data.layout_desc.blocking.strides[0][2] = input->stridesOf()[2];
-        // conv_src_md.data.layout_desc.blocking.strides[0][3] = input->stridesOf()[3];
-
-        // conv_weights_md.data.layout_desc.blocking.strides[0][0] = weights->stridesOf()[0];
-        // conv_weights_md.data.layout_desc.blocking.strides[0][1] = weights->stridesOf()[1];
-        // conv_weights_md.data.layout_desc.blocking.strides[0][2] = weights->stridesOf()[2];
-        // conv_weights_md.data.layout_desc.blocking.strides[0][3] = weights->stridesOf()[3];
-
-        // conv_dst_md.data.layout_desc.blocking.strides[0][0] = output->stridesOf()[0];
-        // conv_dst_md.data.layout_desc.blocking.strides[0][1] = output->stridesOf()[1];
-        // conv_dst_md.data.layout_desc.blocking.strides[0][2] = output->stridesOf()[2];
-        // conv_dst_md.data.layout_desc.blocking.strides[0][3] = output->stridesOf()[3];
-        
-        // conv_bias_md.data.layout_desc.blocking.strides[0][0] = bias->stridesOf()[0];        
- 
         auto conv_desc = bias != nullptr
                 ? convolution_forward::desc(prop_kind::forward,
                         convolution_direct, conv_src_md, conv_weights_md, conv_bias_md,


### PR DESCRIPTION
Fixes  #6419 and fixes #6384 

Incidentally, it looks like MKL-DNN's natural layout for input and output is NCHW and for weights is OIHW as being set for the "descriptor" here:
https://github.com/deeplearning4j/deeplearning4j/blob/sa_mkldnn/libnd4j/include/ops/declarable/generic/helpers/impl/convolutions.cpp#L868-L869