### PR TITLE
Upgrade maven shade plugin version (3.0.0 -> 3.2.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <maven-lifecycle-mapping-plugin.version>1.0.0</maven-lifecycle-mapping-plugin.version>
         <maven-lifecycle-mapping.version>${maven-lifecycle-mapping-plugin.version}
         </maven-lifecycle-mapping.version>
-        <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <mockito.version>2.2.6</mockito.version>
 


### PR DESCRIPTION
Fixes following error, when building nd4j-uberjar with ```-P uberjar```:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.0.0:shade (default) on project nd4j-uberjar: Error creating shaded jar: null: IllegalArgumentException -> [Help 1] 
```
See also: https://stackoverflow.com/questions/49436651/error-creating-shaded-jar-null-illegalargumentexception