### PR TITLE
Infer kernel size from weights if needed

### DIFF
--- a/libnd4j/include/ops/declarable/generic/convo/conv1d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/conv1d.cpp
@@ -39,7 +39,7 @@ CUSTOM_OP_IMPL(conv1d, 2, 1, false, 0, 4) {
 
     auto output  = OUTPUT_VARIABLE(0);                                   // [bS, oW, oC] (NWC) or [bS, oC, oW] (NCW)
 
-    int kW = INT_ARG(0);                                                        // filter(kernel) width
+    int kW = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) width
     int sW = INT_ARG(1);                                                        // strides width
     int pW = INT_ARG(2);                                                        // paddings width
     int isSameMode = INT_ARG(3);                                                // 0-VALID, 1-SAME
@@ -97,7 +97,7 @@ DECLARE_SHAPE_FN(conv1d) {
     auto weightsShapeInfo = inputShape->at(1);
     Nd4jLong* biasShapeInfo    = block.width() > 2 ? inputShape->at(2) : nullptr;
 
-    int kW = INT_ARG(0);                                                        // filter(kernel) width
+    int kW = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0)); // filter(kernel) width
     int sW = INT_ARG(1);                                                        // strides width
     int pW = INT_ARG(2);                                                        // paddings width
     int isSameMode = INT_ARG(3);                                                // 0-VALID, 1-SAME
@@ -168,7 +168,7 @@ CUSTOM_OP_IMPL(conv1d_bp, 3, 2, false, 0, 4) {
     auto gradW = OUTPUT_VARIABLE(1);                                                 // [kW, iC, oC] always
     auto gradB = block.width() > 3 ? OUTPUT_VARIABLE(2) : nullptr;                   // [oC]
 
-    int kW = INT_ARG(0);                                                        // filter(kernel) width
+    int kW = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) width
     int sW = INT_ARG(1);                                                        // strides width
     int pW = INT_ARG(2);                                                        // paddings width
     int isSameMode = INT_ARG(3);                                                // 0-VALID, 1-SAME
@@ -241,7 +241,7 @@ DECLARE_SHAPE_FN(conv1d_bp) {
     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM CONV1D_BP OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
     REQUIRE_TRUE(gradOShapeInfo[0]   == rank, 0, "CUSTOM CONV1D_BP OP: rank of output gradients (next epsilon) array must be equal to %i, but got %i instead !", rank, gradOShapeInfo[0]);
 
-    int kW = INT_ARG(0);                                                        // filter(kernel) width
+    int kW = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) width
     int sW = INT_ARG(1);                                                        // strides width
     int pW = INT_ARG(2);                                                        // paddings width
     int isSameMode = INT_ARG(3);                                                // 0-VALID, 1-SAME

--- a/libnd4j/include/ops/declarable/generic/convo/conv3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/conv3d.cpp
@@ -1,3 +1,4 @@
+
 /*******************************************************************************
  * Copyright (c) 2015-2018 Skymind, Inc.
  *
@@ -42,9 +43,9 @@ CUSTOM_OP_IMPL(conv3dnew, 2, 1, false, 0, 13) {
     REQUIRE_TRUE(input->rankOf()   == 5, 0, "CUSTOM CONV3D OP: rank of input array must be equal to 5, but got %i instead !", input->rankOf());
     REQUIRE_TRUE(weights->rankOf() == 5, 0, "CUSTOM CONV3D OP: rank of weights array must be equal to 5, but got %i instead !", weights->rankOf());
                                      
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(weights->sizeAt(2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width
@@ -149,9 +150,9 @@ DECLARE_SHAPE_FN(conv3dnew) {
     auto weightsShapeInfo = inputShape->at(1);                                  // [kD, kH, kW, iC, oC] always
     auto biasShapeInfo    = block.width() > 2 ? inputShape->at(2) : nullptr;    // [oC]
 
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width
@@ -230,9 +231,9 @@ CUSTOM_OP_IMPL(conv3dnew_bp, 3, 2, false, 0, 13) {
     REQUIRE_TRUE(weights->rankOf() == 5, 0, "CUSTOM CONV3D_BP OP: rank of weights array must be equal to 5, but got %i instead !", weights->rankOf());
     REQUIRE_TRUE(gradO->rankOf() == 5, 0, "CUSTOM CONV3D_BP OP: rank of output gradients (next epsilon) array must be equal to 5, but got %i instead !", gradO->rankOf());
 
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(weights->sizeAt(2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width
@@ -394,9 +395,9 @@ DECLARE_SHAPE_FN(conv3dnew_bp) {
     Nd4jLong* biasShapeInfo    = block.width() > 3 ? inputShape->at(2) : nullptr;                // [oC]
     Nd4jLong* gradOShapeInfo   = block.width() > 3 ? inputShape->at(3) : inputShape->at(2);      // [bS, oD, oH, oW, oC] (NDHWC) or [bS, oC, oD, oH, oW] (NCDHW), epsilon_next
 
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width
@@ -449,310 +450,6 @@ DECLARE_SHAPE_FN(conv3dnew_bp) {
 
     return SHAPELIST(gradIshapeInfo, gradWshapeInfo);        
 }
-
-
-
-
-
-
-
-
-
-
-
-
-// CUSTOM_OP_IMPL(conv3dnew, 2, 1, false, 0, 13) {
-//     auto input   = INPUT_VARIABLE(0);                                    // [bS, iD, iH, iW, iC] (NDHWC) or [bS, iC, iD, iH, iW] (NCDHW)
-//     auto weights = INPUT_VARIABLE(1);                                    // [kD, kH, kW, iC, oC] (NDHWC) or [oC, iC, kD, kH, kW] (NCDHW)
-//     NDArray* bias    = block.width() > 2 ? INPUT_VARIABLE(2) : nullptr;      // [oC]
-//     auto output  = OUTPUT_VARIABLE(0);                                   // [bS, oD, oH, oW, oC] (NDHWC) or [bS, oC, oD, oH, oW] (NCDHW)
-
-//     REQUIRE_TRUE(input->rankOf()   == 5, 0, "CUSTOM CONV3D OP: rank of input array must be equal to 5, but got %i instead !", input->rankOf());
-//     REQUIRE_TRUE(weights->rankOf() == 5, 0, "CUSTOM CONV3D OP: rank of weights array must be equal to 5, but got %i instead !", weights->rankOf());
-
-//     int kD = INT_ARG(0);                                                        // filter(kernel) depth
-//     int kH = INT_ARG(1);                                                        // filter(kernel) height
-//     int kW = INT_ARG(2);                                                        // filter(kernel) width
-//     int sD = INT_ARG(3);                                                        // strides depth
-//     int sH = INT_ARG(4);                                                        // strides height
-//     int sW = INT_ARG(5);                                                        // strides width
-//     int pD = INT_ARG(6);                                                        // paddings depth
-//     int pH = INT_ARG(7);                                                        // paddings height
-//     int pW = INT_ARG(8);                                                        // paddings width
-//     int dD = INT_ARG(9);                                                        // dilations depth
-//     int dH = INT_ARG(10);                                                       // dilations height
-//     int dW = INT_ARG(11);                                                       // dilations width
-//     int isSameMode = INT_ARG(12);                                               // 0-SAME,  1-VALID
-//     int isNCDHW  = block.getIArguments()->size() > 13 ? !INT_ARG(13) : 1;       // 0-NDHWC, 1-NCDHW
-
-//     int bS, iC, iD, iH, iW, oC, oD, oH, oW;                     // batch size, input channels, input depth/height/width, output channels, output depth/height/width;
-//     int indIOioC, indIOioD, indWoC, indWiC, indWkD;       // corresponding indexes
-//     ConvolutionUtils::getSizesAndIndexesConv3d(isNCDHW, *input, *output, bS, iC, iD, iH, iW, oC, oD, oH, oW, indIOioC, indIOioD, indWiC, indWoC, indWkD);
-
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({iC,oC,kD,kH,kW,  indWiC,indWoC,indWkD,indWkD+1,indWkD+2}));
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weights), 0, "CUSTOM CONV3D OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weights).c_str());
-//     if (bias)
-//         REQUIRE_TRUE(bias->rankOf() <= 2 && oC == bias->lengthOf(), 0, "CUSTOM CONV3D OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, bias->rankOf(), bias->lengthOf());
-
-//     std::vector<int> weightsAxesForDot, permutForGradW;
-
-//     if(!isNCDHW) {
-//         weightsAxesForDot = {3,0,1,2};                                          // iC, kD, kH, kW
-//         input = input->permute({0,4,1,2,3});                                    // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-//     }
-//     else {
-//         weightsAxesForDot = {1,2,3,4};                                          // iC, kD, kH, kW
-//         permutForGradW    = {0,2,3,4,1};                                        // [bS, oC, oD, oH, oW] -> [bS, oD, oH, oW, oC]
-//     }
-
-//     if(isSameMode)                       // SAME
-//         ConvolutionUtils::calcPadding3D(pD, pH, pW, oD, oH, oW, iD, iH, iW, kD, kH, kW, sD, sH, sW, dD, dH, dW);
-
-//     NDArray columns(input->ordering(), {bS, iC, kD, kH, kW, oD, oH, oW}, block.getWorkspace());
-//     ConvolutionUtils::vol2col(*input, columns, sD, sH, sW, pD, pH, pW, dD, dH, dW);                 // [bS, iC, iD, iH, iW] is convoluted to [bS, iC, kD, kH, kW, oD, oH, oW]
-//     // [bS, iC, kD, kH, kW, oD, oH, oW] x [kD, kH, kW, iC, oC]/[oC, iC, kD, kH, kW] = [bS, oD, oH, oW, oC]
-//     nd4j::MmulHelper::tensorDot(&columns, weights, output, {1,2,3,4}, weightsAxesForDot, permutForGradW);
-
-//     if(bias) {
-//         output->applyBroadcast(broadcast::Add, {indIOioC}, bias);
-//     }
-
-//     if(!isNCDHW)
-//         delete input;
-
-//     return Status::OK();
-// }
-
-
-// DECLARE_SHAPE_FN(conv3dnew) {
-
-//     auto inputShapeInfo   = inputShape->at(0);                                  // [bS, iD, iH, iW, iC] (NDHWC) or [bS, iC, iD, iH, iW] (NCDHW)
-//     auto weightsShapeInfo = inputShape->at(1);                                  // [kD, kH, kW, iC, oC] (NDHWC) or [oC, iC, kD, kH, kW] (NCDHW)
-//     auto biasShapeInfo    = block.width() > 2 ? inputShape->at(2) : nullptr;    // [oC]
-
-//     int kD = INT_ARG(0);                                                        // filter(kernel) depth
-//     int kH = INT_ARG(1);                                                        // filter(kernel) height
-//     int kW = INT_ARG(2);                                                        // filter(kernel) width
-//     int sD = INT_ARG(3);                                                        // strides depth
-//     int sH = INT_ARG(4);                                                        // strides height
-//     int sW = INT_ARG(5);                                                        // strides width
-//     int pD = INT_ARG(6);                                                        // paddings depth
-//     int pH = INT_ARG(7);                                                        // paddings height
-//     int pW = INT_ARG(8);                                                        // paddings width
-//     int dD = INT_ARG(9);                                                        // dilations depth
-//     int dH = INT_ARG(10);                                                       // dilations height
-//     int dW = INT_ARG(11);                                                       // dilations width
-//     int isSameMode = INT_ARG(12);                                               // 1-SAME,  0-VALID;
-//     int isNCDHW  = block.getIArguments()->size() > 13 ? !INT_ARG(13) : 1;       // 1-NDHWC, 0-NCDHW
-
-//     const int rank = 5;
-//     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM CONV3D OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo);
-//     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM CONV3D OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo);
-
-//     int indIOioC, indIiD, indWkD, indWoC, indWiC;
-//     if(!isNCDHW) {
-//         indIOioC = 4; indIiD = 1; indWkD = 0; indWoC = 4; indWiC = 3;
-//     }
-//     else {
-//         indIOioC = 1; indIiD = 2; indWkD = 2; indWoC = 0; indWiC = 1;
-//     }
-
-//     int bS = inputShapeInfo[1];                           // batch size
-//     int iD = inputShapeInfo[indIiD+1];                    // input depth
-//     int iH = inputShapeInfo[indIiD+2];                    // input height
-//     int iW = inputShapeInfo[indIiD+3];                    // input width
-//     int iC = inputShapeInfo[indIOioC+1];                  // input channels
-//     int oC = weightsShapeInfo[indWoC+1];                  // output channels
-
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({iC,oC,kD,kH,kW,  indWiC,indWoC,indWkD,indWkD+1,indWkD+2}));
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weightsShapeInfo), 0, "CUSTOM CONV3D OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weightsShapeInfo).c_str());
-//     if (biasShapeInfo)
-//         REQUIRE_TRUE(biasShapeInfo[0] <= 2 && oC == shape::length(biasShapeInfo), 0, "CUSTOM CONV3D OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, biasShapeInfo[0], shape::length(biasShapeInfo));
-
-//     int oD, oH, oW;                         // output depth, height, width
-//     ConvolutionUtils::calcOutSizePool3D(oD, oH, oW, kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, iD, iH, iW, isSameMode);
-
-//     Nd4jLong* outputShapeInfo = nullptr;
-//     ALLOCATE(outputShapeInfo, block.getWorkspace(), shape::shapeInfoLength(inputShapeInfo), Nd4jLong);
-
-//     outputShapeInfo[0] = rank;
-//     outputShapeInfo[1] = bS;
-//     if (isNCDHW) {
-//         outputShapeInfo[2] = oC;
-//         outputShapeInfo[3] = oD;
-//         outputShapeInfo[4] = oH;
-//         outputShapeInfo[5] = oW;
-//     } else {
-//         outputShapeInfo[2] = oD;
-//         outputShapeInfo[3] = oH;
-//         outputShapeInfo[4] = oW;
-//         outputShapeInfo[5] = oC;
-//     }
-
-//     shape::updateStrides(outputShapeInfo, shape::order(inputShapeInfo));
-
-//     return SHAPELIST(outputShapeInfo);
-// }
-
-
-// //////////////////////////////////////////////////////////////////////////
-// CUSTOM_OP_IMPL(conv3dnew_bp, 3, 2, false, 0, 13) {
-
-//     auto input   = INPUT_VARIABLE(0);                                                // [bS, iD, iH, iW, iC] (NDHWC) or [bS, iC, iD, iH, iW] (NCDHW)
-//     auto weights = INPUT_VARIABLE(1);                                                // [kD, kH, kW, iC, oC] (NDHWC) or [oC, iC, kD, kH, kW] (NCDHW)
-//     auto bias    = block.width() > 3 ? INPUT_VARIABLE(2) : nullptr;                  // [oC]
-//     auto gradO   = block.width() > 3 ? INPUT_VARIABLE(3) : INPUT_VARIABLE(2);        // [bS, oD, oH, oW, oC] (NDHWC) or [bS, oC, oD, oH, oW] (NCDHW), epsilon_next
-
-//     auto gradI = OUTPUT_VARIABLE(0);                                                 // [bS, iD, iH, iW, iC] (NDHWC) or [bS, iC, iD, iH, iW] (NCDHW), epsilon
-//     auto gradW = OUTPUT_VARIABLE(1);                                                 // [kD, kH, kW, iC, oC] (NDHWC) or [oC, iC, kD, kH, kW] (NCDHW)
-//     auto gradB = block.width() > 3 ? OUTPUT_VARIABLE(2) : nullptr;                   // [oC]
-
-//     REQUIRE_TRUE(input->rankOf()   == 5, 0, "CUSTOM CONV3D_BP OP: rank of input array must be equal to 5, but got %i instead !", input->rankOf());
-//     REQUIRE_TRUE(weights->rankOf() == 5, 0, "CUSTOM CONV3D_BP OP: rank of weights array must be equal to 5, but got %i instead !", weights->rankOf());
-//     REQUIRE_TRUE(gradO->rankOf() == 5, 0, "CUSTOM CONV3D_BP OP: rank of output gradients (next epsilon) array must be equal to 5, but got %i instead !", gradO->rankOf());
-
-//     int kD = INT_ARG(0);                                                        // filter(kernel) depth
-//     int kH = INT_ARG(1);                                                        // filter(kernel) height
-//     int kW = INT_ARG(2);                                                        // filter(kernel) width
-//     int sD = INT_ARG(3);                                                        // strides depth
-//     int sH = INT_ARG(4);                                                        // strides height
-//     int sW = INT_ARG(5);                                                        // strides width
-//     int pD = INT_ARG(6);                                                        // paddings depth
-//     int pH = INT_ARG(7);                                                        // paddings height
-//     int pW = INT_ARG(8);                                                        // paddings width
-//     int dD = INT_ARG(9);                                                        // dilations depth
-//     int dH = INT_ARG(10);                                                       // dilations height
-//     int dW = INT_ARG(11);                                                       // dilations width
-//     int isSameMode = INT_ARG(12);                                               // 1-SAME,  0-VALID
-//     int isNDHWC  = block.getIArguments()->size() > 13 ? !INT_ARG(13) : 1;       // 1-NDHWC, 0-NCDHW
-
-//     int bS, iC, iD, iH, iW, oC, oD, oH, oW;                     // batch size, input channels, input depth/height/width, output channels, output depth/height/width;
-//     int indIOioC, indIOioD, indWoC, indWiC, indWkD;             // corresponding indexes
-//     ConvolutionUtils::getSizesAndIndexesConv3d(isNDHWC, *input, *gradO, bS, iC, iD, iH, iW, oC, oD, oH, oW, indIOioC, indIOioD, indWiC, indWoC, indWkD);
-
-//     int trueoD, trueoH, trueoW;          // true output depth/height/width
-//     ConvolutionUtils::calcOutSizePool3D(trueoD, trueoH, trueoW, kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, iD, iH, iW, isSameMode);
-
-//     std::string expectedGradOShape   = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({bS,oC,trueoD,trueoH,trueoW,  0,indIOioC,indIOioD,indIOioD+1,indIOioD+2}));
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({iC,oC,kD,kH,kW,  indWiC,indWoC,indWkD,indWkD+1,indWkD+2}));
-//     REQUIRE_TRUE(expectedGradOShape == ShapeUtils::shapeAsString(gradO), 0,  "CUSTOM CONV3D_BP OP: wrong shape of output gradients (next epsilon) array, expected is %s, but got %s instead !", expectedGradOShape.c_str(), ShapeUtils::shapeAsString(gradO).c_str());
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weights), 0, "CUSTOM CONV3D_BP OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weights).c_str());
-//     if(bias)
-//         REQUIRE_TRUE(bias->rankOf() <= 2 && oC == bias->lengthOf(), 0, "CUSTOM CONV3D_BP OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, bias->rankOf(), bias->lengthOf());
-
-//     std::vector<int> gradOaxesForDot, permutForGradW, permutForColumns;
-
-//     if(!isNDHWC) {
-//         input = input->permute({0,4,1,2,3});                                    // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-//         gradI = gradI->permute({0,4,1,2,3});                                    // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-//         gradOaxesForDot  = {0,1,2,3};                                           // bS, oD, oH, oW
-//         permutForGradW   = {3,0,1,2,4};                                         // [kD, kH, kW, iC, oC] -> [iC, kD, kH, kW, oC]
-//         permutForColumns = {2,3,4,1,0,5,6,7};                                   // [bS, iC, kD, kH, kW, oD, oH, oW] -> [kD, kH, kW, iC, bS, oD, oH, oW]
-//     }
-//     else {
-//         gradOaxesForDot  = {0,2,3,4};                                           // bS, oD, oH, oW
-//         permutForGradW   = {1,2,3,4,0};                                         // [oC, iC, kD, kH, kW] -> [iC, kD, kH, kW, oC]
-//         permutForColumns = {1,2,3,4,0,5,6,7};                                   // [bS, iC, kD, kH, kW, oD, oH, oW] -> [iC, kD, kH, kW, bS, oD, oH, oW]
-//     }
-
-//     if(isSameMode)                       // SAME
-//         ConvolutionUtils::calcPadding3D(pD, pH, pW, oD, oH, oW, iD, iH, iW, kD, kH, kW, sD, sH, sW, dD, dH, dW);
-
-//     // ----- calculation of gradW and gradB ----- //
-//     NDArray columns(input->ordering(), {bS, iC, kD, kH, kW, oD, oH, oW}, block.getWorkspace());
-//     ConvolutionUtils::vol2col(*input, columns, sD, sH, sW, pD, pH, pW, dD, dH, dW);                         // [bS, iC, iD, iH, iW] is convoluted to [bS, iC, kD, kH, kW, oD, oH, oW]
-//     nd4j::MmulHelper::tensorDot(&columns, gradO, gradW, {0,5,6,7}, gradOaxesForDot, permutForGradW);     // [bS, iC, kD, kH, kW, oD, oH, oW] x [bS, oD, oH, oW, oC]/[bS, oC, oD, oH, oW] = [iC, kD, kH, kW, oC]
-
-//     if(gradB) {
-//         if(gradB->rankOf() == 2)
-//             gradB = gradB->reshape(gradB->ordering(), {(int)gradB->lengthOf()});
-//         gradO->reduceAlongDimension(reduce::Sum, gradB, gradOaxesForDot);                          // sum over bS oD oH oW
-//         if(gradB != OUTPUT_VARIABLE(2))
-//             delete gradB;
-//     }
-
-//     //----- calculation of gradI -----//
-//     nd4j::MmulHelper::tensorDot(weights, gradO, &columns, {indWoC}, {indIOioC}, permutForColumns);   // [kD, kH, kW, iC, oC]/[oC, iC, kD, kH, kW]] x [bS, oD, oH, oW, oC]/[bS, oC, oD, oH, oW] = [kD, kH, kW, iC, bS, oD, oH, oW]/[iC, kD, kH, kW, bS, oD, oH, oW]
-//     ConvolutionUtils::col2vol(columns, *gradI, sD, sH, sW, pD, pH, pW, dD, dH, dW);                     // columns [bS, iC, kD, kH, kW, oD, oH, oW] is de-convoluted to  [bS, iC, iD, iH, iW]
-
-//     if(!isNDHWC) {
-//         delete input;
-//         delete gradI;
-//     }
-
-//     return Status::OK();
-// }
-
-
-
-// DECLARE_SHAPE_FN(conv3dnew_bp) {
-
-//     Nd4jLong* inputShapeInfo   = inputShape->at(0);                                              // [bS, iD, iH, iW, iC] (NDHWC) or [bS, iC, iD, iH, iW] (NCDHW)
-//     Nd4jLong* weightsShapeInfo = inputShape->at(1);                                              // [kD, kH, kW, iC, oC] (NDHWC) or [oC, iC, kD, kH, kW] (NCDHW)
-//     Nd4jLong* biasShapeInfo    = block.width() > 3 ? inputShape->at(2) : nullptr;                // [oC]
-//     Nd4jLong* gradOShapeInfo   = block.width() > 3 ? inputShape->at(3) : inputShape->at(2);      // [bS, oD, oH, oW, oC] (NDHWC) or [bS, oC, oD, oH, oW] (NCDHW), epsilon_next
-
-//     int kD = INT_ARG(0);                                                        // filter(kernel) depth
-//     int kH = INT_ARG(1);                                                        // filter(kernel) height
-//     int kW = INT_ARG(2);                                                        // filter(kernel) width
-//     int sD = INT_ARG(3);                                                        // strides depth
-//     int sH = INT_ARG(4);                                                        // strides height
-//     int sW = INT_ARG(5);                                                        // strides width
-//     int pD = INT_ARG(6);                                                        // paddings depth
-//     int pH = INT_ARG(7);                                                        // paddings height
-//     int pW = INT_ARG(8);                                                        // paddings width
-//     int dD = INT_ARG(9);                                                        // dilations depth
-//     int dH = INT_ARG(10);                                                       // dilations height
-//     int dW = INT_ARG(11);                                                       // dilations width
-//     int isSameMode = INT_ARG(12);                                               // 1-SAME,  0-VALID
-//     int isNDHWC  = block.getIArguments()->size() > 13 ? !INT_ARG(13) : 1;       // 1-NDHWC, 0-NCDHW
-
-//     const int rank = 5;
-//     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM CONV3D_BP OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo);
-//     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM CONV3D_BP OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo);
-//     REQUIRE_TRUE(gradOShapeInfo[0]   == rank, 0, "CUSTOM CONV3D_BP OP: rank of output gradients (next epsilon) array must be equal to %i, but got %i instead !", rank, gradOShapeInfo);
-
-//     int indIOioC, indIiD, indWkD, indWoC, indWiC;
-//     if(!isNDHWC) {
-//         indIOioC = 4; indIiD = 1; indWkD = 0; indWoC = 4; indWiC = 3;
-//     }
-//     else {
-//         indIOioC = 1; indIiD = 2; indWkD = 2; indWoC = 0; indWiC = 1;
-//     }
-
-//     int bS = inputShapeInfo[1];                           // batch size
-//     int iD = inputShapeInfo[indIiD+1];                    // input depth
-//     int iH = inputShapeInfo[indIiD+2];                    // input height
-//     int iW = inputShapeInfo[indIiD+3];                    // input width
-//     int iC = inputShapeInfo[indIOioC+1];                  // input channels
-//     int oC = weightsShapeInfo[indWoC+1];                  // output channels
-
-//     int trueoD, trueoH, trueoW;          // true output depth/height/width
-//     ConvolutionUtils::calcOutSizePool3D(trueoD, trueoH, trueoW, kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, iD, iH, iW, isSameMode);
-
-//     std::string expectedGradOShape   = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({bS,oC,trueoD,trueoH,trueoW,  0,indIOioC,indIiD,indIiD+1,indIiD+2}));
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({iC,oC,kD,kH,kW,  indWiC,indWoC,indWkD,indWkD+1,indWkD+2}));
-//     REQUIRE_TRUE(expectedGradOShape   == ShapeUtils::shapeAsString(gradOShapeInfo),   0, "CUSTOM CONV3D_BP OP: wrong shape of output gradients (next epsilon) array, expected is %s, but got %s instead !", expectedGradOShape.c_str(), ShapeUtils::shapeAsString(gradOShapeInfo).c_str());
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weightsShapeInfo), 0, "CUSTOM CONV3D_BP OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weightsShapeInfo).c_str());
-//     if(biasShapeInfo)
-//         REQUIRE_TRUE(biasShapeInfo[0] <= 2 && oC == shape::length(biasShapeInfo), 0, "CUSTOM CONV3D_BP OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, biasShapeInfo[0], shape::length(biasShapeInfo));
-
-//     Nd4jLong* gradIshapeInfo(nullptr), *gradWshapeInfo(nullptr);
-//     COPY_SHAPE(inputShapeInfo, gradIshapeInfo);
-//     COPY_SHAPE(weightsShapeInfo, gradWshapeInfo);
-
-//     if(biasShapeInfo) {
-//         Nd4jLong* gradBshapeInfo(nullptr);
-//         COPY_SHAPE(biasShapeInfo, gradBshapeInfo);
-//         return SHAPELIST(gradIshapeInfo, gradWshapeInfo, gradBshapeInfo);
-//     }
-
-//     return SHAPELIST(gradIshapeInfo, gradWshapeInfo);
-// }
-
-
-
-
 }
 }
 

--- a/libnd4j/include/ops/declarable/generic/convo/deconv2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/deconv2d.cpp
@@ -43,8 +43,8 @@ CUSTOM_OP_IMPL(deconv2d, 2, 1, false, 0, 9) {
     REQUIRE_TRUE(input->rankOf()   == 4, 0, "CUSTOM DECONV2D OP: rank of input array must be equal to 4, but got %i instead !", input->rankOf());
     REQUIRE_TRUE(weights->rankOf() == 4, 0, "CUSTOM DECONV2D OP: rank of weights array must be equal to 4, but got %i instead !", weights->rankOf());
 
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -103,8 +103,8 @@ DECLARE_SHAPE_FN(deconv2d) {
     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM DECONV2D OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo[0]);
     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DECONV2D OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
 
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -180,8 +180,8 @@ CUSTOM_OP_IMPL(deconv2d_bp, 3, 2, false, 0, 9) {
     REQUIRE_TRUE(gradO->rankOf()   == 4, 0, "CUSTOM DECONV2D_BP OP: rank of output gradients (next epsilon) array must be equal to 4, but got %i instead !", gradO->rankOf());
 
 
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -257,8 +257,8 @@ DECLARE_SHAPE_FN(deconv2d_bp) {
     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DECONV2D_BP OP: rank of weights array must be equal to %i , but got %i instead !", rank, weightsShapeInfo[0]);
     REQUIRE_TRUE(gradOShapeInfo[0]   == rank, 0, "CUSTOM DECONV2D_BP OP: rank of output gradients (next epsilon) array must be equal to %i, but got %i instead !", rank, gradOShapeInfo[0]);
 
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height

--- a/libnd4j/include/ops/declarable/generic/convo/deconv2d_tf.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/deconv2d_tf.cpp
@@ -37,8 +37,8 @@ CUSTOM_OP_IMPL(deconv2d_tf, 3, 1, false, 0, 9) {
             
     auto gradI = OUTPUT_VARIABLE(0);                                                  // [bS, iH, iW, iC] (NHWC) or [bS, iC, iH, iW] (NCHW), epsilon
 
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -94,8 +94,8 @@ DECLARE_SHAPE_FN(deconv2d_tf) {
     REQUIRE_TRUE(gradIShapeShapeInfo[0] == 1,    0, "CUSTOM DECONV2D_TF OP: rank of array with output shape must be equal to %i, but got %i instead !", 1, gradIShapeShapeInfo[0]);    
     
 
-    const int kH = INT_ARG(0);                                                        // filter(kernel) height
-    const int kW = INT_ARG(1);                                                        // filter(kernel) width
+    const int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) height
+    const int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) width
     const int sH = INT_ARG(2);                                                        // strides height
     const int sW = INT_ARG(3);                                                        // strides width
     const int pH = INT_ARG(4);                                                        // paddings height
@@ -155,138 +155,6 @@ DECLARE_SHAPE_FN(deconv2d_tf) {
     return SHAPELIST(gradIshapeInfo);        
 
 }
-
-
-
-/*
-
-
-    CUSTOM_OP_IMPL(deconv2d_tf, 2, 1, false, 0, 9) {
-        NDArray<T> *input   = INPUT_VARIABLE(2);                                    // [bS, iH, iW, iC] (NHWC) or [bS, iC, iH, iW] (NCHW)
-        NDArray<T> *weights = INPUT_VARIABLE(1);                                    // [kH, kW, oC, iC] (NHWC) or [iC, oC, kH, kW] (NCHW)
-
-        NDArray<T> *output  = OUTPUT_VARIABLE(0);                                   // [bS, oH, oW, oC] (NHWC) or [bS, oC, oH, oW] (NCHW)
-
-       REQUIRE_TRUE(input->rankOf()   == 4, 0, "CUSTOM DECONV2D OP: rank of input array must be equal to 4, but got %i instead !", input->rankOf());
-       REQUIRE_TRUE(weights->rankOf() == 4, 0, "CUSTOM DECONV2D OP: rank of weights array must be equal to 4, but got %i instead !", weights->rankOf());
-
-     int kH = INT_ARG(0);                                                        // filter(kernel) height
-     int kW = INT_ARG(1);                                                        // filter(kernel) width
-     int sH = INT_ARG(2);                                                        // strides height
-     int sW = INT_ARG(3);                                                        // strides width
-     int pH = INT_ARG(4);                                                        // paddings height
-     int pW = INT_ARG(5);                                                        // paddings width
-     int dH = INT_ARG(6);                                                        // dilations height
-     int dW = INT_ARG(7);                                                        // dilations width
-     int isSameMode = INT_ARG(8);                                                // 0-VALID, 1-SAME
-     int isNCHW     = block.getIArguments()->size() > 9 ? !INT_ARG(9) : 1;       // INT_ARG(9): 0-NCHW,  1-NHWC
-
-     int bS, iC, iH, iW, oC, oH, oW;                             // batch size, input channels, input height/width, output channels, output height/width;
-     int indIOioC, indIiH, indWoC, indWiC, indWkH, indOoH;       // corresponding indexes
-     ConvolutionUtils<T>::getSizesAndIndexesConv2d(isNCHW, *input, *output, bS, iC, iH, iW, oC, oH, oW, indIOioC, indIiH, indWoC, indWiC, indWkH, indOoH);
-
-     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({iC,oC,kH,kW,  indWiC,indWoC,indWkH,indWkH+1}));
-     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weights), 0, "CUSTOM DECONV2D OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weights).c_str());
-
-     std::vector<int> permutForColumns;
-
-     if(!isNCHW) {
-         output  = output->permute({0, 3, 1, 2});                                // [bS, oH, oW, oC] -> [bS, oC, oH, oW]
-         permutForColumns = {2, 3, 1, 0, 4, 5};                                  // [bS, oC, kH, kW, iH, iW] -> [kH, kW, oC, bS, iH, iW]
-     }
-     else
-         permutForColumns = {1, 2, 3, 0, 4, 5};                                  // [bS, oC, kH, kW, iH, iW] -> [oC, kH, kW, bS, iH, iW]
-
-     if(isSameMode)                       // SAME
-         ConvolutionUtils<T>::calcPadding2D(pH, pW, oH, oW, iH, iW, kH, kW, sH, sW, dH, dW);
-
-        NDArray<T> columns(input->ordering(), {bS, oC, kH, kW, iH, iW}, block.getWorkspace());
-        std::vector<T> extrasCol2Im({(T) sH, (T) sW, (T) pH, (T) pW, (T) oH, (T) oW, (T) dH, (T) dW});
-
-     //----- calculation of output -----//
-     // NHWC: [kH, kW, oC, iC] x [bS, iH, iW, iC] = [kH, kW, oC, bS, iH, iW]
-     // NCHW: [iC, oC, kH, kW] x [bS, iC, iH, iW] = [oC, kH, kW, bS, iH, iW]
-     nd4j::MmulHelper<T>::tensorDot(weights, input, &columns, {indWiC}, {indIOioC}, permutForColumns);
-     columns.template applyTransform<simdOps::Col2Im<T>>(output, extrasCol2Im.data());                            // [bS, oC, kH, kW, iH, iW] is de-convoluted to [bS, oC, oH, oW]
-
-     if(!isNCHW)
-         delete output;
-    
-     return Status::OK();
-
-    }
-
- DECLARE_SHAPE_FN(deconv2d_tf) {
-    
-     auto tfShape = INPUT_VARIABLE(0);
-     auto inputShapeInfo   = inputShape->at(2);                                    // [bS, iH, iW, iC] (NHWC) or [bS, iC, iH, iW] (NCHW)
-     auto weightsShapeInfo = inputShape->at(1);                                    // [kH, kW, oC, iC] (NHWC) or [iC, oC, kH, kW] (NCHW)
-
-     const int rank = 4;
-     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM DECONV2D OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo[0]);
-     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DECONV2D OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
-
-     int kH = INT_ARG(0);                                                        // filter(kernel) height
-     int kW = INT_ARG(1);                                                        // filter(kernel) width
-     int sH = INT_ARG(2);                                                        // strides height
-     int sW = INT_ARG(3);                                                        // strides width
-     int pH = INT_ARG(4);                                                        // paddings height
-     int pW = INT_ARG(5);                                                        // paddings width
-     int dH = INT_ARG(6);                                                        // dilations height
-     int dW = INT_ARG(7);                                                        // dilations width
-     int isSameMode = INT_ARG(8);                                                // 0-VALID, 1-SAME
-     int isNCHW  = block.getIArguments()->size() > 9 ? !INT_ARG(9) : 1;          // INT_ARG(9): 1-NHWC, 0-NCHW
-
-     int indIOioC, indIiH, indWkH, indWoC, indWiC;
-     if(!isNCHW) {
-         indIOioC = 3; indIiH = 1; indWkH = 0; indWiC = 3; indWoC = 2;
-     }
-     else {
-         indIOioC = 1; indIiH = 2; indWkH = 2; indWiC = 0; indWoC = 1;
-     }
-
-     const int bS = inputShapeInfo[1];                            // batch size
-     const int iH = inputShapeInfo[indIiH+1];                     // input height
-     const int iW = inputShapeInfo[indIiH+2];                     // input width
-     const int iC = inputShapeInfo[indIOioC+1];                   // input channels
-     const int oC = weightsShapeInfo[indWoC+1];                   // output channels
-
-     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({iC,oC,kH,kW,  indWiC,indWoC,indWkH,indWkH+1}));
-     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weightsShapeInfo), 0, "CUSTOM DECONV2D OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weightsShapeInfo).c_str());
-
-     int oH, oW;                                         // output height, width
-     ConvolutionUtils<T>::calcOutSizeDeconv2D(oH, oW, kH, kW, sH, sW, pH, pW, dH, dW, iH, iW, isSameMode);
-    
-     Nd4jLong* outputShapeInfo = nullptr;
-     ALLOCATE(outputShapeInfo, block.getWorkspace(), shape::shapeInfoLength(inputShapeInfo), Nd4jLong);
-
-     outputShapeInfo[0] = rank;
-     outputShapeInfo[1] = bS;
-
-     if (isNCHW) {
-         outputShapeInfo[2] = oC;
-         outputShapeInfo[3] = oH;
-         outputShapeInfo[4] = oW;
-     } else {
-         outputShapeInfo[2] = oH;
-         outputShapeInfo[3] = oW;
-         outputShapeInfo[4] = oC;
-     }
-    
-     shape::updateStrides(outputShapeInfo, shape::order(inputShapeInfo));
-
-     auto shapeTF = tfShape->template asVectorT<Nd4jLong>();
-     auto shapeND = shape::shapeOf(outputShapeInfo);
-
-     if (!shape::shapeEquals(shapeTF.size(), shapeTF.data(), 4, shapeND)) {
-         auto e = ShapeUtils::shapeAsString(shapeTF.size(), shapeTF.data());
-         auto a = ShapeUtils::shapeAsString(4, shapeND);
-         REQUIRE_TRUE(false, 0, "deconv2d_tf: shape doesn't match TF value: Expected %s vs actual %s", e.c_str(), a.c_str());
-     }
-
-     return SHAPELIST(outputShapeInfo);
- }
-*/
 
 }
 }

--- a/libnd4j/include/ops/declarable/generic/convo/deconv3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/deconv3d.cpp
@@ -39,9 +39,9 @@ CUSTOM_OP_IMPL(deconv3d, 2, 1, false, 0, 13) {
     REQUIRE_TRUE(input->rankOf()   == 5, 0, "CUSTOM DECONV3D OP: rank of input array must be equal to 5, but got %i instead !", input->rankOf());
     REQUIRE_TRUE(weights->rankOf() == 5, 0, "CUSTOM DECONV3D OP: rank of weights array must be equal to 5, but got %i instead !", weights->rankOf());
 
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(weights->sizeAt(2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width
@@ -106,9 +106,9 @@ DECLARE_SHAPE_FN(deconv3d) {
     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM DECONV3D OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo[0]);
     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DECONV3D OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
 
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width
@@ -185,9 +185,9 @@ CUSTOM_OP_IMPL(deconv3d_bp, 3, 2, false, 0, 13) {
     REQUIRE_TRUE(gradO->rankOf()   == 5, 0, "CUSTOM DECONV3D_BP OP: rank of output gradients (next epsilon) array must be equal to 5, but got %i instead !", gradO->rankOf());
 
 
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(weights->sizeAt(2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width
@@ -273,9 +273,9 @@ DECLARE_SHAPE_FN(deconv3d_bp) {
     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DECONV3D_BP OP: rank of weights array must be equal to %i , but got %i instead !", rank, weightsShapeInfo[0]);
     REQUIRE_TRUE(gradOShapeInfo[0]   == rank, 0, "CUSTOM DECONV3D_BP OP: rank of output gradients (next epsilon) array must be equal to %i, but got %i instead !", rank, gradOShapeInfo[0]);
 
-    int kD = INT_ARG(0);                                                        // filter(kernel) depth
-    int kH = INT_ARG(1);                                                        // filter(kernel) height
-    int kW = INT_ARG(2);                                                        // filter(kernel) width
+    int kD = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) depth
+    int kH = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) height
+    int kW = INT_ARG(2) > 0 ? INT_ARG(2) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 2));// filter(kernel) width
     int sD = INT_ARG(3);                                                        // strides depth
     int sH = INT_ARG(4);                                                        // strides height
     int sW = INT_ARG(5);                                                        // strides width

--- a/libnd4j/include/ops/declarable/generic/convo/depthwiseConv2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/depthwiseConv2d.cpp
@@ -39,9 +39,9 @@ CUSTOM_OP_IMPL(depthwise_conv2d, 2, 1, false, 0, 9) {
 
     REQUIRE_TRUE(input->rankOf()   == 4, 0, "CUSTOM DEPTHWISECONV2D OP: rank of input array must be equal to 4, but got %i instead !", input->rankOf());
     REQUIRE_TRUE(weights->rankOf() == 4, 0, "CUSTOM DEPTHWISECONV2D OP: rank of weights array must be equal to 4, but got %i instead !", weights->rankOf());
-                                     
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -82,8 +82,8 @@ DECLARE_SHAPE_FN(depthwise_conv2d) {
     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM DEPTHWISECONV2D OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo[0]);
     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DEPTHWISECONV2D OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
 
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) :  static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -158,9 +158,9 @@ CUSTOM_OP_IMPL(depthwise_conv2d_bp, 3, 2, false, 0, 9) {
     REQUIRE_TRUE(input->rankOf()   == 4, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of input array must be equal to 4, but got %i instead !", input->rankOf());
     REQUIRE_TRUE(weights->rankOf() == 4, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of weights array must be equal to 4, but got %i instead !", weights->rankOf());
     REQUIRE_TRUE(gradO->rankOf() == 4, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of output gradients (next epsilon) array must be equal to 4, but got %i instead !", gradO->rankOf());
-                                     
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(weights->sizeAt(0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) : static_cast<int>(weights->sizeAt(1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -204,8 +204,8 @@ DECLARE_SHAPE_FN(depthwise_conv2d_bp) {
     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
     REQUIRE_TRUE(gradOShapeInfo[0]   == rank, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of output gradients (next epsilon) array must be equal to %i, but got %i instead !", rank, gradOShapeInfo[0]);
 
-    int kH = INT_ARG(0);                                                        // filter(kernel) height
-    int kW = INT_ARG(1);                                                        // filter(kernel) width
+    int kH = INT_ARG(0) > 0 ? INT_ARG(0) : static_cast<int>(shape::sizeAt(weightsShapeInfo, 0));// filter(kernel) height
+    int kW = INT_ARG(1) > 0 ? INT_ARG(1) :  static_cast<int>(shape::sizeAt(weightsShapeInfo, 1));// filter(kernel) width
     int sH = INT_ARG(2);                                                        // strides height
     int sW = INT_ARG(3);                                                        // strides width
     int pH = INT_ARG(4);                                                        // paddings height
@@ -250,239 +250,6 @@ DECLARE_SHAPE_FN(depthwise_conv2d_bp) {
 
     return SHAPELIST(gradIshapeInfo, gradWshapeInfo);        
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-// CUSTOM_OP_IMPL(depthwise_conv2d, 2, 1, false, 0, 9) {
-//     auto input   = INPUT_VARIABLE(0);                                    // [bS, iH, iW, iC] (NHWC) or [bS, iC, iH, iW] (NCHW)
-//     auto weights = INPUT_VARIABLE(1);                                    // [kH, kW, iC, mC] (NHWC) or [mC, iC, kH, kW] (NCHW)
-//     auto bias    = block.width() > 2 ? INPUT_VARIABLE(2) : nullptr;      // [oC] = iC*mC
-
-//     auto output  = OUTPUT_VARIABLE(0);                                   // [bS, oH, oW, iC*mC] (NHWC) or [bS, iC*mC, oH, oW] (NCHW)
-
-//     REQUIRE_TRUE(input->rankOf()   == 4, 0, "CUSTOM DEPTHWISECONV2D OP: rank of input array must be equal to 4, but got %i instead !", input->rankOf());
-//     REQUIRE_TRUE(weights->rankOf() == 4, 0, "CUSTOM DEPTHWISECONV2D OP: rank of weights array must be equal to 4, but got %i instead !", weights->rankOf());
-
-//     int kH = INT_ARG(0);                                                        // filter(kernel) height
-//     int kW = INT_ARG(1);                                                        // filter(kernel) width
-//     int sH = INT_ARG(2);                                                        // strides height
-//     int sW = INT_ARG(3);                                                        // strides width
-//     int pH = INT_ARG(4);                                                        // paddings height
-//     int pW = INT_ARG(5);                                                        // paddings width
-//     int dH = INT_ARG(6);                                                        // dilations height
-//     int dW = INT_ARG(7);                                                        // dilations width
-//     int isSameMode = INT_ARG(8);                                                // 0-VALID, 1-SAME
-//     int isNCHW     = block.getIArguments()->size() > 9 ? !INT_ARG(9) : 1;       // 0-NCHW,  1-NHWC
-
-//     int bS, iC, iH, iW, mC, oC, oH, oW;                     // batch size, input channels, input height/width, channels multiplier(oC = iC*mC), output channels, output height/width
-//     int indIOioC, indIiH, indWmC, indWiC, indWkH, indOoH;   // corresponding indexes
-//     ConvolutionUtils::getSizesAndIndexesConv2d(isNCHW, *input, *output, bS, iC, iH, iW, oC, oH, oW, indIOioC, indIiH, indWiC, indWmC, indWkH, indOoH);
-//     mC = weights->sizeAt(indWmC);                           // channels multiplier
-
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({mC,iC,kH,kW,  indWmC,indWiC,indWkH,indWkH+1}));
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weights), 0, "CUSTOM DEPTHWISECONV2D OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weights).c_str());
-//     REQUIRE_TRUE(output->sizeAt(indIOioC) == iC*mC, 0, "CUSTOM DEPTHWISECONV2D OP: the output_channels must be equal to input_channels * channels_multiplier = %i !", iC*mC);
-//     if (bias)
-//         REQUIRE_TRUE(bias->rankOf() <= 2 && oC == bias->lengthOf(), 0, "CUSTOM DEPTHWISECONV2D OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, bias->rankOf(), bias->lengthOf());
-
-//     ConvolutionUtils::depthwiseConv2d(input, weights, bias, output,  kH,kW,sH,sW,pH,pW,dH,dW,isSameMode,isNCHW);
-
-//     return Status::OK();
-// }
-
-
-
-// DECLARE_SHAPE_FN(depthwise_conv2d) {
-//     auto inputShapeInfo   = inputShape->at(0);                                    // [bS, iH, iW, iC] (NHWC) or [bS, iC, iH, iW] (NCHW)
-//     auto weightsShapeInfo = inputShape->at(1);                                    // [kH, kW, iC, mC] (NHWC) or [mC, iC, kH, kW] (NCHW)
-//     auto biasShapeInfo    = block.width() > 2 ? inputShape->at(2) : nullptr;      // [oC] = iC*mC
-
-//     const int rank = 4;
-//     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM DEPTHWISECONV2D OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo[0]);
-//     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DEPTHWISECONV2D OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
-
-//     int kH = INT_ARG(0);                                                        // filter(kernel) height
-//     int kW = INT_ARG(1);                                                        // filter(kernel) width
-//     int sH = INT_ARG(2);                                                        // strides height
-//     int sW = INT_ARG(3);                                                        // strides width
-//     int pH = INT_ARG(4);                                                        // paddings height
-//     int pW = INT_ARG(5);                                                        // paddings width
-//     int dH = INT_ARG(6);                                                        // dilations height
-//     int dW = INT_ARG(7);                                                        // dilations width
-//     int isSameMode = INT_ARG(8);                                                // 0-VALID, 1-SAME
-//     int isNCHW  = block.getIArguments()->size() > 9 ? !INT_ARG(9) : 1;          // 0-NDHWC, 1-NCDHW
-
-//     int indIOioC, indIiH, indWkH, indWmC, indWiC;
-//     if(!isNCHW) {
-//         indIOioC = 3; indIiH = 1; indWkH = 0; indWmC = 3; indWiC = 2;
-//     }
-//     else {
-//         indIOioC = 1; indIiH = 2; indWkH = 2; indWmC = 0; indWiC = 1;
-//     }
-
-//     const int bS = inputShapeInfo[1];                            // batch size
-//     const int iH = inputShapeInfo[indIiH+1];                     // input height
-//     const int iW = inputShapeInfo[indIiH+2];                     // input width
-//     const int iC = inputShapeInfo[indIOioC+1];                   // input channels
-//     const int mC = weightsShapeInfo[indWmC+1];                   // channels multiplier(oC = iC*mC)
-//     const int oC = iC*mC;                                        // output channels
-
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({iC,mC,kH,kW,  indWiC,indWmC,indWkH,indWkH+1}));
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weightsShapeInfo), 0, "DEPTHWISECONV2D OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weightsShapeInfo).c_str());
-//     if (biasShapeInfo)
-//         REQUIRE_TRUE(biasShapeInfo[0] <= 2 && oC == shape::length(biasShapeInfo), 0, "DEPTHWISECONV2D OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, biasShapeInfo[0], shape::length(biasShapeInfo));
-
-//     int oH, oW;                                         // output height, width
-//     ConvolutionUtils::calcOutSizePool2D(oH, oW, kH, kW, sH, sW, pH, pW, dH, dW, iH, iW, isSameMode);
-
-//     Nd4jLong* outputShapeInfo = nullptr;
-//     ALLOCATE(outputShapeInfo, block.getWorkspace(), shape::shapeInfoLength(inputShapeInfo), Nd4jLong);
-
-//     outputShapeInfo[0] = rank;
-//     outputShapeInfo[1] = bS;
-
-//     if (isNCHW) {
-//         outputShapeInfo[2] = oC;
-//         outputShapeInfo[3] = oH;
-//         outputShapeInfo[4] = oW;
-//     } else {
-//         outputShapeInfo[2] = oH;
-//         outputShapeInfo[3] = oW;
-//         outputShapeInfo[4] = oC;
-//     }
-
-//     shape::updateStrides(outputShapeInfo, shape::order(inputShapeInfo));
-
-//     return SHAPELIST(outputShapeInfo);
-// }
-
-
-
-// //////////////////////////////////////////////////////////////////////////
-// CUSTOM_OP_IMPL(depthwise_conv2d_bp, 3, 2, false, 0, 9) {
-//     auto input   = INPUT_VARIABLE(0);                                                // [bS, iH, iW, iC] (NDHWC) or [bS, iC, iH, iW] (NCDHW)
-//     auto weights = INPUT_VARIABLE(1);                                                // [kH, kW, iC, mC] (NDHWC) or [mC, iC, kH, kW] (NCDHW)
-//     auto bias    = block.width() > 3 ? INPUT_VARIABLE(2) : nullptr;                  // [oC] = [iC*mC]
-//     auto gradO   = block.width() > 3 ? INPUT_VARIABLE(3) : INPUT_VARIABLE(2);        // [bS, oH, oW, oC] (NDHWC) or [bS, oC, oH, oW] (NCDHW), epsilon_next
-
-//     auto gradI = OUTPUT_VARIABLE(0);                                                 // [bS, iH, iW, iC] (NDHWC) or [bS, iC, iH, iW] (NCDHW), epsilon
-//     auto gradW = OUTPUT_VARIABLE(1);                                                 // [kH, kW, iC, mC] (NDHWC) or [mC, iC, kH, kW] (NCDHW)
-//     auto gradB = block.width() > 3 ? OUTPUT_VARIABLE(2) : nullptr;                   // [oC]
-
-//     REQUIRE_TRUE(input->rankOf()   == 4, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of input array must be equal to 4, but got %i instead !", input->rankOf());
-//     REQUIRE_TRUE(weights->rankOf() == 4, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of weights array must be equal to 4, but got %i instead !", weights->rankOf());
-//     REQUIRE_TRUE(gradO->rankOf() == 4, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of output gradients (next epsilon) array must be equal to 4, but got %i instead !", gradO->rankOf());
-
-//     int kH = INT_ARG(0);                                                        // filter(kernel) height
-//     int kW = INT_ARG(1);                                                        // filter(kernel) width
-//     int sH = INT_ARG(2);                                                        // strides height
-//     int sW = INT_ARG(3);                                                        // strides width
-//     int pH = INT_ARG(4);                                                        // paddings height
-//     int pW = INT_ARG(5);                                                        // paddings width
-//     int dH = INT_ARG(6);                                                        // dilations height
-//     int dW = INT_ARG(7);                                                        // dilations width
-//     int isSameMode = INT_ARG(8);                                                // 0-VALID, 1-SAME
-//     int isNCHW  = block.getIArguments()->size() > 9 ? !INT_ARG(9) : 1;          // 0-NHWC, 1-NCHW
-
-//     int bS, iC, iH, iW, mC, oC, oH, oW;                     // batch size, input channels, input height/width, channels multiplier(oC = iC*mC), output channels, output height/width
-//     int indIOioC, indIiH, indWmC, indWiC, indWkH, indOoH;   // corresponding indexes
-//     ConvolutionUtils::getSizesAndIndexesConv2d(isNCHW, *input, *gradO, bS, iC, iH, iW, oC, oH, oW, indIOioC, indIiH, indWiC, indWmC, indWkH, indOoH);
-//     mC = weights->sizeAt(indWmC);                           // channels multiplier
-
-//     int trueoH, trueoW;          // correct output height, width
-//     ConvolutionUtils::calcOutSizePool2D(trueoH, trueoW, kH, kW, sH, sW, pH, pW, dH, dW, iH, iW, isSameMode);
-
-//     std::string expectedGradOShape   = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({bS,oC,trueoH,trueoW,  0,indIOioC,indOoH,indOoH+1}));
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({mC,iC,kH,kW,  indWmC,indWiC,indWkH,indWkH+1}));
-//     REQUIRE_TRUE(expectedGradOShape == ShapeUtils::shapeAsString(gradO), 0,  "CUSTOM DEPTHWISECONV2D_BP OP: wrong shape of output gradients (next epsilon) array, expected is %s, but got %s instead !", expectedGradOShape.c_str(), ShapeUtils::shapeAsString(gradO).c_str());
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weights), 0, "CUSTOM DEPTHWISECONV2D_BP OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weights).c_str());
-//     if(bias)
-//         REQUIRE_TRUE(bias->rankOf() <= 2 && oC == bias->lengthOf(), 0, "CUSTOM DEPTHWISECONV2D_BP OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, bias->rankOf(), bias->lengthOf());
-
-//     ConvolutionUtils::depthwiseConv2dBP(input, weights, bias, gradO,  gradI, gradW, gradB,  kH,kW, sH,sW, pH,pW, dH,dW, isSameMode, isNCHW);
-
-//     return Status::OK();
-// }
-
-
-
-// DECLARE_SHAPE_FN(depthwise_conv2d_bp) {
-//     auto inputShapeInfo   = inputShape->at(0);
-//     auto weightsShapeInfo = inputShape->at(1);
-//     auto biasShapeInfo    = block.width() > 3 ? inputShape->at(2) : nullptr;
-//     auto gradOShapeInfo   = block.width() > 3 ? inputShape->at(3) : inputShape->at(2);
-
-//     const int rank = 4;
-//     REQUIRE_TRUE(inputShapeInfo[0]   == rank, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of input array must be equal to %i, but got %i instead !", rank, inputShapeInfo[0]);
-//     REQUIRE_TRUE(weightsShapeInfo[0] == rank, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of weights array must be equal to %i, but got %i instead !", rank, weightsShapeInfo[0]);
-//     REQUIRE_TRUE(gradOShapeInfo[0]   == rank, 0, "CUSTOM DEPTHWISECONV2D_BP OP: rank of output gradients (next epsilon) array must be equal to %i, but got %i instead !", rank, gradOShapeInfo[0]);
-
-//     int kH = INT_ARG(0);                                                        // filter(kernel) height
-//     int kW = INT_ARG(1);                                                        // filter(kernel) width
-//     int sH = INT_ARG(2);                                                        // strides height
-//     int sW = INT_ARG(3);                                                        // strides width
-//     int pH = INT_ARG(4);                                                        // paddings height
-//     int pW = INT_ARG(5);                                                        // paddings width
-//     int dH = INT_ARG(6);                                                        // dilations height
-//     int dW = INT_ARG(7);                                                        // dilations width
-//     int isSameMode = INT_ARG(8);                                                // 0-VALID, 1-SAME
-//     int isNCHW  = block.getIArguments()->size() > 9 ? !INT_ARG(9) : 1;          // 0-NHWC, 1-NCHW
-
-//     int indIOioC, indIiH, indWkH, indWmC, indWiC, indOoH;
-//     if(!isNCHW) {
-//         indIOioC = 3; indIiH = 1; indWkH = 0; indWmC = 3; indWiC = 2;
-//     }
-//     else {
-//         indIOioC = 1; indIiH = 2; indWkH = 2; indWmC = 0; indWiC = 1;
-//     }
-
-//     const int bS = inputShapeInfo[1];                            // batch size
-//     const int iH = inputShapeInfo[indIiH+1];                     // input height
-//     const int iW = inputShapeInfo[indIiH+2];                     // input width
-//     const int iC = inputShapeInfo[indIOioC+1];                   // input channels
-//     const int mC = weightsShapeInfo[indWmC+1];                   // channels multiplier(oC = iC*mC)
-//     const int oC = iC*mC;                                        // output channels
-
-//     int trueoH, trueoW;          // correct output height, width
-//     ConvolutionUtils::calcOutSizePool2D(trueoH, trueoW, kH, kW, sH, sW, pH, pW, dH, dW, iH, iW, isSameMode);
-
-//     std::string expectedGradOShape   = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({bS,oC,trueoH,trueoW,  0,indIOioC,indIiH,indIiH+1}));
-//     std::string expectedWeightsShape = ShapeUtils::shapeAsString(ShapeUtils::composeShapeUsingDimsAndIdx({mC,iC,kH,kW,  indWmC,indWiC,indWkH,indWkH+1}));
-//     REQUIRE_TRUE(expectedGradOShape == ShapeUtils::shapeAsString(gradOShapeInfo), 0,  "CUSTOM DEPTHWISECONV2D_BP OP: wrong shape of output gradients (next epsilon) array, expected is %s, but got %s instead !", expectedGradOShape.c_str(), ShapeUtils::shapeAsString(gradOShapeInfo).c_str());
-//     REQUIRE_TRUE(expectedWeightsShape == ShapeUtils::shapeAsString(weightsShapeInfo), 0, "CUSTOM DEPTHWISECONV2D_BP OP: wrong shape of weights array, expected is %s, but got %s instead !", expectedWeightsShape.c_str(), ShapeUtils::shapeAsString(weightsShapeInfo).c_str());
-//     if(biasShapeInfo)
-//         REQUIRE_TRUE(biasShapeInfo[0] <= 2 && oC == shape::length(biasShapeInfo), 0, "CUSTOM DEPTHWISECONV2D_BP OP: wrong shape of array with biases, expected rank, length: <=2, %i, but got %i, %i instead !", oC, biasShapeInfo[0], shape::length(biasShapeInfo));
-
-//     Nd4jLong* gradIshapeInfo(nullptr), *gradWshapeInfo(nullptr);
-//     COPY_SHAPE(inputShapeInfo, gradIshapeInfo);
-//     COPY_SHAPE(weightsShapeInfo, gradWshapeInfo);
-
-//     if(biasShapeInfo) {
-//         Nd4jLong* gradBshapeInfo(nullptr);
-//         COPY_SHAPE(biasShapeInfo, gradBshapeInfo);
-//         return SHAPELIST(gradIshapeInfo, gradWshapeInfo, gradBshapeInfo);
-//     }
-
-//     return SHAPELIST(gradIshapeInfo, gradWshapeInfo);
-// }
-
 
 
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests11.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests11.cpp
@@ -2097,7 +2097,7 @@ TEST_F(DeclarableOpsTests11, softmax_cross_entropy_loss_grad_test6) {
     NDArray weights('c', {2}, nd4j::DataType::DOUBLE);
     
     NDArray dLdpExp('c', {2,4}, {0.0801,  0.0849, -0.2601,  0.0951, 0.0801, -0.2651,  0.0899,  0.0951});
-    NDArray dLdwExp('c', {2}, {-0.0098,  0.0098});
+    NDArray dLdwExp('c', {2}, {-0.014000, 0.014000});
 
     logits.linspace(-0.08, 0.04);
     weights.assign(0.5);

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphs/TFGraphTestAllSameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphs/TFGraphTestAllSameDiff.java
@@ -101,9 +101,6 @@ public class TFGraphTestAllSameDiff {
             //Failing 2019/01/16 - Issue 15 https://github.com/deeplearning4j/deeplearning4j/issues/6958
             "where/cond_only.*",
 
-            //Still failing 2019/01/15 - https://github.com/deeplearning4j/deeplearning4j/issues/7008
-            "sepconv1d_layers/.*",
-
             //scatter_nd: a few cases failing as of 2019/01/08
             "scatter_nd/rank2shape_2indices",
             "scatter_nd/rank3shape_2indices",


### PR DESCRIPTION
If the kernel size isn't set, we can try inferring the proper sizes from the given weights.

Fixes #7008