### PR TITLE
Updated typetools to allow java 9,10,11

### DIFF
--- a/datavec/datavec-spark-inference-parent/datavec-spark-inference-server/pom.xml
+++ b/datavec/datavec-spark-inference-parent/datavec-spark-inference-server/pom.xml
@@ -131,7 +131,16 @@
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.jodah</groupId>
+                    <artifactId>typetools</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>typetools</artifactId>
+            <version>${jodah.typetools.version}</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>

--- a/deeplearning4j/deeplearning4j-nearestneighbors-parent/deeplearning4j-nearestneighbor-server/pom.xml
+++ b/deeplearning4j/deeplearning4j-nearestneighbors-parent/deeplearning4j-nearestneighbor-server/pom.xml
@@ -165,7 +165,16 @@
                     <groupId>org.apache.tomcat</groupId>
                     <artifactId>tomcat-servlet-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.jodah</groupId>
+                    <artifactId>typetools</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>typetools</artifactId>
+            <version>${jodah.typetools.version}</version>
         </dependency>
         <dependency>
             <groupId>com.mashape.unirest</groupId>

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/pom.xml
@@ -186,7 +186,17 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.jodah</groupId>
+                    <artifactId>typetools</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>typetools</artifactId>
+            <version>${jodah.typetools.version}</version>
         </dependency>
 
         <dependency>

--- a/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-status/pom.xml
+++ b/nd4j/nd4j-parameter-server-parent/nd4j-parameter-server-status/pom.xml
@@ -146,7 +146,17 @@
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-servlet-api</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>net.jodah</groupId>
+                <artifactId>typetools</artifactId>
+              </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>typetools</artifactId>
+            <version>${jodah.typetools.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
         <protonpack.version>1.15</protonpack.version>
         <poi.version>3.17</poi.version>
         <play.version>2.4.8</play.version>
+        <jodah.typetools.version>0.5.0</jodah.typetools.version>
         <freemarker.version>2.3.23</freemarker.version>
         <geoip2.version>2.8.1</geoip2.version>
         <stream.analytics.version>2.7.0</stream.analytics.version>


### PR DESCRIPTION
Fix for https://github.com/deeplearning4j/deeplearning4j/issues/5804
tested manually by launching Cifar example + dependency analysis:
```bash
mvn dependency:tree | grep typetools
```
gives [INFO] |  |  +- net.jodah:typetools:jar:0.5.0:compile