### PR TITLE
add nd4j cast and a small test for yolo

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -33,6 +33,7 @@ import org.nd4j.graph.FlatArray;
 import org.nd4j.linalg.api.blas.BlasBufferUtil;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
 import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.buffer.util.DataTypeUtil;
 import org.nd4j.linalg.api.instrumentation.Instrumentation;
 import org.nd4j.linalg.api.iter.FirstAxisIterator;
 import org.nd4j.linalg.api.iter.NdIndexIterator;
@@ -2746,54 +2747,54 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     protected INDArray doColumnWise(INDArray columnVector, char operation) {
         Nd4j.getCompressor().autoDecompress(this);
-       if(columnVector.isScalar()) {
-           switch (operation) {
-               case 'a':
-                   addi(columnVector.getDouble(0));
-                   break;
-               case 'p':
-                   assign(columnVector.getDouble(0));
-                   break;
-               case 's':
-                   subi(columnVector.getDouble(0));
-                   break;
-               case 'm':
-                   muli(columnVector.getDouble(0));
-                   break;
-               case 'd':
-                   divi(columnVector.getDouble(0));
-                   break;
-               case 'h':
-                   rsubi(columnVector.getDouble(0));
-                   break;
-               case 't':
-                   rdivi(columnVector.getDouble(0));
-                   break;
+        if(columnVector.isScalar()) {
+            switch (operation) {
+                case 'a':
+                    addi(columnVector.getDouble(0));
+                    break;
+                case 'p':
+                    assign(columnVector.getDouble(0));
+                    break;
+                case 's':
+                    subi(columnVector.getDouble(0));
+                    break;
+                case 'm':
+                    muli(columnVector.getDouble(0));
+                    break;
+                case 'd':
+                    divi(columnVector.getDouble(0));
+                    break;
+                case 'h':
+                    rsubi(columnVector.getDouble(0));
+                    break;
+                case 't':
+                    rdivi(columnVector.getDouble(0));
+                    break;
 
-           }
+            }
 
-           return this;
-       }
+            return this;
+        }
 
-       else if(isScalar()) {
-           switch (operation) {
-               case 'a':
-                   return columnVector.addi(getDouble(0));
-               case 'p':
-                   return columnVector.assign(getDouble(0));
-               case 's':
-                   return columnVector.subi(getDouble(0));
-               case 'm':
-                   return columnVector.muli(getDouble(0));
-               case 'd':
-                   return columnVector.divi(getDouble(0));
-               case 'h':
-                   return columnVector.rsubi(getDouble(0));
-               case 't':
-                   return columnVector.rdivi(getDouble(0));
+        else if(isScalar()) {
+            switch (operation) {
+                case 'a':
+                    return columnVector.addi(getDouble(0));
+                case 'p':
+                    return columnVector.assign(getDouble(0));
+                case 's':
+                    return columnVector.subi(getDouble(0));
+                case 'm':
+                    return columnVector.muli(getDouble(0));
+                case 'd':
+                    return columnVector.divi(getDouble(0));
+                case 'h':
+                    return columnVector.rsubi(getDouble(0));
+                case 't':
+                    return columnVector.rdivi(getDouble(0));
 
-           }
-       }
+            }
+        }
 
         //Input validation: require (a) columnVector to actually be a column vector, and (b) this.size(0) to match columnVector.size(0)
         //Or, simply require it to be a rank 1 vector
@@ -5419,7 +5420,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
      */
     @Override
     public INDArray broadcast(long... shape) {
-      return broadcast(Nd4j.createUninitialized(shape));
+        return broadcast(Nd4j.createUninitialized(shape));
     }
 
     @Override
@@ -6339,59 +6340,21 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public INDArray convertToHalfs() {
-        if (data.dataType() == DataBuffer.Type.HALF)
-            return this;
+        return Nd4j.cast(this, DataBuffer.Type.HALF);
 
-        val factory = Nd4j.getNDArrayFactory();
-        val buffer = Nd4j.createBuffer(new long[]{this.length()}, DataBuffer.Type.HALF);
-
-        factory.convertDataEx(convertType(data.dataType()), this.data().addressPointer(), DataBuffer.TypeEx.FLOAT16, buffer.addressPointer(), buffer.length());
-
-        return Nd4j.createArrayFromShapeBuffer(buffer, this.shapeInformation);
     }
 
     @Override
     public INDArray convertToFloats() {
-        if (data.dataType() == DataBuffer.Type.FLOAT)
-            return this;
+        return Nd4j.cast(this, DataBuffer.Type.FLOAT);
 
-        val factory = Nd4j.getNDArrayFactory();
-        val buffer = Nd4j.createBuffer(new long[]{this.length()}, DataBuffer.Type.FLOAT);
-
-        factory.convertDataEx(convertType(data.dataType()), this.data().addressPointer(), DataBuffer.TypeEx.FLOAT, buffer.addressPointer(), buffer.length());
-
-        return Nd4j.createArrayFromShapeBuffer(buffer, this.shapeInformation);
     }
 
     @Override
     public INDArray convertToDoubles() {
-        if (data.dataType() == DataBuffer.Type.DOUBLE)
-            return this;
-
-        val factory = Nd4j.getNDArrayFactory();
-        val buffer = Nd4j.createBuffer(new long[]{this.length()}, DataBuffer.Type.DOUBLE);
-
-        factory.convertDataEx(convertType(data.dataType()), this.data().addressPointer(), DataBuffer.TypeEx.DOUBLE, buffer.addressPointer(), buffer.length());
-
-        return Nd4j.createArrayFromShapeBuffer(buffer, this.shapeInformation);
+        return Nd4j.cast(this, DataBuffer.Type.DOUBLE);
     }
 
-    protected static DataBuffer.TypeEx convertType(DataBuffer.Type type) {
-        if (type == DataBuffer.Type.HALF) {
-            return DataBuffer.TypeEx.FLOAT16;
-        } else if (type == DataBuffer.Type.FLOAT) {
-            return DataBuffer.TypeEx.FLOAT;
-        } else if (type == DataBuffer.Type.DOUBLE) {
-            return DataBuffer.TypeEx.DOUBLE;
-
-        } else if(type == DataBuffer.Type.INT) {
-            return DataBuffer.TypeEx.INT8;
-        } else if(type == DataBuffer.Type.LONG) {
-            return DataBuffer.TypeEx.INT16;
-
-        } else
-            throw new IllegalStateException("Unknown dataType: [" + type + "]");
-    }
 
     /**
      * This method returns true if this INDArray is special case: no-value INDArray

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -6172,6 +6172,7 @@ public class Nd4j {
     }
 
 
+
     /**
      * Create an {@link INDArray}
      * from a flatbuffers {@link FlatArray}
@@ -6238,6 +6239,30 @@ public class Nd4j {
         else
             return v;
     }
+
+    /**
+     * Cast the ndarray to a new type.
+     * IF the array is the same type,
+     * the input array will be returned,
+     * otherwise a new array will be created.
+     * @param input the input array
+     * @param typeTo the type to convert to
+     * @return
+     */
+    public static INDArray cast(INDArray input,DataBuffer.Type typeTo) {
+        if (input.data().dataType() == typeTo)
+            return input;
+
+        val factory = Nd4j.getNDArrayFactory();
+        val buffer = Nd4j.createBuffer(new long[]{input.length()}, typeTo);
+
+        factory.convertDataEx(DataTypeUtil.convertType(input.dataType()), input.data().addressPointer(), DataTypeUtil.convertType(typeTo), buffer.addressPointer(), buffer.length());
+
+        return Nd4j.createArrayFromShapeBuffer(buffer, input.shapeInfoDataBuffer());
+    }
+
+
+
 
     /**
      * This method sets maximal allowed number of threads for Nd4j

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
@@ -24,6 +24,7 @@ import org.nd4j.jita.allocator.impl.AllocationPoint;
 import org.nd4j.jita.allocator.impl.AtomicAllocator;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.FloatBuffer;
+import org.nd4j.linalg.api.buffer.util.DataTypeUtil;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.BaseNDArray;
 import org.nd4j.linalg.api.ndarray.BaseNDArrayProxy;
@@ -774,7 +775,7 @@ public class JCublasNDArray extends BaseNDArray {
         val factory = Nd4j.getNDArrayFactory();
         val buffer = Nd4j.createBuffer(new long[]{this.length()}, DataBuffer.Type.HALF);
 
-        factory.convertDataEx(convertType(data.dataType()), AtomicAllocator.getInstance().getPointer(this.data()),
+        factory.convertDataEx(DataTypeUtil.convertType(data.dataType()), AtomicAllocator.getInstance().getPointer(this.data()),
                 DataBuffer.TypeEx.FLOAT16, AtomicAllocator.getInstance().getPointer(buffer), buffer.length());
 
         AtomicAllocator.getInstance().getAllocationPoint(buffer).tickDeviceWrite();
@@ -791,7 +792,7 @@ public class JCublasNDArray extends BaseNDArray {
         val factory = Nd4j.getNDArrayFactory();
         val buffer = Nd4j.createBuffer(new long[]{this.length()}, DataBuffer.Type.FLOAT);
 
-        factory.convertDataEx(convertType(data.dataType()), AtomicAllocator.getInstance().getPointer(this.data()), DataBuffer.TypeEx.FLOAT, AtomicAllocator.getInstance().getPointer(buffer), buffer.length());
+        factory.convertDataEx(DataTypeUtil.convertType(data.dataType()), AtomicAllocator.getInstance().getPointer(this.data()), DataBuffer.TypeEx.FLOAT, AtomicAllocator.getInstance().getPointer(buffer), buffer.length());
 
         AtomicAllocator.getInstance().getAllocationPoint(buffer).tickDeviceWrite();
 
@@ -806,7 +807,7 @@ public class JCublasNDArray extends BaseNDArray {
         val factory = Nd4j.getNDArrayFactory();
         val buffer = Nd4j.createBuffer(new long[]{this.length()}, DataBuffer.Type.DOUBLE);
 
-        factory.convertDataEx(convertType(data.dataType()), AtomicAllocator.getInstance().getPointer(this.data()), DataBuffer.TypeEx.DOUBLE, AtomicAllocator.getInstance().getPointer(buffer), buffer.length());
+        factory.convertDataEx(DataTypeUtil.convertType(data.dataType()), AtomicAllocator.getInstance().getPointer(this.data()), DataBuffer.TypeEx.DOUBLE, AtomicAllocator.getInstance().getPointer(buffer), buffer.length());
 
         AtomicAllocator.getInstance().getAllocationPoint(buffer).tickDeviceWrite();
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
@@ -36449,7 +36449,18 @@ public static final int TAD_THRESHOLD = TAD_THRESHOLD();
                                                     public native ShapeList calculateOutputShape(ShapeList inputShape, @ByRef DoubleContext block);
                                                 }
 //         #endif
-
+        /*
+         * image.non_max_suppression op.
+         * input:
+         *     0 - boxes - 2D-tensor with shape (num_boxes, 4) by float type
+         *     1 - scales - 1D-tensor with shape (num_boxes) by float type
+         *     2 - output_size - 0D-tensor by int type (optional)
+         * float args:
+         *     0 - threshold - threshold value for overlap checks (optional, by default 0.5)
+         * int args:
+         *     0 - output_size - as arg 2 used for same target. Eigher this or arg 2 should be provided.
+         *
+         * */
 //         #if NOT_EXCLUDED(OP_image_non_max_suppression)
         @Name("nd4j::ops::non_max_suppression<float>") public static class float_non_max_suppression extends FloatDeclarableCustomOp {
             static { Loader.load(); }

--- a/nd4j/nd4j-backends/nd4j-tests-tensorflow/src/test/cpujava/org/nd4j/tensorflow/conversion/GraphRunnerTest.java
+++ b/nd4j/nd4j-backends/nd4j-tests-tensorflow/src/test/cpujava/org/nd4j/tensorflow/conversion/GraphRunnerTest.java
@@ -21,17 +21,17 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.compression.BasicNDArrayCompressor;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.io.ClassPathResource;
 import org.nd4j.tensorflow.conversion.graphrunner.GraphRunner;
 import org.nd4j.tensorflow.conversion.graphrunner.SavedModelConfig;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.io.InputStream;
+import java.util.*;
 
 import static org.bytedeco.javacpp.tensorflow.ConfigProto;
 import static org.junit.Assert.assertEquals;
@@ -112,6 +112,19 @@ public class GraphRunnerTest {
 
     }
 
+
+    @Test
+    public void testYolo() throws Exception {
+        ClassPathResource classPathResource = new ClassPathResource("/tf_graphs/examples/yolov2_608x608/frozen_model.pb");
+        File f  = classPathResource.getFile();
+        INDArray randomIntArray = Nd4j.cast(Nd4j.rand(new int[]{1,608,608,3}), DataBuffer.Type.FLOAT);
+        assertEquals(DataBuffer.Type.FLOAT,randomIntArray.data().dataType());
+        try(GraphRunner graphRunner = new GraphRunner(f.getAbsolutePath(),Arrays.asList("input"),Arrays.asList("output"))) {
+            Map<String,INDArray> run = new HashMap<>();
+            run.put("input",randomIntArray);
+            graphRunner.run(run);
+        }
+    }
 
     @Rule
     public TemporaryFolder testDir = new TemporaryFolder();

--- a/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/util/DataTypeUtil.java
+++ b/nd4j/nd4j-buffer/src/main/java/org/nd4j/linalg/api/buffer/util/DataTypeUtil.java
@@ -33,6 +33,29 @@ public class DataTypeUtil {
     private static final ReadWriteLock lock = new ReentrantReadWriteLock();
 
 
+
+    /**
+     * Convert a data buffer type to a
+     * {@link DataBuffer.TypeEx}
+     * @param type the input type
+     * @return the converted type
+     */
+    public static DataBuffer.TypeEx convertType(DataBuffer.Type type) {
+        if (type == DataBuffer.Type.HALF) {
+            return DataBuffer.TypeEx.FLOAT16;
+        } else if (type == DataBuffer.Type.FLOAT) {
+            return DataBuffer.TypeEx.FLOAT;
+        } else if (type == DataBuffer.Type.DOUBLE) {
+            return DataBuffer.TypeEx.DOUBLE;
+
+        } else if(type == DataBuffer.Type.INT) {
+            return DataBuffer.TypeEx.INT8;
+        } else if(type == DataBuffer.Type.LONG) {
+            return DataBuffer.TypeEx.INT16;
+
+        } else
+            throw new IllegalStateException("Unknown dataType: [" + type + "]");
+    }
     /**
      * Returns the length for the given data opType
      * @param type

--- a/nd4j/nd4j-tensorflow/src/main/java/org/nd4j/tensorflow/conversion/graphrunner/GraphRunner.java
+++ b/nd4j/nd4j-tensorflow/src/main/java/org/nd4j/tensorflow/conversion/graphrunner/GraphRunner.java
@@ -483,6 +483,11 @@ public class GraphRunner implements Closeable {
             //reset the position of the pointer for execution
             inputOut.position(0);
 
+            if(outputOrder.isEmpty()) {
+                throw new IllegalStateException("Number of outputs is zero!");
+            }
+
+
             TF_Output outputOut = new tensorflow.TF_Output(outputOrder.size());
             //only setup the output ops
             for(int i = 0; i < outputOrder.size(); i++) {
@@ -503,6 +508,7 @@ public class GraphRunner implements Closeable {
 
             //these are references to the nd4j ndarrays wrapped for tensorflow
             PointerPointer<TF_Tensor> inputTensorsPointer = new PointerPointer<>(inputTensors);
+
             //note that these are the result pointers
             //the result pointers are null, and will be populated automatically by the session run
             PointerPointer<TF_Tensor> outputTensorsPointer = new PointerPointer<>(outputOrder.size());


### PR DESCRIPTION
Converts the internal casting routine we have in BaseNDArray to a public general purpose utility for casting arrays to different types.