### PR TITLE
[WIP] Suggestion to unify DataSetIterator and MultiDataSetIterator under a common base interface

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/BalanceMinibatches.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/BalanceMinibatches.java
@@ -69,7 +69,7 @@ public class BalanceMinibatches {
 
         //lay out each example in their respective label directories tracking the paths along the way
         while (dataSetIterator.hasNext()) {
-            DataSet next = dataSetIterator.next();
+            org.nd4j.linalg.dataset.api.DataSet next = dataSetIterator.next();
             //infer minibatch size from iterator
             if (miniBatchSize < 0)
                 miniBatchSize = next.numExamples();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSetPreProcessor.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/DataSetPreProcessor.java
@@ -16,19 +16,8 @@
 
 package org.nd4j.linalg.dataset.api;
 
-import java.io.Serializable;
-
 /**
  * Pre process a dataset
  */
-public interface DataSetPreProcessor extends Serializable {
-
-    /**
-     * Pre process a dataset
-     *
-     * @param toPreProcess the data set to pre process
-     */
-    void preProcess(DataSet toPreProcess);
-
-
+public interface DataSetPreProcessor extends IDataSetPreProcessor<DataSet> {
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/IDataSetPreProcessor.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/IDataSetPreProcessor.java
@@ -14,31 +14,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.nd4j.linalg.dataset.api.iterator.cache;
+package org.nd4j.linalg.dataset.api;
 
-import org.nd4j.linalg.dataset.api.DataSet;
+import java.io.Serializable;
 
-/**
- * Created by anton on 7/16/16.
+/**PreProcessor interface for MultiDataSets
  */
-public interface DataSetCache {
-    /**
-     * Check is given namespace has complete cache of the data set
-     * @param namespace
-     * @return true if namespace is fully cached
-     */
-    boolean isComplete(String namespace);
+public interface IDataSetPreProcessor<T> extends Serializable {
 
-    /**
-     * Sets the flag indicating whether given namespace is fully cached
-     * @param namespace
-     * @param value
-     */
-    void setComplete(String namespace, boolean value);
+    /** Preprocess the MultiDataSet */
+    void preProcess(T multiDataSet);
 
-    DataSet get(String key);
-
-    void put(String key, DataSet dataSet);
-
-    boolean contains(String key);
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/MultiDataSetPreProcessor.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/MultiDataSetPreProcessor.java
@@ -18,9 +18,7 @@ package org.nd4j.linalg.dataset.api;
 
 /**PreProcessor interface for MultiDataSets
  */
-public interface MultiDataSetPreProcessor {
+public interface MultiDataSetPreProcessor extends IDataSetPreProcessor<MultiDataSet> {
 
-    /** Preprocess the MultiDataSet */
-    void preProcess(MultiDataSet multiDataSet);
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/CachingDataSetIterator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/CachingDataSetIterator.java
@@ -16,7 +16,7 @@
 
 package org.nd4j.linalg.dataset.api.iterator;
 
-import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
 import org.nd4j.linalg.dataset.api.iterator.cache.DataSetCache;
 import org.slf4j.Logger;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/DataSetIterator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/DataSetIterator.java
@@ -16,11 +16,9 @@
 
 package org.nd4j.linalg.dataset.api.iterator;
 
-import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
 
-import java.io.Serializable;
-import java.util.Iterator;
 import java.util.List;
 
 
@@ -48,22 +46,14 @@ import java.util.List;
  *
  * @author Adam Gibson
  */
-public interface DataSetIterator extends Iterator<DataSet>, Serializable {
-
-    /**
-     * Like the standard next method but allows a
-     * customizable number of examples returned
-     *
-     * @param num the number of examples
-     * @return the next data applyTransformToDestination
-     */
-    DataSet next(int num);
+public interface DataSetIterator extends IDataSetIterator<DataSet, DataSetPreProcessor> {
 
     /**
      * Input columns for the dataset
      *
      * @return
      */
+    @Deprecated
     int inputColumns();
 
     /**
@@ -71,62 +61,25 @@ public interface DataSetIterator extends Iterator<DataSet>, Serializable {
      *
      * @return
      */
+    @Deprecated
     int totalOutcomes();
 
 
-    /**
-     * Is resetting supported by this DataSetIterator? Many DataSetIterators do support resetting,
-     * but some don't
-     *
-     * @return true if reset method is supported; false otherwise
-     */
-    boolean resetSupported();
-
-    /**
-     * Does this DataSetIterator support asynchronous prefetching of multiple DataSet objects?
-     * Most DataSetIterators do, but in some cases it may not make sense to wrap this iterator in an
-     * iterator that does asynchronous prefetching. For example, it would not make sense to use asynchronous
-     * prefetching for the following types of iterators:
-     * (a) Iterators that store their full contents in memory already
-     * (b) Iterators that re-use features/labels arrays (as future next() calls will overwrite past contents)
-     * (c) Iterators that already implement some level of asynchronous prefetching
-     * (d) Iterators that may return different data depending on when the next() method is called
-     *
-     * @return true if asynchronous prefetching from this iterator is OK; false if asynchronous prefetching should not
-     * be used with this iterator
-     */
-    boolean asyncSupported();
-
-    /**
-     * Resets the iterator back to the beginning
-     */
-    void reset();
 
     /**
      * Batch size
      *
      * @return
      */
+    @Deprecated
     int batch();
 
-    /**
-     * Set a pre processor
-     *
-     * @param preProcessor a pre processor to set
-     */
-    void setPreProcessor(DataSetPreProcessor preProcessor);
-
-    /**
-     * Returns preprocessors, if defined
-     *
-     * @return
-     */
-    DataSetPreProcessor getPreProcessor();
 
     /**
      * Get dataset iterator class labels, if any.
      * Note that implementations are not required to implement this, and can simply return null
      */
+    @Deprecated
     List<String> getLabels();
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/IDataSetIterator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/IDataSetIterator.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.nd4j.linalg.dataset.api.iterator;
+
+import org.nd4j.linalg.dataset.api.IDataSetPreProcessor;
+import org.nd4j.linalg.dataset.api.MultiDataSet;
+import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
+
+import java.io.Serializable;
+import java.util.Iterator;
+
+/**An iterator for {@link MultiDataSet} objects.
+ * Typical usage is for machine learning algorithms with multiple independent input (features) and output (labels)
+ * arrays.
+ */
+public interface IDataSetIterator<T, U extends IDataSetPreProcessor<T>> extends Iterator<T>, Serializable {
+
+    /** Fetch the next 'num' examples. Similar to the next method, but returns a specified number of examples
+     *
+     * @param num Number of examples to fetch
+     */
+    T next(int num);
+
+    /** Set the preprocessor to be applied to each MultiDataSet, before each MultiDataSet is returned.
+      * @param preProcessor MultiDataSetPreProcessor. May be null.
+     */
+    void setPreProcessor(U preProcessor);
+
+
+    /**
+     * Get the {@link MultiDataSetPreProcessor}, if one has previously been set.
+     * Returns null if no preprocessor has been set
+     *
+     * @return Preprocessor
+     */
+    U getPreProcessor();
+
+    /**
+     * Is resetting supported by this DataSetIterator? Many DataSetIterators do support resetting,
+     * but some don't
+     *
+     * @return true if reset method is supported; false otherwise
+     */
+    boolean resetSupported();
+
+    /**
+     * Does this MultiDataSetIterator support asynchronous prefetching of multiple MultiDataSet objects?
+     * Most MultiDataSetIterators do, but in some cases it may not make sense to wrap this iterator in an
+     * iterator that does asynchronous prefetching. For example, it would not make sense to use asynchronous
+     * prefetching for the following types of iterators:
+     * (a) Iterators that store their full contents in memory already
+     * (b) Iterators that re-use features/labels arrays (as future next() calls will overwrite past contents)
+     * (c) Iterators that already implement some level of asynchronous prefetching
+     * (d) Iterators that may return different data depending on when the next() method is called
+     *
+     * @return true if asynchronous prefetching from this iterator is OK; false if asynchronous prefetching should not
+     * be used with this iterator
+     */
+    boolean asyncSupported();
+
+    /**
+     * Resets the iterator back to the beginning
+     */
+    void reset();
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/MultiDataSetIterator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/MultiDataSetIterator.java
@@ -20,60 +20,11 @@ import org.nd4j.linalg.dataset.api.MultiDataSet;
 import org.nd4j.linalg.dataset.api.MultiDataSetPreProcessor;
 
 import java.io.Serializable;
-import java.util.Iterator;
 
 /**An iterator for {@link org.nd4j.linalg.dataset.api.MultiDataSet} objects.
  * Typical usage is for machine learning algorithms with multiple independent input (features) and output (labels)
  * arrays.
  */
-public interface MultiDataSetIterator extends Iterator<MultiDataSet>, Serializable {
-
-    /** Fetch the next 'num' examples. Similar to the next method, but returns a specified number of examples
-     *
-     * @param num Number of examples to fetch
-     */
-    MultiDataSet next(int num);
-
-    /** Set the preprocessor to be applied to each MultiDataSet, before each MultiDataSet is returned.
-      * @param preProcessor MultiDataSetPreProcessor. May be null.
-     */
-    void setPreProcessor(MultiDataSetPreProcessor preProcessor);
-
-
-    /**
-     * Get the {@link MultiDataSetPreProcessor}, if one has previously been set.
-     * Returns null if no preprocessor has been set
-     *
-     * @return Preprocessor
-     */
-    MultiDataSetPreProcessor getPreProcessor();
-
-    /**
-     * Is resetting supported by this DataSetIterator? Many DataSetIterators do support resetting,
-     * but some don't
-     *
-     * @return true if reset method is supported; false otherwise
-     */
-    boolean resetSupported();
-
-    /**
-     * Does this MultiDataSetIterator support asynchronous prefetching of multiple MultiDataSet objects?
-     * Most MultiDataSetIterators do, but in some cases it may not make sense to wrap this iterator in an
-     * iterator that does asynchronous prefetching. For example, it would not make sense to use asynchronous
-     * prefetching for the following types of iterators:
-     * (a) Iterators that store their full contents in memory already
-     * (b) Iterators that re-use features/labels arrays (as future next() calls will overwrite past contents)
-     * (c) Iterators that already implement some level of asynchronous prefetching
-     * (d) Iterators that may return different data depending on when the next() method is called
-     *
-     * @return true if asynchronous prefetching from this iterator is OK; false if asynchronous prefetching should not
-     * be used with this iterator
-     */
-    boolean asyncSupported();
-
-    /**
-     * Resets the iterator back to the beginning
-     */
-    void reset();
+public interface MultiDataSetIterator extends IDataSetIterator<MultiDataSet, MultiDataSetPreProcessor>, Serializable {
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/MultipleEpochsIterator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/MultipleEpochsIterator.java
@@ -16,7 +16,7 @@
 
 package org.nd4j.linalg.dataset.api.iterator;
 
-import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/StandardScaler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/StandardScaler.java
@@ -18,7 +18,7 @@ package org.nd4j.linalg.dataset.api.iterator;
 
 
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.ops.transforms.Transforms;
 import org.slf4j.Logger;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileAndMemoryDataSetCache.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileAndMemoryDataSetCache.java
@@ -16,7 +16,7 @@
 
 package org.nd4j.linalg.dataset.api.iterator.cache;
 
-import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSet;
 
 import java.io.File;
 import java.nio.file.Path;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileDataSetCache.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InFileDataSetCache.java
@@ -16,7 +16,7 @@
 
 package org.nd4j.linalg.dataset.api.iterator.cache;
 
-import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSet;
 
 import java.io.File;
 import java.io.IOException;
@@ -88,7 +88,7 @@ public class InFileDataSetCache implements DataSetCache {
         } else if (!file.isFile()) {
             throw new IllegalStateException("ERROR: cannot read DataSet: cache path " + file + " is not a file");
         } else {
-            DataSet ds = new DataSet();
+            DataSet ds = new org.nd4j.linalg.dataset.DataSet();
             ds.load(file);
             return ds;
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InMemoryDataSetCache.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/iterator/cache/InMemoryDataSetCache.java
@@ -16,7 +16,7 @@
 
 package org.nd4j.linalg.dataset.api.iterator.cache;
 
-import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +62,7 @@ public class InMemoryDataSetCache implements DataSetCache {
 
         ByteArrayInputStream is = new ByteArrayInputStream(data);
 
-        DataSet ds = new DataSet();
+        DataSet ds = new org.nd4j.linalg.dataset.DataSet();
 
         ds.load(is);
 


### PR DESCRIPTION
Notice that I haven't adapted the documentation yet. This is just meant to be a starting point for a discussion.

To give some more context:

MultiDataSetIterator and DataSetIterator are quite similar to each other, especially if you consider that the extra methods on DataSetIterator are often left unimplemented. 

In this pull request I suggest to deprecated those extra methods, and to unify MultiDataSetIterator and DataSetIterator under a common interface IDataSetIterator. As far as my preliminary testing went, the change is mostly backwards compatible. With the only big change being that DataSet should also be the Interface variant.