### PR TITLE
upgrade metrics version from 3.1.2 to 3.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <jsch.version>0.1.51</jsch.version>
         <leveldb.version>1.8</leveldb.version>
         <lz4.version>1.3.0</lz4.version>
-        <metrics.version>3.1.2</metrics.version>
+        <metrics.version>3.2.6</metrics.version>
         <netty.version>3.10.4.Final</netty.version>
         <objenesis.version>2.6</objenesis.version>
         <paranamer.version>2.6</paranamer.version>


### PR DESCRIPTION
This is currently used by `deeplearning4j/deeplearning4j-modelexport-solr` and `nd4j/nd4j-instrumentation/pom.xml` and running their tests locally seems to work fine for me at least.

A (long) list of release notes is here:
https://metrics.dropwizard.io/4.0.0/about/release-notes.html#v3-2-6-dec-24-2017