### PR TITLE
Mark Jetbrains annotations as provided

### DIFF
--- a/datavec/datavec-api/pom.xml
+++ b/datavec/datavec-api/pom.xml
@@ -32,6 +32,7 @@
           <groupId>org.jetbrains</groupId>
           <artifactId>annotations</artifactId>
           <version>${jetbrains-annotations.version}</version>
+          <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
* Jetbrains annotations all have `RetentionPolicy#CLASS` or lower (`SOURCE`); they have no value at runtime.
* Merely found 9 usages throughout the monorepo; `@NotNull` most prominently. Might as well discard entirely.
  * could be coming from auto-generation—or are those _actually_ checked?