### PR TITLE
Zoo: Fix U-Net disconnected vertex and output activation function, fix VGG16, add test

### DIFF
--- a/deeplearning4j/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/UNet.java
+++ b/deeplearning4j/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/UNet.java
@@ -204,7 +204,7 @@ public class UNet extends ZooModel {
                 .addLayer("up9-1", new Upsampling2D.Builder(2).build(), "conv8-2")
                 .addLayer("up9-2", new ConvolutionLayer.Builder(2,2).stride(1,1).nOut(64)
                         .convolutionMode(ConvolutionMode.Same).cudnnAlgoMode(cudnnAlgoMode)
-                        .activation(Activation.RELU).build(), "up8-1")
+                        .activation(Activation.RELU).build(), "up9-1")
                 .addVertex("merge9", new MergeVertex(), "conv1-2", "up9-2")
                 .addLayer("conv9-1", new ConvolutionLayer.Builder(3,3).stride(1,1).nOut(64)
                         .convolutionMode(ConvolutionMode.Same).cudnnAlgoMode(cudnnAlgoMode)
@@ -219,7 +219,8 @@ public class UNet extends ZooModel {
                 .addLayer("conv10", new ConvolutionLayer.Builder(3,3).stride(1,1).nOut(1)
                         .convolutionMode(ConvolutionMode.Truncate).cudnnAlgoMode(cudnnAlgoMode)
                         .activation(Activation.SIGMOID).build(), "conv9-3")
-                .addLayer("output", new CnnLossLayer.Builder(LossFunctions.LossFunction.MCXENT).build(), "conv10")
+                .addLayer("output", new CnnLossLayer.Builder(LossFunctions.LossFunction.MCXENT)
+                        .activation(Activation.SOFTMAX).build(), "conv10")
 
                 .setOutputs("output");
 

--- a/deeplearning4j/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/UNet.java
+++ b/deeplearning4j/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/UNet.java
@@ -217,7 +217,7 @@ public class UNet extends ZooModel {
                         .activation(Activation.RELU).build(), "conv9-2")
 
                 .addLayer("conv10", new ConvolutionLayer.Builder(3,3).stride(1,1).nOut(1)
-                        .convolutionMode(ConvolutionMode.Truncate).cudnnAlgoMode(cudnnAlgoMode)
+                        .convolutionMode(ConvolutionMode.Same).cudnnAlgoMode(cudnnAlgoMode)
                         .activation(Activation.SIGMOID).build(), "conv9-3")
                 .addLayer("output", new CnnLossLayer.Builder(LossFunctions.LossFunction.MCXENT)
                         .activation(Activation.SOFTMAX).build(), "conv10")

--- a/deeplearning4j/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/VGG16.java
+++ b/deeplearning4j/deeplearning4j-zoo/src/main/java/org/deeplearning4j/zoo/model/VGG16.java
@@ -158,9 +158,9 @@ public class VGG16 extends ZooModel {
                                 .poolingType(SubsamplingLayer.PoolingType.MAX).kernelSize(2, 2)
                                 .stride(2, 2).build(), "16")
                         .layer(18, new DenseLayer.Builder().nOut(4096).dropOut(0.5)
-                                                .build())
+                                                .build(), "17")
                         .layer(19, new DenseLayer.Builder().nOut(4096).dropOut(0.5)
-                                                .build())
+                                                .build(), "18")
                         .layer(20, new OutputLayer.Builder(
                                 LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD).name("output")
                                 .nOut(numClasses).activation(Activation.SOFTMAX) // radial basis function required

--- a/deeplearning4j/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestInstantiation.java
+++ b/deeplearning4j/deeplearning4j-zoo/src/test/java/org/deeplearning4j/zoo/TestInstantiation.java
@@ -308,27 +308,28 @@ public class TestInstantiation extends BaseDL4JTest {
     }
 
     @Test
-    public void testInitNotPretrained(){
-        //Sanity check on the non-pretrained versions:
+    public void testInitNotPretrained() throws Exception {
+        // Sanity check on the non-pretrained versions:
         ZooModel[] models = new ZooModel[]{
                 VGG16.builder().numClasses(10).build(),
                 VGG19.builder().numClasses(10).build(),
-                FaceNetNN4Small2.builder().embeddingSize(100).numClasses(10).build()
+                FaceNetNN4Small2.builder().embeddingSize(100).numClasses(10).build(),
+                UNet.builder().build()
         };
 
         int[][] inputSizes = new int[][]{
                 {1,3,224,224},
                 {1,3,224,224},
-                {1,3,64,64}
+                {1,3,64,64},
+                {1,3,512,512}
         };
 
-//        for(ZooModel zm : models){
-        for( int i=0; i<models.length; i++ ){
+        for (int i = 0; i < models.length; i++) {
             ZooModel zm = models[i];
             INDArray in = Nd4j.create(inputSizes[i]);
             Model m = zm.init();
 
-            if(m instanceof MultiLayerNetwork){
+            if (m instanceof MultiLayerNetwork) {
                 MultiLayerNetwork mln = (MultiLayerNetwork)m;
                 mln.output(in);
             } else {


### PR DESCRIPTION
FYI @AlexDBlack @crockpotveggies 

When using UNet without the pretrained model e.g. `ZooModel zooModel = UNet.builder().build().init();`, one receives the error:

```
java.lang.IllegalStateException: Invalid configuration: disconnected vertices
found - [up9-1]. Disconnected vertices are those that do not connect to either
another vertex, and are also not a network output. To disable this error (i.e.,
allow network configurations with disconnected vertices) use GraphBuilder.allowDisconnected(true)

	at org.deeplearning4j.nn.conf.ComputationGraphConfiguration.validate(ComputationGraphConfiguration.java:347)
	at org.deeplearning4j.nn.conf.ComputationGraphConfiguration$GraphBuilder.build(ComputationGraphConfiguration.java:1036)
	at org.deeplearning4j.zoo.model.UNet.init(UNet.java:93)
	at org.deeplearning4j.zoo.model.UNet.init(UNet.java:51)
```

Fix by connecting disconnected `up9-1` vertex.

The current U-Net non-pretrained model has one Truncate convolutional layer - replace this with Same, as it seems the existing solver isn't equipped to handle the truncated pixels on the label side. If you input both labels and input as 128x128, you end up with:

```
java.lang.IllegalArgumentException: Labels and preOutput must have equal shapes: got shapes [16384, 1] vs [15876, 1]

	at org.nd4j.base.Preconditions.throwEx(Preconditions.java:621)
	at org.nd4j.linalg.lossfunctions.impl.LossMCXENT.computeGradient(LossMCXENT.java:155)
	at org.deeplearning4j.nn.layers.convolution.CnnLossLayer.backpropGradient(CnnLossLayer.java:84)
	at org.deeplearning4j.nn.graph.vertex.impl.LayerVertex.doBackward(LayerVertex.java:148)
	at org.deeplearning4j.nn.graph.ComputationGraph.calcBackpropGradients(ComputationGraph.java:2592)
	at org.deeplearning4j.nn.graph.ComputationGraph.computeGradientAndScore(ComputationGraph.java:1366)
	at org.deeplearning4j.nn.graph.ComputationGraph.computeGradientAndScore(ComputationGraph.java:1326)
	at org.deeplearning4j.optimize.solvers.BaseOptimizer.gradientAndScore(BaseOptimizer.java:160)
	at org.deeplearning4j.optimize.solvers.StochasticGradientDescent.optimize(StochasticGradientDescent.java:51)
	at org.deeplearning4j.optimize.Solver.optimize(Solver.java:52)
	at org.deeplearning4j.nn.graph.ComputationGraph.fitHelper(ComputationGraph.java:1149)
	at org.deeplearning4j.nn.graph.ComputationGraph.fit(ComputationGraph.java:1098)
	at org.deeplearning4j.nn.graph.ComputationGraph.fit(ComputationGraph.java:1085)
```

Similarly, when one uses VGG16, the connections on vertices 17 and 18 are missing: Add them. (Right now, `Instantiation.testInitNotPretrained` is already failing)

Finally, also add UNet to `testInitNotPretrained` to have coverage