### PR TITLE
allow KerasTokenizer.numWords to be null

### DIFF
--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessing/text/KerasTokenizer.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessing/text/KerasTokenizer.java
@@ -114,7 +114,7 @@ public class KerasTokenizer {
             throw new InvalidKerasConfigurationException("No configuration found for Keras tokenizer");
 
 
-        int numWords = (int) tokenizerConfig.get("num_words");
+        Integer numWords = (Integer) tokenizerConfig.get("num_words");
         String filters = (String) tokenizerConfig.get("filters");
         Boolean lower = (Boolean) tokenizerConfig.get("lower");
         String split = (String) tokenizerConfig.get("split");

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessing/text/KerasTokenizer.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessing/text/KerasTokenizer.java
@@ -120,7 +120,7 @@ public class KerasTokenizer {
         String split = (String) tokenizerConfig.get("split");
         Boolean charLevel = (Boolean) tokenizerConfig.get("char_level");
         String oovToken = (String) tokenizerConfig.get("oov_token");
-        int documentCount = (int) tokenizerConfig.get("document_count");
+        Integer documentCount = (Integer) tokenizerConfig.get("document_count");
 
         @SuppressWarnings("unchecked")
         Map<String, Integer> wordCounts = (Map) parseJsonString((String) tokenizerConfig.get("word_counts"));

--- a/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/preprocessing/text/TokenizerImportTest.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/preprocessing/text/TokenizerImportTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -51,5 +52,20 @@ public class TokenizerImportTest {
         assertEquals(0, tokenizer.getDocumentCount().intValue());
 
 
+    }
+
+    @Test
+    public void importNumWordsNullTest() throws IOException, InvalidKerasConfigurationException {
+
+        String path = "modelimport/keras/preprocessing/tokenizer_num_words_null.json";
+
+        ClassPathResource configResource = new ClassPathResource(path, classLoader);
+        KerasTokenizer tokenizer = KerasTokenizer.fromJson(configResource.getFile().getAbsolutePath());
+
+        assertNull(tokenizer.getNumWords());
+        assertTrue(tokenizer.isLower());
+        assertEquals(" ", tokenizer.getSplit());
+        assertFalse(tokenizer.isCharLevel());
+        assertEquals(0, tokenizer.getDocumentCount().intValue());
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR allow `KerasTokenizer.numWords` to be `null`. Keras allows `num_words=None`, in fact this is the default.

## How was this patch tested?

I ensured that Keras `TokenizerImportTest` continues to pass, and added an additional test.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
- [x] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
