### PR TITLE
Change classifier to take platform extension into account

### DIFF
--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -84,7 +84,7 @@
             <artifactId>libnd4j</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
-            <classifier>${dependency.platform}</classifier>
+            <classifier>${javacpp.platform}${javacpp.platform.extension}</classifier>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
@sshepel has told me about a build error when platform extensions (e.g. AVX2) are used, this fixes the issue.

I'm using the explicit `${javacpp.platform}${javacpp.platform.extension}` here instead of `${dependency.classifier}` because the latter, for some reason, stayed empty when I tried it out even though it is defined in the parent pom. 