### PR TITLE
RL4J: Fix rank 1 array getting returned by Learning.getInput()

### DIFF
--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
@@ -65,7 +65,7 @@ public abstract class Learning<O extends Encodable, A, AS extends ActionSpace<A>
         INDArray arr = Nd4j.create(obs.toArray());
         int[] shape = mdp.getObservationSpace().getShape();
         if (shape.length == 1)
-            return arr;
+            return arr.reshape(new long[] {1, arr.length()});
         else
             return arr.reshape(shape);
     }


### PR DESCRIPTION
Fixes #6824

Tested manually with Cartpole and A3CCartpole examples.