### PR TITLE
Treat center like non-center on 1x1 images when resizing using resize_bilinear

### DIFF
--- a/libnd4j/include/ops/declarable/helpers/cpu/image_resize.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/image_resize.cpp
@@ -133,6 +133,11 @@ namespace helpers {
             return ND4J_STATUS_OK;
         }
 
+        // Special case for TF compatibility
+        if((center && inHeight < 2) || (center && inWidth < 2)){
+            center = false;
+        }
+
         if ((center && inHeight < 2) || (inHeight < 1) || (outHeight < 1) || (center && outHeight < 2) ||
             (center && inWidth < 2) || (inWidth < 1) || (outWidth < 1) || (center && outWidth < 2)) {
             // wrong input data

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphs/CustomOpTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/imports/TFGraphs/CustomOpTests.java
@@ -10,7 +10,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-public class TestPad {
+public class CustomOpTests {
 
     @Test
     public void testPad(){
@@ -30,5 +30,23 @@ public class TestPad {
         assertArrayEquals(new long[]{1, 29, 29, 264}, outShape.get(0).getShape());
 
         Nd4j.getExecutioner().exec(op); //Crash here
+    }
+
+    @Test
+    public void testResizeBilinearEdgeCase(){
+        INDArray in = Nd4j.ones(DataType.FLOAT, 1, 1, 1, 3);
+        INDArray size = Nd4j.createFromArray(8, 8);
+        INDArray out = Nd4j.create(DataType.FLOAT, 1, 8, 8, 3);
+
+        DynamicCustomOp op = DynamicCustomOp.builder("resize_bilinear")
+                .addInputs(in, size)
+                .addOutputs(out)
+                .addIntegerArguments(1) //1 = center. Though TF works with align_corners == false or true
+                .build();
+
+        Nd4j.getExecutioner().exec(op);
+
+        INDArray exp = Nd4j.ones(DataType.FLOAT, 1, 8, 8, 3);
+        assertEquals(exp, out);
     }
 }


### PR DESCRIPTION
Fixes issue 8 of https://github.com/deeplearning4j/deeplearning4j/issues/6958

@AlexDBlack I've left the deeplab tests on ignore though, because deeplabv3_pascal_train_aug_2018_01_04 didn't pass in a reasonable amount of time, and deeplab_mobilenetv2_coco_voc_trainval still fails, but now with: 

```
java.lang.IllegalArgumentException: Unable to broadcast dimension 1 due to shape mismatch. Right shape must be 1. Left array shape: [367, 513], right array shape: [1, 513, 3]

	at org.nd4j.linalg.api.shape.Shape.getBroadcastDimensions(Shape.java:181)
	at org.nd4j.linalg.api.ndarray.BaseNDArray.subi(BaseNDArray.java:3859)
	at org.nd4j.linalg.api.ndarray.BaseNDArray.sub(BaseNDArray.java:3559)
	at org.nd4j.imports.TFGraphs.TFGraphTestAllHelper.checkOnlyOutput(TFGraphTestAllHelper.java:189)
	at org.nd4j.imports.TFGraphs.TFGraphTestZooModels.testOutputOnly(TFGraphTestZooModels.java:183)
[...]
```