### PR TITLE
Mitigating ZipSlip vulnerability 

### DIFF
--- a/nd4j/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/util/ArchiveUtils.java
@@ -65,7 +65,15 @@ public class ArchiveUtils {
 
                 while (ze != null) {
                     String fileName = ze.getName();
+
+                    String canonicalDestinationDirPath = new File(dest).getCanonicalPath();
                     File newFile = new File(dest + File.separator + fileName);
+                    String canonicalDestinationFile = newFile.getCanonicalPath();
+
+                    if (!canonicalDestinationFile.startsWith(canonicalDestinationDirPath + File.separator)) {
+                        log.debug("Attempt to trigger ZipSlip vulnerability");
+                        throw new IOException("Entry is outside of the target dir: ");
+                    }
 
                     if (ze.isDirectory()) {
                         newFile.mkdirs();


### PR DESCRIPTION
patched org/nd4j/util/ArchiveUtils.java to mitigate ZipSlip vulnerability  (https://nakedsecurity.sophos.com/2018/06/06/the-zip-slip-vulnerability-what-you-need-to-know/)