### PR TITLE
Fix wrong derivative reference

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
@@ -667,7 +667,7 @@ public class Transforms {
      * @return
      */
     public static INDArray sigmoidDerivative(INDArray ndArray) {
-        return sigmoid(ndArray, true);
+        return sigmoidDerivative(ndArray, true);
     }
 
     /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default `sigmoidDerivative` method had wrong reference.

## How was this patch tested?

Build, now it gives the right results.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
- [x] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
