### PR TITLE
DL4J Fixes; remove UI and Scala name suffix from parallel wrapper module

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/MiscRegressionTests.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/MiscRegressionTests.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.regressiontest;
+
+import org.apache.commons.io.FileUtils;
+import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.graph.GraphVertex;
+import org.deeplearning4j.nn.conf.graph.LayerVertex;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.layers.misc.FrozenLayer;
+import org.junit.Test;
+import org.nd4j.linalg.io.ClassPathResource;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class MiscRegressionTests {
+
+    @Test
+    public void testFrozen() throws Exception {
+        File f = new ClassPathResource("regression_testing/misc/legacy_frozen/configuration.json").getFile();
+        String json = FileUtils.readFileToString(f, StandardCharsets.UTF_8.name());
+        ComputationGraphConfiguration conf = ComputationGraphConfiguration.fromJson(json);
+
+        int countFrozen = 0;
+        for(Map.Entry<String,GraphVertex> e : conf.getVertices().entrySet()){
+            GraphVertex gv = e.getValue();
+            assertNotNull(gv);
+            if(gv instanceof LayerVertex){
+                LayerVertex lv = (LayerVertex)gv;
+                Layer layer = lv.getLayerConf().getLayer();
+                if(layer instanceof FrozenLayer)
+                    countFrozen++;
+            }
+        }
+
+        assertTrue(countFrozen > 0);
+    }
+
+    @Test
+    public void testFrozenNewFormat(){
+        MultiLayerConfiguration configuration = new NeuralNetConfiguration.Builder()
+                .list()
+                .layer(0, new FrozenLayer(new DenseLayer.Builder().nIn(10).nOut(10).build()))
+                .build();
+
+        String json = configuration.toJson();
+        MultiLayerConfiguration fromJson = MultiLayerConfiguration.fromJson(json);
+        assertEquals(configuration, fromJson);
+    }
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
@@ -26,11 +26,13 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.Layer;
 import org.deeplearning4j.nn.conf.memory.LayerMemoryReport;
+import org.deeplearning4j.nn.conf.serde.FrozenLayerDeserializer;
 import org.deeplearning4j.nn.params.FrozenLayerParamInitializer;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.learning.config.IUpdater;
 import org.nd4j.shade.jackson.annotation.JsonProperty;
+import org.nd4j.shade.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Collection;
 import java.util.List;
@@ -45,6 +47,7 @@ import java.util.List;
  * @author Alex Black
  */
 @EqualsAndHashCode(callSuper = false)
+@JsonDeserialize(using = FrozenLayerDeserializer.class)
 public class FrozenLayer extends Layer {
 
     @Getter

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/serde/FrozenLayerDeserializer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/serde/FrozenLayerDeserializer.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.conf.serde;
+
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.Layer;
+import org.deeplearning4j.nn.conf.layers.misc.FrozenLayer;
+import org.deeplearning4j.nn.conf.serde.legacyformat.LegacyLayerDeserializer;
+import org.nd4j.shade.jackson.core.JsonFactory;
+import org.nd4j.shade.jackson.core.JsonParser;
+import org.nd4j.shade.jackson.databind.DeserializationContext;
+import org.nd4j.shade.jackson.databind.JsonDeserializer;
+import org.nd4j.shade.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/**
+ * A custom deserializer for handling Frozen layers
+ * This is used to handle the 2 different Layer JSON formats - old/legacy, and current
+ *
+ * @author Alex Black
+ */
+public class FrozenLayerDeserializer extends JsonDeserializer<Layer> {
+    @Override
+    public Layer deserialize(JsonParser jp, DeserializationContext deserializationContext) throws IOException {
+        JsonNode n = jp.getCodec().readTree(jp);
+        JsonNode layer = n.get("layer");
+        boolean newFormat = layer.has("@class");
+
+        String internalText = layer.toString();
+        Layer internal;
+        if(newFormat){
+            //Standard/new format
+            internal = NeuralNetConfiguration.mapper().readValue(internalText, Layer.class);
+        } else {
+            //Legacy format
+            JsonFactory factory = new JsonFactory();
+            JsonParser  parser  = factory.createParser(internalText);
+            parser.setCodec(jp.getCodec());
+            internal = new LegacyLayerDeserializer().deserialize(parser, deserializationContext);
+        }
+        return new FrozenLayer(internal);
+    }
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/serde/legacyformat/LegacyLayerDeserializer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/serde/legacyformat/LegacyLayerDeserializer.java
@@ -21,6 +21,7 @@ import org.deeplearning4j.nn.conf.layers.*;
 import org.deeplearning4j.nn.conf.layers.convolutional.Cropping1D;
 import org.deeplearning4j.nn.conf.layers.convolutional.Cropping2D;
 import org.deeplearning4j.nn.conf.layers.misc.ElementWiseMultiplicationLayer;
+import org.deeplearning4j.nn.conf.layers.misc.FrozenLayer;
 import org.deeplearning4j.nn.conf.layers.objdetect.Yolo2OutputLayer;
 import org.deeplearning4j.nn.conf.layers.recurrent.Bidirectional;
 import org.deeplearning4j.nn.conf.layers.recurrent.LastTimeStep;
@@ -29,16 +30,11 @@ import org.deeplearning4j.nn.conf.layers.util.MaskLayer;
 import org.deeplearning4j.nn.conf.layers.util.MaskZeroLayer;
 import org.deeplearning4j.nn.conf.layers.variational.VariationalAutoencoder;
 import org.deeplearning4j.nn.conf.serde.JsonMappers;
-import org.deeplearning4j.nn.layers.FrozenLayer;
 import org.nd4j.serde.json.BaseLegacyDeserializer;
-import org.nd4j.shade.jackson.core.JsonParser;
-import org.nd4j.shade.jackson.databind.DeserializationContext;
-import org.nd4j.shade.jackson.databind.JsonDeserializer;
-import org.nd4j.shade.jackson.databind.JsonNode;
 import org.nd4j.shade.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Deserializer for Layer JSON in legacy format - see {@link BaseLegacyDeserializer}

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper-parameter-server/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper-parameter-server/pom.xml
@@ -55,7 +55,7 @@
     <dependencies>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
-            <artifactId>deeplearning4j-parallel-wrapper_2.11</artifactId>
+            <artifactId>deeplearning4j-parallel-wrapper</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/pom.xml
@@ -94,6 +94,7 @@
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-play_2.11</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>deeplearning4j-parallel-wrapper_2.11</artifactId>
+    <artifactId>deeplearning4j-parallel-wrapper</artifactId>
     <packaging>jar</packaging>
 
     <name>deeplearning4j-parallel-wrapper</name>

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/main/ParallelWrapperMain.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/main/ParallelWrapperMain.java
@@ -23,8 +23,8 @@ import lombok.Data;
 import org.deeplearning4j.api.storage.StatsStorageRouter;
 import org.deeplearning4j.api.storage.impl.RemoteUIStatsStorageRouter;
 import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.parallelism.ParallelWrapper;
-import org.deeplearning4j.ui.stats.StatsListener;
 import org.deeplearning4j.util.ModelGuesser;
 import org.deeplearning4j.util.ModelSerializer;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
@@ -129,7 +129,14 @@ public class ParallelWrapperMain {
                 // it's important that the UI can report results from parallel training
                 // there's potential for StatsListener to fail if certain properties aren't set in the model
                 StatsStorageRouter remoteUIRouter = new RemoteUIStatsStorageRouter("http://" + uiUrl);
-                wrapper.setListeners(remoteUIRouter, new StatsListener(null));
+                TrainingListener l;
+                try {
+                    l = (TrainingListener) Class.forName("org.deeplearning4j.ui.stats.StatsListener").getConstructor(StatsStorageRouter.class)
+                            .newInstance(new Object[]{null});
+                } catch (ClassNotFoundException e){
+                    throw new IllegalStateException("deeplearning4j-ui module must be on the classpath to use ParallelWrapperMain with the UI", e);
+                }
+                wrapper.setListeners(remoteUIRouter, l);
 
             }
             wrapper.fit(dataSetIterator);
@@ -144,7 +151,14 @@ public class ParallelWrapperMain {
                 // it's important that the UI can report results from parallel training
                 // there's potential for StatsListener to fail if certain properties aren't set in the model
                 StatsStorageRouter remoteUIRouter = new RemoteUIStatsStorageRouter("http://" + uiUrl);
-                wrapper.setListeners(remoteUIRouter, new StatsListener(null));
+                TrainingListener l;
+                try {
+                    l = (TrainingListener) Class.forName("org.deeplearning4j.ui.stats.StatsListener").getConstructor(StatsStorageRouter.class)
+                            .newInstance(new Object[]{null});
+                } catch (ClassNotFoundException e){
+                    throw new IllegalStateException("deeplearning4j-ui module must be on the classpath to use ParallelWrapperMain with the UI", e);
+                }
+                wrapper.setListeners(remoteUIRouter, l);
 
             }
             wrapper.fit(iterator);

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-parameterserver/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
-            <artifactId>deeplearning4j-parallel-wrapper_2.11</artifactId>
+            <artifactId>deeplearning4j-parallel-wrapper</artifactId>
             <version>${nd4j.version}</version>
         </dependency>
 

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
@@ -175,14 +175,6 @@
             <version>${playframework.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>

--- a/deeplearning4j/dl4j-integration-tests/pom.xml
+++ b/deeplearning4j/dl4j-integration-tests/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
-            <artifactId>deeplearning4j-parallel-wrapper_2.11</artifactId>
+            <artifactId>deeplearning4j-parallel-wrapper</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- For unit tests -->

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -977,7 +977,8 @@ public class Nd4j {
                                 double alpha,
                                 double beta) {
         //Note: some views have non-zero offset but 'default' strides (these are OK). And a 'c' order vector such as [10,1] is OK - same buffer as an 'f' order vector with same shape
-        Preconditions.checkState(c.length() == 1 || ((c.ordering() == 'f' || c.isVectorOrScalar()) && Shape.hasDefaultStridesForShape(c)),
+        Preconditions.checkState(c.length() == 1 || c.ordering() == 'f' && Shape.hasDefaultStridesForShape(c) ||
+                        c.isVectorOrScalar() && c.elementWiseStride() == 1,
                 "C (result) array is not F order or is a view. Nd4j.gemm requires the result array to be F order " +
                         "and not a view. C (result) array: [%ndSInfo]", c);
         getBlasWrapper().level3().gemm(a, b, c, transposeA, transposeB, alpha, beta);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -976,7 +976,8 @@ public class Nd4j {
                                 boolean transposeB,
                                 double alpha,
                                 double beta) {
-        Preconditions.checkState(c.length() == 1 || (c.ordering() == 'f' && Shape.hasDefaultStridesForShape(c)),    //Note: some views
+        //Note: some views have non-zero offset but 'default' strides (these are OK). And a 'c' order vector such as [10,1] is OK - same buffer as an 'f' order vector with same shape
+        Preconditions.checkState(c.length() == 1 || || ((c.ordering() == 'f' || c.isVectorOrScalar()) && Shape.hasDefaultStridesForShape(c)),
                 "C (result) array is not F order or is a view. Nd4j.gemm requires the result array to be F order " +
                         "and not a view. C (result) array: [%ndSInfo]", c);
         getBlasWrapper().level3().gemm(a, b, c, transposeA, transposeB, alpha, beta);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -977,7 +977,7 @@ public class Nd4j {
                                 double alpha,
                                 double beta) {
         //Note: some views have non-zero offset but 'default' strides (these are OK). And a 'c' order vector such as [10,1] is OK - same buffer as an 'f' order vector with same shape
-        Preconditions.checkState(c.length() == 1 || || ((c.ordering() == 'f' || c.isVectorOrScalar()) && Shape.hasDefaultStridesForShape(c)),
+        Preconditions.checkState(c.length() == 1 || ((c.ordering() == 'f' || c.isVectorOrScalar()) && Shape.hasDefaultStridesForShape(c)),
                 "C (result) array is not F order or is a view. Nd4j.gemm requires the result array to be F order " +
                         "and not a view. C (result) array: [%ndSInfo]", c);
         getBlasWrapper().level3().gemm(a, b, c, transposeA, transposeB, alpha, beta);


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/6552
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/6551

Also a fix for Nd4j.gemm validation.