### PR TITLE
Builder properties

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/custom/testclasses/CustomOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/custom/testclasses/CustomOutputLayer.java
@@ -35,8 +35,8 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * A custom output layer for testing. Functionally equivalent to {@link OutputLayer}, but
- * defined here to test JSON etc.
+ * A custom output layer for testing. Functionally equivalent to {@link OutputLayer}, but defined here to test JSON
+ * etc.
  *
  * @author Alex Black
  */
@@ -45,13 +45,14 @@ import java.util.Map;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class CustomOutputLayer extends BaseOutputLayer {
+
     protected CustomOutputLayer(Builder builder) {
         super(builder);
     }
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         CustomOutputLayerImpl ret = new CustomOutputLayerImpl(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffConv.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffConv.java
@@ -16,9 +16,7 @@
 
 package org.deeplearning4j.nn.layers.samediff.testlayers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.val;
+import lombok.*;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -31,6 +29,7 @@ import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
 import org.deeplearning4j.nn.weights.WeightInitUtil;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.base.Preconditions;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -161,14 +160,48 @@ public class SameDiffConv extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private int nIn;
+        @Getter
+        @Setter
         private int nOut;
+        @Getter
+        @Setter
         private Activation activation = Activation.TANH;
+        @Getter
         private int[] kernel = new int[]{2, 2};
+
+        public void setKernel(int[] kernel) {
+            Preconditions.checkArgument(kernel.length == 2, "Must have 2 kernel values - got %s", kernel);
+            this.kernel = kernel;
+        }
+        @Getter
         private int[] stride = new int[]{1, 1};
+
+        public void setStride(int[] stride) {
+            Preconditions.checkArgument(stride.length == 2, "Must have 2 stride values - got %s", stride);
+            this.stride = stride;
+        }
+        @Getter
         private int[] padding = new int[]{0, 0};
+
+        public void setPadding(int[] padding) {
+            Preconditions.checkArgument(padding.length == 2, "Must have 2 padding values - got %s", padding);
+            this.padding = padding;
+        }
+        @Getter
         private int[] dilation = new int[]{1, 1};
+
+        public void setDilation(int[] dilation) {
+            Preconditions.checkArgument(dilation.length == 2, "Must have 2 dilation values - got %s", dilation);
+            this.dilation = dilation;
+        }
+        @Getter
+        @Setter
         private ConvolutionMode cm = ConvolutionMode.Same;
+        @Getter
+        @Setter
         private boolean hasBias = true;
 
         public Builder nIn(int nIn) {

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffConv.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffConv.java
@@ -160,51 +160,15 @@ public class SameDiffConv extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
-        @Getter
-        @Setter
         private int nIn;
-
-        @Getter
-        @Setter
         private int nOut;
-
-        @Getter
-        @Setter
         private Activation activation = Activation.TANH;
-
-        @Getter
         private int[] kernel = new int[]{2, 2};
 
-        public void setKernel(int[] kernel) {
-            Preconditions.checkArgument(kernel.length == 2, "Must have 2 kernel values - got %s", kernel);
-            this.kernel = kernel;
-        }
-        @Getter
         private int[] stride = new int[]{1, 1};
-
-        public void setStride(int[] stride) {
-            Preconditions.checkArgument(stride.length == 2, "Must have 2 stride values - got %s", stride);
-            this.stride = stride;
-        }
-        @Getter
         private int[] padding = new int[]{0, 0};
-
-        public void setPadding(int[] padding) {
-            Preconditions.checkArgument(padding.length == 2, "Must have 2 padding values - got %s", padding);
-            this.padding = padding;
-        }
-        @Getter
         private int[] dilation = new int[]{1, 1};
-
-        public void setDilation(int[] dilation) {
-            Preconditions.checkArgument(dilation.length == 2, "Must have 2 dilation values - got %s", dilation);
-            this.dilation = dilation;
-        }
-        @Getter
-        @Setter
         private ConvolutionMode cm = ConvolutionMode.Same;
-        @Getter
-        @Setter
         private boolean hasBias = true;
 
         public Builder nIn(int nIn) {

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffConv.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffConv.java
@@ -163,12 +163,15 @@ public class SameDiffConv extends SameDiffLayer {
         @Getter
         @Setter
         private int nIn;
+
         @Getter
         @Setter
         private int nOut;
+
         @Getter
         @Setter
         private Activation activation = Activation.TANH;
+
         @Getter
         private int[] kernel = new int[]{2, 2};
 

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffDense.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffDense.java
@@ -126,9 +126,11 @@ public class SameDiffDense extends SameDiffLayer {
         @Getter
         @Setter
         private int nIn;
+
         @Getter
         @Setter
         private int nOut;
+
         @Getter
         @Setter
         private Activation activation;

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffDense.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffDense.java
@@ -123,16 +123,9 @@ public class SameDiffDense extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
-        @Getter
-        @Setter
         private int nIn;
-
-        @Getter
-        @Setter
         private int nOut;
 
-        @Getter
-        @Setter
         private Activation activation;
 
         public Builder nIn(int nIn){

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffDense.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/samediff/testlayers/SameDiffDense.java
@@ -18,6 +18,8 @@ package org.deeplearning4j.nn.layers.samediff.testlayers;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
@@ -121,8 +123,14 @@ public class SameDiffDense extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private int nIn;
+        @Getter
+        @Setter
         private int nOut;
+        @Getter
+        @Setter
         private Activation activation;
 
         public Builder nIn(int nIn){

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/customlayer100a/CustomLayer.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/customlayer100a/CustomLayer.java
@@ -67,7 +67,7 @@ public class CustomLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> iterationListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         //The instantiate method is how we go from the configuration class (i.e., this class) to the implementation class
         // (i.e., a CustomLayerImpl instance)
         //For the most part, it's the same for each type of layer
@@ -112,11 +112,11 @@ public class CustomLayer extends FeedForwardLayer {
         InputType outputType = getOutputType(-1, inputType);
 
         val numParams = initializer().numParams(this);
-        int updaterStateSize = (int)getIUpdater().stateSize(numParams);
+        int updaterStateSize = (int) getIUpdater().stateSize(numParams);
 
         int trainSizeFixed = 0;
         int trainSizeVariable = 0;
-        if(getIDropout() != null){
+        if (getIDropout() != null) {
             //Assume we dup the input for dropout
             trainSizeVariable += inputType.arrayElementsPerExample();
         }
@@ -127,10 +127,12 @@ public class CustomLayer extends FeedForwardLayer {
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, CustomLayer.class, inputType, outputType)
-            .standardMemory(numParams, updaterStateSize)
-            .workingMemory(0, 0, trainSizeFixed, trainSizeVariable)     //No additional memory (beyond activations) for inference
-            .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
-            .build();
+                .standardMemory(numParams, updaterStateSize)
+                .workingMemory(0, 0, trainSizeFixed,
+                        trainSizeVariable)     //No additional memory (beyond activations) for inference
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS,
+                        MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
+                .build();
     }
 
 
@@ -158,7 +160,7 @@ public class CustomLayer extends FeedForwardLayer {
          *
          * @param secondActivationFunction Second activation function for the layer
          */
-        public Builder secondActivationFunction(Activation secondActivationFunction){
+        public Builder secondActivationFunction(Activation secondActivationFunction) {
             this.secondActivationFunction = secondActivationFunction.getActivationFunction();
             return this;
         }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/customlayer100a/CustomLayer.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/customlayer100a/CustomLayer.java
@@ -16,6 +16,8 @@
 
 package org.deeplearning4j.regressiontest.customlayer100a;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.val;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.ParamInitializer;
@@ -136,6 +138,8 @@ public class CustomLayer extends FeedForwardLayer {
     //Note that we are inheriting all of the FeedForwardLayer.Builder options: things like n
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private IActivation secondActivationFunction;
 
         //This is an example of a custom property in the configuration

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
@@ -67,22 +67,20 @@ public abstract class AbstractLSTM extends BaseRecurrentLayer {
 
     @AllArgsConstructor
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static abstract class Builder<T extends Builder<T>> extends BaseRecurrentLayer.Builder<T> {
 
         /**
          * Set forget gate bias initalizations. Values in range 1-5 can potentially help with learning or longer-term
          * dependencies.
          */
-        @Getter
-        @Setter
         protected double forgetGateBiasInit = 1.0;
 
         /**
          * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
          * for example
          */
-        @Getter
-        @Setter
         protected IActivation gateActivationFn = new ActivationSigmoid();
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
@@ -72,7 +72,11 @@ public abstract class AbstractLSTM extends BaseRecurrentLayer {
     @NoArgsConstructor
     public static abstract class Builder<T extends Builder<T>> extends BaseRecurrentLayer.Builder<T> {
 
+        @Getter
+        @Setter
         protected double forgetGateBiasInit = 1.0;
+        @Getter
+        @Setter
         protected IActivation gateActivationFn = new ActivationSigmoid();
 
         /** Set forget gate bias initalizations. Values in range 1-5 can potentially

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
@@ -72,15 +72,25 @@ public abstract class AbstractLSTM extends BaseRecurrentLayer {
     @NoArgsConstructor
     public static abstract class Builder<T extends Builder<T>> extends BaseRecurrentLayer.Builder<T> {
 
+        /**
+         * Set forget gate bias initalizations. Values in range 1-5 can potentially help with learning or longer-term
+         * dependencies.
+         */
         @Getter
         @Setter
         protected double forgetGateBiasInit = 1.0;
+
+        /**
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
+         */
         @Getter
         @Setter
         protected IActivation gateActivationFn = new ActivationSigmoid();
 
-        /** Set forget gate bias initalizations. Values in range 1-5 can potentially
-         * help with learning or longer-term dependencies.
+        /**
+         * Set forget gate bias initalizations. Values in range 1-5 can potentially help with learning or longer-term
+         * dependencies.
          */
         public T forgetGateBiasInit(double biasInit) {
             this.forgetGateBiasInit = biasInit;
@@ -88,8 +98,8 @@ public abstract class AbstractLSTM extends BaseRecurrentLayer {
         }
 
         /**
-         * Activation function for the LSTM gates.
-         * Note: This should be bounded to range 0-1: sigmoid or hard sigmoid, for example
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
          *
          * @param gateActivationFn Activation function for the LSTM gates
          */
@@ -98,8 +108,8 @@ public abstract class AbstractLSTM extends BaseRecurrentLayer {
         }
 
         /**
-         * Activation function for the LSTM gates.
-         * Note: This should be bounded to range 0-1: sigmoid or hard sigmoid, for example
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
          *
          * @param gateActivationFn Activation function for the LSTM gates
          */
@@ -108,8 +118,8 @@ public abstract class AbstractLSTM extends BaseRecurrentLayer {
         }
 
         /**
-         * Activation function for the LSTM gates.
-         * Note: This should be bounded to range 0-1: sigmoid or hard sigmoid, for example
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
          *
          * @param gateActivationFn Activation function for the LSTM gates
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AbstractLSTM.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
@@ -119,13 +119,13 @@ public class ActivationLayer extends NoParamLayer {
 
     @AllArgsConstructor
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends org.deeplearning4j.nn.conf.layers.Layer.Builder<Builder> {
 
         /**
          * Activation function for the layer
          */
-        @Getter
-        @Setter
         private IActivation activationFn = null;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
@@ -53,14 +53,14 @@ public class ActivationLayer extends NoParamLayer {
     /**
      * @param activation Activation function for the layer
      */
-    public ActivationLayer(Activation activation){
+    public ActivationLayer(Activation activation) {
         this(new Builder().activation(activation));
     }
 
     /**
      * @param activationFn Activation function for the layer
      */
-    public ActivationLayer(IActivation activationFn){
+    public ActivationLayer(IActivation activationFn) {
         this(new Builder().activation(activationFn));
     }
 
@@ -72,7 +72,7 @@ public class ActivationLayer extends NoParamLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.ActivationLayer ret = new org.deeplearning4j.nn.layers.ActivationLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -90,8 +90,9 @@ public class ActivationLayer extends NoParamLayer {
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        if (inputType == null)
+        if (inputType == null) {
             throw new IllegalStateException("Invalid input type: null for layer name \"" + getLayerName() + "\"");
+        }
         return inputType;
     }
 
@@ -106,12 +107,12 @@ public class ActivationLayer extends NoParamLayer {
         val actElementsPerEx = inputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, ActivationLayer.class, inputType, inputType)
-                        .standardMemory(0, 0) //No params
-                        //During inference: modify input activation in-place
-                        //During  backprop: dup the input for later re-use
-                        .workingMemory(0, 0, 0, actElementsPerEx)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(0, 0) //No params
+                //During inference: modify input activation in-place
+                //During  backprop: dup the input for later re-use
+                .workingMemory(0, 0, 0, actElementsPerEx)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
     @Override
@@ -123,15 +124,17 @@ public class ActivationLayer extends NoParamLayer {
     @NoArgsConstructor
     public static class Builder extends org.deeplearning4j.nn.conf.layers.Layer.Builder<Builder> {
 
+        /**
+         * Activation function for the layer
+         */
         @Getter
         @Setter
         private IActivation activationFn = null;
 
         /**
-         * Layer activation function.
-         * Typical values include:<br>
-         * "relu" (rectified linear), "tanh", "sigmoid", "softmax",
-         * "hardtanh", "leakyrelu", "maxout", "softsign", "softplus"
+         * Layer activation function. Typical values include:<br> "relu" (rectified linear), "tanh", "sigmoid",
+         * "softmax", "hardtanh", "leakyrelu", "maxout", "softsign", "softplus"
+         *
          * @deprecated Use {@link #activation(Activation)} or {@link @activation(IActivation)}
          */
         @Deprecated

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
@@ -123,6 +123,8 @@ public class ActivationLayer extends NoParamLayer {
     @NoArgsConstructor
     public static class Builder extends org.deeplearning4j.nn.conf.layers.Layer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private IActivation activationFn = null;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -72,7 +69,7 @@ public class ActivationLayer extends NoParamLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.ActivationLayer ret = new org.deeplearning4j.nn.layers.ActivationLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -107,12 +104,12 @@ public class ActivationLayer extends NoParamLayer {
         val actElementsPerEx = inputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, ActivationLayer.class, inputType, inputType)
-                .standardMemory(0, 0) //No params
-                //During inference: modify input activation in-place
-                //During  backprop: dup the input for later re-use
-                .workingMemory(0, 0, 0, actElementsPerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        //During inference: modify input activation in-place
+                        //During  backprop: dup the input for later re-use
+                        .workingMemory(0, 0, 0, actElementsPerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ActivationLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -97,22 +97,20 @@ public class AutoEncoder extends BasePretrainNetwork {
     }
 
     @AllArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends BasePretrainNetwork.Builder<Builder> {
 
         /**
          * Level of corruption - 0.0 (none) to 1.0 (all values corrupted)
          *
          */
-        @Getter
-        @Setter
         private double corruptionLevel = 3e-1f;
 
         /**
          * Autoencoder sparity parameter
          *
          */
-        @Getter
-        @Setter
         private double sparsity = 0f;
 
         public Builder() {}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -102,7 +102,11 @@ public class AutoEncoder extends BasePretrainNetwork {
 
     @AllArgsConstructor
     public static class Builder extends BasePretrainNetwork.Builder<Builder> {
+        @Getter
+        @Setter
         private double corruptionLevel = 3e-1f;
+        @Getter
+        @Setter
         private double sparsity = 0f;
 
         public Builder() {}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -31,15 +31,14 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Autoencoder layer.
- * Adds noise to input and learn a reconstruction function.
- *
+ * Autoencoder layer. Adds noise to input and learn a reconstruction function.
  */
 @Data
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class AutoEncoder extends BasePretrainNetwork {
+
     protected double corruptionLevel;
     protected double sparsity;
 
@@ -53,9 +52,9 @@ public class AutoEncoder extends BasePretrainNetwork {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.feedforward.autoencoder.AutoEncoder ret =
-                        new org.deeplearning4j.nn.layers.feedforward.autoencoder.AutoEncoder(conf);
+                new org.deeplearning4j.nn.layers.feedforward.autoencoder.AutoEncoder(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -95,24 +94,36 @@ public class AutoEncoder extends BasePretrainNetwork {
         trainSizePerEx += actElementsPerEx;
 
         return new LayerMemoryReport.Builder(layerName, AutoEncoder.class, inputType, outputType)
-                        .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, trainSizePerEx)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, trainSizePerEx)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
     @AllArgsConstructor
     public static class Builder extends BasePretrainNetwork.Builder<Builder> {
+
+        /**
+         * Level of corruption - 0.0 (none) to 1.0 (all values corrupted)
+         *
+         */
         @Getter
         @Setter
         private double corruptionLevel = 3e-1f;
+
+        /**
+         * Autoencoder sparity parameter
+         *
+         */
         @Getter
         @Setter
         private double sparsity = 0f;
 
-        public Builder() {}
+        public Builder() {
+        }
 
         /**
          * Builder - sets the level of corruption - 0.0 (none) to 1.0 (all values corrupted)
+         *
          * @param corruptionLevel Corruption level (0 to 1)
          */
         public Builder(double corruptionLevel) {
@@ -121,6 +132,7 @@ public class AutoEncoder extends BasePretrainNetwork {
 
         /**
          * Level of corruption - 0.0 (none) to 1.0 (all values corrupted)
+         *
          * @param corruptionLevel Corruption level (0 to 1)
          */
         public Builder corruptionLevel(double corruptionLevel) {
@@ -130,6 +142,7 @@ public class AutoEncoder extends BasePretrainNetwork {
 
         /**
          * Autoencoder sparity parameter
+         *
          * @param sparsity Sparsity
          */
         public Builder sparsity(double sparsity) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/AutoEncoder.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -52,9 +49,9 @@ public class AutoEncoder extends BasePretrainNetwork {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.feedforward.autoencoder.AutoEncoder ret =
-                new org.deeplearning4j.nn.layers.feedforward.autoencoder.AutoEncoder(conf);
+                        new org.deeplearning4j.nn.layers.feedforward.autoencoder.AutoEncoder(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -94,9 +91,9 @@ public class AutoEncoder extends BasePretrainNetwork {
         trainSizePerEx += actElementsPerEx;
 
         return new LayerMemoryReport.Builder(layerName, AutoEncoder.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, trainSizePerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, trainSizePerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @AllArgsConstructor
@@ -118,8 +115,7 @@ public class AutoEncoder extends BasePretrainNetwork {
         @Setter
         private double sparsity = 0f;
 
-        public Builder() {
-        }
+        public Builder() {}
 
         /**
          * Builder - sets the level of corruption - 0.0 (none) to 1.0 (all values corrupted)

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
@@ -114,6 +114,8 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
     }
 
     @SuppressWarnings("unchecked")
+    @Getter
+    @Setter
     public abstract static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
 
         /**
@@ -121,8 +123,6 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          * instances
          *
          */
-        @Getter
-        @Setter
         protected IActivation activationFn = null;
 
         /**
@@ -130,46 +130,34 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          *
          * @see IWeightInit
          */
-        @Getter
-        @Setter
         protected IWeightInit weightInitFn = null;
 
         /**
          * Bias initialization value, for layers with biases. Defaults to 0
          *
          */
-        @Getter
-        @Setter
         protected double biasInit = Double.NaN;
 
         /**
          * L1 regularization coefficient (weights only). Use {@link #l1Bias(double)} to configure the l1 regularization
          * coefficient for the bias.
          */
-        @Getter
-        @Setter
         protected double l1 = Double.NaN;
 
         /**
          * L2 regularization coefficient (weights only). Use {@link #l2Bias(double)} to configure the l2 regularization
          * coefficient for the bias.
          */
-        @Getter
-        @Setter
         protected double l2 = Double.NaN;
 
         /**
          * L1 regularization coefficient for the bias. Default: 0. See also {@link #l1(double)}
          */
-        @Getter
-        @Setter
         protected double l1Bias = Double.NaN;
 
         /**
          * L2 regularization coefficient for the bias. Default: 0. See also {@link #l2(double)}
          */
-        @Getter
-        @Setter
         protected double l2Bias = Double.NaN;
 
         /**
@@ -177,8 +165,6 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          * org.nd4j.linalg.learning.config.Nesterovs}
          *
          */
-        @Getter
-        @Setter
         protected IUpdater iupdater = null;
 
         /**
@@ -186,8 +172,6 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          * #updater(IUpdater)}
          *
          */
-        @Getter
-        @Setter
         protected IUpdater biasUpdater = null;
 
         /**
@@ -195,8 +179,6 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          *
          * @see GradientNormalization
          */
-        @Getter
-        @Setter
         protected GradientNormalization gradientNormalization = null;
 
         /**
@@ -205,8 +187,6 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          * otherwise.<br> L2 threshold for first two types of clipping, or absolute value threshold for last type of
          * clipping.
          */
-        @Getter
-        @Setter
         protected double gradientNormalizationThreshold = Double.NaN;
 
         /**
@@ -214,8 +194,6 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          * org.deeplearning4j.nn.conf.weightnoise.WeightNoise}) for this layer
          *
          */
-        @Getter
-        @Setter
         protected IWeightNoise weightNoise;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
@@ -16,9 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.deeplearning4j.nn.conf.GradientNormalization;
 import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -118,17 +116,41 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
 
     @SuppressWarnings("unchecked")
     public abstract static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
+        @Getter
+        @Setter
         protected IActivation activationFn = null;
+        @Getter
+        @Setter
         protected IWeightInit weightInitFn = null;
+        @Getter
+        @Setter
         protected double biasInit = Double.NaN;
+        @Getter
+        @Setter
         protected double l1 = Double.NaN;
+        @Getter
+        @Setter
         protected double l2 = Double.NaN;
+        @Getter
+        @Setter
         protected double l1Bias = Double.NaN;
+        @Getter
+        @Setter
         protected double l2Bias = Double.NaN;
+        @Getter
+        @Setter
         protected IUpdater iupdater = null;
+        @Getter
+        @Setter
         protected IUpdater biasUpdater = null;
+        @Getter
+        @Setter
         protected GradientNormalization gradientNormalization = null;
+        @Getter
+        @Setter
         protected double gradientNormalizationThreshold = Double.NaN;
+        @Getter
+        @Setter
         protected IWeightNoise weightNoise;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 public abstract class BaseLayer extends Layer implements Serializable, Cloneable {
+
     protected IActivation activationFn;
     protected IWeightInit weightInitFn;
     protected double biasInit;
@@ -69,9 +70,9 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
     }
 
     /**
-     * Reset the learning related configs of the layer to default. When instantiated with a global neural network configuration
-     * the parameters specified in the neural network configuration will be used.
-     * For internal use with the transfer learning API. Users should not have to call this method directly.
+     * Reset the learning related configs of the layer to default. When instantiated with a global neural network
+     * configuration the parameters specified in the neural network configuration will be used. For internal use with
+     * the transfer learning API. Users should not have to call this method directly.
      */
     public void resetLayerDefaultConfig() {
         //clear the learning related params for all layers in the origConf and set to defaults
@@ -89,72 +90,140 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
     @Override
     public BaseLayer clone() {
         BaseLayer clone = (BaseLayer) super.clone();
-        if(clone.iDropout != null)
+        if (clone.iDropout != null) {
             clone.iDropout = clone.iDropout.clone();
+        }
         return clone;
     }
 
     /**
-     * Get the updater for the given parameter. Typically the same updater will be used for all updaters, but this
-     * is not necessarily the case
+     * Get the updater for the given parameter. Typically the same updater will be used for all updaters, but this is
+     * not necessarily the case
      *
-     * @param paramName    Parameter name
-     * @return             IUpdater for the parameter
+     * @param paramName Parameter name
+     * @return IUpdater for the parameter
      */
     @Override
     public IUpdater getUpdaterByParam(String paramName) {
-        if(biasUpdater != null && initializer().isBiasParam(this, paramName)){
+        if (biasUpdater != null && initializer().isBiasParam(this, paramName)) {
             return biasUpdater;
         }
         return iUpdater;
     }
 
     @Override
-    public GradientNormalization getGradientNormalization(){
+    public GradientNormalization getGradientNormalization() {
         return gradientNormalization;
     }
 
     @SuppressWarnings("unchecked")
     public abstract static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
+
+        /**
+         * Set the activation function for the layer. This overload can be used for custom {@link IActivation}
+         * instances
+         *
+         */
         @Getter
         @Setter
         protected IActivation activationFn = null;
+
+        /**
+         * Weight initialization scheme to use, for initial weight values
+         *
+         * @see IWeightInit
+         */
         @Getter
         @Setter
         protected IWeightInit weightInitFn = null;
+
+        /**
+         * Bias initialization value, for layers with biases. Defaults to 0
+         *
+         */
         @Getter
         @Setter
         protected double biasInit = Double.NaN;
+
+        /**
+         * L1 regularization coefficient (weights only). Use {@link #l1Bias(double)} to configure the l1 regularization
+         * coefficient for the bias.
+         */
         @Getter
         @Setter
         protected double l1 = Double.NaN;
+
+        /**
+         * L2 regularization coefficient (weights only). Use {@link #l2Bias(double)} to configure the l2 regularization
+         * coefficient for the bias.
+         */
         @Getter
         @Setter
         protected double l2 = Double.NaN;
+
+        /**
+         * L1 regularization coefficient for the bias. Default: 0. See also {@link #l1(double)}
+         */
         @Getter
         @Setter
         protected double l1Bias = Double.NaN;
+
+        /**
+         * L2 regularization coefficient for the bias. Default: 0. See also {@link #l2(double)}
+         */
         @Getter
         @Setter
         protected double l2Bias = Double.NaN;
+
+        /**
+         * Gradient updater. For example, {@link org.nd4j.linalg.learning.config.Adam} or {@link
+         * org.nd4j.linalg.learning.config.Nesterovs}
+         *
+         */
         @Getter
         @Setter
         protected IUpdater iupdater = null;
+
+        /**
+         * Gradient updater configuration, for the biases only. If not set, biases will use the updater as set by {@link
+         * #updater(IUpdater)}
+         *
+         */
         @Getter
         @Setter
         protected IUpdater biasUpdater = null;
+
+        /**
+         * Gradient normalization strategy. Used to specify gradient renormalization, gradient clipping etc.
+         *
+         * @see GradientNormalization
+         */
         @Getter
         @Setter
         protected GradientNormalization gradientNormalization = null;
+
+        /**
+         * Threshold for gradient normalization, only used for GradientNormalization.ClipL2PerLayer,
+         * GradientNormalization.ClipL2PerParamType, and GradientNormalization.ClipElementWiseAbsoluteValue<br> Not used
+         * otherwise.<br> L2 threshold for first two types of clipping, or absolute value threshold for last type of
+         * clipping.
+         */
         @Getter
         @Setter
         protected double gradientNormalizationThreshold = Double.NaN;
+
+        /**
+         * Set the weight noise (such as {@link org.deeplearning4j.nn.conf.weightnoise.DropConnect} and {@link
+         * org.deeplearning4j.nn.conf.weightnoise.WeightNoise}) for this layer
+         *
+         */
         @Getter
         @Setter
         protected IWeightNoise weightNoise;
 
         /**
-         * Set the activation function for the layer. This overload can be used for custom {@link IActivation} instances
+         * Set the activation function for the layer. This overload can be used for custom {@link IActivation}
+         * instances
          *
          * @param activationFunction Activation function to use for the layer
          */
@@ -188,8 +257,9 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
          * @see WeightInit
          */
         public T weightInit(WeightInit weightInit) {
-            if(weightInit == WeightInit.DISTRIBUTION) {
-                throw new UnsupportedOperationException("Not supported!, Use weightInit(Distribution distribution) instead!");
+            if (weightInit == WeightInit.DISTRIBUTION) {
+                throw new UnsupportedOperationException(
+                        "Not supported!, Use weightInit(Distribution distribution) instead!");
             }
 
             this.weightInitFn = weightInit.getWeightInitFunction();
@@ -197,12 +267,12 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
         }
 
         /**
-         * Set weight initialization scheme to random sampling via the specified distribution.
-         * Equivalent to: {@code .weightInit(new WeightInitDistribution(distribution))}
+         * Set weight initialization scheme to random sampling via the specified distribution. Equivalent to: {@code
+         * .weightInit(new WeightInitDistribution(distribution))}
          *
          * @param distribution Distribution to use for weight initialization
          */
-        public T weightInit(Distribution distribution){
+        public T weightInit(Distribution distribution) {
             return weightInit(new WeightInitDistribution(distribution));
         }
 
@@ -217,8 +287,8 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
         }
 
         /**
-         * Distribution to sample initial weights from.
-         * Equivalent to: {@code .weightInit(new WeightInitDistribution(distribution))}
+         * Distribution to sample initial weights from. Equivalent to: {@code .weightInit(new
+         * WeightInitDistribution(distribution))}
          */
         @Deprecated
         public T dist(Distribution dist) {
@@ -271,8 +341,8 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
         }
 
         /**
-         * Gradient updater. For example, {@link org.nd4j.linalg.learning.config.Adam}
-         * or {@link org.nd4j.linalg.learning.config.Nesterovs}
+         * Gradient updater. For example, {@link org.nd4j.linalg.learning.config.Adam} or {@link
+         * org.nd4j.linalg.learning.config.Nesterovs}
          *
          * @param updater Updater to use
          */
@@ -282,12 +352,12 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
         }
 
         /**
-         * Gradient updater configuration, for the biases only. If not set, biases will use the updater as
-         * set by {@link #updater(IUpdater)}
+         * Gradient updater configuration, for the biases only. If not set, biases will use the updater as set by {@link
+         * #updater(IUpdater)}
          *
          * @param biasUpdater Updater to use for bias parameters
          */
-        public T biasUpdater(IUpdater biasUpdater){
+        public T biasUpdater(IUpdater biasUpdater) {
             this.biasUpdater = biasUpdater;
             return (T) this;
         }
@@ -305,9 +375,9 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
 
         /**
          * Threshold for gradient normalization, only used for GradientNormalization.ClipL2PerLayer,
-         * GradientNormalization.ClipL2PerParamType, and GradientNormalization.ClipElementWiseAbsoluteValue<br>
-         * Not used otherwise.<br>
-         * L2 threshold for first two types of clipping, or absolute value threshold for last type of clipping.
+         * GradientNormalization.ClipL2PerParamType, and GradientNormalization.ClipElementWiseAbsoluteValue<br> Not used
+         * otherwise.<br> L2 threshold for first two types of clipping, or absolute value threshold for last type of
+         * clipping.
          */
         public T gradientNormalizationThreshold(double threshold) {
             this.gradientNormalizationThreshold = threshold;
@@ -315,14 +385,14 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
         }
 
         /**
-         * Set the weight noise (such as {@link org.deeplearning4j.nn.conf.weightnoise.DropConnect} and
-         * {@link org.deeplearning4j.nn.conf.weightnoise.WeightNoise}) for this layer
+         * Set the weight noise (such as {@link org.deeplearning4j.nn.conf.weightnoise.DropConnect} and {@link
+         * org.deeplearning4j.nn.conf.weightnoise.WeightNoise}) for this layer
          *
          * @param weightNoise Weight noise instance to use
          */
-        public T weightNoise(IWeightNoise weightNoise){
+        public T weightNoise(IWeightNoise weightNoise) {
             this.weightNoise = weightNoise;
-            return (T)this;
+            return (T) this;
         }
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -259,7 +256,7 @@ public abstract class BaseLayer extends Layer implements Serializable, Cloneable
         public T weightInit(WeightInit weightInit) {
             if (weightInit == WeightInit.DISTRIBUTION) {
                 throw new UnsupportedOperationException(
-                        "Not supported!, Use weightInit(Distribution distribution) instead!");
+                                "Not supported!, Use weightInit(Distribution distribution) instead!");
             }
 
             this.weightInitFn = weightInit.getWeightInitFunction();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
@@ -43,7 +43,7 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
         this.hasBias = builder.hasBias;
     }
 
-    public boolean hasBias(){
+    public boolean hasBias() {
         return hasBias;
     }
 
@@ -74,22 +74,33 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, OutputLayer.class, inputType, outputType)
-                        .standardMemory(numParams, updaterStateSize)
-                        .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(numParams, updaterStateSize)
+                .workingMemory(0, 0, trainSizeFixed,
+                        trainSizeVariable) //No additional memory (beyond activations) for inference
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
 
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
+
+        /**
+         * Loss function for the output layer
+         */
         @Getter
         @Setter
         protected ILossFunction lossFn = new LossMCXENT();
+
+        /**
+         * If true (default): include bias parameters in the model. False: no bias.
+         *
+         */
         @Getter
         @Setter
         private boolean hasBias = true;
 
-        public Builder() {}
+        public Builder() {
+        }
 
         /**
          * @param lossFunction Loss function for the output layer
@@ -117,9 +128,9 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
          *
          * @param hasBias If true: include bias parameters in this model
          */
-        public T hasBias(boolean hasBias){
+        public T hasBias(boolean hasBias) {
             this.hasBias = hasBias;
-            return (T)this;
+            return (T) this;
         }
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
@@ -78,21 +78,19 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
     }
 
 
+    @Getter
+    @Setter
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
 
         /**
          * Loss function for the output layer
          */
-        @Getter
-        @Setter
         protected ILossFunction lossFn = new LossMCXENT();
 
         /**
          * If true (default): include bias parameters in the model. False: no bias.
          *
          */
-        @Getter
-        @Setter
         private boolean hasBias = true;
 
         public Builder() {}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
@@ -82,7 +82,11 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
 
 
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
+        @Getter
+        @Setter
         protected ILossFunction lossFn = new LossMCXENT();
+        @Getter
+        @Setter
         private boolean hasBias = true;
 
         public Builder() {}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -35,7 +32,7 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
 
     protected ILossFunction lossFn;
     protected boolean hasBias = true;
-    protected boolean legacyBatchScaledL2 = true;   //Default to legacy for pre 1.0.0-beta3 networks on deserialization
+    protected boolean legacyBatchScaledL2 = true; //Default to legacy for pre 1.0.0-beta3 networks on deserialization
 
     protected BaseOutputLayer(Builder builder) {
         super(builder);
@@ -74,11 +71,10 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, OutputLayer.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, trainSizeFixed,
-                        trainSizeVariable) //No additional memory (beyond activations) for inference
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(numParams, updaterStateSize)
+                        .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
 
@@ -99,8 +95,7 @@ public abstract class BaseOutputLayer extends FeedForwardLayer {
         @Setter
         private boolean hasBias = true;
 
-        public Builder() {
-        }
+        public Builder() {}
 
         /**
          * @param lossFunction Loss function for the output layer

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseOutputLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
@@ -72,14 +72,17 @@ public abstract class BasePretrainNetwork extends FeedForwardLayer {
     }
 
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
+
         @Getter
         @Setter
         protected LossFunctions.LossFunction lossFunction = LossFunctions.LossFunction.RECONSTRUCTION_CROSSENTROPY;
+
         @Getter
         @Setter
         protected double visibleBiasInit = 0.0;
 
-        public Builder() {}
+        public Builder() {
+        }
 
         public T lossFunction(LossFunctions.LossFunction lossFunction) {
             this.lossFunction = lossFunction;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -81,8 +78,7 @@ public abstract class BasePretrainNetwork extends FeedForwardLayer {
         @Setter
         protected double visibleBiasInit = 0.0;
 
-        public Builder() {
-        }
+        public Builder() {}
 
         public T lossFunction(LossFunctions.LossFunction lossFunction) {
             this.lossFunction = lossFunction;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.deeplearning4j.nn.params.PretrainParamInitializer;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 import org.nd4j.shade.jackson.annotation.JsonIgnoreProperties;
@@ -75,7 +72,11 @@ public abstract class BasePretrainNetwork extends FeedForwardLayer {
     }
 
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
+        @Getter
+        @Setter
         protected LossFunctions.LossFunction lossFunction = LossFunctions.LossFunction.RECONSTRUCTION_CROSSENTROPY;
+        @Getter
+        @Setter
         protected double visibleBiasInit = 0.0;
 
         public Builder() {}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
@@ -68,14 +68,12 @@ public abstract class BasePretrainNetwork extends FeedForwardLayer {
         return PretrainParamInitializer.VISIBLE_BIAS_KEY.equals(paramName);
     }
 
+    @Getter
+    @Setter
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
 
-        @Getter
-        @Setter
         protected LossFunctions.LossFunction lossFunction = LossFunctions.LossFunction.RECONSTRUCTION_CROSSENTROPY;
 
-        @Getter
-        @Setter
         protected double visibleBiasInit = 0.0;
 
         public Builder() {}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BasePretrainNetwork.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -45,8 +42,8 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for RNN layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
+                            + inputType);
         }
 
         InputType.InputTypeRecurrent itr = (InputType.InputTypeRecurrent) inputType;
@@ -58,7 +55,7 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName()
-                    + "\"): expect RNN input type with size > 0. Got: " + inputType);
+                            + "\"): expect RNN input type with size > 0. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -149,7 +146,7 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
         public T weightInitRecurrent(WeightInit weightInit) {
             if (weightInit == WeightInit.DISTRIBUTION) {
                 throw new UnsupportedOperationException(
-                        "Not supported!, Use weightInit(Distribution distribution) instead!");
+                                "Not supported!, Use weightInit(Distribution distribution) instead!");
             }
 
             this.weightInitFnRecurrent = weightInit.getWeightInitFunction();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -45,8 +45,8 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for RNN layer (layer index = " + layerIndex
-                            + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
-                            + inputType);
+                    + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
+                    + inputType);
         }
 
         InputType.InputTypeRecurrent itr = (InputType.InputTypeRecurrent) inputType;
@@ -58,7 +58,7 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for RNN layer (layer name = \"" + getLayerName()
-                            + "\"): expect RNN input type with size > 0. Got: " + inputType);
+                    + "\"): expect RNN input type with size > 0. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -74,20 +74,41 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
 
     @NoArgsConstructor
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
+
+        /**
+         * Set constraints to be applied to the RNN recurrent weight parameters of this layer. Default: no
+         * constraints.<br> Constraints can be used to enforce certain conditions (non-negativity of parameters,
+         * max-norm regularization, etc). These constraints are applied at each iteration, after the parameters have
+         * been updated.
+         */
         @Getter
         @Setter
         protected List<LayerConstraint> recurrentConstraints;
+
+        /**
+         * Set constraints to be applied to the RNN input weight parameters of this layer. Default: no constraints.<br>
+         * Constraints can be used to enforce certain conditions (non-negativity of parameters, max-norm regularization,
+         * etc). These constraints are applied at each iteration, after the parameters have been updated.
+         *
+         */
         @Getter
         @Setter
         protected List<LayerConstraint> inputWeightConstraints;
+
+        /**
+         * Set the weight initialization for the recurrent weights. Not that if this is not set explicitly, the same
+         * weight initialization as the layer input weights is also used for the recurrent weights.
+         *
+         */
         @Getter
         @Setter
         protected IWeightInit weightInitFnRecurrent;
 
         /**
-         * Set constraints to be applied to the RNN recurrent weight parameters of this layer. Default: no constraints.<br>
-         * Constraints can be used to enforce certain conditions (non-negativity of parameters, max-norm regularization,
-         * etc). These constraints are applied at each iteration, after the parameters have been updated.
+         * Set constraints to be applied to the RNN recurrent weight parameters of this layer. Default: no
+         * constraints.<br> Constraints can be used to enforce certain conditions (non-negativity of parameters,
+         * max-norm regularization, etc). These constraints are applied at each iteration, after the parameters have
+         * been updated.
          *
          * @param constraints Constraints to apply to the recurrent weight parameters of this layer
          */
@@ -114,7 +135,7 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
          *
          * @param weightInit Weight initialization for the recurrent weights only.
          */
-        public T weightInitRecurrent(IWeightInit weightInit){
+        public T weightInitRecurrent(IWeightInit weightInit) {
             this.weightInitFnRecurrent = weightInit;
             return (T) this;
         }
@@ -125,9 +146,10 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
          *
          * @param weightInit Weight initialization for the recurrent weights only.
          */
-        public T weightInitRecurrent(WeightInit weightInit){
-            if(weightInit == WeightInit.DISTRIBUTION) {
-                throw new UnsupportedOperationException("Not supported!, Use weightInit(Distribution distribution) instead!");
+        public T weightInitRecurrent(WeightInit weightInit) {
+            if (weightInit == WeightInit.DISTRIBUTION) {
+                throw new UnsupportedOperationException(
+                        "Not supported!, Use weightInit(Distribution distribution) instead!");
             }
 
             this.weightInitFnRecurrent = weightInit.getWeightInitFunction();
@@ -135,13 +157,13 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
         }
 
         /**
-         * Set the weight initialization for the recurrent weights, based on the specified distribution. Not that if this
-         * is not set explicitly, the same weight initialization as the layer input weights is also used for the recurrent
-         * weights.
+         * Set the weight initialization for the recurrent weights, based on the specified distribution. Not that if
+         * this is not set explicitly, the same weight initialization as the layer input weights is also used for the
+         * recurrent weights.
          *
          * @param dist Distribution to use for initializing the recurrent weights
          */
-        public T weightInitRecurrent(Distribution dist){
+        public T weightInitRecurrent(Distribution dist) {
             this.weightInitFnRecurrent = new WeightInitDistribution(dist);
             return (T) this;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.deeplearning4j.nn.api.layers.LayerConstraint;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.distribution.Distribution;
@@ -77,8 +74,14 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
 
     @NoArgsConstructor
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
+        @Getter
+        @Setter
         protected List<LayerConstraint> recurrentConstraints;
+        @Getter
+        @Setter
         protected List<LayerConstraint> inputWeightConstraints;
+        @Getter
+        @Setter
         protected IWeightInit weightInitFnRecurrent;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -70,6 +70,8 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static abstract class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
 
         /**
@@ -78,8 +80,6 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
          * max-norm regularization, etc). These constraints are applied at each iteration, after the parameters have
          * been updated.
          */
-        @Getter
-        @Setter
         protected List<LayerConstraint> recurrentConstraints;
 
         /**
@@ -88,8 +88,6 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
          * etc). These constraints are applied at each iteration, after the parameters have been updated.
          *
          */
-        @Getter
-        @Setter
         protected List<LayerConstraint> inputWeightConstraints;
 
         /**
@@ -97,8 +95,6 @@ public abstract class BaseRecurrentLayer extends FeedForwardLayer {
          * weight initialization as the layer input weights is also used for the recurrent weights.
          *
          */
-        @Getter
-        @Setter
         protected IWeightInit weightInitFnRecurrent;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseRecurrentLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -51,15 +48,14 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Upsampling layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
 
 
     @NoArgsConstructor
-    protected static abstract class UpsamplingBuilder<T extends UpsamplingBuilder<T>>
-            extends Layer.Builder<T> {
+    protected static abstract class UpsamplingBuilder<T extends UpsamplingBuilder<T>> extends Layer.Builder<T> {
 
         /**
          * An int array to specify upsampling dimensions, the length of which has to equal to the number of spatial
@@ -68,7 +64,7 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
          */
         @Getter
         @Setter
-        protected int[] size = new int[]{1};
+        protected int[] size = new int[] {1};
 
         /**
          * A single size integer is used for upsampling in all spatial dimensions
@@ -76,7 +72,7 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
          * @param size int for upsampling
          */
         protected UpsamplingBuilder(int size) {
-            this.size = new int[]{size};
+            this.size = new int[] {size};
         }
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
@@ -51,7 +51,7 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Upsampling layer (layer name=\"" + getLayerName()
-                            + "\"): input is null");
+                    + "\"): input is null");
         }
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
@@ -59,10 +59,16 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
 
     @NoArgsConstructor
     protected static abstract class UpsamplingBuilder<T extends UpsamplingBuilder<T>>
-                    extends Layer.Builder<T> {
+            extends Layer.Builder<T> {
+
+        /**
+         * An int array to specify upsampling dimensions, the length of which has to equal to the number of spatial
+         * dimensions (e.g. 2 for Upsampling2D etc.)
+         *
+         */
         @Getter
         @Setter
-        protected int[] size = new int[] {1};
+        protected int[] size = new int[]{1};
 
         /**
          * A single size integer is used for upsampling in all spatial dimensions
@@ -70,12 +76,12 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
          * @param size int for upsampling
          */
         protected UpsamplingBuilder(int size) {
-            this.size = new int[] {size};
+            this.size = new int[]{size};
         }
 
         /**
-         * An int array to specify upsampling dimensions, the length of which has to equal to the number of
-         * spatial dimensions (e.g. 2 for Upsampling2D etc.)
+         * An int array to specify upsampling dimensions, the length of which has to equal to the number of spatial
+         * dimensions (e.g. 2 for Upsampling2D etc.)
          *
          * @param size int for upsampling
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
@@ -55,6 +55,8 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
 
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     protected static abstract class UpsamplingBuilder<T extends UpsamplingBuilder<T>> extends Layer.Builder<T> {
 
         /**
@@ -62,8 +64,6 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
          * dimensions (e.g. 2 for Upsampling2D etc.)
          *
          */
-        @Getter
-        @Setter
         protected int[] size = new int[] {1};
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BaseUpsamplingLayer.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
@@ -63,6 +60,8 @@ public abstract class BaseUpsamplingLayer extends NoParamLayer {
     @NoArgsConstructor
     protected static abstract class UpsamplingBuilder<T extends UpsamplingBuilder<T>>
                     extends Layer.Builder<T> {
+        @Getter
+        @Setter
         protected int[] size = new int[] {1};
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -226,15 +226,35 @@ public class BatchNormalization extends FeedForwardLayer {
 
     @AllArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
+        @Getter
+        @Setter
         protected double decay = 0.9;
+        @Getter
+        @Setter
         protected double eps = 1e-5;
+        @Getter
+        @Setter
         protected boolean isMinibatch = true; // TODO auto set this if layer conf is batch
+        @Getter
+        @Setter
         protected boolean lockGammaBeta = false;
+        @Getter
+        @Setter
         protected double gamma = 1.0;
+        @Getter
+        @Setter
         protected double beta = 0.0;
+        @Getter
+        @Setter
         protected List<LayerConstraint> betaConstraints;
+        @Getter
+        @Setter
         protected List<LayerConstraint> gammaConstraints;
+        @Getter
+        @Setter
         protected boolean cudnnAllowFallback = true;
+        @Getter
+        @Setter
         protected boolean useLogStd = true;
 
         public Builder(double decay, boolean isMinibatch) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -222,6 +222,8 @@ public class BatchNormalization extends FeedForwardLayer {
     }
 
     @AllArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
         /**
@@ -231,8 +233,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * (1-decay) * batchVariance<br>
          *
          */
-        @Getter
-        @Setter
         protected double decay = 0.9;
 
         /**
@@ -240,8 +240,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * href="http://arxiv.org/pdf/1502.03167v3.pdf">http://arxiv.org/pdf/1502.03167v3.pdf</a>) to reduce/avoid
          * underflow issues.<br> Default: 1e-5
          */
-        @Getter
-        @Setter
         protected double eps = 1e-5;
 
         /**
@@ -250,8 +248,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * should be set to false. Affects how global mean/variance estimates are calculated.
          *
          */
-        @Getter
-        @Setter
         protected boolean isMinibatch = true; // TODO auto set this if layer conf is batch
 
         /**
@@ -260,8 +256,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * network training.
          *
          */
-        @Getter
-        @Setter
         protected boolean lockGammaBeta = false;
 
         /**
@@ -269,8 +263,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * 1.0
          *
          */
-        @Getter
-        @Setter
         protected double gamma = 1.0;
 
         /**
@@ -278,8 +270,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * 0.0
          *
          */
-        @Getter
-        @Setter
         protected double beta = 0.0;
 
         /**
@@ -289,8 +279,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * been updated.
          *
          */
-        @Getter
-        @Setter
         protected List<LayerConstraint> betaConstraints;
 
         /**
@@ -300,8 +288,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * been updated.
          *
          */
-        @Getter
-        @Setter
         protected List<LayerConstraint> gammaConstraints;
 
         /**
@@ -310,8 +296,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * (non-CuDNN) implementation for BatchNormalization will be used
          *
          */
-        @Getter
-        @Setter
         protected boolean cudnnAllowFallback = true;
 
         /**
@@ -322,8 +306,6 @@ public class BatchNormalization extends FeedForwardLayer {
          * numerical issues. For example, a standard deviation of 1e-3 (something that could be encountered in practice)
          * gives a variance of 1e-6, which can be problematic for 16-bit floating point
          */
-        @Getter
-        @Setter
         protected boolean useLogStd = true;
 
         public Builder(double decay, boolean isMinibatch) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -57,7 +54,7 @@ public class BatchNormalization extends FeedForwardLayer {
     protected double beta = 0.0;
     protected boolean lockGammaBeta = false;
     protected boolean cudnnAllowFallback = true;
-    protected boolean useLogStd = false;            //Default for deserialized models (1.0.0-beta3) and earlier: store variance as variance. Post 1.0.0-beta3: use log stdev instead
+    protected boolean useLogStd = false; //Default for deserialized models (1.0.0-beta3) and earlier: store variance as variance. Post 1.0.0-beta3: use log stdev instead
 
     private BatchNormalization(Builder builder) {
         super(builder);
@@ -73,7 +70,7 @@ public class BatchNormalization extends FeedForwardLayer {
     }
 
     public BatchNormalization() {
-        this(new Builder());    //Defaults from builder
+        this(new Builder()); //Defaults from builder
     }
 
     @Override
@@ -84,11 +81,11 @@ public class BatchNormalization extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNOutSet("BatchNormalization", getLayerName(), layerIndex, getNOut());
 
         org.deeplearning4j.nn.layers.normalization.BatchNormalization ret =
-                new org.deeplearning4j.nn.layers.normalization.BatchNormalization(conf);
+                        new org.deeplearning4j.nn.layers.normalization.BatchNormalization(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -108,8 +105,8 @@ public class BatchNormalization extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException(
-                    "Invalid input type: Batch norm layer expected input of type CNN, got null for layer \""
-                            + getLayerName() + "\"");
+                            "Invalid input type: Batch norm layer expected input of type CNN, got null for layer \""
+                                            + getLayerName() + "\"");
         }
 
         //Can handle CNN, flat CNN, CNN3D or FF input formats only
@@ -121,9 +118,9 @@ public class BatchNormalization extends FeedForwardLayer {
                 return inputType; //OK
             default:
                 throw new IllegalStateException(
-                        "Invalid input type: Batch norm layer expected input of type CNN, CNN Flat or FF, got "
-                                + inputType + " for layer index " + layerIndex + ", layer name = "
-                                + getLayerName());
+                                "Invalid input type: Batch norm layer expected input of type CNN, CNN Flat or FF, got "
+                                                + inputType + " for layer index " + layerIndex + ", layer name = "
+                                                + getLayerName());
         }
     }
 
@@ -144,8 +141,8 @@ public class BatchNormalization extends FeedForwardLayer {
                     nIn = ((InputType.InputTypeConvolutionalFlat) inputType).getDepth();
                 default:
                     throw new IllegalStateException(
-                            "Invalid input type: Batch norm layer expected input of type CNN, CNN Flat or FF, got "
-                                    + inputType + " for layer " + getLayerName() + "\"");
+                                    "Invalid input type: Batch norm layer expected input of type CNN, CNN Flat or FF, got "
+                                                    + inputType + " for layer " + getLayerName() + "\"");
             }
             nOut = nIn;
         }
@@ -210,14 +207,13 @@ public class BatchNormalization extends FeedForwardLayer {
         val trainWorkFixed = 2 * nOut;
         //During backprop: multiple working arrays... output size, 2 * output size (indep. of example size),
         val trainWorkingSizePerExample = inferenceWorkingSize //Inference during backprop
-                + (outputType.arrayElementsPerExample() + 2 * nOut); //Backprop gradient calculation
+                        + (outputType.arrayElementsPerExample() + 2 * nOut); //Backprop gradient calculation
 
         return new LayerMemoryReport.Builder(layerName, BatchNormalization.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, trainWorkFixed,
-                        trainWorkingSizePerExample) //No additional memory (beyond activations) for inference
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(numParams, updaterStateSize)
+                        .workingMemory(0, 0, trainWorkFixed, trainWorkingSizePerExample) //No additional memory (beyond activations) for inference
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override
@@ -350,8 +346,7 @@ public class BatchNormalization extends FeedForwardLayer {
             this.lockGammaBeta = lockGammaBeta;
         }
 
-        public Builder() {
-        }
+        public Builder() {}
 
         /**
          * If doing minibatch training or not. Default: true. Under most circumstances, this should be set to true. If

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
@@ -175,8 +175,14 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
 
     @NoArgsConstructor
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
+        @Getter
+        @Setter
         protected double alpha = 0.05;
+        @Getter
+        @Setter
         protected double lambda = 2e-4;
+        @Getter
+        @Setter
         protected boolean gradientCheck = false;
 
         public Builder(LossFunction lossFunction) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
@@ -171,18 +171,12 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
-        @Getter
-        @Setter
         protected double alpha = 0.05;
-
-        @Getter
-        @Setter
         protected double lambda = 2e-4;
-
-        @Getter
-        @Setter
         protected boolean gradientCheck = false;
 
         public Builder(LossFunction lossFunction) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
@@ -35,13 +35,12 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Center loss is similar to triplet loss except that it enforces
- * intraclass consistency and doesn't require feed forward of multiple
- * examples. Center loss typically converges faster for training
- * ImageNet-based convolutional networks.
+ * Center loss is similar to triplet loss except that it enforces intraclass consistency and doesn't require feed
+ * forward of multiple examples. Center loss typically converges faster for training ImageNet-based convolutional
+ * networks.
  *
- * "If example x is in class Y, ensure that embedding(x) is close to
- * {@code average(embedding(y))} for all examples y in Y"
+ * "If example x is in class Y, ensure that embedding(x) is close to {@code average(embedding(y))} for all examples y in
+ * Y"
  *
  * @author Justin Long (@crockpotveggies)
  * @author Alex Black (@AlexDBlack)
@@ -51,6 +50,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class CenterLossOutputLayer extends BaseOutputLayer {
+
     protected double alpha;
     protected double lambda;
     protected boolean gradientCheck;
@@ -65,7 +65,7 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("CenterLossOutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         Layer ret = new org.deeplearning4j.nn.layers.training.CenterLossOutputLayer(conf);
@@ -145,8 +145,8 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
         val numParams = nParamsW + nParamsB + nParamsCenter;
 
         int updaterStateSize = (int) (getUpdaterByParam(CenterLossParamInitializer.WEIGHT_KEY).stateSize(nParamsW)
-                        + getUpdaterByParam(CenterLossParamInitializer.BIAS_KEY).stateSize(nParamsB)
-                        + getUpdaterByParam(CenterLossParamInitializer.CENTER_KEY).stateSize(nParamsCenter));
+                + getUpdaterByParam(CenterLossParamInitializer.BIAS_KEY).stateSize(nParamsB)
+                + getUpdaterByParam(CenterLossParamInitializer.CENTER_KEY).stateSize(nParamsCenter));
 
         int trainSizeFixed = 0;
         int trainSizeVariable = 0;
@@ -167,20 +167,24 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, CenterLossOutputLayer.class, inputType, outputType)
-                        .standardMemory(numParams, updaterStateSize)
-                        .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(numParams, updaterStateSize)
+                .workingMemory(0, 0, trainSizeFixed,
+                        trainSizeVariable) //No additional memory (beyond activations) for inference
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
     @NoArgsConstructor
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
+
         @Getter
         @Setter
         protected double alpha = 0.05;
+
         @Getter
         @Setter
         protected double lambda = 2e-4;
+
         @Getter
         @Setter
         protected boolean gradientCheck = false;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -65,7 +62,7 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("CenterLossOutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         Layer ret = new org.deeplearning4j.nn.layers.training.CenterLossOutputLayer(conf);
@@ -145,8 +142,8 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
         val numParams = nParamsW + nParamsB + nParamsCenter;
 
         int updaterStateSize = (int) (getUpdaterByParam(CenterLossParamInitializer.WEIGHT_KEY).stateSize(nParamsW)
-                + getUpdaterByParam(CenterLossParamInitializer.BIAS_KEY).stateSize(nParamsB)
-                + getUpdaterByParam(CenterLossParamInitializer.CENTER_KEY).stateSize(nParamsCenter));
+                        + getUpdaterByParam(CenterLossParamInitializer.BIAS_KEY).stateSize(nParamsB)
+                        + getUpdaterByParam(CenterLossParamInitializer.CENTER_KEY).stateSize(nParamsCenter));
 
         int trainSizeFixed = 0;
         int trainSizeVariable = 0;
@@ -167,11 +164,10 @@ public class CenterLossOutputLayer extends BaseOutputLayer {
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, CenterLossOutputLayer.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, trainSizeFixed,
-                        trainSizeVariable) //No additional memory (beyond activations) for inference
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(numParams, updaterStateSize)
+                        .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @NoArgsConstructor

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CenterLossOutputLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
@@ -35,24 +35,23 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * 3D Convolutional Neural Network Loss Layer.<br>
- * Handles calculation of gradients etc for various loss (objective) functions.<br>
- * NOTE: Cnn3DLossLayer does not have any parameters. Consequently, the output activations size is equal to the input size.<br>
- * Input and output activations are same as 3D CNN layers: 5 dimensions with one of two possible shape, depending
- * on the data format:<br>
- * NCDHW ("channels first") format: data has shape [miniBatchSize,channels,depth,height,width]<br>
- * NDHWC ("channels last") format: data has shape [miniBatchSize,channels,depth,height,width]<br>
- * Cnn3DLossLayer has support for a built-in activation function (tanh, softmax etc) - if this is not required, set
- * activation function to Activation.IDENTITY. For activations such as softmax, note that this is applied channel-wise:
- * that is, softmax is applied along dimension 1 for NCDHW, or dimension 4 for NDHWC for each minibatch, and x/y/z location separately.<br>
+ * 3D Convolutional Neural Network Loss Layer.<br> Handles calculation of gradients etc for various loss (objective)
+ * functions.<br> NOTE: Cnn3DLossLayer does not have any parameters. Consequently, the output activations size is equal
+ * to the input size.<br> Input and output activations are same as 3D CNN layers: 5 dimensions with one of two possible
+ * shape, depending on the data format:<br> NCDHW ("channels first") format: data has shape
+ * [miniBatchSize,channels,depth,height,width]<br> NDHWC ("channels last") format: data has shape
+ * [miniBatchSize,channels,depth,height,width]<br> Cnn3DLossLayer has support for a built-in activation function (tanh,
+ * softmax etc) - if this is not required, set activation function to Activation.IDENTITY. For activations such as
+ * softmax, note that this is applied channel-wise: that is, softmax is applied along dimension 1 for NCDHW, or
+ * dimension 4 for NDHWC for each minibatch, and x/y/z location separately.<br>
  * <br>
  * Note that multiple types of masking are supported. Mask arrays (when present) must be 5d in a 'broadcastable' format:
- * that is, for (n=minibatchSize, c=channels, d=depth, h=height, w=width):<br>
- * - Per example masking: Where an example is present or not (and all outputs are masked by it). Mask shape [n,1,1,1,1] for both NCDHW and NDHWC<br>
- * - Per x/y/z location masking: where each spatial X/Y/Z location is present or not (all channels at a given x/y/z are masked by it).
- * Mask shape: [n,1,d,h,w] (NCDHW format) or [n,d,h,w,1] (NDHWC format).<br>
- * - Per output masking: Where each output activation value is present or not - mask shape [n,c,d,h,w] (NCDHW format) or
- * [n,d,h,w,c] (NDHWC format) - same as input/output in both cases<br>
+ * that is, for (n=minibatchSize, c=channels, d=depth, h=height, w=width):<br> - Per example masking: Where an example
+ * is present or not (and all outputs are masked by it). Mask shape [n,1,1,1,1] for both NCDHW and NDHWC<br> - Per x/y/z
+ * location masking: where each spatial X/Y/Z location is present or not (all channels at a given x/y/z are masked by
+ * it). Mask shape: [n,1,d,h,w] (NCDHW format) or [n,d,h,w,1] (NDHWC format).<br> - Per output masking: Where each
+ * output activation value is present or not - mask shape [n,c,d,h,w] (NCDHW format) or [n,d,h,w,c] (NDHWC format) -
+ * same as input/output in both cases<br>
  *
  * @author Alex Black
  */
@@ -73,9 +72,9 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.Cnn3DLossLayer ret =
-                        new org.deeplearning4j.nn.layers.convolution.Cnn3DLossLayer(conf);
+                new org.deeplearning4j.nn.layers.convolution.Cnn3DLossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -92,9 +91,10 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        if (inputType == null || (inputType.getType() != InputType.Type.CNN3D && inputType.getType() != InputType.Type.CNNFlat)) {
+        if (inputType == null || (inputType.getType() != InputType.Type.CNN3D
+                && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type for CnnLossLayer (layer index = " + layerIndex
-                            + ", layer name=\"" + getLayerName() + "\"): Expected CNN3D or CNNFlat input, got " + inputType);
+                    + ", layer name=\"" + getLayerName() + "\"): Expected CNN3D or CNNFlat input, got " + inputType);
         }
         return inputType;
     }
@@ -107,7 +107,8 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType).standardMemory(0, 0) //No params
+        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType)
+                .standardMemory(0, 0) //No params
                 .workingMemory(0, 0, 0, 0)
                 .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
                 .build();
@@ -121,6 +122,9 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
 
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
+        /**
+         * Format of the input/output data. See {@link Convolution3D.DataFormat} for details
+         */
         @Getter
         @Setter
         protected Convolution3D.DataFormat dataFormat;
@@ -136,13 +140,15 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
         @Override
         @SuppressWarnings("unchecked")
         public Builder nIn(int nIn) {
-            throw new UnsupportedOperationException("Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
+            throw new UnsupportedOperationException(
+                    "Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
         }
 
         @Override
         @SuppressWarnings("unchecked")
         public Builder nOut(int nOut) {
-            throw new UnsupportedOperationException("Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
+            throw new UnsupportedOperationException(
+                    "Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
         }
 
         @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -72,9 +69,9 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.Cnn3DLossLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.Cnn3DLossLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.Cnn3DLossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -92,9 +89,10 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || (inputType.getType() != InputType.Type.CNN3D
-                && inputType.getType() != InputType.Type.CNNFlat)) {
+                        && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type for CnnLossLayer (layer index = " + layerIndex
-                    + ", layer name=\"" + getLayerName() + "\"): Expected CNN3D or CNNFlat input, got " + inputType);
+                            + ", layer name=\"" + getLayerName() + "\"): Expected CNN3D or CNNFlat input, got "
+                            + inputType);
         }
         return inputType;
     }
@@ -107,11 +105,10 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, 0, 0, 0)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, 0, 0, 0)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override
@@ -141,14 +138,14 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
         @SuppressWarnings("unchecked")
         public Builder nIn(int nIn) {
             throw new UnsupportedOperationException(
-                    "Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
+                            "Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
         }
 
         @Override
         @SuppressWarnings("unchecked")
         public Builder nOut(int nOut) {
             throw new UnsupportedOperationException(
-                    "Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
+                            "Cnn3DLossLayer has no parameters, thus nIn will always equal nOut.");
         }
 
         @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
@@ -121,6 +121,8 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
 
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         protected Convolution3D.DataFormat dataFormat;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Cnn3DLossLayer.java
@@ -117,13 +117,13 @@ public class Cnn3DLossLayer extends FeedForwardLayer {
     }
 
 
+    @Getter
+    @Setter
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
         /**
          * Format of the input/output data. See {@link Convolution3D.DataFormat} for details
          */
-        @Getter
-        @Setter
         protected Convolution3D.DataFormat dataFormat;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CnnLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CnnLossLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -69,9 +66,9 @@ public class CnnLossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.CnnLossLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.CnnLossLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.CnnLossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -89,9 +86,10 @@ public class CnnLossLayer extends FeedForwardLayer {
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || (inputType.getType() != InputType.Type.CNN
-                && inputType.getType() != InputType.Type.CNNFlat)) {
-            throw new IllegalStateException("Invalid input type for CnnLossLayer (layer index = " + layerIndex
-                    + ", layer name=\"" + getLayerName() + "\"): Expected CNN or CNNFlat input, got " + inputType);
+                        && inputType.getType() != InputType.Type.CNNFlat)) {
+            throw new IllegalStateException(
+                            "Invalid input type for CnnLossLayer (layer index = " + layerIndex + ", layer name=\""
+                                            + getLayerName() + "\"): Expected CNN or CNNFlat input, got " + inputType);
         }
         return inputType;
     }
@@ -104,11 +102,10 @@ public class CnnLossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, 0, 0, 0)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, 0, 0, 0)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CnnLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CnnLossLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CnnLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/CnnLossLayer.java
@@ -38,19 +38,19 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Convolutional Neural Network Loss Layer.<br>
- * Handles calculation of gradients etc for various loss (objective) functions.<br>
- * NOTE: CnnLossLayer does not have any parameters. Consequently, the output activations size is equal to the input size.<br>
- * Input and output activations are same as other CNN layers: 4 dimensions with shape [miniBatchSize,channels,height,width]<br>
- * CnnLossLayer has support for a built-in activation function (tanh, softmax etc) - if this is not required, set
- * activation function to Activation.IDENTITY. For activations such as softmax, note that this is applied channel-wise:
- * that is, softmax is applied along dimension 1 (channel) for each minibatch, and x/y location separately.<br>
+ * Convolutional Neural Network Loss Layer.<br> Handles calculation of gradients etc for various loss (objective)
+ * functions.<br> NOTE: CnnLossLayer does not have any parameters. Consequently, the output activations size is equal to
+ * the input size.<br> Input and output activations are same as other CNN layers: 4 dimensions with shape
+ * [miniBatchSize,channels,height,width]<br> CnnLossLayer has support for a built-in activation function (tanh, softmax
+ * etc) - if this is not required, set activation function to Activation.IDENTITY. For activations such as softmax, note
+ * that this is applied channel-wise: that is, softmax is applied along dimension 1 (channel) for each minibatch, and
+ * x/y location separately.<br>
  * <br>
- * Note that 3 types of masking are supported, where (n=minibatchSize, c=channels, h=height, w=width):<br>
- * - Per example masking: Where an example is present or not (and all outputs are masked by it). Mask shape [n,1]<br>
- * - Per x/y location masking: where each spatial X/Y location is present or not (all channels at a given x/y are masked by it).
- * Mask shape: [n,h,w].<br>
- * - Per output masking: Where each output activation value is present or not - mask shape [n,c,h,w] (same as output)<br>
+ * Note that 3 types of masking are supported, where (n=minibatchSize, c=channels, h=height, w=width):<br> - Per example
+ * masking: Where an example is present or not (and all outputs are masked by it). Mask shape [n,1]<br> - Per x/y
+ * location masking: where each spatial X/Y location is present or not (all channels at a given x/y are masked by it).
+ * Mask shape: [n,h,w].<br> - Per output masking: Where each output activation value is present or not - mask shape
+ * [n,c,h,w] (same as output)<br>
  *
  * @author Alex Black
  */
@@ -69,9 +69,9 @@ public class CnnLossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.CnnLossLayer ret =
-                        new org.deeplearning4j.nn.layers.convolution.CnnLossLayer(conf);
+                new org.deeplearning4j.nn.layers.convolution.CnnLossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -88,9 +88,10 @@ public class CnnLossLayer extends FeedForwardLayer {
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        if (inputType == null || (inputType.getType() != InputType.Type.CNN && inputType.getType() != InputType.Type.CNNFlat)) {
+        if (inputType == null || (inputType.getType() != InputType.Type.CNN
+                && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type for CnnLossLayer (layer index = " + layerIndex
-                            + ", layer name=\"" + getLayerName() + "\"): Expected CNN or CNNFlat input, got " + inputType);
+                    + ", layer name=\"" + getLayerName() + "\"): Expected CNN or CNNFlat input, got " + inputType);
         }
         return inputType;
     }
@@ -103,7 +104,8 @@ public class CnnLossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType).standardMemory(0, 0) //No params
+        return new LayerMemoryReport.Builder(layerName, getClass(), inputType, inputType)
+                .standardMemory(0, 0) //No params
                 .workingMemory(0, 0, 0, 0)
                 .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
                 .build();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -30,4 +27,5 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class Convolution1D extends Convolution1DLayer { }
+public class Convolution1D extends Convolution1DLayer {
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
@@ -59,8 +59,8 @@ public class Convolution1DLayer extends ConvolutionLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         LayerValidation.assertNInNOutSet("Convolution1DLayer", getLayerName(), layerIndex,
                 getNIn(), getNOut());
 
@@ -85,11 +85,13 @@ public class Convolution1DLayer extends ConvolutionLayer {
         InputType.InputTypeRecurrent it = (InputType.InputTypeRecurrent) inputType;
         long inputTsLength = it.getTimeSeriesLength();
         long outLength;
-        if(inputTsLength < 0){
+        if (inputTsLength < 0) {
             //Probably: user did InputType.recurrent(x) without specifying sequence length
             outLength = -1;
         } else {
-            outLength = Convolution1DUtils.getOutputSize((int)inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode, dilation[0]);
+            outLength = Convolution1DUtils
+                    .getOutputSize((int) inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode,
+                            dilation[0]);
         }
         return InputType.recurrent(nOut, outLength);
     }
@@ -126,7 +128,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
 
         /**
          * @param kernelSize Kernel size
-         * @param stride     Stride
+         * @param stride Stride
          */
         public Builder(int kernelSize, int stride) {
             this(kernelSize, stride, 0);
@@ -134,6 +136,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
 
         /**
          * Constructor with specified kernel size, stride of 1, padding of 0
+         *
          * @param kernelSize Kernel size
          */
         public Builder(int kernelSize) {
@@ -142,8 +145,8 @@ public class Convolution1DLayer extends ConvolutionLayer {
 
         /**
          * @param kernelSize Kernel size
-         * @param stride     Stride
-         * @param padding    Padding
+         * @param stride Stride
+         * @param padding Padding
          */
         public Builder(int kernelSize, int stride, int padding) {
             this.kernelSize = new int[]{kernelSize, 1};
@@ -163,6 +166,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
 
         /**
          * Stride for the convolution. Must be > 0
+         *
          * @param stride Stride
          */
         public Builder stride(int stride) {
@@ -172,6 +176,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
 
         /**
          * Padding value for the convolution. Not used with {@link org.deeplearning4j.nn.conf.ConvolutionMode#Same}
+         *
          * @param padding Padding value
          */
         public Builder padding(int padding) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -59,13 +56,12 @@ public class Convolution1DLayer extends ConvolutionLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
-        LayerValidation.assertNInNOutSet("Convolution1DLayer", getLayerName(), layerIndex,
-                getNIn(), getNOut());
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
+        LayerValidation.assertNInNOutSet("Convolution1DLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.convolution.Convolution1DLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.Convolution1DLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.Convolution1DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -79,8 +75,8 @@ public class Convolution1DLayer extends ConvolutionLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for 1D CNN layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
+                            + inputType);
         }
         InputType.InputTypeRecurrent it = (InputType.InputTypeRecurrent) inputType;
         long inputTsLength = it.getTimeSeriesLength();
@@ -89,9 +85,8 @@ public class Convolution1DLayer extends ConvolutionLayer {
             //Probably: user did InputType.recurrent(x) without specifying sequence length
             outLength = -1;
         } else {
-            outLength = Convolution1DUtils
-                    .getOutputSize((int) inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode,
-                            dilation[0]);
+            outLength = Convolution1DUtils.getOutputSize((int) inputTsLength, kernelSize[0], stride[0], padding[0],
+                            convolutionMode, dilation[0]);
         }
         return InputType.recurrent(nOut, outLength);
     }
@@ -100,7 +95,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for 1D CNN layer (layer name = \"" + getLayerName()
-                    + "\"): expect RNN input type with size > 0. Got: " + inputType);
+                            + "\"): expect RNN input type with size > 0. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -113,7 +108,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Convolution1D layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreprocessorForInputTypeRnnLayers(inputType, getLayerName());
@@ -149,9 +144,9 @@ public class Convolution1DLayer extends ConvolutionLayer {
          * @param padding Padding
          */
         public Builder(int kernelSize, int stride, int padding) {
-            this.kernelSize = new int[]{kernelSize, 1};
-            this.stride = new int[]{stride, 1};
-            this.padding = new int[]{padding, 0};
+            this.kernelSize = new int[] {kernelSize, 1};
+            this.stride = new int[] {stride, 1};
+            this.padding = new int[] {padding, 0};
         }
 
         /**
@@ -160,7 +155,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
          * @param kernelSize the length of the kernel
          */
         public Builder kernelSize(int kernelSize) {
-            this.kernelSize = new int[]{kernelSize, 1};
+            this.kernelSize = new int[] {kernelSize, 1};
             return this;
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -30,4 +27,5 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class Convolution2D extends ConvolutionLayer { }
+public class Convolution2D extends ConvolutionLayer {
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
@@ -46,10 +46,10 @@ import java.util.Map;
 public class Convolution3D extends ConvolutionLayer {
 
     /**
-     * An optional dataFormat: "NDHWC" or "NCDHW". Defaults to "NCDHW".<br>
-     * The data format of the input and output data. <br>
-     * For "NCDHW" (also known as 'channels first' format), the data storage order is: [batchSize, inputChannels, inputDepth, inputHeight, inputWidth].<br>
-     * For "NDHWC" ('channels last' format), the data is stored in the order of: [batchSize, inputDepth, inputHeight, inputWidth, inputChannels].
+     * An optional dataFormat: "NDHWC" or "NCDHW". Defaults to "NCDHW".<br> The data format of the input and output
+     * data. <br> For "NCDHW" (also known as 'channels first' format), the data storage order is: [batchSize,
+     * inputChannels, inputDepth, inputHeight, inputWidth].<br> For "NDHWC" ('channels last' format), the data is stored
+     * in the order of: [batchSize, inputDepth, inputHeight, inputWidth, inputChannels].
      */
     public enum DataFormat {
         NCDHW, NDHWC
@@ -59,11 +59,9 @@ public class Convolution3D extends ConvolutionLayer {
     private DataFormat dataFormat = DataFormat.NCDHW; // in libnd4j: 1 - NCDHW, 0 - NDHWC
 
     /**
-     * 3-dimensional convolutional layer configuration
-     * nIn in the input layer is the number of channels
-     * nOut is the number of filters to be used in the net or in other words the depth
-     * The builder specifies the filter/kernel size, the stride and padding
-     * The pooling layer takes the kernel size
+     * 3-dimensional convolutional layer configuration nIn in the input layer is the number of channels nOut is the
+     * number of filters to be used in the net or in other words the depth The builder specifies the filter/kernel size,
+     * the stride and padding The pooling layer takes the kernel size
      */
     public Convolution3D(Builder builder) {
         super(builder);
@@ -79,20 +77,24 @@ public class Convolution3D extends ConvolutionLayer {
     @Override
     public Convolution3D clone() {
         Convolution3D clone = (Convolution3D) super.clone();
-        if (clone.kernelSize != null)
+        if (clone.kernelSize != null) {
             clone.kernelSize = clone.kernelSize.clone();
-        if (clone.stride != null)
+        }
+        if (clone.stride != null) {
             clone.stride = clone.stride.clone();
-        if (clone.padding != null)
+        }
+        if (clone.padding != null) {
             clone.padding = clone.padding.clone();
-        if (clone.dilation != null)
+        }
+        if (clone.dilation != null) {
             clone.dilation = clone.dilation.clone();
+        }
         return clone;
     }
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> iterationListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("Convolution3D", getLayerName(), layerIndex, getNIn(), getNOut());
 
         Convolution3DLayer ret = new Convolution3DLayer(conf);
@@ -147,6 +149,11 @@ public class Convolution3D extends ConvolutionLayer {
     @AllArgsConstructor
     public static class Builder extends ConvolutionLayer.BaseConvBuilder<Builder> {
 
+        /**
+         * The data format for input and output activations.<br> NCDHW: activations (in/out) should have shape
+         * [minibatch, channels, depth, height, width]<br> NDHWC: activations (in/out) should have shape [minibatch,
+         * depth, height, width, channels]<br>
+         */
         @Getter
         @Setter
         private DataFormat dataFormat = DataFormat.NCDHW;
@@ -164,15 +171,15 @@ public class Convolution3D extends ConvolutionLayer {
         }
 
         public Builder(int[] kernelSize, int[] stride, int[] padding) {
-            this(kernelSize, stride, padding, new int[]{1,1,1});
+            this(kernelSize, stride, padding, new int[]{1, 1, 1});
         }
 
         public Builder(int[] kernelSize, int[] stride) {
-            this(kernelSize, stride, new int[]{0,0,0});
+            this(kernelSize, stride, new int[]{0, 0, 0});
         }
 
         public Builder(int... kernelSize) {
-            this(kernelSize, new int[]{1,1,1});
+            this(kernelSize, new int[]{1, 1, 1});
         }
 
         /**
@@ -230,9 +237,9 @@ public class Convolution3D extends ConvolutionLayer {
         }
 
         /**
-         * The data format for input and output activations.<br>
-         * NCDHW: activations (in/out) should have shape [minibatch, channels, depth, height, width]<br>
-         * NDHWC: activations (in/out) should have shape [minibatch, depth, height, width, channels]<br>
+         * The data format for input and output activations.<br> NCDHW: activations (in/out) should have shape
+         * [minibatch, channels, depth, height, width]<br> NDHWC: activations (in/out) should have shape [minibatch,
+         * depth, height, width, channels]<br>
          *
          * @param dataFormat Data format to use for activations
          */
@@ -240,6 +247,47 @@ public class Convolution3D extends ConvolutionLayer {
             this.dataFormat = dataFormat;
             return this;
         }
+
+        /**
+         * Set kernel size for 3D convolutions in (depth, height, width) order
+         *
+         * @param kernelSize kernel size
+         */
+        @Override
+        public void setKernelSize(int[] kernelSize) {
+            kernelSize(kernelSize);
+        }
+
+        /**
+         * Set stride size for 3D convolutions in (depth, height, width) order
+         *
+         * @param stride kernel size
+         */
+        @Override
+        public void setStride(int[] stride) {
+            stride(stride);
+        }
+
+        /**
+         * Set padding size for 3D convolutions in (depth, height, width) order
+         *
+         * @param padding kernel size
+         */
+        @Override
+        public void setPadding(int[] padding) {
+            padding(padding);
+        }
+
+        /**
+         * Set dilation size for 3D convolutions in (depth, height, width) order
+         *
+         * @param dilation kernel size
+         */
+        @Override
+        public void setDilation(int[] dilation) {
+            dilation(dilation);
+        }
+
 
 
         @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -55,7 +52,7 @@ public class Convolution3D extends ConvolutionLayer {
         NCDHW, NDHWC
     }
 
-    private ConvolutionMode mode = ConvolutionMode.Same;  // in libnd4j: 0 - same mode, 1 - valid mode
+    private ConvolutionMode mode = ConvolutionMode.Same; // in libnd4j: 0 - same mode, 1 - valid mode
     private DataFormat dataFormat = DataFormat.NCDHW; // in libnd4j: 1 - NCDHW, 0 - NDHWC
 
     /**
@@ -94,7 +91,7 @@ public class Convolution3D extends ConvolutionLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> iterationListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("Convolution3D", getLayerName(), layerIndex, getNIn(), getNOut());
 
         Convolution3DLayer ret = new Convolution3DLayer(conf);
@@ -116,17 +113,17 @@ public class Convolution3D extends ConvolutionLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN3D) {
             throw new IllegalStateException("Invalid input for Convolution3D layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN3D input, got " + inputType);
+                            + "\"): Expected CNN3D input, got " + inputType);
         }
-        return InputTypeUtil.getOutputTypeCnn3DLayers(inputType, kernelSize, stride, padding, dilation,
-                convolutionMode, nOut, layerIndex, getLayerName(), Convolution3DLayer.class);
+        return InputTypeUtil.getOutputTypeCnn3DLayers(inputType, kernelSize, stride, padding, dilation, convolutionMode,
+                        nOut, layerIndex, getLayerName(), Convolution3DLayer.class);
     }
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Convolution3D layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreProcessorForInputTypeCnn3DLayers(inputType, getLayerName());
@@ -137,7 +134,7 @@ public class Convolution3D extends ConvolutionLayer {
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN3D) {
             throw new IllegalStateException("Invalid input for Convolution 3D layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN3D input, got " + inputType);
+                            + "\"): Expected CNN3D input, got " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -159,7 +156,7 @@ public class Convolution3D extends ConvolutionLayer {
         private DataFormat dataFormat = DataFormat.NCDHW;
 
         public Builder() {
-            super(new int[]{2, 2, 2}, new int[]{1, 1, 1}, new int[]{0, 0, 0}, new int[]{1, 1, 1}, 3);
+            super(new int[] {2, 2, 2}, new int[] {1, 1, 1}, new int[] {0, 0, 0}, new int[] {1, 1, 1}, 3);
         }
 
         public Builder(int[] kernelSize, int[] stride, int[] padding, int[] dilation) {
@@ -171,15 +168,15 @@ public class Convolution3D extends ConvolutionLayer {
         }
 
         public Builder(int[] kernelSize, int[] stride, int[] padding) {
-            this(kernelSize, stride, padding, new int[]{1, 1, 1});
+            this(kernelSize, stride, padding, new int[] {1, 1, 1});
         }
 
         public Builder(int[] kernelSize, int[] stride) {
-            this(kernelSize, stride, new int[]{0, 0, 0});
+            this(kernelSize, stride, new int[] {0, 0, 0});
         }
 
         public Builder(int... kernelSize) {
-            this(kernelSize, new int[]{1, 1, 1});
+            this(kernelSize, new int[] {1, 1, 1});
         }
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
@@ -144,6 +144,8 @@ public class Convolution3D extends ConvolutionLayer {
     }
 
     @AllArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends ConvolutionLayer.BaseConvBuilder<Builder> {
 
         /**
@@ -151,8 +153,6 @@ public class Convolution3D extends ConvolutionLayer {
          * [minibatch, channels, depth, height, width]<br> NDHWC: activations (in/out) should have shape [minibatch,
          * depth, height, width, channels]<br>
          */
-        @Getter
-        @Setter
         private DataFormat dataFormat = DataFormat.NCDHW;
 
         public Builder() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
@@ -147,6 +147,8 @@ public class Convolution3D extends ConvolutionLayer {
     @AllArgsConstructor
     public static class Builder extends ConvolutionLayer.BaseConvBuilder<Builder> {
 
+        @Getter
+        @Setter
         private DataFormat dataFormat = DataFormat.NCDHW;
 
         public Builder() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution3D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -332,26 +332,22 @@ public class ConvolutionLayer extends FeedForwardLayer {
         }
     }
 
+    @Getter
+    @Setter
     public static abstract class BaseConvBuilder<T extends BaseConvBuilder<T>> extends FeedForwardLayer.Builder<T> {
 
-        @Getter
-        @Setter
         protected int convolutionDim = 2; // 2D convolution by default
 
         /**
          * If true (default): include bias parameters in the model. False: no bias.
          *
          */
-        @Getter
-        @Setter
         protected boolean hasBias = true;
 
         /**
          * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
          *
          */
-        @Getter
-        @Setter
         protected ConvolutionMode convolutionMode;
 
         /**
@@ -365,39 +361,17 @@ public class ConvolutionLayer extends FeedForwardLayer {
          * http://deeplearning.net/software/theano/tutorial/conv_arithmetic.html#dilated-convolutions</a><br>
          *
          */
-        @Getter
-        @Setter
         protected int[] dilation = new int[] {1, 1};
-
-        @Getter
-        @Setter
         public int[] kernelSize = new int[] {5, 5};
-
-        @Getter
-        @Setter
         protected int[] stride = new int[] {1, 1};
-
-        @Getter
-        @Setter
         protected int[] padding = new int[] {0, 0};
 
         /**
          * Defaults to "PREFER_FASTEST", but "NO_WORKSPACE" uses less memory.
          */
-        @Getter
-        @Setter
         protected AlgoMode cudnnAlgoMode = null;
-
-        @Getter
-        @Setter
         protected FwdAlgo cudnnFwdAlgo;
-
-        @Getter
-        @Setter
         protected BwdFilterAlgo cudnnBwdFilterAlgo;
-
-        @Getter
-        @Setter
         protected BwdDataAlgo cudnnBwdDataAlgo;
 
         /**
@@ -406,8 +380,6 @@ public class ConvolutionLayer extends FeedForwardLayer {
          * (non-CuDNN) implementation for ConvolutionLayer will be used
          *
          */
-        @Getter
-        @Setter
         protected boolean cudnnAllowFallback = true;
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -36,8 +36,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 2D Convolution layer (for example, spatial convolution over images).
- * Input activations should be format {@code [minibatch, channels, height, width]}
+ * 2D Convolution layer (for example, spatial convolution over images). Input activations should be format {@code
+ * [minibatch, channels, height, width]}
  *
  * @author Adam Gibson
  */
@@ -46,6 +46,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class ConvolutionLayer extends FeedForwardLayer {
+
     protected boolean hasBias = true;
     protected ConvolutionMode convolutionMode = ConvolutionMode.Truncate; //Default to truncate here - default for 0.6.0 and earlier networks on JSON deserialization
     protected int dilation[] = new int[]{1, 1};
@@ -55,11 +56,10 @@ public class ConvolutionLayer extends FeedForwardLayer {
     protected boolean cudnnAllowFallback = true;
 
     /**
-     * The "PREFER_FASTEST" mode will pick the fastest algorithm for the specified parameters
-     * from the {@link FwdAlgo}, {@link BwdFilterAlgo}, and {@link BwdDataAlgo} lists, but they
-     * may be very memory intensive, so if weird errors occur when using cuDNN, please try the
-     * "NO_WORKSPACE" mode. Alternatively, it is possible to specify the algorithm manually by
-     * setting the "USER_SPECIFIED" mode, but this is not recommended.
+     * The "PREFER_FASTEST" mode will pick the fastest algorithm for the specified parameters from the {@link FwdAlgo},
+     * {@link BwdFilterAlgo}, and {@link BwdDataAlgo} lists, but they may be very memory intensive, so if weird errors
+     * occur when using cuDNN, please try the "NO_WORKSPACE" mode. Alternatively, it is possible to specify the
+     * algorithm manually by setting the "USER_SPECIFIED" mode, but this is not recommended.
      * <p>
      * Note: Currently only supported with cuDNN.
      */
@@ -103,11 +103,9 @@ public class ConvolutionLayer extends FeedForwardLayer {
     protected BwdDataAlgo cudnnBwdDataAlgo;
 
     /**
-     * ConvolutionLayer
-     * nIn in the input layer is the number of channels
-     * nOut is the number of filters to be used in the net or in other words the channels
-     * The builder specifies the filter/kernel size, the stride and padding
-     * The pooling layer takes the kernel size
+     * ConvolutionLayer nIn in the input layer is the number of channels nOut is the number of filters to be used in the
+     * net or in other words the channels The builder specifies the filter/kernel size, the stride and padding The
+     * pooling layer takes the kernel size
      */
     protected ConvolutionLayer(BaseConvBuilder<?> builder) {
         super(builder);
@@ -116,17 +114,21 @@ public class ConvolutionLayer extends FeedForwardLayer {
         this.hasBias = builder.hasBias;
         this.convolutionMode = builder.convolutionMode;
         this.dilation = builder.dilation;
-        if (builder.kernelSize.length != dim)
+        if (builder.kernelSize.length != dim) {
             throw new IllegalArgumentException("Kernel argument should be a " + dim + "d array");
+        }
         this.kernelSize = builder.kernelSize;
-        if (builder.stride.length != dim)
+        if (builder.stride.length != dim) {
             throw new IllegalArgumentException("Strides argument should be a " + dim + "d array");
+        }
         this.stride = builder.stride;
-        if (builder.padding.length != dim)
+        if (builder.padding.length != dim) {
             throw new IllegalArgumentException("Padding argument should be a " + dim + "d array");
+        }
         this.padding = builder.padding;
-        if (builder.dilation.length != dim)
+        if (builder.dilation.length != dim) {
             throw new IllegalArgumentException("Dilation argument should be a " + dim + "d array");
+        }
         this.dilation = builder.dilation;
         this.cudnnAlgoMode = builder.cudnnAlgoMode;
         this.cudnnFwdAlgo = builder.cudnnFwdAlgo;
@@ -144,18 +146,21 @@ public class ConvolutionLayer extends FeedForwardLayer {
     @Override
     public ConvolutionLayer clone() {
         ConvolutionLayer clone = (ConvolutionLayer) super.clone();
-        if (clone.kernelSize != null)
+        if (clone.kernelSize != null) {
             clone.kernelSize = clone.kernelSize.clone();
-        if (clone.stride != null)
+        }
+        if (clone.stride != null) {
             clone.stride = clone.stride.clone();
-        if (clone.padding != null)
+        }
+        if (clone.padding != null) {
             clone.padding = clone.padding.clone();
+        }
         return clone;
     }
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("ConvolutionLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.convolution.ConvolutionLayer ret =
@@ -274,7 +279,6 @@ public class ConvolutionLayer extends FeedForwardLayer {
             cachedPerEx.put(cm, cacheMemSizePerEx);
         }
 
-
         return new LayerMemoryReport.Builder(layerName, ConvolutionLayer.class, inputType, outputType)
                 .standardMemory(paramSize, updaterStateSize)
                 //im2col caching -> only variable size caching
@@ -302,12 +306,9 @@ public class ConvolutionLayer extends FeedForwardLayer {
         }
 
         /**
-         * Size of the convolution
-         * rows/columns
+         * Size of the convolution rows/columns
          *
-         * @param kernelSize the height and width of the
-         *                   kernel
-         * @return
+         * @param kernelSize the height and width of the kernel
          */
         public Builder kernelSize(int... kernelSize) {
             this.kernelSize = kernelSize;
@@ -335,39 +336,79 @@ public class ConvolutionLayer extends FeedForwardLayer {
     }
 
     public static abstract class BaseConvBuilder<T extends BaseConvBuilder<T>> extends FeedForwardLayer.Builder<T> {
+
         @Getter
         @Setter
         protected int convolutionDim = 2; // 2D convolution by default
+
+        /**
+         * If true (default): include bias parameters in the model. False: no bias.
+         *
+         */
         @Getter
         @Setter
         protected boolean hasBias = true;
+
+        /**
+         * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
+         *
+         */
         @Getter
         @Setter
         protected ConvolutionMode convolutionMode;
+
+        /**
+         * Kernel dilation. Default: {1, 1}, which is standard convolutions. Used for implementing dilated convolutions,
+         * which are also known as atrous convolutions.
+         * <p>
+         * For more details, see:
+         * <a href="https://arxiv.org/abs/1511.07122">Yu and Koltun (2014)</a> and
+         * <a href="https://arxiv.org/abs/1412.7062">Chen et al. (2014)</a>, as well as
+         * <a href="http://deeplearning.net/software/theano/tutorial/conv_arithmetic.html#dilated-convolutions">
+         * http://deeplearning.net/software/theano/tutorial/conv_arithmetic.html#dilated-convolutions</a><br>
+         *
+         */
         @Getter
         @Setter
         protected int[] dilation = new int[]{1, 1};
+
         @Getter
         @Setter
         public int[] kernelSize = new int[]{5, 5};
+
         @Getter
         @Setter
         protected int[] stride = new int[]{1, 1};
+
         @Getter
         @Setter
         protected int[] padding = new int[]{0, 0};
+
+        /**
+         * Defaults to "PREFER_FASTEST", but "NO_WORKSPACE" uses less memory.
+         */
         @Getter
         @Setter
         protected AlgoMode cudnnAlgoMode = null;
+
         @Getter
         @Setter
         protected FwdAlgo cudnnFwdAlgo;
+
         @Getter
         @Setter
         protected BwdFilterAlgo cudnnBwdFilterAlgo;
+
         @Getter
         @Setter
         protected BwdDataAlgo cudnnBwdDataAlgo;
+
+        /**
+         * When using CuDNN and an error is encountered, should fallback to the non-CuDNN implementatation be allowed?
+         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in
+         * (non-CuDNN) implementation for ConvolutionLayer will be used
+         *
+         */
         @Getter
         @Setter
         protected boolean cudnnAllowFallback = true;
@@ -437,8 +478,7 @@ public class ConvolutionLayer extends FeedForwardLayer {
         }
 
         /**
-         * Set the convolution mode for the Convolution layer.
-         * See {@link ConvolutionMode} for more details
+         * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
          *
          * @param convolutionMode Convolution mode for layer
          */
@@ -504,8 +544,8 @@ public class ConvolutionLayer extends FeedForwardLayer {
 
         /**
          * When using CuDNN and an error is encountered, should fallback to the non-CuDNN implementatation be allowed?
-         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in (non-CuDNN)
-         * implementation for ConvolutionLayer will be used
+         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in
+         * (non-CuDNN) implementation for ConvolutionLayer will be used
          *
          * @param allowFallback Whether fallback to non-CuDNN implementation should be used
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -49,7 +46,7 @@ public class ConvolutionLayer extends FeedForwardLayer {
 
     protected boolean hasBias = true;
     protected ConvolutionMode convolutionMode = ConvolutionMode.Truncate; //Default to truncate here - default for 0.6.0 and earlier networks on JSON deserialization
-    protected int dilation[] = new int[]{1, 1};
+    protected int dilation[] = new int[] {1, 1};
     protected int[] kernelSize; // Square filter
     protected int[] stride; // Default is 2. Down-sample by a factor of 2
     protected int[] padding;
@@ -160,11 +157,11 @@ public class ConvolutionLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("ConvolutionLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.convolution.ConvolutionLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.ConvolutionLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.ConvolutionLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -183,18 +180,18 @@ public class ConvolutionLayer extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation,
-                convolutionMode, nOut, layerIndex, getLayerName(), ConvolutionLayer.class);
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation, convolutionMode,
+                        nOut, layerIndex, getLayerName(), ConvolutionLayer.class);
     }
 
     @Override
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -207,7 +204,7 @@ public class ConvolutionLayer extends FeedForwardLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
@@ -248,8 +245,8 @@ public class ConvolutionLayer extends FeedForwardLayer {
         //TODO convolution helper memory use... (CuDNN etc)
 
         //During forward pass: im2col array, mmul (result activations), in-place broadcast add
-        val im2colSizePerEx =
-                c.getChannels() * outputType.getHeight() * outputType.getWidth() * kernelSize[0] * kernelSize[1];
+        val im2colSizePerEx = c.getChannels() * outputType.getHeight() * outputType.getWidth() * kernelSize[0]
+                        * kernelSize[1];
 
         //During training: have im2col array, in-place gradient calculation, then epsilons...
         //But: im2col array may be cached...
@@ -280,10 +277,10 @@ public class ConvolutionLayer extends FeedForwardLayer {
         }
 
         return new LayerMemoryReport.Builder(layerName, ConvolutionLayer.class, inputType, outputType)
-                .standardMemory(paramSize, updaterStateSize)
-                //im2col caching -> only variable size caching
-                .workingMemory(0, im2colSizePerEx, MemoryReport.CACHE_MODE_ALL_ZEROS, trainWorkingMemoryPerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, cachedPerEx).build();
+                        .standardMemory(paramSize, updaterStateSize)
+                        //im2col caching -> only variable size caching
+                        .workingMemory(0, im2colSizePerEx, MemoryReport.CACHE_MODE_ALL_ZEROS, trainWorkingMemoryPerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, cachedPerEx).build();
 
     }
 
@@ -370,19 +367,19 @@ public class ConvolutionLayer extends FeedForwardLayer {
          */
         @Getter
         @Setter
-        protected int[] dilation = new int[]{1, 1};
+        protected int[] dilation = new int[] {1, 1};
 
         @Getter
         @Setter
-        public int[] kernelSize = new int[]{5, 5};
+        public int[] kernelSize = new int[] {5, 5};
 
         @Getter
         @Setter
-        protected int[] stride = new int[]{1, 1};
+        protected int[] stride = new int[] {1, 1};
 
         @Getter
         @Setter
-        protected int[] padding = new int[]{0, 0};
+        protected int[] padding = new int[] {0, 0};
 
         /**
          * Defaults to "PREFER_FASTEST", but "NO_WORKSPACE" uses less memory.
@@ -464,8 +461,7 @@ public class ConvolutionLayer extends FeedForwardLayer {
             this.kernelSize = kernelSize;
         }
 
-        protected BaseConvBuilder() {
-        }
+        protected BaseConvBuilder() {}
 
         /**
          * If true (default): include bias parameters in the model. False: no bias.

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -335,17 +335,41 @@ public class ConvolutionLayer extends FeedForwardLayer {
     }
 
     public static abstract class BaseConvBuilder<T extends BaseConvBuilder<T>> extends FeedForwardLayer.Builder<T> {
+        @Getter
+        @Setter
         protected int convolutionDim = 2; // 2D convolution by default
+        @Getter
+        @Setter
         protected boolean hasBias = true;
+        @Getter
+        @Setter
         protected ConvolutionMode convolutionMode;
+        @Getter
+        @Setter
         protected int[] dilation = new int[]{1, 1};
+        @Getter
+        @Setter
         public int[] kernelSize = new int[]{5, 5};
+        @Getter
+        @Setter
         protected int[] stride = new int[]{1, 1};
+        @Getter
+        @Setter
         protected int[] padding = new int[]{0, 0};
+        @Getter
+        @Setter
         protected AlgoMode cudnnAlgoMode = null;
+        @Getter
+        @Setter
         protected FwdAlgo cudnnFwdAlgo;
+        @Getter
+        @Setter
         protected BwdFilterAlgo cudnnBwdFilterAlgo;
+        @Getter
+        @Setter
         protected BwdDataAlgo cudnnBwdDataAlgo;
+        @Getter
+        @Setter
         protected boolean cudnnAllowFallback = true;
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ConvolutionLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Deconvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Deconvolution2D.java
@@ -36,8 +36,8 @@ import java.util.Map;
 /**
  * 2D deconvolution layer configuration<br>
  *
- * Deconvolutions are also known as transpose convolutions or fractionally strided convolutions.
- * In essence, deconvolutions swap forward and backward pass with regular 2D convolutions.
+ * Deconvolutions are also known as transpose convolutions or fractionally strided convolutions. In essence,
+ * deconvolutions swap forward and backward pass with regular 2D convolutions.
  *
  * See the paper by Matt Zeiler for details: <a href="http://www.matthewzeiler.com/wp-content/uploads/2017/07/cvpr2010.pdf">http://www.matthewzeiler.com/wp-content/uploads/2017/07/cvpr2010.pdf</a>
  *
@@ -53,10 +53,8 @@ import java.util.Map;
 public class Deconvolution2D extends ConvolutionLayer {
 
     /**
-     * Deconvolution2D layer
-     * nIn in the input layer is the number of channels
-     * nOut is the number of filters to be used in the net or in other words the channels
-     * The builder specifies the filter/kernel size, the stride and padding
+     * Deconvolution2D layer nIn in the input layer is the number of channels nOut is the number of filters to be used
+     * in the net or in other words the channels The builder specifies the filter/kernel size, the stride and padding
      * The pooling layer takes the kernel size
      */
     protected Deconvolution2D(BaseConvBuilder<?> builder) {
@@ -64,25 +62,28 @@ public class Deconvolution2D extends ConvolutionLayer {
         initializeConstraints(builder);
     }
 
-    public boolean hasBias(){
+    public boolean hasBias() {
         return hasBias;
     }
 
     @Override
     public Deconvolution2D clone() {
         Deconvolution2D clone = (Deconvolution2D) super.clone();
-        if (clone.kernelSize != null)
+        if (clone.kernelSize != null) {
             clone.kernelSize = clone.kernelSize.clone();
-        if (clone.stride != null)
+        }
+        if (clone.stride != null) {
             clone.stride = clone.stride.clone();
-        if (clone.padding != null)
+        }
+        if (clone.padding != null) {
             clone.padding = clone.padding.clone();
+        }
         return clone;
     }
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("Deconvolution2D", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.convolution.Deconvolution2DLayer ret =
@@ -131,21 +132,18 @@ public class Deconvolution2D extends ConvolutionLayer {
         }
 
         /**
-         * Set the convolution mode for the Convolution layer.
-         * See {@link ConvolutionMode} for more details
+         * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
          *
-         * @param convolutionMode    Convolution mode for layer
+         * @param convolutionMode Convolution mode for layer
          */
         public Builder convolutionMode(ConvolutionMode convolutionMode) {
             return super.convolutionMode(convolutionMode);
         }
 
         /**
-         * Size of the convolution
-         * rows/columns
-         * @param kernelSize the height and width of the
-         *                   kernel
-         * @return
+         * Size of the convolution rows/columns
+         *
+         * @param kernelSize the height and width of the kernel
          */
         public Builder kernelSize(int... kernelSize) {
             this.kernelSize = kernelSize;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Deconvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Deconvolution2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -83,11 +80,11 @@ public class Deconvolution2D extends ConvolutionLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("Deconvolution2D", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.convolution.Deconvolution2DLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.Deconvolution2DLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.Deconvolution2DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -106,11 +103,11 @@ public class Deconvolution2D extends ConvolutionLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeDeconvLayer(inputType, kernelSize, stride, padding, dilation,
-                convolutionMode, nOut, layerIndex, getLayerName(), Deconvolution2DLayer.class);
+        return InputTypeUtil.getOutputTypeDeconvLayer(inputType, kernelSize, stride, padding, dilation, convolutionMode,
+                        nOut, layerIndex, getLayerName(), Deconvolution2DLayer.class);
     }
 
     public static class Builder extends BaseConvBuilder<Builder> {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Deconvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Deconvolution2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -50,11 +47,11 @@ public class DenseLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("DenseLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer ret =
-                new org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer(conf);
+                        new org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -95,12 +92,10 @@ public class DenseLayer extends FeedForwardLayer {
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, DenseLayer.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, trainSizeFixed,
-                        trainSizeVariable) //No additional memory (beyond activations) for inference
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS,
-                        MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
-                .build();
+                        .standardMemory(numParams, updaterStateSize)
+                        .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
+                        .build();
     }
 
     public boolean hasBias() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -103,14 +103,14 @@ public class DenseLayer extends FeedForwardLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
         /**
          * If true (default): include bias parameters in the model. False: no bias.
          *
          */
-        @Getter
-        @Setter
         private boolean hasBias = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -107,6 +107,8 @@ public class DenseLayer extends FeedForwardLayer {
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private boolean hasBias = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -38,6 +38,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class DenseLayer extends FeedForwardLayer {
+
     private boolean hasBias = true;
 
     private DenseLayer(Builder builder) {
@@ -49,11 +50,11 @@ public class DenseLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("DenseLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer ret =
-                        new org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer(conf);
+                new org.deeplearning4j.nn.layers.feedforward.dense.DenseLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -94,19 +95,25 @@ public class DenseLayer extends FeedForwardLayer {
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, DenseLayer.class, inputType, outputType)
-                        .standardMemory(numParams, updaterStateSize)
-                        .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
-                        .build();
+                .standardMemory(numParams, updaterStateSize)
+                .workingMemory(0, 0, trainSizeFixed,
+                        trainSizeVariable) //No additional memory (beyond activations) for inference
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS,
+                        MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
+                .build();
     }
 
-    public boolean hasBias(){
+    public boolean hasBias() {
         return hasBias;
     }
 
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
+        /**
+         * If true (default): include bias parameters in the model. False: no bias.
+         *
+         */
         @Getter
         @Setter
         private boolean hasBias = true;
@@ -116,7 +123,7 @@ public class DenseLayer extends FeedForwardLayer {
          *
          * @param hasBias If true: include bias parameters in this model
          */
-        public Builder hasBias(boolean hasBias){
+        public Builder hasBias(boolean hasBias) {
             this.hasBias = hasBias;
             return this;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DenseLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -64,9 +61,8 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        LayerValidation.assertNInNOutSet(
-                "DepthwiseConvolution2D", getLayerName(), layerIndex, getNIn(), getNOut());
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        LayerValidation.assertNInNOutSet("DepthwiseConvolution2D", getLayerName(), layerIndex, getNIn(), getNOut());
 
         DepthwiseConvolution2DLayer ret = new DepthwiseConvolution2DLayer(conf);
         ret.setListeners(trainingListeners);
@@ -88,11 +84,11 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for  depth-wise convolution layer (layer name=\""
-                    + getLayerName() + "\"): Expected CNN input, got " + inputType);
+                            + getLayerName() + "\"): Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation,
-                convolutionMode, nOut, layerIndex, getLayerName(), DepthwiseConvolution2DLayer.class);
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation, convolutionMode,
+                        nOut, layerIndex, getLayerName(), DepthwiseConvolution2DLayer.class);
     }
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
@@ -92,14 +92,14 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
     }
 
 
+    @Getter
+    @Setter
     public static class Builder extends BaseConvBuilder<Builder> {
 
         /**
          * Set channels multiplier for depth-wise convolution
          *
          */
-        @Getter
-        @Setter
         public int depthMultiplier = 1;
 
         public Builder(int[] kernelSize, int[] stride, int[] padding) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -103,6 +100,8 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
 
     public static class Builder extends BaseConvBuilder<Builder> {
 
+        @Getter
+        @Setter
         public int depthMultiplier = 1;
 
         public Builder(int[] kernelSize, int[] stride, int[] padding) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DepthwiseConvolution2D.java
@@ -32,10 +32,9 @@ import java.util.*;
 /**
  * 2D depth-wise convolution layer configuration.
  * <p>
- * Performs a channels-wise convolution, which
- * operates on each of the input maps separately. A channel multiplier is used to
- * specify the number of outputs per input map. This convolution
- * is carried out with the specified kernel sizes, stride and padding values.
+ * Performs a channels-wise convolution, which operates on each of the input maps separately. A channel multiplier is
+ * used to specify the number of outputs per input map. This convolution is carried out with the specified kernel sizes,
+ * stride and padding values.
  *
  * @author Max Pumperla
  */
@@ -65,7 +64,7 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet(
                 "DepthwiseConvolution2D", getLayerName(), layerIndex, getNIn(), getNOut());
 
@@ -92,7 +91,6 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
                     + getLayerName() + "\"): Expected CNN input, got " + inputType);
         }
 
-
         return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation,
                 convolutionMode, nOut, layerIndex, getLayerName(), DepthwiseConvolution2DLayer.class);
     }
@@ -100,6 +98,10 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
 
     public static class Builder extends BaseConvBuilder<Builder> {
 
+        /**
+         * Set channels multiplier for depth-wise convolution
+         *
+         */
         @Getter
         @Setter
         public int depthMultiplier = 1;
@@ -123,8 +125,8 @@ public class DepthwiseConvolution2D extends ConvolutionLayer {
         /**
          * Set channels multiplier for depth-wise convolution
          *
-         * @param depthMultiplier integer value, for each input map we get depthMultiplier
-         *                        outputs in channels-wise step.
+         * @param depthMultiplier integer value, for each input map we get depthMultiplier outputs in channels-wise
+         * step.
          * @return Builder
          */
         public Builder depthMultiplier(int depthMultiplier) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -56,8 +53,8 @@ public class DropoutLayer extends FeedForwardLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.DropoutLayer ret = new org.deeplearning4j.nn.layers.DropoutLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -116,11 +113,10 @@ public class DropoutLayer extends FeedForwardLayer {
         //But: this will be counted in the activations
         //(technically inference memory is over-estimated as a result)
 
-        return new LayerMemoryReport.Builder(layerName, DropoutLayer.class, inputType, inputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, 0, 0, 0) //No working mem, other than activations etc
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, DropoutLayer.class, inputType, inputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, 0, 0, 0) //No working mem, other than activations etc
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
@@ -34,19 +34,17 @@ import java.util.Map;
 
 /**
  * Dropout layer. This layer simply applies dropout at training time, and passes activations through unmodified at test
- * time. Internally, this uses an {@link IDropout} instance. See the IDropout instances for details:<br>
- * {@link Dropout}<br>
- * {@link org.nd4j.linalg.api.ops.random.impl.AlphaDropOut}<br>
- * {@link org.deeplearning4j.nn.conf.dropout.GaussianDropout}<br>
- * {@link org.deeplearning4j.nn.conf.dropout.GaussianNoise}<br>
+ * time. Internally, this uses an {@link IDropout} instance. See the IDropout instances for details:<br> {@link
+ * Dropout}<br> {@link org.nd4j.linalg.api.ops.random.impl.AlphaDropOut}<br> {@link
+ * org.deeplearning4j.nn.conf.dropout.GaussianDropout}<br> {@link org.deeplearning4j.nn.conf.dropout.GaussianNoise}<br>
  * {@link org.deeplearning4j.nn.conf.dropout.SpatialDropout}
- *
  */
 @Data
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class DropoutLayer extends FeedForwardLayer {
+
     private DropoutLayer(Builder builder) {
         super(builder);
     }
@@ -58,8 +56,8 @@ public class DropoutLayer extends FeedForwardLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                    boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.DropoutLayer ret = new org.deeplearning4j.nn.layers.DropoutLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -77,8 +75,9 @@ public class DropoutLayer extends FeedForwardLayer {
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        if (inputType == null)
+        if (inputType == null) {
             throw new IllegalStateException("Invalid input type: null for layer name \"" + getLayerName() + "\"");
+        }
         return inputType;
     }
 
@@ -117,10 +116,11 @@ public class DropoutLayer extends FeedForwardLayer {
         //But: this will be counted in the activations
         //(technically inference memory is over-estimated as a result)
 
-        return new LayerMemoryReport.Builder(layerName, DropoutLayer.class, inputType, inputType).standardMemory(0, 0) //No params
-                        .workingMemory(0, 0, 0, 0) //No working mem, other than activations etc
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+        return new LayerMemoryReport.Builder(layerName, DropoutLayer.class, inputType, inputType)
+                .standardMemory(0, 0) //No params
+                .workingMemory(0, 0, 0, 0) //No working mem, other than activations etc
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
 
@@ -128,19 +128,19 @@ public class DropoutLayer extends FeedForwardLayer {
     public static class Builder extends FeedForwardLayer.Builder<DropoutLayer.Builder> {
 
         /**
-         * Create a dropout layer with standard {@link Dropout}, with the specified probability of retaining the
-         * input activation. See {@link Dropout} for the full details
+         * Create a dropout layer with standard {@link Dropout}, with the specified probability of retaining the input
+         * activation. See {@link Dropout} for the full details
          *
          * @param dropout Activation retain probability.
          */
-        public Builder(double dropout){
+        public Builder(double dropout) {
             this.dropOut(new Dropout(dropout));
         }
 
         /**
          * @param dropout Specified {@link IDropout} instance for the dropout layer
          */
-        public Builder(IDropout dropout){
+        public Builder(IDropout dropout) {
             this.dropOut(dropout);
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/DropoutLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -59,9 +56,9 @@ public class EmbeddingLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingLayer ret =
-                new org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingLayer(conf);
+                        new org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -90,9 +87,9 @@ public class EmbeddingLayer extends FeedForwardLayer {
         //Training: preout op, the only in-place ops on epsilon (from layer above) + assign ops
 
         return new LayerMemoryReport.Builder(layerName, EmbeddingLayer.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, actElementsPerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, actElementsPerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public boolean hasBias() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
@@ -102,6 +102,8 @@ public class EmbeddingLayer extends FeedForwardLayer {
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private boolean hasBias = false;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
@@ -31,16 +31,15 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Embedding layer: feed-forward layer that expects single integers per example as input (class numbers, in range 0 to numClass-1)
- * as input. This input has shape {@code [numExamples,1]} instead of {@code [numExamples,numClasses]} for the equivalent one-hot representation.
- * Mathematically, EmbeddingLayer is equivalent to using a DenseLayer with a one-hot representation for the input; however,
- * it can be much more efficient with a large number of classes (as a dense layer + one-hot input does a matrix multiply
- * with all but one value being zero).<br>
+ * Embedding layer: feed-forward layer that expects single integers per example as input (class numbers, in range 0 to
+ * numClass-1) as input. This input has shape {@code [numExamples,1]} instead of {@code [numExamples,numClasses]} for
+ * the equivalent one-hot representation. Mathematically, EmbeddingLayer is equivalent to using a DenseLayer with a
+ * one-hot representation for the input; however, it can be much more efficient with a large number of classes (as a
+ * dense layer + one-hot input does a matrix multiply with all but one value being zero).<br>
  * <b>Note</b>: can only be used as the first layer for a network<br>
  * <b>Note 2</b>: For a given example index i, the output is activationFunction(weights.getRow(i) + bias), hence the
- * weight rows can be considered a vector/embedding for each example.<br>
- * Note also that embedding layer has an activation function (set to IDENTITY to disable) and optional bias (which is
- * disabled by default)
+ * weight rows can be considered a vector/embedding for each example.<br> Note also that embedding layer has an
+ * activation function (set to IDENTITY to disable) and optional bias (which is disabled by default)
  *
  * @author Alex Black
  */
@@ -49,6 +48,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class EmbeddingLayer extends FeedForwardLayer {
+
     private boolean hasBias = true; //Default for pre-0.9.2 implementations
 
     private EmbeddingLayer(Builder builder) {
@@ -59,9 +59,9 @@ public class EmbeddingLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingLayer ret =
-                        new org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingLayer(conf);
+                new org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -90,18 +90,22 @@ public class EmbeddingLayer extends FeedForwardLayer {
         //Training: preout op, the only in-place ops on epsilon (from layer above) + assign ops
 
         return new LayerMemoryReport.Builder(layerName, EmbeddingLayer.class, inputType, outputType)
-                        .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, actElementsPerEx)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, actElementsPerEx)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
-    public boolean hasBias(){
+    public boolean hasBias() {
         return hasBias;
     }
 
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
+        /**
+         * If true: include bias parameters in the layer. False (default): no bias.
+         *
+         */
         @Getter
         @Setter
         private boolean hasBias = false;
@@ -111,7 +115,7 @@ public class EmbeddingLayer extends FeedForwardLayer {
          *
          * @param hasBias If true: include bias parameters in this layer
          */
-        public Builder hasBias(boolean hasBias){
+        public Builder hasBias(boolean hasBias) {
             this.hasBias = hasBias;
             return this;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
@@ -97,14 +97,14 @@ public class EmbeddingLayer extends FeedForwardLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
         /**
          * If true: include bias parameters in the layer. False (default): no bias.
          *
          */
-        @Getter
-        @Setter
         private boolean hasBias = false;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
@@ -112,8 +112,14 @@ public class EmbeddingSequenceLayer extends FeedForwardLayer {
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private boolean hasBias = false;
+        @Getter
+        @Setter
         private int inputLength = 1;
+        @Getter
+        @Setter
         private boolean inferInputLength = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -62,9 +59,9 @@ public class EmbeddingSequenceLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingSequenceLayer ret =
-                new org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingSequenceLayer(conf);
+                        new org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingSequenceLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -78,8 +75,7 @@ public class EmbeddingSequenceLayer extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.FF) {
             throw new IllegalStateException("Invalid input for Embedding layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect FFN input type. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect FFN input type. Got: " + inputType);
         }
         return InputType.recurrent(nOut, inputLength);
     }
@@ -98,10 +94,9 @@ public class EmbeddingSequenceLayer extends FeedForwardLayer {
         val updaterStateSize = (int) getIUpdater().stateSize(numParams);
 
         return new LayerMemoryReport.Builder(layerName, EmbeddingSequenceLayer.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, 0, actElementsPerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, actElementsPerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public boolean hasBias() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
@@ -104,30 +104,26 @@ public class EmbeddingSequenceLayer extends FeedForwardLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
         /**
          * If true: include bias parameters in the layer. False (default): no bias.
          *
          */
-        @Getter
-        @Setter
         private boolean hasBias = false;
 
         /**
          * Set input sequence length for this embedding layer.
          *
          */
-        @Getter
-        @Setter
         private int inputLength = 1;
 
         /**
          * Set input sequence inference mode for embedding layer.
          *
          */
-        @Getter
-        @Setter
         private boolean inferInputLength = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
@@ -32,14 +32,13 @@ import java.util.Map;
 
 /**
  * Embedding layer for sequences: feed-forward layer that expects fixed-length number (inputLength) of integers/indices
- * per example as input, ranged from 0 to numClasses - 1. This input thus has shape [numExamples, inputLength] or
- * shape [numExamples, 1, inputLength].<br>
- * The output of this layer is 3D (sequence/time series), namely of shape [numExamples, nOut, inputLength].
+ * per example as input, ranged from 0 to numClasses - 1. This input thus has shape [numExamples, inputLength] or shape
+ * [numExamples, 1, inputLength].<br> The output of this layer is 3D (sequence/time series), namely of shape
+ * [numExamples, nOut, inputLength].
  * <b>Note</b>: can only be used as the first layer for a network<br>
  * <b>Note 2</b>: For a given example index i, the output is activationFunction(weights.getRow(i) + bias), hence the
- * weight rows can be considered a vector/embedding of each index.<br>
- * Note also that embedding layer has an activation function (set to IDENTITY to disable) and optional bias (which is
- * disabled by default)
+ * weight rows can be considered a vector/embedding of each index.<br> Note also that embedding layer has an activation
+ * function (set to IDENTITY to disable) and optional bias (which is disabled by default)
  *
  * @author Max Pumperla
  */
@@ -63,7 +62,7 @@ public class EmbeddingSequenceLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingSequenceLayer ret =
                 new org.deeplearning4j.nn.layers.feedforward.embedding.EmbeddingSequenceLayer(conf);
         ret.setListeners(trainingListeners);
@@ -112,12 +111,26 @@ public class EmbeddingSequenceLayer extends FeedForwardLayer {
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<Builder> {
 
+        /**
+         * If true: include bias parameters in the layer. False (default): no bias.
+         *
+         */
         @Getter
         @Setter
         private boolean hasBias = false;
+
+        /**
+         * Set input sequence length for this embedding layer.
+         *
+         */
         @Getter
         @Setter
         private int inputLength = 1;
+
+        /**
+         * Set input sequence inference mode for embedding layer.
+         *
+         */
         @Getter
         @Setter
         private boolean inferInputLength = true;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/EmbeddingSequenceLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -32,6 +32,7 @@ import org.deeplearning4j.nn.params.DefaultParamInitializer;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class FeedForwardLayer extends BaseLayer {
+
     protected long nIn;
     protected long nOut;
 
@@ -45,9 +46,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                        && inputType.getType() != InputType.Type.CNNFlat)) {
+                && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer index = " + layerIndex + ", layer name=\""
-                            + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
+                    + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         return InputType.feedForward(nOut);
@@ -56,9 +57,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                        && inputType.getType() != InputType.Type.CNNFlat)) {
+                && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName()
-                            + "\"): expected FeedForward input type. Got: " + inputType);
+                    + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -76,7 +77,7 @@ public abstract class FeedForwardLayer extends BaseLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException(
-                            "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
+                    "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
         }
 
         switch (inputType.getType()) {
@@ -93,9 +94,10 @@ public abstract class FeedForwardLayer extends BaseLayer {
                 return new CnnToFeedForwardPreProcessor(c.getHeight(), c.getWidth(), c.getChannels());
             case CNN3D:
                 //CNN3D -> FF
-                InputType.InputTypeConvolutional3D c3d = (InputType.InputTypeConvolutional3D)inputType;
+                InputType.InputTypeConvolutional3D c3d = (InputType.InputTypeConvolutional3D) inputType;
                 //TODO don't hardcode NCDHW
-                return new Cnn3DToFeedForwardPreProcessor(c3d.getDepth(), c3d.getHeight(), c3d.getWidth(), c3d.getChannels(), true);
+                return new Cnn3DToFeedForwardPreProcessor(c3d.getDepth(), c3d.getHeight(), c3d.getWidth(),
+                        c3d.getChannels(), true);
             default:
                 throw new RuntimeException("Unknown input type: " + inputType);
         }
@@ -131,16 +133,28 @@ public abstract class FeedForwardLayer extends BaseLayer {
     }
 
     public abstract static class Builder<T extends Builder<T>> extends BaseLayer.Builder<T> {
+
+        /**
+         * Number of inputs for the layer (usually the size of the last layer). <br> Note that for Convolutional layers,
+         * this is the input channels, otherwise is the previous layer size.
+         *
+         */
         @Getter
         @Setter
         protected int nIn = 0;
+
+        /**
+         * Number of inputs for the layer (usually the size of the last layer). <br> Note that for Convolutional layers,
+         * this is the input channels, otherwise is the previous layer size.
+         *
+         */
         @Getter
         @Setter
         protected int nOut = 0;
 
         /**
-         * Number of inputs for the layer (usually the size of the last layer). <br>
-         * Note that for Convolutional layers, this is the input channels, otherwise is the previous layer size.
+         * Number of inputs for the layer (usually the size of the last layer). <br> Note that for Convolutional layers,
+         * this is the input channels, otherwise is the previous layer size.
          *
          * @param nIn Number of inputs for the layer
          */
@@ -150,8 +164,8 @@ public abstract class FeedForwardLayer extends BaseLayer {
         }
 
         /**
-         * Number of inputs for the layer (usually the size of the last layer). <br>
-         * Note that for Convolutional layers, this is the input channels, otherwise is the previous layer size.
+         * Number of inputs for the layer (usually the size of the last layer). <br> Note that for Convolutional layers,
+         * this is the input channels, otherwise is the previous layer size.
          *
          * @param nIn Number of inputs for the layer
          */
@@ -162,8 +176,8 @@ public abstract class FeedForwardLayer extends BaseLayer {
         }
 
         /**
-         * Number of outputs - used to set the layer size (number of units/nodes for the current layer).
-         * Note that this is equivalent to {@link #units(int)}
+         * Number of outputs - used to set the layer size (number of units/nodes for the current layer). Note that this
+         * is equivalent to {@link #units(int)}
          *
          * @param nOut Number of outputs / layer size
          */
@@ -173,8 +187,8 @@ public abstract class FeedForwardLayer extends BaseLayer {
         }
 
         /**
-         * Number of outputs - used to set the layer size (number of units/nodes for the current layer).
-         * Note that this is equivalent to {@link #units(int)}
+         * Number of outputs - used to set the layer size (number of units/nodes for the current layer). Note that this
+         * is equivalent to {@link #units(int)}
          *
          * @param nOut Number of outputs / layer size
          */
@@ -184,13 +198,12 @@ public abstract class FeedForwardLayer extends BaseLayer {
         }
 
         /**
-         * Set the number of units / layer size for this layer.<br>
-         * This is equivalent to {@link #nOut(int)}
+         * Set the number of units / layer size for this layer.<br> This is equivalent to {@link #nOut(int)}
          *
          * @param units Size of the layer (number of units) / nOut
          * @see #nOut(int)
          */
-        public T units(int units){
+        public T units(int units) {
             return nOut(units);
         }
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -129,6 +129,8 @@ public abstract class FeedForwardLayer extends BaseLayer {
         return false; //No pretrain params in standard FF layers
     }
 
+    @Getter
+    @Setter
     public abstract static class Builder<T extends Builder<T>> extends BaseLayer.Builder<T> {
 
         /**
@@ -136,8 +138,6 @@ public abstract class FeedForwardLayer extends BaseLayer {
          * this is the input channels, otherwise is the previous layer size.
          *
          */
-        @Getter
-        @Setter
         protected int nIn = 0;
 
         /**
@@ -145,8 +145,6 @@ public abstract class FeedForwardLayer extends BaseLayer {
          * this is the input channels, otherwise is the previous layer size.
          *
          */
-        @Getter
-        @Setter
         protected int nOut = 0;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.preprocessor.Cnn3DToFeedForwardPreProcessor;
@@ -134,7 +131,11 @@ public abstract class FeedForwardLayer extends BaseLayer {
     }
 
     public abstract static class Builder<T extends Builder<T>> extends BaseLayer.Builder<T> {
+        @Getter
+        @Setter
         protected int nIn = 0;
+        @Getter
+        @Setter
         protected int nOut = 0;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -46,9 +43,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                && inputType.getType() != InputType.Type.CNNFlat)) {
+                        && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer index = " + layerIndex + ", layer name=\""
-                    + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
+                            + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         return InputType.feedForward(nOut);
@@ -57,9 +54,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                && inputType.getType() != InputType.Type.CNNFlat)) {
+                        && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName()
-                    + "\"): expected FeedForward input type. Got: " + inputType);
+                            + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -77,7 +74,7 @@ public abstract class FeedForwardLayer extends BaseLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException(
-                    "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
+                            "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
         }
 
         switch (inputType.getType()) {
@@ -97,7 +94,7 @@ public abstract class FeedForwardLayer extends BaseLayer {
                 InputType.InputTypeConvolutional3D c3d = (InputType.InputTypeConvolutional3D) inputType;
                 //TODO don't hardcode NCDHW
                 return new Cnn3DToFeedForwardPreProcessor(c3d.getDepth(), c3d.getHeight(), c3d.getWidth(),
-                        c3d.getChannels(), true);
+                                c3d.getChannels(), true);
             default:
                 throw new RuntimeException("Unknown input type: " + inputType);
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -85,10 +82,10 @@ public class GlobalPoolingLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.pooling.GlobalPoolingLayer ret =
-                new org.deeplearning4j.nn.layers.pooling.GlobalPoolingLayer(conf);
+                        new org.deeplearning4j.nn.layers.pooling.GlobalPoolingLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -109,8 +106,8 @@ public class GlobalPoolingLayer extends NoParamLayer {
         switch (inputType.getType()) {
             case FF:
                 throw new UnsupportedOperationException(
-                        "Global max pooling cannot be applied to feed-forward input type. Got input type = "
-                                + inputType);
+                                "Global max pooling cannot be applied to feed-forward input type. Got input type = "
+                                                + inputType);
             case RNN:
                 InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
                 if (collapseDimensions) {
@@ -157,8 +154,8 @@ public class GlobalPoolingLayer extends NoParamLayer {
         switch (inputType.getType()) {
             case FF:
                 throw new UnsupportedOperationException(
-                        "Global max pooling cannot be applied to feed-forward input type. Got input type = "
-                                + inputType);
+                                "Global max pooling cannot be applied to feed-forward input type. Got input type = "
+                                                + inputType);
             case RNN:
             case CNN:
             case CNN3D:
@@ -203,11 +200,11 @@ public class GlobalPoolingLayer extends NoParamLayer {
         }
 
         return new LayerMemoryReport.Builder(layerName, GlobalPoolingLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                //Train + Inference: no additional working memory (except pnorm) - the reduction is the output activations
-                .workingMemory(0, fwdTrainInferenceWorkingPerEx, 0, fwdTrainInferenceWorkingPerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        //Train + Inference: no additional working memory (except pnorm) - the reduction is the output activations
+                        .workingMemory(0, fwdTrainInferenceWorkingPerEx, 0, fwdTrainInferenceWorkingPerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public static class Builder extends Layer.Builder<Builder> {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -207,13 +207,13 @@ public class GlobalPoolingLayer extends NoParamLayer {
                         .build();
     }
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
         /**
          * Pooling type for global pooling
          */
-        @Getter
-        @Setter
         private PoolingType poolingType = PoolingType.MAX;
 
         /**
@@ -222,16 +222,12 @@ public class GlobalPoolingLayer extends NoParamLayer {
          * width) Default for CNN3D data: pooling dimensions 2,3,4 (depth, height and width)
          *
          */
-        @Getter
-        @Setter
         private int[] poolingDimensions;
 
         /**
          * P-norm constant. Only used if using {@link PoolingType#PNORM} for the pooling type
          *
          */
-        @Getter
-        @Setter
         private int pnorm = 2;
 
         /**
@@ -248,8 +244,6 @@ public class GlobalPoolingLayer extends NoParamLayer {
          * height, width] -> 2d output [miniBatchSize, channels, 1, 1, 1]<br>
          *
          */
-        @Getter
-        @Setter
         private boolean collapseDimensions = true;
 
         public Builder() {
@@ -311,6 +305,10 @@ public class GlobalPoolingLayer extends NoParamLayer {
             }
             this.pnorm = pnorm;
             return this;
+        }
+
+        public void setPnorm(int pnorm){
+            pnorm(pnorm);
         }
 
         @SuppressWarnings("unchecked")

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -16,9 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -217,9 +215,17 @@ public class GlobalPoolingLayer extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private PoolingType poolingType = PoolingType.MAX;
+        @Getter
+        @Setter
         private int[] poolingDimensions;
+        @Getter
+        @Setter
         private int pnorm = 2;
+        @Getter
+        @Setter
         private boolean collapseDimensions = true;
 
         public Builder() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -32,29 +32,26 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Global pooling layer - used to do pooling over time for RNNs, and 2d pooling for CNNs.<br>
- * Supports the following {@link PoolingType}s: SUM, AVG, MAX, PNORM<br>
+ * Global pooling layer - used to do pooling over time for RNNs, and 2d pooling for CNNs.<br> Supports the following
+ * {@link PoolingType}s: SUM, AVG, MAX, PNORM<br>
  *
- * Global pooling layer can also handle mask arrays when dealing with variable length inputs. Mask arrays are assumed
- * to be 2d, and are fed forward through the network during training or post-training forward pass:<br>
- * - Time series: mask arrays are shape [miniBatchSize, maxTimeSeriesLength] and contain values 0 or 1 only<br>
- * - CNNs: mask have shape [miniBatchSize, height] or [miniBatchSize, width]. Important: the current implementation assumes
- *   that for CNNs + variable length (masking), the input shape is [miniBatchSize, channels, height, 1] or
- *   [miniBatchSize, channels, 1, width] respectively. This is the case with global pooling in architectures like CNN for
- *   sentence classification.<br>
+ * Global pooling layer can also handle mask arrays when dealing with variable length inputs. Mask arrays are assumed to
+ * be 2d, and are fed forward through the network during training or post-training forward pass:<br> - Time series: mask
+ * arrays are shape [miniBatchSize, maxTimeSeriesLength] and contain values 0 or 1 only<br> - CNNs: mask have shape
+ * [miniBatchSize, height] or [miniBatchSize, width]. Important: the current implementation assumes that for CNNs +
+ * variable length (masking), the input shape is [miniBatchSize, channels, height, 1] or [miniBatchSize, channels, 1,
+ * width] respectively. This is the case with global pooling in architectures like CNN for sentence classification.<br>
  * <p>
  *
- * Behaviour with default settings:<br>
- * - 3d (time series) input with shape [miniBatchSize, vectorSize, timeSeriesLength] -> 2d output [miniBatchSize, vectorSize]<br>
- * - 4d (CNN) input with shape [miniBatchSize, channels, height, width] -> 2d output [miniBatchSize, channels]<br>
- * - 5d (CNN3D) input with shape [miniBatchSize, channels, depth, height, width] -> 2d output [miniBatchSize, channels]<br>
+ * Behaviour with default settings:<br> - 3d (time series) input with shape [miniBatchSize, vectorSize,
+ * timeSeriesLength] -> 2d output [miniBatchSize, vectorSize]<br> - 4d (CNN) input with shape [miniBatchSize, channels,
+ * height, width] -> 2d output [miniBatchSize, channels]<br> - 5d (CNN3D) input with shape [miniBatchSize, channels,
+ * depth, height, width] -> 2d output [miniBatchSize, channels]<br>
  *
  * <p>
- * Alternatively, by setting collapseDimensions = false in the configuration, it is possible to retain the reduced dimensions
- * as 1s: this gives<br>
- * - [miniBatchSize, vectorSize, 1] for RNN output,<br>
- * - [miniBatchSize, channels, 1, 1] for CNN output, and<br>
- * - [miniBatchSize, channels, 1, 1, 1] for CNN3D output.<br>
+ * Alternatively, by setting collapseDimensions = false in the configuration, it is possible to retain the reduced
+ * dimensions as 1s: this gives<br> - [miniBatchSize, vectorSize, 1] for RNN output,<br> - [miniBatchSize, channels, 1,
+ * 1] for CNN output, and<br> - [miniBatchSize, channels, 1, 1, 1] for CNN3D output.<br>
  * <br>
  *
  * @author Alex Black
@@ -77,21 +74,21 @@ public class GlobalPoolingLayer extends NoParamLayer {
         this.layerName = builder.layerName;
     }
 
-    public GlobalPoolingLayer(){
+    public GlobalPoolingLayer() {
         this(PoolingType.MAX);
     }
 
-    public GlobalPoolingLayer(PoolingType poolingType){
+    public GlobalPoolingLayer(PoolingType poolingType) {
         this(new GlobalPoolingLayer.Builder().poolingType(poolingType));
     }
 
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                    boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.pooling.GlobalPoolingLayer ret =
-                        new org.deeplearning4j.nn.layers.pooling.GlobalPoolingLayer(conf);
+                new org.deeplearning4j.nn.layers.pooling.GlobalPoolingLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -112,8 +109,8 @@ public class GlobalPoolingLayer extends NoParamLayer {
         switch (inputType.getType()) {
             case FF:
                 throw new UnsupportedOperationException(
-                                "Global max pooling cannot be applied to feed-forward input type. Got input type = "
-                                                + inputType);
+                        "Global max pooling cannot be applied to feed-forward input type. Got input type = "
+                                + inputType);
             case RNN:
                 InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
                 if (collapseDimensions) {
@@ -135,7 +132,7 @@ public class GlobalPoolingLayer extends NoParamLayer {
                 if (collapseDimensions) {
                     return InputType.feedForward(conv3d.getChannels());
                 } else {
-                    return InputType.convolutional3D(1,1,1, conv3d.getChannels());
+                    return InputType.convolutional3D(1, 1, 1, conv3d.getChannels());
                 }
             case CNNFlat:
                 InputType.InputTypeConvolutionalFlat convFlat = (InputType.InputTypeConvolutionalFlat) inputType;
@@ -160,8 +157,8 @@ public class GlobalPoolingLayer extends NoParamLayer {
         switch (inputType.getType()) {
             case FF:
                 throw new UnsupportedOperationException(
-                                "Global max pooling cannot be applied to feed-forward input type. Got input type = "
-                                                + inputType);
+                        "Global max pooling cannot be applied to feed-forward input type. Got input type = "
+                                + inputType);
             case RNN:
             case CNN:
             case CNN3D:
@@ -206,24 +203,54 @@ public class GlobalPoolingLayer extends NoParamLayer {
         }
 
         return new LayerMemoryReport.Builder(layerName, GlobalPoolingLayer.class, inputType, outputType)
-                        .standardMemory(0, 0) //No params
-                        //Train + Inference: no additional working memory (except pnorm) - the reduction is the output activations
-                        .workingMemory(0, fwdTrainInferenceWorkingPerEx, 0, fwdTrainInferenceWorkingPerEx)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(0, 0) //No params
+                //Train + Inference: no additional working memory (except pnorm) - the reduction is the output activations
+                .workingMemory(0, fwdTrainInferenceWorkingPerEx, 0, fwdTrainInferenceWorkingPerEx)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        /**
+         * Pooling type for global pooling
+         */
         @Getter
         @Setter
         private PoolingType poolingType = PoolingType.MAX;
+
+        /**
+         * Pooling dimensions. Note: most of the time, this doesn't need to be set, and the defaults can be used.
+         * Default for RNN data: pooling dimension 2 (time). Default for CNN data: pooling dimensions 2,3 (height and
+         * width) Default for CNN3D data: pooling dimensions 2,3,4 (depth, height and width)
+         *
+         */
         @Getter
         @Setter
         private int[] poolingDimensions;
+
+        /**
+         * P-norm constant. Only used if using {@link PoolingType#PNORM} for the pooling type
+         *
+         */
         @Getter
         @Setter
         private int pnorm = 2;
+
+        /**
+         * Whether to collapse dimensions when pooling or not. Usually you *do* want to do this. Default: true. If
+         * true:<br> - 3d (time series) input with shape [miniBatchSize, vectorSize, timeSeriesLength] -> 2d output
+         * [miniBatchSize, vectorSize]<br> - 4d (CNN) input with shape [miniBatchSize, channels, height, width] -> 2d
+         * output [miniBatchSize, channels]<br> - 5d (CNN3D) input with shape [miniBatchSize, channels, depth, height,
+         * width] -> 2d output [miniBatchSize, channels]<br>
+         *
+         *
+         * If false:<br> - 3d (time series) input with shape [miniBatchSize, vectorSize, timeSeriesLength] -> 3d output
+         * [miniBatchSize, vectorSize, 1]<br> - 4d (CNN) input with shape [miniBatchSize, channels, height, width] -> 2d
+         * output [miniBatchSize, channels, 1, 1]<br> - 5d (CNN3D) input with shape [miniBatchSize, channels, depth,
+         * height, width] -> 2d output [miniBatchSize, channels, 1, 1, 1]<br>
+         *
+         */
         @Getter
         @Setter
         private boolean collapseDimensions = true;
@@ -238,10 +265,9 @@ public class GlobalPoolingLayer extends NoParamLayer {
 
         /**
          * Pooling dimensions. Note: most of the time, this doesn't need to be set, and the defaults can be used.
-         * Default for RNN data: pooling dimension 2 (time).
-         * Default for CNN data: pooling dimensions 2,3 (height and width)
-         * Default for CNN3D data: pooling dimensions 2,3,4 (depth, height and width)
-
+         * Default for RNN data: pooling dimension 2 (time). Default for CNN data: pooling dimensions 2,3 (height and
+         * width) Default for CNN3D data: pooling dimensions 2,3,4 (depth, height and width)
+         *
          * @param poolingDimensions Pooling dimensions to use
          */
         public Builder poolingDimensions(int... poolingDimensions) {
@@ -258,17 +284,17 @@ public class GlobalPoolingLayer extends NoParamLayer {
         }
 
         /**
-         * Whether to collapse dimensions when pooling or not. Usually you *do* want to do this. Default: true.
-         * If true:<br>
-         * - 3d (time series) input with shape [miniBatchSize, vectorSize, timeSeriesLength] -> 2d output [miniBatchSize, vectorSize]<br>
-         * - 4d (CNN) input with shape [miniBatchSize, channels, height, width] -> 2d output [miniBatchSize, channels]<br>
-         * - 5d (CNN3D) input with shape [miniBatchSize, channels, depth, height, width] -> 2d output [miniBatchSize, channels]<br>
-
+         * Whether to collapse dimensions when pooling or not. Usually you *do* want to do this. Default: true. If
+         * true:<br> - 3d (time series) input with shape [miniBatchSize, vectorSize, timeSeriesLength] -> 2d output
+         * [miniBatchSize, vectorSize]<br> - 4d (CNN) input with shape [miniBatchSize, channels, height, width] -> 2d
+         * output [miniBatchSize, channels]<br> - 5d (CNN3D) input with shape [miniBatchSize, channels, depth, height,
+         * width] -> 2d output [miniBatchSize, channels]<br>
          *
-         * If false:<br>
-         * - 3d (time series) input with shape [miniBatchSize, vectorSize, timeSeriesLength] -> 3d output [miniBatchSize, vectorSize, 1]<br>
-         * - 4d (CNN) input with shape [miniBatchSize, channels, height, width] -> 2d output [miniBatchSize, channels, 1, 1]<br>
-         * - 5d (CNN3D) input with shape [miniBatchSize, channels, depth, height, width] -> 2d output [miniBatchSize, channels, 1, 1, 1]<br>
+         *
+         * If false:<br> - 3d (time series) input with shape [miniBatchSize, vectorSize, timeSeriesLength] -> 3d output
+         * [miniBatchSize, vectorSize, 1]<br> - 4d (CNN) input with shape [miniBatchSize, channels, height, width] -> 2d
+         * output [miniBatchSize, channels, 1, 1]<br> - 5d (CNN3D) input with shape [miniBatchSize, channels, depth,
+         * height, width] -> 2d output [miniBatchSize, channels, 1, 1, 1]<br>
          *
          * @param collapseDimensions Whether to collapse the dimensions or not
          */
@@ -283,8 +309,9 @@ public class GlobalPoolingLayer extends NoParamLayer {
          * @param pnorm P-norm constant
          */
         public Builder pnorm(int pnorm) {
-            if (pnorm <= 0)
+            if (pnorm <= 0) {
                 throw new IllegalArgumentException("Invalid input: p-norm value must be greater than 0. Got: " + pnorm);
+            }
             this.pnorm = pnorm;
             return this;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
@@ -134,14 +134,14 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
 
     @AllArgsConstructor
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends BaseRecurrentLayer.Builder<Builder> {
 
         /**
          * Set forget gate bias initalizations. Values in range 1-5 can potentially help with learning or longer-term
          * dependencies.
          */
-        @Getter
-        @Setter
         private double forgetGateBiasInit = 1.0;
 
         /**
@@ -149,8 +149,6 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
          * for example
          *
          */
-        @Getter
-        @Setter
         private IActivation gateActivationFn = new ActivationSigmoid();
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
@@ -37,9 +37,9 @@ import java.util.*;
  * Bidirectional LSTM recurrent net, based on Graves: Supervised Sequence Labelling with Recurrent Neural Networks
  * <a href="http://www.cs.toronto.edu/~graves/phd.pdf">http://www.cs.toronto.edu/~graves/phd.pdf</a>
  *
- * @deprecated use {@link org.deeplearning4j.nn.conf.layers.recurrent.Bidirectional} instead. With the
- * Bidirectional layer wrapper you can make any recurrent layer bidirectional, in particular GravesLSTM.
- * Note that this layer adds the output of both directions, which translates into "ADD" mode in Bidirectional.
+ * @deprecated use {@link org.deeplearning4j.nn.conf.layers.recurrent.Bidirectional} instead. With the Bidirectional
+ * layer wrapper you can make any recurrent layer bidirectional, in particular GravesLSTM. Note that this layer adds the
+ * output of both directions, which translates into "ADD" mode in Bidirectional.
  *
  * Usage: {@code .layer(new Bidirectional(Bidirectional.Mode.ADD, new GravesLSTM.Builder()....build()))}
  */
@@ -62,10 +62,10 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
     }
 
     @Override
-    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder){
+    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder) {
         super.initializeConstraints(builder);
-        if(((Builder)builder).recurrentConstraints != null){
-            if(constraints == null){
+        if (((Builder) builder).recurrentConstraints != null) {
+            if (constraints == null) {
                 constraints = new ArrayList<>();
             }
             for (LayerConstraint c : ((Builder) builder).recurrentConstraints) {
@@ -81,9 +81,9 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.recurrent.GravesBidirectionalLSTM ret =
-                        new org.deeplearning4j.nn.layers.recurrent.GravesBidirectionalLSTM(conf);
+                new org.deeplearning4j.nn.layers.recurrent.GravesBidirectionalLSTM(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -139,15 +139,26 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
     @NoArgsConstructor
     public static class Builder extends BaseRecurrentLayer.Builder<Builder> {
 
+        /**
+         * Set forget gate bias initalizations. Values in range 1-5 can potentially help with learning or longer-term
+         * dependencies.
+         */
         @Getter
         @Setter
         private double forgetGateBiasInit = 1.0;
+
+        /**
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
+         *
+         */
         @Getter
         @Setter
         private IActivation gateActivationFn = new ActivationSigmoid();
 
-        /** Set forget gate bias initalizations. Values in range 1-5 can potentially
-         * help with learning or longer-term dependencies.
+        /**
+         * Set forget gate bias initalizations. Values in range 1-5 can potentially help with learning or longer-term
+         * dependencies.
          */
         public Builder forgetGateBiasInit(double biasInit) {
             this.forgetGateBiasInit = biasInit;
@@ -155,8 +166,8 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
         }
 
         /**
-         * Activation function for the LSTM gates.
-         * Note: This should be bounded to range 0-1: sigmoid or hard sigmoid, for example
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
          *
          * @param gateActivationFn Activation function for the LSTM gates
          */
@@ -165,8 +176,8 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
         }
 
         /**
-         * Activation function for the LSTM gates.
-         * Note: This should be bounded to range 0-1: sigmoid or hard sigmoid, for example
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
          *
          * @param gateActivationFn Activation function for the LSTM gates
          */
@@ -175,8 +186,8 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
         }
 
         /**
-         * Activation function for the LSTM gates.
-         * Note: This should be bounded to range 0-1: sigmoid or hard sigmoid, for example
+         * Activation function for the LSTM gates. Note: This should be bounded to range 0-1: sigmoid or hard sigmoid,
+         * for example
          *
          * @param gateActivationFn Activation function for the LSTM gates
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -81,9 +78,9 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.recurrent.GravesBidirectionalLSTM ret =
-                new org.deeplearning4j.nn.layers.recurrent.GravesBidirectionalLSTM(conf);
+                        new org.deeplearning4j.nn.layers.recurrent.GravesBidirectionalLSTM(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
@@ -139,7 +139,11 @@ public class GravesBidirectionalLSTM extends BaseRecurrentLayer {
     @NoArgsConstructor
     public static class Builder extends BaseRecurrentLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private double forgetGateBiasInit = 1.0;
+        @Getter
+        @Setter
         private IActivation gateActivationFn = new ActivationSigmoid();
 
         /** Set forget gate bias initalizations. Values in range 1-5 can potentially

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesBidirectionalLSTM.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
@@ -63,10 +63,10 @@ public class GravesLSTM extends AbstractLSTM {
     }
 
     @Override
-    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder){
+    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder) {
         super.initializeConstraints(builder);
-        if(((Builder)builder).recurrentConstraints != null){
-            if(constraints == null){
+        if (((Builder) builder).recurrentConstraints != null) {
+            if (constraints == null) {
                 constraints = new ArrayList<>();
             }
             for (LayerConstraint c : ((Builder) builder).recurrentConstraints) {
@@ -79,10 +79,10 @@ public class GravesLSTM extends AbstractLSTM {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("GravesLSTM", getLayerName(), layerIndex, getNIn(), getNOut());
         org.deeplearning4j.nn.layers.recurrent.GravesLSTM ret =
-                        new org.deeplearning4j.nn.layers.recurrent.GravesLSTM(conf);
+                new org.deeplearning4j.nn.layers.recurrent.GravesLSTM(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -79,10 +76,10 @@ public class GravesLSTM extends AbstractLSTM {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("GravesLSTM", getLayerName(), layerIndex, getNIn(), getNOut());
         org.deeplearning4j.nn.layers.recurrent.GravesLSTM ret =
-                new org.deeplearning4j.nn.layers.recurrent.GravesLSTM(conf);
+                        new org.deeplearning4j.nn.layers.recurrent.GravesLSTM(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GravesLSTM.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -37,8 +34,8 @@ import java.util.Arrays;
 public class InputTypeUtil {
 
     public static InputType getOutputTypeDeconvLayer(InputType inputType, int[] kernelSize, int[] stride, int[] padding,
-                                                     int[] dilation, ConvolutionMode convolutionMode, long outputDepth,
-                                                     long layerIdx, String layerName, Class<?> layerClass) {
+                    int[] dilation, ConvolutionMode convolutionMode, long outputDepth, long layerIdx, String layerName,
+                    Class<?> layerClass) {
         InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional) inputType;
 
         // FIXME: int cast
@@ -46,16 +43,16 @@ public class InputTypeUtil {
         val wIn = (int) i.getWidth();
 
         val inHeight = (int) i.getHeight();
-        val inWidth = (int)  i.getWidth();
+        val inWidth = (int) i.getWidth();
         int padH = (padding == null ? 0 : padding[0]); //May be null for ConvolutionMode.Same
         int padW = (padding == null ? 0 : padding[1]);
         int kH = kernelSize[0];
         int kW = kernelSize[1];
-        if(dilation[0] != 1){
-            kH = kH + (kH-1)*(dilation[0]-1);
+        if (dilation[0] != 1) {
+            kH = kH + (kH - 1) * (dilation[0] - 1);
         }
-        if(dilation[1] != 1){
-            kW = kW + (kW-1)*(dilation[1]-1);
+        if (dilation[1] != 1) {
+            kW = kW + (kW - 1) * (dilation[1] - 1);
         }
 
         int sH = stride[0];
@@ -63,14 +60,14 @@ public class InputTypeUtil {
 
         if (sH <= 0 || sW <= 0) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, sH <= 0)
-                    + " Invalid strides: strides must be > 0 (strideH = " + sH + ", strideW = " + sW + ")"
-                    + "\n" + getConfigErrorCommonLastLine(inputType, kernelSize, stride, padding, outputDepth,
-                    convolutionMode));
+                            + " Invalid strides: strides must be > 0 (strideH = " + sH + ", strideW = " + sW + ")"
+                            + "\n" + getConfigErrorCommonLastLine(inputType, kernelSize, stride, padding, outputDepth,
+                                            convolutionMode));
         }
 
         if (convolutionMode == ConvolutionMode.Same) {
             int hOut = stride[0] * hIn;
-            int wOut = stride[1] * wIn ;
+            int wOut = stride[1] * wIn;
             return InputType.convolutional(hOut, wOut, outputDepth);
         }
 
@@ -81,12 +78,12 @@ public class InputTypeUtil {
     }
 
     public static InputType getOutputTypeCnn3DLayers(InputType inputType, int[] kernelSize, int[] stride, int[] padding,
-                                                   int[] dilation, ConvolutionMode convolutionMode, long outputChannels, long layerIdx, String layerName,
-                                                   Class<?> layerClass) {
+                    int[] dilation, ConvolutionMode convolutionMode, long outputChannels, long layerIdx,
+                    String layerName, Class<?> layerClass) {
         if (convolutionMode == null) {
             String name = layerName == null ? "(not named)" : layerName;
             throw new DL4JInvalidConfigException("Invalid configuration: convolution mode is null for layer (idx="
-                    + layerIdx + ", name=" + name + ", type=" + layerClass.getName() + ")");
+                            + layerIdx + ", name=" + name + ", type=" + layerClass.getName() + ")");
         }
 
         InputType.InputTypeConvolutional3D i = (InputType.InputTypeConvolutional3D) inputType;
@@ -105,15 +102,15 @@ public class InputTypeUtil {
         int kW = kernelSize[2];
 
 
-        if(dilation[0] != 1){
+        if (dilation[0] != 1) {
             //Use *effective* kernel size, accounting for dilation
-            kD = kD + (kD-1)*(dilation[0]-1);
+            kD = kD + (kD - 1) * (dilation[0] - 1);
         }
-        if(dilation[1] != 1){
-            kH = kH + (kH-1)*(dilation[1]-1);
+        if (dilation[1] != 1) {
+            kH = kH + (kH - 1) * (dilation[1] - 1);
         }
-        if(dilation[2] != 1){
-            kW = kW + (kW-1)*(dilation[2]-1);
+        if (dilation[2] != 1) {
+            kW = kW + (kW - 1) * (dilation[2] - 1);
         }
 
         int sD = stride[0];
@@ -122,30 +119,29 @@ public class InputTypeUtil {
 
         if (sH <= 0 || sW <= 0 || sD <= 0) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, sH <= 0)
-                    + " Invalid strides: strides must be > 0 (strideH = " + sH + ", strideW = " +
-                    sW + ", strideD = " + sD + ")"
-                    + "\n" + getConfigErrorCommonLastLine(inputType, kernelSize, stride, padding, outputChannels,
-                    convolutionMode));
+                            + " Invalid strides: strides must be > 0 (strideH = " + sH + ", strideW = " + sW
+                            + ", strideD = " + sD + ")" + "\n" + getConfigErrorCommonLastLine(inputType, kernelSize,
+                                            stride, padding, outputChannels, convolutionMode));
         }
 
         if (kH <= 0 || kH > inHeight + 2 * padH) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, true)
-                    + " Invalid input configuration for kernel height. Require 0 < kH <= inHeight + 2*padH; got (kH="
-                    + kH + ", inHeight=" + inHeight + ", padH=" + padH + ")\n" + getConfigErrorCommonLastLine(
-                    inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
+                            + " Invalid input configuration for kernel height. Require 0 < kH <= inHeight + 2*padH; got (kH="
+                            + kH + ", inHeight=" + inHeight + ", padH=" + padH + ")\n" + getConfigErrorCommonLastLine(
+                                            inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
         }
 
         if (kW <= 0 || kW > inWidth + 2 * padW) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, false)
-                    + " Invalid input configuration for kernel width. Require 0 < kW <= inWidth + 2*padW; got (kW="
-                    + kW + ", inWidth=" + inWidth + ", padW=" + padW + ")\n" + getConfigErrorCommonLastLine(
-                    inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
+                            + " Invalid input configuration for kernel width. Require 0 < kW <= inWidth + 2*padW; got (kW="
+                            + kW + ", inWidth=" + inWidth + ", padW=" + padW + ")\n" + getConfigErrorCommonLastLine(
+                                            inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
         }
         if (kD <= 0 || kD > inDepth + 2 * padD) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, false)
-                    + " Invalid input configuration for kernel channels. Require 0 < kD <= inDepth + 2*padD; got (kD="
-                    + kD + ", inDepth=" + inDepth + ", padD=" + padD + ")\n" + getConfigErrorCommonLastLine(
-                    inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
+                            + " Invalid input configuration for kernel channels. Require 0 < kD <= inDepth + 2*padD; got (kD="
+                            + kD + ", inDepth=" + inDepth + ", padD=" + padD + ")\n" + getConfigErrorCommonLastLine(
+                                            inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
         }
 
         //Strict mode: require exactly the right size...
@@ -156,15 +152,16 @@ public class InputTypeUtil {
                 int truncated = (int) d;
                 int sameSize = (int) Math.ceil(inHeight / ((double) stride[0]));
                 throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, true)
-                        + "\nCombination of kernel size, stride and padding are not valid for given input height, using ConvolutionMode.Strict\n"
-                        + "ConvolutionMode.Strict requires: output height = (input height - kernelSize + 2*padding)/stride + 1 in height dimension to be an integer. Got: ("
-                        + inHeight + " - " + kH + " + 2*" + padH + ")/" + sH + " + 1 = " + str + "\n"
-                        + "See ConvolutionType enumeration Javadoc and \"Constraints on strides\" at http://cs231n.github.io/convolutional-networks/\n"
-                        + "To truncate/crop the input, such that output height = floor(" + str + ") = "
-                        + truncated + ", use ConvolutionType.Truncate.\n"
-                        + "Alternatively use ConvolutionType.Same, which will use padding to give an output height of ceil("
-                        + inHeight + "/" + stride[0] + ")=" + sameSize + "\n" + getConfigErrorCommonLastLine(
-                        inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
+                                + "\nCombination of kernel size, stride and padding are not valid for given input height, using ConvolutionMode.Strict\n"
+                                + "ConvolutionMode.Strict requires: output height = (input height - kernelSize + 2*padding)/stride + 1 in height dimension to be an integer. Got: ("
+                                + inHeight + " - " + kH + " + 2*" + padH + ")/" + sH + " + 1 = " + str + "\n"
+                                + "See ConvolutionType enumeration Javadoc and \"Constraints on strides\" at http://cs231n.github.io/convolutional-networks/\n"
+                                + "To truncate/crop the input, such that output height = floor(" + str + ") = "
+                                + truncated + ", use ConvolutionType.Truncate.\n"
+                                + "Alternatively use ConvolutionType.Same, which will use padding to give an output height of ceil("
+                                + inHeight + "/" + stride[0] + ")=" + sameSize + "\n"
+                                + getConfigErrorCommonLastLine(inputType, kernelSize, stride, padding, outputChannels,
+                                                convolutionMode));
             }
 
             if ((inWidth - kW + 2 * padW) % sW != 0) {
@@ -173,15 +170,16 @@ public class InputTypeUtil {
                 int truncated = (int) d;
                 int sameSize = (int) Math.ceil(inWidth / ((double) stride[1]));
                 throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, false)
-                        + "\nCombination of kernel size, stride and padding are not valid for given input width, using ConvolutionMode.Strict\n"
-                        + "ConvolutionMode.Strict requires: output width = (input width - kernelSize + 2*padding)/stride + 1 in width dimension to be an integer. Got: ("
-                        + inWidth + " - " + kW + " + 2*" + padW + ")/" + sW + " + 1 = " + str + "\n"
-                        + "See \"Constraints on strides\" at http://cs231n.github.io/convolutional-networks/ and ConvolutionType enumeration Javadoc.\n"
-                        + "To truncate/crop the input, such that output width = floor(" + str + ") = "
-                        + truncated + ", use ConvolutionType.Truncate.\n"
-                        + "Alternatively use ConvolutionType.Same, which will use padding to give an output width of ceil("
-                        + inWidth + "/" + stride[1] + ")=" + sameSize + "\n" + getConfigErrorCommonLastLine(
-                        inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
+                                + "\nCombination of kernel size, stride and padding are not valid for given input width, using ConvolutionMode.Strict\n"
+                                + "ConvolutionMode.Strict requires: output width = (input width - kernelSize + 2*padding)/stride + 1 in width dimension to be an integer. Got: ("
+                                + inWidth + " - " + kW + " + 2*" + padW + ")/" + sW + " + 1 = " + str + "\n"
+                                + "See \"Constraints on strides\" at http://cs231n.github.io/convolutional-networks/ and ConvolutionType enumeration Javadoc.\n"
+                                + "To truncate/crop the input, such that output width = floor(" + str + ") = "
+                                + truncated + ", use ConvolutionType.Truncate.\n"
+                                + "Alternatively use ConvolutionType.Same, which will use padding to give an output width of ceil("
+                                + inWidth + "/" + stride[1] + ")=" + sameSize + "\n"
+                                + getConfigErrorCommonLastLine(inputType, kernelSize, stride, padding, outputChannels,
+                                                convolutionMode));
             }
 
             if ((inDepth - kD + 2 * padD) % sD != 0) {
@@ -190,15 +188,16 @@ public class InputTypeUtil {
                 int truncated = (int) d;
                 int sameSize = (int) Math.ceil(inDepth / ((double) stride[2]));
                 throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, false)
-                        + "\nCombination of kernel size, stride and padding are not valid for given input width, using ConvolutionMode.Strict\n"
-                        + "ConvolutionMode.Strict requires: output channels = (input channels - kernelSize + 2*padding)/stride + 1 in width dimension to be an integer. Got: ("
-                        + inDepth + " - " + kD + " + 2*" + padD + ")/" + sD + " + 1 = " + str + "\n"
-                        + "See \"Constraints on strides\" at http://cs231n.github.io/convolutional-networks/ and ConvolutionType enumeration Javadoc.\n"
-                        + "To truncate/crop the input, such that output width = floor(" + str + ") = "
-                        + truncated + ", use ConvolutionType.Truncate.\n"
-                        + "Alternatively use ConvolutionType.Same, which will use padding to give an output width of ceil("
-                        + inDepth + "/" + stride[2] + ")=" + sameSize + "\n" + getConfigErrorCommonLastLine(
-                        inputType, kernelSize, stride, padding, outputChannels, convolutionMode));
+                                + "\nCombination of kernel size, stride and padding are not valid for given input width, using ConvolutionMode.Strict\n"
+                                + "ConvolutionMode.Strict requires: output channels = (input channels - kernelSize + 2*padding)/stride + 1 in width dimension to be an integer. Got: ("
+                                + inDepth + " - " + kD + " + 2*" + padD + ")/" + sD + " + 1 = " + str + "\n"
+                                + "See \"Constraints on strides\" at http://cs231n.github.io/convolutional-networks/ and ConvolutionType enumeration Javadoc.\n"
+                                + "To truncate/crop the input, such that output width = floor(" + str + ") = "
+                                + truncated + ", use ConvolutionType.Truncate.\n"
+                                + "Alternatively use ConvolutionType.Same, which will use padding to give an output width of ceil("
+                                + inDepth + "/" + stride[2] + ")=" + sameSize + "\n"
+                                + getConfigErrorCommonLastLine(inputType, kernelSize, stride, padding, outputChannels,
+                                                convolutionMode));
             }
         } else if (convolutionMode == ConvolutionMode.Same) {
 
@@ -216,36 +215,34 @@ public class InputTypeUtil {
     }
 
 
-    public static InputType getOutputTypeCnn1DLayers(InputType inputType, int kH, int sH, int padH,
-                                                     int dilation, ConvolutionMode convolutionMode, long outputDepth,
-                                                     long layerIdx, String layerName,
-                                                   Class<?> layerClass) {
+    public static InputType getOutputTypeCnn1DLayers(InputType inputType, int kH, int sH, int padH, int dilation,
+                    ConvolutionMode convolutionMode, long outputDepth, long layerIdx, String layerName,
+                    Class<?> layerClass) {
 
         if (convolutionMode == null) {
             String name = layerName == null ? "(not named)" : layerName;
             throw new DL4JInvalidConfigException("Invalid configuration: convolution mode is null for layer (idx="
-                    + layerIdx + ", name=" + name + ", type=" + layerClass.getName() + ")");
+                            + layerIdx + ", name=" + name + ", type=" + layerClass.getName() + ")");
         }
 
         InputType.InputTypeRecurrent i = (InputType.InputTypeRecurrent) inputType;
 
         val inHeight = (int) i.getTimeSeriesLength();
-        if(dilation != 1){
-            kH = kH + (kH-1)*(dilation-1);
+        if (dilation != 1) {
+            kH = kH + (kH - 1) * (dilation - 1);
         }
 
         if (sH <= 0) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, sH <= 0)
-                    + " Invalid strides: strides must be > 0 (strideH = " + sH + ")"
-                    + "\n" + getConfigErrorCommonLastLine1D(inputType, kH, sH, padH, outputDepth,
-                    convolutionMode));
+                            + " Invalid strides: strides must be > 0 (strideH = " + sH + ")" + "\n"
+                            + getConfigErrorCommonLastLine1D(inputType, kH, sH, padH, outputDepth, convolutionMode));
         }
 
         if (kH <= 0 || kH > inHeight + 2 * padH) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, true)
-                    + " Invalid input configuration for kernel height. Require 0 < kH <= inHeight + 2*padH; got (kH="
-                    + kH + ", inHeight=" + inHeight + ", padH=" + padH + ")\n" + getConfigErrorCommonLastLine1D(
-                    inputType, kH, sH, padH, outputDepth, convolutionMode));
+                            + " Invalid input configuration for kernel height. Require 0 < kH <= inHeight + 2*padH; got (kH="
+                            + kH + ", inHeight=" + inHeight + ", padH=" + padH + ")\n"
+                            + getConfigErrorCommonLastLine1D(inputType, kH, sH, padH, outputDepth, convolutionMode));
         }
 
 
@@ -256,21 +253,20 @@ public class InputTypeUtil {
                 String str = String.format("%.2f", d);
                 int truncated = (int) d;
                 int sameSize = (int) Math.ceil(inHeight / ((double) sH));
-                throw new DL4JInvalidConfigException(getConfigErrorCommonLine(
-                        layerIdx, layerName, layerClass, true)
-                        + "\nCombination of kernel size, stride and padding are not valid for given input height, " +
-                        "using ConvolutionMode.Strict\n"
-                        + "ConvolutionMode.Strict requires: output height = (input height - kernelSize + " +
-                        "2*padding)/stride + 1 in height dimension to be an integer. Got: ("
-                        + inHeight + " - " + kH + " + 2*" + padH + ")/" + sH + " + 1 = " + str + "\n"
-                        + "See ConvolutionType enumeration Javadoc and \"Constraints on strides\" at " +
-                        "http://cs231n.github.io/convolutional-networks/\n"
-                        + "To truncate/crop the input, such that output height = floor(" + str + ") = "
-                        + truncated + ", use ConvolutionType.Truncate.\n"
-                        + "Alternatively use ConvolutionType.Same, which will use padding to give an " +
-                        "output height of ceil("
-                        + inHeight + "/" + sH + ")=" + sameSize + "\n" + getConfigErrorCommonLastLine1D(
-                        inputType, kH, sH, padH, outputDepth, convolutionMode));
+                throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, true)
+                                + "\nCombination of kernel size, stride and padding are not valid for given input height, "
+                                + "using ConvolutionMode.Strict\n"
+                                + "ConvolutionMode.Strict requires: output height = (input height - kernelSize + "
+                                + "2*padding)/stride + 1 in height dimension to be an integer. Got: (" + inHeight
+                                + " - " + kH + " + 2*" + padH + ")/" + sH + " + 1 = " + str + "\n"
+                                + "See ConvolutionType enumeration Javadoc and \"Constraints on strides\" at "
+                                + "http://cs231n.github.io/convolutional-networks/\n"
+                                + "To truncate/crop the input, such that output height = floor(" + str + ") = "
+                                + truncated + ", use ConvolutionType.Truncate.\n"
+                                + "Alternatively use ConvolutionType.Same, which will use padding to give an "
+                                + "output height of ceil(" + inHeight + "/" + sH + ")=" + sameSize + "\n"
+                                + getConfigErrorCommonLastLine1D(inputType, kH, sH, padH, outputDepth,
+                                                convolutionMode));
             }
 
         } else if (convolutionMode == ConvolutionMode.Same) {
@@ -304,12 +300,12 @@ public class InputTypeUtil {
         int padW = (padding == null ? 0 : padding[1]);
         int kH = kernelSize[0];
         int kW = kernelSize[1];
-        if(dilation[0] != 1){
+        if (dilation[0] != 1) {
             //Use *effective* kernel size, accounting for dilation
-            kH = kH + (kH-1)*(dilation[0]-1);
+            kH = kH + (kH - 1) * (dilation[0] - 1);
         }
-        if(dilation[1] != 1){
-            kW = kW + (kW-1)*(dilation[1]-1);
+        if (dilation[1] != 1) {
+            kW = kW + (kW - 1) * (dilation[1] - 1);
         }
 
         int sH = stride[0];
@@ -386,7 +382,7 @@ public class InputTypeUtil {
     }
 
     private static String getConfigErrorCommonLine(long layerIdx, String layerName, Class<?> layerClass,
-                                                   boolean isHeight) {
+                    boolean isHeight) {
         String name = layerName == null ? "(not named)" : layerName;
         String layerType = layerClass.getSimpleName();
 
@@ -394,11 +390,11 @@ public class InputTypeUtil {
                         + (isHeight ? "height" : "width") + " dimension: ";
     }
 
-    private static String getConfigErrorCommonLastLine1D(InputType inputType, int kernelSize, int stride,
-                                                       int padding, long outputDepth, ConvolutionMode convolutionMode) {
+    private static String getConfigErrorCommonLastLine1D(InputType inputType, int kernelSize, int stride, int padding,
+                    long outputDepth, ConvolutionMode convolutionMode) {
         return "Input type = " + inputType + ", kernel = " + kernelSize + ", strides = " + stride + ", padding = "
-                + padding + ", layer size (output channels) = " + outputDepth + ", convolution mode = "
-                + convolutionMode;
+                        + padding + ", layer size (output channels) = " + outputDepth + ", convolution mode = "
+                        + convolutionMode;
     }
 
     private static String getConfigErrorCommonLastLine(InputType inputType, int[] kernelSize, int[] stride,
@@ -419,11 +415,11 @@ public class InputTypeUtil {
         switch (inputType.getType()) {
             case FF:
                 log.info("Automatic addition of FF -> CNN3D preprocessors: not yet implemented (layer name: \""
-                        + layerName + "\")");
+                                + layerName + "\")");
                 return null;
             case RNN:
                 log.warn("Automatic addition of RNN -> CNN3D preprocessors: not yet implemented (layer name: \""
-                        + layerName + "\")");
+                                + layerName + "\")");
                 return null;
             // TODO: handle CNN to CNN3D
             case CNN3D:

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
@@ -36,11 +36,11 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * LSTM recurrent neural network layer without peephole connections.
- * Supports CuDNN acceleration - see <a href="https://deeplearning4j.org/cudnn>https://deeplearning4j.org/cudnn</a> for details
+ * LSTM recurrent neural network layer without peephole connections. Supports CuDNN acceleration - see <a
+ * href="https://deeplearning4j.org/cudnn>https://deeplearning4j.org/cudnn</a> for details
  *
- * @see GravesLSTM GravesLSTM class for an alternative LSTM (with peephole connections)
  * @author Alex Black
+ * @see GravesLSTM GravesLSTM class for an alternative LSTM (with peephole connections)
  */
 @Data
 @NoArgsConstructor
@@ -59,10 +59,10 @@ public class LSTM extends AbstractLSTM {
     }
 
     @Override
-    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder){
+    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder) {
         super.initializeConstraints(builder);
-        if(((Builder)builder).recurrentConstraints != null){
-            if(constraints == null){
+        if (((Builder) builder).recurrentConstraints != null) {
+            if (constraints == null) {
                 constraints = new ArrayList<>();
             }
             for (LayerConstraint c : ((Builder) builder).recurrentConstraints) {
@@ -75,7 +75,7 @@ public class LSTM extends AbstractLSTM {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("LSTM", getLayerName(), layerIndex, getNIn(), getNOut());
         org.deeplearning4j.nn.layers.recurrent.LSTM ret = new org.deeplearning4j.nn.layers.recurrent.LSTM(conf);
         ret.setListeners(trainingListeners);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -75,7 +72,7 @@ public class LSTM extends AbstractLSTM {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("LSTM", getLayerName(), layerIndex, getNIn(), getNOut());
         org.deeplearning4j.nn.layers.recurrent.LSTM ret = new org.deeplearning4j.nn.layers.recurrent.LSTM(conf);
         ret.setListeners(trainingListeners);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LSTM.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -45,7 +42,7 @@ import java.util.*;
  */
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class",
-        defaultImpl = LegacyLayerDeserializerHelper.class)
+                defaultImpl = LegacyLayerDeserializerHelper.class)
 @Data
 @NoArgsConstructor
 public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
@@ -148,9 +145,8 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
     }
 
     public abstract org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex,
-            INDArray layerParamsView,
-            boolean initializeParams);
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams);
 
     /**
      * @return The parameter initializer for this model
@@ -231,7 +227,7 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
      */
     public IUpdater getUpdaterByParam(String paramName) {
         throw new UnsupportedOperationException(
-                "Not supported: all layers with parameters should override this method");
+                        "Not supported: all layers with parameters should override this method");
     }
 
     /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -49,6 +49,7 @@ import java.util.*;
 @Data
 @NoArgsConstructor
 public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
+
     protected String layerName;
     protected IDropout iDropout;
     protected List<LayerConstraint> constraints;
@@ -98,9 +99,10 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
     }
 
     /**
-     * Reset the learning related configs of the layer to default. When instantiated with a global neural network configuration
-     * the parameters specified in the neural network configuration will be used.
-     * For internal use with the transfer learning API. Users should not have to call this method directly.
+     * Reset the learning related configs of the layer to default. When instantiated with a global
+     * neural network configuration the parameters specified in the neural network configuration
+     * will be used. For internal use with the transfer learning API. Users should not have to call
+     * this method directly.
      */
     public void resetLayerDefaultConfig() {
         //clear the learning related params for all layers in the origConf and set to defaults
@@ -115,21 +117,21 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
             //Let's check for any INDArray fields and dup them (in case cloned layer will be used in different threads on CUDA...
             // we don't want it being relocated contantly between devices)
             Class<?> c = getClass();
-            while(c != Object.class){
+            while (c != Object.class) {
                 Field[] fields = c.getDeclaredFields();
-                for(Field f : fields){
-                    if(f.getType() == INDArray.class){
+                for (Field f : fields) {
+                    if (f.getType() == INDArray.class) {
                         f.setAccessible(true);
                         INDArray toClone;
-                        try{
+                        try {
                             toClone = (INDArray) f.get(this);
-                        } catch (Exception e){
+                        } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
-                        if(toClone != null){
+                        if (toClone != null) {
                             try {
                                 f.set(this, toClone.dup());
-                            } catch (Exception e){
+                            } catch (Exception e) {
                                 throw new RuntimeException(e);
                             }
                         }
@@ -146,8 +148,9 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
     }
 
     public abstract org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                    boolean initializeParams);
+            Collection<TrainingListener> trainingListeners, int layerIndex,
+            INDArray layerParamsView,
+            boolean initializeParams);
 
     /**
      * @return The parameter initializer for this model
@@ -158,18 +161,19 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
      * For a given type of input to this layer, what is the type of the output?
      *
      * @param layerIndex Index of the layer
-     * @param inputType  Type of input for the layer
+     * @param inputType Type of input for the layer
      * @return Type of output from the layer
      * @throws IllegalStateException if input type is invalid for this layer
      */
     public abstract InputType getOutputType(int layerIndex, InputType inputType);
 
     /**
-     * Set the nIn value (number of inputs, or input channels for CNNs) based on the given input type
+     * Set the nIn value (number of inputs, or input channels for CNNs) based on the given input
+     * type
      *
      * @param inputType Input type for this layer
-     * @param override  If false: only set the nIn value if it's not already set. If true: set it regardless of whether it's
-     *                  already set or not.
+     * @param override If false: only set the nIn value if it's not already set. If true: set it
+     * regardless of whether it's already set or not.
      * @throws IllegalStateException if input type is invalid for this layer
      */
     public abstract void setNIn(InputType inputType, boolean override);
@@ -177,19 +181,20 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
 
     /**
      * For the given type of input to this layer, what preprocessor (if any) is required?<br>
-     * Returns null if no preprocessor is required, otherwise returns an appropriate {@link InputPreProcessor}
-     * for this layer, such as a {@link org.deeplearning4j.nn.conf.preprocessor.CnnToFeedForwardPreProcessor}
+     * Returns null if no preprocessor is required, otherwise returns an appropriate {@link
+     * InputPreProcessor} for this layer, such as a {@link org.deeplearning4j.nn.conf.preprocessor.CnnToFeedForwardPreProcessor}
      *
      * @param inputType InputType to this layer
-     * @return Null if no preprocessor is required, otherwise the type of preprocessor necessary for this layer/input combination
+     * @return Null if no preprocessor is required, otherwise the type of preprocessor necessary for
+     * this layer/input combination
      * @throws IllegalStateException if input type is invalid for this layer
      */
     public abstract InputPreProcessor getPreProcessorForInputType(InputType inputType);
 
     /**
-     * Get the L1 coefficient for the given parameter.
-     * Different parameters may have different L1 values, even for a single .l1(x) configuration.
-     * For example, biases generally aren't L1 regularized, even if weights are
+     * Get the L1 coefficient for the given parameter. Different parameters may have different L1
+     * values, even for a single .l1(x) configuration. For example, biases generally aren't L1
+     * regularized, even if weights are
      *
      * @param paramName Parameter name
      * @return L1 value for that parameter
@@ -197,9 +202,9 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
     public abstract double getL1ByParam(String paramName);
 
     /**
-     * Get the L2 coefficient for the given parameter.
-     * Different parameters may have different L2 values, even for a single .l2(x) configuration.
-     * For example, biases generally aren't L1 regularized, even if weights are
+     * Get the L2 coefficient for the given parameter. Different parameters may have different L2
+     * values, even for a single .l2(x) configuration. For example, biases generally aren't L1
+     * regularized, even if weights are
      *
      * @param paramName Parameter name
      * @return L2 value for that parameter
@@ -207,10 +212,10 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
     public abstract double getL2ByParam(String paramName);
 
     /**
-     * Is the specified parameter a layerwise pretraining only parameter?<br>
-     * For example, visible bias params in an autoencoder (or, decoder params in a variational autoencoder) aren't
-     * used during supervised backprop.<br>
-     * Layers (like DenseLayer, etc) with no pretrainable parameters will return false for all (valid) inputs.
+     * Is the specified parameter a layerwise pretraining only parameter?<br> For example, visible
+     * bias params in an autoencoder (or, decoder params in a variational autoencoder) aren't used
+     * during supervised backprop.<br> Layers (like DenseLayer, etc) with no pretrainable parameters
+     * will return false for all (valid) inputs.
      *
      * @param paramName Parameter name/key
      * @return True if the parameter is for layerwise pretraining only, false otherwise
@@ -218,8 +223,8 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
     public abstract boolean isPretrainParam(String paramName);
 
     /**
-     * Get the updater for the given parameter. Typically the same updater will be used for all updaters, but this
-     * is not necessarily the case
+     * Get the updater for the given parameter. Typically the same updater will be used for all
+     * updaters, but this is not necessarily the case
      *
      * @param paramName Parameter name
      * @return IUpdater for the parameter
@@ -232,7 +237,8 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
     /**
      * This is a report of the estimated memory consumption for the given layer
      *
-     * @param inputType Input type to the layer. Memory consumption is often a function of the input type
+     * @param inputType Input type to the layer. Memory consumption is often a function of the input
+     * type
      * @return Memory report for the layer
      */
     public abstract LayerMemoryReport getMemoryReport(InputType inputType);
@@ -261,8 +267,7 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
         protected IDropout iDropout;
 
         /**
-         * Layer name assigns layer string name.
-         * Allows easier differentiation between layers.
+         * Layer name assigns layer string name. Allows easier differentiation between layers.
          */
         public T name(String layerName) {
             this.layerName = layerName;
@@ -270,26 +275,28 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
         }
 
         /**
-         * Dropout probability. This is the probability of <it>retaining</it> each input activation value for a layer.
-         * dropOut(x) will keep an input activation with probability x, and set to 0 with probability 1-x.<br>
-         * dropOut(0.0) is a special value / special case - when set to 0.0., dropout is disabled (not applied). Note
-         * that a dropout value of 1.0 is functionally equivalent to no dropout: i.e., 100% probability of retaining
-         * each input activation.<br>
-         * When useDropConnect(boolean) is set to true (false by default), this method sets the drop connect
-         * probability instead.
+         * Dropout probability. This is the probability of <it>retaining</it> each input activation
+         * value for a layer. dropOut(x) will keep an input activation with probability x, and set
+         * to 0 with probability 1-x.<br> dropOut(0.0) is a special value / special case - when set
+         * to 0.0., dropout is disabled (not applied). Note that a dropout value of 1.0 is
+         * functionally equivalent to no dropout: i.e., 100% probability of retaining each input
+         * activation.<br> When useDropConnect(boolean) is set to true (false by default), this
+         * method sets the drop connect probability instead.
          * <p>
-         * Note 1: Dropout is applied at training time only - and is automatically not applied at test time
-         * (for evaluation, etc)<br>
-         * Note 2: This sets the probability per-layer. Care should be taken when setting lower values for
-         * complex networks (too much information may be lost with aggressive (very low) dropout values).<br>
-         * Note 3: Frequently, dropout is not applied to (or, has higher retain probability for) input (first layer)
-         * layers. Dropout is also often not applied to output layers. This needs to be handled MANUALLY by the user
-         * - set .dropout(0) on those layers when using global dropout setting.<br>
-         * Note 4: Implementation detail (most users can ignore): DL4J uses inverted dropout, as described here:
+         * Note 1: Dropout is applied at training time only - and is automatically not applied at
+         * test time (for evaluation, etc)<br> Note 2: This sets the probability per-layer. Care
+         * should be taken when setting lower values for complex networks (too much information may
+         * be lost with aggressive (very low) dropout values).<br> Note 3: Frequently, dropout is
+         * not applied to (or, has higher retain probability for) input (first layer) layers.
+         * Dropout is also often not applied to output layers. This needs to be handled MANUALLY by
+         * the user - set .dropout(0) on those layers when using global dropout setting.<br> Note 4:
+         * Implementation detail (most users can ignore): DL4J uses inverted dropout, as described
+         * here:
          * <a href="http://cs231n.github.io/neural-networks-2/">http://cs231n.github.io/neural-networks-2/</a>
          * </p>
          *
-         * @param inputRetainProbability Dropout probability (probability of retaining each input activation value for a layer)
+         * @param inputRetainProbability Dropout probability (probability of retaining each input
+         * activation value for a layer)
          * @see #dropOut(IDropout)
          */
         public T dropOut(double inputRetainProbability) {
@@ -303,7 +310,7 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
          * Set the dropout for all layers in this network
          *
          * @param dropout Dropout, such as {@link Dropout}, {@link org.deeplearning4j.nn.conf.dropout.GaussianDropout},
-         *                {@link org.deeplearning4j.nn.conf.dropout.GaussianNoise} etc
+         * {@link org.deeplearning4j.nn.conf.dropout.GaussianNoise} etc
          */
         public T dropOut(IDropout dropout) {
             this.iDropout = dropout;
@@ -311,9 +318,10 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
         }
 
         /**
-         * Set constraints to be applied to this layer. Default: no constraints.<br>
-         * Constraints can be used to enforce certain conditions (non-negativity of parameters, max-norm regularization,
-         * etc). These constraints are applied at each iteration, after the parameters have been updated.
+         * Set constraints to be applied to this layer. Default: no constraints.<br> Constraints can
+         * be used to enforce certain conditions (non-negativity of parameters, max-norm
+         * regularization, etc). These constraints are applied at each iteration, after the
+         * parameters have been updated.
          *
          * @param constraints Constraints to apply to all parameters of this layer
          */
@@ -323,9 +331,10 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
         }
 
         /**
-         * Set constraints to be applied to bias parameters of this layer. Default: no constraints.<br>
-         * Constraints can be used to enforce certain conditions (non-negativity of parameters, max-norm regularization,
-         * etc). These constraints are applied at each iteration, after the parameters have been updated.
+         * Set constraints to be applied to bias parameters of this layer. Default: no
+         * constraints.<br> Constraints can be used to enforce certain conditions (non-negativity of
+         * parameters, max-norm regularization, etc). These constraints are applied at each
+         * iteration, after the parameters have been updated.
          *
          * @param constraints Constraints to apply to all bias parameters of this layer
          */
@@ -335,9 +344,10 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
         }
 
         /**
-         * Set constraints to be applied to the weight parameters of this layer. Default: no constraints.<br>
-         * Constraints can be used to enforce certain conditions (non-negativity of parameters, max-norm regularization,
-         * etc). These constraints are applied at each iteration, after the parameters have been updated.
+         * Set constraints to be applied to the weight parameters of this layer. Default: no
+         * constraints.<br> Constraints can be used to enforce certain conditions (non-negativity of
+         * parameters, max-norm regularization, etc). These constraints are applied at each
+         * iteration, after the parameters have been updated.
          *
          * @param constraints Constraints to apply to all weight parameters of this layer
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -16,8 +16,11 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
+import jdk.nashorn.internal.objects.annotations.Property;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.api.TrainingConfig;
 import org.deeplearning4j.nn.api.layers.LayerConstraint;
@@ -236,10 +239,25 @@ public abstract class Layer implements TrainingConfig, Serializable, Cloneable {
 
     @SuppressWarnings("unchecked")
     public abstract static class Builder<T extends Builder<T>> {
+
+        @Getter
+        @Setter
         protected String layerName = null;
+
+        @Getter
+        @Setter
         protected List<LayerConstraint> allParamConstraints;
+
+        @Getter
+        @Setter
         protected List<LayerConstraint> weightConstraints;
+
+        @Getter
+        @Setter
         protected List<LayerConstraint> biasConstraints;
+
+        @Getter
+        @Setter
         protected IDropout iDropout;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Layer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LayerValidation.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LayerValidation.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -35,7 +32,7 @@ import java.util.List;
 @Slf4j
 public class LayerValidation {
 
-    private LayerValidation(){ }
+    private LayerValidation() {}
 
     /**
      * Asserts that the layer nIn and nOut values are set for the layer
@@ -51,7 +48,7 @@ public class LayerValidation {
             if (layerName == null)
                 layerName = "(name not set)";
             throw new DL4JInvalidConfigException(layerType + " (index=" + layerIndex + ", name=" + layerName + ") nIn="
-                    + nIn + ", nOut=" + nOut + "; nIn and nOut must be > 0");
+                            + nIn + ", nOut=" + nOut + "; nIn and nOut must be > 0");
         }
     }
 
@@ -68,26 +65,23 @@ public class LayerValidation {
             if (layerName == null)
                 layerName = "(name not set)";
             throw new DL4JInvalidConfigException(layerType + " (index=" + layerIndex + ", name=" + layerName + ") nOut="
-                    + nOut + "; nOut must be > 0");
+                            + nOut + "; nOut must be > 0");
         }
     }
 
 
 
-
-    public static void generalValidation(String layerName, Layer layer, IDropout iDropOut,
-                                         Double l2, Double l2Bias, Double l1, Double l1Bias,
-                                         List<LayerConstraint> allParamConstraints,
-                                         List<LayerConstraint> weightConstraints, List<LayerConstraint> biasConstraints) {
-        generalValidation(layerName, layer, iDropOut,
-                        l2 == null ? Double.NaN : l2, l2Bias == null ? Double.NaN : l2Bias,
-                        l1 == null ? Double.NaN : l1, l1Bias == null ? Double.NaN : l1Bias, allParamConstraints, weightConstraints, biasConstraints);
+    public static void generalValidation(String layerName, Layer layer, IDropout iDropOut, Double l2, Double l2Bias,
+                    Double l1, Double l1Bias, List<LayerConstraint> allParamConstraints,
+                    List<LayerConstraint> weightConstraints, List<LayerConstraint> biasConstraints) {
+        generalValidation(layerName, layer, iDropOut, l2 == null ? Double.NaN : l2,
+                        l2Bias == null ? Double.NaN : l2Bias, l1 == null ? Double.NaN : l1,
+                        l1Bias == null ? Double.NaN : l1Bias, allParamConstraints, weightConstraints, biasConstraints);
     }
 
-    public static void generalValidation(String layerName, Layer layer, IDropout iDropout,
-                                         double l2, double l2Bias, double l1, double l1Bias,
-                                         List<LayerConstraint> allParamConstraints,
-                                         List<LayerConstraint> weightConstraints, List<LayerConstraint> biasConstraints) {
+    public static void generalValidation(String layerName, Layer layer, IDropout iDropout, double l2, double l2Bias,
+                    double l1, double l1Bias, List<LayerConstraint> allParamConstraints,
+                    List<LayerConstraint> weightConstraints, List<LayerConstraint> biasConstraints) {
 
         if (layer != null) {
             if (layer instanceof BaseLayer) {
@@ -96,15 +90,15 @@ public class LayerValidation {
             } else if (layer instanceof FrozenLayer && ((FrozenLayer) layer).getLayer() instanceof BaseLayer) {
                 BaseLayer bLayer = (BaseLayer) ((FrozenLayer) layer).getLayer();
                 configureBaseLayer(layerName, bLayer, iDropout, l2, l2Bias, l1, l1Bias);
-            } else if (layer instanceof Bidirectional){
-                Bidirectional l = (Bidirectional)layer;
+            } else if (layer instanceof Bidirectional) {
+                Bidirectional l = (Bidirectional) layer;
                 generalValidation(layerName, l.getFwd(), iDropout, l2, l2Bias, l1, l1Bias, allParamConstraints,
-                        weightConstraints, biasConstraints);
+                                weightConstraints, biasConstraints);
                 generalValidation(layerName, l.getBwd(), iDropout, l2, l2Bias, l1, l1Bias, allParamConstraints,
-                        weightConstraints, biasConstraints);
+                                weightConstraints, biasConstraints);
             }
 
-            if(layer.getConstraints() == null || layer.constraints.isEmpty()) {
+            if (layer.getConstraints() == null || layer.constraints.isEmpty()) {
                 List<LayerConstraint> allConstraints = new ArrayList<>();
                 if (allParamConstraints != null && !layer.initializer().paramKeys(layer).isEmpty()) {
                     for (LayerConstraint c : allConstraints) {
@@ -130,7 +124,7 @@ public class LayerValidation {
                     }
                 }
 
-                if(!allConstraints.isEmpty()){
+                if (!allConstraints.isEmpty()) {
                     layer.setConstraints(allConstraints);
                 } else {
                     layer.setConstraints(null);
@@ -139,8 +133,8 @@ public class LayerValidation {
         }
     }
 
-    private static void configureBaseLayer(String layerName, BaseLayer bLayer, IDropout iDropout, Double l2, Double l2Bias,
-                                           Double l1, Double l1Bias) {
+    private static void configureBaseLayer(String layerName, BaseLayer bLayer, IDropout iDropout, Double l2,
+                    Double l2Bias, Double l1, Double l1Bias) {
 
         if (!Double.isNaN(l1) && Double.isNaN(bLayer.getL1())) {
             bLayer.setL1(l1);
@@ -168,7 +162,7 @@ public class LayerValidation {
             bLayer.setL1Bias(0.0);
         }
 
-        if(bLayer.getIDropout() == null){
+        if (bLayer.getIDropout() == null) {
             bLayer.setIDropout(iDropout);
         }
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LayerValidation.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LayerValidation.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -65,10 +62,10 @@ public class LocalResponseNormalization extends Layer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization ret =
-                new org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization(conf);
+                        new org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -88,8 +85,8 @@ public class LocalResponseNormalization extends Layer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException(
-                    "Invalid input type for LRN layer (layer index = " + layerIndex + ", layer name = \""
-                            + getLayerName() + "\"): Expected input of type CNN, got " + inputType);
+                            "Invalid input type for LRN layer (layer index = " + layerIndex + ", layer name = \""
+                                            + getLayerName() + "\"): Expected input of type CNN, got " + inputType);
         }
         return inputType;
     }
@@ -103,7 +100,7 @@ public class LocalResponseNormalization extends Layer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException(
-                    "Invalid input type for LRN layer (layer name = \"" + getLayerName() + "\"): null");
+                            "Invalid input type for LRN layer (layer name = \"" + getLayerName() + "\"): null");
         }
 
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
@@ -144,10 +141,9 @@ public class LocalResponseNormalization extends Layer {
         //Backward pass: 2x input size as working memory, in addition to epsilons
 
         return new LayerMemoryReport.Builder(layerName, DenseLayer.class, inputType, inputType).standardMemory(0, 0)
-                .workingMemory(0, 2 * actElementsPerEx, 0, 3 * actElementsPerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS,
-                        MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
-                .build();
+                        .workingMemory(0, 2 * actElementsPerEx, 0, 3 * actElementsPerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
+                        .build();
     }
 
     @AllArgsConstructor
@@ -207,8 +203,7 @@ public class LocalResponseNormalization extends Layer {
             this.beta = beta;
         }
 
-        public Builder() {
-        }
+        public Builder() {}
 
         /**
          * LRN scaling constant k. Default: 2

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -152,10 +152,20 @@ public class LocalResponseNormalization extends Layer {
     @AllArgsConstructor
     public static class Builder extends Layer.Builder<Builder> {
         // defaults based on AlexNet model
+        @Getter
+        @Setter
         private double k = 2;
+        @Getter
+        @Setter
         private double n = 5;
+        @Getter
+        @Setter
         private double alpha = 1e-4;
+        @Getter
+        @Setter
         private double beta = 0.75;
+        @Getter
+        @Setter
         protected boolean cudnnAllowFallback = true;
 
         public Builder(double k, double n, double alpha, double beta){

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -147,6 +147,8 @@ public class LocalResponseNormalization extends Layer {
     }
 
     @AllArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
         // defaults based on AlexNet model
@@ -155,32 +157,24 @@ public class LocalResponseNormalization extends Layer {
          * LRN scaling constant k. Default: 2
          *
          */
-        @Getter
-        @Setter
         private double k = 2;
 
         /**
          * Number of adjacent kernel maps to use when doing LRN. default: 5
          *
          */
-        @Getter
-        @Setter
         private double n = 5;
 
         /**
          * LRN scaling constant alpha. Default: 1e-4
          *
          */
-        @Getter
-        @Setter
         private double alpha = 1e-4;
 
         /**
          * Scaling constant beta. Default: 0.75
          *
          */
-        @Getter
-        @Setter
         private double beta = 0.75;
 
         /**
@@ -189,8 +183,6 @@ public class LocalResponseNormalization extends Layer {
          * (non-CuDNN) implementation for BatchNormalization will be used
          *
          */
-        @Getter
-        @Setter
         protected boolean cudnnAllowFallback = true;
 
         public Builder(double k, double n, double alpha, double beta) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocalResponseNormalization.java
@@ -32,14 +32,14 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Local response normalization layer<br>
- * See section 3.3 of <a href="http://www.cs.toronto.edu/~fritz/absps/imagenet.pdf">http://www.cs.toronto.edu/~fritz/absps/imagenet.pdf</a>
+ * Local response normalization layer<br> See section 3.3 of <a href="http://www.cs.toronto.edu/~fritz/absps/imagenet.pdf">http://www.cs.toronto.edu/~fritz/absps/imagenet.pdf</a>
  */
 @Data
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class LocalResponseNormalization extends Layer {
+
     // Defaults as per http://www.cs.toronto.edu/~fritz/absps/imagenet.pdf
     //Set defaults here as well as in builder, in case users use no-arg constructor instead of builder
     protected double n = 5; // # adjacent kernal maps
@@ -65,10 +65,10 @@ public class LocalResponseNormalization extends Layer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                    boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization ret =
-                        new org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization(conf);
+                new org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -88,8 +88,8 @@ public class LocalResponseNormalization extends Layer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException(
-                            "Invalid input type for LRN layer (layer index = " + layerIndex + ", layer name = \""
-                                            + getLayerName() + "\"): Expected input of type CNN, got " + inputType);
+                    "Invalid input type for LRN layer (layer index = " + layerIndex + ", layer name = \""
+                            + getLayerName() + "\"): Expected input of type CNN, got " + inputType);
         }
         return inputType;
     }
@@ -103,7 +103,7 @@ public class LocalResponseNormalization extends Layer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException(
-                            "Invalid input type for LRN layer (layer name = \"" + getLayerName() + "\"): null");
+                    "Invalid input type for LRN layer (layer name = \"" + getLayerName() + "\"): null");
         }
 
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
@@ -144,31 +144,60 @@ public class LocalResponseNormalization extends Layer {
         //Backward pass: 2x input size as working memory, in addition to epsilons
 
         return new LayerMemoryReport.Builder(layerName, DenseLayer.class, inputType, inputType).standardMemory(0, 0)
-                        .workingMemory(0, 2 * actElementsPerEx, 0, 3 * actElementsPerEx)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
-                        .build();
+                .workingMemory(0, 2 * actElementsPerEx, 0, 3 * actElementsPerEx)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS,
+                        MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
+                .build();
     }
 
     @AllArgsConstructor
     public static class Builder extends Layer.Builder<Builder> {
+
         // defaults based on AlexNet model
+
+        /**
+         * LRN scaling constant k. Default: 2
+         *
+         */
         @Getter
         @Setter
         private double k = 2;
+
+        /**
+         * Number of adjacent kernel maps to use when doing LRN. default: 5
+         *
+         */
         @Getter
         @Setter
         private double n = 5;
+
+        /**
+         * LRN scaling constant alpha. Default: 1e-4
+         *
+         */
         @Getter
         @Setter
         private double alpha = 1e-4;
+
+        /**
+         * Scaling constant beta. Default: 0.75
+         *
+         */
         @Getter
         @Setter
         private double beta = 0.75;
+
+        /**
+         * When using CuDNN and an error is encountered, should fallback to the non-CuDNN implementatation be allowed?
+         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in
+         * (non-CuDNN) implementation for BatchNormalization will be used
+         *
+         */
         @Getter
         @Setter
         protected boolean cudnnAllowFallback = true;
 
-        public Builder(double k, double n, double alpha, double beta){
+        public Builder(double k, double n, double alpha, double beta) {
             this(k, n, alpha, beta, true);
         }
 
@@ -178,7 +207,8 @@ public class LocalResponseNormalization extends Layer {
             this.beta = beta;
         }
 
-        public Builder() {}
+        public Builder() {
+        }
 
         /**
          * LRN scaling constant k. Default: 2
@@ -193,7 +223,7 @@ public class LocalResponseNormalization extends Layer {
         /**
          * Number of adjacent kernel maps to use when doing LRN. default: 5
          *
-         * @param n    Number of adjacent kernel maps
+         * @param n Number of adjacent kernel maps
          */
         public Builder n(double n) {
             this.n = n;
@@ -203,7 +233,7 @@ public class LocalResponseNormalization extends Layer {
         /**
          * LRN scaling constant alpha. Default: 1e-4
          *
-         * @param alpha    Scaling constant
+         * @param alpha Scaling constant
          */
         public Builder alpha(double alpha) {
             this.alpha = alpha;
@@ -213,7 +243,7 @@ public class LocalResponseNormalization extends Layer {
         /**
          * Scaling constant beta. Default: 0.75
          *
-         * @param beta    Scaling constant
+         * @param beta Scaling constant
          */
         public Builder beta(double beta) {
             this.beta = beta;
@@ -222,8 +252,8 @@ public class LocalResponseNormalization extends Layer {
 
         /**
          * When using CuDNN and an error is encountered, should fallback to the non-CuDNN implementatation be allowed?
-         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in (non-CuDNN)
-         * implementation for BatchNormalization will be used
+         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in
+         * (non-CuDNN) implementation for BatchNormalization will be used
          *
          * @param allowFallback Whether fallback to non-CuDNN implementation should be used
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
@@ -1,12 +1,15 @@
-/*
+/*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
@@ -16,9 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.val;
+import lombok.*;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -217,15 +215,35 @@ public class LocallyConnected1D extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private int nIn;
+        @Getter
+        @Setter
         private int nOut;
+        @Getter
+        @Setter
         private Activation activation = Activation.TANH;
+        @Getter
+        @Setter
         private int kernel = 2;
+        @Getter
+        @Setter
         private int stride = 1;
+        @Getter
+        @Setter
         private int padding = 0;
+        @Getter
+        @Setter
         private int dilation = 1;
+        @Getter
+        @Setter
         private int inputSize;
+        @Getter
+        @Setter
         private ConvolutionMode cm = ConvolutionMode.Same;
+        @Getter
+        @Setter
         private boolean hasBias = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
@@ -215,33 +215,72 @@ public class LocallyConnected1D extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
+        /**
+         * Number of inputs to the layer (input size)
+         */
         @Getter
         @Setter
         private int nIn;
+
+        /**
+         * Number of outputs (output size)
+         */
         @Getter
         @Setter
         private int nOut;
+
+        /**
+         * Activation function for the layer
+         */
         @Getter
         @Setter
         private Activation activation = Activation.TANH;
+
+        /**
+         * Kernel size for the layer
+         */
         @Getter
         @Setter
         private int kernel = 2;
+
+        /**
+         * Stride for the layer
+         */
         @Getter
         @Setter
         private int stride = 1;
+
+        /**
+         * Padding for the layer. Not used if {@link ConvolutionMode#Same} is set
+         */
         @Getter
         @Setter
         private int padding = 0;
+
+        /**
+         * Dilation for the layer
+         */
         @Getter
         @Setter
         private int dilation = 1;
+
+        /**
+         * Input filter size for this locally connected 1D layer
+         *
+         */
         @Getter
-        @Setter
         private int inputSize;
+
+        /**
+         * Convolution mode for the layer. See {@link ConvolutionMode} for details
+         */
         @Getter
         @Setter
         private ConvolutionMode cm = ConvolutionMode.Same;
+
+        /**
+         * If true (default is false) the layer will have a bias
+         */
         @Getter
         @Setter
         private boolean hasBias = true;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected1D.java
@@ -1,15 +1,12 @@
 /*
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -53,9 +50,8 @@ public class LocallyConnected1D extends SameDiffLayer {
 
     private static final List<String> WEIGHT_KEYS = Collections.singletonList(ConvolutionParamInitializer.WEIGHT_KEY);
     private static final List<String> BIAS_KEYS = Collections.singletonList(ConvolutionParamInitializer.BIAS_KEY);
-    private static final List<String> PARAM_KEYS = Arrays.asList(
-            ConvolutionParamInitializer.BIAS_KEY,
-            ConvolutionParamInitializer.WEIGHT_KEY);
+    private static final List<String> PARAM_KEYS =
+                    Arrays.asList(ConvolutionParamInitializer.BIAS_KEY, ConvolutionParamInitializer.WEIGHT_KEY);
 
     private long nIn;
     private long nOut;
@@ -85,7 +81,7 @@ public class LocallyConnected1D extends SameDiffLayer {
         this.featureDim = kernel * (int) nIn;
     }
 
-    private LocallyConnected1D(){
+    private LocallyConnected1D() {
         //No arg constructor for Jackson/JSON serialization
     }
 
@@ -98,28 +94,29 @@ public class LocallyConnected1D extends SameDiffLayer {
         INDArray dummyInputForShapeInference = Nd4j.ones(inputShape);
 
         if (cm == ConvolutionMode.Same) {
-            this.outputSize = Convolution1DUtils.getOutputSize(
-                    dummyInputForShapeInference, kernel, stride, 0, cm, dilation);
-            this.padding = Convolution1DUtils.getSameModeTopLeftPadding(outputSize, inputSize, kernel, stride, dilation);
+            this.outputSize = Convolution1DUtils.getOutputSize(dummyInputForShapeInference, kernel, stride, 0, cm,
+                            dilation);
+            this.padding = Convolution1DUtils.getSameModeTopLeftPadding(outputSize, inputSize, kernel, stride,
+                            dilation);
         } else {
-            this.outputSize = Convolution1DUtils.getOutputSize(
-                    dummyInputForShapeInference, kernel, stride, padding, cm, dilation);
+            this.outputSize = Convolution1DUtils.getOutputSize(dummyInputForShapeInference, kernel, stride, padding, cm,
+                            dilation);
         }
     }
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
-            throw new IllegalArgumentException("Provided input type for locally connected 1D layers has to be " +
-                    "of CNN1D/RNN type, got: " + inputType);
+            throw new IllegalArgumentException("Provided input type for locally connected 1D layers has to be "
+                            + "of CNN1D/RNN type, got: " + inputType);
         }
         // dynamically compute input size from input type
         InputType.InputTypeRecurrent rnnType = (InputType.InputTypeRecurrent) inputType;
         this.inputSize = (int) rnnType.getTimeSeriesLength();
         computeOutputSize();
 
-        return InputTypeUtil.getOutputTypeCnn1DLayers(inputType, kernel, stride, padding, 1,
-                cm, nOut, layerIndex, getLayerName(), LocallyConnected1D.class);
+        return InputTypeUtil.getOutputTypeCnn1DLayers(inputType, kernel, stride, padding, 1, cm, nOut, layerIndex,
+                        getLayerName(), LocallyConnected1D.class);
     }
 
     @Override
@@ -138,25 +135,25 @@ public class LocallyConnected1D extends SameDiffLayer {
     @Override
     public void defineParameters(SDLayerParams params) {
         params.clear();
-        val weightsShape = new long[]{outputSize, featureDim, nOut};
+        val weightsShape = new long[] {outputSize, featureDim, nOut};
         params.addWeightParam(ConvolutionParamInitializer.WEIGHT_KEY, weightsShape);
-        if(hasBias) {
-            val biasShape = new long[]{1, nOut};
+        if (hasBias) {
+            val biasShape = new long[] {1, nOut};
             params.addBiasParam(ConvolutionParamInitializer.BIAS_KEY, biasShape);
         }
     }
 
     @Override
     public void initializeParameters(Map<String, INDArray> params) {
-        try(MemoryWorkspace ws = Nd4j.getWorkspaceManager().scopeOutOfWorkspaces()) {
+        try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().scopeOutOfWorkspaces()) {
             for (Map.Entry<String, INDArray> e : params.entrySet()) {
                 if (ConvolutionParamInitializer.BIAS_KEY.equals(e.getKey())) {
                     e.getValue().assign(0);
                 } else {
                     double fanIn = nIn * kernel;
                     double fanOut = nOut * kernel / ((double) stride);
-                    WeightInitUtil.initWeights(
-                            fanIn, fanOut, e.getValue().shape(), weightInit, null, 'c', e.getValue());
+                    WeightInitUtil.initWeights(fanIn, fanOut, e.getValue().shape(), weightInit, null, 'c',
+                                    e.getValue());
                 }
             }
         }
@@ -176,12 +173,11 @@ public class LocallyConnected1D extends SameDiffLayer {
 
         SDVariable[] inputArray = new SDVariable[outH];
         for (int i = 0; i < outH; i++) {
-                SDVariable slice = layerInput.get(
-                        SDIndex.all(), // miniBatch
-                        SDIndex.all(), // nIn
-                        SDIndex.interval(i * sH, i * sH + kH) // kernel
-                );
-                inputArray[i] = sameDiff.reshape(slice, 1, miniBatch, featureDim);
+            SDVariable slice = layerInput.get(SDIndex.all(), // miniBatch
+                            SDIndex.all(), // nIn
+                            SDIndex.interval(i * sH, i * sH + kH) // kernel
+            );
+            inputArray[i] = sameDiff.reshape(slice, 1, miniBatch, featureDim);
         }
         SDVariable concatOutput = sameDiff.concat(0, inputArray); // (outH, miniBatch, featureDim)
         sameDiff.exec();
@@ -191,9 +187,9 @@ public class LocallyConnected1D extends SameDiffLayer {
         SDVariable mmulResult = sameDiff.mmul(concatOutput, w); // (outH, miniBatch, nOut)
         System.out.println(Arrays.toString(mmulResult.getShape()));
 
-        SDVariable result = sameDiff.permute(mmulResult,1, 2, 0); // (miniBatch, nOut, outH)
+        SDVariable result = sameDiff.permute(mmulResult, 1, 2, 0); // (miniBatch, nOut, outH)
 
-        if(hasBias){
+        if (hasBias) {
             SDVariable b = paramTable.get(ConvolutionParamInitializer.BIAS_KEY);
             SDVariable biasAddedResult = sameDiff.biasAdd(result, b);
             return activation.asSameDiff("out", sameDiff, biasAddedResult);
@@ -352,7 +348,7 @@ public class LocallyConnected1D extends SameDiffLayer {
         /**
          * @param hasBias If true (default is false) the layer will have a bias
          */
-        public Builder hasBias(boolean hasBias){
+        public Builder hasBias(boolean hasBias) {
             this.hasBias = hasBias;
             return this;
         }
@@ -363,7 +359,8 @@ public class LocallyConnected1D extends SameDiffLayer {
          * @param inputSize height of the input filters
          * @return Builder
          */
-        public Builder setInputSize(int inputSize){ ;
+        public Builder setInputSize(int inputSize) {
+            ;
             this.inputSize = inputSize;
             return this;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
@@ -220,48 +220,100 @@ public class LocallyConnected2D extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
+        /**
+         * Number of inputs to the layer (input size)
+         */
         @Getter
         @Setter
         private int nIn;
+
+        /**
+         * Number of outputs (output size)
+         */
         @Getter
         @Setter
         private int nOut;
+
+        /**
+         * Activation function for the layer
+         */
         @Getter
         @Setter
         private Activation activation = Activation.TANH;
+
+        /**
+         * Kernel size for the layer. Must be 2 values (height/width)
+         */
         @Getter
         private int[] kernel = new int[]{2, 2};
 
+        /**
+         * @param kernel Kernel size for the layer. Must be 2 values (height/width)
+         */
         public void setKernel(int[] kernel) {
             Preconditions.checkArgument(kernel.length == 2, "Must have 2 kernel values - got %s", kernel);
             this.kernel = kernel;
         }
+
+        /**
+         * Stride for the layer. Must be 2 values (height/width)
+         */
         @Getter
         private int[] stride = new int[]{1, 1};
 
+        /**
+         * @param stride Stride for the layer. Must be 2 values (height/width)
+         */
         public void setStride(int[] stride) {
             Preconditions.checkArgument(stride.length == 2, "Must have 2 stride values - got %s", stride);
             this.stride = stride;
         }
+
+        /**
+         * Padding for the layer. Not used if {@link ConvolutionMode#Same} is set. Must be 2 values (height/width)
+         */
         @Getter
         private int[] padding = new int[]{0, 0};
 
+        /**
+         * @param padding Padding for the layer. Not used if {@link ConvolutionMode#Same} is set. Must be 2 values (height/width)
+         */
         public void setPadding(int[] padding) {
             Preconditions.checkArgument(padding.length == 2, "Must have 2 padding values - got %s", padding);
             this.padding = padding;
         }
+
+        /**
+         * Dilation for the layer. Must be 2 values (height/width)
+         */
         @Getter
         private int[] dilation = new int[]{1, 1};
 
+        /**
+         * @param dilation Dilation for the layer. Must be 2 values (height/width)
+         */
         public void setDilation(int[] dilation) {
             Preconditions.checkArgument(dilation.length == 2, "Must have 2 dilation values - got %s", dilation);
             this.dilation = dilation;
         }
+
+        /**
+         * Set input filter size (h,w) for this locally connected 2D layer
+         *
+         */
         @Getter
         private int[] inputSize;
+
+        /**
+         * Convolution mode for the layer. See {@link ConvolutionMode} for details
+         */
         @Getter
         @Setter
         private ConvolutionMode cm = ConvolutionMode.Same;
+
+        /**
+         * If true (default is false) the layer will have a bias
+         */
         @Getter
         @Setter
         private boolean hasBias = true;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -53,9 +50,8 @@ public class LocallyConnected2D extends SameDiffLayer {
 
     private static final List<String> WEIGHT_KEYS = Collections.singletonList(ConvolutionParamInitializer.WEIGHT_KEY);
     private static final List<String> BIAS_KEYS = Collections.singletonList(ConvolutionParamInitializer.BIAS_KEY);
-    private static final List<String> PARAM_KEYS = Arrays.asList(
-            ConvolutionParamInitializer.BIAS_KEY,
-            ConvolutionParamInitializer.WEIGHT_KEY);
+    private static final List<String> PARAM_KEYS =
+                    Arrays.asList(ConvolutionParamInitializer.BIAS_KEY, ConvolutionParamInitializer.WEIGHT_KEY);
 
     private long nIn;
     private long nOut;
@@ -85,7 +81,7 @@ public class LocallyConnected2D extends SameDiffLayer {
         this.featureDim = kernel[0] * kernel[1] * (int) nIn;
     }
 
-    private LocallyConnected2D(){
+    private LocallyConnected2D() {
         //No arg constructor for Jackson/JSON serialization
     }
 
@@ -100,28 +96,28 @@ public class LocallyConnected2D extends SameDiffLayer {
         INDArray dummyInputForShapeInference = Nd4j.ones(inputShape);
 
         if (cm == ConvolutionMode.Same) {
-            this.outputSize = ConvolutionUtils.getOutputSize(
-                    dummyInputForShapeInference, kernel, stride, null, cm, dilation);
+            this.outputSize = ConvolutionUtils.getOutputSize(dummyInputForShapeInference, kernel, stride, null, cm,
+                            dilation);
             this.padding = ConvolutionUtils.getSameModeTopLeftPadding(outputSize, inputSize, kernel, stride, dilation);
         } else {
-            this.outputSize = ConvolutionUtils.getOutputSize(
-                    dummyInputForShapeInference, kernel, stride, padding, cm, dilation);
+            this.outputSize = ConvolutionUtils.getOutputSize(dummyInputForShapeInference, kernel, stride, padding, cm,
+                            dilation);
         }
     }
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
-            throw new IllegalArgumentException("Provided input type for locally connected 2D layers has to be " +
-                    "of CNN type, got: " + inputType);
+            throw new IllegalArgumentException("Provided input type for locally connected 2D layers has to be "
+                            + "of CNN type, got: " + inputType);
         }
         // dynamically compute input size from input type
         InputType.InputTypeConvolutional cnnType = (InputType.InputTypeConvolutional) inputType;
-        this.inputSize = new int[] { (int) cnnType.getHeight(), (int) cnnType.getWidth()};
+        this.inputSize = new int[] {(int) cnnType.getHeight(), (int) cnnType.getWidth()};
         computeOutputSize();
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernel, stride, padding, new int[]{1, 1},
-                cm, nOut, layerIndex, getLayerName(), LocallyConnected2D.class);
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernel, stride, padding, new int[] {1, 1}, cm, nOut,
+                        layerIndex, getLayerName(), LocallyConnected2D.class);
     }
 
     @Override
@@ -140,25 +136,25 @@ public class LocallyConnected2D extends SameDiffLayer {
     @Override
     public void defineParameters(SDLayerParams params) {
         params.clear();
-        val weightsShape = new long[]{outputSize[0] * outputSize[1], featureDim, nOut};
+        val weightsShape = new long[] {outputSize[0] * outputSize[1], featureDim, nOut};
         params.addWeightParam(ConvolutionParamInitializer.WEIGHT_KEY, weightsShape);
-        if(hasBias) {
-            val biasShape = new long[]{1, nOut};
+        if (hasBias) {
+            val biasShape = new long[] {1, nOut};
             params.addBiasParam(ConvolutionParamInitializer.BIAS_KEY, biasShape);
         }
     }
 
     @Override
     public void initializeParameters(Map<String, INDArray> params) {
-        try(MemoryWorkspace ws = Nd4j.getWorkspaceManager().scopeOutOfWorkspaces()) {
+        try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().scopeOutOfWorkspaces()) {
             for (Map.Entry<String, INDArray> e : params.entrySet()) {
                 if (ConvolutionParamInitializer.BIAS_KEY.equals(e.getKey())) {
                     e.getValue().assign(0);
                 } else {
                     double fanIn = nIn * kernel[0] * kernel[1];
                     double fanOut = nOut * kernel[0] * kernel[1] / ((double) stride[0] * stride[1]);
-                    WeightInitUtil.initWeights(
-                            fanIn, fanOut, e.getValue().shape(), weightInit, null, 'c', e.getValue());
+                    WeightInitUtil.initWeights(fanIn, fanOut, e.getValue().shape(), weightInit, null, 'c',
+                                    e.getValue());
                 }
             }
         }
@@ -181,11 +177,10 @@ public class LocallyConnected2D extends SameDiffLayer {
         SDVariable[] inputArray = new SDVariable[outH * outW];
         for (int i = 0; i < outH; i++) {
             for (int j = 0; j < outW; j++) {
-                SDVariable slice = layerInput.get(
-                        SDIndex.all(), // miniBatch
-                        SDIndex.all(), // nIn
-                        SDIndex.interval(i * sH, i * sH + kH), // kernel height
-                        SDIndex.interval(j * sW, j * sW + kW) // kernel width
+                SDVariable slice = layerInput.get(SDIndex.all(), // miniBatch
+                                SDIndex.all(), // nIn
+                                SDIndex.interval(i * sH, i * sH + kH), // kernel height
+                                SDIndex.interval(j * sW, j * sW + kW) // kernel width
                 );
                 inputArray[i * outH + j] = sameDiff.reshape(slice, 1, miniBatch, featureDim);
             }
@@ -196,9 +191,9 @@ public class LocallyConnected2D extends SameDiffLayer {
 
         SDVariable reshapeResult = sameDiff.reshape(mmulResult, outH, outW, miniBatch, nOut);
 
-        SDVariable permutedResult = sameDiff.permute(reshapeResult,2, 3, 0, 1); // (mb, nOut, outH, outW)
+        SDVariable permutedResult = sameDiff.permute(reshapeResult, 2, 3, 0, 1); // (mb, nOut, outH, outW)
 
-        if(hasBias){
+        if (hasBias) {
             SDVariable b = paramTable.get(ConvolutionParamInitializer.BIAS_KEY);
             SDVariable biasAddedResult = sameDiff.biasAdd(permutedResult, b);
             return activation.asSameDiff("out", sameDiff, biasAddedResult);
@@ -245,7 +240,7 @@ public class LocallyConnected2D extends SameDiffLayer {
          * Kernel size for the layer. Must be 2 values (height/width)
          */
         @Getter
-        private int[] kernel = new int[]{2, 2};
+        private int[] kernel = new int[] {2, 2};
 
         /**
          * @param kernel Kernel size for the layer. Must be 2 values (height/width)
@@ -259,7 +254,7 @@ public class LocallyConnected2D extends SameDiffLayer {
          * Stride for the layer. Must be 2 values (height/width)
          */
         @Getter
-        private int[] stride = new int[]{1, 1};
+        private int[] stride = new int[] {1, 1};
 
         /**
          * @param stride Stride for the layer. Must be 2 values (height/width)
@@ -273,7 +268,7 @@ public class LocallyConnected2D extends SameDiffLayer {
          * Padding for the layer. Not used if {@link ConvolutionMode#Same} is set. Must be 2 values (height/width)
          */
         @Getter
-        private int[] padding = new int[]{0, 0};
+        private int[] padding = new int[] {0, 0};
 
         /**
          * @param padding Padding for the layer. Not used if {@link ConvolutionMode#Same} is set. Must be 2 values (height/width)
@@ -287,7 +282,7 @@ public class LocallyConnected2D extends SameDiffLayer {
          * Dilation for the layer. Must be 2 values (height/width)
          */
         @Getter
-        private int[] dilation = new int[]{1, 1};
+        private int[] dilation = new int[] {1, 1};
 
         /**
          * @param dilation Dilation for the layer. Must be 2 values (height/width)
@@ -385,7 +380,7 @@ public class LocallyConnected2D extends SameDiffLayer {
         /**
          * @param hasBias If true (default is false) the layer will have a bias
          */
-        public Builder hasBias(boolean hasBias){
+        public Builder hasBias(boolean hasBias) {
             this.hasBias = hasBias;
             return this;
         }
@@ -396,9 +391,9 @@ public class LocallyConnected2D extends SameDiffLayer {
          * @param inputSize pair of height and width of the input filters to this layer
          * @return Builder
          */
-        public Builder setInputSize(int... inputSize){
-            Preconditions.checkState(inputSize.length == 2, "Input size argument of a locally connected" +
-                    "layer has to have length 2, got " + inputSize.length);
+        public Builder setInputSize(int... inputSize) {
+            Preconditions.checkState(inputSize.length == 2, "Input size argument of a locally connected"
+                            + "layer has to have length 2, got " + inputSize.length);
             this.inputSize = inputSize;
             return this;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
@@ -16,9 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.val;
+import lombok.*;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -222,15 +220,50 @@ public class LocallyConnected2D extends SameDiffLayer {
 
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private int nIn;
+        @Getter
+        @Setter
         private int nOut;
+        @Getter
+        @Setter
         private Activation activation = Activation.TANH;
+        @Getter
         private int[] kernel = new int[]{2, 2};
+
+        public void setKernel(int[] kernel) {
+            Preconditions.checkArgument(kernel.length == 2, "Must have 2 kernel values - got %s", kernel);
+            this.kernel = kernel;
+        }
+        @Getter
         private int[] stride = new int[]{1, 1};
+
+        public void setStride(int[] stride) {
+            Preconditions.checkArgument(stride.length == 2, "Must have 2 stride values - got %s", stride);
+            this.stride = stride;
+        }
+        @Getter
         private int[] padding = new int[]{0, 0};
+
+        public void setPadding(int[] padding) {
+            Preconditions.checkArgument(padding.length == 2, "Must have 2 padding values - got %s", padding);
+            this.padding = padding;
+        }
+        @Getter
         private int[] dilation = new int[]{1, 1};
+
+        public void setDilation(int[] dilation) {
+            Preconditions.checkArgument(dilation.length == 2, "Must have 2 dilation values - got %s", dilation);
+            this.dilation = dilation;
+        }
+        @Getter
         private int[] inputSize;
+        @Getter
+        @Setter
         private ConvolutionMode cm = ConvolutionMode.Same;
+        @Getter
+        @Setter
         private boolean hasBias = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
@@ -213,34 +213,63 @@ public class LocallyConnected2D extends SameDiffLayer {
         }
     }
 
+    @Getter
+    @Setter
     public static class Builder extends SameDiffLayer.Builder<Builder> {
 
         /**
          * Number of inputs to the layer (input size)
          */
-        @Getter
-        @Setter
         private int nIn;
 
         /**
          * Number of outputs (output size)
          */
-        @Getter
-        @Setter
         private int nOut;
 
         /**
          * Activation function for the layer
          */
-        @Getter
-        @Setter
         private Activation activation = Activation.TANH;
 
         /**
          * Kernel size for the layer. Must be 2 values (height/width)
          */
-        @Getter
         private int[] kernel = new int[] {2, 2};
+
+        /**
+         * Stride for the layer. Must be 2 values (height/width)
+         */
+        private int[] stride = new int[] {1, 1};
+
+        /**
+         * Padding for the layer. Not used if {@link ConvolutionMode#Same} is set. Must be 2 values (height/width)
+         */
+        private int[] padding = new int[] {0, 0};
+
+        /**
+         * Dilation for the layer. Must be 2 values (height/width)
+         */
+        private int[] dilation = new int[] {1, 1};
+
+        /**
+         * Set input filter size (h,w) for this locally connected 2D layer
+         *
+         */
+        @Setter(AccessLevel.NONE)
+        private int[] inputSize;
+
+        /**
+         * Convolution mode for the layer. See {@link ConvolutionMode} for details
+         */
+        private ConvolutionMode cm = ConvolutionMode.Same;
+
+        /**
+         * If true (default is false) the layer will have a bias
+         */
+        private boolean hasBias = true;
+
+
 
         /**
          * @param kernel Kernel size for the layer. Must be 2 values (height/width)
@@ -251,24 +280,12 @@ public class LocallyConnected2D extends SameDiffLayer {
         }
 
         /**
-         * Stride for the layer. Must be 2 values (height/width)
-         */
-        @Getter
-        private int[] stride = new int[] {1, 1};
-
-        /**
          * @param stride Stride for the layer. Must be 2 values (height/width)
          */
         public void setStride(int[] stride) {
             Preconditions.checkArgument(stride.length == 2, "Must have 2 stride values - got %s", stride);
             this.stride = stride;
         }
-
-        /**
-         * Padding for the layer. Not used if {@link ConvolutionMode#Same} is set. Must be 2 values (height/width)
-         */
-        @Getter
-        private int[] padding = new int[] {0, 0};
 
         /**
          * @param padding Padding for the layer. Not used if {@link ConvolutionMode#Same} is set. Must be 2 values (height/width)
@@ -279,39 +296,12 @@ public class LocallyConnected2D extends SameDiffLayer {
         }
 
         /**
-         * Dilation for the layer. Must be 2 values (height/width)
-         */
-        @Getter
-        private int[] dilation = new int[] {1, 1};
-
-        /**
          * @param dilation Dilation for the layer. Must be 2 values (height/width)
          */
         public void setDilation(int[] dilation) {
             Preconditions.checkArgument(dilation.length == 2, "Must have 2 dilation values - got %s", dilation);
             this.dilation = dilation;
         }
-
-        /**
-         * Set input filter size (h,w) for this locally connected 2D layer
-         *
-         */
-        @Getter
-        private int[] inputSize;
-
-        /**
-         * Convolution mode for the layer. See {@link ConvolutionMode} for details
-         */
-        @Getter
-        @Setter
-        private ConvolutionMode cm = ConvolutionMode.Same;
-
-        /**
-         * If true (default is false) the layer will have a bias
-         */
-        @Getter
-        @Setter
-        private boolean hasBias = true;
 
         /**
          * @param nIn Number of inputs to the layer (input size)

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LocallyConnected2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -59,7 +56,7 @@ public class LossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.LossLayer ret = new org.deeplearning4j.nn.layers.LossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -78,11 +75,10 @@ public class LossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, 0, 0, 0)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, 0, 0, 0)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
@@ -37,10 +37,10 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * LossLayer is a flexible output layer that performs a loss function on an input without MLP logic.<br>
- * LossLayer is similar to {@link OutputLayer} in that both perform loss calculations for network outputs vs. labels,
- * but LossLayer does not have any parameters. Consequently, setting nIn/nOut isn't supported - the output size
- * is the same size as the input activations.
+ * LossLayer is a flexible output layer that performs a loss function on an input without MLP logic.<br> LossLayer is
+ * similar to {@link OutputLayer} in that both perform loss calculations for network outputs vs. labels, but LossLayer
+ * does not have any parameters. Consequently, setting nIn/nOut isn't supported - the output size is the same size as
+ * the input activations.
  *
  * @author Justin Long (crockpotveggies)
  */
@@ -49,6 +49,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class LossLayer extends FeedForwardLayer {
+
     protected ILossFunction lossFn;
 
     protected LossLayer(Builder builder) {
@@ -58,7 +59,7 @@ public class LossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.LossLayer ret = new org.deeplearning4j.nn.layers.LossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -77,10 +78,11 @@ public class LossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType).standardMemory(0, 0) //No params
-                        .workingMemory(0, 0, 0, 0)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType)
+                .standardMemory(0, 0) //No params
+                .workingMemory(0, 0, 0, 0)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/LossLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/NoParamLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/NoParamLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/NoParamLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/NoParamLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -25,7 +22,7 @@ import org.deeplearning4j.nn.params.EmptyParamInitializer;
 @NoArgsConstructor
 public abstract class NoParamLayer extends Layer {
 
-    protected NoParamLayer(Builder builder){
+    protected NoParamLayer(Builder builder) {
         super(builder);
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
@@ -34,12 +34,10 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Output layer used for training via backpropagation based on labels and a specified loss function.
- * Can be configured for both classification and regression.
- * Note that OutputLayer has parameters - it contains a fully-connected layer (effectively contains a DenseLayer)
- * internally. This allows the output size to be different to the layer input size.
+ * Output layer used for training via backpropagation based on labels and a specified loss function. Can be configured
+ * for both classification and regression. Note that OutputLayer has parameters - it contains a fully-connected layer
+ * (effectively contains a DenseLayer) internally. This allows the output size to be different to the layer input size.
  * OutputLayer is equivalent to ({@link DenseLayer} + {@link LossLayer})
- *
  */
 @Data
 @NoArgsConstructor
@@ -54,7 +52,7 @@ public class OutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("OutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.OutputLayer ret = new org.deeplearning4j.nn.layers.OutputLayer(conf);
@@ -74,7 +72,7 @@ public class OutputLayer extends BaseOutputLayer {
 
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
-        public Builder(){
+        public Builder() {
             //Set default activation function to softmax (to match default loss function MCXENT)
             this.activationFn = new ActivationSoftmax();
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -52,7 +49,7 @@ public class OutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("OutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.OutputLayer ret = new org.deeplearning4j.nn.layers.OutputLayer(conf);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/OutputLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
@@ -62,9 +62,9 @@ public class PReLULayer extends BaseLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.feedforward.PReLU ret =
-                        new org.deeplearning4j.nn.layers.feedforward.PReLU(conf);
+                new org.deeplearning4j.nn.layers.feedforward.PReLU(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -76,8 +76,9 @@ public class PReLULayer extends BaseLayer {
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        if (inputType == null)
+        if (inputType == null) {
             throw new IllegalStateException("Invalid input type: null for layer name \"" + getLayerName() + "\"");
+        }
         return inputType;
     }
 
@@ -130,31 +131,42 @@ public class PReLULayer extends BaseLayer {
         val updaterStateSize = (int) getIUpdater().stateSize(numParams);
 
         return new LayerMemoryReport.Builder(layerName, PReLULayer.class, inputType, outputType)
-                        .standardMemory(numParams, updaterStateSize)
-                        .workingMemory(0, 0, 0, 0)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
-                        .build();
+                .standardMemory(numParams, updaterStateSize)
+                .workingMemory(0, 0, 0, 0)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
+                .build();
     }
 
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<PReLULayer.Builder> {
 
+        /**
+         * Explicitly set input shape of incoming activations so that parameters can be initialized properly. This
+         * explicitly excludes the mini-batch dimension.
+         *
+         */
         @Getter
         @Setter
         private long[] inputShape = null;
+
+        /**
+         * Set the broadcasting axes of PReLU's alpha parameter.
+         *
+         * For instance, given input data of shape [mb, channels, height, width], setting axes to [2,3] will set alpha
+         * to shape [channels, 1, 1] and broadcast alpha across height and width dimensions of each channel.
+         *
+         */
         @Getter
         @Setter
         private long[] sharedAxes = null;
 
         /**
-         * Explicitly set input shape of incoming activations so that parameters
-         * can be initialized properly. This explicitly excludes the mini-batch
-         * dimension.
+         * Explicitly set input shape of incoming activations so that parameters can be initialized properly. This
+         * explicitly excludes the mini-batch dimension.
          *
          * @param shape shape of input data
-         * @return
          */
-        public Builder inputShape(long... shape){
+        public Builder inputShape(long... shape) {
             this.inputShape = shape;
             return this;
         }
@@ -162,10 +174,8 @@ public class PReLULayer extends BaseLayer {
         /**
          * Set the broadcasting axes of PReLU's alpha parameter.
          *
-         * For instance, given input data of shape
-         * [mb, channels, height, width], setting axes to [2,3] will
-         * set alpha to shape [channels, 1, 1] and broadcast alpha across
-         * height and width dimensions of each channel.
+         * For instance, given input data of shape [mb, channels, height, width], setting axes to [2,3] will set alpha
+         * to shape [channels, 1, 1] and broadcast alpha across height and width dimensions of each channel.
          *
          * @param axes shared/broadcasting axes
          * @return Builder

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -62,9 +59,8 @@ public class PReLULayer extends BaseLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        org.deeplearning4j.nn.layers.feedforward.PReLU ret =
-                new org.deeplearning4j.nn.layers.feedforward.PReLU(conf);
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        org.deeplearning4j.nn.layers.feedforward.PReLU ret = new org.deeplearning4j.nn.layers.feedforward.PReLU(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -131,10 +127,8 @@ public class PReLULayer extends BaseLayer {
         val updaterStateSize = (int) getIUpdater().stateSize(numParams);
 
         return new LayerMemoryReport.Builder(layerName, PReLULayer.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, 0, 0)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
-                .build();
+                        .standardMemory(numParams, updaterStateSize).workingMemory(0, 0, 0, 0)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS).build();
     }
 
     @NoArgsConstructor

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
@@ -132,6 +132,8 @@ public class PReLULayer extends BaseLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends FeedForwardLayer.Builder<PReLULayer.Builder> {
 
         /**
@@ -139,8 +141,6 @@ public class PReLULayer extends BaseLayer {
          * explicitly excludes the mini-batch dimension.
          *
          */
-        @Getter
-        @Setter
         private long[] inputShape = null;
 
         /**
@@ -150,8 +150,6 @@ public class PReLULayer extends BaseLayer {
          * to shape [channels, 1, 1] and broadcast alpha across height and width dimensions of each channel.
          *
          */
-        @Getter
-        @Setter
         private long[] sharedAxes = null;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
@@ -139,7 +139,11 @@ public class PReLULayer extends BaseLayer {
     @NoArgsConstructor
     public static class Builder extends FeedForwardLayer.Builder<PReLULayer.Builder> {
 
+        @Getter
+        @Setter
         private long[] inputShape = null;
+        @Getter
+        @Setter
         private long[] sharedAxes = null;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PReLULayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling1D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -31,4 +28,5 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class Pooling1D extends Subsampling1DLayer {}
+public class Pooling1D extends Subsampling1DLayer {
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling1D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -31,4 +28,5 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class Pooling2D extends SubsamplingLayer {}
+public class Pooling2D extends SubsamplingLayer {
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Pooling2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PoolingType.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PoolingType.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PoolingType.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/PoolingType.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -23,6 +20,6 @@ package org.deeplearning4j.nn.conf.layers;
  * <b>SUM</b>: Sum pooling - output is the sum of the input values<br>
  * <b>PNORM</b>: P-norm pooling<br>
  */
-public enum  PoolingType {
+public enum PoolingType {
     MAX, AVG, SUM, PNORM
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnLossLayer.java
@@ -37,13 +37,12 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Recurrent Neural Network Loss Layer.<br>
- * Handles calculation of gradients etc for various objective (loss) functions.<br>
- * Note: Unlike {@link RnnOutputLayer} this RnnLossLayer does not have any parameters - i.e., there is no time
- * distributed dense component here. Consequently, the output activations size is equal to the input size.<br>
+ * Recurrent Neural Network Loss Layer.<br> Handles calculation of gradients etc for various objective (loss)
+ * functions.<br> Note: Unlike {@link RnnOutputLayer} this RnnLossLayer does not have any parameters - i.e., there is no
+ * time distributed dense component here. Consequently, the output activations size is equal to the input size.<br>
  * Input and output activations are same as other RNN layers: 3 dimensions with shape
- * [miniBatchSize,nIn,timeSeriesLength] and [miniBatchSize,nOut,timeSeriesLength] respectively.<br>
- * Note that RnnLossLayer also has the option to configure an activation function
+ * [miniBatchSize,nIn,timeSeriesLength] and [miniBatchSize,nOut,timeSeriesLength] respectively.<br> Note that
+ * RnnLossLayer also has the option to configure an activation function
  *
  * @author Alex Black
  * @see RnnOutputLayer
@@ -63,9 +62,9 @@ public class RnnLossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.recurrent.RnnLossLayer ret =
-                        new org.deeplearning4j.nn.layers.recurrent.RnnLossLayer(conf);
+                new org.deeplearning4j.nn.layers.recurrent.RnnLossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -84,7 +83,7 @@ public class RnnLossLayer extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input type for RnnLossLayer (layer index = " + layerIndex
-                            + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
+                    + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
         }
         return inputType;
     }
@@ -97,7 +96,8 @@ public class RnnLossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType).standardMemory(0, 0) //No params
+        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType)
+                .standardMemory(0, 0) //No params
                 .workingMemory(0, 0, 0, 0)
                 .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
                 .build();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnLossLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnLossLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnLossLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -62,9 +59,9 @@ public class RnnLossLayer extends FeedForwardLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         org.deeplearning4j.nn.layers.recurrent.RnnLossLayer ret =
-                new org.deeplearning4j.nn.layers.recurrent.RnnLossLayer(conf);
+                        new org.deeplearning4j.nn.layers.recurrent.RnnLossLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -83,7 +80,7 @@ public class RnnLossLayer extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input type for RnnLossLayer (layer index = " + layerIndex
-                    + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
+                            + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
         }
         return inputType;
     }
@@ -96,11 +93,10 @@ public class RnnLossLayer extends FeedForwardLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         //During inference and training: dup the input array. But, this counts as *activations* not working memory
-        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, 0, 0, 0)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, LossLayer.class, inputType, inputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, 0, 0, 0)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -57,11 +54,11 @@ public class RnnOutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("RnnOutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer ret =
-                new org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer(conf);
+                        new org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -80,7 +77,7 @@ public class RnnOutputLayer extends BaseOutputLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer index = " + layerIndex
-                    + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
+                            + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
         }
         InputType.InputTypeRecurrent itr = (InputType.InputTypeRecurrent) inputType;
 
@@ -91,7 +88,7 @@ public class RnnOutputLayer extends BaseOutputLayer {
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer name=\"" + getLayerName()
-                    + "\"): Expected RNN input, got " + inputType);
+                            + "\"): Expected RNN input, got " + inputType);
         }
 
         if (nIn <= 0 || override) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -38,7 +38,7 @@ import java.util.Map;
 /**
  * A version of {@link OutputLayer} for recurrent neural networks. Expects inputs of size [minibatch,nIn,sequenceLength]
  * and labels of shape [minibatch,nOut,sequenceLength]. It also supports mask arrays.
- *<br>
+ * <br>
  * Note that RnnOutputLayer can also be used for 1D CNN layers, which also have [minibatch,nOut,sequenceLength]
  * activations/labels shape.
  *
@@ -57,11 +57,11 @@ public class RnnOutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("RnnOutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer ret =
-                        new org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer(conf);
+                new org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -80,7 +80,7 @@ public class RnnOutputLayer extends BaseOutputLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer index = " + layerIndex
-                            + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
+                    + ", layer name=\"" + getLayerName() + "\"): Expected RNN input, got " + inputType);
         }
         InputType.InputTypeRecurrent itr = (InputType.InputTypeRecurrent) inputType;
 
@@ -91,7 +91,7 @@ public class RnnOutputLayer extends BaseOutputLayer {
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input type for RnnOutputLayer (layer name=\"" + getLayerName()
-                            + "\"): Expected RNN input, got " + inputType);
+                    + "\"): Expected RNN input, got " + inputType);
         }
 
         if (nIn <= 0 || override) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/RnnOutputLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.api.layers.LayerConstraint;
@@ -186,6 +183,8 @@ public class SeparableConvolution2D extends ConvolutionLayer {
 
     public static class Builder extends BaseConvBuilder<Builder> {
 
+        @Getter
+        @Setter
         public int depthMultiplier = 1;
 
         public Builder(int[] kernelSize, int[] stride, int[] padding) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
@@ -33,20 +33,18 @@ import java.util.*;
 /**
  * 2D Separable convolution layer configuration.
  *
- * Separable convolutions split a regular convolution operation into two
- * simpler operations, which are usually computationally more efficient.
+ * Separable convolutions split a regular convolution operation into two simpler operations, which are usually
+ * computationally more efficient.
  *
- * The first step in a separable convolution is a channels-wise convolution, which
- * operates on each of the input maps separately. A channels multiplier is used to
- * specify the number of outputs per input map in this step. This convolution
- * is carried out with the specified kernel sizes, stride and padding values.
+ * The first step in a separable convolution is a channels-wise convolution, which operates on each of the input maps
+ * separately. A channels multiplier is used to specify the number of outputs per input map in this step. This
+ * convolution is carried out with the specified kernel sizes, stride and padding values.
  *
- * The second step is a point-wise operation, in which the intermediary outputs
- * of the channels-wise convolution are mapped to the desired number of feature
- * maps, by using a 1x1 convolution.
+ * The second step is a point-wise operation, in which the intermediary outputs of the channels-wise convolution are
+ * mapped to the desired number of feature maps, by using a 1x1 convolution.
  *
- * The result of chaining these two operations will result in a tensor of the
- * same shape as that for a standard conv2d operation.
+ * The result of chaining these two operations will result in a tensor of the same shape as that for a standard conv2d
+ * operation.
  *
  * @author Max Pumperla
  */
@@ -59,11 +57,9 @@ public class SeparableConvolution2D extends ConvolutionLayer {
     int depthMultiplier;
 
     /**
-     * SeparableConvolution2D layer
-     * nIn in the input layer is the number of channels
-     * nOut is the number of filters to be used in the net or in other words the channels
-     * The builder specifies the filter/kernel size, the stride and padding
-     * The pooling layer takes the kernel size
+     * SeparableConvolution2D layer nIn in the input layer is the number of channels nOut is the number of filters to be
+     * used in the net or in other words the channels The builder specifies the filter/kernel size, the stride and
+     * padding The pooling layer takes the kernel size
      */
     protected SeparableConvolution2D(Builder builder) {
         super(builder);
@@ -71,14 +67,17 @@ public class SeparableConvolution2D extends ConvolutionLayer {
         this.depthMultiplier = builder.depthMultiplier;
         this.convolutionMode = builder.convolutionMode;
         this.dilation = builder.dilation;
-        if (builder.kernelSize.length != 2)
+        if (builder.kernelSize.length != 2) {
             throw new IllegalArgumentException("Kernel size of should be rows x columns (a 2d array)");
+        }
         this.kernelSize = builder.kernelSize;
-        if (builder.stride.length != 2)
+        if (builder.stride.length != 2) {
             throw new IllegalArgumentException("Stride should include stride for rows and columns (a 2d array)");
+        }
         this.stride = builder.stride;
-        if (builder.padding.length != 2)
+        if (builder.padding.length != 2) {
             throw new IllegalArgumentException("Padding should include padding for rows and columns (a 2d array)");
+        }
         this.padding = builder.padding;
         this.cudnnAlgoMode = builder.cudnnAlgoMode;
         this.cudnnFwdAlgo = builder.cudnnFwdAlgo;
@@ -89,33 +88,37 @@ public class SeparableConvolution2D extends ConvolutionLayer {
     }
 
     @Override
-    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder){
+    protected void initializeConstraints(org.deeplearning4j.nn.conf.layers.Layer.Builder<?> builder) {
         super.initializeConstraints(builder);
-        if(((Builder)builder).pointWiseConstraints != null){
-            if(constraints == null){
+        if (((Builder) builder).pointWiseConstraints != null) {
+            if (constraints == null) {
                 constraints = new ArrayList<>();
             }
             for (LayerConstraint constraint : ((Builder) builder).pointWiseConstraints) {
                 LayerConstraint clonedConstraint = constraint.clone();
-                clonedConstraint.setParams(Collections.singleton(SeparableConvolutionParamInitializer.POINT_WISE_WEIGHT_KEY));
+                clonedConstraint
+                        .setParams(Collections.singleton(SeparableConvolutionParamInitializer.POINT_WISE_WEIGHT_KEY));
                 constraints.add(clonedConstraint);
             }
         }
     }
 
-    public boolean hasBias(){
+    public boolean hasBias() {
         return hasBias;
     }
 
     @Override
     public SeparableConvolution2D clone() {
         SeparableConvolution2D clone = (SeparableConvolution2D) super.clone();
-        if (clone.kernelSize != null)
+        if (clone.kernelSize != null) {
             clone.kernelSize = clone.kernelSize.clone();
-        if (clone.stride != null)
+        }
+        if (clone.stride != null) {
             clone.stride = clone.stride.clone();
-        if (clone.padding != null)
+        }
+        if (clone.padding != null) {
             clone.padding = clone.padding.clone();
+        }
         return clone;
     }
 
@@ -149,7 +152,7 @@ public class SeparableConvolution2D extends ConvolutionLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("SeparableConvolution2D", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.convolution.SeparableConvolution2DLayer ret =
@@ -183,6 +186,10 @@ public class SeparableConvolution2D extends ConvolutionLayer {
 
     public static class Builder extends BaseConvBuilder<Builder> {
 
+        /**
+         * Set channels multiplier of channels-wise step in separable convolution
+         *
+         */
         @Getter
         @Setter
         public int depthMultiplier = 1;
@@ -206,11 +213,11 @@ public class SeparableConvolution2D extends ConvolutionLayer {
         /**
          * Set channels multiplier of channels-wise step in separable convolution
          *
-         * @param depthMultiplier integer value, for each input map we get depthMultipler
-         *                        outputs in channels-wise step.
+         * @param depthMultiplier integer value, for each input map we get depthMultipler outputs in channels-wise
+         * step.
          * @return Builder
          */
-        public  Builder depthMultiplier(int depthMultiplier) {
+        public Builder depthMultiplier(int depthMultiplier) {
             this.depthMultiplier = depthMultiplier;
             return this;
         }
@@ -218,10 +225,10 @@ public class SeparableConvolution2D extends ConvolutionLayer {
         protected List<LayerConstraint> pointWiseConstraints;
 
         /**
-         * Set constraints to be applied to the point-wise convolution weight parameters of this layer.
-         * Default: no constraints.<br>
-         * Constraints can be used to enforce certain conditions (non-negativity of parameters, max-norm regularization,
-         * etc). These constraints are applied at each iteration, after the parameters have been updated.
+         * Set constraints to be applied to the point-wise convolution weight parameters of this layer. Default: no
+         * constraints.<br> Constraints can be used to enforce certain conditions (non-negativity of parameters,
+         * max-norm regularization, etc). These constraints are applied at each iteration, after the parameters have
+         * been updated.
          *
          * @param constraints Constraints to apply to the point-wise convolution parameters of this layer
          */
@@ -232,6 +239,7 @@ public class SeparableConvolution2D extends ConvolutionLayer {
 
         /**
          * Size of the convolution rows/columns (height/width)
+         *
          * @param kernelSize the height and width of the kernel
          */
         public Builder kernelSize(int... kernelSize) {
@@ -241,6 +249,7 @@ public class SeparableConvolution2D extends ConvolutionLayer {
 
         /**
          * Stride of the convolution rows/columns (height/width)
+         *
          * @param stride the stride of the kernel (in h/w dimensions)
          */
         public Builder stride(int... stride) {
@@ -250,6 +259,7 @@ public class SeparableConvolution2D extends ConvolutionLayer {
 
         /**
          * Padding - rows/columns (height/width)
+         *
          * @param padding the padding in h/w dimensions
          */
         public Builder padding(int... padding) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
@@ -181,14 +181,14 @@ public class SeparableConvolution2D extends ConvolutionLayer {
     }
 
 
+    @Getter
+    @Setter
     public static class Builder extends BaseConvBuilder<Builder> {
 
         /**
          * Set channels multiplier of channels-wise step in separable convolution
          *
          */
-        @Getter
-        @Setter
         public int depthMultiplier = 1;
 
         public Builder(int[] kernelSize, int[] stride, int[] padding) {
@@ -225,8 +225,6 @@ public class SeparableConvolution2D extends ConvolutionLayer {
          * max-norm regularization, etc). These constraints are applied at each iteration, after the parameters have
          * been updated.
          */
-        @Getter
-        @Setter
         protected List<LayerConstraint> pointWiseConstraints;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -96,8 +93,8 @@ public class SeparableConvolution2D extends ConvolutionLayer {
             }
             for (LayerConstraint constraint : ((Builder) builder).pointWiseConstraints) {
                 LayerConstraint clonedConstraint = constraint.clone();
-                clonedConstraint
-                        .setParams(Collections.singleton(SeparableConvolutionParamInitializer.POINT_WISE_WEIGHT_KEY));
+                clonedConstraint.setParams(
+                                Collections.singleton(SeparableConvolutionParamInitializer.POINT_WISE_WEIGHT_KEY));
                 constraints.add(clonedConstraint);
             }
         }
@@ -152,11 +149,11 @@ public class SeparableConvolution2D extends ConvolutionLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("SeparableConvolution2D", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.convolution.SeparableConvolution2DLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.SeparableConvolution2DLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.SeparableConvolution2DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -176,11 +173,11 @@ public class SeparableConvolution2D extends ConvolutionLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for Convolution layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
 
-        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation,
-                convolutionMode, nOut, layerIndex, getLayerName(), SeparableConvolution2DLayer.class);
+        return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation, convolutionMode,
+                        nOut, layerIndex, getLayerName(), SeparableConvolution2DLayer.class);
     }
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
@@ -219,6 +219,14 @@ public class SeparableConvolution2D extends ConvolutionLayer {
             return this;
         }
 
+        /**
+         * Set constraints to be applied to the point-wise convolution weight parameters of this layer. Default: no
+         * constraints.<br> Constraints can be used to enforce certain conditions (non-negativity of parameters,
+         * max-norm regularization, etc). These constraints are applied at each iteration, after the parameters have
+         * been updated.
+         */
+        @Getter
+        @Setter
         protected List<LayerConstraint> pointWiseConstraints;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SeparableConvolution2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -79,11 +76,10 @@ public class SpaceToBatchLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.SpaceToBatch ret =
-                new org.deeplearning4j.nn.layers.convolution.SpaceToBatch(conf);
+                        new org.deeplearning4j.nn.layers.convolution.SpaceToBatch(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -99,23 +95,20 @@ public class SpaceToBatchLayer extends NoParamLayer {
         InputType.InputTypeConvolutional outputType = (InputType.InputTypeConvolutional) getOutputType(-1, inputType);
 
         return new LayerMemoryReport.Builder(layerName, SpaceToBatchLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for Subsampling layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
         InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional) inputType;
-        return InputType.convolutional(
-                (i.getHeight() + padding[0][0] + padding[0][1]) / blocks[0],
-                (i.getWidth() + padding[1][0] + padding[1][1]) / blocks[1],
-                i.getChannels()
-        );
+        return InputType.convolutional((i.getHeight() + padding[0][0] + padding[0][1]) / blocks[0],
+                        (i.getWidth() + padding[1][0] + padding[1][1]) / blocks[1], i.getChannels());
     }
 
     @Override
@@ -133,7 +126,7 @@ public class SpaceToBatchLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for space to batch layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
@@ -186,7 +179,8 @@ public class SpaceToBatchLayer extends NoParamLayer {
          */
         public void setPadding(int[][] padding) {
             Preconditions.checkArgument(padding.length == 2 && padding[0].length == 2 && padding[1].length == 2,
-                    "Padding must be a 2d array of shape [[padTop, padBottom], [padLeft, padRight]] - got %s", padding);
+                            "Padding must be a 2d array of shape [[padTop, padBottom], [padLeft, padRight]] - got %s",
+                            padding);
             this.padding = padding;
         }
 
@@ -197,7 +191,7 @@ public class SpaceToBatchLayer extends NoParamLayer {
          */
         public Builder(int[] blocks) {
             this.blocks = blocks;
-            this.padding = new int[][]{{0, 0}, {0, 0}};
+            this.padding = new int[][] {{0, 0}, {0, 0}};
         }
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
@@ -16,10 +16,8 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import com.google.common.base.Preconditions;
+import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -160,8 +158,23 @@ public class SpaceToBatchLayer extends NoParamLayer {
 
     @NoArgsConstructor
     public static class Builder<T extends Builder<T>> extends Layer.Builder<T>{
+        @Getter
         protected int[] blocks;
+
+        public void setBlocks(int[] blocks) {
+            Preconditions.checkArgument(blocks.length == 2, "Must have 2 block values - got %s", blocks);
+            this.blocks = blocks;
+        }
+
+        @Getter
         protected int[][] padding;
+
+        public void setPadding(int[][] padding) {
+            Preconditions.checkArgument(padding.length == 2 && padding[0].length == 2 && padding[1].length == 2, "Padding must be a 2d array of shape [[padTop, padBottom], [padLeft, padRight]] - got %s", padding);
+            this.padding = padding;
+        }
+
+
 
         /**
          * @param blocks Block size for SpaceToBatch layer. Should be a length 2 array for the height and width dimensions

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
@@ -34,9 +34,9 @@ import java.util.Map;
 /**
  * Space to batch utility layer configuration for convolutional input types.
  * <p>
- * Does a 2-dimensional space to batch operation, i.e. ransforms data from a tensor from 2 spatial dimensions
- * into batch dimension according to the "blocks" specified (a vector of length 2). Afterwards the spatial
- * dimensions are optionally padded, as specified in "padding", a tensor of dim (2, 2), denoting the padding range.
+ * Does a 2-dimensional space to batch operation, i.e. ransforms data from a tensor from 2 spatial dimensions into batch
+ * dimension according to the "blocks" specified (a vector of length 2). Afterwards the spatial dimensions are
+ * optionally padded, as specified in "padding", a tensor of dim (2, 2), denoting the padding range.
  * <p>
  * Example:
  * <pre>
@@ -79,9 +79,9 @@ public class SpaceToBatchLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.SpaceToBatch ret =
                 new org.deeplearning4j.nn.layers.convolution.SpaceToBatch(conf);
         ret.setListeners(trainingListeners);
@@ -113,7 +113,7 @@ public class SpaceToBatchLayer extends NoParamLayer {
         InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional) inputType;
         return InputType.convolutional(
                 (i.getHeight() + padding[0][0] + padding[0][1]) / blocks[0],
-                (i.getWidth()+ padding[1][0] + padding[1][1]) / blocks[1],
+                (i.getWidth() + padding[1][0] + padding[1][1]) / blocks[1],
                 i.getChannels()
         );
     }
@@ -157,27 +157,43 @@ public class SpaceToBatchLayer extends NoParamLayer {
 
 
     @NoArgsConstructor
-    public static class Builder<T extends Builder<T>> extends Layer.Builder<T>{
+    public static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
+
+        /**
+         * Block size for SpaceToBatch layer. Should be a length 2 array for the height and width
+         * dimensions
+         */
         @Getter
         protected int[] blocks;
 
+        /**
+         * @param blocks Block size for SpaceToBatch layer. Should be a length 2 array for the height and width
+         * dimensions
+         */
         public void setBlocks(int[] blocks) {
             Preconditions.checkArgument(blocks.length == 2, "Must have 2 block values - got %s", blocks);
             this.blocks = blocks;
         }
 
+        /**
+         * A 2d array, with format [[padTop, padBottom], [padLeft, padRight]]
+         */
         @Getter
         protected int[][] padding;
 
+        /**
+         * @param padding Padding - should be a 2d array, with format [[padTop, padBottom], [padLeft, padRight]]
+         */
         public void setPadding(int[][] padding) {
-            Preconditions.checkArgument(padding.length == 2 && padding[0].length == 2 && padding[1].length == 2, "Padding must be a 2d array of shape [[padTop, padBottom], [padLeft, padRight]] - got %s", padding);
+            Preconditions.checkArgument(padding.length == 2 && padding[0].length == 2 && padding[1].length == 2,
+                    "Padding must be a 2d array of shape [[padTop, padBottom], [padLeft, padRight]] - got %s", padding);
             this.padding = padding;
         }
 
 
-
         /**
-         * @param blocks Block size for SpaceToBatch layer. Should be a length 2 array for the height and width dimensions
+         * @param blocks Block size for SpaceToBatch layer. Should be a length 2 array for the height and width
+         * dimensions
          */
         public Builder(int[] blocks) {
             this.blocks = blocks;
@@ -185,7 +201,8 @@ public class SpaceToBatchLayer extends NoParamLayer {
         }
 
         /**
-         * @param blocks  Block size for SpaceToBatch layer. Should be a length 2 array for the height and width dimensions
+         * @param blocks Block size for SpaceToBatch layer. Should be a length 2 array for the height and width
+         * dimensions
          * @param padding Padding - should be a 2d array, with format [[padTop, padBottom], [padLeft, padRight]]
          */
         public Builder(int[] blocks, int[][] padding) {
@@ -194,7 +211,8 @@ public class SpaceToBatchLayer extends NoParamLayer {
         }
 
         /**
-         * @param blocks  Block size for SpaceToBatch layer. Should be a length 2 array for the height and width dimensions
+         * @param blocks Block size for SpaceToBatch layer. Should be a length 2 array for the height and width
+         * dimensions
          */
         public T blocks(int[] blocks) {
             this.blocks = blocks;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
@@ -150,14 +150,20 @@ public class SpaceToBatchLayer extends NoParamLayer {
 
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
 
         /**
          * Block size for SpaceToBatch layer. Should be a length 2 array for the height and width
          * dimensions
          */
-        @Getter
         protected int[] blocks;
+
+        /**
+         * A 2d array, with format [[padTop, padBottom], [padLeft, padRight]]
+         */
+        protected int[][] padding;
 
         /**
          * @param blocks Block size for SpaceToBatch layer. Should be a length 2 array for the height and width
@@ -167,12 +173,6 @@ public class SpaceToBatchLayer extends NoParamLayer {
             Preconditions.checkArgument(blocks.length == 2, "Must have 2 block values - got %s", blocks);
             this.blocks = blocks;
         }
-
-        /**
-         * A 2d array, with format [[padTop, padBottom], [padLeft, padRight]]
-         */
-        @Getter
-        protected int[][] padding;
 
         /**
          * @param padding Padding - should be a 2d array, with format [[padTop, padBottom], [padLeft, padRight]]

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToBatchLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
@@ -147,17 +147,15 @@ public class SpaceToDepthLayer extends NoParamLayer {
 
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
 
-        @Getter
-        @Setter
         protected int blockSize;
 
         /**
          * Data format for input activations. Note DL4J uses NCHW in most cases
          */
-        @Getter
-        @Setter
         protected DataFormat dataFormat = DataFormat.NCHW;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -158,7 +155,11 @@ public class SpaceToDepthLayer extends NoParamLayer {
 
     @NoArgsConstructor
     public static class Builder<T extends Builder<T>> extends Layer.Builder<T>{
+        @Getter
+        @Setter
         protected int blockSize;
+        @Getter
+        @Setter
         protected DataFormat dataFormat = DataFormat.NCHW;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -76,11 +73,10 @@ public class SpaceToDepthLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.SpaceToDepth ret =
-                new org.deeplearning4j.nn.layers.convolution.SpaceToDepth(conf);
+                        new org.deeplearning4j.nn.layers.convolution.SpaceToDepth(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -96,21 +92,20 @@ public class SpaceToDepthLayer extends NoParamLayer {
         InputType.InputTypeConvolutional outputType = (InputType.InputTypeConvolutional) getOutputType(-1, inputType);
 
         return new LayerMemoryReport.Builder(layerName, SpaceToDepthLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for space to channels layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
         InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional) inputType;
-        return InputType.convolutional(
-                i.getHeight() / blockSize, i.getWidth() / blockSize, i.getChannels() * blockSize * blockSize
-        );
+        return InputType.convolutional(i.getHeight() / blockSize, i.getWidth() / blockSize,
+                        i.getChannels() * blockSize * blockSize);
     }
 
     @Override
@@ -128,7 +123,7 @@ public class SpaceToDepthLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for space to channels layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
@@ -33,11 +33,10 @@ import java.util.Map;
 /**
  * Space to channels utility layer configuration for convolutional input types.
  * <p>
- * This operation takes 4D array in, in either NCHW or NHWC format, and moves data from spatial dimensions (HW)
- * to channels (C) for given blockSize.<br>
- * The idea is that blocks of the input of size [blockSize,blockSize] are moved from the spatial dimension
- * to the depth dimension.<br>
- * Thus, for NCHW input format, input shape {@code [mb, inChannels, H, W]}, output has shape {@code [mb, inChannels * blockSize * blockSize, H/blockSize, W/blockSize]}
+ * This operation takes 4D array in, in either NCHW or NHWC format, and moves data from spatial dimensions (HW) to
+ * channels (C) for given blockSize.<br> The idea is that blocks of the input of size [blockSize,blockSize] are moved
+ * from the spatial dimension to the depth dimension.<br> Thus, for NCHW input format, input shape {@code [mb,
+ * inChannels, H, W]}, output has shape {@code [mb, inChannels * blockSize * blockSize, H/blockSize, W/blockSize]}
  * <p></p>
  * Example:
  * <pre>
@@ -46,7 +45,6 @@ import java.util.Map;
  * input shape =  [128, 16, 16, 3]
  * output shape = [128, 16/4, 16/4, 3*4*4]
  * </pre>
- *
  *
  * @author Max Pumperla
  */
@@ -78,9 +76,9 @@ public class SpaceToDepthLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.SpaceToDepth ret =
                 new org.deeplearning4j.nn.layers.convolution.SpaceToDepth(conf);
         ret.setListeners(trainingListeners);
@@ -154,10 +152,15 @@ public class SpaceToDepthLayer extends NoParamLayer {
 
 
     @NoArgsConstructor
-    public static class Builder<T extends Builder<T>> extends Layer.Builder<T>{
+    public static class Builder<T extends Builder<T>> extends Layer.Builder<T> {
+
         @Getter
         @Setter
         protected int blockSize;
+
+        /**
+         * Data format for input activations. Note DL4J uses NCHW in most cases
+         */
         @Getter
         @Setter
         protected DataFormat dataFormat = DataFormat.NCHW;
@@ -170,7 +173,7 @@ public class SpaceToDepthLayer extends NoParamLayer {
         }
 
         /**
-         * @param blockSize  Block size
+         * @param blockSize Block size
          * @param dataFormat Data format for input activations. Note DL4J uses NCHW in most cases
          */
         public Builder(int blockSize, DataFormat dataFormat) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SpaceToDepthLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
+import com.google.common.base.Preconditions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -211,6 +212,24 @@ public class Subsampling1DLayer extends SubsamplingLayer {
         public Subsampling1DLayer.Builder padding(int padding) {
             this.padding[0] = padding;
             return this;
+        }
+
+        @Override
+        public void setKernelSize(int[] kernelSize) {
+            Preconditions.checkArgument(kernelSize.length == 1, "Must have 1 kernelSize value - got %s", kernelSize);
+            super.setKernelSize(kernelSize);
+        }
+
+        @Override
+        public void setStride(int[] stride) {
+            Preconditions.checkArgument(stride.length == 1, "Must have 1 stride value - got %s", stride);
+            super.setStride(stride);
+        }
+
+        @Override
+        public void setPadding(int[] padding) {
+            Preconditions.checkArgument(kernelSize.length == 1, "Must have 1 padding value - got %s", padding);
+            super.setPadding(padding);
         }
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
@@ -33,8 +33,8 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * 1D (temporal) subsampling layer - also known as pooling layer.<br>
- * Expects input of shape {@code [minibatch, nIn, sequenceLength]}. This layer accepts RNN InputTypes instead of CNN InputTypes.<br>
+ * 1D (temporal) subsampling layer - also known as pooling layer.<br> Expects input of shape {@code [minibatch, nIn,
+ * sequenceLength]}. This layer accepts RNN InputTypes instead of CNN InputTypes.<br>
  *
  * Supports the following pooling types: MAX, AVG, SUM, PNORM
  *
@@ -60,8 +60,8 @@ public class Subsampling1DLayer extends SubsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer ret =
                 new org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer(conf);
         ret.setListeners(trainingListeners);
@@ -79,14 +79,16 @@ public class Subsampling1DLayer extends SubsamplingLayer {
             throw new IllegalStateException("Invalid input for Subsampling1D layer (layer name=\"" + getLayerName()
                     + "\"): Expected RNN input, got " + inputType);
         }
-        InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent)inputType;
+        InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent) inputType;
         long inputTsLength = r.getTimeSeriesLength();
         int outLength;
-        if(inputTsLength < 0){
+        if (inputTsLength < 0) {
             //Probably: user did InputType.recurrent(x) without specifying sequence length
             outLength = -1;
         } else {
-            outLength = Convolution1DUtils.getOutputSize((int)inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode, dilation[0]);
+            outLength = Convolution1DUtils
+                    .getOutputSize((int) inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode,
+                            dilation[0]);
         }
         return InputType.recurrent(r.getSize(), outLength);
     }
@@ -110,18 +112,23 @@ public class Subsampling1DLayer extends SubsamplingLayer {
     public Subsampling1DLayer clone() {
         Subsampling1DLayer clone = (Subsampling1DLayer) super.clone();
 
-        if (clone.kernelSize != null)
+        if (clone.kernelSize != null) {
             clone.kernelSize = clone.kernelSize.clone();
-        if (clone.stride != null)
+        }
+        if (clone.stride != null) {
             clone.stride = clone.stride.clone();
-        if (clone.padding != null)
+        }
+        if (clone.padding != null) {
             clone.padding = clone.padding.clone();
-        if (clone.dilation != null)
+        }
+        if (clone.dilation != null) {
             clone.dilation = clone.dilation.clone();
+        }
         return clone;
     }
 
     public static class Builder extends SubsamplingLayer.BaseSubsamplingBuilder<Builder> {
+
         private static final org.deeplearning4j.nn.conf.layers.PoolingType DEFAULT_POOLING =
                 org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
         private static final int DEFAULT_KERNEL = 2;
@@ -165,7 +172,7 @@ public class Subsampling1DLayer extends SubsamplingLayer {
         }
 
         public Builder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int kernelSize, int stride,
-                       int padding) {
+                int padding) {
             super(poolingType, new int[]{kernelSize, 1}, new int[]{stride, 1}, new int[]{padding, 0});
         }
 
@@ -175,9 +182,10 @@ public class Subsampling1DLayer extends SubsamplingLayer {
 
         @SuppressWarnings("unchecked")
         public Subsampling1DLayer build() {
-            if (poolingType == org.deeplearning4j.nn.conf.layers.PoolingType.PNORM && pnorm <= 0)
+            if (poolingType == org.deeplearning4j.nn.conf.layers.PoolingType.PNORM && pnorm <= 0) {
                 throw new IllegalStateException(
                         "Incorrect Subsampling config: p-norm must be set when using PoolingType.PNORM");
+            }
             ConvolutionUtils.validateConvolutionModePadding(convolutionMode, padding);
             ConvolutionUtils.validateCnnKernelStridePadding(kernelSize, stride, padding);
 
@@ -214,18 +222,33 @@ public class Subsampling1DLayer extends SubsamplingLayer {
             return this;
         }
 
+        /**
+         * Kernel size
+         *
+         * @param kernelSize kernel size
+         */
         @Override
         public void setKernelSize(int[] kernelSize) {
             Preconditions.checkArgument(kernelSize.length == 1, "Must have 1 kernelSize value - got %s", kernelSize);
             super.setKernelSize(kernelSize);
         }
 
+        /**
+         * Stride
+         *
+         * @param stride stride value
+         */
         @Override
         public void setStride(int[] stride) {
             Preconditions.checkArgument(stride.length == 1, "Must have 1 stride value - got %s", stride);
             super.setStride(stride);
         }
 
+        /**
+         * Padding
+         *
+         * @param padding padding value
+         */
         @Override
         public void setPadding(int[] padding) {
             Preconditions.checkArgument(kernelSize.length == 1, "Must have 1 padding value - got %s", padding);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -60,10 +57,10 @@ public class Subsampling1DLayer extends SubsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -77,7 +74,7 @@ public class Subsampling1DLayer extends SubsamplingLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for Subsampling1D layer (layer name=\"" + getLayerName()
-                    + "\"): Expected RNN input, got " + inputType);
+                            + "\"): Expected RNN input, got " + inputType);
         }
         InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent) inputType;
         long inputTsLength = r.getTimeSeriesLength();
@@ -86,9 +83,8 @@ public class Subsampling1DLayer extends SubsamplingLayer {
             //Probably: user did InputType.recurrent(x) without specifying sequence length
             outLength = -1;
         } else {
-            outLength = Convolution1DUtils
-                    .getOutputSize((int) inputTsLength, kernelSize[0], stride[0], padding[0], convolutionMode,
-                            dilation[0]);
+            outLength = Convolution1DUtils.getOutputSize((int) inputTsLength, kernelSize[0], stride[0], padding[0],
+                            convolutionMode, dilation[0]);
         }
         return InputType.recurrent(r.getSize(), outLength);
     }
@@ -102,7 +98,7 @@ public class Subsampling1DLayer extends SubsamplingLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Subsampling1D layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreprocessorForInputTypeRnnLayers(inputType, getLayerName());
@@ -130,7 +126,7 @@ public class Subsampling1DLayer extends SubsamplingLayer {
     public static class Builder extends SubsamplingLayer.BaseSubsamplingBuilder<Builder> {
 
         private static final org.deeplearning4j.nn.conf.layers.PoolingType DEFAULT_POOLING =
-                org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
+                        org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
         private static final int DEFAULT_KERNEL = 2;
         private static final int DEFAULT_STRIDE = 1;
         private static final int DEFAULT_PADDING = 0;
@@ -172,19 +168,19 @@ public class Subsampling1DLayer extends SubsamplingLayer {
         }
 
         public Builder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int kernelSize, int stride,
-                int padding) {
-            super(poolingType, new int[]{kernelSize, 1}, new int[]{stride, 1}, new int[]{padding, 0});
+                        int padding) {
+            super(poolingType, new int[] {kernelSize, 1}, new int[] {stride, 1}, new int[] {padding, 0});
         }
 
         public Builder(PoolingType poolingType, int kernelSize, int stride, int padding) {
-            super(poolingType, new int[]{kernelSize, 1}, new int[]{stride, 1}, new int[]{padding, 0});
+            super(poolingType, new int[] {kernelSize, 1}, new int[] {stride, 1}, new int[] {padding, 0});
         }
 
         @SuppressWarnings("unchecked")
         public Subsampling1DLayer build() {
             if (poolingType == org.deeplearning4j.nn.conf.layers.PoolingType.PNORM && pnorm <= 0) {
                 throw new IllegalStateException(
-                        "Incorrect Subsampling config: p-norm must be set when using PoolingType.PNORM");
+                                "Incorrect Subsampling config: p-norm must be set when using PoolingType.PNORM");
             }
             ConvolutionUtils.validateConvolutionModePadding(convolutionMode, padding);
             ConvolutionUtils.validateCnnKernelStridePadding(kernelSize, stride, padding);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
+import com.google.common.base.Preconditions;
 import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
@@ -198,6 +199,8 @@ public class Subsampling3DLayer extends NoParamLayer {
     @NoArgsConstructor
     public static class Builder extends BaseSubsamplingBuilder<Builder> {
 
+        @Getter
+        @Setter
         protected Convolution3D.DataFormat dataFormat = Convolution3D.DataFormat.NCDHW;
 
         public Builder(PoolingType poolingType, int[] kernelSize, int[] stride) {
@@ -296,18 +299,71 @@ public class Subsampling3DLayer extends NoParamLayer {
             Convolution3DUtils.validateCnn3DKernelStridePadding(kernelSize, stride, padding);
             return new Subsampling3DLayer(this);
         }
+
+        @Override
+        public void setKernelSize(int[] kernelSize) {
+            Preconditions.checkArgument(kernelSize.length == 1 || kernelSize.length == 3, "Must have 1 or 3 kernelSize values - got %s", kernelSize);
+
+            if(kernelSize.length == 1)
+                super.setKernelSize(new int[]{kernelSize[0], kernelSize[0], kernelSize[0]});
+            else
+                super.setKernelSize(kernelSize);
+        }
+
+        @Override
+        public void setStride(int[] stride) {
+            Preconditions.checkArgument(stride.length == 1 || stride.length == 3, "Must have 1 or 3 stride values - got %s", stride);
+
+            if(stride.length == 1)
+                super.setStride(new int[]{stride[0], stride[0], stride[0]});
+            else
+                super.setStride(stride);
+        }
+
+        @Override
+        public void setPadding(int[] padding) {
+            Preconditions.checkArgument(kernelSize.length == 1 || stride.length == 3, "Must have 1 or 3 padding values - got %s", padding);
+
+            if(padding.length == 1)
+                super.setPadding(new int[]{padding[0], padding[0], padding[0]});
+            else
+                super.setPadding(padding);
+        }
     }
 
     @NoArgsConstructor
     protected static abstract class BaseSubsamplingBuilder<T extends BaseSubsamplingBuilder<T>>
             extends Layer.Builder<T> {
+        @Getter
+        @Setter
         protected org.deeplearning4j.nn.conf.layers.PoolingType poolingType =
                 org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
+        @Getter
+        @Setter
         protected int[] kernelSize = new int[]{1, 1, 1};
+        @Getter
+        @Setter
         protected int[] stride = new int[]{2, 2, 2};
+        @Getter
+        @Setter
         protected int[] padding = new int[]{0, 0, 0};
+
+        public void setDilation(int[] dilation) {
+            Preconditions.checkArgument(dilation.length == 1 || dilation.length == 3, "Must have 1 or 3 dilation values - got %s", dilation);
+            
+            if(dilation.length == 1)
+                dilation(dilation[0], dilation[0], dilation[0]);
+            else
+                dilation(dilation[0], dilation[1], dilation[2]);
+        }
+
+        @Getter
         protected int[] dilation = new int[]{1, 1, 1};
+        @Getter
+        @Setter
         protected ConvolutionMode convolutionMode = ConvolutionMode.Same;
+        @Getter
+        @Setter
         protected boolean cudnnAllowFallback = true;
 
         protected BaseSubsamplingBuilder(PoolingType poolingType, int[] kernelSize, int[] stride) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -110,11 +107,10 @@ public class Subsampling3DLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> iterationListeners,
-            int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> iterationListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling3DLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling3DLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling3DLayer(conf);
         ret.setListeners(iterationListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -133,15 +129,13 @@ public class Subsampling3DLayer extends NoParamLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN3D) {
             throw new IllegalStateException("Invalid input for Subsampling 3D layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
 
         // FIXME: int cast
-        return InputTypeUtil.getOutputTypeCnn3DLayers(inputType, kernelSize, stride, padding,
-                new int[]{1, 1, 1}, // no dilation
-                convolutionMode,
-                (int) ((InputType.InputTypeConvolutional3D) inputType).getChannels(), layerIndex, getLayerName(),
-                Subsampling3DLayer.class);
+        return InputTypeUtil.getOutputTypeCnn3DLayers(inputType, kernelSize, stride, padding, new int[] {1, 1, 1}, // no dilation
+                        convolutionMode, (int) ((InputType.InputTypeConvolutional3D) inputType).getChannels(),
+                        layerIndex, getLayerName(), Subsampling3DLayer.class);
     }
 
     @Override
@@ -153,7 +147,7 @@ public class Subsampling3DLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Subsampling 3D layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreProcessorForInputTypeCnn3DLayers(inputType, getLayerName());
@@ -179,13 +173,12 @@ public class Subsampling3DLayer extends NoParamLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         InputType.InputTypeConvolutional3D c = (InputType.InputTypeConvolutional3D) inputType;
-        InputType.InputTypeConvolutional3D outputType = (InputType.InputTypeConvolutional3D) getOutputType(-1,
-                inputType);
+        InputType.InputTypeConvolutional3D outputType =
+                        (InputType.InputTypeConvolutional3D) getOutputType(-1, inputType);
         val actElementsPerEx = outputType.arrayElementsPerExample();
 
         //During forward pass: im2col array + reduce. Reduce is counted as activations, so only im2col is working mem
-        val im2colSizePerEx =
-                c.getChannels() * outputType.getHeight() * outputType.getWidth() * outputType.getDepth()
+        val im2colSizePerEx = c.getChannels() * outputType.getHeight() * outputType.getWidth() * outputType.getDepth()
                         * kernelSize[0] * kernelSize[1];
 
         //Current implementation does NOT cache im2col etc... which means: it's recalculated on each backward pass
@@ -196,10 +189,10 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         return new LayerMemoryReport.Builder(layerName, Subsampling3DLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @NoArgsConstructor
@@ -231,7 +224,7 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         public Builder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int[] kernelSize, int[] stride,
-                int[] padding) {
+                        int[] padding) {
             super(poolingType, kernelSize, stride, padding);
         }
 
@@ -322,10 +315,10 @@ public class Subsampling3DLayer extends NoParamLayer {
         @Override
         public void setKernelSize(int[] kernelSize) {
             Preconditions.checkArgument(kernelSize.length == 1 || kernelSize.length == 3,
-                    "Must have 1 or 3 kernelSize values - got %s", kernelSize);
+                            "Must have 1 or 3 kernelSize values - got %s", kernelSize);
 
             if (kernelSize.length == 1) {
-                super.setKernelSize(new int[]{kernelSize[0], kernelSize[0], kernelSize[0]});
+                super.setKernelSize(new int[] {kernelSize[0], kernelSize[0], kernelSize[0]});
             } else {
                 super.setKernelSize(kernelSize);
             }
@@ -338,12 +331,11 @@ public class Subsampling3DLayer extends NoParamLayer {
          */
         @Override
         public void setStride(int[] stride) {
-            Preconditions
-                    .checkArgument(stride.length == 1 || stride.length == 3, "Must have 1 or 3 stride values - got %s",
-                            stride);
+            Preconditions.checkArgument(stride.length == 1 || stride.length == 3,
+                            "Must have 1 or 3 stride values - got %s", stride);
 
             if (stride.length == 1) {
-                super.setStride(new int[]{stride[0], stride[0], stride[0]});
+                super.setStride(new int[] {stride[0], stride[0], stride[0]});
             } else {
                 super.setStride(stride);
             }
@@ -357,10 +349,10 @@ public class Subsampling3DLayer extends NoParamLayer {
         @Override
         public void setPadding(int[] padding) {
             Preconditions.checkArgument(kernelSize.length == 1 || stride.length == 3,
-                    "Must have 1 or 3 padding values - got %s", padding);
+                            "Must have 1 or 3 padding values - got %s", padding);
 
             if (padding.length == 1) {
-                super.setPadding(new int[]{padding[0], padding[0], padding[0]});
+                super.setPadding(new int[] {padding[0], padding[0], padding[0]});
             } else {
                 super.setPadding(padding);
             }
@@ -369,28 +361,28 @@ public class Subsampling3DLayer extends NoParamLayer {
 
     @NoArgsConstructor
     protected static abstract class BaseSubsamplingBuilder<T extends BaseSubsamplingBuilder<T>>
-            extends Layer.Builder<T> {
+                    extends Layer.Builder<T> {
 
         @Getter
         @Setter
         protected org.deeplearning4j.nn.conf.layers.PoolingType poolingType =
-                org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
+                        org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
 
         @Getter
         @Setter
-        protected int[] kernelSize = new int[]{1, 1, 1};
+        protected int[] kernelSize = new int[] {1, 1, 1};
 
         @Getter
         @Setter
-        protected int[] stride = new int[]{2, 2, 2};
+        protected int[] stride = new int[] {2, 2, 2};
 
         @Getter
         @Setter
-        protected int[] padding = new int[]{0, 0, 0};
+        protected int[] padding = new int[] {0, 0, 0};
 
         public void setDilation(int[] dilation) {
             Preconditions.checkArgument(dilation.length == 1 || dilation.length == 3,
-                    "Must have 1 or 3 dilation values - got %s", dilation);
+                            "Must have 1 or 3 dilation values - got %s", dilation);
 
             if (dilation.length == 1) {
                 dilation(dilation[0], dilation[0], dilation[0]);
@@ -400,7 +392,7 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         @Getter
-        protected int[] dilation = new int[]{1, 1, 1};
+        protected int[] dilation = new int[] {1, 1, 1};
 
         /**
          * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
@@ -443,7 +435,7 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         protected BaseSubsamplingBuilder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int[] kernelSize,
-                int[] stride, int[] padding) {
+                        int[] stride, int[] padding) {
             this.poolingType = poolingType;
             this.kernelSize = kernelSize;
             this.stride = stride;
@@ -489,7 +481,7 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         public T dilation(int dDepth, int dHeight, int dWidth) {
-            this.dilation = new int[]{dDepth, dHeight, dWidth};
+            this.dilation = new int[] {dDepth, dHeight, dWidth};
             return (T) this;
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
@@ -196,6 +196,8 @@ public class Subsampling3DLayer extends NoParamLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends BaseSubsamplingBuilder<Builder> {
 
         /**
@@ -203,8 +205,6 @@ public class Subsampling3DLayer extends NoParamLayer {
          * [minibatch, channels, depth, height, width]<br> NDHWC: activations (in/out) should have shape [minibatch,
          * depth, height, width, channels]<br>
          */
-        @Getter
-        @Setter
         protected Convolution3D.DataFormat dataFormat = Convolution3D.DataFormat.NCDHW;
 
         public Builder(PoolingType poolingType, int[] kernelSize, int[] stride) {
@@ -359,47 +359,24 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
     }
 
+    @Getter
+    @Setter
     @NoArgsConstructor
     protected static abstract class BaseSubsamplingBuilder<T extends BaseSubsamplingBuilder<T>>
                     extends Layer.Builder<T> {
 
-        @Getter
-        @Setter
         protected org.deeplearning4j.nn.conf.layers.PoolingType poolingType =
                         org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
 
-        @Getter
-        @Setter
         protected int[] kernelSize = new int[] {1, 1, 1};
-
-        @Getter
-        @Setter
         protected int[] stride = new int[] {2, 2, 2};
-
-        @Getter
-        @Setter
         protected int[] padding = new int[] {0, 0, 0};
-
-        public void setDilation(int[] dilation) {
-            Preconditions.checkArgument(dilation.length == 1 || dilation.length == 3,
-                            "Must have 1 or 3 dilation values - got %s", dilation);
-
-            if (dilation.length == 1) {
-                dilation(dilation[0], dilation[0], dilation[0]);
-            } else {
-                dilation(dilation[0], dilation[1], dilation[2]);
-            }
-        }
-
-        @Getter
         protected int[] dilation = new int[] {1, 1, 1};
 
         /**
          * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
          *
          */
-        @Getter
-        @Setter
         protected ConvolutionMode convolutionMode = ConvolutionMode.Same;
 
         /**
@@ -407,9 +384,18 @@ public class Subsampling3DLayer extends NoParamLayer {
          * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in
          * (non-CuDNN) implementation for ConvolutionLayer will be used
          */
-        @Getter
-        @Setter
         protected boolean cudnnAllowFallback = true;
+
+        public void setDilation(int[] dilation) {
+            Preconditions.checkArgument(dilation.length == 1 || dilation.length == 3,
+                    "Must have 1 or 3 dilation values - got %s", dilation);
+
+            if (dilation.length == 1) {
+                dilation(dilation[0], dilation[0], dilation[0]);
+            } else {
+                dilation(dilation[0], dilation[1], dilation[2]);
+            }
+        }
 
         protected BaseSubsamplingBuilder(PoolingType poolingType, int[] kernelSize, int[] stride) {
             this.poolingType = poolingType.toPoolingType();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling3DLayer.java
@@ -74,11 +74,13 @@ public class Subsampling3DLayer extends NoParamLayer {
     protected Subsampling3DLayer(Builder builder) {
         super(builder);
         this.poolingType = builder.poolingType;
-        if (builder.kernelSize.length != 3)
+        if (builder.kernelSize.length != 3) {
             throw new IllegalArgumentException("Kernel size must be length 3");
+        }
         this.kernelSize = builder.kernelSize;
-        if (builder.stride.length != 3)
+        if (builder.stride.length != 3) {
             throw new IllegalArgumentException("Invalid stride, must be length 3");
+        }
         this.stride = builder.stride;
         this.padding = builder.padding;
         this.dilation = builder.dilation;
@@ -91,22 +93,26 @@ public class Subsampling3DLayer extends NoParamLayer {
     public Subsampling3DLayer clone() {
         Subsampling3DLayer clone = (Subsampling3DLayer) super.clone();
 
-        if (clone.kernelSize != null)
+        if (clone.kernelSize != null) {
             clone.kernelSize = clone.kernelSize.clone();
-        if (clone.stride != null)
+        }
+        if (clone.stride != null) {
             clone.stride = clone.stride.clone();
-        if (clone.padding != null)
+        }
+        if (clone.padding != null) {
             clone.padding = clone.padding.clone();
-        if (clone.dilation != null)
+        }
+        if (clone.dilation != null) {
             clone.dilation = clone.dilation.clone();
+        }
         return clone;
     }
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> iterationListeners,
-                                                       int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> iterationListeners,
+            int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling3DLayer ret =
                 new org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling3DLayer(conf);
         ret.setListeners(iterationListeners);
@@ -173,9 +179,9 @@ public class Subsampling3DLayer extends NoParamLayer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         InputType.InputTypeConvolutional3D c = (InputType.InputTypeConvolutional3D) inputType;
-        InputType.InputTypeConvolutional3D outputType = (InputType.InputTypeConvolutional3D) getOutputType(-1, inputType);
+        InputType.InputTypeConvolutional3D outputType = (InputType.InputTypeConvolutional3D) getOutputType(-1,
+                inputType);
         val actElementsPerEx = outputType.arrayElementsPerExample();
-
 
         //During forward pass: im2col array + reduce. Reduce is counted as activations, so only im2col is working mem
         val im2colSizePerEx =
@@ -199,6 +205,11 @@ public class Subsampling3DLayer extends NoParamLayer {
     @NoArgsConstructor
     public static class Builder extends BaseSubsamplingBuilder<Builder> {
 
+        /**
+         * The data format for input and output activations.<br> NCDHW: activations (in/out) should have shape
+         * [minibatch, channels, depth, height, width]<br> NDHWC: activations (in/out) should have shape [minibatch,
+         * depth, height, width, channels]<br>
+         */
         @Getter
         @Setter
         protected Convolution3D.DataFormat dataFormat = Convolution3D.DataFormat.NCDHW;
@@ -220,7 +231,7 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         public Builder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int[] kernelSize, int[] stride,
-                       int[] padding) {
+                int[] padding) {
             super(poolingType, kernelSize, stride, padding);
         }
 
@@ -250,8 +261,9 @@ public class Subsampling3DLayer extends NoParamLayer {
          * @param kernelSize kernel size in height and width dimensions
          */
         public Builder kernelSize(int... kernelSize) {
-            if (kernelSize.length != 3)
+            if (kernelSize.length != 3) {
                 throw new IllegalArgumentException("Invalid input: must be length 3");
+            }
             this.kernelSize = kernelSize;
             return this;
         }
@@ -262,8 +274,9 @@ public class Subsampling3DLayer extends NoParamLayer {
          * @param stride stride in height and width dimensions
          */
         public Builder stride(int... stride) {
-            if (stride.length != 3)
+            if (stride.length != 3) {
                 throw new IllegalArgumentException("Invalid input: must be length 3");
+            }
             this.stride = stride;
             return this;
         }
@@ -274,20 +287,21 @@ public class Subsampling3DLayer extends NoParamLayer {
          * @param padding padding in the height and width dimensions
          */
         public Builder padding(int... padding) {
-            if (padding.length != 3)
+            if (padding.length != 3) {
                 throw new IllegalArgumentException("Invalid input: must be length 3");
+            }
             this.padding = padding;
             return this;
         }
 
         /**
-         * The data format for input and output activations.<br>
-         * NCDHW: activations (in/out) should have shape [minibatch, channels, depth, height, width]<br>
-         * NDHWC: activations (in/out) should have shape [minibatch, depth, height, width, channels]<br>
+         * The data format for input and output activations.<br> NCDHW: activations (in/out) should have shape
+         * [minibatch, channels, depth, height, width]<br> NDHWC: activations (in/out) should have shape [minibatch,
+         * depth, height, width, channels]<br>
          *
          * @param dataFormat Data format to use for activations
          */
-        public Builder dataFormat(Convolution3D.DataFormat dataFormat){
+        public Builder dataFormat(Convolution3D.DataFormat dataFormat) {
             this.dataFormat = dataFormat;
             return this;
         }
@@ -300,68 +314,107 @@ public class Subsampling3DLayer extends NoParamLayer {
             return new Subsampling3DLayer(this);
         }
 
+        /**
+         * Kernel size
+         *
+         * @param kernelSize kernel size in height and width dimensions
+         */
         @Override
         public void setKernelSize(int[] kernelSize) {
-            Preconditions.checkArgument(kernelSize.length == 1 || kernelSize.length == 3, "Must have 1 or 3 kernelSize values - got %s", kernelSize);
+            Preconditions.checkArgument(kernelSize.length == 1 || kernelSize.length == 3,
+                    "Must have 1 or 3 kernelSize values - got %s", kernelSize);
 
-            if(kernelSize.length == 1)
+            if (kernelSize.length == 1) {
                 super.setKernelSize(new int[]{kernelSize[0], kernelSize[0], kernelSize[0]});
-            else
+            } else {
                 super.setKernelSize(kernelSize);
+            }
         }
 
+        /**
+         * Stride
+         *
+         * @param stride stride in height and width dimensions
+         */
         @Override
         public void setStride(int[] stride) {
-            Preconditions.checkArgument(stride.length == 1 || stride.length == 3, "Must have 1 or 3 stride values - got %s", stride);
+            Preconditions
+                    .checkArgument(stride.length == 1 || stride.length == 3, "Must have 1 or 3 stride values - got %s",
+                            stride);
 
-            if(stride.length == 1)
+            if (stride.length == 1) {
                 super.setStride(new int[]{stride[0], stride[0], stride[0]});
-            else
+            } else {
                 super.setStride(stride);
+            }
         }
 
+        /**
+         * Padding
+         *
+         * @param padding padding in the height and width dimensions
+         */
         @Override
         public void setPadding(int[] padding) {
-            Preconditions.checkArgument(kernelSize.length == 1 || stride.length == 3, "Must have 1 or 3 padding values - got %s", padding);
+            Preconditions.checkArgument(kernelSize.length == 1 || stride.length == 3,
+                    "Must have 1 or 3 padding values - got %s", padding);
 
-            if(padding.length == 1)
+            if (padding.length == 1) {
                 super.setPadding(new int[]{padding[0], padding[0], padding[0]});
-            else
+            } else {
                 super.setPadding(padding);
+            }
         }
     }
 
     @NoArgsConstructor
     protected static abstract class BaseSubsamplingBuilder<T extends BaseSubsamplingBuilder<T>>
             extends Layer.Builder<T> {
+
         @Getter
         @Setter
         protected org.deeplearning4j.nn.conf.layers.PoolingType poolingType =
                 org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
+
         @Getter
         @Setter
         protected int[] kernelSize = new int[]{1, 1, 1};
+
         @Getter
         @Setter
         protected int[] stride = new int[]{2, 2, 2};
+
         @Getter
         @Setter
         protected int[] padding = new int[]{0, 0, 0};
 
         public void setDilation(int[] dilation) {
-            Preconditions.checkArgument(dilation.length == 1 || dilation.length == 3, "Must have 1 or 3 dilation values - got %s", dilation);
-            
-            if(dilation.length == 1)
+            Preconditions.checkArgument(dilation.length == 1 || dilation.length == 3,
+                    "Must have 1 or 3 dilation values - got %s", dilation);
+
+            if (dilation.length == 1) {
                 dilation(dilation[0], dilation[0], dilation[0]);
-            else
+            } else {
                 dilation(dilation[0], dilation[1], dilation[2]);
+            }
         }
 
         @Getter
         protected int[] dilation = new int[]{1, 1, 1};
+
+        /**
+         * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
+         *
+         */
         @Getter
         @Setter
         protected ConvolutionMode convolutionMode = ConvolutionMode.Same;
+
+        /**
+         * When using CuDNN and an error is encountered, should fallback to the non-CuDNN implementatation be allowed?
+         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in
+         * (non-CuDNN) implementation for ConvolutionLayer will be used
+         */
         @Getter
         @Setter
         protected boolean cudnnAllowFallback = true;
@@ -390,7 +443,7 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         protected BaseSubsamplingBuilder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int[] kernelSize,
-                                         int[] stride, int[] padding) {
+                int[] stride, int[] padding) {
             this.poolingType = poolingType;
             this.kernelSize = kernelSize;
             this.stride = stride;
@@ -421,8 +474,7 @@ public class Subsampling3DLayer extends NoParamLayer {
         }
 
         /**
-         * Set the convolution mode for the Convolution layer.
-         * See {@link ConvolutionMode} for more details
+         * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
          *
          * @param convolutionMode Convolution mode for layer
          */
@@ -436,15 +488,15 @@ public class Subsampling3DLayer extends NoParamLayer {
             return (T) this;
         }
 
-        public T dilation(int dDepth, int dHeight, int dWidth){
+        public T dilation(int dDepth, int dHeight, int dWidth) {
             this.dilation = new int[]{dDepth, dHeight, dWidth};
             return (T) this;
         }
 
         /**
          * When using CuDNN and an error is encountered, should fallback to the non-CuDNN implementatation be allowed?
-         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in (non-CuDNN)
-         * implementation for ConvolutionLayer will be used
+         * If set to false, an exception in CuDNN will be propagated back to the user. If false, the built-in
+         * (non-CuDNN) implementation for ConvolutionLayer will be used
          *
          * @param allowFallback Whether fallback to non-CuDNN implementation should be used
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
+import com.google.common.base.Preconditions;
 import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
@@ -208,6 +209,8 @@ public class SubsamplingLayer extends NoParamLayer {
     @NoArgsConstructor
     public static class Builder extends BaseSubsamplingBuilder<Builder> {
 
+        @Getter
+        @Setter
         private int[] dilation = new int[]{1,1};
 
         public Builder(PoolingType poolingType, int[] kernelSize, int[] stride) {
@@ -317,19 +320,65 @@ public class SubsamplingLayer extends NoParamLayer {
 
             return new SubsamplingLayer(this);
         }
+
+        @Override
+        public void setKernelSize(int[] kernelSize) {
+            Preconditions.checkArgument(kernelSize.length == 1 || kernelSize.length == 2, "Must have 1 or 2 kernelSize values - got %s", kernelSize);
+
+            if(kernelSize.length == 1)
+                super.setKernelSize(new int[]{kernelSize[0], kernelSize[0]});
+            else
+                super.setKernelSize(kernelSize);
+        }
+
+        @Override
+        public void setStride(int[] stride) {
+            Preconditions.checkArgument(stride.length == 1 || stride.length == 2, "Must have 1 or 2 stride values - got %s", stride);
+
+            if(stride.length == 1)
+                super.setStride(new int[]{stride[0], stride[0]});
+            else
+                super.setStride(stride);
+        }
+
+        @Override
+        public void setPadding(int[] padding) {
+            Preconditions.checkArgument(kernelSize.length == 1 || stride.length == 2, "Must have 1 or 2 padding values - got %s", padding);
+
+            if(padding.length == 1)
+                super.setPadding(new int[]{padding[0], padding[0]});
+            else
+                super.setPadding(padding);
+        }
     }
 
     @NoArgsConstructor
     protected static abstract class BaseSubsamplingBuilder<T extends BaseSubsamplingBuilder<T>>
                     extends Layer.Builder<T> {
+        @Getter
+        @Setter
         protected org.deeplearning4j.nn.conf.layers.PoolingType poolingType =
                         org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
+        @Getter
+        @Setter
         protected int[] kernelSize = new int[] {1, 1}; // Same as filter size from the last conv layer
+        @Getter
+        @Setter
         protected int[] stride = new int[] {2, 2}; // Default is 2. Down-sample by a factor of 2
+        @Getter
+        @Setter
         protected int[] padding = new int[] {0, 0};
+        @Getter
+        @Setter
         protected ConvolutionMode convolutionMode = null;
+        @Getter
+        @Setter
         protected int pnorm;
+        @Getter
+        @Setter
         protected double eps = 1e-8;
+        @Getter
+        @Setter
         protected boolean cudnnAllowFallback = true;
 
         protected BaseSubsamplingBuilder(PoolingType poolingType, int[] kernelSize, int[] stride) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -211,6 +211,8 @@ public class SubsamplingLayer extends NoParamLayer {
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends BaseSubsamplingBuilder<Builder> {
 
         /**
@@ -226,8 +228,6 @@ public class SubsamplingLayer extends NoParamLayer {
          *
          * Dilation for kernel
          */
-        @Getter
-        @Setter
         private int[] dilation = new int[] {1, 1};
 
         public Builder(PoolingType poolingType, int[] kernelSize, int[] stride) {
@@ -344,60 +344,31 @@ public class SubsamplingLayer extends NoParamLayer {
 
         @Override
         public void setKernelSize(int[] kernelSize) {
-            Preconditions.checkArgument(kernelSize.length == 1 || kernelSize.length == 2,
-                            "Must have 1 or 2 kernelSize values - got %s", kernelSize);
-
-            if (kernelSize.length == 1) {
-                super.setKernelSize(new int[] {kernelSize[0], kernelSize[0]});
-            } else {
-                super.setKernelSize(kernelSize);
-            }
+            kernelSize(kernelSize);
         }
 
         @Override
         public void setStride(int[] stride) {
-            Preconditions.checkArgument(stride.length == 1 || stride.length == 2,
-                            "Must have 1 or 2 stride values - got %s", stride);
-
-            if (stride.length == 1) {
-                super.setStride(new int[] {stride[0], stride[0]});
-            } else {
-                super.setStride(stride);
-            }
+            stride(stride);
         }
 
         @Override
         public void setPadding(int[] padding) {
-            Preconditions.checkArgument(kernelSize.length == 1 || stride.length == 2,
-                            "Must have 1 or 2 padding values - got %s", padding);
-
-            if (padding.length == 1) {
-                super.setPadding(new int[] {padding[0], padding[0]});
-            } else {
-                super.setPadding(padding);
-            }
+            padding(padding);
         }
     }
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     protected static abstract class BaseSubsamplingBuilder<T extends BaseSubsamplingBuilder<T>>
                     extends Layer.Builder<T> {
 
-        @Getter
-        @Setter
         protected org.deeplearning4j.nn.conf.layers.PoolingType poolingType =
                         org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
 
-        @Getter
-        @Setter
         protected int[] kernelSize = new int[] {1, 1}; // Same as filter size from the last conv layer
-
-        @Getter
-        @Setter
         protected int[] stride = new int[] {2, 2}; // Default is 2. Down-sample by a factor of 2
-
-        @Getter
-        @Setter
         protected int[] padding = new int[] {0, 0};
 
         /**
@@ -405,16 +376,8 @@ public class SubsamplingLayer extends NoParamLayer {
          *
          * Convolution mode for layer
          */
-        @Getter
-        @Setter
         protected ConvolutionMode convolutionMode = null;
-
-        @Getter
-        @Setter
         protected int pnorm;
-
-        @Getter
-        @Setter
         protected double eps = 1e-8;
 
         /**
@@ -424,8 +387,6 @@ public class SubsamplingLayer extends NoParamLayer {
          *
          * Whether fallback to non-CuDNN implementation should be used
          */
-        @Getter
-        @Setter
         protected boolean cudnnAllowFallback = true;
 
         protected BaseSubsamplingBuilder(PoolingType poolingType, int[] kernelSize, int[] stride) {
@@ -505,12 +466,20 @@ public class SubsamplingLayer extends NoParamLayer {
             return (T) this;
         }
 
+        public void setPnorm(int pnorm){
+            pnorm(pnorm);
+        }
+
         public T eps(double eps) {
             if (eps <= 0) {
                 throw new IllegalArgumentException("Invalid input: epsilon for p-norm must be greater than 0");
             }
             this.eps = eps;
             return (T) this;
+        }
+
+        public void setEps(double eps){
+            eps(eps);
         }
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -52,7 +49,7 @@ public class SubsamplingLayer extends NoParamLayer {
     protected int[] kernelSize; // Same as filter size from the last conv layer
     protected int[] stride; // Default is 2. Down-sample by a factor of 2
     protected int[] padding;
-    protected int[] dilation = new int[]{1, 1};
+    protected int[] dilation = new int[] {1, 1};
     protected int pnorm;
     protected double eps;
     protected boolean cudnnAllowFallback = true;
@@ -117,10 +114,10 @@ public class SubsamplingLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -139,12 +136,12 @@ public class SubsamplingLayer extends NoParamLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for Subsampling layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
 
         return InputTypeUtil.getOutputTypeCnnLayers(inputType, kernelSize, stride, padding, dilation, convolutionMode,
-                ((InputType.InputTypeConvolutional) inputType).getChannels(), layerIndex, getLayerName(),
-                SubsamplingLayer.class);
+                        ((InputType.InputTypeConvolutional) inputType).getChannels(), layerIndex, getLayerName(),
+                        SubsamplingLayer.class);
     }
 
     @Override
@@ -156,7 +153,7 @@ public class SubsamplingLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Subsampling layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
@@ -188,8 +185,8 @@ public class SubsamplingLayer extends NoParamLayer {
         //TODO Subsampling helper memory use... (CuDNN etc)
 
         //During forward pass: im2col array + reduce. Reduce is counted as activations, so only im2col is working mem
-        val im2colSizePerEx =
-                c.getChannels() * outputType.getHeight() * outputType.getWidth() * kernelSize[0] * kernelSize[1];
+        val im2colSizePerEx = c.getChannels() * outputType.getHeight() * outputType.getWidth() * kernelSize[0]
+                        * kernelSize[1];
 
         //Current implementation does NOT cache im2col etc... which means: it's recalculated on each backward pass
         long trainingWorkingSizePerEx = im2colSizePerEx;
@@ -199,10 +196,10 @@ public class SubsamplingLayer extends NoParamLayer {
         }
 
         return new LayerMemoryReport.Builder(layerName, SubsamplingLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public int getPnorm() {
@@ -231,7 +228,7 @@ public class SubsamplingLayer extends NoParamLayer {
          */
         @Getter
         @Setter
-        private int[] dilation = new int[]{1, 1};
+        private int[] dilation = new int[] {1, 1};
 
         public Builder(PoolingType poolingType, int[] kernelSize, int[] stride) {
             super(poolingType, kernelSize, stride);
@@ -250,7 +247,7 @@ public class SubsamplingLayer extends NoParamLayer {
         }
 
         public Builder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int[] kernelSize, int[] stride,
-                int[] padding) {
+                        int[] padding) {
             super(poolingType, kernelSize, stride, padding);
         }
 
@@ -337,7 +334,7 @@ public class SubsamplingLayer extends NoParamLayer {
         public SubsamplingLayer build() {
             if (poolingType == org.deeplearning4j.nn.conf.layers.PoolingType.PNORM && pnorm <= 0) {
                 throw new IllegalStateException(
-                        "Incorrect Subsampling config: p-norm must be set when using PoolingType.PNORM");
+                                "Incorrect Subsampling config: p-norm must be set when using PoolingType.PNORM");
             }
             ConvolutionUtils.validateConvolutionModePadding(convolutionMode, padding);
             ConvolutionUtils.validateCnnKernelStridePadding(kernelSize, stride, padding);
@@ -348,10 +345,10 @@ public class SubsamplingLayer extends NoParamLayer {
         @Override
         public void setKernelSize(int[] kernelSize) {
             Preconditions.checkArgument(kernelSize.length == 1 || kernelSize.length == 2,
-                    "Must have 1 or 2 kernelSize values - got %s", kernelSize);
+                            "Must have 1 or 2 kernelSize values - got %s", kernelSize);
 
             if (kernelSize.length == 1) {
-                super.setKernelSize(new int[]{kernelSize[0], kernelSize[0]});
+                super.setKernelSize(new int[] {kernelSize[0], kernelSize[0]});
             } else {
                 super.setKernelSize(kernelSize);
             }
@@ -359,12 +356,11 @@ public class SubsamplingLayer extends NoParamLayer {
 
         @Override
         public void setStride(int[] stride) {
-            Preconditions
-                    .checkArgument(stride.length == 1 || stride.length == 2, "Must have 1 or 2 stride values - got %s",
-                            stride);
+            Preconditions.checkArgument(stride.length == 1 || stride.length == 2,
+                            "Must have 1 or 2 stride values - got %s", stride);
 
             if (stride.length == 1) {
-                super.setStride(new int[]{stride[0], stride[0]});
+                super.setStride(new int[] {stride[0], stride[0]});
             } else {
                 super.setStride(stride);
             }
@@ -373,10 +369,10 @@ public class SubsamplingLayer extends NoParamLayer {
         @Override
         public void setPadding(int[] padding) {
             Preconditions.checkArgument(kernelSize.length == 1 || stride.length == 2,
-                    "Must have 1 or 2 padding values - got %s", padding);
+                            "Must have 1 or 2 padding values - got %s", padding);
 
             if (padding.length == 1) {
-                super.setPadding(new int[]{padding[0], padding[0]});
+                super.setPadding(new int[] {padding[0], padding[0]});
             } else {
                 super.setPadding(padding);
             }
@@ -385,24 +381,24 @@ public class SubsamplingLayer extends NoParamLayer {
 
     @NoArgsConstructor
     protected static abstract class BaseSubsamplingBuilder<T extends BaseSubsamplingBuilder<T>>
-            extends Layer.Builder<T> {
+                    extends Layer.Builder<T> {
 
         @Getter
         @Setter
         protected org.deeplearning4j.nn.conf.layers.PoolingType poolingType =
-                org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
+                        org.deeplearning4j.nn.conf.layers.PoolingType.MAX;
 
         @Getter
         @Setter
-        protected int[] kernelSize = new int[]{1, 1}; // Same as filter size from the last conv layer
+        protected int[] kernelSize = new int[] {1, 1}; // Same as filter size from the last conv layer
 
         @Getter
         @Setter
-        protected int[] stride = new int[]{2, 2}; // Default is 2. Down-sample by a factor of 2
+        protected int[] stride = new int[] {2, 2}; // Default is 2. Down-sample by a factor of 2
 
         @Getter
         @Setter
-        protected int[] padding = new int[]{0, 0};
+        protected int[] padding = new int[] {0, 0};
 
         /**
          * Set the convolution mode for the Convolution layer. See {@link ConvolutionMode} for more details
@@ -456,7 +452,7 @@ public class SubsamplingLayer extends NoParamLayer {
         }
 
         protected BaseSubsamplingBuilder(org.deeplearning4j.nn.conf.layers.PoolingType poolingType, int[] kernelSize,
-                int[] stride, int[] padding) {
+                        int[] stride, int[] padding) {
             this.poolingType = poolingType;
             this.kernelSize = kernelSize;
             this.stride = stride;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
@@ -157,6 +157,11 @@ public class Upsampling1D extends BaseUpsamplingLayer {
         public Upsampling1D build() {
             return new Upsampling1D(this);
         }
+
+        @Override
+        public void setSize(int[] size) {
+            size(size);
+        }
     }
 
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -62,10 +59,10 @@ public class Upsampling1D extends BaseUpsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling1D ret =
-                new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling1D(conf);
+                        new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling1D(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -85,8 +82,8 @@ public class Upsampling1D extends BaseUpsamplingLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for 1D Upsampling layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
+                            + inputType);
         }
         InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
         long outLength = recurrent.getTimeSeriesLength();
@@ -100,7 +97,7 @@ public class Upsampling1D extends BaseUpsamplingLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Upsampling layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
@@ -116,18 +113,17 @@ public class Upsampling1D extends BaseUpsamplingLayer {
             trainingWorkingSizePerEx += inputType.arrayElementsPerExample();
         }
 
-        return new LayerMemoryReport.Builder(layerName, Upsampling1D.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, Upsampling1D.class, inputType, outputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     @NoArgsConstructor
     public static class Builder extends UpsamplingBuilder<Builder> {
 
         public Builder(int size) {
-            super(new int[]{size, size});
+            super(new int[] {size, size});
         }
 
         /**
@@ -137,7 +133,7 @@ public class Upsampling1D extends BaseUpsamplingLayer {
          */
         public Builder size(int size) {
 
-            this.size = new int[]{size, size};
+            this.size = new int[] {size, size};
             return this;
         }
 
@@ -148,7 +144,7 @@ public class Upsampling1D extends BaseUpsamplingLayer {
          */
         public Builder size(int[] size) {
             Preconditions.checkArgument(size.length == 1, "Input array must be length 1");
-            this.size = new int[]{size[0], size[0]}; // Since this is 2D under the hood, we need to hide this.
+            this.size = new int[] {size[0], size[0]}; // Since this is 2D under the hood, we need to hide this.
             return this;
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
@@ -33,10 +33,9 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Upsampling 1D layer<br>
- * Repeats each step {@code size} times along the temporal/sequence axis (dimension 2)<br>
- * For input shape {@code [minibatch, channels, sequenceLength]} output has shape {@code [minibatch, channels, size * sequenceLength]}<br>
- * Example:
+ * Upsampling 1D layer<br> Repeats each step {@code size} times along the temporal/sequence axis (dimension 2)<br> For
+ * input shape {@code [minibatch, channels, sequenceLength]} output has shape {@code [minibatch, channels, size *
+ * sequenceLength]}<br> Example:
  * <pre>
  * If input (for a single example, with channels down page, and sequence from left to right) is:
  * [ A1, A2, A3]
@@ -63,8 +62,8 @@ public class Upsampling1D extends BaseUpsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling1D ret =
                 new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling1D(conf);
         ret.setListeners(trainingListeners);
@@ -91,8 +90,9 @@ public class Upsampling1D extends BaseUpsamplingLayer {
         }
         InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
         long outLength = recurrent.getTimeSeriesLength();
-        if(outLength > 0)
+        if (outLength > 0) {
             outLength *= size[0];
+        }
         return InputType.recurrent(recurrent.getSize(), outLength);
     }
 
@@ -127,28 +127,28 @@ public class Upsampling1D extends BaseUpsamplingLayer {
     public static class Builder extends UpsamplingBuilder<Builder> {
 
         public Builder(int size) {
-            super(new int[] {size, size});
+            super(new int[]{size, size});
         }
 
         /**
          * Upsampling size
          *
-         * @param size    upsampling size in single spatial dimension of this 1D layer
+         * @param size upsampling size in single spatial dimension of this 1D layer
          */
         public Builder size(int size) {
 
-            this.size = new int[] {size, size};
+            this.size = new int[]{size, size};
             return this;
         }
 
         /**
          * Upsampling size int array with a single element. Array must be length 1
          *
-         * @param size    upsampling size in single spatial dimension of this 1D layer
+         * @param size upsampling size in single spatial dimension of this 1D layer
          */
         public Builder size(int[] size) {
             Preconditions.checkArgument(size.length == 1, "Input array must be length 1");
-            this.size = new int[] {size[0], size[0]}; // Since this is 2D under the hood, we need to hide this.
+            this.size = new int[]{size[0], size[0]}; // Since this is 2D under the hood, we need to hide this.
             return this;
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling1D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -72,10 +69,10 @@ public class Upsampling2D extends BaseUpsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling2D ret =
-                new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling2D(conf);
+                        new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling2D(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -89,7 +86,7 @@ public class Upsampling2D extends BaseUpsamplingLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN) {
             throw new IllegalStateException("Invalid input for Upsampling 2D layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN input, got " + inputType);
+                            + "\"): Expected CNN input, got " + inputType);
         }
         InputType.InputTypeConvolutional i = (InputType.InputTypeConvolutional) inputType;
         val inHeight = i.getHeight();
@@ -103,7 +100,7 @@ public class Upsampling2D extends BaseUpsamplingLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Upsampling 2D layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
@@ -114,8 +111,8 @@ public class Upsampling2D extends BaseUpsamplingLayer {
         InputType.InputTypeConvolutional outputType = (InputType.InputTypeConvolutional) getOutputType(-1, inputType);
 
         // During forward pass: im2col array + reduce. Reduce is counted as activations, so only im2col is working mem
-        val im2colSizePerEx = c.getChannels() * outputType.getHeight() * outputType.getWidth()
-                * size[0] * size[1] * size[2];
+        val im2colSizePerEx =
+                        c.getChannels() * outputType.getHeight() * outputType.getWidth() * size[0] * size[1] * size[2];
 
         // Current implementation does NOT cache im2col etc... which means: it's recalculated on each backward pass
         long trainingWorkingSizePerEx = im2colSizePerEx;
@@ -124,11 +121,10 @@ public class Upsampling2D extends BaseUpsamplingLayer {
             trainingWorkingSizePerEx += inputType.arrayElementsPerExample();
         }
 
-        return new LayerMemoryReport.Builder(layerName, Upsampling2D.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, Upsampling2D.class, inputType, outputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
 
@@ -136,7 +132,7 @@ public class Upsampling2D extends BaseUpsamplingLayer {
     public static class Builder extends UpsamplingBuilder<Builder> {
 
         public Builder(int size) {
-            super(new int[]{size, size});
+            super(new int[] {size, size});
         }
 
         /**
@@ -146,7 +142,7 @@ public class Upsampling2D extends BaseUpsamplingLayer {
          */
         public Builder size(int size) {
 
-            this.size = new int[]{size, size};
+            this.size = new int[] {size, size};
             return this;
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
@@ -32,12 +32,9 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Upsampling 2D layer<br>
- * Repeats each value (or rather, set of depth values) in the height and width dimensions by size[0] and size[1]
- * times respectively.<br>
- * If input has shape {@code [minibatch, channels, height, width]} then output has shape
- * {@code [minibatch, channels, height*size[0], width*size[1]]}<br>
- * Example:
+ * Upsampling 2D layer<br> Repeats each value (or rather, set of depth values) in the height and width dimensions by
+ * size[0] and size[1] times respectively.<br> If input has shape {@code [minibatch, channels, height, width]} then
+ * output has shape {@code [minibatch, channels, height*size[0], width*size[1]]}<br> Example:
  * <pre>
  * Input (slice for one example and channel)
  * [ A, B ]
@@ -59,7 +56,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 public class Upsampling2D extends BaseUpsamplingLayer {
 
-    @JsonDeserialize(using= LegacyIntArrayDeserializer.class)
+    @JsonDeserialize(using = LegacyIntArrayDeserializer.class)
     protected int[] size;
 
     protected Upsampling2D(UpsamplingBuilder builder) {
@@ -75,8 +72,8 @@ public class Upsampling2D extends BaseUpsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling2D ret =
                 new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling2D(conf);
         ret.setListeners(trainingListeners);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
@@ -171,6 +171,11 @@ public class Upsampling2D extends BaseUpsamplingLayer {
         public Upsampling2D build() {
             return new Upsampling2D(this);
         }
+
+        @Override
+        public void setSize(int[] size) {
+            size(size);
+        }
     }
 
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
@@ -31,10 +31,9 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Upsampling 3D layer<br>
- * Repeats each value (all channel values for each x/y/z location) by size[0], size[1] and size[2]<br>
- * If input has shape {@code [minibatch, channels, depth, height, width]} then output has shape
- * {@code [minibatch, channels, size[0] * depth, size[1] * height, size[2] * width]}
+ * Upsampling 3D layer<br> Repeats each value (all channel values for each x/y/z location) by size[0], size[1] and
+ * size[2]<br> If input has shape {@code [minibatch, channels, depth, height, width]} then output has shape {@code
+ * [minibatch, channels, size[0] * depth, size[1] * height, size[2] * width]}
  *
  * @author Max Pumperla
  */
@@ -58,9 +57,9 @@ public class Upsampling3D extends BaseUpsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> iterationListeners,
-                                                       int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> iterationListeners,
+            int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling3D ret =
                 new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling3D(conf);
         ret.setListeners(iterationListeners);
@@ -87,7 +86,7 @@ public class Upsampling3D extends BaseUpsamplingLayer {
         int inChannels = (int) i.getChannels();
 
         return InputType.convolutional3D(
-                size[0] * inDepth,size[1] * inHeight, size[2] * inWidth,  inChannels);
+                size[0] * inDepth, size[1] * inHeight, size[2] * inWidth, inChannels);
     }
 
     @Override
@@ -128,7 +127,7 @@ public class Upsampling3D extends BaseUpsamplingLayer {
     public static class Builder extends UpsamplingBuilder<Builder> {
 
         public Builder(int size) {
-            super(new int[] {size, size, size});
+            super(new int[]{size, size, size});
         }
 
         /**
@@ -138,7 +137,7 @@ public class Upsampling3D extends BaseUpsamplingLayer {
          */
         public Builder size(int size) {
 
-            this.size = new int[] {size, size, size};
+            this.size = new int[]{size, size, size};
             return this;
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -57,11 +54,10 @@ public class Upsampling3D extends BaseUpsamplingLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> iterationListeners,
-            int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> iterationListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling3D ret =
-                new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling3D(conf);
+                        new org.deeplearning4j.nn.layers.convolution.upsampling.Upsampling3D(conf);
         ret.setListeners(iterationListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -75,7 +71,7 @@ public class Upsampling3D extends BaseUpsamplingLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN3D) {
             throw new IllegalStateException("Invalid input for Upsampling 3D layer (layer name=\"" + getLayerName()
-                    + "\"): Expected CNN3D input, got " + inputType);
+                            + "\"): Expected CNN3D input, got " + inputType);
         }
         InputType.InputTypeConvolutional3D i = (InputType.InputTypeConvolutional3D) inputType;
 
@@ -85,15 +81,14 @@ public class Upsampling3D extends BaseUpsamplingLayer {
         int inDepth = (int) i.getDepth();
         int inChannels = (int) i.getChannels();
 
-        return InputType.convolutional3D(
-                size[0] * inDepth, size[1] * inHeight, size[2] * inWidth, inChannels);
+        return InputType.convolutional3D(size[0] * inDepth, size[1] * inHeight, size[2] * inWidth, inChannels);
     }
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for Upsampling 3D layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
         return InputTypeUtil.getPreProcessorForInputTypeCnn3DLayers(inputType, getLayerName());
     }
@@ -102,11 +97,11 @@ public class Upsampling3D extends BaseUpsamplingLayer {
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         InputType.InputTypeConvolutional3D c = (InputType.InputTypeConvolutional3D) inputType;
         InputType.InputTypeConvolutional3D outputType =
-                (InputType.InputTypeConvolutional3D) getOutputType(-1, inputType);
+                        (InputType.InputTypeConvolutional3D) getOutputType(-1, inputType);
 
         // During forward pass: im2col array + reduce. Reduce is counted as activations, so only im2col is working mem
-        val im2colSizePerEx = c.getChannels() & outputType.getDepth() * outputType.getHeight()
-                * outputType.getWidth() * size[0] * size[1] * size[2];
+        val im2colSizePerEx = c.getChannels() & outputType.getDepth() * outputType.getHeight() * outputType.getWidth()
+                        * size[0] * size[1] * size[2];
 
         // Current implementation does NOT cache im2col etc... which means: it's recalculated on each backward pass
         long trainingWorkingSizePerEx = im2colSizePerEx;
@@ -115,11 +110,10 @@ public class Upsampling3D extends BaseUpsamplingLayer {
             trainingWorkingSizePerEx += inputType.arrayElementsPerExample();
         }
 
-        return new LayerMemoryReport.Builder(layerName, Upsampling3D.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+        return new LayerMemoryReport.Builder(layerName, Upsampling3D.class, inputType, outputType).standardMemory(0, 0) //No params
+                        .workingMemory(0, im2colSizePerEx, 0, trainingWorkingSizePerEx)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
 
@@ -127,7 +121,7 @@ public class Upsampling3D extends BaseUpsamplingLayer {
     public static class Builder extends UpsamplingBuilder<Builder> {
 
         public Builder(int size) {
-            super(new int[]{size, size, size});
+            super(new int[] {size, size, size});
         }
 
         /**
@@ -137,7 +131,7 @@ public class Upsampling3D extends BaseUpsamplingLayer {
          */
         public Builder size(int size) {
 
-            this.size = new int[]{size, size, size};
+            this.size = new int[] {size, size, size};
             return this;
         }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
@@ -158,6 +158,11 @@ public class Upsampling3D extends BaseUpsamplingLayer {
         public Upsampling3D build() {
             return new Upsampling3D(this);
         }
+
+        @Override
+        public void setSize(int[] size) {
+            size(size);
+        }
     }
 
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Upsampling3D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -139,7 +136,19 @@ public class ZeroPadding1DLayer extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        @Getter
         private int[] padding = new int[] {0, 0}; //Padding: left, right
+
+
+        public void setPadding(int[] padding) {
+            if(padding.length == 2)
+                this.padding = padding;
+            else if(padding.length == 1)
+                this.padding = new int[] {padding[0], padding[0]};
+            else
+                Preconditions.checkArgument(false, "Must have 1 or 2 padding values - got %s", padding);
+        }
+
 
         /**
          * @param padding  Padding for both the left and right

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -63,10 +60,10 @@ public class ZeroPadding1DLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.ZeroPadding1DLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.ZeroPadding1DLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.ZeroPadding1DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);
@@ -84,12 +81,11 @@ public class ZeroPadding1DLayer extends NoParamLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for 1D CNN layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
+                            + inputType);
         }
         InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
-        return InputType.recurrent(recurrent.getSize(),
-                recurrent.getTimeSeriesLength() + padding[0] + padding[1]);
+        return InputType.recurrent(recurrent.getSize(), recurrent.getTimeSeriesLength() + padding[0] + padding[1]);
     }
 
     @Override
@@ -101,7 +97,7 @@ public class ZeroPadding1DLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for ZeroPadding1DLayer layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreprocessorForInputTypeRnnLayers(inputType, getLayerName());
@@ -127,10 +123,10 @@ public class ZeroPadding1DLayer extends NoParamLayer {
         InputType outputType = getOutputType(-1, inputType);
 
         return new LayerMemoryReport.Builder(layerName, ZeroPaddingLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public static class Builder extends Layer.Builder<Builder> {
@@ -139,7 +135,7 @@ public class ZeroPadding1DLayer extends NoParamLayer {
          * Padding value for left and right. Must be length 2 array
          */
         @Getter
-        private int[] padding = new int[]{0, 0}; //Padding: left, right
+        private int[] padding = new int[] {0, 0}; //Padding: left, right
 
         /**
          * @param padding Padding value for left and right. Must be length 2 array
@@ -148,7 +144,7 @@ public class ZeroPadding1DLayer extends NoParamLayer {
             if (padding.length == 2) {
                 this.padding = padding;
             } else if (padding.length == 1) {
-                this.padding = new int[]{padding[0], padding[0]};
+                this.padding = new int[] {padding[0], padding[0]};
             } else {
                 Preconditions.checkArgument(false, "Must have 1 or 2 padding values - got %s", padding);
             }
@@ -167,7 +163,7 @@ public class ZeroPadding1DLayer extends NoParamLayer {
          * @param padRight Padding value for right
          */
         public Builder(int padLeft, int padRight) {
-            this(new int[]{padLeft, padRight});
+            this(new int[] {padLeft, padRight});
         }
 
         /**
@@ -183,10 +179,8 @@ public class ZeroPadding1DLayer extends NoParamLayer {
         public ZeroPadding1DLayer build() {
             for (int p : padding) {
                 if (p < 0) {
-                    throw new IllegalStateException(
-                            "Invalid zero padding layer config: padding [left, right]"
-                                    + " must be > 0 for all elements. Got: "
-                                    + Arrays.toString(padding));
+                    throw new IllegalStateException("Invalid zero padding layer config: padding [left, right]"
+                                    + " must be > 0 for all elements. Got: " + Arrays.toString(padding));
                 }
             }
             return new ZeroPadding1DLayer(this);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
@@ -129,12 +129,13 @@ public class ZeroPadding1DLayer extends NoParamLayer {
                         .build();
     }
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
         /**
          * Padding value for left and right. Must be length 2 array
          */
-        @Getter
         private int[] padding = new int[] {0, 0}; //Padding: left, right
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding1DLayer.java
@@ -33,8 +33,7 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Zero padding 1D layer for convolutional neural networks.
- * Allows padding to be done separately for top and bottom.
+ * Zero padding 1D layer for convolutional neural networks. Allows padding to be done separately for top and bottom.
  *
  * @author Max Pumperla
  */
@@ -50,22 +49,22 @@ public class ZeroPadding1DLayer extends NoParamLayer {
         this.padding = builder.padding;
     }
 
-    public ZeroPadding1DLayer(int padding){
+    public ZeroPadding1DLayer(int padding) {
         this(new Builder(padding));
     }
 
-    public ZeroPadding1DLayer(int padLeft, int padRight){
+    public ZeroPadding1DLayer(int padLeft, int padRight) {
         this(new Builder(padLeft, padRight));
     }
 
-    public ZeroPadding1DLayer(int[] padding){
+    public ZeroPadding1DLayer(int[] padding) {
         this(new Builder(padding));
     }
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.ZeroPadding1DLayer ret =
                 new org.deeplearning4j.nn.layers.convolution.ZeroPadding1DLayer(conf);
         ret.setListeners(trainingListeners);
@@ -136,33 +135,39 @@ public class ZeroPadding1DLayer extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        /**
+         * Padding value for left and right. Must be length 2 array
+         */
         @Getter
-        private int[] padding = new int[] {0, 0}; //Padding: left, right
+        private int[] padding = new int[]{0, 0}; //Padding: left, right
 
-
+        /**
+         * @param padding Padding value for left and right. Must be length 2 array
+         */
         public void setPadding(int[] padding) {
-            if(padding.length == 2)
+            if (padding.length == 2) {
                 this.padding = padding;
-            else if(padding.length == 1)
-                this.padding = new int[] {padding[0], padding[0]};
-            else
+            } else if (padding.length == 1) {
+                this.padding = new int[]{padding[0], padding[0]};
+            } else {
                 Preconditions.checkArgument(false, "Must have 1 or 2 padding values - got %s", padding);
+            }
         }
 
 
         /**
-         * @param padding  Padding for both the left and right
+         * @param padding Padding for both the left and right
          */
         public Builder(int padding) {
             this(padding, padding);
         }
 
         /**
-         * @param padLeft  Padding value for left
+         * @param padLeft Padding value for left
          * @param padRight Padding value for right
          */
         public Builder(int padLeft, int padRight) {
-            this(new int[] {padLeft, padRight});
+            this(new int[]{padLeft, padRight});
         }
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
@@ -121,12 +121,13 @@ public class ZeroPadding3DLayer extends NoParamLayer {
                         .build();
     }
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
         /**
          * [padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW]
          */
-        @Getter
         private int[] padding = new int[] {0, 0, 0, 0, 0, 0};
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
@@ -16,9 +16,8 @@
 
 package org.deeplearning4j.nn.conf.layers;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import com.google.common.base.Preconditions;
+import lombok.*;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -132,7 +131,21 @@ public class ZeroPadding3DLayer extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        @Getter
         private int[] padding = new int[]{0, 0, 0, 0, 0, 0}; // [padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW]
+
+
+        public void setPadding(int[] padding) {
+            if (padding.length == 3) {
+                this.padding = new int[]{padding[0], padding[0], padding[1], padding[1], padding[2], padding[2]};
+            } else if (padding.length == 6) {
+                this.padding = padding;
+            } else if (padding.length == 1) {
+                this.padding = new int[]{padding[0], padding[0], padding[0], padding[0], padding[0], padding[0]};
+            } else {
+                throw new IllegalStateException("Padding length has to be either 1, 3 or 6, got " + padding.length);
+            }
+        }
 
         /**
          * @param padding Padding for both the left and right in all three spatial dimensions

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -53,11 +50,10 @@ public class ZeroPadding3DLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> iterationListeners,
-            int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> iterationListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.ZeroPadding3DLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.ZeroPadding3DLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.ZeroPadding3DLayer(conf);
         ret.setListeners(iterationListeners);
         ret.setIndex(layerIndex);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);
@@ -75,15 +71,13 @@ public class ZeroPadding3DLayer extends NoParamLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN3D) {
             throw new IllegalStateException("Invalid input for 3D CNN layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect CNN3D input type with size > 0. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect CNN3D input type with size > 0. Got: "
+                            + inputType);
         }
         InputType.InputTypeConvolutional3D c = (InputType.InputTypeConvolutional3D) inputType;
-        return InputType.convolutional3D(
-                c.getDepth() + padding[0] + padding[1],
-                c.getHeight() + padding[2] + padding[3],
-                c.getWidth() + padding[4] + padding[5],
-                c.getChannels());
+        return InputType.convolutional3D(c.getDepth() + padding[0] + padding[1],
+                        c.getHeight() + padding[2] + padding[3], c.getWidth() + padding[4] + padding[5],
+                        c.getChannels());
     }
 
     @Override
@@ -95,7 +89,7 @@ public class ZeroPadding3DLayer extends NoParamLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException("Invalid input for ZeroPadding3DLayer layer (layer name=\"" + getLayerName()
-                    + "\"): input is null");
+                            + "\"): input is null");
         }
 
         return InputTypeUtil.getPreProcessorForInputTypeCnn3DLayers(inputType, getLayerName());
@@ -121,11 +115,10 @@ public class ZeroPadding3DLayer extends NoParamLayer {
         InputType outputType = getOutputType(-1, inputType);
 
         return new LayerMemoryReport.Builder(layerName, ZeroPadding3DLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS,
-                        MemoryReport.CACHE_MODE_ALL_ZEROS)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public static class Builder extends Layer.Builder<Builder> {
@@ -134,19 +127,18 @@ public class ZeroPadding3DLayer extends NoParamLayer {
          * [padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW]
          */
         @Getter
-        private int[] padding = new int[]{0, 0, 0, 0, 0,
-                0};
+        private int[] padding = new int[] {0, 0, 0, 0, 0, 0};
 
         /**
          * [padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW]
          */
         public void setPadding(int[] padding) {
             if (padding.length == 3) {
-                this.padding = new int[]{padding[0], padding[0], padding[1], padding[1], padding[2], padding[2]};
+                this.padding = new int[] {padding[0], padding[0], padding[1], padding[1], padding[2], padding[2]};
             } else if (padding.length == 6) {
                 this.padding = padding;
             } else if (padding.length == 1) {
-                this.padding = new int[]{padding[0], padding[0], padding[0], padding[0], padding[0], padding[0]};
+                this.padding = new int[] {padding[0], padding[0], padding[0], padding[0], padding[0], padding[0]};
             } else {
                 throw new IllegalStateException("Padding length has to be either 1, 3 or 6, got " + padding.length);
             }
@@ -181,19 +173,17 @@ public class ZeroPadding3DLayer extends NoParamLayer {
          * @param padLeftW Width padding left
          * @param padRightW Width padding right
          */
-        public Builder(int padLeftD, int padRightD,
-                int padLeftH, int padRightH,
-                int padLeftW, int padRightW) {
-            this(new int[]{padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW});
+        public Builder(int padLeftD, int padRightD, int padLeftH, int padRightH, int padLeftW, int padRightW) {
+            this(new int[] {padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW});
         }
 
         public Builder(int[] padding) {
             if (padding.length == 3) {
-                this.padding = new int[]{padding[0], padding[0], padding[1], padding[1], padding[2], padding[2]};
+                this.padding = new int[] {padding[0], padding[0], padding[1], padding[1], padding[2], padding[2]};
             } else if (padding.length == 6) {
                 this.padding = padding;
             } else if (padding.length == 1) {
-                this.padding = new int[]{padding[0], padding[0], padding[0], padding[0], padding[0], padding[0]};
+                this.padding = new int[] {padding[0], padding[0], padding[0], padding[0], padding[0], padding[0]};
             } else {
                 throw new IllegalStateException("Padding length has to be either 1, 3 or 6, got " + padding.length);
             }
@@ -205,7 +195,7 @@ public class ZeroPadding3DLayer extends NoParamLayer {
             for (int p : padding) {
                 if (p < 0) {
                     throw new IllegalStateException("Invalid zero padding layer config: padding [left, right]"
-                            + " must be > 0 for all elements. Got: " + Arrays.toString(padding));
+                                    + " must be > 0 for all elements. Got: " + Arrays.toString(padding));
                 }
             }
             return new ZeroPadding3DLayer(this);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
@@ -34,8 +34,7 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Zero padding 3D layer for convolutional neural networks.
- * Allows padding to be done separately for "left" and "right"
+ * Zero padding 3D layer for convolutional neural networks. Allows padding to be done separately for "left" and "right"
  * in all three spatial dimensions.
  *
  * @author Max Pumperla
@@ -54,9 +53,9 @@ public class ZeroPadding3DLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> iterationListeners,
-                                                       int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> iterationListeners,
+            int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.ZeroPadding3DLayer ret =
                 new org.deeplearning4j.nn.layers.convolution.ZeroPadding3DLayer(conf);
         ret.setListeners(iterationListeners);
@@ -131,10 +130,16 @@ public class ZeroPadding3DLayer extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        /**
+         * [padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW]
+         */
         @Getter
-        private int[] padding = new int[]{0, 0, 0, 0, 0, 0}; // [padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW]
+        private int[] padding = new int[]{0, 0, 0, 0, 0,
+                0};
 
-
+        /**
+         * [padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW]
+         */
         public void setPadding(int[] padding) {
             if (padding.length == 3) {
                 this.padding = new int[]{padding[0], padding[0], padding[1], padding[1], padding[2], padding[2]};
@@ -177,8 +182,8 @@ public class ZeroPadding3DLayer extends NoParamLayer {
          * @param padRightW Width padding right
          */
         public Builder(int padLeftD, int padRightD,
-                       int padLeftH, int padRightH,
-                       int padLeftW, int padRightW) {
+                int padLeftH, int padRightH,
+                int padLeftW, int padRightW) {
             this(new int[]{padLeftD, padRightD, padLeftH, padRightH, padLeftW, padRightW});
         }
 
@@ -198,9 +203,10 @@ public class ZeroPadding3DLayer extends NoParamLayer {
         @SuppressWarnings("unchecked")
         public ZeroPadding3DLayer build() {
             for (int p : padding) {
-                if (p < 0)
+                if (p < 0) {
                     throw new IllegalStateException("Invalid zero padding layer config: padding [left, right]"
                             + " must be > 0 for all elements. Got: " + Arrays.toString(padding));
+                }
             }
             return new ZeroPadding3DLayer(this);
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPadding3DLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -56,8 +53,8 @@ public class ZeroPaddingLayer extends NoParamLayer {
         super(builder);
         if (builder.padding == null || builder.padding.length != 4) {
             throw new IllegalArgumentException(
-                    "Invalid padding values: must have exactly 4 values [top, bottom, left, right]." +
-                            " Got: " + (builder.padding == null ? null : Arrays.toString(builder.padding)));
+                            "Invalid padding values: must have exactly 4 values [top, bottom, left, right]." + " Got: "
+                                            + (builder.padding == null ? null : Arrays.toString(builder.padding)));
         }
 
         this.padding = builder.padding;
@@ -65,10 +62,10 @@ public class ZeroPaddingLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.ZeroPaddingLayer ret =
-                new org.deeplearning4j.nn.layers.convolution.ZeroPaddingLayer(conf);
+                        new org.deeplearning4j.nn.layers.convolution.ZeroPaddingLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);
@@ -89,7 +86,7 @@ public class ZeroPaddingLayer extends NoParamLayer {
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         Preconditions.checkArgument(inputType != null, "Invalid input for ZeroPaddingLayer layer (layer name=\""
-                + getLayerName() + "\"): InputType is null");
+                        + getLayerName() + "\"): InputType is null");
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
 
@@ -98,11 +95,11 @@ public class ZeroPaddingLayer extends NoParamLayer {
         InputType outputType = getOutputType(-1, inputType);
 
         return new LayerMemoryReport.Builder(layerName, ZeroPaddingLayer.class, inputType, outputType)
-                .standardMemory(0, 0) //No params
-                //Inference and training is same - just output activations, no working memory in addition to that
-                .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(0, 0) //No params
+                        //Inference and training is same - just output activations, no working memory in addition to that
+                        .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public static class Builder extends Layer.Builder<Builder> {
@@ -111,16 +108,16 @@ public class ZeroPaddingLayer extends NoParamLayer {
          * Padding value for top, bottom, left, and right. Must be length 4 array
          */
         @Getter
-        private int[] padding = new int[]{0, 0, 0, 0}; //Padding: top, bottom, left, right
+        private int[] padding = new int[] {0, 0, 0, 0}; //Padding: top, bottom, left, right
 
         /**
          * @param padding Padding value for top, bottom, left, and right. Must be length 4 array
          */
         public void setPadding(int[] padding) {
             if (padding.length == 2) {
-                this.padding = new int[]{padding[0], padding[0], padding[1], padding[1]};
+                this.padding = new int[] {padding[0], padding[0], padding[1], padding[1]};
             } else if (padding.length == 1) {
-                this.padding = new int[]{padding[0], padding[0], padding[0], padding[0]};
+                this.padding = new int[] {padding[0], padding[0], padding[0], padding[0]};
             } else if (padding.length == 4) {
                 this.padding = padding;
             } else {
@@ -143,7 +140,7 @@ public class ZeroPaddingLayer extends NoParamLayer {
          * @param padRight Right padding value
          */
         public Builder(int padTop, int padBottom, int padLeft, int padRight) {
-            this(new int[]{padTop, padBottom, padLeft, padRight});
+            this(new int[] {padTop, padBottom, padLeft, padRight});
         }
 
         /**
@@ -152,10 +149,10 @@ public class ZeroPaddingLayer extends NoParamLayer {
          */
         public Builder(int[] padding) {
             if (padding.length == 2) {
-                padding = new int[]{padding[0], padding[0], padding[1], padding[1]};
+                padding = new int[] {padding[0], padding[0], padding[1], padding[1]};
             } else if (padding.length != 4) {
                 throw new IllegalArgumentException(
-                        "Padding must have exactly 2 or 4 values - got " + Arrays.toString(padding));
+                                "Padding must have exactly 2 or 4 values - got " + Arrays.toString(padding));
             }
             this.padding = padding;
         }
@@ -166,9 +163,9 @@ public class ZeroPaddingLayer extends NoParamLayer {
             for (int p : padding) {
                 if (p < 0) {
                     throw new IllegalStateException(
-                            "Invalid zero padding layer config: padding [top, bottom, left, right]"
-                                    + " must be > 0 for all elements. Got: "
-                                    + Arrays.toString(padding));
+                                    "Invalid zero padding layer config: padding [top, bottom, left, right]"
+                                                    + " must be > 0 for all elements. Got: "
+                                                    + Arrays.toString(padding));
                 }
             }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
@@ -17,9 +17,7 @@
 package org.deeplearning4j.nn.conf.layers;
 
 import com.google.common.base.Preconditions;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
@@ -108,7 +106,21 @@ public class ZeroPaddingLayer extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+
+        @Getter
         private int[] padding = new int[] {0, 0, 0, 0}; //Padding: top, bottom, left, right
+
+
+        public void setPadding(int[] padding) {
+            if(padding.length == 2)
+                this.padding = new int[]{padding[0], padding[0], padding[1], padding[1]};
+            else if(padding.length == 1)
+                this.padding = new int[] {padding[0], padding[0], padding[0], padding[0]};
+            else if(padding.length == 4)
+                this.padding = padding;
+            else
+                Preconditions.checkArgument(false, "Must have 1, 2, or 4 padding values - got %s", padding);
+        }
 
         /**
          *

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
@@ -32,8 +32,8 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Zero padding layer for convolutional neural networks (2D CNNs).
- * Allows padding to be done separately for top/bottom/left/right
+ * Zero padding layer for convolutional neural networks (2D CNNs). Allows padding to be done separately for
+ * top/bottom/left/right
  *
  * @author Alex Black
  */
@@ -44,19 +44,20 @@ public class ZeroPaddingLayer extends NoParamLayer {
 
     private int[] padding;
 
-    public ZeroPaddingLayer(int padTopBottom, int padLeftRight){
+    public ZeroPaddingLayer(int padTopBottom, int padLeftRight) {
         this(new Builder(padTopBottom, padLeftRight));
     }
 
-    public ZeroPaddingLayer(int padTop, int padBottom, int padLeft, int padRight){
+    public ZeroPaddingLayer(int padTop, int padBottom, int padLeft, int padRight) {
         this(new Builder(padTop, padBottom, padLeft, padRight));
     }
 
     private ZeroPaddingLayer(Builder builder) {
         super(builder);
-        if(builder.padding == null || builder.padding.length != 4){
-            throw new IllegalArgumentException("Invalid padding values: must have exactly 4 values [top, bottom, left, right]." +
-                    " Got: " + (builder.padding == null ? null : Arrays.toString(builder.padding)));
+        if (builder.padding == null || builder.padding.length != 4) {
+            throw new IllegalArgumentException(
+                    "Invalid padding values: must have exactly 4 values [top, bottom, left, right]." +
+                            " Got: " + (builder.padding == null ? null : Arrays.toString(builder.padding)));
         }
 
         this.padding = builder.padding;
@@ -64,10 +65,10 @@ public class ZeroPaddingLayer extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                    boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.convolution.ZeroPaddingLayer ret =
-                        new org.deeplearning4j.nn.layers.convolution.ZeroPaddingLayer(conf);
+                new org.deeplearning4j.nn.layers.convolution.ZeroPaddingLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);
@@ -97,59 +98,64 @@ public class ZeroPaddingLayer extends NoParamLayer {
         InputType outputType = getOutputType(-1, inputType);
 
         return new LayerMemoryReport.Builder(layerName, ZeroPaddingLayer.class, inputType, outputType)
-                        .standardMemory(0, 0) //No params
-                        //Inference and training is same - just output activations, no working memory in addition to that
-                        .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(0, 0) //No params
+                //Inference and training is same - just output activations, no working memory in addition to that
+                .workingMemory(0, 0, MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
     public static class Builder extends Layer.Builder<Builder> {
 
-
+        /**
+         * Padding value for top, bottom, left, and right. Must be length 4 array
+         */
         @Getter
-        private int[] padding = new int[] {0, 0, 0, 0}; //Padding: top, bottom, left, right
+        private int[] padding = new int[]{0, 0, 0, 0}; //Padding: top, bottom, left, right
 
-
+        /**
+         * @param padding Padding value for top, bottom, left, and right. Must be length 4 array
+         */
         public void setPadding(int[] padding) {
-            if(padding.length == 2)
+            if (padding.length == 2) {
                 this.padding = new int[]{padding[0], padding[0], padding[1], padding[1]};
-            else if(padding.length == 1)
-                this.padding = new int[] {padding[0], padding[0], padding[0], padding[0]};
-            else if(padding.length == 4)
+            } else if (padding.length == 1) {
+                this.padding = new int[]{padding[0], padding[0], padding[0], padding[0]};
+            } else if (padding.length == 4) {
                 this.padding = padding;
-            else
+            } else {
                 Preconditions.checkArgument(false, "Must have 1, 2, or 4 padding values - got %s", padding);
+            }
         }
 
         /**
-         *
          * @param padHeight Padding for both the top and bottom
-         * @param padWidth  Padding for both the left and right
+         * @param padWidth Padding for both the left and right
          */
         public Builder(int padHeight, int padWidth) {
             this(padHeight, padHeight, padWidth, padWidth);
         }
 
         /**
-         * @param padTop    Top padding value
+         * @param padTop Top padding value
          * @param padBottom Bottom padding value
-         * @param padLeft   Left padding value
-         * @param padRight  Right padding value
+         * @param padLeft Left padding value
+         * @param padRight Right padding value
          */
         public Builder(int padTop, int padBottom, int padLeft, int padRight) {
-            this(new int[] {padTop, padBottom, padLeft, padRight});
+            this(new int[]{padTop, padBottom, padLeft, padRight});
         }
 
         /**
          * @param padding Must be a length 2 array with values [padTopBottom, padLeftRight] or a length 4 array with
-         *                values [padTop, padBottom, padLeft, padRight]
+         * values [padTop, padBottom, padLeft, padRight]
          */
         public Builder(int[] padding) {
-            if(padding.length == 2){
+            if (padding.length == 2) {
                 padding = new int[]{padding[0], padding[0], padding[1], padding[1]};
-            } else if(padding.length != 4){
-                throw new IllegalArgumentException("Padding must have exactly 2 or 4 values - got " + Arrays.toString(padding));
+            } else if (padding.length != 4) {
+                throw new IllegalArgumentException(
+                        "Padding must have exactly 2 or 4 values - got " + Arrays.toString(padding));
             }
             this.padding = padding;
         }
@@ -160,9 +166,9 @@ public class ZeroPaddingLayer extends NoParamLayer {
             for (int p : padding) {
                 if (p < 0) {
                     throw new IllegalStateException(
-                                    "Invalid zero padding layer config: padding [top, bottom, left, right]"
-                                                    + " must be > 0 for all elements. Got: "
-                                                    + Arrays.toString(padding));
+                            "Invalid zero padding layer config: padding [top, bottom, left, right]"
+                                    + " must be > 0 for all elements. Got: "
+                                    + Arrays.toString(padding));
                 }
             }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
@@ -102,22 +102,23 @@ public class ZeroPaddingLayer extends NoParamLayer {
                         .build();
     }
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
         /**
          * Padding value for top, bottom, left, and right. Must be length 4 array
          */
-        @Getter
         private int[] padding = new int[] {0, 0, 0, 0}; //Padding: top, bottom, left, right
 
         /**
          * @param padding Padding value for top, bottom, left, and right. Must be length 4 array
          */
         public void setPadding(int[] padding) {
-            if (padding.length == 2) {
-                this.padding = new int[] {padding[0], padding[0], padding[1], padding[1]};
-            } else if (padding.length == 1) {
+            if (padding.length == 1) {
                 this.padding = new int[] {padding[0], padding[0], padding[0], padding[0]};
+            } else if (padding.length == 2) {
+                this.padding = new int[] {padding[0], padding[0], padding[1], padding[1]};
             } else if (padding.length == 4) {
                 this.padding = padding;
             } else {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/ZeroPaddingLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
@@ -34,8 +34,7 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Cropping layer for convolutional (1d) neural networks.
- * Allows cropping to be done separately for top/bottom
+ * Cropping layer for convolutional (1d) neural networks. Allows cropping to be done separately for top/bottom
  *
  * @author Max Pumperla
  */
@@ -54,7 +53,7 @@ public class Cropping1D extends NoParamLayer {
     }
 
     /**
-     * @param cropTop    Amount of cropping to apply to the top of the input activations
+     * @param cropTop Amount of cropping to apply to the top of the input activations
      * @param cropBottom Amount of cropping to apply to the bottom of the input activations
      */
     public Cropping1D(int cropTop, int cropBottom) {
@@ -74,8 +73,9 @@ public class Cropping1D extends NoParamLayer {
     }
 
     @Override
-    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         Cropping1DLayer ret = new Cropping1DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -112,17 +112,24 @@ public class Cropping1D extends NoParamLayer {
 
 
     public static class Builder extends Layer.Builder<Builder> {
-
+        /**
+         * Cropping amount for top/bottom (in that order). Must be length 1 or 2 array.
+         */
         @Getter
         private int[] cropping = new int[]{0, 0};
 
+        /**
+         * @param cropping Cropping amount for top/bottom (in that order). Must be length 1 or 2 array.
+         */
         public void setCropping(int[] cropping) {
-            if(cropping.length == 2)
+            if (cropping.length == 2) {
                 this.cropping = cropping;
-            else if(cropping.length == 1)
-                this.cropping = new int[] {cropping[0], cropping[0]};
-            else
-                org.nd4j.base.Preconditions.checkArgument(false, "Must have 1 or 2 cropping values - got %s", this.cropping);
+            } else if (cropping.length == 1) {
+                this.cropping = new int[]{cropping[0], cropping[0]};
+            } else {
+                org.nd4j.base.Preconditions
+                        .checkArgument(false, "Must have 1 or 2 cropping values - got %s", this.cropping);
+            }
         }
 
         public Builder() {
@@ -139,7 +146,7 @@ public class Cropping1D extends NoParamLayer {
             if (cropping.length == 2) {
                 this.cropping = cropping;
             } else {
-                this.cropping = new int[] {cropping[0], cropping[0]};
+                this.cropping = new int[]{cropping[0], cropping[0]};
             }
         }
 
@@ -151,7 +158,7 @@ public class Cropping1D extends NoParamLayer {
         }
 
         /**
-         * @param cropTop    Amount of cropping to apply to the top of the input activations
+         * @param cropTop Amount of cropping to apply to the top of the input activations
          * @param cropBottom Amount of cropping to apply to the bottom of the input activations
          */
         public Builder(int cropTop, int cropBottom) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
@@ -113,7 +113,17 @@ public class Cropping1D extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        @Getter
         private int[] cropping = new int[]{0, 0};
+
+        public void setCropping(int[] cropping) {
+            if(cropping.length == 2)
+                this.cropping = cropping;
+            else if(cropping.length == 1)
+                this.cropping = new int[] {cropping[0], cropping[0]};
+            else
+                org.nd4j.base.Preconditions.checkArgument(false, "Must have 1 or 2 cropping values - got %s", this.cropping);
+        }
 
         public Builder() {
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -74,8 +71,8 @@ public class Cropping1D extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         Cropping1DLayer ret = new Cropping1DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -89,8 +86,8 @@ public class Cropping1D extends NoParamLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.RNN) {
             throw new IllegalStateException("Invalid input for 1D Cropping layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect RNN input type with size > 0. Got: "
+                            + inputType);
         }
         InputType.InputTypeRecurrent cnn1d = (InputType.InputTypeRecurrent) inputType;
         val length = cnn1d.getTimeSeriesLength();
@@ -101,7 +98,7 @@ public class Cropping1D extends NoParamLayer {
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         Preconditions.checkArgument(inputType != null, "Invalid input for Cropping1D layer (layer name=\""
-                + getLayerName() + "\"): InputType is null");
+                        + getLayerName() + "\"): InputType is null");
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
 
@@ -116,7 +113,7 @@ public class Cropping1D extends NoParamLayer {
          * Cropping amount for top/bottom (in that order). Must be length 1 or 2 array.
          */
         @Getter
-        private int[] cropping = new int[]{0, 0};
+        private int[] cropping = new int[] {0, 0};
 
         /**
          * @param cropping Cropping amount for top/bottom (in that order). Must be length 1 or 2 array.
@@ -125,10 +122,10 @@ public class Cropping1D extends NoParamLayer {
             if (cropping.length == 2) {
                 this.cropping = cropping;
             } else if (cropping.length == 1) {
-                this.cropping = new int[]{cropping[0], cropping[0]};
+                this.cropping = new int[] {cropping[0], cropping[0]};
             } else {
-                org.nd4j.base.Preconditions
-                        .checkArgument(false, "Must have 1 or 2 cropping values - got %s", this.cropping);
+                org.nd4j.base.Preconditions.checkArgument(false, "Must have 1 or 2 cropping values - got %s",
+                                this.cropping);
             }
         }
 
@@ -141,12 +138,13 @@ public class Cropping1D extends NoParamLayer {
          */
         public Builder(@NonNull int[] cropping) {
             Preconditions.checkArgument(cropping.length == 2 || cropping.length == 1,
-                    "Two cropping values, i.e. top and bottom, or one value for bot top and bottom" +
-                            "must be provided. Got " + cropping.length + " values: " + Arrays.toString(cropping));
+                            "Two cropping values, i.e. top and bottom, or one value for bot top and bottom"
+                                            + "must be provided. Got " + cropping.length + " values: "
+                                            + Arrays.toString(cropping));
             if (cropping.length == 2) {
                 this.cropping = cropping;
             } else {
-                this.cropping = new int[]{cropping[0], cropping[0]};
+                this.cropping = new int[] {cropping[0], cropping[0]};
             }
         }
 
@@ -162,10 +160,10 @@ public class Cropping1D extends NoParamLayer {
          * @param cropBottom Amount of cropping to apply to the bottom of the input activations
          */
         public Builder(int cropTop, int cropBottom) {
-            this.cropping = new int[]{cropTop, cropBottom};
+            this.cropping = new int[] {cropTop, cropBottom};
             Preconditions.checkArgument(cropTop >= 0 && cropBottom >= 0,
-                    "Invalid arguments: crop dimensions must be > 0. Got [t,b] = "
-                            + Arrays.toString(this.cropping));
+                            "Invalid arguments: crop dimensions must be > 0. Got [t,b] = "
+                                            + Arrays.toString(this.cropping));
         }
 
         public Cropping1D build() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
@@ -108,11 +108,12 @@ public class Cropping1D extends NoParamLayer {
     }
 
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
         /**
          * Cropping amount for top/bottom (in that order). Must be length 1 or 2 array.
          */
-        @Getter
         private int[] cropping = new int[] {0, 0};
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping1D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
@@ -35,8 +35,8 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Cropping layer for convolutional (2d) neural networks.
- * Allows cropping to be done separately for top/bottom/left/right
+ * Cropping layer for convolutional (2d) neural networks. Allows cropping to be done separately for
+ * top/bottom/left/right
  *
  * @author Alex Black
  */
@@ -56,18 +56,18 @@ public class Cropping2D extends NoParamLayer {
     }
 
     /**
-     * @param cropTop    Amount of cropping to apply to the top of the input activations
+     * @param cropTop Amount of cropping to apply to the top of the input activations
      * @param cropBottom Amount of cropping to apply to the bottom of the input activations
-     * @param cropLeft   Amount of cropping to apply to the left of the input activations
-     * @param cropRight  Amount of cropping to apply to the right of the input activations
+     * @param cropLeft Amount of cropping to apply to the left of the input activations
+     * @param cropRight Amount of cropping to apply to the right of the input activations
      */
     public Cropping2D(int cropTop, int cropBottom, int cropLeft, int cropRight) {
         this(new Builder(cropTop, cropBottom, cropLeft, cropRight));
     }
 
     /**
-     * @param cropping Cropping as either a length 2 array, with values {@code [cropTopBottom, cropLeftRight]},
-     *                 or as a length 4 array, with values {@code [cropTop, cropBottom, cropLeft, cropRight]}
+     * @param cropping Cropping as either a length 2 array, with values {@code [cropTopBottom, cropLeftRight]}, or as a
+     * length 4 array, with values {@code [cropTop, cropBottom, cropLeft, cropRight]}
      */
     public Cropping2D(int[] cropping) {
         this(new Builder(cropping));
@@ -79,8 +79,9 @@ public class Cropping2D extends NoParamLayer {
     }
 
     @Override
-    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         Cropping2DLayer ret = new Cropping2DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -114,14 +115,21 @@ public class Cropping2D extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        /**
+         * Cropping amount for top/bottom/left/right (in that order). A length 4 array.
+         */
         @Getter
         private int[] cropping = new int[]{0, 0, 0, 0};
 
+        /**
+         * @param cropping Cropping amount for top/bottom/left/right (in that order). Must be length 1, 2, or 4 array.
+         */
         public void setCropping(int[] cropping) {
-            Preconditions.checkArgument(cropping.length == 1 || cropping.length == 2 || cropping.length == 4, "Must have 1, 2, or 4 cropping values - got %s", cropping);
-            if(cropping.length == 1)
-                this.cropping = new int[] {cropping[0], cropping[0], cropping[0], cropping[0]};
-            else if (cropping.length == 2) {
+            Preconditions.checkArgument(cropping.length == 1 || cropping.length == 2 || cropping.length == 4,
+                    "Must have 1, 2, or 4 cropping values - got %s", cropping);
+            if (cropping.length == 1) {
+                this.cropping = new int[]{cropping[0], cropping[0], cropping[0], cropping[0]};
+            } else if (cropping.length == 2) {
                 this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1]};
             } else {
                 this.cropping = cropping;
@@ -138,7 +146,8 @@ public class Cropping2D extends NoParamLayer {
         public Builder(@NonNull int[] cropping) {
             Preconditions.checkArgument(cropping.length == 4 || cropping.length == 2,
                     "Either 2 or 4 cropping values,  i.e. (top/bottom. left/right) or (top, bottom," +
-                            " left, right) must be provided. Got " + cropping.length + " values: " + Arrays.toString(cropping));
+                            " left, right) must be provided. Got " + cropping.length + " values: " + Arrays
+                            .toString(cropping));
             if (cropping.length == 2) {
                 this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1]};
             } else {
@@ -155,15 +164,16 @@ public class Cropping2D extends NoParamLayer {
         }
 
         /**
-         * @param cropTop    Amount of cropping to apply to the top of the input activations
+         * @param cropTop Amount of cropping to apply to the top of the input activations
          * @param cropBottom Amount of cropping to apply to the bottom of the input activations
-         * @param cropLeft   Amount of cropping to apply to the left of the input activations
-         * @param cropRight  Amount of cropping to apply to the right of the input activations
+         * @param cropLeft Amount of cropping to apply to the left of the input activations
+         * @param cropRight Amount of cropping to apply to the right of the input activations
          */
         public Builder(int cropTop, int cropBottom, int cropLeft, int cropRight) {
             this.cropping = new int[]{cropTop, cropBottom, cropLeft, cropRight};
             Preconditions.checkArgument(cropTop >= 0 && cropBottom >= 0 && cropLeft >= 0 && cropRight >= 0,
-                    "Invalid arguments: crop dimensions must be > 0. Got [t,b,l,r] = " + Arrays.toString(this.cropping));
+                    "Invalid arguments: crop dimensions must be > 0. Got [t,b,l,r] = " + Arrays
+                            .toString(this.cropping));
         }
 
         public Cropping2D build() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
@@ -110,12 +110,13 @@ public class Cropping2D extends NoParamLayer {
     }
 
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
         /**
          * Cropping amount for top/bottom/left/right (in that order). A length 4 array.
          */
-        @Getter
         private int[] cropping = new int[] {0, 0, 0, 0};
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -80,8 +77,8 @@ public class Cropping2D extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         Cropping2DLayer ret = new Cropping2DLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -103,7 +100,7 @@ public class Cropping2D extends NoParamLayer {
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         Preconditions.checkArgument(inputType != null, "Invalid input for Cropping2D layer (layer name=\""
-                + getLayerName() + "\"): InputType is null");
+                        + getLayerName() + "\"): InputType is null");
         return InputTypeUtil.getPreProcessorForInputTypeCnnLayers(inputType, getLayerName());
     }
 
@@ -119,18 +116,18 @@ public class Cropping2D extends NoParamLayer {
          * Cropping amount for top/bottom/left/right (in that order). A length 4 array.
          */
         @Getter
-        private int[] cropping = new int[]{0, 0, 0, 0};
+        private int[] cropping = new int[] {0, 0, 0, 0};
 
         /**
          * @param cropping Cropping amount for top/bottom/left/right (in that order). Must be length 1, 2, or 4 array.
          */
         public void setCropping(int[] cropping) {
             Preconditions.checkArgument(cropping.length == 1 || cropping.length == 2 || cropping.length == 4,
-                    "Must have 1, 2, or 4 cropping values - got %s", cropping);
+                            "Must have 1, 2, or 4 cropping values - got %s", cropping);
             if (cropping.length == 1) {
-                this.cropping = new int[]{cropping[0], cropping[0], cropping[0], cropping[0]};
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[0], cropping[0]};
             } else if (cropping.length == 2) {
-                this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1]};
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[1], cropping[1]};
             } else {
                 this.cropping = cropping;
             }
@@ -145,11 +142,11 @@ public class Cropping2D extends NoParamLayer {
          */
         public Builder(@NonNull int[] cropping) {
             Preconditions.checkArgument(cropping.length == 4 || cropping.length == 2,
-                    "Either 2 or 4 cropping values,  i.e. (top/bottom. left/right) or (top, bottom," +
-                            " left, right) must be provided. Got " + cropping.length + " values: " + Arrays
-                            .toString(cropping));
+                            "Either 2 or 4 cropping values,  i.e. (top/bottom. left/right) or (top, bottom,"
+                                            + " left, right) must be provided. Got " + cropping.length + " values: "
+                                            + Arrays.toString(cropping));
             if (cropping.length == 2) {
-                this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1]};
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[1], cropping[1]};
             } else {
                 this.cropping = cropping;
             }
@@ -170,10 +167,10 @@ public class Cropping2D extends NoParamLayer {
          * @param cropRight Amount of cropping to apply to the right of the input activations
          */
         public Builder(int cropTop, int cropBottom, int cropLeft, int cropRight) {
-            this.cropping = new int[]{cropTop, cropBottom, cropLeft, cropRight};
+            this.cropping = new int[] {cropTop, cropBottom, cropLeft, cropRight};
             Preconditions.checkArgument(cropTop >= 0 && cropBottom >= 0 && cropLeft >= 0 && cropRight >= 0,
-                    "Invalid arguments: crop dimensions must be > 0. Got [t,b,l,r] = " + Arrays
-                            .toString(this.cropping));
+                            "Invalid arguments: crop dimensions must be > 0. Got [t,b,l,r] = "
+                                            + Arrays.toString(this.cropping));
         }
 
         public Cropping2D build() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
@@ -17,10 +17,7 @@
 package org.deeplearning4j.nn.conf.layers.convolutional;
 
 import com.google.common.base.Preconditions;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import lombok.*;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
@@ -117,7 +114,19 @@ public class Cropping2D extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        @Getter
         private int[] cropping = new int[]{0, 0, 0, 0};
+
+        public void setCropping(int[] cropping) {
+            Preconditions.checkArgument(cropping.length == 1 || cropping.length == 2 || cropping.length == 4, "Must have 1, 2, or 4 cropping values - got %s", cropping);
+            if(cropping.length == 1)
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[0], cropping[0]};
+            else if (cropping.length == 2) {
+                this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1]};
+            } else {
+                this.cropping = cropping;
+            }
+        }
 
         public Builder() {
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping2D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
@@ -38,9 +38,8 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Cropping layer for convolutional (3d) neural networks.
- * Allows cropping to be done separately for upper and lower bounds of
- * depth, height and width dimensions.
+ * Cropping layer for convolutional (3d) neural networks. Allows cropping to be done separately for upper and lower
+ * bounds of depth, height and width dimensions.
  *
  * @author Max Pumperla
  */
@@ -52,20 +51,20 @@ public class Cropping3D extends NoParamLayer {
     private int[] cropping;
 
     /**
-     * @param cropDepth  Amount of cropping to apply to both depth boundaries of the input activations
+     * @param cropDepth Amount of cropping to apply to both depth boundaries of the input activations
      * @param cropHeight Amount of cropping to apply to both height boundaries of the input activations
-     * @param cropWidth  Amount of cropping to apply to both width boundaries of the input activations
+     * @param cropWidth Amount of cropping to apply to both width boundaries of the input activations
      */
     public Cropping3D(int cropDepth, int cropHeight, int cropWidth) {
         this(cropDepth, cropDepth, cropHeight, cropHeight, cropWidth, cropWidth);
     }
 
     /**
-     * @param cropLeftD  Amount of cropping to apply to the left of the depth dimension
+     * @param cropLeftD Amount of cropping to apply to the left of the depth dimension
      * @param cropRightD Amount of cropping to apply to the right of the depth dimension
-     * @param cropLeftH  Amount of cropping to apply to the left of the height dimension
+     * @param cropLeftH Amount of cropping to apply to the left of the height dimension
      * @param cropRightH Amount of cropping to apply to the right of the height dimension
-     * @param cropLeftW  Amount of cropping to apply to the left of the width dimension
+     * @param cropLeftW Amount of cropping to apply to the left of the width dimension
      * @param cropRightW Amount of cropping to apply to the right of the width dimension
      */
     public Cropping3D(int cropLeftD, int cropRightD, int cropLeftH, int cropRightH, int cropLeftW, int cropRightW) {
@@ -73,8 +72,9 @@ public class Cropping3D extends NoParamLayer {
     }
 
     /**
-     * @param cropping Cropping as either a length 3 array, with values {@code [cropDepth, cropHeight, cropWidth]},
-     *                 or as a length 4 array, with values {@code [cropLeftDepth, cropRightDepth, cropLeftHeight, cropRightHeight, cropLeftWidth, cropRightWidth]}
+     * @param cropping Cropping as either a length 3 array, with values {@code [cropDepth, cropHeight, cropWidth]}, or
+     * as a length 4 array, with values {@code [cropLeftDepth, cropRightDepth, cropLeftHeight, cropRightHeight,
+     * cropLeftWidth, cropRightWidth]}
      */
     public Cropping3D(int[] cropping) {
         this(new Builder(cropping));
@@ -87,9 +87,9 @@ public class Cropping3D extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> iterationListeners,
-                                                       int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> iterationListeners,
+            int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         Cropping3DLayer ret = new Cropping3DLayer(conf);
         ret.setListeners(iterationListeners);
         ret.setIndex(layerIndex);
@@ -108,9 +108,9 @@ public class Cropping3D extends NoParamLayer {
         }
         InputType.InputTypeConvolutional3D c = (InputType.InputTypeConvolutional3D) inputType;
         return InputType.convolutional3D(
-                c.getDepth()  - cropping[0] - cropping[1],
-                c.getHeight()  - cropping[2] - cropping[3],
-                c.getWidth()  - cropping[4] - cropping[5],
+                c.getDepth() - cropping[0] - cropping[1],
+                c.getHeight() - cropping[2] - cropping[3],
+                c.getWidth() - cropping[4] - cropping[5],
                 c.getChannels());
     }
 
@@ -129,14 +129,22 @@ public class Cropping3D extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        /**
+         * Cropping amount, a length 6 array, i.e. crop left depth, crop right depth, crop left height, crop right height, crop left width, crop right width
+         */
         @Getter
         private int[] cropping = new int[]{0, 0, 0, 0, 0, 0};
 
+        /**
+         * @param cropping Cropping amount, must be length 1, 3, or 6 array, i.e. either all values, crop depth, crop height, crop width
+         * or crop left depth, crop right depth, crop left height, crop right height, crop left width, crop right width
+         */
         public void setCropping(int[] cropping) {
-            Preconditions.checkArgument(cropping.length == 1 || cropping.length == 3 || cropping.length == 6, "Must have 1, 3, or 6 cropping values - got %s", cropping);
-            if(cropping.length == 1)
-                this.cropping = new int[] {cropping[0], cropping[0], cropping[0], cropping[0], cropping[0], cropping[0]};
-            else if (cropping.length == 3) {
+            Preconditions.checkArgument(cropping.length == 1 || cropping.length == 3 || cropping.length == 6,
+                    "Must have 1, 3, or 6 cropping values - got %s", cropping);
+            if (cropping.length == 1) {
+                this.cropping = new int[]{cropping[0], cropping[0], cropping[0], cropping[0], cropping[0], cropping[0]};
+            } else if (cropping.length == 3) {
                 this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1], cropping[2], cropping[2]};
             } else {
                 this.cropping = cropping;
@@ -148,10 +156,8 @@ public class Cropping3D extends NoParamLayer {
         }
 
         /**
-         * @param cropping Cropping amount, must be length 3 or 6 array, i.e. either
-         *                 crop depth, crop height, crop width or
-         *                 crop left depth, crop right depth, crop left height, crop right height, crop left width,
-         *                 crop right width
+         * @param cropping Cropping amount, must be length 3 or 6 array, i.e. either crop depth, crop height, crop width
+         * or crop left depth, crop right depth, crop left height, crop right height, crop left width, crop right width
          */
         public Builder(@NonNull int[] cropping) {
             Preconditions.checkArgument(cropping.length == 6 || cropping.length == 3,
@@ -165,20 +171,20 @@ public class Cropping3D extends NoParamLayer {
         }
 
         /**
-         * @param cropDepth  Amount of cropping to apply to both depth boundaries of the input activations
+         * @param cropDepth Amount of cropping to apply to both depth boundaries of the input activations
          * @param cropHeight Amount of cropping to apply to both height boundaries of the input activations
-         * @param cropWidth  Amount of cropping to apply to both width boundaries of the input activations
+         * @param cropWidth Amount of cropping to apply to both width boundaries of the input activations
          */
         public Builder(int cropDepth, int cropHeight, int cropWidth) {
             this(cropDepth, cropDepth, cropHeight, cropHeight, cropWidth, cropWidth);
         }
 
         /**
-         * @param cropLeftD  Amount of cropping to apply to the left of the depth dimension
+         * @param cropLeftD Amount of cropping to apply to the left of the depth dimension
          * @param cropRightD Amount of cropping to apply to the right of the depth dimension
-         * @param cropLeftH  Amount of cropping to apply to the left of the height dimension
+         * @param cropLeftH Amount of cropping to apply to the left of the height dimension
          * @param cropRightH Amount of cropping to apply to the right of the height dimension
-         * @param cropLeftW  Amount of cropping to apply to the left of the width dimension
+         * @param cropLeftW Amount of cropping to apply to the left of the width dimension
          * @param cropRightW Amount of cropping to apply to the right of the width dimension
          */
         public Builder(int cropLeftD, int cropRightD, int cropLeftH, int cropRightH, int cropLeftW, int cropRightW) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -87,9 +84,8 @@ public class Cropping3D extends NoParamLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> iterationListeners,
-            int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> iterationListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         Cropping3DLayer ret = new Cropping3DLayer(conf);
         ret.setListeners(iterationListeners);
         ret.setIndex(layerIndex);
@@ -103,21 +99,19 @@ public class Cropping3D extends NoParamLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.CNN3D) {
             throw new IllegalStateException("Invalid input for 3D cropping layer (layer index = " + layerIndex
-                    + ", layer name = \"" + getLayerName() + "\"): expect CNN3D input type with size > 0. Got: "
-                    + inputType);
+                            + ", layer name = \"" + getLayerName() + "\"): expect CNN3D input type with size > 0. Got: "
+                            + inputType);
         }
         InputType.InputTypeConvolutional3D c = (InputType.InputTypeConvolutional3D) inputType;
-        return InputType.convolutional3D(
-                c.getDepth() - cropping[0] - cropping[1],
-                c.getHeight() - cropping[2] - cropping[3],
-                c.getWidth() - cropping[4] - cropping[5],
-                c.getChannels());
+        return InputType.convolutional3D(c.getDepth() - cropping[0] - cropping[1],
+                        c.getHeight() - cropping[2] - cropping[3], c.getWidth() - cropping[4] - cropping[5],
+                        c.getChannels());
     }
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
-        Preconditions.checkArgument(inputType != null, "Invalid input for Cropping3D " +
-                "layer (layer name=\"" + getLayerName() + "\"): InputType is null");
+        Preconditions.checkArgument(inputType != null, "Invalid input for Cropping3D " + "layer (layer name=\""
+                        + getLayerName() + "\"): InputType is null");
         return InputTypeUtil.getPreProcessorForInputTypeCnn3DLayers(inputType, getLayerName());
     }
 
@@ -133,7 +127,7 @@ public class Cropping3D extends NoParamLayer {
          * Cropping amount, a length 6 array, i.e. crop left depth, crop right depth, crop left height, crop right height, crop left width, crop right width
          */
         @Getter
-        private int[] cropping = new int[]{0, 0, 0, 0, 0, 0};
+        private int[] cropping = new int[] {0, 0, 0, 0, 0, 0};
 
         /**
          * @param cropping Cropping amount, must be length 1, 3, or 6 array, i.e. either all values, crop depth, crop height, crop width
@@ -141,11 +135,13 @@ public class Cropping3D extends NoParamLayer {
          */
         public void setCropping(int[] cropping) {
             Preconditions.checkArgument(cropping.length == 1 || cropping.length == 3 || cropping.length == 6,
-                    "Must have 1, 3, or 6 cropping values - got %s", cropping);
+                            "Must have 1, 3, or 6 cropping values - got %s", cropping);
             if (cropping.length == 1) {
-                this.cropping = new int[]{cropping[0], cropping[0], cropping[0], cropping[0], cropping[0], cropping[0]};
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[0], cropping[0], cropping[0],
+                                cropping[0]};
             } else if (cropping.length == 3) {
-                this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1], cropping[2], cropping[2]};
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[1], cropping[1], cropping[2],
+                                cropping[2]};
             } else {
                 this.cropping = cropping;
             }
@@ -161,10 +157,11 @@ public class Cropping3D extends NoParamLayer {
          */
         public Builder(@NonNull int[] cropping) {
             Preconditions.checkArgument(cropping.length == 6 || cropping.length == 3,
-                    "Either 3 or 6 cropping values, got "
-                            + cropping.length + " values: " + Arrays.toString(cropping));
+                            "Either 3 or 6 cropping values, got " + cropping.length + " values: "
+                                            + Arrays.toString(cropping));
             if (cropping.length == 3) {
-                this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1], cropping[2], cropping[2]};
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[1], cropping[1], cropping[2],
+                                cropping[2]};
             } else {
                 this.cropping = cropping;
             }
@@ -188,10 +185,11 @@ public class Cropping3D extends NoParamLayer {
          * @param cropRightW Amount of cropping to apply to the right of the width dimension
          */
         public Builder(int cropLeftD, int cropRightD, int cropLeftH, int cropRightH, int cropLeftW, int cropRightW) {
-            this.cropping = new int[]{cropLeftD, cropRightD, cropLeftH, cropRightH, cropLeftW, cropRightW};
-            Preconditions.checkArgument(cropLeftD >= 0 && cropLeftH >= 0 && cropLeftW >= 0
-                            && cropRightD >= 0 && cropRightH >= 0 && cropRightW >= 0,
-                    "Invalid arguments: crop dimensions must be > 0. Got " + Arrays.toString(this.cropping));
+            this.cropping = new int[] {cropLeftD, cropRightD, cropLeftH, cropRightH, cropLeftW, cropRightW};
+            Preconditions.checkArgument(
+                            cropLeftD >= 0 && cropLeftH >= 0 && cropLeftW >= 0 && cropRightD >= 0 && cropRightH >= 0
+                                            && cropRightW >= 0,
+                            "Invalid arguments: crop dimensions must be > 0. Got " + Arrays.toString(this.cropping));
         }
 
         public Cropping3D build() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
@@ -121,12 +121,13 @@ public class Cropping3D extends NoParamLayer {
     }
 
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
         /**
          * Cropping amount, a length 6 array, i.e. crop left depth, crop right depth, crop left height, crop right height, crop left width, crop right width
          */
-        @Getter
         private int[] cropping = new int[] {0, 0, 0, 0, 0, 0};
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
@@ -17,10 +17,7 @@
 package org.deeplearning4j.nn.conf.layers.convolutional;
 
 import com.google.common.base.Preconditions;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import lombok.*;
 import org.deeplearning4j.nn.conf.GradientNormalization;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -132,7 +129,19 @@ public class Cropping3D extends NoParamLayer {
 
     public static class Builder extends Layer.Builder<Builder> {
 
+        @Getter
         private int[] cropping = new int[]{0, 0, 0, 0, 0, 0};
+
+        public void setCropping(int[] cropping) {
+            Preconditions.checkArgument(cropping.length == 1 || cropping.length == 3 || cropping.length == 6, "Must have 1, 3, or 6 cropping values - got %s", cropping);
+            if(cropping.length == 1)
+                this.cropping = new int[] {cropping[0], cropping[0], cropping[0], cropping[0], cropping[0], cropping[0]};
+            else if (cropping.length == 3) {
+                this.cropping = new int[]{cropping[0], cropping[0], cropping[1], cropping[1], cropping[2], cropping[2]};
+            } else {
+                this.cropping = cropping;
+            }
+        }
 
         public Builder() {
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/convolutional/Cropping3D.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -46,8 +43,7 @@ import java.util.Map;
 public class ElementWiseMultiplicationLayer extends org.deeplearning4j.nn.conf.layers.FeedForwardLayer {
 
     //  We have to add an empty constructor for custom layers otherwise we will have errors when loading the model
-    protected ElementWiseMultiplicationLayer() {
-    }
+    protected ElementWiseMultiplicationLayer() {}
 
     protected ElementWiseMultiplicationLayer(Builder builder) {
         super(builder);
@@ -61,14 +57,13 @@ public class ElementWiseMultiplicationLayer extends org.deeplearning4j.nn.conf.l
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex,
-            INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         if (this.nIn != this.nOut) {
             throw new IllegalStateException("Element wise layer must have the same input and output size. Got nIn="
-                    + nIn + ", nOut=" + nOut);
+                            + nIn + ", nOut=" + nOut);
         }
-        org.deeplearning4j.nn.layers.feedforward.elementwise.ElementWiseMultiplicationLayer ret
-                = new org.deeplearning4j.nn.layers.feedforward.elementwise.ElementWiseMultiplicationLayer(conf);
+        org.deeplearning4j.nn.layers.feedforward.elementwise.ElementWiseMultiplicationLayer ret =
+                        new org.deeplearning4j.nn.layers.feedforward.elementwise.ElementWiseMultiplicationLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -116,12 +111,10 @@ public class ElementWiseMultiplicationLayer extends org.deeplearning4j.nn.conf.l
         trainSizeVariable += outputType.arrayElementsPerExample();
 
         return new LayerMemoryReport.Builder(layerName, ElementWiseMultiplicationLayer.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, trainSizeFixed,
-                        trainSizeVariable) //No additional memory (beyond activations) for inference
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS,
-                        MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
-                .build();
+                        .standardMemory(numParams, updaterStateSize)
+                        .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
+                        .build();
     }
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
@@ -33,10 +33,8 @@ import java.util.Map;
 
 
 /**
- * Elementwise multiplication layer with weights: implements {@code out = activationFn(input .* w + b)} where:<br>
- * - w is a learnable weight vector of length nOut<br>
- * - ".*" is element-wise multiplication<br>
- * - b is a bias vector<br>
+ * Elementwise multiplication layer with weights: implements {@code out = activationFn(input .* w + b)} where:<br> - w
+ * is a learnable weight vector of length nOut<br> - ".*" is element-wise multiplication<br> - b is a bias vector<br>
  * <br>
  * Note that the input and output sizes of the element-wise layer are the same for this layer
  * <p>
@@ -48,7 +46,8 @@ import java.util.Map;
 public class ElementWiseMultiplicationLayer extends org.deeplearning4j.nn.conf.layers.FeedForwardLayer {
 
     //  We have to add an empty constructor for custom layers otherwise we will have errors when loading the model
-    protected ElementWiseMultiplicationLayer() { }
+    protected ElementWiseMultiplicationLayer() {
+    }
 
     protected ElementWiseMultiplicationLayer(Builder builder) {
         super(builder);
@@ -61,8 +60,9 @@ public class ElementWiseMultiplicationLayer extends org.deeplearning4j.nn.conf.l
     }
 
     @Override
-    public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners, int layerIndex,
-                             INDArray layerParamsView, boolean initializeParams) {
+    public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
+            int layerIndex,
+            INDArray layerParamsView, boolean initializeParams) {
         if (this.nIn != this.nOut) {
             throw new IllegalStateException("Element wise layer must have the same input and output size. Got nIn="
                     + nIn + ", nOut=" + nOut);
@@ -117,8 +117,10 @@ public class ElementWiseMultiplicationLayer extends org.deeplearning4j.nn.conf.l
 
         return new LayerMemoryReport.Builder(layerName, ElementWiseMultiplicationLayer.class, inputType, outputType)
                 .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, 0, trainSizeFixed, trainSizeVariable) //No additional memory (beyond activations) for inference
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
+                .workingMemory(0, 0, trainSizeFixed,
+                        trainSizeVariable) //No additional memory (beyond activations) for inference
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS,
+                        MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching in DenseLayer
                 .build();
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/ElementWiseMultiplicationLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -76,12 +73,12 @@ public class FrozenLayer extends Layer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
 
         //Need to be able to instantiate a layer, from a config - for JSON -> net type situations
         org.deeplearning4j.nn.api.Layer underlying = layer.instantiate(getInnerConf(conf), trainingListeners,
-                layerIndex, layerParamsView, initializeParams);
+                        layerIndex, layerParamsView, initializeParams);
 
         NeuralNetConfiguration nncUnderlying = underlying.conf();
         if (nncUnderlying.variables() != null) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
@@ -39,11 +39,9 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * FrozenLayer is used for the purposes of transfer learning.<br>
- * A frozen layer wraps another DL4J Layer within it.
- * During backprop, the FrozenLayer is skipped, and any parameters are not be updated.
- * Usually users will typically not create FrozenLayer instances directly - they are usually used in the process of performing
- * transfer learning
+ * FrozenLayer is used for the purposes of transfer learning.<br> A frozen layer wraps another DL4J Layer within it.
+ * During backprop, the FrozenLayer is skipped, and any parameters are not be updated. Usually users will typically not
+ * create FrozenLayer instances directly - they are usually used in the process of performing transfer learning
  *
  * @author Alex Black
  */
@@ -78,12 +76,12 @@ public class FrozenLayer extends Layer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
-                    boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
 
         //Need to be able to instantiate a layer, from a config - for JSON -> net type situations
         org.deeplearning4j.nn.api.Layer underlying = layer.instantiate(getInnerConf(conf), trainingListeners,
-                        layerIndex, layerParamsView, initializeParams);
+                layerIndex, layerParamsView, initializeParams);
 
         NeuralNetConfiguration nncUnderlying = underlying.conf();
         if (nncUnderlying.variables() != null) {
@@ -161,12 +159,13 @@ public class FrozenLayer extends Layer {
     }
 
     @Override
-    public void setConstraints(List<LayerConstraint> constraints){
+    public void setConstraints(List<LayerConstraint> constraints) {
         this.constraints = constraints;
         this.layer.setConstraints(constraints);
     }
 
     public static class Builder extends Layer.Builder<Builder> {
+
         @Getter
         @Setter
         private Layer layer;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
@@ -18,6 +18,7 @@ package org.deeplearning4j.nn.conf.layers.misc;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.api.layers.LayerConstraint;
 import org.deeplearning4j.nn.conf.GradientNormalization;
@@ -166,6 +167,8 @@ public class FrozenLayer extends Layer {
     }
 
     public static class Builder extends Layer.Builder<Builder> {
+        @Getter
+        @Setter
         private Layer layer;
 
         public Builder layer(Layer layer) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
@@ -161,10 +161,10 @@ public class FrozenLayer extends Layer {
         this.layer.setConstraints(constraints);
     }
 
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
-        @Getter
-        @Setter
         private Layer layer;
 
         public Builder layer(Layer layer) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -120,7 +117,7 @@ public class FrozenLayerWithBackprop extends BaseWrapperLayer {
     }
 
     @Override
-    public void setConstraints(List<LayerConstraint> constraints){
+    public void setConstraints(List<LayerConstraint> constraints) {
         this.constraints = constraints;
         this.underlying.setConstraints(constraints);
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/FrozenLayerWithBackprop.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
@@ -33,8 +33,8 @@ import java.util.Map;
 /**
  * RepeatVector layer configuration.
  *
- * RepeatVector takes a mini-batch of vectors of shape (mb, length) and a repeat factor n and outputs
- * a 3D tensor of shape (mb, n, length) in which x is repeated n times.
+ * RepeatVector takes a mini-batch of vectors of shape (mb, length) and a repeat factor n and outputs a 3D tensor of
+ * shape (mb, n, length) in which x is repeated n times.
  *
  * @author Max Pumperla
  */
@@ -53,7 +53,7 @@ public class RepeatVector extends FeedForwardLayer {
 
     @Override
     public RepeatVector clone() {
-        return  (RepeatVector) super.clone();
+        return (RepeatVector) super.clone();
     }
 
     @Override
@@ -63,9 +63,9 @@ public class RepeatVector extends FeedForwardLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView,
-                                                       boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView,
+            boolean initializeParams) {
         org.deeplearning4j.nn.layers.RepeatVector ret =
                 new org.deeplearning4j.nn.layers.RepeatVector(conf);
         ret.setListeners(trainingListeners);
@@ -121,11 +121,18 @@ public class RepeatVector extends FeedForwardLayer {
     public static class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
 
         private int n = 1; // no repetition by default
-
+        /**
+         * Set repetition factor for RepeatVector layer
+         */
         public int getRepetitionFactor() {
             return n;
         }
 
+        /**
+         * Set repetition factor for RepeatVector layer
+         *
+         * @param n upsampling size in height and width dimensions
+         */
         public void setRepetitionFactor(int n) {
             this.n = n;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
@@ -122,6 +122,14 @@ public class RepeatVector extends FeedForwardLayer {
 
         private int n = 1; // no repetition by default
 
+        public int getRepetitionFactor() {
+            return n;
+        }
+
+        public void setRepetitionFactor(int n) {
+            this.n = n;
+        }
+
         public Builder(int n) {
             this.n = n;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -63,11 +60,9 @@ public class RepeatVector extends FeedForwardLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView,
-            boolean initializeParams) {
-        org.deeplearning4j.nn.layers.RepeatVector ret =
-                new org.deeplearning4j.nn.layers.RepeatVector(conf);
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
+        org.deeplearning4j.nn.layers.RepeatVector ret = new org.deeplearning4j.nn.layers.RepeatVector(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -81,7 +76,7 @@ public class RepeatVector extends FeedForwardLayer {
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || inputType.getType() != InputType.Type.FF) {
             throw new IllegalStateException("Invalid input for RepeatVector layer (layer name=\"" + getLayerName()
-                    + "\"): Expected FF input, got " + inputType);
+                            + "\"): Expected FF input, got " + inputType);
         }
         InputType.InputTypeFeedForward ffInput = (InputType.InputTypeFeedForward) inputType;
         return InputType.recurrent(ffInput.getSize(), n);
@@ -91,11 +86,9 @@ public class RepeatVector extends FeedForwardLayer {
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         InputType outputType = getOutputType(-1, inputType);
 
-        return new LayerMemoryReport.Builder(layerName, RepeatVector.class, inputType, outputType)
-                .standardMemory(0, 0)
-                .workingMemory(0, 0, 0, 0)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS)
-                .build();
+        return new LayerMemoryReport.Builder(layerName, RepeatVector.class, inputType, outputType).standardMemory(0, 0)
+                        .workingMemory(0, 0, 0, 0)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS).build();
     }
 
 
@@ -121,6 +114,7 @@ public class RepeatVector extends FeedForwardLayer {
     public static class Builder<T extends Builder<T>> extends FeedForwardLayer.Builder<T> {
 
         private int n = 1; // no repetition by default
+
         /**
          * Set repetition factor for RepeatVector layer
          */

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/misc/RepeatVector.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
@@ -42,35 +42,28 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Output (loss) layer for YOLOv2 object detection model, based on the papers:
- * YOLO9000: Better, Faster, Stronger - Redmon & Farhadi (2016) - <a href="https://arxiv.org/abs/1612.08242">https://arxiv.org/abs/1612.08242</a><br>
- * and<br>
+ * Output (loss) layer for YOLOv2 object detection model, based on the papers: YOLO9000: Better, Faster, Stronger -
+ * Redmon & Farhadi (2016) - <a href="https://arxiv.org/abs/1612.08242">https://arxiv.org/abs/1612.08242</a><br> and<br>
  * You Only Look Once: Unified, Real-Time Object Detection - Redmon et al. (2016) -
  * <a href="http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf">http://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Redmon_You_Only_Look_CVPR_2016_paper.pdf</a>
  * <br>
  * This loss function implementation is based on the YOLOv2 version of the paper. However, note that it doesn't
- * currently support simultaneous training on both detection and classification datasets as described in the
- * YOlO9000 paper.<br>
+ * currently support simultaneous training on both detection and classification datasets as described in the YOlO9000
+ * paper.<br>
  *
- * Note: Input activations to the Yolo2OutputLayer should have shape: [minibatch, b*(5+c), H, W], where:<br>
- * b = number of bounding boxes (determined by config - see papers for details)<br>
- * c = number of classes<br>
- * H = output/label height<br>
- * W = output/label width<br>
+ * Note: Input activations to the Yolo2OutputLayer should have shape: [minibatch, b*(5+c), H, W], where:<br> b = number
+ * of bounding boxes (determined by config - see papers for details)<br> c = number of classes<br> H = output/label
+ * height<br> W = output/label width<br>
  * <br>
  * Important: In practice, this means that the last convolutional layer before your Yolo2OutputLayer should have output
- * depth of b*(5+c). Thus if you change the number of bounding boxes, or change the number of object classes,
- * the number of channels (nOut of the last convolution layer) needs to also change.
+ * depth of b*(5+c). Thus if you change the number of bounding boxes, or change the number of object classes, the number
+ * of channels (nOut of the last convolution layer) needs to also change.
  * <br>
- * Label format: [minibatch, 4+C, H, W]<br>
- * Order for labels depth: [x1,y1,x2,y2,(class labels)]<br>
- * x1 = box top left position<br>
- * y1 = as above, y axis<br>
- * x2 = box bottom right position<br>
- * y2 = as above y axis<br>
- * Note: labels are represented as a multiple of grid size - for a 13x13 grid, (0,0) is top left, (13,13) is bottom right<br>
- * Note also that mask arrays are not required - this implementation infers the presence or absence of objects in each grid
- * cell from the class labels (which should be 1-hot if an object is present, or all 0s otherwise).
+ * Label format: [minibatch, 4+C, H, W]<br> Order for labels depth: [x1,y1,x2,y2,(class labels)]<br> x1 = box top left
+ * position<br> y1 = as above, y axis<br> x2 = box bottom right position<br> y2 = as above y axis<br> Note: labels are
+ * represented as a multiple of grid size - for a 13x13 grid, (0,0) is top left, (13,13) is bottom right<br> Note also
+ * that mask arrays are not required - this implementation infers the presence or absence of objects in each grid cell
+ * from the class labels (which should be 1-hot if an object is present, or all 0s otherwise).
  *
  * @author Alex Black
  */
@@ -85,11 +78,11 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
     @JsonDeserialize(using = VectorDeSerializer.class)
     private INDArray boundingBoxes;
 
-    private Yolo2OutputLayer(){
+    private Yolo2OutputLayer() {
         //No-arg costructor for Jackson JSON
     }
 
-    private Yolo2OutputLayer(Builder builder){
+    private Yolo2OutputLayer(Builder builder) {
         super(builder);
         this.lambdaCoord = builder.lambdaCoord;
         this.lambdaNoObj = builder.lambdaNoObj;
@@ -99,8 +92,10 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
     }
 
     @Override
-    public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer ret = new org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer(conf);
+    public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer ret = new org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer(
+                conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -127,14 +122,14 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
-        switch (inputType.getType()){
+        switch (inputType.getType()) {
             case FF:
             case RNN:
                 throw new UnsupportedOperationException("Cannot use FF or RNN input types");
             case CNN:
                 return null;
             case CNNFlat:
-                InputType.InputTypeConvolutionalFlat cf = (InputType.InputTypeConvolutionalFlat)inputType;
+                InputType.InputTypeConvolutionalFlat cf = (InputType.InputTypeConvolutionalFlat) inputType;
                 return new FeedForwardToCnnPreProcessor(cf.getHeight(), cf.getWidth(), cf.getDepth());
             default:
                 return null;
@@ -180,40 +175,70 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
     public static class Builder extends org.deeplearning4j.nn.conf.layers.Layer.Builder<Builder> {
 
+        /**
+         * Loss function coefficient for position and size/scale components of the loss function. Default (as per
+         * paper): 5
+         *
+         */
         @Getter
         @Setter
         private double lambdaCoord = 5;
+
+        /**
+         * Loss function coefficient for the "no object confidence" components of the loss function. Default (as per
+         * paper): 0.5
+         *
+         */
         @Getter
         @Setter
         private double lambdaNoObj = 0.5;
+
+        /**
+         * Loss function for position/scale component of the loss function
+         *
+         */
         @Getter
         @Setter
         private ILossFunction lossPositionScale = new LossL2();
+
+        /**
+         * Loss function for the class predictions - defaults to L2 loss (i.e., sum of squared errors, as per the
+         * paper), however Loss MCXENT could also be used (which is more common for classification).
+         *
+         */
         @Getter
         @Setter
         private ILossFunction lossClassPredictions = new LossL2();
+
+        /**
+         * Bounding box priors dimensions [width, height]. For N bounding boxes, input has shape [rows, columns] = [N,
+         * 2] Note that dimensions should be specified as fraction of grid size. For example, a network with 13x13
+         * output, a value of 1.0 would correspond to one grid cell; a value of 13 would correspond to the entire
+         * image.
+         *
+         */
         @Getter
         @Setter
         private INDArray boundingBoxes;
 
         /**
-         * Loss function coefficient for position and size/scale components of the loss function.
-         * Default (as per paper): 5
+         * Loss function coefficient for position and size/scale components of the loss function. Default (as per
+         * paper): 5
          *
          * @param lambdaCoord Lambda value for size/scale component of loss function
          */
-        public Builder lambdaCoord(double lambdaCoord){
+        public Builder lambdaCoord(double lambdaCoord) {
             this.lambdaCoord = lambdaCoord;
             return this;
         }
 
         /**
-         * Loss function coefficient for the "no object confidence" components of the loss function.
-         * Default (as per paper): 0.5
+         * Loss function coefficient for the "no object confidence" components of the loss function. Default (as per
+         * paper): 0.5
          *
          * @param lambdaNoObj Lambda value for no-object (confidence) component of the loss function
          */
-        public Builder lambbaNoObj(double lambdaNoObj){
+        public Builder lambbaNoObj(double lambdaNoObj) {
             this.lambdaNoObj = lambdaNoObj;
             return this;
         }
@@ -223,7 +248,7 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
          *
          * @param lossPositionScale Loss function for position/scale
          */
-        public Builder lossPositionScale(ILossFunction lossPositionScale){
+        public Builder lossPositionScale(ILossFunction lossPositionScale) {
             this.lossPositionScale = lossPositionScale;
             return this;
         }
@@ -234,30 +259,31 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
          *
          * @param lossClassPredictions Loss function for the class prediction error component of the YOLO loss function
          */
-        public Builder lossClassPredictions(ILossFunction lossClassPredictions){
+        public Builder lossClassPredictions(ILossFunction lossClassPredictions) {
             this.lossClassPredictions = lossClassPredictions;
             return this;
         }
 
         /**
-         * Bounding box priors dimensions [width, height]. For N bounding boxes, input has shape [rows, columns] = [N, 2]
-         * Note that dimensions should be specified as fraction of grid size. For example, a network with 13x13 output,
-         * a value of 1.0 would correspond to one grid cell; a value of 13 would correspond to the entire image.
+         * Bounding box priors dimensions [width, height]. For N bounding boxes, input has shape [rows, columns] = [N,
+         * 2] Note that dimensions should be specified as fraction of grid size. For example, a network with 13x13
+         * output, a value of 1.0 would correspond to one grid cell; a value of 13 would correspond to the entire
+         * image.
          *
          * @param boundingBoxes Bounding box prior dimensions (width, height)
          */
-        public Builder boundingBoxPriors(INDArray boundingBoxes){
+        public Builder boundingBoxPriors(INDArray boundingBoxes) {
             this.boundingBoxes = boundingBoxes;
             return this;
         }
 
         @Override
         public Yolo2OutputLayer build() {
-            if(boundingBoxes == null){
+            if (boundingBoxes == null) {
                 throw new IllegalStateException("Bounding boxes have not been set");
             }
 
-            if(boundingBoxes.rank() != 2 || boundingBoxes.size(1) != 2){
+            if (boundingBoxes.rank() != 2 || boundingBoxes.size(1) != 2) {
                 throw new IllegalStateException("Bounding box priors must have shape [nBoxes, 2]. Has shape: "
                         + Arrays.toString(boundingBoxes.shape()));
             }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
@@ -17,6 +17,8 @@
 package org.deeplearning4j.nn.conf.layers.objdetect;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.GradientNormalization;
@@ -178,10 +180,20 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
     public static class Builder extends org.deeplearning4j.nn.conf.layers.Layer.Builder<Builder> {
 
+        @Getter
+        @Setter
         private double lambdaCoord = 5;
+        @Getter
+        @Setter
         private double lambdaNoObj = 0.5;
+        @Getter
+        @Setter
         private ILossFunction lossPositionScale = new LossL2();
+        @Getter
+        @Setter
         private ILossFunction lossClassPredictions = new LossL2();
+        @Getter
+        @Setter
         private INDArray boundingBoxes;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
@@ -169,6 +169,8 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
                         .build();
     }
 
+    @Getter
+    @Setter
     public static class Builder extends org.deeplearning4j.nn.conf.layers.Layer.Builder<Builder> {
 
         /**
@@ -176,8 +178,6 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
          * paper): 5
          *
          */
-        @Getter
-        @Setter
         private double lambdaCoord = 5;
 
         /**
@@ -185,16 +185,12 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
          * paper): 0.5
          *
          */
-        @Getter
-        @Setter
         private double lambdaNoObj = 0.5;
 
         /**
          * Loss function for position/scale component of the loss function
          *
          */
-        @Getter
-        @Setter
         private ILossFunction lossPositionScale = new LossL2();
 
         /**
@@ -202,8 +198,6 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
          * paper), however Loss MCXENT could also be used (which is more common for classification).
          *
          */
-        @Getter
-        @Setter
         private ILossFunction lossClassPredictions = new LossL2();
 
         /**
@@ -213,8 +207,6 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
          * image.
          *
          */
-        @Getter
-        @Setter
         private INDArray boundingBoxes;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -93,9 +90,9 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer ret = new org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer(
-                conf);
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer ret =
+                        new org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -112,7 +109,7 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        return inputType;   //Same shape output as input
+        return inputType; //Same shape output as input
     }
 
     @Override
@@ -138,17 +135,17 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
     @Override
     public double getL1ByParam(String paramName) {
-        return 0;   //No params
+        return 0; //No params
     }
 
     @Override
     public double getL2ByParam(String paramName) {
-        return 0;   //No params
+        return 0; //No params
     }
 
     @Override
     public boolean isPretrainParam(String paramName) {
-        return false;   //No params
+        return false; //No params
     }
 
     @Override
@@ -167,10 +164,9 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
         //This is a VERY rough estimate...
         return new LayerMemoryReport.Builder(layerName, Yolo2OutputLayer.class, inputType, inputType)
-                .standardMemory(0, 0)   //No params
-                .workingMemory(0, numValues, 0, 6 * numValues)
-                .cacheMemory(0, 0)  //No cache
-                .build();
+                        .standardMemory(0, 0) //No params
+                        .workingMemory(0, numValues, 0, 6 * numValues).cacheMemory(0, 0) //No cache
+                        .build();
     }
 
     public static class Builder extends org.deeplearning4j.nn.conf.layers.Layer.Builder<Builder> {
@@ -285,7 +281,7 @@ public class Yolo2OutputLayer extends org.deeplearning4j.nn.conf.layers.Layer {
 
             if (boundingBoxes.rank() != 2 || boundingBoxes.size(1) != 2) {
                 throw new IllegalStateException("Bounding box priors must have shape [nBoxes, 2]. Has shape: "
-                        + Arrays.toString(boundingBoxes.shape()));
+                                + Arrays.toString(boundingBoxes.shape()));
             }
 
             return new Yolo2OutputLayer(this);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/objdetect/Yolo2OutputLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
@@ -244,7 +244,15 @@ public class Bidirectional extends Layer {
     @AllArgsConstructor
     public static class Builder extends Layer.Builder<Bidirectional.Builder> {
 
+        @Getter
+        @Setter
         private Mode mode;
+
+        public void setLayer(Layer layer) {
+            rnnLayer(layer);
+        }
+
+        @Getter
         private Layer layer;
 
         public Builder mode(Mode mode) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -96,10 +93,10 @@ public class Bidirectional extends Layer {
      */
     public Bidirectional(@NonNull Mode mode, @NonNull Layer layer) {
         if (!(layer instanceof BaseRecurrentLayer || layer instanceof LastTimeStep
-                || layer instanceof BaseWrapperLayer)) {
-            throw new IllegalArgumentException("Cannot wrap a non-recurrent layer: " +
-                    "config must extend BaseRecurrentLayer or LastTimeStep " +
-                    "Got class: " + layer.getClass());
+                        || layer instanceof BaseWrapperLayer)) {
+            throw new IllegalArgumentException("Cannot wrap a non-recurrent layer: "
+                            + "config must extend BaseRecurrentLayer or LastTimeStep " + "Got class: "
+                            + layer.getClass());
         }
         this.fwd = layer;
         this.bwd = layer.clone();
@@ -124,8 +121,8 @@ public class Bidirectional extends Layer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners, int layerIndex,
-            INDArray layerParamsView, boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         NeuralNetConfiguration c1 = conf.clone();
         NeuralNetConfiguration c2 = conf.clone();
         c1.setLayer(fwd);
@@ -134,11 +131,9 @@ public class Bidirectional extends Layer {
         long n = layerParamsView.length() / 2;
         INDArray fp = layerParamsView.get(point(0), interval(0, n));
         INDArray bp = layerParamsView.get(point(0), interval(n, 2 * n));
-        org.deeplearning4j.nn.api.Layer f
-                = fwd.instantiate(c1, trainingListeners, layerIndex, fp, initializeParams);
+        org.deeplearning4j.nn.api.Layer f = fwd.instantiate(c1, trainingListeners, layerIndex, fp, initializeParams);
 
-        org.deeplearning4j.nn.api.Layer b
-                = bwd.instantiate(c2, trainingListeners, layerIndex, bp, initializeParams);
+        org.deeplearning4j.nn.api.Layer b = bwd.instantiate(c2, trainingListeners, layerIndex, bp, initializeParams);
 
         BidirectionalLayer ret = new BidirectionalLayer(conf, f, b, layerParamsView);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);
@@ -236,7 +231,7 @@ public class Bidirectional extends Layer {
     @Override
     public LayerMemoryReport getMemoryReport(InputType inputType) {
         LayerMemoryReport lmr = fwd.getMemoryReport(inputType);
-        lmr.scale(2);   //Double all memory use
+        lmr.scale(2); //Double all memory use
         return lmr;
     }
 
@@ -261,10 +256,10 @@ public class Bidirectional extends Layer {
 
         public Builder rnnLayer(Layer layer) {
             if (!(layer instanceof BaseRecurrentLayer || layer instanceof LastTimeStep
-                    || layer instanceof BaseWrapperLayer)) {
-                throw new IllegalArgumentException("Cannot wrap a non-recurrent layer: " +
-                        "config must extend BaseRecurrentLayer or LastTimeStep " +
-                        "Got class: " + layer.getClass());
+                            || layer instanceof BaseWrapperLayer)) {
+                throw new IllegalArgumentException("Cannot wrap a non-recurrent layer: "
+                                + "config must extend BaseRecurrentLayer or LastTimeStep " + "Got class: "
+                                + layer.getClass());
             }
             this.layer = layer;
             return this;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
@@ -236,13 +236,11 @@ public class Bidirectional extends Layer {
     }
 
     @AllArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Bidirectional.Builder> {
 
-        @Getter
-        @Setter
         private Mode mode;
-
-        @Getter
         private Layer layer;
 
         public void setLayer(Layer layer) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
@@ -42,10 +42,10 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
 import static org.nd4j.linalg.indexing.NDArrayIndex.point;
 
 /**
- * Bidirectional is a "wrapper" layer: it wraps any uni-directional RNN layer to make it bidirectional.<br>
- * Note that multiple different modes are supported - these specify how the activations should be combined from
- * the forward and backward RNN networks. See {@link Mode} javadoc for more details.<br>
- * Parameters are not shared here - there are 2 separate copies of the wrapped RNN layer, each with separate parameters.
+ * Bidirectional is a "wrapper" layer: it wraps any uni-directional RNN layer to make it bidirectional.<br> Note that
+ * multiple different modes are supported - these specify how the activations should be combined from the forward and
+ * backward RNN networks. See {@link Mode} javadoc for more details.<br> Parameters are not shared here - there are 2
+ * separate copies of the wrapped RNN layer, each with separate parameters.
  * <br>
  * Usage: {@code .layer(new Bidirectional(new LSTM.Builder()....build())}
  *
@@ -59,13 +59,11 @@ public class Bidirectional extends Layer {
 
     /**
      * This Mode enumeration defines how the activations for the forward and backward networks should be combined.<br>
-     * ADD: out = forward + backward (elementwise addition)<br>
-     * MUL: out = forward * backward (elementwise multiplication)<br>
-     * AVERAGE: out = 0.5 * (forward + backward)<br>
-     * CONCAT: Concatenate the activations.<br>
-     * Where 'forward' is the activations for the forward RNN, and 'backward' is the activations for the backward RNN.
-     * In all cases except CONCAT, the output activations size is the same size as the standard RNN that is being wrapped
-     * by this layer. In the CONCAT case, the output activations size (dimension 1) is 2x larger than the standard RNN's
+     * ADD: out = forward + backward (elementwise addition)<br> MUL: out = forward * backward (elementwise
+     * multiplication)<br> AVERAGE: out = 0.5 * (forward + backward)<br> CONCAT: Concatenate the activations.<br> Where
+     * 'forward' is the activations for the forward RNN, and 'backward' is the activations for the backward RNN. In all
+     * cases except CONCAT, the output activations size is the same size as the standard RNN that is being wrapped by
+     * this layer. In the CONCAT case, the output activations size (dimension 1) is 2x larger than the standard RNN's
      * activations array.
      */
     public enum Mode {
@@ -93,11 +91,12 @@ public class Bidirectional extends Layer {
     /**
      * Create a Bidirectional wrapper for the specified layer
      *
-     * @param mode  Mode to use to combine activations. See {@link Mode} for details
+     * @param mode Mode to use to combine activations. See {@link Mode} for details
      * @param layer layer to wrap
      */
     public Bidirectional(@NonNull Mode mode, @NonNull Layer layer) {
-        if (!(layer instanceof BaseRecurrentLayer || layer instanceof LastTimeStep || layer instanceof BaseWrapperLayer)) {
+        if (!(layer instanceof BaseRecurrentLayer || layer instanceof LastTimeStep
+                || layer instanceof BaseWrapperLayer)) {
             throw new IllegalArgumentException("Cannot wrap a non-recurrent layer: " +
                     "config must extend BaseRecurrentLayer or LastTimeStep " +
                     "Got class: " + layer.getClass());
@@ -117,7 +116,7 @@ public class Bidirectional extends Layer {
 
     public long getNIn() {
         if (this.fwd instanceof LastTimeStep) {
-            return  ((FeedForwardLayer)((LastTimeStep) this.fwd).getUnderlying()).getNIn();
+            return ((FeedForwardLayer) ((LastTimeStep) this.fwd).getUnderlying()).getNIn();
         } else {
             return ((FeedForwardLayer) this.fwd).getNIn();
         }
@@ -125,8 +124,8 @@ public class Bidirectional extends Layer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-                                                       Collection<TrainingListener> trainingListeners, int layerIndex,
-                                                       INDArray layerParamsView, boolean initializeParams) {
+            Collection<TrainingListener> trainingListeners, int layerIndex,
+            INDArray layerParamsView, boolean initializeParams) {
         NeuralNetConfiguration c1 = conf.clone();
         NeuralNetConfiguration c2 = conf.clone();
         c1.setLayer(fwd);
@@ -206,8 +205,8 @@ public class Bidirectional extends Layer {
     }
 
     /**
-     * Get the updater for the given parameter. Typically the same updater will be used for all updaters, but this
-     * is not necessarily the case
+     * Get the updater for the given parameter. Typically the same updater will be used for all updaters, but this is
+     * not necessarily the case
      *
      * @param paramName Parameter name
      * @return IUpdater for the parameter
@@ -248,12 +247,12 @@ public class Bidirectional extends Layer {
         @Setter
         private Mode mode;
 
+        @Getter
+        private Layer layer;
+
         public void setLayer(Layer layer) {
             rnnLayer(layer);
         }
-
-        @Getter
-        private Layer layer;
 
         public Builder mode(Mode mode) {
             this.mode = mode;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/Bidirectional.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -37,9 +34,9 @@ import java.util.Collection;
  */
 public class LastTimeStep extends BaseWrapperLayer {
 
-    private LastTimeStep(){ }
+    private LastTimeStep() {}
 
-    public LastTimeStep(Layer underlying){
+    public LastTimeStep(Layer underlying) {
         super(underlying);
         this.layerName = underlying.getLayerName(); // needed for keras import to match names
     }
@@ -50,20 +47,22 @@ public class LastTimeStep extends BaseWrapperLayer {
 
 
     @Override
-    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         NeuralNetConfiguration conf2 = conf.clone();
-        conf2.setLayer(((LastTimeStep)conf2.getLayer()).getUnderlying());
-        return new LastTimeStepLayer(underlying.instantiate(conf2, trainingListeners, layerIndex, layerParamsView, initializeParams));
+        conf2.setLayer(((LastTimeStep) conf2.getLayer()).getUnderlying());
+        return new LastTimeStepLayer(underlying.instantiate(conf2, trainingListeners, layerIndex, layerParamsView,
+                        initializeParams));
     }
 
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
-        if(inputType.getType() != InputType.Type.RNN){
+        if (inputType.getType() != InputType.Type.RNN) {
             throw new IllegalArgumentException("Require RNN input type - got " + inputType);
         }
         InputType outType = underlying.getOutputType(layerIndex, inputType);
-        InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent)outType;
+        InputType.InputTypeRecurrent r = (InputType.InputTypeRecurrent) outType;
         return InputType.feedForward(r.getSize());
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/LastTimeStep.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -54,11 +51,11 @@ public class SimpleRnn extends BaseRecurrentLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("SimpleRnn", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.recurrent.SimpleRnn ret =
-                new org.deeplearning4j.nn.layers.recurrent.SimpleRnn(conf);
+                        new org.deeplearning4j.nn.layers.recurrent.SimpleRnn(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
@@ -32,29 +32,29 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Simple RNN - aka "vanilla" RNN is the simplest type of recurrent neural network layer.
- * It implements {@code out_t = activationFn( in_t * inWeight + out_(t-1) * recurrentWeights + bias)}.
+ * Simple RNN - aka "vanilla" RNN is the simplest type of recurrent neural network layer. It implements {@code out_t =
+ * activationFn( in_t * inWeight + out_(t-1) * recurrentWeights + bias)}.
  *
- * Note that other architectures (LSTM, etc) are usually much more effective, especially for longer time series;
- * however SimpleRnn is very fast to compute, and hence may be considered where the length of the temporal dependencies
- * in the dataset are only a few steps long.
+ * Note that other architectures (LSTM, etc) are usually much more effective, especially for longer time series; however
+ * SimpleRnn is very fast to compute, and hence may be considered where the length of the temporal dependencies in the
+ * dataset are only a few steps long.
  *
  * @author Alex Black
  */
 @Data
 public class SimpleRnn extends BaseRecurrentLayer {
 
-    protected SimpleRnn(Builder builder){
+    protected SimpleRnn(Builder builder) {
         super(builder);
     }
 
-    private SimpleRnn(){
+    private SimpleRnn() {
 
     }
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                             int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("SimpleRnn", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.recurrent.SimpleRnn ret =
@@ -74,8 +74,8 @@ public class SimpleRnn extends BaseRecurrentLayer {
     }
 
     @Override
-    public double getL1ByParam(String paramName){
-        switch (paramName){
+    public double getL1ByParam(String paramName) {
+        switch (paramName) {
             case SimpleRnnParamInitializer.WEIGHT_KEY:
             case SimpleRnnParamInitializer.RECURRENT_WEIGHT_KEY:
                 return l1;
@@ -87,8 +87,8 @@ public class SimpleRnn extends BaseRecurrentLayer {
     }
 
     @Override
-    public double getL2ByParam(String paramName){
-        switch (paramName){
+    public double getL2ByParam(String paramName) {
+        switch (paramName) {
             case SimpleRnnParamInitializer.WEIGHT_KEY:
             case SimpleRnnParamInitializer.RECURRENT_WEIGHT_KEY:
                 return l2;
@@ -104,7 +104,7 @@ public class SimpleRnn extends BaseRecurrentLayer {
         return null;
     }
 
-    public static class Builder extends BaseRecurrentLayer.Builder<Builder>{
+    public static class Builder extends BaseRecurrentLayer.Builder<Builder> {
 
 
         @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/recurrent/SimpleRnn.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
@@ -204,36 +204,30 @@ public abstract class AbstractSameDiffLayer extends Layer {
         applyGlobalConfigToLayer(b);
     }
 
+    @Getter
+    @Setter
     public static abstract class Builder<T extends Builder<T>> extends Layer.Builder<T> {
 
         /**
          * L1 regularization coefficient (weights only). Use {@link #l1Bias(double)} to configure the l1 regularization
          * coefficient for the bias.
          */
-        @Getter
-        @Setter
         protected double l1 = Double.NaN;
 
         /**
          * L2 regularization coefficient (weights only). Use {@link #l2Bias(double)} to configure the l2 regularization
          * coefficient for the bias.
          */
-        @Getter
-        @Setter
         protected double l2 = Double.NaN;
 
         /**
          * L1 regularization coefficient for the bias. Default: 0. See also {@link #l1(double)}
          */
-        @Getter
-        @Setter
         protected double l1Bias = Double.NaN;
 
         /**
          * L2 regularization coefficient for the bias. Default: 0. See also {@link #l2(double)}
          */
-        @Getter
-        @Setter
         protected double l2Bias = Double.NaN;
 
         /**
@@ -241,8 +235,6 @@ public abstract class AbstractSameDiffLayer extends Layer {
          * org.nd4j.linalg.learning.config.Nesterovs}
          *
          */
-        @Getter
-        @Setter
         protected IUpdater updater = null;
 
         /**
@@ -250,8 +242,6 @@ public abstract class AbstractSameDiffLayer extends Layer {
          * #updater(IUpdater)}
          *
          */
-        @Getter
-        @Setter
         protected IUpdater biasUpdater = null;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -68,15 +65,11 @@ public abstract class AbstractSameDiffLayer extends Layer {
         try {
             getClass().getDeclaredConstructor();
         } catch (NoSuchMethodException e) {
-            log.warn(
-                    "***SameDiff layer {} does not have a zero argument (no-arg) constructor.***\nA no-arg constructor "
-                            +
-                            "is required for JSON deserialization, which is used for both model saving and distributed (Spark) "
-                            +
-                            "training.\nA no-arg constructor (private, protected or public) as well as setters (or simply a "
-                            +
-                            "Lombok @Data annotation) should be added to avoid JSON errors later.",
-                    getClass().getName());
+            log.warn("***SameDiff layer {} does not have a zero argument (no-arg) constructor.***\nA no-arg constructor "
+                            + "is required for JSON deserialization, which is used for both model saving and distributed (Spark) "
+                            + "training.\nA no-arg constructor (private, protected or public) as well as setters (or simply a "
+                            + "Lombok @Data annotation) should be added to avoid JSON errors later.",
+                            getClass().getName());
         } catch (SecurityException e) {
             //Ignore
         }
@@ -127,8 +120,8 @@ public abstract class AbstractSameDiffLayer extends Layer {
 
     @Override
     public abstract org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams);
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams);
 
     //==================================================================================================================
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
@@ -54,7 +54,7 @@ public abstract class AbstractSameDiffLayer extends Layer {
 
     private SDLayerParams layerParams;
 
-    protected AbstractSameDiffLayer(Builder builder){
+    protected AbstractSameDiffLayer(Builder builder) {
         super(builder);
         this.l1 = builder.l1;
         this.l2 = builder.l2;
@@ -65,24 +65,29 @@ public abstract class AbstractSameDiffLayer extends Layer {
 
         //Check that this class has a no-arg constructor for JSON: better to detect this now provide useful information
         // to pre-empt a failure later for users, which will have a more difficult to understand message
-        try{
+        try {
             getClass().getDeclaredConstructor();
-        } catch (NoSuchMethodException e){
-            log.warn("***SameDiff layer {} does not have a zero argument (no-arg) constructor.***\nA no-arg constructor " +
-                    "is required for JSON deserialization, which is used for both model saving and distributed (Spark) " +
-                    "training.\nA no-arg constructor (private, protected or public) as well as setters (or simply a " +
-                    "Lombok @Data annotation) should be added to avoid JSON errors later.", getClass().getName());
-        } catch (SecurityException e){
+        } catch (NoSuchMethodException e) {
+            log.warn(
+                    "***SameDiff layer {} does not have a zero argument (no-arg) constructor.***\nA no-arg constructor "
+                            +
+                            "is required for JSON deserialization, which is used for both model saving and distributed (Spark) "
+                            +
+                            "training.\nA no-arg constructor (private, protected or public) as well as setters (or simply a "
+                            +
+                            "Lombok @Data annotation) should be added to avoid JSON errors later.",
+                    getClass().getName());
+        } catch (SecurityException e) {
             //Ignore
         }
     }
 
-    protected AbstractSameDiffLayer(){
+    protected AbstractSameDiffLayer() {
         //No op constructor for Jackson
     }
 
-    public SDLayerParams getLayerParams(){
-        if(layerParams == null){
+    public SDLayerParams getLayerParams() {
+        if (layerParams == null) {
             layerParams = new SDLayerParams();
             defineParameters(layerParams);
         }
@@ -106,21 +111,24 @@ public abstract class AbstractSameDiffLayer extends Layer {
     }
 
     /**
-     * Define the parameters for the network. Use {@link SDLayerParams#addWeightParam(String, long...)} and
-     * {@link SDLayerParams#addBiasParam(String, long...)}
+     * Define the parameters for the network. Use {@link SDLayerParams#addWeightParam(String, long...)} and {@link
+     * SDLayerParams#addBiasParam(String, long...)}
+     *
      * @param params Object used to set parameters for this layer
      */
     public abstract void defineParameters(SDLayerParams params);
 
     /**
      * Set the initial parameter values for this layer, if required
+     *
      * @param params Parameter arrays that may be initialized
      */
-    public abstract void initializeParameters(Map<String,INDArray> params);
+    public abstract void initializeParameters(Map<String, INDArray> params);
 
     @Override
-    public abstract org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                                int layerIndex, INDArray layerParamsView, boolean initializeParams);
+    public abstract org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView, boolean initializeParams);
 
     //==================================================================================================================
 
@@ -131,19 +139,19 @@ public abstract class AbstractSameDiffLayer extends Layer {
 
     @Override
     public double getL1ByParam(String paramName) {
-        return (initializer().isWeightParam(this, paramName) ? l1 :  l1Bias);
+        return (initializer().isWeightParam(this, paramName) ? l1 : l1Bias);
     }
 
     @Override
     public double getL2ByParam(String paramName) {
-        return (initializer().isWeightParam(this, paramName) ? l2 :  l2Bias);
+        return (initializer().isWeightParam(this, paramName) ? l2 : l2Bias);
     }
 
     @Override
-    public IUpdater getUpdaterByParam(String paramName){
-        if(biasUpdater != null && initializer().isBiasParam(this, paramName)){
+    public IUpdater getUpdaterByParam(String paramName) {
+        if (biasUpdater != null && initializer().isBiasParam(this, paramName)) {
             return biasUpdater;
-        } else if(initializer().isBiasParam(this, paramName) || initializer().isWeightParam(this, paramName)){
+        } else if (initializer().isBiasParam(this, paramName) || initializer().isWeightParam(this, paramName)) {
             return updater;
         }
         throw new IllegalStateException("Unknown parameter key: " + paramName);
@@ -160,42 +168,43 @@ public abstract class AbstractSameDiffLayer extends Layer {
     }
 
     /**
-     * Returns the memory layout ('c' or 'f' order - i.e., row/column major) of the parameters. In most cases,
-     * this can/should be left
+     * Returns the memory layout ('c' or 'f' order - i.e., row/column major) of the parameters. In most cases, this
+     * can/should be left
+     *
      * @param param Name of the parameter
      * @return Memory layout ('c' or 'f') of the parameter
      */
-    public char paramReshapeOrder(String param){
+    public char paramReshapeOrder(String param) {
         return 'c';
     }
 
-    protected void initWeights(int fanIn, int fanOut, WeightInit weightInit, INDArray array){
+    protected void initWeights(int fanIn, int fanOut, WeightInit weightInit, INDArray array) {
         WeightInitUtil.initWeights(fanIn, fanOut, array.shape(), weightInit, null, paramReshapeOrder(null), array);
     }
 
-    public void applyGlobalConfig(NeuralNetConfiguration.Builder b){
-        if(Double.isNaN(l1)){
+    public void applyGlobalConfig(NeuralNetConfiguration.Builder b) {
+        if (Double.isNaN(l1)) {
             l1 = b.getL1();
         }
-        if(Double.isNaN(l2)){
+        if (Double.isNaN(l2)) {
             l2 = b.getL2();
         }
-        if(Double.isNaN(l1Bias)){
+        if (Double.isNaN(l1Bias)) {
             l1Bias = b.getL1Bias();
         }
-        if(Double.isNaN(l2Bias)){
+        if (Double.isNaN(l2Bias)) {
             l2Bias = b.getL2Bias();
         }
-        if(updater == null){
+        if (updater == null) {
             updater = b.getIUpdater();
         }
-        if(biasUpdater == null){
+        if (biasUpdater == null) {
             biasUpdater = b.getBiasUpdater();
         }
-        if(gradientNormalization == null){
+        if (gradientNormalization == null) {
             gradientNormalization = b.getGradientNormalization();
         }
-        if(Double.isNaN(gradientNormalizationThreshold)){
+        if (Double.isNaN(gradientNormalizationThreshold)) {
             gradientNormalizationThreshold = b.getGradientNormalizationThreshold();
         }
 
@@ -204,21 +213,50 @@ public abstract class AbstractSameDiffLayer extends Layer {
 
     public static abstract class Builder<T extends Builder<T>> extends Layer.Builder<T> {
 
+        /**
+         * L1 regularization coefficient (weights only). Use {@link #l1Bias(double)} to configure the l1 regularization
+         * coefficient for the bias.
+         */
         @Getter
         @Setter
         protected double l1 = Double.NaN;
+
+        /**
+         * L2 regularization coefficient (weights only). Use {@link #l2Bias(double)} to configure the l2 regularization
+         * coefficient for the bias.
+         */
         @Getter
         @Setter
         protected double l2 = Double.NaN;
+
+        /**
+         * L1 regularization coefficient for the bias. Default: 0. See also {@link #l1(double)}
+         */
         @Getter
         @Setter
         protected double l1Bias = Double.NaN;
+
+        /**
+         * L2 regularization coefficient for the bias. Default: 0. See also {@link #l2(double)}
+         */
         @Getter
         @Setter
         protected double l2Bias = Double.NaN;
+
+        /**
+         * Gradient updater. For example, {@link org.nd4j.linalg.learning.config.Adam} or {@link
+         * org.nd4j.linalg.learning.config.Nesterovs}
+         *
+         */
         @Getter
         @Setter
         protected IUpdater updater = null;
+
+        /**
+         * Gradient updater configuration, for the biases only. If not set, biases will use the updater as set by {@link
+         * #updater(IUpdater)}
+         *
+         */
         @Getter
         @Setter
         protected IUpdater biasUpdater = null;
@@ -258,8 +296,8 @@ public abstract class AbstractSameDiffLayer extends Layer {
         }
 
         /**
-         * Gradient updater. For example, {@link org.nd4j.linalg.learning.config.Adam}
-         * or {@link org.nd4j.linalg.learning.config.Nesterovs}
+         * Gradient updater. For example, {@link org.nd4j.linalg.learning.config.Adam} or {@link
+         * org.nd4j.linalg.learning.config.Nesterovs}
          *
          * @param updater Updater to use
          */
@@ -269,12 +307,12 @@ public abstract class AbstractSameDiffLayer extends Layer {
         }
 
         /**
-         * Gradient updater configuration, for the biases only. If not set, biases will use the updater as
-         * set by {@link #updater(IUpdater)}
+         * Gradient updater configuration, for the biases only. If not set, biases will use the updater as set by {@link
+         * #updater(IUpdater)}
          *
          * @param biasUpdater Updater to use for bias parameters
          */
-        public T biasUpdater(IUpdater biasUpdater){
+        public T biasUpdater(IUpdater biasUpdater) {
             this.biasUpdater = biasUpdater;
             return (T) this;
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/AbstractSameDiffLayer.java
@@ -18,6 +18,8 @@ package org.deeplearning4j.nn.conf.layers.samediff;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.GradientNormalization;
@@ -202,11 +204,23 @@ public abstract class AbstractSameDiffLayer extends Layer {
 
     public static abstract class Builder<T extends Builder<T>> extends Layer.Builder<T> {
 
+        @Getter
+        @Setter
         protected double l1 = Double.NaN;
+        @Getter
+        @Setter
         protected double l2 = Double.NaN;
+        @Getter
+        @Setter
         protected double l1Bias = Double.NaN;
+        @Getter
+        @Setter
         protected double l2Bias = Double.NaN;
+        @Getter
+        @Setter
         protected IUpdater updater = null;
+        @Getter
+        @Setter
         protected IUpdater biasUpdater = null;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDLayerParams.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDLayerParams.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -39,15 +36,18 @@ import java.util.*;
 @Data
 public class SDLayerParams implements Serializable {
 
-    private Map<String,long[]> weightParams = new LinkedHashMap<>();
-    private Map<String,long[]> biasParams = new LinkedHashMap<>();
+    private Map<String, long[]> weightParams = new LinkedHashMap<>();
+    private Map<String, long[]> biasParams = new LinkedHashMap<>();
 
-    @JsonIgnore private List<String> paramsList;
-    @JsonIgnore private List<String> weightParamsList;
-    @JsonIgnore private List<String> biasParamsList;
+    @JsonIgnore
+    private List<String> paramsList;
+    @JsonIgnore
+    private List<String> weightParamsList;
+    @JsonIgnore
+    private List<String> biasParamsList;
 
-    public SDLayerParams(@JsonProperty("weightParams") Map<String,long[]> weightParams,
-                                @JsonProperty("biasParams") Map<String,long[]> biasParams){
+    public SDLayerParams(@JsonProperty("weightParams") Map<String, long[]> weightParams,
+                    @JsonProperty("biasParams") Map<String, long[]> biasParams) {
         this.weightParams = weightParams;
         this.biasParams = biasParams;
     }
@@ -60,8 +60,8 @@ public class SDLayerParams implements Serializable {
      * @param paramShape Shape of the weight parameter array
      */
     public void addWeightParam(@NonNull String paramKey, @NonNull long... paramShape) {
-        Preconditions.checkArgument(paramShape.length > 0, "Provided weight parameter shape is" +
-                " invalid: length 0 provided for shape. Parameter: " + paramKey);
+        Preconditions.checkArgument(paramShape.length > 0, "Provided weight parameter shape is"
+                        + " invalid: length 0 provided for shape. Parameter: " + paramKey);
         weightParams.put(paramKey, paramShape);
         paramsList = null;
         weightParamsList = null;
@@ -76,8 +76,8 @@ public class SDLayerParams implements Serializable {
      * @param paramShape Shape of the bias parameter array
      */
     public void addBiasParam(@NonNull String paramKey, @NonNull long... paramShape) {
-        Preconditions.checkArgument(paramShape.length > 0, "Provided mia- parameter shape is" +
-                " invalid: length 0 provided for shape. Parameter: " + paramKey);
+        Preconditions.checkArgument(paramShape.length > 0, "Provided mia- parameter shape is"
+                        + " invalid: length 0 provided for shape. Parameter: " + paramKey);
         biasParams.put(paramKey, paramShape);
         paramsList = null;
         weightParamsList = null;
@@ -90,7 +90,7 @@ public class SDLayerParams implements Serializable {
      */
     @JsonIgnore
     public List<String> getParameterKeys() {
-        if(paramsList == null) {
+        if (paramsList == null) {
             List<String> out = new ArrayList<>();
             out.addAll(getWeightParameterKeys());
             out.addAll(getBiasParameterKeys());
@@ -105,7 +105,7 @@ public class SDLayerParams implements Serializable {
      */
     @JsonIgnore
     public List<String> getWeightParameterKeys() {
-        if(weightParamsList == null){
+        if (weightParamsList == null) {
             weightParamsList = Collections.unmodifiableList(new ArrayList<>(weightParams.keySet()));
         }
         return weightParamsList;
@@ -117,7 +117,7 @@ public class SDLayerParams implements Serializable {
      */
     @JsonIgnore
     public List<String> getBiasParameterKeys() {
-        if(biasParamsList == null){
+        if (biasParamsList == null) {
             biasParamsList = Collections.unmodifiableList(new ArrayList<>(biasParams.keySet()));
         }
         return biasParamsList;
@@ -147,30 +147,30 @@ public class SDLayerParams implements Serializable {
         biasParamsList = null;
     }
 
-    public boolean isWeightParam(String param){
+    public boolean isWeightParam(String param) {
         return weightParams.containsKey(param);
     }
 
-    public boolean isBiasParam(String param){
+    public boolean isBiasParam(String param) {
         return biasParams.containsKey(param);
     }
 
     @Override
     public boolean equals(Object o) {
-        if(!(o instanceof SDLayerParams)){
+        if (!(o instanceof SDLayerParams)) {
             return false;
         }
-        SDLayerParams s = (SDLayerParams)o;
+        SDLayerParams s = (SDLayerParams) o;
         return equals(weightParams, s.weightParams) && equals(biasParams, s.biasParams);
     }
 
-    private static boolean equals(Map<String,long[]> first, Map<String,long[]> second){
+    private static boolean equals(Map<String, long[]> first, Map<String, long[]> second) {
         //Helper method - Lombok equals method seems to have trouble with arrays...
-        if(!first.keySet().equals(second.keySet())){
+        if (!first.keySet().equals(second.keySet())) {
             return false;
         }
-        for(Map.Entry<String,long[]> e : first.entrySet()){
-            if(!Arrays.equals(e.getValue(), second.get(e.getKey()))){
+        for (Map.Entry<String, long[]> e : first.entrySet()) {
+            if (!Arrays.equals(e.getValue(), second.get(e.getKey()))) {
                 return false;
             }
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDLayerParams.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDLayerParams.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDVertexParams.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDVertexParams.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -37,9 +34,9 @@ public class SDVertexParams extends SDLayerParams {
      * @param inputNames Names of the inputs. Number here also defines the number of vertex inputs
      * @see #defineInputs(int)
      */
-    public void defineInputs(String... inputNames){
+    public void defineInputs(String... inputNames) {
         Preconditions.checkArgument(inputNames != null && inputNames.length > 0,
-                "Input names must not be null, and must have length > 0: got %s", inputNames);
+                        "Input names must not be null, and must have length > 0: got %s", inputNames);
         this.inputs = Arrays.asList(inputNames);
     }
 
@@ -48,10 +45,10 @@ public class SDVertexParams extends SDLayerParams {
      *
      * @param numInputs Number of inputs to the vertex.
      */
-    public void defineInputs(int numInputs){
+    public void defineInputs(int numInputs) {
         Preconditions.checkArgument(numInputs > 0, "Number of inputs must be > 0: Got %s", numInputs);
         String[] inputNames = new String[numInputs];
-        for( int i=0; i<numInputs; i++ ){
+        for (int i = 0; i < numInputs; i++) {
             inputNames[i] = "input_" + i;
         }
     }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDVertexParams.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SDVertexParams.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -50,7 +47,8 @@ public abstract class SameDiffLambdaLayer extends SameDiffLayer {
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         //TODO let's try to infer output shape from input shape, using SameDiff + DefineLayer
-        throw new UnsupportedOperationException("Override SameDiffLamdaLayer.getOutputType to use OutputType functionality");
+        throw new UnsupportedOperationException(
+                        "Override SameDiffLamdaLayer.getOutputType to use OutputType functionality");
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaVertex.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -47,11 +44,12 @@ public abstract class SameDiffLambdaVertex extends SameDiffVertex {
     public abstract SDVariable defineVertex(SameDiff sameDiff, VertexInputs inputs);
 
     @Override
-    public SDVariable defineVertex(SameDiff sameDiff, Map<String, SDVariable> layerInput, Map<String, SDVariable> paramTable) {
+    public SDVariable defineVertex(SameDiff sameDiff, Map<String, SDVariable> layerInput,
+                    Map<String, SDVariable> paramTable) {
         VertexInputs vi = getInputs(sameDiff);
-        int i=0;
-        if(vi.map.size() == 0 && layerInput.size() > 0){
-            for(SDVariable v : layerInput.values()){
+        int i = 0;
+        if (vi.map.size() == 0 && layerInput.size() > 0) {
+            for (SDVariable v : layerInput.values()) {
                 vi.map.put(i++, v);
             }
         }
@@ -65,7 +63,7 @@ public abstract class SameDiffLambdaVertex extends SameDiffVertex {
         VertexInputs tempInputs = new VertexInputs(temp);
         defineVertex(temp, tempInputs);
         List<String> list = new ArrayList<>();
-        for(Integer i : tempInputs.map.keySet()){
+        for (Integer i : tempInputs.map.keySet()) {
             list.add(tempInputs.map.get(i).getVarName());
         }
         params.defineInputs(list.toArray(new String[list.size()]));
@@ -76,8 +74,8 @@ public abstract class SameDiffLambdaVertex extends SameDiffVertex {
         //No op, for lambda vertex
     }
 
-    protected VertexInputs getInputs(SameDiff sd){
-        if(inputs == null){
+    protected VertexInputs getInputs(SameDiff sd) {
+        if (inputs == null) {
             inputs = new VertexInputs(sd);
         }
         return inputs;
@@ -86,19 +84,18 @@ public abstract class SameDiffLambdaVertex extends SameDiffVertex {
     public class VertexInputs {
 
         private SameDiff sameDiff;
-        private Map<Integer,SDVariable> map = new LinkedHashMap<>();
+        private Map<Integer, SDVariable> map = new LinkedHashMap<>();
 
-        protected VertexInputs(SameDiff sd){
+        protected VertexInputs(SameDiff sd) {
             this.sameDiff = sd;
         }
 
-        public SDVariable getInput(int inputNum){
-            Preconditions.checkArgument(inputNum >= 0, "Input number must be >= 0." +
-                    "Got: %s", inputNum);
+        public SDVariable getInput(int inputNum) {
+            Preconditions.checkArgument(inputNum >= 0, "Input number must be >= 0." + "Got: %s", inputNum);
 
-            if(!map.containsKey(inputNum)){
+            if (!map.containsKey(inputNum)) {
                 //Lazily define extra input variable as required
-                SDVariable var = sameDiff.var("var_" + inputNum, 1);    //TODO is this shape safe?
+                SDVariable var = sameDiff.var("var_" + inputNum, 1); //TODO is this shape safe?
                 map.put(inputNum, var);
             }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLambdaVertex.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
@@ -18,6 +18,8 @@ package org.deeplearning4j.nn.conf.layers.samediff;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
@@ -94,6 +96,8 @@ public abstract class SameDiffLayer extends AbstractSameDiffLayer {
     @SuppressWarnings("unchecked")
     public static abstract class Builder<T extends Builder<T>> extends AbstractSameDiffLayer.Builder<T> {
 
+        @Getter
+        @Setter
         protected WeightInit weightInit = WeightInit.XAVIER;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
@@ -34,24 +34,20 @@ import java.util.Map;
 
 /**
  * A base layer used for implementing Deeplearning4j layers using SameDiff. These layers are not scoring/output layers:
- * that is, they should be used as the intermediate layer in a network only.<br>
- * To implement an output layer, extend {@link SameDiffOutputLayer} instead.<br>
- * Note also that if multiple inputs are required, it is possible to implement a vertex instead: {@link SameDiffVertex}<br>
+ * that is, they should be used as the intermediate layer in a network only.<br> To implement an output layer, extend
+ * {@link SameDiffOutputLayer} instead.<br> Note also that if multiple inputs are required, it is possible to implement
+ * a vertex instead: {@link SameDiffVertex}<br>
  * <br>
- * To implement a Deeplearning layer using SameDiff, extend this class.<br>
- * There are 4 required methods:<br>
- * - defineLayer: Defines the forward pass for the layer<br>
- * - defineParameters: Define the layer's parameters in a way suitable for DL4J<br>
- * - initializeParameters: if required, set the initial parameter values for the layer<br>
- * - getOutputType: determine the type of output/activations for the layer (without actually executing the layer's
- * forward pass)<br>
+ * To implement a Deeplearning layer using SameDiff, extend this class.<br> There are 4 required methods:<br> -
+ * defineLayer: Defines the forward pass for the layer<br> - defineParameters: Define the layer's parameters in a way
+ * suitable for DL4J<br> - initializeParameters: if required, set the initial parameter values for the layer<br> -
+ * getOutputType: determine the type of output/activations for the layer (without actually executing the layer's forward
+ * pass)<br>
  * <br>
- * Furthermore, there are 3 optional methods:<br>
- * - setNIn(InputType inputType, boolean override): if implemented, set the number of inputs to the layer during network
- *   initialization<br>
- * - getPreProcessorForInputType: return the preprocessor that should be added (if any), for the given input type<br>
- * - applyGlobalConfigToLayer: apply any global configuration options (weight init, activation functions etc) to the
- *   layer's configuration.<br>
+ * Furthermore, there are 3 optional methods:<br> - setNIn(InputType inputType, boolean override): if implemented, set
+ * the number of inputs to the layer during network initialization<br> - getPreProcessorForInputType: return the
+ * preprocessor that should be added (if any), for the given input type<br> - applyGlobalConfigToLayer: apply any global
+ * configuration options (weight init, activation functions etc) to the layer's configuration.<br>
  *
  * @author Alex Black
  */
@@ -61,30 +57,34 @@ public abstract class SameDiffLayer extends AbstractSameDiffLayer {
 
     protected WeightInit weightInit;
 
-    protected SameDiffLayer(Builder builder){
+    protected SameDiffLayer(Builder builder) {
         super(builder);
         this.weightInit = builder.weightInit;
     }
 
-    protected SameDiffLayer(){
+    protected SameDiffLayer() {
         //No op constructor for Jackson
     }
 
     /**
      * Define the layer
-     * @param sameDiff   SameDiff instance
+     *
+     * @param sameDiff SameDiff instance
      * @param layerInput Input to the layer
      * @param paramTable Parameter table - keys as defined by {@link #defineParameters(SDLayerParams)}
      * @return The final layer variable corresponding to the activations/output from the forward pass
      */
-    public abstract SDVariable defineLayer(SameDiff sameDiff, SDVariable layerInput, Map<String,SDVariable> paramTable);
+    public abstract SDVariable defineLayer(SameDiff sameDiff, SDVariable layerInput,
+            Map<String, SDVariable> paramTable);
 
     //==================================================================================================================
 
     @Override
-    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        org.deeplearning4j.nn.layers.samediff.SameDiffLayer ret = new org.deeplearning4j.nn.layers.samediff.SameDiffLayer(conf);
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+        org.deeplearning4j.nn.layers.samediff.SameDiffLayer ret = new org.deeplearning4j.nn.layers.samediff.SameDiffLayer(
+                conf);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);
@@ -103,9 +103,9 @@ public abstract class SameDiffLayer extends AbstractSameDiffLayer {
         /**
          * @param weightInit Weight initialization to use for the layer
          */
-        public T weightInit(WeightInit weightInit){
+        public T weightInit(WeightInit weightInit) {
             this.weightInit = weightInit;
-            return (T)this;
+            return (T) this;
         }
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
@@ -91,10 +91,10 @@ public abstract class SameDiffLayer extends AbstractSameDiffLayer {
     }
 
     @SuppressWarnings("unchecked")
+    @Getter
+    @Setter
     public static abstract class Builder<T extends Builder<T>> extends AbstractSameDiffLayer.Builder<T> {
 
-        @Getter
-        @Setter
         protected WeightInit weightInit = WeightInit.XAVIER;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -75,16 +72,16 @@ public abstract class SameDiffLayer extends AbstractSameDiffLayer {
      * @return The final layer variable corresponding to the activations/output from the forward pass
      */
     public abstract SDVariable defineLayer(SameDiff sameDiff, SDVariable layerInput,
-            Map<String, SDVariable> paramTable);
+                    Map<String, SDVariable> paramTable);
 
     //==================================================================================================================
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        org.deeplearning4j.nn.layers.samediff.SameDiffLayer ret = new org.deeplearning4j.nn.layers.samediff.SameDiffLayer(
-                conf);
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
+        org.deeplearning4j.nn.layers.samediff.SameDiffLayer ret =
+                        new org.deeplearning4j.nn.layers.samediff.SameDiffLayer(conf);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayerUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayerUtils.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -31,13 +28,13 @@ public class SameDiffLayerUtils {
 
     private static Map<Class<?>, Activation> activationMap;
 
-    private SameDiffLayerUtils(){ }
+    private SameDiffLayerUtils() {}
 
-    public static Activation fromIActivation(IActivation a){
+    public static Activation fromIActivation(IActivation a) {
 
-        if(activationMap == null){
-            Map<Class<?>,Activation> m = new HashMap<>();
-            for(Activation act : Activation.values()){
+        if (activationMap == null) {
+            Map<Class<?>, Activation> m = new HashMap<>();
+            for (Activation act : Activation.values()) {
                 m.put(act.getActivationFunction().getClass(), act);
             }
             activationMap = m;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayerUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffLayerUtils.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffOutputLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -50,7 +47,7 @@ import java.util.Map;
 public abstract class SameDiffOutputLayer extends AbstractSameDiffLayer {
 
 
-    protected SameDiffOutputLayer(){
+    protected SameDiffOutputLayer() {
         //No op constructor for Jackson
     }
 
@@ -63,7 +60,7 @@ public abstract class SameDiffOutputLayer extends AbstractSameDiffLayer {
      * @return The final layer variable corresponding to the score/loss during forward pass. This must be a single scalar value.
      */
     public abstract SDVariable defineLayer(SameDiff sameDiff, SDVariable layerInput, SDVariable labels,
-                                           Map<String,SDVariable> paramTable);
+                    Map<String, SDVariable> paramTable);
 
     /**
      * Output layers should terminate in a single scalar value (i.e., a score) - however, sometimes the output activations
@@ -81,16 +78,18 @@ public abstract class SameDiffOutputLayer extends AbstractSameDiffLayer {
      * this can be set to false.
      * @return True if labels are required to calculate the score/output, false otherwise.
      */
-    public boolean labelsRequired(){
+    public boolean labelsRequired() {
         return true;
     }
 
     //==================================================================================================================
 
     @Override
-    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
-        org.deeplearning4j.nn.layers.samediff.SameDiffOutputLayer ret = new org.deeplearning4j.nn.layers.samediff.SameDiffOutputLayer(conf);
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
+        org.deeplearning4j.nn.layers.samediff.SameDiffOutputLayer ret =
+                        new org.deeplearning4j.nn.layers.samediff.SameDiffOutputLayer(conf);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
         Map<String, INDArray> paramTable = initializer().init(conf, layerParamsView, initializeParams);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffOutputLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffVertex.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -67,7 +64,8 @@ public abstract class SameDiffVertex extends GraphVertex implements TrainingConf
      * @param paramTable Parameter table - keys as defined by {@link #defineParametersAndInputs(SDVertexParams)}
      * @return The final layer variable corresponding to the activations/output from the forward pass
      */
-    public abstract SDVariable defineVertex(SameDiff sameDiff, Map<String,SDVariable> layerInput, Map<String,SDVariable> paramTable);
+    public abstract SDVariable defineVertex(SameDiff sameDiff, Map<String, SDVariable> layerInput,
+                    Map<String, SDVariable> paramTable);
 
     /**
      * Define the parameters - and inputs - for the network.
@@ -83,10 +81,10 @@ public abstract class SameDiffVertex extends GraphVertex implements TrainingConf
      * Set the initial parameter values for this layer, if required
      * @param params Parameter arrays that may be initialized
      */
-    public abstract void initializeParameters(Map<String,INDArray> params);
+    public abstract void initializeParameters(Map<String, INDArray> params);
 
-    public SDVertexParams getVertexParams(){
-        if(vertexParams == null){
+    public SDVertexParams getVertexParams() {
+        if (vertexParams == null) {
             vertexParams = new SDVertexParams();
             defineParametersAndInputs(vertexParams);
         }
@@ -102,10 +100,10 @@ public abstract class SameDiffVertex extends GraphVertex implements TrainingConf
     public long numParams(boolean backprop) {
         SDLayerParams params = getVertexParams();
         long count = 0;
-        for(long[] l : params.getParamShapes().values()){
+        for (long[] l : params.getParamShapes().values()) {
             count += ArrayUtil.prodLong(l);
         }
-        return (int)count;
+        return (int) count;
     }
 
     @Override
@@ -120,9 +118,9 @@ public abstract class SameDiffVertex extends GraphVertex implements TrainingConf
 
     @Override
     public org.deeplearning4j.nn.graph.vertex.GraphVertex instantiate(ComputationGraph graph, String name, int idx,
-                                                                      INDArray paramsView, boolean initializeParams) {
+                    INDArray paramsView, boolean initializeParams) {
         this.name = name;
-        return new SameDiffGraphVertex(this, graph, name, idx, paramsView, initializeParams );
+        return new SameDiffGraphVertex(this, graph, name, idx, paramsView, initializeParams);
     }
 
     @Override
@@ -136,34 +134,34 @@ public abstract class SameDiffVertex extends GraphVertex implements TrainingConf
     }
 
 
-    public char paramReshapeOrder(String paramName){
+    public char paramReshapeOrder(String paramName) {
         return 'c';
     }
 
 
-    public void applyGlobalConfig(NeuralNetConfiguration.Builder b){
-        if(Double.isNaN(l1)){
+    public void applyGlobalConfig(NeuralNetConfiguration.Builder b) {
+        if (Double.isNaN(l1)) {
             l1 = b.getL1();
         }
-        if(Double.isNaN(l2)){
+        if (Double.isNaN(l2)) {
             l2 = b.getL2();
         }
-        if(Double.isNaN(l1Bias)){
+        if (Double.isNaN(l1Bias)) {
             l1Bias = b.getL1Bias();
         }
-        if(Double.isNaN(l2Bias)){
+        if (Double.isNaN(l2Bias)) {
             l2Bias = b.getL2Bias();
         }
-        if(updater == null){
+        if (updater == null) {
             updater = b.getIUpdater();
         }
-        if(biasUpdater == null){
+        if (biasUpdater == null) {
             biasUpdater = b.getBiasUpdater();
         }
-        if(gradientNormalization == null){
+        if (gradientNormalization == null) {
             gradientNormalization = b.getGradientNormalization();
         }
-        if(Double.isNaN(gradientNormalizationThreshold)){
+        if (Double.isNaN(gradientNormalizationThreshold)) {
             gradientNormalizationThreshold = b.getGradientNormalizationThreshold();
         }
 
@@ -181,32 +179,34 @@ public abstract class SameDiffVertex extends GraphVertex implements TrainingConf
 
     @Override
     public double getL1ByParam(String paramName) {
-        if(l1 == 0.0 && l1Bias == 0.0 ){
+        if (l1 == 0.0 && l1Bias == 0.0) {
             return 0.0;
         }
-        if(getVertexParams().isWeightParam(paramName)){
+        if (getVertexParams().isWeightParam(paramName)) {
             return l1;
         }
-        if(getVertexParams().isBiasParam(paramName)){
+        if (getVertexParams().isBiasParam(paramName)) {
             return l1Bias;
         }
-        throw new IllegalStateException("Unknown parameter name: " + paramName + " - not in weights (" + getVertexParams().getWeightParameterKeys()
-                + ") or biases (" + getVertexParams().getBiasParameterKeys() + ")");
+        throw new IllegalStateException("Unknown parameter name: " + paramName + " - not in weights ("
+                        + getVertexParams().getWeightParameterKeys() + ") or biases ("
+                        + getVertexParams().getBiasParameterKeys() + ")");
     }
 
     @Override
     public double getL2ByParam(String paramName) {
-        if(l2 == 0.0 && l2Bias == 0.0 ){
+        if (l2 == 0.0 && l2Bias == 0.0) {
             return 0.0;
         }
-        if(getVertexParams().isWeightParam(paramName)){
+        if (getVertexParams().isWeightParam(paramName)) {
             return l2;
         }
-        if(getVertexParams().isBiasParam(paramName)){
+        if (getVertexParams().isBiasParam(paramName)) {
             return l2Bias;
         }
-        throw new IllegalStateException("Unknown parameter name: " + paramName + " - not in weights (" + getVertexParams().getWeightParameterKeys()
-                + ") or biases (" + getVertexParams().getBiasParameterKeys() + ")");
+        throw new IllegalStateException("Unknown parameter name: " + paramName + " - not in weights ("
+                        + getVertexParams().getWeightParameterKeys() + ") or biases ("
+                        + getVertexParams().getBiasParameterKeys() + ")");
     }
 
     @Override
@@ -216,17 +216,18 @@ public abstract class SameDiffVertex extends GraphVertex implements TrainingConf
 
     @Override
     public IUpdater getUpdaterByParam(String paramName) {
-        if(getVertexParams().isWeightParam(paramName)){
+        if (getVertexParams().isWeightParam(paramName)) {
             return updater;
         }
-        if(getVertexParams().isBiasParam(paramName)){
-            if(biasUpdater == null){
+        if (getVertexParams().isBiasParam(paramName)) {
+            if (biasUpdater == null) {
                 return updater;
             }
             return biasUpdater;
         }
-        throw new IllegalStateException("Unknown parameter name: " + paramName + " - not in weights (" + getVertexParams().getWeightParameterKeys()
-                + ") or biases (" + getVertexParams().getBiasParameterKeys() + ")");
+        throw new IllegalStateException("Unknown parameter name: " + paramName + " - not in weights ("
+                        + getVertexParams().getWeightParameterKeys() + ") or biases ("
+                        + getVertexParams().getBiasParameterKeys() + ")");
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffVertex.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/samediff/SameDiffVertex.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -40,8 +37,9 @@ import java.util.Map;
 @NoArgsConstructor
 public class MaskLayer extends NoParamLayer {
     @Override
-    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
         org.deeplearning4j.nn.layers.util.MaskLayer ret = new org.deeplearning4j.nn.layers.util.MaskLayer(conf);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -68,17 +66,17 @@ public class MaskLayer extends NoParamLayer {
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
-        return null;    //No op
+        return null; //No op
     }
 
     @Override
     public double getL1ByParam(String paramName) {
-        return 0;   //No params
+        return 0; //No params
     }
 
     @Override
     public double getL2ByParam(String paramName) {
-        return 0;   //No params
+        return 0; //No params
     }
 
     @Override
@@ -92,7 +90,7 @@ public class MaskLayer extends NoParamLayer {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return "MaskLayer()";
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
@@ -17,7 +17,9 @@
 package org.deeplearning4j.nn.conf.layers.util;
 
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
@@ -110,7 +112,9 @@ public class MaskZeroLayer extends BaseWrapperLayer {
     @NoArgsConstructor
     public static class Builder extends Layer.Builder<Builder> {
 
+        @Getter
         private Layer underlying;
+        @Getter
         private double maskValue;
 
         public Builder setUnderlying(Layer underlying) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
@@ -109,11 +109,11 @@ public class MaskZeroLayer extends BaseWrapperLayer {
 
 
     @NoArgsConstructor
+    @Getter
+    @Setter
     public static class Builder extends Layer.Builder<Builder> {
 
-        @Getter
         private Layer underlying;
-        @Getter
         private double maskValue;
 
         public Builder setUnderlying(Layer underlying) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
@@ -32,8 +32,9 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import java.util.Collection;
 
 /**
- * Wrapper which masks timesteps with activation equal to the specified masking value (0.0 default).
- * Assumes that the input shape is [batch_size, input_size, timesteps].
+ * Wrapper which masks timesteps with activation equal to the specified masking value (0.0 default). Assumes that the
+ * input shape is [batch_size, input_size, timesteps].
+ *
  * @author Martin Boyanov mboyanov@gmail.com
  */
 @Data
@@ -57,11 +58,12 @@ public class MaskZeroLayer extends BaseWrapperLayer {
 
 
     @Override
-    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                                                       int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+    public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
+            Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
 
         NeuralNetConfiguration conf2 = conf.clone();
-        conf2.setLayer(((BaseWrapperLayer)conf2.getLayer()).getUnderlying());
+        conf2.setLayer(((BaseWrapperLayer) conf2.getLayer()).getUnderlying());
 
         org.deeplearning4j.nn.api.Layer underlyingLayer =
                 underlying.instantiate(conf2, trainingListeners, layerIndex, layerParamsView, initializeParams);
@@ -104,7 +106,7 @@ public class MaskZeroLayer extends BaseWrapperLayer {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return "MaskZeroLayer(" + underlying.toString() + ")";
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -59,14 +56,14 @@ public class MaskZeroLayer extends BaseWrapperLayer {
 
     @Override
     public org.deeplearning4j.nn.api.Layer instantiate(NeuralNetConfiguration conf,
-            Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView,
+                    boolean initializeParams) {
 
         NeuralNetConfiguration conf2 = conf.clone();
         conf2.setLayer(((BaseWrapperLayer) conf2.getLayer()).getUnderlying());
 
         org.deeplearning4j.nn.api.Layer underlyingLayer =
-                underlying.instantiate(conf2, trainingListeners, layerIndex, layerParamsView, initializeParams);
+                        underlying.instantiate(conf2, trainingListeners, layerIndex, layerParamsView, initializeParams);
         return new org.deeplearning4j.nn.layers.recurrent.MaskZeroLayer(underlyingLayer, maskingValue);
     }
 
@@ -82,17 +79,17 @@ public class MaskZeroLayer extends BaseWrapperLayer {
 
     @Override
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
-        return underlying.getPreProcessorForInputType(inputType);    //No op
+        return underlying.getPreProcessorForInputType(inputType); //No op
     }
 
     @Override
     public double getL1ByParam(String paramName) {
-        return underlying.getL1ByParam(paramName);   //No params
+        return underlying.getL1ByParam(paramName); //No params
     }
 
     @Override
     public double getL2ByParam(String paramName) {
-        return underlying.getL2ByParam(paramName);   //No params
+        return underlying.getL2ByParam(paramName); //No params
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/util/MaskZeroLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/BernoulliReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/BernoulliReconstructionDistribution.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/BernoulliReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/BernoulliReconstructionDistribution.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/CompositeReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/CompositeReconstructionDistribution.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/CompositeReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/CompositeReconstructionDistribution.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ExponentialReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ExponentialReconstructionDistribution.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ExponentialReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ExponentialReconstructionDistribution.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/GaussianReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/GaussianReconstructionDistribution.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -98,7 +95,8 @@ public class GaussianReconstructionDistribution implements ReconstructionDistrib
 
         INDArray[] logProbArrays = calcLogProbArrayExConstants(x, preOutDistributionParams);
 
-        return logProbArrays[0].sum(true, 1).muli(0.5).subi(size * NEG_HALF_LOG_2PI).addi(logProbArrays[1].sum(true, 1));
+        return logProbArrays[0].sum(true, 1).muli(0.5).subi(size * NEG_HALF_LOG_2PI)
+                        .addi(logProbArrays[1].sum(true, 1));
     }
 
     private INDArray[] calcLogProbArrayExConstants(INDArray x, INDArray preOutDistributionParams) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/GaussianReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/GaussianReconstructionDistribution.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/LossFunctionWrapper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/LossFunctionWrapper.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/LossFunctionWrapper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/LossFunctionWrapper.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ReconstructionDistribution.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ReconstructionDistribution.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/ReconstructionDistribution.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -33,7 +30,7 @@ import java.io.Serializable;
  * @author Alex Black
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class",
-        defaultImpl = LegacyReconstructionDistributionDeserializerHelper.class)
+                defaultImpl = LegacyReconstructionDistributionDeserializerHelper.class)
 public interface ReconstructionDistribution extends Serializable {
 
     /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
@@ -40,15 +40,16 @@ import java.util.Map;
 
 /**
  * Variational Autoencoder layer
- *<p>
- * See: Kingma & Welling, 2013: Auto-Encoding Variational Bayes - <a href="https://arxiv.org/abs/1312.6114">https://arxiv.org/abs/1312.6114</a>
- *<p>
- * This implementation allows multiple encoder and decoder layers, the number and sizes of which can be set independently.
  * <p>
- * A note on scores during pretraining: This implementation minimizes the negative of the variational lower bound objective
- * as described in Kingma & Welling; the mathematics in that paper is based on maximization of the variational lower bound instead.
- * Thus, scores reported during pretraining in DL4J are the negative of the variational lower bound equation in the paper.
- * The backpropagation and learning procedure is otherwise as described there.
+ * See: Kingma & Welling, 2013: Auto-Encoding Variational Bayes - <a href="https://arxiv.org/abs/1312.6114">https://arxiv.org/abs/1312.6114</a>
+ * <p>
+ * This implementation allows multiple encoder and decoder layers, the number and sizes of which can be set
+ * independently.
+ * <p>
+ * A note on scores during pretraining: This implementation minimizes the negative of the variational lower bound
+ * objective as described in Kingma & Welling; the mathematics in that paper is based on maximization of the variational
+ * lower bound instead. Thus, scores reported during pretraining in DL4J are the negative of the variational lower bound
+ * equation in the paper. The backpropagation and learning procedure is otherwise as described there.
  *
  * @author Alex Black
  */
@@ -74,11 +75,11 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("VariationalAutoencoder", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.variational.VariationalAutoencoder ret =
-                        new org.deeplearning4j.nn.layers.variational.VariationalAutoencoder(conf);
+                new org.deeplearning4j.nn.layers.variational.VariationalAutoencoder(conf);
 
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -96,15 +97,17 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
 
     @Override
     public double getL1ByParam(String paramName) {
-        if (paramName.endsWith(VariationalAutoencoderParamInitializer.BIAS_KEY_SUFFIX))
+        if (paramName.endsWith(VariationalAutoencoderParamInitializer.BIAS_KEY_SUFFIX)) {
             return l1Bias;
+        }
         return l1;
     }
 
     @Override
     public double getL2ByParam(String paramName) {
-        if (paramName.endsWith(VariationalAutoencoderParamInitializer.BIAS_KEY_SUFFIX))
+        if (paramName.endsWith(VariationalAutoencoderParamInitializer.BIAS_KEY_SUFFIX)) {
             return l2Bias;
+        }
         return l2;
     }
 
@@ -147,11 +150,8 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
         //Plus, component of score
         decoderFwdSizeWorking += nOut;
 
-
-
         //Backprop size through the decoder and decoder: approx. 2x forward pass size
         long trainWorkingMemSize = 2 * (inferenceWorkingMemSizePerEx + decoderFwdSizeWorking);
-
 
         if (getIDropout() != null) {
             if (false) {
@@ -164,41 +164,90 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
         }
 
         return new LayerMemoryReport.Builder(layerName, VariationalAutoencoder.class, inputType, outputType)
-                        .standardMemory(numParams, updaterStateSize)
-                        .workingMemory(0, inferenceWorkingMemSizePerEx, 0, trainWorkingMemSize)
-                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                        .build();
+                .standardMemory(numParams, updaterStateSize)
+                .workingMemory(0, inferenceWorkingMemSizePerEx, 0, trainWorkingMemSize)
+                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                .build();
     }
 
     public static class Builder extends BasePretrainNetwork.Builder<Builder> {
-
+        /**
+         * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers (set via
+         * {@link #decoderLayerSizes(int...)} is similar to the encoder layers.
+         *
+         */
         @Getter
-        private int[] encoderLayerSizes = new int[] {100};
+        private int[] encoderLayerSizes = new int[]{100};
 
+        /**
+         * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers (set via
+         * {@link #decoderLayerSizes(int...)} is similar to the encoder layers.
+         *
+         * @param encoderLayerSizes Size of each encoder layer in the variational autoencoder
+         */
         public void setEncoderLayerSizes(int[] encoderLayerSizes) {
             encoderLayerSizes(encoderLayerSizes);
         }
-        @Getter
-        private int[] decoderLayerSizes = new int[] {100};
 
+        /**
+         * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers is similar
+         * to the encoder layers (set via {@link #encoderLayerSizes(int...)}.
+         *
+         */
+        @Getter
+        private int[] decoderLayerSizes = new int[]{100};
+
+        /**
+         * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers is similar
+         * to the encoder layers (set via {@link #encoderLayerSizes(int...)}.
+         *
+         * @param decoderLayerSizes Size of each deccoder layer in the variational autoencoder
+         */
         public void setDecoderLayerSizes(int[] decoderLayerSizes) {
             decoderLayerSizes(decoderLayerSizes);
         }
+
+        /**
+         * The reconstruction distribution for the data given the hidden state - i.e., P(data|Z).<br> This should be
+         * selected carefully based on the type of data being modelled. For example:<br> - {@link
+         * GaussianReconstructionDistribution} + {identity or tanh} for real-valued (Gaussian) data<br> - {@link
+         * BernoulliReconstructionDistribution} + sigmoid for binary-valued (0 or 1) data<br>
+         *
+         */
         @Getter
         @Setter
         private ReconstructionDistribution outputDistribution = new GaussianReconstructionDistribution(Activation.TANH);
+
+        /**
+         * Activation function for the input to P(z|data).<br> Care should be taken with this, as some activation
+         * functions (relu, etc) are not suitable due to being bounded in range [0,infinity).
+         *
+         */
         @Getter
         @Setter
         private IActivation pzxActivationFn = new ActivationIdentity();
+
+        /**
+         * Set the number of samples per data point (from VAE state Z) used when doing pretraining. Default value: 1.
+         * <p>
+         * This is parameter L from Kingma and Welling: "In our experiments we found that the number of samples L per
+         * datapoint can be set to 1 as long as the minibatch size M was large enough, e.g. M = 100."
+         *
+         */
         @Getter
         @Setter
         private int numSamples = 1;
 
         /**
-         * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link org.deeplearning4j.nn.conf.layers.DenseLayer}.
-         * Typically the number and size of the decoder layers (set via {@link #decoderLayerSizes(int...)} is similar to the encoder layers.
+         * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers (set via
+         * {@link #decoderLayerSizes(int...)} is similar to the encoder layers.
          *
-         * @param encoderLayerSizes    Size of each encoder layer in the variational autoencoder
+         * @param encoderLayerSizes Size of each encoder layer in the variational autoencoder
          */
         public Builder encoderLayerSizes(int... encoderLayerSizes) {
             if (encoderLayerSizes == null || encoderLayerSizes.length < 1) {
@@ -209,10 +258,11 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
         }
 
         /**
-         * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link org.deeplearning4j.nn.conf.layers.DenseLayer}.
-         * Typically the number and size of the decoder layers is similar to the encoder layers (set via {@link #encoderLayerSizes(int...)}.
+         * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers is similar
+         * to the encoder layers (set via {@link #encoderLayerSizes(int...)}.
          *
-         * @param decoderLayerSizes    Size of each deccoder layer in the variational autoencoder
+         * @param decoderLayerSizes Size of each deccoder layer in the variational autoencoder
          */
         public Builder decoderLayerSizes(int... decoderLayerSizes) {
             if (decoderLayerSizes == null || decoderLayerSizes.length < 1) {
@@ -223,12 +273,12 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
         }
 
         /**
-         * The reconstruction distribution for the data given the hidden state - i.e., P(data|Z).<br>
-         * This should be selected carefully based on the type of data being modelled. For example:<br>
-         * - {@link GaussianReconstructionDistribution} + {identity or tanh} for real-valued (Gaussian) data<br>
-         * - {@link BernoulliReconstructionDistribution} + sigmoid for binary-valued (0 or 1) data<br>
+         * The reconstruction distribution for the data given the hidden state - i.e., P(data|Z).<br> This should be
+         * selected carefully based on the type of data being modelled. For example:<br> - {@link
+         * GaussianReconstructionDistribution} + {identity or tanh} for real-valued (Gaussian) data<br> - {@link
+         * BernoulliReconstructionDistribution} + sigmoid for binary-valued (0 or 1) data<br>
          *
-         * @param distribution    Reconstruction distribution
+         * @param distribution Reconstruction distribution
          */
         public Builder reconstructionDistribution(ReconstructionDistribution distribution) {
             this.outputDistribution = distribution;
@@ -236,53 +286,52 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
         }
 
         /**
-         * Configure the VAE to use the specified loss function for the reconstruction, instead of a ReconstructionDistribution.
-         * Note that this is NOT following the standard VAE design (as per Kingma & Welling), which assumes a probabilistic
-         * output - i.e., some p(x|z). It is however a valid network configuration, allowing for optimization of more traditional
-         * objectives such as mean squared error.<br>
-         * Note: clearly, setting the loss function here will override any previously set recontruction distribution
+         * Configure the VAE to use the specified loss function for the reconstruction, instead of a
+         * ReconstructionDistribution. Note that this is NOT following the standard VAE design (as per Kingma &
+         * Welling), which assumes a probabilistic output - i.e., some p(x|z). It is however a valid network
+         * configuration, allowing for optimization of more traditional objectives such as mean squared error.<br> Note:
+         * clearly, setting the loss function here will override any previously set recontruction distribution
          *
          * @param outputActivationFn Activation function for the output/reconstruction
-         * @param lossFunction       Loss function to use
+         * @param lossFunction Loss function to use
          */
         public Builder lossFunction(IActivation outputActivationFn, LossFunctions.LossFunction lossFunction) {
             return lossFunction(outputActivationFn, lossFunction.getILossFunction());
         }
 
         /**
-         * Configure the VAE to use the specified loss function for the reconstruction, instead of a ReconstructionDistribution.
-         * Note that this is NOT following the standard VAE design (as per Kingma & Welling), which assumes a probabilistic
-         * output - i.e., some p(x|z). It is however a valid network configuration, allowing for optimization of more traditional
-         * objectives such as mean squared error.<br>
-         * Note: clearly, setting the loss function here will override any previously set recontruction distribution
+         * Configure the VAE to use the specified loss function for the reconstruction, instead of a
+         * ReconstructionDistribution. Note that this is NOT following the standard VAE design (as per Kingma &
+         * Welling), which assumes a probabilistic output - i.e., some p(x|z). It is however a valid network
+         * configuration, allowing for optimization of more traditional objectives such as mean squared error.<br> Note:
+         * clearly, setting the loss function here will override any previously set recontruction distribution
          *
          * @param outputActivationFn Activation function for the output/reconstruction
-         * @param lossFunction       Loss function to use
+         * @param lossFunction Loss function to use
          */
         public Builder lossFunction(Activation outputActivationFn, LossFunctions.LossFunction lossFunction) {
             return lossFunction(outputActivationFn.getActivationFunction(), lossFunction.getILossFunction());
         }
 
         /**
-         * Configure the VAE to use the specified loss function for the reconstruction, instead of a ReconstructionDistribution.
-         * Note that this is NOT following the standard VAE design (as per Kingma & Welling), which assumes a probabilistic
-         * output - i.e., some p(x|z). It is however a valid network configuration, allowing for optimization of more traditional
-         * objectives such as mean squared error.<br>
-         * Note: clearly, setting the loss function here will override any previously set recontruction distribution
+         * Configure the VAE to use the specified loss function for the reconstruction, instead of a
+         * ReconstructionDistribution. Note that this is NOT following the standard VAE design (as per Kingma &
+         * Welling), which assumes a probabilistic output - i.e., some p(x|z). It is however a valid network
+         * configuration, allowing for optimization of more traditional objectives such as mean squared error.<br> Note:
+         * clearly, setting the loss function here will override any previously set recontruction distribution
          *
          * @param outputActivationFn Activation function for the output/reconstruction
-         * @param lossFunction       Loss function to use
+         * @param lossFunction Loss function to use
          */
         public Builder lossFunction(IActivation outputActivationFn, ILossFunction lossFunction) {
             return reconstructionDistribution(new LossFunctionWrapper(outputActivationFn, lossFunction));
         }
 
         /**
-         * Activation function for the input to P(z|data).<br>
-         * Care should be taken with this, as some activation functions (relu, etc) are not suitable due to being
-         * bounded in range [0,infinity).
+         * Activation function for the input to P(z|data).<br> Care should be taken with this, as some activation
+         * functions (relu, etc) are not suitable due to being bounded in range [0,infinity).
          *
-         * @param activationFunction    Activation function for p(z|x)
+         * @param activationFunction Activation function for p(z|x)
          */
         public Builder pzxActivationFn(IActivation activationFunction) {
             this.pzxActivationFn = activationFunction;
@@ -290,11 +339,10 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
         }
 
         /**
-         * Activation function for the input to P(z|data).<br>
-         * Care should be taken with this, as some activation functions (relu, etc) are not suitable due to being
-         * bounded in range [0,infinity).
+         * Activation function for the input to P(z|data).<br> Care should be taken with this, as some activation
+         * functions (relu, etc) are not suitable due to being bounded in range [0,infinity).
          *
-         * @param activation    Activation function for p(z|x)
+         * @param activation Activation function for p(z|x)
          */
         public Builder pzxActivationFunction(Activation activation) {
             return pzxActivationFn(activation.getActivationFunction());
@@ -304,7 +352,7 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
          * Set the size of the VAE state Z. This is the output size during standard forward pass, and the size of the
          * distribution P(Z|data) during pretraining.
          *
-         * @param nOut    Size of P(Z|data) and output size
+         * @param nOut Size of P(Z|data) and output size
          */
         @Override
         public Builder nOut(int nOut) {
@@ -318,7 +366,7 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
          * This is parameter L from Kingma and Welling: "In our experiments we found that the number of samples L per
          * datapoint can be set to 1 as long as the minibatch size M was large enough, e.g. M = 100."
          *
-         * @param numSamples    Number of samples per data point for pretraining
+         * @param numSamples Number of samples per data point for pretraining
          */
         public Builder numSamples(int numSamples) {
             this.numSamples = numSamples;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
@@ -167,47 +167,25 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
                         .build();
     }
 
+    @Getter
+    @Setter
     public static class Builder extends BasePretrainNetwork.Builder<Builder> {
+
         /**
          * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
          * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers (set via
          * {@link #decoderLayerSizes(int...)} is similar to the encoder layers.
          *
          */
-        @Getter
         private int[] encoderLayerSizes = new int[] {100};
 
         /**
-         * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
-         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers (set via
-         * {@link #decoderLayerSizes(int...)} is similar to the encoder layers.
-         *
-         * @param encoderLayerSizes Size of each encoder layer in the variational autoencoder
-         */
-        public void setEncoderLayerSizes(int[] encoderLayerSizes) {
-            encoderLayerSizes(encoderLayerSizes);
-        }
-
-        /**
          * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link
          * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers is similar
          * to the encoder layers (set via {@link #encoderLayerSizes(int...)}.
          *
          */
-        @Getter
         private int[] decoderLayerSizes = new int[] {100};
-
-        /**
-         * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link
-         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers is similar
-         * to the encoder layers (set via {@link #encoderLayerSizes(int...)}.
-         *
-         * @param decoderLayerSizes Size of each deccoder layer in the variational autoencoder
-         */
-        public void setDecoderLayerSizes(int[] decoderLayerSizes) {
-            decoderLayerSizes(decoderLayerSizes);
-        }
-
         /**
          * The reconstruction distribution for the data given the hidden state - i.e., P(data|Z).<br> This should be
          * selected carefully based on the type of data being modelled. For example:<br> - {@link
@@ -215,8 +193,6 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
          * BernoulliReconstructionDistribution} + sigmoid for binary-valued (0 or 1) data<br>
          *
          */
-        @Getter
-        @Setter
         private ReconstructionDistribution outputDistribution = new GaussianReconstructionDistribution(Activation.TANH);
 
         /**
@@ -224,8 +200,6 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
          * functions (relu, etc) are not suitable due to being bounded in range [0,infinity).
          *
          */
-        @Getter
-        @Setter
         private IActivation pzxActivationFn = new ActivationIdentity();
 
         /**
@@ -235,9 +209,9 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
          * datapoint can be set to 1 as long as the minibatch size M was large enough, e.g. M = 100."
          *
          */
-        @Getter
-        @Setter
         private int numSamples = 1;
+
+
 
         /**
          * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
@@ -254,6 +228,19 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
             return this;
         }
 
+
+        /**
+         * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers (set via
+         * {@link #decoderLayerSizes(int...)} is similar to the encoder layers.
+         *
+         * @param encoderLayerSizes Size of each encoder layer in the variational autoencoder
+         */
+        public void setEncoderLayerSizes(int[] encoderLayerSizes) {
+            encoderLayerSizes(encoderLayerSizes);
+        }
+
+
         /**
          * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link
          * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers is similar
@@ -268,6 +255,18 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
             this.decoderLayerSizes = decoderLayerSizes;
             return this;
         }
+
+        /**
+         * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link
+         * org.deeplearning4j.nn.conf.layers.DenseLayer}. Typically the number and size of the decoder layers is similar
+         * to the encoder layers (set via {@link #encoderLayerSizes(int...)}.
+         *
+         * @param decoderLayerSizes Size of each deccoder layer in the variational autoencoder
+         */
+        public void setDecoderLayerSizes(int[] decoderLayerSizes) {
+            decoderLayerSizes(decoderLayerSizes);
+        }
+
 
         /**
          * The reconstruction distribution for the data given the hidden state - i.e., P(data|Z).<br> This should be

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
@@ -16,10 +16,7 @@
 
 package org.deeplearning4j.nn.conf.layers.variational;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.val;
+import lombok.*;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.ParamInitializer;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -175,10 +172,26 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
 
     public static class Builder extends BasePretrainNetwork.Builder<Builder> {
 
+        @Getter
         private int[] encoderLayerSizes = new int[] {100};
+
+        public void setEncoderLayerSizes(int[] encoderLayerSizes) {
+            encoderLayerSizes(encoderLayerSizes);
+        }
+        @Getter
         private int[] decoderLayerSizes = new int[] {100};
+
+        public void setDecoderLayerSizes(int[] decoderLayerSizes) {
+            decoderLayerSizes(decoderLayerSizes);
+        }
+        @Getter
+        @Setter
         private ReconstructionDistribution outputDistribution = new GaussianReconstructionDistribution(Activation.TANH);
+        @Getter
+        @Setter
         private IActivation pzxActivationFn = new ActivationIdentity();
+        @Getter
+        @Setter
         private int numSamples = 1;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -75,11 +72,11 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("VariationalAutoencoder", getLayerName(), layerIndex, getNIn(), getNOut());
 
         org.deeplearning4j.nn.layers.variational.VariationalAutoencoder ret =
-                new org.deeplearning4j.nn.layers.variational.VariationalAutoencoder(conf);
+                        new org.deeplearning4j.nn.layers.variational.VariationalAutoencoder(conf);
 
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
@@ -164,10 +161,10 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
         }
 
         return new LayerMemoryReport.Builder(layerName, VariationalAutoencoder.class, inputType, outputType)
-                .standardMemory(numParams, updaterStateSize)
-                .workingMemory(0, inferenceWorkingMemSizePerEx, 0, trainWorkingMemSize)
-                .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
-                .build();
+                        .standardMemory(numParams, updaterStateSize)
+                        .workingMemory(0, inferenceWorkingMemSizePerEx, 0, trainWorkingMemSize)
+                        .cacheMemory(MemoryReport.CACHE_MODE_ALL_ZEROS, MemoryReport.CACHE_MODE_ALL_ZEROS) //No caching
+                        .build();
     }
 
     public static class Builder extends BasePretrainNetwork.Builder<Builder> {
@@ -178,7 +175,7 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
          *
          */
         @Getter
-        private int[] encoderLayerSizes = new int[]{100};
+        private int[] encoderLayerSizes = new int[] {100};
 
         /**
          * Size of the encoder layers, in units. Each encoder layer is functionally equivalent to a {@link
@@ -198,7 +195,7 @@ public class VariationalAutoencoder extends BasePretrainNetwork {
          *
          */
         @Getter
-        private int[] decoderLayerSizes = new int[]{100};
+        private int[] decoderLayerSizes = new int[] {100};
 
         /**
          * Size of the decoder layers, in units. Each decoder layer is functionally equivalent to a {@link

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/variational/VariationalAutoencoder.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -42,9 +39,9 @@ public abstract class BaseWrapperLayer extends Layer {
         super(builder);
     }
 
-    protected BaseWrapperLayer(){ }
+    protected BaseWrapperLayer() {}
 
-    public BaseWrapperLayer(Layer underlying){
+    public BaseWrapperLayer(Layer underlying) {
         this.underlying = underlying;
     }
 
@@ -99,9 +96,9 @@ public abstract class BaseWrapperLayer extends Layer {
     }
 
     @Override
-    public void setLayerName(String layerName){
+    public void setLayerName(String layerName) {
         super.setLayerName(layerName);
-        if(underlying != null){
+        if (underlying != null) {
             //May be null at some points during JSON deserialization
             underlying.setLayerName(layerName);
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/wrapper/BaseWrapperLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
@@ -39,11 +39,9 @@ import java.util.Map;
  * An implementation of one class neural networks from:
  * <a href="https://arxiv.org/pdf/1802.06360.pdf">https://arxiv.org/pdf/1802.06360.pdf</a>
  *
- * The one class neural network approach is an extension of the standard output layer
- * with a single set of weights, an activation function, and a bias to:
- * 2 sets of weights, a learnable "r" parameter that is held static
- * 1 traditional set of weights.
- * 1 additional weight matrix
+ * The one class neural network approach is an extension of the standard output layer with a single set of weights, an
+ * activation function, and a bias to: 2 sets of weights, a learnable "r" parameter that is held static 1 traditional
+ * set of weights. 1 additional weight matrix
  *
  * @author Adam Gibson
  */
@@ -53,6 +51,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties("lossFn")
 public class OCNNOutputLayer extends BaseOutputLayer {
+
     //embedded hidden layer size
     //aka "K"
     private int hiddenSize;
@@ -66,19 +65,9 @@ public class OCNNOutputLayer extends BaseOutputLayer {
     private boolean configureR = true;
 
     /**
-     * Psuedo code from keras:
-     *  start_time = time.time()
-     for epoch in range(100):
-     # Train with each example
-     sess.run(updates, feed_dict={X: train_X,r:rvalue})
-     rvalue = nnScore(train_X, w_1, w_2, g)
-     with sess.as_default():
-     rvalue = rvalue.eval()
-     rvalue = np.percentile(rvalue,q=100*nu)
-     print("Epoch = %d, r = %f"
-     % (epoch + 1,rvalue))
-
-
+     * Psuedo code from keras: start_time = time.time() for epoch in range(100): # Train with each example
+     * sess.run(updates, feed_dict={X: train_X,r:rvalue}) rvalue = nnScore(train_X, w_1, w_2, g) with sess.as_default():
+     * rvalue = rvalue.eval() rvalue = np.percentile(rvalue,q=100*nu) print("Epoch = %d, r = %f" % (epoch + 1,rvalue))
      */
     private int lastEpochSinceRUpdated = 0;
 
@@ -95,7 +84,9 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
     @JsonCreator
     @SuppressWarnings("unused")
-    public OCNNOutputLayer(@JsonProperty("hiddenSize") int hiddenSize,@JsonProperty("nu") double nu,@JsonProperty("activation") IActivation activation,@JsonProperty("windowSize") int windowSize, @JsonProperty("initialRValue") double initialRValue,@JsonProperty("configureR") boolean configureR) {
+    public OCNNOutputLayer(@JsonProperty("hiddenSize") int hiddenSize, @JsonProperty("nu") double nu,
+            @JsonProperty("activation") IActivation activation, @JsonProperty("windowSize") int windowSize,
+            @JsonProperty("initialRValue") double initialRValue, @JsonProperty("configureR") boolean configureR) {
         this.hiddenSize = hiddenSize;
         this.nu = nu;
         this.activationFn = activation;
@@ -110,10 +101,12 @@ public class OCNNOutputLayer extends BaseOutputLayer {
     }
 
     @Override
-    public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners, int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+    public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
+            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("OCNNOutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
-        org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer ret = new org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer(conf);
+        org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer ret = new org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer(
+                conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -121,8 +114,9 @@ public class OCNNOutputLayer extends BaseOutputLayer {
         ret.setParamTable(paramTable);
         ret.setConf(conf);
         ret.setActivation(activationFn);
-        if(lastEpochSinceRUpdated == 0 && configureR)
-            paramTable.get(OCNNParamInitializer.R_KEY).putScalar(0,initialRValue);
+        if (lastEpochSinceRUpdated == 0 && configureR) {
+            paramTable.get(OCNNParamInitializer.R_KEY).putScalar(0, initialRValue);
+        }
         return ret;
     }
 
@@ -150,34 +144,62 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
     @NoArgsConstructor
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
+
+        /**
+         * The hidden layer size for the one class neural network. Note this would be nOut on a dense layer. NOut in
+         * this neural net is always set to 1 though.
+         *
+         */
         @Getter
         @Setter
-        protected  int hiddenLayerSize;
+        protected int hiddenLayerSize;
+
+        /**
+         * For nu definition see the paper
+         *
+         */
         @Getter
         @Setter
-        protected  double nu = 0.04;
+        protected double nu = 0.04;
+
+        /**
+         * The number of examples to use for computing the quantile for the r value update. This value should generally
+         * be the same as the number of examples in the dataset
+         *
+         */
         @Getter
         @Setter
         protected int windowSize = 10000;
+
+        /**
+         * The activation function to use with ocnn
+         *
+         */
         @Getter
         @Setter
         protected IActivation activation = new ActivationIdentity();
+
+        /**
+         * The initial r value to use for ocnn for definition, see the paper, note this is only active when {@link
+         * #configureR} is specified as true
+         */
         @Getter
         @Setter
-        protected  double initialRValue = 0.1;
+        protected double initialRValue = 0.1;
+
+        /**
+         * Whether to use the specified {@link #initialRValue} or use the weight initialization with the neural network
+         * for the r value
+         */
         @Getter
         @Setter
         protected boolean configureR = true;
 
         /**
-         * Whether to use the specified
-         * {@link #initialRValue} or
-         * use the weight initialization with
-         * the neural network for the r value
-         * @param configureR true if we should use the
-         *                   initial {@link #initialRValue}
+         * Whether to use the specified {@link #initialRValue} or use the weight initialization with the neural network
+         * for the r value
          *
-         * @return
+         * @param configureR true if we should use the initial {@link #initialRValue}
          */
         public Builder configureR(boolean configureR) {
             this.configureR = configureR;
@@ -186,12 +208,10 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
 
         /**
-         * The initial r value to use for ocnn
-         * for definition, see the paper,
-         * note this is only active when {@link #configureR}
-         * is specified as true
+         * The initial r value to use for ocnn for definition, see the paper, note this is only active when {@link
+         * #configureR} is specified as true
+         *
          * @param initialRValue the int
-         * @return
          */
         public Builder initialRValue(double initialRValue) {
             this.initialRValue = initialRValue;
@@ -199,14 +219,11 @@ public class OCNNOutputLayer extends BaseOutputLayer {
         }
 
         /**
-         * The number of examples to use for computing the
-         * quantile for the r value update.
-         * This value should generally be the same
-         * as the number of examples in the dataset
-         * @param windowSize the number of examples to use
-         *                   for computing the quantile
-         *                   of the dataset for the r value update
-         * @return
+         * The number of examples to use for computing the quantile for the r value update. This value should generally
+         * be the same as the number of examples in the dataset
+         *
+         * @param windowSize the number of examples to use for computing the quantile of the dataset for the r value
+         * update
          */
         public Builder windowSize(int windowSize) {
             this.windowSize = windowSize;
@@ -216,8 +233,8 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
         /**
          * For nu definition see the paper
+         *
          * @param nu the nu for ocnn
-         * @return
          */
         public Builder nu(double nu) {
             this.nu = nu;
@@ -226,8 +243,8 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
         /**
          * The activation function to use with ocnn
+         *
          * @param activation the activation function to sue
-         * @return
          */
         public Builder activation(IActivation activation) {
             this.activation = activation;
@@ -235,12 +252,10 @@ public class OCNNOutputLayer extends BaseOutputLayer {
         }
 
         /**
-         * The hidden layer size for the one class neural network.
-         * Note this would be nOut on a dense layer.
-         * NOut in this neural net is always set to 1 though.
-         * @param hiddenLayerSize the hidden layer size to use
-         *                        with ocnn
-         * @return
+         * The hidden layer size for the one class neural network. Note this would be nOut on a dense layer. NOut in
+         * this neural net is always set to 1 though.
+         *
+         * @param hiddenLayerSize the hidden layer size to use with ocnn
          */
         public Builder hiddenLayerSize(int hiddenLayerSize) {
             this.hiddenLayerSize = hiddenLayerSize;
@@ -249,7 +264,8 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
         @Override
         public Builder nOut(int nOut) {
-            throw new UnsupportedOperationException("Unable to specify number of outputs with ocnn. Outputs are fixed to 1.");
+            throw new UnsupportedOperationException(
+                    "Unable to specify number of outputs with ocnn. Outputs are fixed to 1.");
         }
 
         @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
@@ -140,6 +140,8 @@ public class OCNNOutputLayer extends BaseOutputLayer {
         return l2;
     }
 
+    @Getter
+    @Setter
     @NoArgsConstructor
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
 
@@ -148,16 +150,12 @@ public class OCNNOutputLayer extends BaseOutputLayer {
          * this neural net is always set to 1 though.
          *
          */
-        @Getter
-        @Setter
         protected int hiddenLayerSize;
 
         /**
          * For nu definition see the paper
          *
          */
-        @Getter
-        @Setter
         protected double nu = 0.04;
 
         /**
@@ -165,32 +163,24 @@ public class OCNNOutputLayer extends BaseOutputLayer {
          * be the same as the number of examples in the dataset
          *
          */
-        @Getter
-        @Setter
         protected int windowSize = 10000;
 
         /**
          * The activation function to use with ocnn
          *
          */
-        @Getter
-        @Setter
         protected IActivation activation = new ActivationIdentity();
 
         /**
          * The initial r value to use for ocnn for definition, see the paper, note this is only active when {@link
          * #configureR} is specified as true
          */
-        @Getter
-        @Setter
         protected double initialRValue = 0.1;
 
         /**
          * Whether to use the specified {@link #initialRValue} or use the weight initialization with the neural network
          * for the r value
          */
-        @Getter
-        @Setter
         protected boolean configureR = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
@@ -150,11 +150,23 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
     @NoArgsConstructor
     public static class Builder extends BaseOutputLayer.Builder<Builder> {
+        @Getter
+        @Setter
         protected  int hiddenLayerSize;
+        @Getter
+        @Setter
         protected  double nu = 0.04;
+        @Getter
+        @Setter
         protected int windowSize = 10000;
+        @Getter
+        @Setter
         protected IActivation activation = new ActivationIdentity();
+        @Getter
+        @Setter
         protected  double initialRValue = 0.1;
+        @Getter
+        @Setter
         protected boolean configureR = true;
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
@@ -1,15 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
@@ -85,8 +82,9 @@ public class OCNNOutputLayer extends BaseOutputLayer {
     @JsonCreator
     @SuppressWarnings("unused")
     public OCNNOutputLayer(@JsonProperty("hiddenSize") int hiddenSize, @JsonProperty("nu") double nu,
-            @JsonProperty("activation") IActivation activation, @JsonProperty("windowSize") int windowSize,
-            @JsonProperty("initialRValue") double initialRValue, @JsonProperty("configureR") boolean configureR) {
+                    @JsonProperty("activation") IActivation activation, @JsonProperty("windowSize") int windowSize,
+                    @JsonProperty("initialRValue") double initialRValue,
+                    @JsonProperty("configureR") boolean configureR) {
         this.hiddenSize = hiddenSize;
         this.nu = nu;
         this.activationFn = activation;
@@ -102,11 +100,11 @@ public class OCNNOutputLayer extends BaseOutputLayer {
 
     @Override
     public Layer instantiate(NeuralNetConfiguration conf, Collection<TrainingListener> trainingListeners,
-            int layerIndex, INDArray layerParamsView, boolean initializeParams) {
+                    int layerIndex, INDArray layerParamsView, boolean initializeParams) {
         LayerValidation.assertNInNOutSet("OCNNOutputLayer", getLayerName(), layerIndex, getNIn(), getNOut());
 
-        org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer ret = new org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer(
-                conf);
+        org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer ret =
+                        new org.deeplearning4j.nn.layers.ocnn.OCNNOutputLayer(conf);
         ret.setListeners(trainingListeners);
         ret.setIndex(layerIndex);
         ret.setParamsViewArray(layerParamsView);
@@ -265,7 +263,7 @@ public class OCNNOutputLayer extends BaseOutputLayer {
         @Override
         public Builder nOut(int nOut) {
             throw new UnsupportedOperationException(
-                    "Unable to specify number of outputs with ocnn. Outputs are fixed to 1.");
+                            "Unable to specify number of outputs with ocnn. Outputs are fixed to 1.");
         }
 
         @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/ocnn/OCNNOutputLayer.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
- * This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/


### PR DESCRIPTION
## What changes were proposed in this pull request?

Property getters and setters were added to layer builders.  Primarily for Kotlin integration.

These properties can usually be accessed in the layer classes, but didn't have accessors in the Builder class.  In the interest of maintaining a single "build pipeline" and keeping things consistent, I think it makes more sense to add them here, rather than use the layer class constructors in Kotlin.

Mostly done via Lombok annotations (I used `@Getter`/`@Setter`, would `@Data` be better?).  Some were implemented to respect array size/shape constraints.

## How was this patch tested?

No functionality was changed, and it compiles.  After looking at what other tests there are, I didn't create any for the properties.  I can if requested.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions (N/A). 
- [x] Relevant tests for your changes are passing (N/A).
- [x] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
