### PR TITLE
Fix excludes for libnd4j build artifacts

### DIFF
--- a/libnd4j/assembly-cuda.xml
+++ b/libnd4j/assembly-cuda.xml
@@ -24,21 +24,15 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/> <!-- DO NOT remove this tag, alternative way to specify cross platform root path is to provide ${file.separator} -->
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
                 <exclude>**/target/**</exclude>
                 <exclude>**/CMakeFiles/**</exclude>
-                <exclude>**/blasbuild/**</exclude>
+                <exclude>**/CMakeCache.txt</exclude>
+                <exclude>%regex[(?!.*cuda/).*blasbuild.*]</exclude>
+                <exclude>%regex[.*/lib/googletest.*]</exclude>
             </excludes>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/</directory>
-            <outputDirectory>/</outputDirectory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <includes>
-                <include>blasbuild/cuda/**</include>
-            </includes>
         </fileSet>
     </fileSets>
 </assembly>

--- a/libnd4j/assembly.xml
+++ b/libnd4j/assembly.xml
@@ -24,21 +24,15 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/> <!-- DO NOT remove this tag, alternative way to specify cross platform root path is to provide ${file.separator} -->
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
                 <exclude>**/target/**</exclude>
                 <exclude>**/CMakeFiles/**</exclude>
-                <exclude>**/blasbuild/**</exclude>
+                <exclude>**/CMakeCache.txt</exclude>
+                <exclude>%regex[(?!.*${libnd4j.chip}/).*blasbuild.*]</exclude>
+                <exclude>%regex[.*/lib/googletest.*]</exclude>
             </excludes>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/</directory>
-            <outputDirectory>/</outputDirectory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <includes>
-                <include>blasbuild/${libnd4j.chip}/**</include>
-            </includes>
         </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update assembly manifests (both for cpu and cuda backend)
to add excludes of googletest folder, CmakeCache.txt and
fix excludes for CmakeFiles.

## How was this patch tested?
Locally.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
