### PR TITLE
fix initialization of parameter space in AdaGradSpace

### DIFF
--- a/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/conf/updater/AdaGradSpace.java
+++ b/arbiter/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/conf/updater/AdaGradSpace.java
@@ -37,9 +37,6 @@ public class AdaGradSpace extends BaseUpdaterSpace {
     private ParameterSpace<Double> learningRate;
     private ParameterSpace<ISchedule> lrSchedule;
 
-    @Getter @Setter
-    private int[] indices;
-
     public AdaGradSpace(ParameterSpace<Double> learningRate) {
         this(learningRate, null);
     }


### PR DESCRIPTION
This fields overrides and breaks the `setIndex` logic that uses reflection to initialize nested fields (in this case it's `learningRate` and `lrSchedule`.