### PR TITLE
Make layerConf() public

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/AbstractLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/AbstractLayer.java
@@ -76,7 +76,7 @@ public abstract class AbstractLayer<LayerConfT extends org.deeplearning4j.nn.con
         this.cacheMode = mode;
     }
 
-    protected LayerConfT layerConf() {
+    public LayerConfT layerConf() {
         return (LayerConfT) this.conf.getLayer();
     }
 


### PR DESCRIPTION
In order to get later configuration parameters like kernelSize, stride, etc for `SubsamplingLayer` and any others that directly extend `AbstractLayer`, this method should be public. For cases like `ConvolutionLayer` that extend `BaseLayer` `layerConf()` is already public.