### PR TITLE
correct reverse op and check mirror pad op

### DIFF
--- a/libnd4j/blas/cpu/NDArray.cpp
+++ b/libnd4j/blas/cpu/NDArray.cpp
@@ -5024,7 +5024,7 @@ template void NDArray::operator/=(const bool scalar);
 
         // we need to sort dimensions (?)
         if (dimensions.size() > 1)
-            std::sort (copy.begin(), copy.end());
+            std::sort(copy.begin(), copy.end());
 
         if(copy.back() >= rankOf())
             throw std::runtime_error("NDArray::allTensorsAlongDimension static function: all input dimensions must be smaller than rank of input array !");

--- a/libnd4j/include/helpers/shape.h
+++ b/libnd4j/include/helpers/shape.h
@@ -4179,7 +4179,6 @@ INLINEDEF _CUDA_HD bool areStridesDefault(const Nd4jLong* shapeInfo) {
         // check if min dimension is still negative and whether max dimension is bigger then rank-1
         if(dimensions[0] < 0 || dimensions.back() > (rank-1))
             throw std::runtime_error("shape::checkDimensions method: the negative dimension is still present in input array after transform or the too big dimension is present ( > rank of array) !");
-
     }
 
 

--- a/libnd4j/include/ops/declarable/generic/transforms/mirrorPad.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/mirrorPad.cpp
@@ -37,7 +37,7 @@ CUSTOM_OP_IMPL(mirror_pad, 2, 1, false, 0, 1) {
     const int mode = INT_ARG(0);    // 0 - REFLECT, else - SYMMETRIC
     const int includeBorder = mode ? 0 : 1;
 
-    if(input->rankOf() <= 1) {  // when in put scalar or vector;
+    if(input->rankOf() <= 1) {  // when input is scalar or vector;
         REQUIRE_TRUE(paddings->lengthOf() == 2, 0, "MIRROR_PAD OP: the length of paddings array must be equal 2, when input array is vector or scalar, bot but got %i instead !", paddings->rankOf());
         REQUIRE_TRUE( (paddings->e<Nd4jLong>(0) <= (input->lengthOf() - includeBorder)) && (paddings->e<Nd4jLong>(1) <= (input->lengthOf() - includeBorder)), 0, "MIRROR_PAD OP: wrong content of paddings array, its elements must be no grater then length of input array (being vector or scalar) for symmetric mode (or length-1 for reflect mode) !");
     }
@@ -68,7 +68,7 @@ DECLARE_SHAPE_FN(mirror_pad) {
     const int rank = input->rankOf() ? input->rankOf() : 1;                 // if scalar is input then vector is output
     const int includeBorder = static_cast<bool>(INT_ARG(0)) ? 0 : 1;        // 0 - REFLECT, else - SYMMETRIC
 
-    if(rank == 1) {  // when in put scalar or vector;
+    if(rank == 1) {  // when input is scalar or vector;
         REQUIRE_TRUE(paddings->lengthOf() == 2, 0, "MIRROR_PAD OP: the length of paddings array must be equal 2, when input array is vector or scalar, bot but got %i instead !", paddings->rankOf());
         REQUIRE_TRUE( (paddings->e<Nd4jLong>(0) <= (input->lengthOf() - includeBorder)) && (paddings->e<Nd4jLong>(1) <= (input->lengthOf() - includeBorder)), 0, "MIRROR_PAD OP: wrong content of paddings array, its elements must be no grater then length of input array (being vector or scalar) for symmetric mode (or length-1 for reflect mode) !");
     }

--- a/libnd4j/include/ops/declarable/generic/transforms/reverse.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/reverse.cpp
@@ -29,41 +29,25 @@ namespace nd4j {
 namespace ops  {
 
     CONFIGURABLE_OP_IMPL(reverse, 1, 1, true, 0, -2) {
+        
         auto input = INPUT_VARIABLE(0);
         auto output = OUTPUT_VARIABLE(0);
-        std::vector<int> axis;
-        auto isLegacy = false;
+        
+        std::vector<int> axis;        
 
-        if (block.width() > 1) {
-            // dynamic input
+        if (block.width() > 1)            
             axis = INPUT_VARIABLE(1)->template asVectorT<int>();
-            if (block.numI() > 0)
-                isLegacy = INT_ARG(0) == 1;
+        else if (block.numI() > 0) 
+            axis = *block.getIArguments();        
 
-        } else if (block.numI() > 0) {
-            axis = *block.getIArguments();
+        if(axis.empty()) {      // do not perform reversion 
+            output->assign(input);
         }
-
-        for (int e = 0; e < axis.size(); e++)
-            if (axis[e] < 0)
-                axis[e] += input->rankOf();
-
-        // if full range of axis - then clear all axis for default behavior
-        if (axis.size() == input->rankOf()) {
-            bool dropAll = true;
-            for (int e = 0; e < axis.size(); e++)
-                if (e != axis[e]) {
-                    dropAll = false;
-                    break;
-                }
-           if (dropAll)
-                axis.clear();
+        else {
+            // check the consistency of input dimensions to reverse along
+            shape::checkDimensions(input->rankOf(), axis);
+            helpers::reverse(input, output, &axis, false);
         }
-
-        if (input->rankOf() == 1) // there are no axis can be used for 1D tensor
-            axis.clear();
-            
-        helpers::reverse(input, output, &axis, isLegacy);
    
         return Status::OK();
     }
@@ -83,19 +67,20 @@ namespace ops  {
         auto output = OUTPUT_VARIABLE(0);
         std::vector<int> axis;
 
-        if (block.width() == 3) {
-            // dynamic input
+        if (block.width() == 3)             
             axis = INPUT_VARIABLE(1)->template asVectorT<int>();
-        } else if (block.numI() > 0) {
-            axis = *block.getIArguments();
+        else if (block.numI() > 0) 
+            axis = *block.getIArguments();        
+
+        if(axis.empty()) {      // reversion is not performed in this case
+            output->assign(eps);
         }
-
-        for (int e = 0; e < axis.size(); e++)
-            if (axis[e] < 0)
-                axis[e] += input->rankOf();
-
-        // we just reverse back original array
-        helpers::reverse(eps, output, &axis, false);
+        else {
+            // check the consistency of input dimensions to reverse along
+            shape::checkDimensions(input->rankOf(), axis);
+            // we just reverse back original array
+            helpers::reverse(eps, output, &axis, true);
+        }
 
         return Status::OK();
     }

--- a/libnd4j/include/ops/declarable/helpers/cpu/reverse.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/reverse.cpp
@@ -180,16 +180,15 @@ static void _reverseSequence(const NDArray* input, const NDArray* seqLengths, ND
     }
 
 //////////////////////////////////////////////////////////////////////////
-void reverse(const NDArray* input, NDArray* output, const std::vector<int>* intArgs, bool isLegacy) {
+void reverse(const NDArray* input, NDArray* output, const std::vector<int>* intArgs, bool isBackProp) {
 
     // we need to reverse axis only if that's new op
-    std::vector<int> dimensions = isLegacy ? *intArgs : ShapeUtils::evalDimsToExclude(input->rankOf(), *intArgs);
+    std::vector<int> dimensions = isBackProp ? ShapeUtils::evalDimsToExclude(input->rankOf(), *intArgs) : *intArgs;
 
     auto listOut = output->allTensorsAlongDimension(dimensions);
     auto listIn  = input->allTensorsAlongDimension(dimensions);
        
-    NDArray* subArrIn  = nullptr;
-    NDArray* subArrOut = nullptr;
+    NDArray *subArrIn, *subArrOut;
 
     for(int i = 0; i < listIn->size(); ++i) {               // listIn->size() = listOut->size()
         subArrIn   = listIn->at(i);

--- a/libnd4j/include/ops/declarable/helpers/reverse.h
+++ b/libnd4j/include/ops/declarable/helpers/reverse.h
@@ -32,7 +32,7 @@ namespace helpers {
 
 	void reverseSequence(const NDArray* input, const NDArray* seqLengths, NDArray* output, int seqDim, const int batchDim);
 
-	void reverse(const NDArray* input, NDArray* output, const std::vector<int>* intArgs, bool isLegacy);
+	void reverse(const NDArray* input, NDArray* output, const std::vector<int>* intArgs, bool isBackProp);
 
     
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
@@ -4025,7 +4025,7 @@ TEST_F(DeclarableOpsTests1, Reverse_1 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {});
+    auto results = op.execute({&input}, {}, {0,1,2});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4041,7 +4041,7 @@ TEST_F(DeclarableOpsTests1, Reverse_1 ) {
 TEST_F(DeclarableOpsTests1, Reverse_2 ) {
 
     float inBuff[]  = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24};
-    float expBuff[] = {24., 23., 22., 21., 20., 19., 18., 17., 16., 15., 14., 13., 12., 11., 10., 9., 8., 7., 6., 5., 4., 3., 2., 1.};
+    float expBuff[] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24};
     Nd4jLong shapeInfo[] = {3, 2, 3, 4, 12, 4, 1, 0, 1, 99};
     ArrayOptions::setDataType(shapeInfo, nd4j::DataType::FLOAT32);
 
@@ -4075,7 +4075,7 @@ TEST_F(DeclarableOpsTests1, Reverse_3 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {0});
+    auto results = op.execute({&input}, {}, {1,2});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4101,7 +4101,7 @@ TEST_F(DeclarableOpsTests1, Reverse_4 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {1});
+    auto results = op.execute({&input}, {}, {0,2});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4127,7 +4127,7 @@ TEST_F(DeclarableOpsTests1, Reverse_5 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {2});
+    auto results = op.execute({&input}, {}, {0,1});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4152,7 +4152,7 @@ TEST_F(DeclarableOpsTests1, Reverse_6 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {0,1}, {}, true);
+    auto results = op.execute({&input}, {}, {2}, {}, true);
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4179,7 +4179,7 @@ TEST_F(DeclarableOpsTests1, Reverse_7 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {0,2});
+    auto results = op.execute({&input}, {}, {1});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4193,11 +4193,12 @@ TEST_F(DeclarableOpsTests1, Reverse_7 ) {
 }
 
 
-////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, Reverse_8 ) {
 
     float inBuff[]  = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24};
-    float expBuff[] = {9., 10., 11., 12., 5., 6., 7., 8., 1., 2., 3., 4., 21., 22., 23., 24., 17., 18., 19., 20., 13., 14., 15., 16.};
+    float expBuff[] = {12., 11., 10., 9., 8., 7., 6., 5., 4., 3., 2., 1., 24., 23., 22., 21., 20., 19., 18., 17., 16., 15., 14., 13.};
     Nd4jLong shapeInfo[] = {3, 2, 3, 4, 12, 4, 1, 0, 1, 99};
     ArrayOptions::setDataType(shapeInfo, nd4j::DataType::FLOAT32);
 
@@ -4206,7 +4207,7 @@ TEST_F(DeclarableOpsTests1, Reverse_8 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {2,0});
+    auto results = op.execute({&input}, {}, {2,1});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4218,7 +4219,6 @@ TEST_F(DeclarableOpsTests1, Reverse_8 ) {
 
     delete results;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, Reverse_9 ) {
@@ -4233,7 +4233,7 @@ TEST_F(DeclarableOpsTests1, Reverse_9 ) {
     NDArray output(shapeInfo);
 
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {1,2});
+    auto results = op.execute({&input}, {}, {0});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
@@ -4251,7 +4251,7 @@ TEST_F(DeclarableOpsTests1, Reverse_10 ) {
     auto e = NDArrayFactory::create<double>('c', {4, 3}, {0.09966054, 0.1592365, 1.5375735,  -1.0355669, 1.144433, 0.677872,   0.85020787, -0.67863184, 0.48456487,  -1.1660044, 0.20998026, 0.13950661});
 
     nd4j::ops::reverse op;
-    auto result = op.execute({&x, &i}, {}, {1}, {}, false, nd4j::DataType::DOUBLE);
+    auto result = op.execute({&x, &i}, {}, {}, {}, false, nd4j::DataType::DOUBLE);
 
     auto z = result->at(0);
 
@@ -4330,11 +4330,11 @@ TEST_F(DeclarableOpsTests1, Reverse_14 ) {
 
 
     auto input = NDArrayFactory::create<double>({0.f, 1.f, 2.f, 3.f, 4.f});
-    auto expected = NDArrayFactory::create<double>({4.f, 3.f, 2.f, 1.f, 0.f});
+    auto expected = NDArrayFactory::create<double>({0.f, 1.f, 2.f, 3.f, 4.f});
 
     //input.linspace(1);
     nd4j::ops::reverse op;
-    auto results = op.execute({&input}, {}, {1}, {}, false, nd4j::DataType::DOUBLE);
+    auto results = op.execute({&input}, {}, {}, {}, false, nd4j::DataType::DOUBLE);
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests12.cpp
@@ -587,3 +587,49 @@ TEST_F(DeclarableOpsTests12, TestMinimumBP_1) {
     ASSERT_TRUE(output1.equalsTo(exp1));
     ASSERT_TRUE(output2.equalsTo(exp2));
 }
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, reverse_test15) {
+    
+    NDArray x('c', {5}, {1,2,3,4,5}, nd4j::DataType::DOUBLE);
+    NDArray axis('c', {0}, {0}, nd4j::DataType::INT32);
+    NDArray z('c', {5}, nd4j::DataType::DOUBLE);
+    NDArray exp('c', {5}, {5,4,3,2,1}, nd4j::DataType::DOUBLE);
+    
+
+    nd4j::ops::reverse op;
+    // auto result = op.execute({&x, &axis}, {}, {1}, {});
+    Nd4jStatus status = op.execute({&x, &axis}, {&z}, {}, {1}, {});    
+    // auto z = result->at(0);
+    // z->printIndexedBuffer();
+
+    ASSERT_EQ(Status::OK(), status);
+    ASSERT_TRUE(exp.isSameShape(z));
+    ASSERT_TRUE(exp.equalsTo(z));    
+    // delete result;
+}
+
+/////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests12, mirrorPad_test17) {
+    
+    NDArray x('c', {2,3}, {1,2,3,4,5,6}, nd4j::DataType::DOUBLE);
+    NDArray padding('c', {2,2}, {1,1,2,2}, nd4j::DataType::INT32);
+    NDArray z('c', {4,7}, nd4j::DataType::DOUBLE);
+    NDArray exp1('c', {4,7}, {6, 5, 4, 5, 6, 5, 4,3, 2, 1, 2, 3, 2, 1,6, 5, 4, 5, 6, 5, 4,3, 2, 1, 2, 3, 2, 1}, nd4j::DataType::DOUBLE);
+    NDArray exp2('c', {4,7}, {2, 1, 1, 2, 3, 3, 2,2, 1, 1, 2, 3, 3, 2,5, 4, 4, 5, 6, 6, 5,5, 4, 4, 5, 6, 6, 5}, nd4j::DataType::DOUBLE);
+    
+    nd4j::ops::mirror_pad op;    
+    Nd4jStatus status = op.execute({&x, &padding}, {&z}, {}, {0}, {});      // reflect
+    
+    ASSERT_EQ(Status::OK(), status);
+    ASSERT_TRUE(exp1.isSameShape(z));
+    ASSERT_TRUE(exp1.equalsTo(z));
+
+    z = 0.;
+    status = op.execute({&x, &padding}, {&z}, {}, {1}, {});                 // symmetric
+
+    ASSERT_EQ(Status::OK(), status);
+    ASSERT_TRUE(exp2.isSameShape(z));
+    ASSERT_TRUE(exp2.equalsTo(z));    
+}
+


### PR DESCRIPTION
reverse op has been fixed - the reason of fail was in erasing of content of axis array when length of this array is equal to input array rank. Also isLegacy parameter has been removed since it is not actual any more.
the possible fail in mirrorPad was not confirmed on c++ side. 

