### PR TITLE
libnd4j: Install both CPU and CUDA assembly ZIP files on Maven build

### DIFF
--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -131,7 +131,6 @@
         <module>deeplearning4j-scaleout</module>
         <module>deeplearning4j-ui-parent</module>
         <module>deeplearning4j-graph</module>
-        <module>deeplearning4j-cuda</module>
         <module>deeplearning4j-nlp-parent</module>
         <module>deeplearning4j-nn</module>
         <module>deeplearning4j-dataimport-solrj</module>
@@ -452,6 +451,17 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>cuda</id>
+            <activation>
+                <property>
+                    <name>libnd4j.cuda</name>
+                </property>
+            </activation>
+            <modules>
+                <module>deeplearning4j-cuda</module>
+            </modules>
+        </profile>
         <!-- For running unit tests with nd4j-native: "mvn clean test -P test-nd4j-native"
              Note that this excludes DL4J-cuda -->
         <profile>

--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -455,6 +455,18 @@
             <id>cuda</id>
             <activation>
                 <property>
+                    <name>libnd4j.chip</name>
+                    <value>cuda</value>
+                </property>
+            </activation>
+            <modules>
+                <module>deeplearning4j-cuda</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>cuda2</id>
+            <activation>
+                <property>
                     <name>libnd4j.cuda</name>
                 </property>
             </activation>

--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -464,7 +464,7 @@
             </modules>
         </profile>
         <profile>
-            <id>cuda2</id>
+            <id>libnd4j-cuda</id>
             <activation>
                 <property>
                     <name>libnd4j.cuda</name>

--- a/libnd4j/assembly-cuda.xml
+++ b/libnd4j/assembly-cuda.xml
@@ -16,7 +16,7 @@
 
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-    <id>${libnd4j.classifier}</id>
+    <id>${libnd4j.platform}-cuda-${cuda.version}</id>
     <formats>
         <format>zip</format>
     </formats>
@@ -37,7 +37,7 @@
             <outputDirectory>/</outputDirectory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <includes>
-                <include>blasbuild/${libnd4j.chip}/**</include>
+                <include>blasbuild/cuda/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -63,6 +63,9 @@
     </developers>
 
     <properties>
+        <!-- CUDA version is linked with the artifact name so cannot move to parent pom.xml -->
+        <cuda.version>10.0</cuda.version>
+        <cudnn.version>7.3</cudnn.version>
         <libnd4j.build>release</libnd4j.build>
         <libnd4j.chip>cpu</libnd4j.chip>
         <libnd4j.platform>${javacpp.platform}</libnd4j.platform>
@@ -143,7 +146,7 @@
                                 <argument>--chip-extension</argument>
                                 <argument>${libnd4j.extension}</argument>
                                 <argument>--chip-version</argument>
-                                <argument>${libnd4j.cuda}</argument>
+                                <argument>${cuda.version}</argument>
                                 <argument>--compute</argument>
                                 <argument>${libnd4j.compute}</argument>
                                 <argument>${libnd4j.tests}</argument>
@@ -239,9 +242,9 @@
                 </property>
             </activation>
             <properties>
-                <!-- Leave libnd4j.chip as is to build CPU version as well. -->
+                <!-- Leave libnd4j.chip and libnd4j.classifier as is to build CPU version as well. -->
                 <!-- <libnd4j.chip>cuda</libnd4j.chip> -->
-                <libnd4j.classifier>${libnd4j.platform}-cuda-${libnd4j.cuda}</libnd4j.classifier>
+                <!-- <libnd4j.classifier>${libnd4j.platform}-cuda-${cuda.version}</libnd4j.classifier> -->
             </properties>
             <build>
                 <plugins>
@@ -272,11 +275,29 @@
                                         <argument>--chip-extension</argument>
                                         <argument>${libnd4j.extension}</argument>
                                         <argument>--chip-version</argument>
-                                        <argument>${libnd4j.cuda}</argument>
+                                        <argument>${cuda.version}</argument>
                                         <argument>--compute</argument>
                                         <argument>${libnd4j.compute}</argument>
                                     </buildCommand>
                                     <workingDirectory>${project.basedir}</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>libnd4j.package.cuda</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>assembly-cuda.xml</descriptor>
+                                    </descriptors>
                                 </configuration>
                             </execution>
                         </executions>

--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -220,7 +220,7 @@
                 </property>
             </activation>
             <properties>
-                <libnd4j.classifier>${libnd4j.platform}-${libnd4j.chip}</libnd4j.classifier>
+                <libnd4j.classifier>${libnd4j.platform}-${libnd4j.chip}-${cuda.version}</libnd4j.classifier>
             </properties>
         </profile>
         <profile>
@@ -268,6 +268,8 @@
                                         <program>bash</program>
                                         <argument>${project.basedir}/buildnativeoperations.sh
                                         </argument>
+                                        <argument>--build-type</argument>
+                                        <argument>${libnd4j.build}</argument>
                                         <argument>--chip</argument>
                                         <argument>cuda</argument>
                                         <argument>--platform</argument>
@@ -278,6 +280,7 @@
                                         <argument>${cuda.version}</argument>
                                         <argument>--compute</argument>
                                         <argument>${libnd4j.compute}</argument>
+                                        <argument>${libnd4j.tests}</argument>
                                     </buildCommand>
                                     <workingDirectory>${project.basedir}</workingDirectory>
                                 </configuration>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -30,8 +30,6 @@
     <modules>
         <module>nd4j-native</module>
         <module>nd4j-native-platform</module>
-        <module>nd4j-cuda</module>
-        <module>nd4j-cuda-platform</module>
     </modules>
     <dependencies>
     </dependencies>
@@ -181,6 +179,19 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>cuda</id>
+            <activation>
+                <property>
+                    <name>libnd4j.cuda</name>
+                </property>
+            </activation>
+            <modules>
+                <module>nd4j-cuda</module>
+                <module>nd4j-cuda-platform</module>
+            </modules>
+        </profile>
+
         <profile>
             <id>javacpp-platform-default</id>
             <activation>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -27,13 +27,6 @@
 
     <name>nd4j-backend-impls</name>
 
-    <modules>
-        <module>nd4j-native</module>
-        <module>nd4j-native-platform</module>
-    </modules>
-    <dependencies>
-    </dependencies>
-
     <properties>
         <!-- Hack to load only at runtime platform specific dependency with Maven -->
         <dependency.groupId>${project.groupId}</dependency.groupId>
@@ -180,7 +173,33 @@
 
     <profiles>
         <profile>
+            <id>cpu</id>
+            <activation>
+                <property>
+                    <name>libnd4j.chip</name>
+                    <value>!cuda</value>
+                </property>
+            </activation>
+            <modules>
+                <module>nd4j-native</module>
+                <module>nd4j-native-platform</module>
+            </modules>
+        </profile>
+        <profile>
             <id>cuda</id>
+            <activation>
+                <property>
+                    <name>libnd4j.chip</name>
+                    <value>cuda</value>
+                </property>
+            </activation>
+            <modules>
+                <module>nd4j-cuda</module>
+                <module>nd4j-cuda-platform</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>cuda2</id>
             <activation>
                 <property>
                     <name>libnd4j.cuda</name>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -199,7 +199,7 @@
             </modules>
         </profile>
         <profile>
-            <id>cuda2</id>
+            <id>libnd4j-cuda</id>
             <activation>
                 <property>
                     <name>libnd4j.cuda</name>


### PR DESCRIPTION
Also move all CUDA modules in "cuda" profiles

## What changes were proposed in this pull request?

Allows the build to pass again with only one Maven build and the assembly ZIP files used as dependencies. We can also now build for Android, for example, with a command like this without having to exclude any artifacts manually:
```
ANDROID_NDK=/path/to/android-ndk/ mvn clean install -Djavacpp.platform=android-arm64 -Dmaven.test.skip
```

## How was this patch tested?

Build passes with and without CUDA with a single Maven command.
