### PR TITLE
rewrite/profile mmulNxN helper

### DIFF
--- a/libnd4j/blas/cpu/NDArray.cpp
+++ b/libnd4j/blas/cpu/NDArray.cpp
@@ -3028,20 +3028,18 @@ bool NDArray<T>::isUnitary() {
         result._isShapeAlloc = true;
 
         if(!keepUnitiesInShape) {
-            // check whether units are present in newShape, if yes then remove them by applying corresponding reshape
-            // for example if result has shape {1,a,1,b} then after reshaping it acquire new shape {a,b}
-            
-            // std::vector<Nd4jLong > nonUnitDims;
-            // for(int i = 0; i < result.rankOf(); ++i)
-            //     if(newShape[i+1] != 1)
-            //         nonUnitDims.push_back(newShape[i+1]);
 
+            std::vector<Nd4jLong> nonUnitDims;
+            for (int d = 0; d < rank; ++d) {
+                if(!(idx[2*d] != idx[2*d+1] && newShape[d+1] == 1))
+                    nonUnitDims.push_back(newShape[d+1]);
+            }
+            if(nonUnitDims.size() != rank)
+                result.reshapei(nonUnitDims);
+
+            // std::vector<Nd4jLong> nonUnitDims = ShapeUtils<T>::evalDimsWithoutUnities(newShape);
             // if(nonUnitDims.size() != result.rankOf())
             //     result.reshapei(nonUnitDims);
-
-            std::vector<Nd4jLong> nonUnitDims = ShapeUtils<T>::evalDimsWithoutUnities(newShape);
-            if(nonUnitDims.size() != result.rankOf())
-                result.reshapei(nonUnitDims);
         }
 
         return result;

--- a/libnd4j/include/ops/declarable/generic/convo/depthwiseConv2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/depthwiseConv2d.cpp
@@ -69,7 +69,6 @@ CUSTOM_OP_IMPL(depthwise_conv2d, 2, 1, false, 0, 9) {
 }
 
 
-
 DECLARE_SHAPE_FN(depthwise_conv2d) {
 
     Nd4jLong* inputShapeInfo   = inputShape->at(0);                                    // [bS, iH, iW, iC] (NHWC) or [bS, iC, iH, iW] (NCHW)
@@ -99,7 +98,7 @@ DECLARE_SHAPE_FN(depthwise_conv2d) {
         indIOioC = 1; indIiH = 2;
     }    
 
-    const int bS = inputShapeInfo[1];                            // batch size
+    const int bS = inputShapeInfo[1];                            // batch size 
     const int iH = inputShapeInfo[indIiH+1];                     // input height
     const int iW = inputShapeInfo[indIiH+2];                     // input width
     const int iC = inputShapeInfo[indIOioC+1];                   // input channels        

--- a/libnd4j/include/ops/declarable/generic/helpers/impl/convolutions.cpp
+++ b/libnd4j/include/ops/declarable/generic/helpers/impl/convolutions.cpp
@@ -1044,7 +1044,7 @@ void ConvolutionUtils<T>::depthwiseConv2d(const std::vector<NDArray<T>*>& inArrs
     NDArray<T>* outputReshaped = output->reshape(output->ordering(), outReShape);
     std::vector<T> extrasIm2Col({(T) kH, (T) kW, (T) sH, (T) sW, (T) pH, (T) pW, (T) dH, (T) dW, (T)0.f, (T)0.f});
 
-    input->template applyTransform<simdOps::Im2col<T>>(&columns, extrasIm2Col.data());                                 // [bS, iC, iH, iW] is convoluted to [bS, iC, kH, kW, oH, oW]    
+    input->template applyTransform<simdOps::Im2col<T>>(&columns, extrasIm2Col.data());                                 // [bS, iC, iH, iW] is convoluted to [bS, iC, kH, kW, oH, oW]
     nd4j::MmulHelper<T>::tensorDot(&columns, weights, outputReshaped, modifColumns, {{2,0,1,3},{iC,kH*kW,mC}}, modifOutput);    // [iC, bS*oH*oW, kW*kH] x [iC, kH*kW, mC] = [iC, bS*oH*oW, mC]
     
     if(bias)
@@ -1090,8 +1090,8 @@ void ConvolutionUtils<T>::depthwiseConv2dBP(const std::vector<NDArray<T>*>& inAr
     std::vector<Nd4jLong> gradOreShape;
 
     if(!isNCHW) {        
-        input = input->permute({0, 3, 1, 2});                                           // [bS,iH,iW,iC]    -> [bS,iC,iH,iW] 
-        gradI = gradI->permute({0, 3, 1, 2});                                           // [bS,iH,iW,iC]    -> [bS,iC,iH,iW] 
+        input = input->permute({0, 3, 1, 2});                                           // [bS,iH,iW,iC]    -> [bS,iC,iH,iW]
+        gradI = gradI->permute({0, 3, 1, 2});                                           // [bS,iH,iW,iC]    -> [bS,iC,iH,iW]
         gradOreShape = {bS, oH, oW, iC, mC};                                            // [bS,oH,oW,iC*mC] -> [bS,oH,oW,iC,mC]
         modifGradO1 = {{3,0,1,2,4},{iC, bS*oH*oW, mC}};                                 // [bS,oH,oW,iC,mC] -> [iC,bS,oH,oW,mC] -> [iC,bS*oH*oW,mC]
         modifGradO2 = {{3,0,1,2},{iC, mC, bS*oH*oW}};                                   // [bS,oH,oW,iC*mC] -> [iC*mC,bS,oH,oW] -> [iC,mC,bS*oH*oW]

--- a/libnd4j/tests_cpu/layers_tests/ConvolutionTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ConvolutionTests.cpp
@@ -2451,5 +2451,36 @@ TEST_F(ConvolutionTests, conv2D_input_BP_test1) {
     delete results;
 }
 
+//////////////////////////////////////////////////////////////////////
+TEST_F(ConvolutionTests, depthwise_conv2d_test4) {
+
+    int bS=1, iH=3,iW=3,  iC=2,mC=1,  kH=2,kW=2,  sH=1,sW=1,  pH=0,pW=0,  dH=1,dW=1;    
+    int       oC=iC*mC;
+    int       oH=3,oW=3;    
+    int paddingMode = 1;             // 1-SAME, 0-VALID;
+    int dataFormat  = 1;             // 1-NHWC, 0-NCHW    
+
+    NDArray<double> input   ('c', {bS, iH, iW, iC});
+    NDArray<double> weights ('c', {kH, kW, iC, mC});
+
+    
+    NDArray<double> expOutput('c', {bS, oH, oW, oC}, {20., 24.,28., 32.,16., 18.,44., 48.,52., 56.,28., 30.,28., 30.,32., 34.,17., 18.});
+    input.linspace(1.);
+    weights = 1.;
+
+    nd4j::ops::depthwise_conv2d<double> op;
+    ResultSet<double>* results = op.execute({&input, &weights}, {}, {kH,kW,  sH,sW,  pH,pW,  dH,dW, paddingMode, dataFormat});
+    NDArray<double>* output = results->at(0);
+    // output->printIndexedBuffer();
+
+    ASSERT_EQ(Status::OK(), results->status());
+
+    ASSERT_TRUE(expOutput.isSameShape(output));
+    ASSERT_TRUE(expOutput.equalsTo(output));    
+    
+    delete results; 
+}
+
 #endif //LIBND4J_CONVOLUTIONTESTS_H
+
 


### PR DESCRIPTION
it turns out there was bug in mmulNxN helper when dealing with permuted/reshaped C (resulting) array. Previous version of mmulNxN was based on old TAD stuff which is buggy for unusual shapes like {...,1} / {1,...} that is with trailing/leading unity. Now mmulNxN doesn't use TADs and is based on new NDArray stuff which however works on the same principle as TAD.