### PR TITLE
Shugeo divide bp

### DIFF
--- a/libnd4j/include/ops/declarable/generic/broadcastable/divide.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/divide.cpp
@@ -75,19 +75,22 @@ namespace nd4j {
 
                 // X gradient
                 //epsNext->applyPairwiseLambda(y, lambdaX, gradX);
-                epsNext->applyPairwiseTransform(pairwise::Divide, y, gradX);
-
+                gradX->assign((*epsNext) / (*y));
                 // Y gradient
                 //epsNext->applyTriplewiseLambda(x, y, lambdaY, gradY);
-                gradY->assign(epsNext * - (*x) / ((*y) * (*y)));
+                gradY->assign((*epsNext) * (*x) / ((*y) * (*y)));
+                gradY->applyTransform(transform::Neg, nullptr, nullptr);
 
             } else if (y->isScalar()) {
                 // scalar case
 
                 auto tmp = epsNext->reduceNumber(reduce::Sum);
                 auto tmpX = x->reduceNumber(reduce::Sum);
-                gradY->assign(tmp * -tmpX / ((*y) * (*y)));
-                
+                tmpX.printBuffer("SumX");
+                tmp.printBuffer("Sum Eps");
+                gradY->assign(tmp * tmpX / ((*y) * (*y)));
+                gradY->applyTransform(transform::Neg, nullptr, nullptr);
+
                 //epsNext->applyLambda(lambdaS, gradX);
                 epsNext->applyScalarArr(scalar::Divide, y, gradX, nullptr);
             } else {

--- a/libnd4j/include/ops/declarable/generic/broadcastable/maximum.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/maximum.cpp
@@ -23,7 +23,7 @@
 
 #include <ops/declarable/generic/helpers/BroadcastHelper.h>
 #include <ops/declarable/CustomOperations.h>
-
+#include <ops/declarable/helpers/minimax.h>
 namespace nd4j {
     namespace ops {
         BROADCASTABLE_OP_IMPL(maximum, 0, 0) {
@@ -56,84 +56,14 @@ namespace nd4j {
         }
 
         CUSTOM_OP_IMPL(maximum_bp, 3, 2, false, 0, 0) {
-            // FIXME: lambdas
-            /*
             auto x = INPUT_VARIABLE(0);
             auto y = INPUT_VARIABLE(1);
             auto epsNext = INPUT_VARIABLE(2);
 
             auto gradX = OUTPUT_VARIABLE(0);
             auto gradY = OUTPUT_VARIABLE(1);
-
-            auto lambdaX = LAMBDA_TTT(_e, _x, _y) {
-                return _x >= _y ? _e : (T) 0.;
-            };
-
-            auto lambdaY = LAMBDA_TTT(_e, _x, _y) {
-                return _x <= _y ? _e : (T) 0.;
-            };
-
-
-            if (x->isSameShape(y)) {
-                // PWT case case
-
-                // X gradient
-                epsNext->applyTriplewiseLambda(x, y, lambdaX, gradX);
-
-                // Y gradient
-                epsNext->applyTriplewiseLambda(x, y, lambdaY, gradY);
-
-            } else if (y->isScalar()) {
-                T s = y->e(0);
-                auto lambdaS = LAMBDA_TT(_e, _x, s) {
-                    return _x >= s ? _e : (T) 0.;
-                };
-
-                // scalar case
-                auto tmp = epsNext->reduceNumber(reduce::Sum);
-                if (x <= y)
-                    gradY->assign(tmp);
-                else
-                    gradY->assign(0.0f);
-                
-                epsNext->applyPairwiseLambda(x, lambdaS, gradX);
-            } else {
-                // broadcast case
-
-                // in this case we want to boost our X and Y shapes to the size of FF pass output (or epsNext, which has the same shape)
-                auto preX = x->dup();
-                auto preY = y->dup();
-
-                auto targetShape = epsNext->getShapeAsVector();
-
-                preX->tileToShape(targetShape);
-                preY->tileToShape(targetShape);
-
-                epsNext->applyTriplewiseLambda(preX, preY, lambdaX, preX);
-                epsNext->applyTriplewiseLambda(preX, preY, lambdaY, preY);
-
-                auto axisX = ShapeUtils::evalBroadcastBackwardAxis(x->shapeInfo(), epsNext->shapeInfo());
-                auto axisY = ShapeUtils::evalBroadcastBackwardAxis(y->shapeInfo(), epsNext->shapeInfo());
-
-                if (axisX.size() > 0) {
-                    auto sum = preX->reduceAlongDimension(reduce::Sum, axisX);
-                    gradX->assign(sum);
-                    delete sum;
-                } else 
-                    gradX->assign(preX);
-
-                if (axisY.size() > 0) {
-                    auto sum = preY->reduceAlongDimension(reduce::Sum, axisY);
-                    gradY->assign(sum);
-                    delete sum;
-                } else
-                    gradY->assign(preY);
-
-
-                delete preX;
-                delete preY;
-            }
-            */
+            
+            helpers::maximumBPFunctor(x, y, epsNext, gradX, gradY);
             return Status::OK();
         }
 

--- a/libnd4j/include/ops/declarable/generic/broadcastable/minimum.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/minimum.cpp
@@ -23,6 +23,7 @@
 
 #include <ops/declarable/CustomOperations.h>
 #include <ops/declarable/generic/helpers/BroadcastHelper.h>
+#include <ops/declarable/helpers/minimax.h>
 
 namespace nd4j {
     namespace ops {
@@ -56,85 +57,14 @@ namespace nd4j {
         }
 
         CUSTOM_OP_IMPL(minimum_bp, 3, 2, false, 0, 0) {
-            // FIXME: lambdas
-            /*
+
             auto x = INPUT_VARIABLE(0);
             auto y = INPUT_VARIABLE(1);
             auto epsNext = INPUT_VARIABLE(2);
 
             auto gradX = OUTPUT_VARIABLE(0);
             auto gradY = OUTPUT_VARIABLE(1);
-
-            auto lambdaX = LAMBDA_TTT(_e, _x, _y) {
-                return _x <= _y ? _e : (T) 0.;
-            };
-
-            auto lambdaY = LAMBDA_TTT(_e, _x, _y) {
-                return _x >= _y ? _e : (T) 0.;
-            };
-
-
-            if (x->isSameShape(y)) {
-                // PWT case case
-
-                // X gradient
-                epsNext->applyTriplewiseLambda(x, y, lambdaX, gradX);
-
-                // Y gradient
-                epsNext->applyTriplewiseLambda(x, y, lambdaY, gradY);
-
-            } else if (y->isScalar()) {
-                T s = y->e(0);
-                auto lambdaS = LAMBDA_TT(_e, _x, s) {
-                    return _x <= s ? _e : (T) 0.;
-                };
-
-                // scalar case
-                auto tmp = epsNext->reduceNumber(reduce::Sum);
-                if (x <= y)
-                    gradY->assign(tmp);
-                else
-                    gradY->assign(0.0f);
-                
-                epsNext->applyPairwiseLambda(x, lambdaS, gradX);
-            } else {
-                // broadcast case
-
-                // in this case we want to boost our X and Y shapes to the size of FF pass output (or epsNext, which has the same shape)
-                auto preX = x->dup();
-                auto preY = y->dup();
-
-                auto targetShape = epsNext->getShapeAsVector();
-
-                preX->tileToShape(targetShape);
-                preY->tileToShape(targetShape);
-
-                epsNext->applyTriplewiseLambda(preX, preY, lambdaX, preX);
-                epsNext->applyTriplewiseLambda(preX, preY, lambdaY, preY);
-
-                auto axisX = ShapeUtils::evalBroadcastBackwardAxis(x->shapeInfo(), epsNext->shapeInfo());
-                auto axisY = ShapeUtils::evalBroadcastBackwardAxis(y->shapeInfo(), epsNext->shapeInfo());
-
-                if (axisX.size() > 0) {
-                    auto sum = preX->reduceAlongDimension(reduce::Sum, axisX);
-                    gradX->assign(sum);
-                    delete sum;
-                } else 
-                    gradX->assign(preX);
-
-                if (axisY.size() > 0) {
-                    auto sum = preY->reduceAlongDimension(reduce::Sum, axisY);
-                    gradY->assign(sum);
-                    delete sum;
-                } else
-                    gradY->assign(preY);
-
-
-                delete preX;
-                delete preY;
-            }
-
-            */
+            helpers::minimumBPFunctor(x, y, epsNext, gradX, gradY);
             return Status::OK();
         }
 

--- a/libnd4j/include/ops/declarable/generic/broadcastable/reverse_divide.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/reverse_divide.cpp
@@ -64,27 +64,26 @@ namespace nd4j {
 
                 // X gradient
                 //epsNext->applyTriplewiseLambda(x, y, lambdaX, gradX);
-                gradX->assign(epsNext * -(*y) / ((*x) * (*x)));
-
+                gradX->assign((*epsNext) * (*y) / ((*x) * (*x)));
+                gradX->applyTransform(transform::Neg, nullptr, nullptr);
                 // Y gradient
                 //epsNext->applyPairwiseLambda(x, lambdaY, gradY);
-                epsNext->applyPairwiseTransform(pairwise::Divide, x, gradY, nullptr);
-
+                gradY->assign((*epsNext) / (*x));
             } else if (y->isScalar()) {
                 // scalar case
                 auto tmp = epsNext->reduceNumber(reduce::Sum);
                 auto tmpX = x->reduceNumber(reduce::Sum);
                 gradY->assign(tmp / tmpX);
 
-                gradX->assign(epsNext * -(*y) / ((*x) * (*x)));
+                gradX->assign((*epsNext) * (*y) / ((*x) * (*x)));
+                gradX->applyTransform(transform::Neg, nullptr, nullptr);
             } else {
                 // broadcast case
 
                 auto preY = (*epsNext) / (*x);
 
-                NDArray negY(*y);
-                y->applyTransform(transform::Neg, &negY);
-                auto preX = *epsNext * negY / ((*x) * (*x));
+                auto preX = *epsNext * (*y) / ((*x) * (*x));
+                preX.applyTransform(transform::Neg, nullptr, nullptr);
 
                 auto axisX = ShapeUtils::evalBroadcastBackwardAxis(x->shapeInfo(), epsNext->shapeInfo());
                 auto axisY = ShapeUtils::evalBroadcastBackwardAxis(y->shapeInfo(), epsNext->shapeInfo());

--- a/libnd4j/include/ops/declarable/generic/parity_ops/confusion_matrix.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/confusion_matrix.cpp
@@ -46,7 +46,7 @@ namespace nd4j {
                 REQUIRE_TRUE(weights->isSameShape(predictions),0, "CONFUSION_MATRIX: Weights and predictions should have equal shape");
             }
             auto output = OUTPUT_VARIABLE(0);
-
+            output->assign(0.);
             int minPrediction = predictions->reduceNumber(reduce::Min).e<int>(0);
             int minLabel = labels->reduceNumber(reduce::Min).e<int>(0);
 

--- a/libnd4j/include/ops/declarable/generic/parity_ops/slice.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/slice.cpp
@@ -133,7 +133,7 @@ namespace nd4j {
             auto epsNext = block.width() == 4 ? INPUT_VARIABLE(3) : INPUT_VARIABLE(1);
 
             auto output = OUTPUT_VARIABLE(0);
-
+            output->assign(0.);
             int x_rank = input->rankOf();
 
             std::vector<int> begin;

--- a/libnd4j/include/ops/declarable/helpers/cpu/minimax.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/minimax.cpp
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+//
+//  @author sgazeos@gmail.com
+//
+#ifndef __MIN_I_MAX_H_HELPERS__
+#define __MIN_I_MAX_H_HELPERS__
+#include <op_boilerplate.h>
+#include <NDArray.h>
+#include <helpers/ShapeUtils.h>
+
+namespace nd4j {
+namespace ops {
+namespace helpers {
+
+    template <typename T> 
+    static void minimumBPFunctor_(NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY) {
+
+            auto lambdaX = LAMBDA_TTT(_e, _x, _y) {
+                return _x <= _y ? _e : (T) 0.;
+            };
+
+            auto lambdaY = LAMBDA_TTT(_e, _x, _y) {
+                return _x >= _y ? _e : (T) 0.;
+            };
+
+
+            if (x->isSameShape(y)) {
+                // PWT case case
+
+                // X gradient
+                epsNext->applyTriplewiseLambda<T>(x, y, lambdaX, gradX);
+
+                // Y gradient
+                epsNext->applyTriplewiseLambda<T>(x, y, lambdaY, gradY);
+
+            } else if (y->isScalar()) {
+                T s = y->e<T>(0);
+                auto lambdaS = LAMBDA_TT(_e, _x, s) {
+                    return _x <= s ? _e : (T) 0.;
+                };
+
+                // scalar case
+                auto tmp = epsNext->reduceNumber(reduce::Sum);
+                if (x <= y)
+                    gradY->assign(tmp);
+                else
+                    gradY->assign(0.0f);
+                
+                epsNext->applyPairwiseLambda<T>(x, lambdaS, gradX);
+            } else {
+                // broadcast case
+
+                // in this case we want to boost our X and Y shapes to the size of FF pass output (or epsNext, which has the same shape)
+                auto preX = x->dup();
+                auto preY = y->dup();
+
+                auto targetShape = epsNext->getShapeAsVector();
+
+                preX->tileToShape(targetShape);
+                preY->tileToShape(targetShape);
+
+                epsNext->applyTriplewiseLambda<T>(preX, preY, lambdaX, preX);
+                epsNext->applyTriplewiseLambda<T>(preX, preY, lambdaY, preY);
+
+                auto axisX = ShapeUtils::evalBroadcastBackwardAxis(x->shapeInfo(), epsNext->shapeInfo());
+                auto axisY = ShapeUtils::evalBroadcastBackwardAxis(y->shapeInfo(), epsNext->shapeInfo());
+
+                if (axisX.size() > 0) {
+                    auto sum = preX->reduceAlongDimension(reduce::Sum, axisX);
+                    gradX->assign(sum);
+                    delete sum;
+                } else 
+                    gradX->assign(preX);
+
+                if (axisY.size() > 0) {
+                    auto sum = preY->reduceAlongDimension(reduce::Sum, axisY);
+                    gradY->assign(sum);
+                    delete sum;
+                } else
+                    gradY->assign(preY);
+
+
+                delete preX;
+                delete preY;
+            }
+
+    }
+    template <typename T>
+    void maximumBPFunctor_(NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY) {
+
+            auto lambdaX = LAMBDA_TTT(_e, _x, _y) {
+                return _x >= _y ? _e : (T) 0.;
+            };
+
+            auto lambdaY = LAMBDA_TTT(_e, _x, _y) {
+                return _x <= _y ? _e : (T) 0.;
+            };
+
+
+            if (x->isSameShape(y)) {
+                // PWT case case
+
+                // X gradient
+                epsNext->applyTriplewiseLambda<T>(x, y, lambdaX, gradX);
+
+                // Y gradient
+                epsNext->applyTriplewiseLambda<T>(x, y, lambdaY, gradY);
+
+            } else if (y->isScalar()) {
+                T s = y->e<T>(0);
+                auto lambdaS = LAMBDA_TT(_e, _x, s) {
+                    return _x >= s ? _e : (T) 0.;
+                };
+
+                // scalar case
+                auto tmp = epsNext->reduceNumber(reduce::Sum);
+                if (x <= y)
+                    gradY->assign(tmp);
+                else
+                    gradY->assign(0.0f);
+                
+                epsNext->applyPairwiseLambda<T>(x, lambdaS, gradX);
+            } else {
+                // broadcast case
+
+                // in this case we want to boost our X and Y shapes to the size of FF pass output (or epsNext, which has the same shape)
+                auto preX = x->dup();
+                auto preY = y->dup();
+
+                auto targetShape = epsNext->getShapeAsVector();
+
+                preX->tileToShape(targetShape);
+                preY->tileToShape(targetShape);
+
+                epsNext->applyTriplewiseLambda<T>(preX, preY, lambdaX, preX);
+                epsNext->applyTriplewiseLambda<T>(preX, preY, lambdaY, preY);
+
+                auto axisX = ShapeUtils::evalBroadcastBackwardAxis(x->shapeInfo(), epsNext->shapeInfo());
+                auto axisY = ShapeUtils::evalBroadcastBackwardAxis(y->shapeInfo(), epsNext->shapeInfo());
+
+                if (axisX.size() > 0) {
+                    auto sum = preX->reduceAlongDimension(reduce::Sum, axisX);
+                    gradX->assign(sum);
+                    delete sum;
+                } else 
+                    gradX->assign(preX);
+
+                if (axisY.size() > 0) {
+                    auto sum = preY->reduceAlongDimension(reduce::Sum, axisY);
+                    gradY->assign(sum);
+                    delete sum;
+                } else
+                    gradY->assign(preY);
+
+
+                delete preX;
+                delete preY;
+            }
+    }
+
+    void minimumBPFunctor(NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY) {
+        BUILD_SINGLE_SELECTOR(x->dataType(), minimumBPFunctor_, (x, y, epsNext, gradX, gradY), NUMERIC_TYPES);
+    }
+
+    void maximumBPFunctor(NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY) {
+        BUILD_SINGLE_SELECTOR(x->dataType(), maximumBPFunctor_, (x, y, epsNext, gradX, gradY), NUMERIC_TYPES);
+    }
+    BUILD_SINGLE_TEMPLATE(template void minimumBPFunctor_, (NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY), NUMERIC_TYPES);
+    BUILD_SINGLE_TEMPLATE(template void maximumBPFunctor_, (NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY), NUMERIC_TYPES);
+
+}
+}
+}
+#endif

--- a/libnd4j/include/ops/declarable/helpers/minimax.h
+++ b/libnd4j/include/ops/declarable/helpers/minimax.h
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+//
+//  @author sgazeos@gmail.com
+//
+#ifndef __MIN_I_MAX_H_HELPERS__
+#define __MIN_I_MAX_H_HELPERS__
+#include <op_boilerplate.h>
+#include <NDArray.h>
+
+namespace nd4j {
+namespace ops {
+namespace helpers {
+
+    void minimumBPFunctor(NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY);
+    void maximumBPFunctor(NDArray* x, NDArray* y, NDArray* epsNext, NDArray* gradX, NDArray* gradY);
+
+}
+}
+}
+#endif

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
@@ -383,3 +383,48 @@ TEST_F(DeclarableOpsTests12, hinge_loss_14) {
 
     ASSERT_TRUE(output.e<double>(0) == 47.);
 }
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestDivideBP_1) {
+
+    NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray y = NDArrayFactory::create<double>(2.);
+    NDArray eps('c', {3,4}, nd4j::DataType::DOUBLE);
+
+    NDArray output1('c', {3, 4}, nd4j::DataType::DOUBLE);
+    NDArray output2(nd4j::DataType::DOUBLE);
+
+    x.linspace(2., 2.);
+    eps.linspace(1.);
+
+    nd4j::ops::divide_bp op;
+    Nd4jStatus status = op.execute({&x, &y, &eps}, {&output1, &output2}, {}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output1.printIndexedBuffer("DivideBP X out");
+    output2.printIndexedBuffer("DivideBP Y out");
+    //ASSERT_TRUE(output.e<double>(0) == 47.);
+}
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestDivideBP_2) {
+
+    NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray y = NDArrayFactory::create<double>('c', {3,4});
+    NDArray eps('c', {3,4}, nd4j::DataType::DOUBLE);
+
+    NDArray output1('c', {3, 4}, nd4j::DataType::DOUBLE);
+    NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
+
+    x.linspace(2., 2.);
+    y.linspace(1.);
+    eps.linspace(1.);
+
+    nd4j::ops::divide_bp op;
+    Nd4jStatus status = op.execute({&x, &y, &eps}, {&output1, &output2}, {}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output1.printIndexedBuffer("2DivideBP X out");
+    output2.printIndexedBuffer("2DivideBP Y out");
+    //ASSERT_TRUE(output.e<double>(0) == 47.);
+}

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
@@ -446,7 +446,7 @@ TEST_F(DeclarableOpsTests12, TestReverseDivideBP_1) {
     eps.linspace(1.);
 
     nd4j::ops::reversedivide_bp op;
-    Nd4jStatus status = op.execute({&y, &x, &eps}, {&output1, &output2}, {}, {}, {});
+    Nd4jStatus status = op.execute({&y, &x, &eps}, {&output2, &output1}, {}, {}, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, status);
     output1.printIndexedBuffer("RDivideBP X out");
@@ -480,3 +480,28 @@ TEST_F(DeclarableOpsTests12, TestReverseDivideBP_2) {
     ASSERT_TRUE(output1.equalsTo(exp1));
     ASSERT_TRUE(output2.equalsTo(exp2));
 }
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestSliceBP_1) {
+
+    NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray eps('c', {2,2}, nd4j::DataType::DOUBLE);
+    //NDArray exp1('c', {3,4}, nd4j::DataType::DOUBLE);
+    //NDArray exp2('c', {3,4}, nd4j::DataType::DOUBLE);
+
+    NDArray output('c', {3, 4}, nd4j::DataType::DOUBLE);
+    //NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
+
+    x.linspace(1.);
+    eps.assign(1.);
+    //exp1.assign(1.);
+    //exp2.assign(-2.);
+    nd4j::ops::slice_bp op;
+    Nd4jStatus status = op.execute({&x, &eps}, {&output}, {}, {1,1,2,2}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output.printIndexedBuffer("SLICE_BP out");
+    //ASSERT_TRUE(output1.equalsTo(exp1));
+    //ASSERT_TRUE(output2.equalsTo(exp2));
+}
+

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
@@ -529,3 +529,61 @@ TEST_F(DeclarableOpsTests12, TestConfusionZero_1) {
     ASSERT_TRUE(output.equalsTo(exp));
     //ASSERT_TRUE(output2.equalsTo(exp2));
 }
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestMaximumBP_1) {
+
+    NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray y('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray eps('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray exp1('c', {3,4}, {0, 0, 0, 0, 0, 0, 7, 8, 9, 10, 11, 12}, nd4j::DataType::DOUBLE);
+    NDArray exp2('c', {3,4}, {1, 2, 3, 4, 5, 6, 0, 0, 0,  0,  0,  0}, nd4j::DataType::DOUBLE);
+
+    NDArray output1('c', {3, 4}, nd4j::DataType::DOUBLE);
+    NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
+    output1.assign(119);
+    x.linspace(1.);
+    y.linspace(12., -1.);
+    x.printBuffer("X");
+    y.printBuffer("Y");
+    eps.linspace(1.);
+    //exp1.assign(1.);
+    //exp2.assign(-2.);
+    nd4j::ops::maximum_bp op;
+    Nd4jStatus status = op.execute({&x, &y, &eps}, {&output1, &output2}, {}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output1.printIndexedBuffer("X max");
+    output2.printIndexedBuffer("Y max");
+    ASSERT_TRUE(output1.equalsTo(exp1));
+    ASSERT_TRUE(output2.equalsTo(exp2));
+}
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestMinimumBP_1) {
+
+    NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray y('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray eps('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray exp1('c', {3,4}, {0, 0, 0, 0, 0, 0, 7, 8, 9, 10, 11, 12}, nd4j::DataType::DOUBLE);
+    NDArray exp2('c', {3,4}, {1, 2, 3, 4, 5, 6, 0, 0, 0,  0,  0,  0}, nd4j::DataType::DOUBLE);
+
+    NDArray output1('c', {3, 4}, nd4j::DataType::DOUBLE);
+    NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
+    output1.assign(119);
+    x.linspace(1.);
+    y.linspace(12., -1.);
+    x.printBuffer("X");
+    y.printBuffer("Y");
+    eps.linspace(1.);
+    //exp1.assign(1.);
+    //exp2.assign(-2.);
+    nd4j::ops::minimum_bp op;
+    Nd4jStatus status = op.execute({&x, &y, &eps}, {&output2, &output1}, {}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output2.printIndexedBuffer("X min");
+    output1.printIndexedBuffer("Y min");
+    ASSERT_TRUE(output1.equalsTo(exp1));
+    ASSERT_TRUE(output2.equalsTo(exp2));
+}

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
@@ -505,3 +505,27 @@ TEST_F(DeclarableOpsTests12, TestSliceBP_1) {
     //ASSERT_TRUE(output2.equalsTo(exp2));
 }
 
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestConfusionZero_1) {
+
+    NDArray x('c', {2}, {1,2}, nd4j::DataType::INT64);
+    NDArray i('c', {2}, {0,2}, nd4j::DataType::INT64);
+    //NDArray eps('c', {2,2}, nd4j::DataType::DOUBLE);
+    NDArray exp('c', {4,4}, {0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0}, nd4j::DataType::INT64);
+    //NDArray exp2('c', {3,4}, nd4j::DataType::DOUBLE);
+
+    NDArray output('c', {4, 4}, nd4j::DataType::INT64);
+    //NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
+    output.assign(119.113);
+    x.linspace(1.);
+    //eps.assign(1.);
+    //exp1.assign(1.);
+    //exp2.assign(-2.);
+    nd4j::ops::confusion_matrix op;
+    Nd4jStatus status = op.execute({&x, &i}, {&output}, {}, {4}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output.printIndexedBuffer("Confusion out");
+    ASSERT_TRUE(output.equalsTo(exp));
+    //ASSERT_TRUE(output2.equalsTo(exp2));
+}

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
@@ -412,10 +412,12 @@ TEST_F(DeclarableOpsTests12, TestDivideBP_2) {
     NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
     NDArray y = NDArrayFactory::create<double>('c', {3,4});
     NDArray eps('c', {3,4}, nd4j::DataType::DOUBLE);
-
+    NDArray exp1('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray exp2('c', {3,4}, nd4j::DataType::DOUBLE);
     NDArray output1('c', {3, 4}, nd4j::DataType::DOUBLE);
     NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
-
+    exp1.assign(1.);
+    exp2.assign(-2.);
     x.linspace(2., 2.);
     y.linspace(1.);
     eps.linspace(1.);
@@ -426,5 +428,55 @@ TEST_F(DeclarableOpsTests12, TestDivideBP_2) {
     ASSERT_EQ(ND4J_STATUS_OK, status);
     output1.printIndexedBuffer("2DivideBP X out");
     output2.printIndexedBuffer("2DivideBP Y out");
+    ASSERT_TRUE(output1.equalsTo(exp1));
+    ASSERT_TRUE(output2.equalsTo(exp2));
+}
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestReverseDivideBP_1) {
+
+    NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray y = NDArrayFactory::create<double>(2.);
+    NDArray eps('c', {3,4}, nd4j::DataType::DOUBLE);
+
+    NDArray output1('c', {3, 4}, nd4j::DataType::DOUBLE);
+    NDArray output2(nd4j::DataType::DOUBLE);
+
+    x.linspace(2., 2.);
+    eps.linspace(1.);
+
+    nd4j::ops::reversedivide_bp op;
+    Nd4jStatus status = op.execute({&y, &x, &eps}, {&output1, &output2}, {}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output1.printIndexedBuffer("RDivideBP X out");
+    output2.printIndexedBuffer("RDivideBP Y out");
     //ASSERT_TRUE(output.e<double>(0) == 47.);
+}
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, TestReverseDivideBP_2) {
+
+    NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray y = NDArrayFactory::create<double>('c', {3,4});
+    NDArray eps('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray exp1('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray exp2('c', {3,4}, nd4j::DataType::DOUBLE);
+
+    NDArray output1('c', {3, 4}, nd4j::DataType::DOUBLE);
+    NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
+
+    x.linspace(2., 2.);
+    y.linspace(1.);
+    eps.linspace(1.);
+    exp1.assign(1.);
+    exp2.assign(-2.);
+    nd4j::ops::reversedivide_bp op;
+    Nd4jStatus status = op.execute({&y, &x, &eps}, {&output2, &output1}, {}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    output1.printIndexedBuffer("2RDivideBP X out");
+    output2.printIndexedBuffer("2RDivideBP Y out");
+    ASSERT_TRUE(output1.equalsTo(exp1));
+    ASSERT_TRUE(output2.equalsTo(exp2));
 }

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
@@ -486,12 +486,12 @@ TEST_F(DeclarableOpsTests12, TestSliceBP_1) {
 
     NDArray x('c', {3,4}, nd4j::DataType::DOUBLE);
     NDArray eps('c', {2,2}, nd4j::DataType::DOUBLE);
-    //NDArray exp1('c', {3,4}, nd4j::DataType::DOUBLE);
+    NDArray exp('c', {3,4}, {0., 0., 0., 0., 0., 1.,1., 0., 0., 1., 1., 0.});
     //NDArray exp2('c', {3,4}, nd4j::DataType::DOUBLE);
 
     NDArray output('c', {3, 4}, nd4j::DataType::DOUBLE);
     //NDArray output2('c', {3, 4}, nd4j::DataType::DOUBLE);
-
+    output.assign(119.113);
     x.linspace(1.);
     eps.assign(1.);
     //exp1.assign(1.);
@@ -501,7 +501,7 @@ TEST_F(DeclarableOpsTests12, TestSliceBP_1) {
 
     ASSERT_EQ(ND4J_STATUS_OK, status);
     output.printIndexedBuffer("SLICE_BP out");
-    //ASSERT_TRUE(output1.equalsTo(exp1));
+    ASSERT_TRUE(output.equalsTo(exp));
     //ASSERT_TRUE(output2.equalsTo(exp2));
 }
 


### PR DESCRIPTION
Libnd4j: multiple bugs/issues #6873
Fixed:
     Issue 10: divide_bp/reversedivide_bp were fixed and tested.
     Issues 11 and 12: slice_bp and confusion_matrix were fixed and tested.
     Issue 13: maximum_bp and minimum_bp were reimplemented.
