### PR TITLE
Handle SQLite REAL type correctly

### DIFF
--- a/datavec/datavec-jdbc/src/main/java/org/datavec/api/util/jdbc/JdbcWritableConverter.java
+++ b/datavec/datavec-jdbc/src/main/java/org/datavec/api/util/jdbc/JdbcWritableConverter.java
@@ -55,8 +55,12 @@ public class JdbcWritableConverter {
                 return new Text(columnValue.toString());
 
             case Types.FLOAT:
-            case Types.REAL:
                 return new FloatWritable((float) columnValue);
+                
+            case Types.REAL:
+                return columnValue instanceof Float
+                    ? new FloatWritable((float) columnValue)
+                    : new DoubleWritable((double) columnValue);
 
             case Types.DECIMAL:
             case Types.NUMERIC:


### PR DESCRIPTION
JDBCRecordReader is throwing a java.lang.ClassCastException when reading REAL columns on a sqlite database

See issue #6615 