### PR TITLE
[WIP] DL4J MKL-DNN Support

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/LayerHelperValidationUtil.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/LayerHelperValidationUtil.java
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j;
+
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.optimize.listeners.CollectScoresListener;
+import org.nd4j.base.Preconditions;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.reduce.longer.MatchCondition;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.BooleanIndexing;
+import org.nd4j.linalg.indexing.conditions.Conditions;
+import org.nd4j.linalg.ops.transforms.Transforms;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+@Slf4j
+public class LayerHelperValidationUtil {
+
+    public static final double MAX_REL_ERROR = 1e-5;
+    public static final double MIN_ABS_ERROR = 1e-6;
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Data
+    @Builder
+    public static class TestCase {
+        private String testName;
+        private List<Class<?>> allowHelpersForClasses;
+        @Builder.Default private boolean testForward = true;
+        @Builder.Default private boolean testScore = true;
+        @Builder.Default private boolean testBackward = true;
+        @Builder.Default private boolean testTraining = false;
+        INDArray features;
+        INDArray labels;
+        private DataSetIterator data;
+    }
+
+    public static void validateMLN(MultiLayerNetwork netOrig, TestCase t){
+        assertNotNull(t.getAllowHelpersForClasses());
+        assertFalse(t.getAllowHelpersForClasses().isEmpty());
+
+        //Don't allow fallback:
+        for(Layer l : netOrig.getLayers()){
+            org.deeplearning4j.nn.conf.layers.Layer lConf = l.conf().getLayer();
+            if(lConf instanceof ConvolutionLayer){
+                ((ConvolutionLayer) lConf).setCudnnAllowFallback(false);
+            } else if(lConf instanceof SubsamplingLayer){
+                ((SubsamplingLayer) lConf).setCudnnAllowFallback(false);
+            }
+        }
+
+
+        MultiLayerNetwork net1NoHelper = new MultiLayerNetwork(netOrig.getLayerWiseConfigurations().clone());
+        net1NoHelper.init();
+        log.info("Removing all layer helpers from network copy 1");
+        removeHelpers(net1NoHelper.getLayers(), null);
+
+        MultiLayerNetwork net2With = new MultiLayerNetwork(netOrig.getLayerWiseConfigurations().clone());
+        net2With.init();
+        net2With.params().assign(netOrig.params());
+        log.info("Removing all except for specified helpers from network copy 2: " + t.getAllowHelpersForClasses());
+        removeHelpers(net2With.getLayers(), t.getAllowHelpersForClasses());
+
+        if(t.isTestForward()){
+            Preconditions.checkNotNull(t.getFeatures(), "Features are not set (null)");
+
+            for (boolean train : new boolean[]{false, true}) {
+                assertEquals(net1NoHelper.params(), net2With.params());
+                String s = "Feed forward test - " + t.getTestName() + " - " + (train ? "Train: " : "Test: ");
+                List<INDArray> ff1 = net1NoHelper.feedForward(t.getFeatures(), train);
+                List<INDArray> ff2 = net2With.feedForward(t.getFeatures(), train);
+                List<String> paramKeys = new ArrayList<>(net1NoHelper.paramTable().keySet());
+                Collections.sort(paramKeys);
+                for (String p : paramKeys) {
+                    INDArray p1 = net1NoHelper.getParam(p);
+                    INDArray p2 = net2With.getParam(p);
+                    INDArray re = relError(p1, p2, MIN_ABS_ERROR);
+                    double maxRE = re.maxNumber().doubleValue();
+                    if (maxRE >= MAX_REL_ERROR) {
+                        System.out.println("Failed param values: parameter " + p + " - No heper vs. with helper - train=" + train);
+                        System.out.println(p1);
+                        System.out.println(p2);
+                    }
+                    assertTrue(s + " - param changed during forward pass: " + p, maxRE < MAX_REL_ERROR);
+                }
+
+                for( int i=0; i<ff1.size(); i++ ){
+                    int layerIdx = i-1; //FF includes input
+                    String layerName = "layer_" + layerIdx + " - " +
+                            (i == 0 ? "input" : net1NoHelper.getLayer(layerIdx).getClass().getSimpleName());
+                    INDArray arr1 = ff1.get(i);
+                    INDArray arr2 = ff2.get(i);
+
+                    INDArray relError = relError(arr1, arr2, MIN_ABS_ERROR);
+                    double maxRE = relError.maxNumber().doubleValue();
+                    int idx = relError.argMax(Integer.MAX_VALUE).getInt(0);
+                    if(maxRE >= MAX_REL_ERROR){
+                        double d1 = arr1.dup('c').getDouble(idx);
+                        double d2 = arr2.dup('c').getDouble(idx);
+                        System.out.println("Different values at index " + idx + ": " + d1 + ", " + d2 + " - RE = " + maxRE);
+                    }
+                    assertTrue(s + layerName + " - max RE: " + maxRE, maxRE < MAX_REL_ERROR);
+                    log.info("Forward pass, max relative error: " + layerName + " - " + maxRE);
+                }
+
+                INDArray out1 = net1NoHelper.output(t.getFeatures(), train);
+                INDArray out2 = net2With.output(t.getFeatures(), train);
+                INDArray relError = relError(out1, out2, MIN_ABS_ERROR);
+                double maxRE = relError.maxNumber().doubleValue();
+                log.info(s + "Output, max relative error: " + maxRE);
+
+                assertEquals(net1NoHelper.params(), net2With.params());  //Check that forward pass does not modify params
+                assertTrue(s + "Max RE: " + maxRE, maxRE < MAX_REL_ERROR);
+            }
+        }
+
+
+        if(t.isTestScore()) {
+            Preconditions.checkNotNull(t.getFeatures(), "Features are not set (null)");
+            Preconditions.checkNotNull(t.getLabels(), "Labels are not set (null)");
+
+            log.info("Validation - checking scores");
+            double s1 = net1NoHelper.score(new DataSet(t.getFeatures(), t.getLabels()));
+            double s2 = net2With.score(new DataSet(t.getFeatures(), t.getLabels()));
+
+            double re = relError(s1, s2);
+            String s = "Relative error: " + re;
+            assertTrue(s, re < MAX_REL_ERROR);
+        }
+
+        if(t.isTestBackward()) {
+            Preconditions.checkNotNull(t.getFeatures(), "Features are not set (null)");
+            Preconditions.checkNotNull(t.getLabels(), "Labels are not set (null)");
+            log.info("Validation - checking backward pass");
+
+            //Check gradients
+            net1NoHelper.setInput(t.getFeatures());
+            net1NoHelper.setLabels(t.getLabels());
+
+            net2With.setInput(t.getFeatures());
+            net2With.setLabels(t.getLabels());
+
+            net1NoHelper.computeGradientAndScore();
+            net2With.computeGradientAndScore();
+
+            List<String> paramKeys = new ArrayList<>(net1NoHelper.paramTable().keySet());
+            Collections.sort(paramKeys);
+            for(String p : paramKeys){
+                INDArray g1 = net1NoHelper.gradient().gradientForVariable().get(p);
+                INDArray g2 = net2With.gradient().gradientForVariable().get(p);
+
+                if(g1 == null || g2 == null){
+                    throw new RuntimeException("Null gradients");
+                }
+
+                INDArray re = relError(g1, g2, MIN_ABS_ERROR);
+                double maxRE = re.maxNumber().doubleValue();
+                if (maxRE >= MAX_REL_ERROR) {
+                    System.out.println("Failed param values: no helper vs. with helper - parameter: " + p);
+                    System.out.println(Arrays.toString(g1.dup().data().asFloat()));
+                    System.out.println(Arrays.toString(g2.dup().data().asFloat()));
+                } else {
+                    System.out.println("OK: " + p);
+                }
+                assertTrue("Gradients are not equal: " + p, maxRE < MAX_REL_ERROR);
+            }
+        }
+
+        if(t.isTestTraining()){
+            Preconditions.checkNotNull(t.getData(), "DataSetIterator is not set (null)");
+            log.info("Testing run-to-run consistency of training with layer helper");
+
+            net2With = new MultiLayerNetwork(netOrig.getLayerWiseConfigurations().clone());
+            net2With.init();
+            net2With.params().assign(netOrig.params());
+            log.info("Removing all except for specified layer helpers from network copy 2: " + t.getAllowHelpersForClasses());
+            removeHelpers(net2With.getLayers(), t.getAllowHelpersForClasses());
+
+            CollectScoresListener listener = new CollectScoresListener(1);
+            net2With.setListeners(listener);
+            net2With.fit(t.getData());
+
+            for( int i=0; i<2; i++ ) {
+
+                net2With = new MultiLayerNetwork(netOrig.getLayerWiseConfigurations().clone());
+                net2With.init();
+                net2With.params().assign(netOrig.params());
+                log.info("Removing all except for specified layer helpers from network copy 2: " + t.getAllowHelpersForClasses());
+                removeHelpers(net2With.getLayers(), t.getAllowHelpersForClasses());
+
+                CollectScoresListener listener2 = new CollectScoresListener(1);
+                net2With.setListeners(listener2);
+                net2With.fit(t.getData());
+
+                DoubleArrayList listOrig = listener.getListScore();
+                DoubleArrayList listNew = listener2.getListScore();
+
+                assertEquals(listOrig.size(), listNew.size());
+                for (int j = 0; j < listOrig.size(); j++) {
+                    double d1 = listOrig.get(j);
+                    double d2 = listNew.get(j);
+                    double re = relError(d1, d2);
+                    String msg = "Scores at iteration " + j + " - relError = " + re + ", score1 = " + d1 + ", score2 = " + d2;
+                    assertTrue(msg, re < MAX_REL_ERROR);
+                    System.out.println("j=" + j + ", d1 = " + d1 + ", d2 = " + d2);
+                }
+            }
+        }
+    }
+
+    private static void removeHelpers(Layer[] layers, List<Class<?>> keepHelpersFor){
+
+        Map<Class<?>, Integer> map = new HashMap<>();
+        for(Layer l : layers){
+            Field f;
+            try{
+                f = l.getClass().getDeclaredField("helper");
+            } catch (Exception e){
+                //OK, may not be a layer helper supported layer
+                continue;
+            }
+
+            f.setAccessible(true);
+            boolean keepAndAssertPresent = false;
+            if(keepHelpersFor != null) {
+                for (Class<?> c : keepHelpersFor) {
+                    if(c.isAssignableFrom(l.getClass())){
+                        keepAndAssertPresent = true;
+                        break;
+                    }
+                }
+            }
+            try {
+                if (keepAndAssertPresent) {
+                    Object o = f.get(l);
+                    assertNotNull(o);
+                } else {
+                    f.set(l, null);
+                    Integer i = map.get(l.getClass());
+                    if(i == null){
+                        i = 0;
+                    }
+                    map.put(l.getClass(), i+1);
+                }
+            } catch (IllegalAccessException e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        for(Map.Entry<Class<?>,Integer> c : map.entrySet()){
+            System.out.println("Removed " + c.getValue() + " layer helpers instances from layer " + c.getKey());
+        }
+    }
+
+    private static double relError(double d1, double d2){
+        Preconditions.checkState(!Double.isNaN(d1), "d1 is NaN");
+        Preconditions.checkState(!Double.isNaN(d2), "d2 is NaN");
+        if(d1 == 0.0 && d2 == 0.0){
+            return 0.0;
+        }
+
+        return Math.abs(d1-d2) / (Math.abs(d1) + Math.abs(d2));
+    }
+
+    private static INDArray relError(@NonNull INDArray a1, @NonNull INDArray a2, double minAbsError){
+        long numNaN1 = Nd4j.getExecutioner().exec(new MatchCondition(a1, Conditions.isNan(), Integer.MAX_VALUE)).getInt(0);
+        long numNaN2 = Nd4j.getExecutioner().exec(new MatchCondition(a2, Conditions.isNan(), Integer.MAX_VALUE)).getInt(0);
+        Preconditions.checkState(numNaN1 == 0, "Array 1 has NaNs");
+        Preconditions.checkState(numNaN2 == 0, "Array 2 has NaNs");
+
+        INDArray abs1 = Transforms.abs(a1, true);
+        INDArray abs2 = Transforms.abs(a2, true);
+        INDArray absDiff = Transforms.abs(a1.sub(a2), false);
+
+        //abs(a1-a2) < minAbsError ? 1 : 0
+        INDArray greaterThanMinAbs = Transforms.abs(a1.sub(a2), false);
+        BooleanIndexing.replaceWhere(greaterThanMinAbs, 0.0, Conditions.lessThan(minAbsError));
+        BooleanIndexing.replaceWhere(greaterThanMinAbs, 1.0, Conditions.greaterThan(0.0));
+
+        INDArray result = absDiff.divi(abs1.add(abs2));
+        //Only way to have NaNs given there weren't any in original : both 0s
+        BooleanIndexing.replaceWhere(result, 0.0, Conditions.isNan());
+        //Finally, set to 0 if less than min abs error, or unchanged otherwise
+        result.muli(greaterThanMinAbs);
+
+        return result;
+    }
+
+}

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/LayerHelperValidationUtil.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/LayerHelperValidationUtil.java
@@ -127,7 +127,7 @@ public class LayerHelperValidationUtil {
                         double d2 = arr2.dup('c').getDouble(idx);
                         System.out.println("Different values at index " + idx + ": " + d1 + ", " + d2 + " - RE = " + maxRE);
                     }
-                    assertTrue(s + layerName + " - max RE: " + maxRE, maxRE < t.getMaxRelError());
+                    assertTrue(s + layerName + "activations - max RE: " + maxRE, maxRE < t.getMaxRelError());
                     log.info("Forward pass, max relative error: " + layerName + " - " + maxRE);
                 }
 
@@ -190,7 +190,8 @@ public class LayerHelperValidationUtil {
                 } else {
                     System.out.println("OK: " + p);
                 }
-                assertTrue("Gradients are not equal: " + p, maxRE < t.getMaxRelError());
+                assertTrue("Gradients are not equal: " + p + " - highest relative error = " + maxRE + " > max relative error = " + t.getMaxRelError(),
+                        maxRE < t.getMaxRelError());
             }
         }
 
@@ -261,7 +262,7 @@ public class LayerHelperValidationUtil {
             try {
                 if (keepAndAssertPresent) {
                     Object o = f.get(l);
-                    assertNotNull(o);
+                    assertNotNull("Expect helper to be present for layer: " + l.getClass(), o);
                 } else {
                     f.set(l, null);
                     Integer i = map.get(l.getClass());

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/TestUtils.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/TestUtils.java
@@ -17,13 +17,20 @@
 package org.deeplearning4j;
 
 import org.apache.commons.compress.utils.IOUtils;
+import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.layers.BaseLayer;
 import org.deeplearning4j.nn.conf.layers.samediff.AbstractSameDiffLayer;
 import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.layers.convolution.ConvolutionLayer;
+import org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer;
+import org.deeplearning4j.nn.layers.normalization.BatchNormalization;
+import org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization;
+import org.deeplearning4j.nn.layers.recurrent.LSTM;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.base.Preconditions;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.random.impl.BernoulliDistribution;
 import org.nd4j.linalg.factory.Nd4j;
@@ -33,6 +40,7 @@ import org.nd4j.linalg.learning.regularization.Regularization;
 import org.nd4j.linalg.learning.regularization.WeightDecay;
 
 import java.io.*;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Random;
 
@@ -240,5 +248,60 @@ public class TestUtils {
 
     public static double getWeightDecay(BaseLayer layer) {
         return getWeightDecayReg(layer.getRegularization()).getCoeff().valueAt(0,0);
+    }
+
+    public static void removeHelper(Layer layer) throws Exception {
+        removeHelpers(new Layer[]{layer});
+    }
+
+    public static void removeHelpers(Layer[] layers) throws Exception {
+        for(Layer l : layers){
+
+            if(l instanceof ConvolutionLayer){
+                Field f1 = ConvolutionLayer.class.getDeclaredField("helper");
+                f1.setAccessible(true);
+                f1.set(l, null);
+            } else if(l instanceof SubsamplingLayer){
+                Field f2 = SubsamplingLayer.class.getDeclaredField("helper");
+                f2.setAccessible(true);
+                f2.set(l, null);
+            } else if(l instanceof BatchNormalization) {
+                Field f3 = BatchNormalization.class.getDeclaredField("helper");
+                f3.setAccessible(true);
+                f3.set(l, null);
+            } else if(l instanceof LSTM){
+                Field f4 = LSTM.class.getDeclaredField("helper");
+                f4.setAccessible(true);
+                f4.set(l, null);
+            } else if(l instanceof LocalResponseNormalization){
+                Field f5 = LocalResponseNormalization.class.getDeclaredField("helper");
+                f5.setAccessible(true);
+                f5.set(l, null);
+            }
+
+
+            if(l.getHelper() != null){
+                throw new IllegalStateException("Did not remove helper for layer: " + l.getClass().getSimpleName());
+            }
+        }
+    }
+
+    public static void assertHelperPresent(Layer layer){
+
+    }
+
+    public static void assertHelpersPresent(Layer[] layers) throws Exception {
+        for(Layer l : layers){
+            //Don't use instanceof here - there are sub conv subclasses
+            if(l.getClass() == ConvolutionLayer.class || l instanceof SubsamplingLayer || l instanceof BatchNormalization || l instanceof LSTM){
+                Preconditions.checkNotNull(l.getHelper(), l.conf().getLayer().getLayerName());
+            }
+        }
+    }
+
+    public static void assertHelpersAbsent(Layer[] layers) throws Exception {
+        for(Layer l : layers){
+            Preconditions.checkState(l.getHelper() == null, l.conf().getLayer().getLayerName());
+        }
     }
 }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/DropoutLayerTest.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/DropoutLayerTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.random.impl.DropOut;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.factory.Nd4j;
@@ -220,6 +219,7 @@ public class DropoutLayerTest extends BaseDL4JTest {
 
     @Test
     public void testDropoutLayerWithConvMnist() throws Exception {
+        Nd4j.setDefaultDataTypes(DataType.DOUBLE, DataType.DOUBLE); //Set to double datatype - MKL-DNN not used for CPU (otherwise different strides due to Dl4J impl permutes)
         DataSetIterator iter = new MnistDataSetIterator(2, 2);
         DataSet next = iter.next();
 

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -35,7 +35,6 @@ import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.Adam;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
-import org.nd4j.nativeblas.Nd4jCpu;
 
 import java.util.Arrays;
 
@@ -91,7 +90,8 @@ public class ValidateMKLDNN extends BaseDL4JTest {
                         netWithout.init();
 
                         LayerHelperValidationUtil.TestCase tc = LayerHelperValidationUtil.TestCase.builder()
-                                .allowHelpersForClasses(Arrays.<Class<?>>asList(org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer.class))
+                                .allowHelpersForClasses(Arrays.<Class<?>>asList(org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer.class,
+                                        org.deeplearning4j.nn.layers.convolution.ConvolutionLayer.class))
                                 .testForward(true)
                                 .testScore(true)
                                 .testBackward(true)

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -36,6 +36,7 @@ import org.nd4j.linalg.lossfunctions.LossFunctions;
 import org.nd4j.nativeblas.Nd4jCpu;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.Assume.assumeTrue;
 
@@ -222,7 +223,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
                 netWithout.init();
 
                 LayerHelperValidationUtil.TestCase tc = LayerHelperValidationUtil.TestCase.builder()
-                        .allowHelpersForClasses(Arrays.<Class<?>>asList(org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization.class))
+                        .allowHelpersForClasses(Collections.<Class<?>>singletonList(org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization.class))
                         .testForward(true)
                         .testScore(true)
                         .testBackward(true)

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -24,10 +24,7 @@ import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.inputs.InputType;
-import org.deeplearning4j.nn.conf.layers.BatchNormalization;
-import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
-import org.deeplearning4j.nn.conf.layers.OutputLayer;
-import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
+import org.deeplearning4j.nn.conf.layers.*;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.Test;
 import org.nd4j.linalg.activations.Activation;
@@ -36,6 +33,7 @@ import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.Adam;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.nativeblas.Nd4jCpu;
 
 import java.util.Arrays;
 
@@ -45,6 +43,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
 
     @Test
     public void validateConvSubsampling() throws Exception {
+        Nd4jCpu.Environment.getInstance();
         //Only run test if using nd4j-native backend
         assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
 
@@ -164,6 +163,77 @@ public class ValidateMKLDNN extends BaseDL4JTest {
                     .build();
 
             LayerHelperValidationUtil.validateMLN(netWith, tc);
+        }
+    }
+
+    @Test
+    public void validateLRN() {
+        //Only run test if using nd4j-native backend
+        assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
+
+        int[] inputSize = {-1, 3, 16, 16};
+        int[] stride = {1, 1};
+        int[] kernel = {2, 2};
+        ConvolutionMode cm = ConvolutionMode.Truncate;
+
+        double[] a = new double[]{1e-4, 1e-4, 1e-3, 1e-3};
+        double[] b = new double[]{0.75, 0.9, 0.6, 0.75};
+        double[] n = new double[]{5, 3, 2, 4};
+        double[] k = new double[]{2, 3, 1.5, 2};
+
+        for (int minibatch : new int[]{1, 3}) {
+            for( int i=0; i<a.length; i++ ) {
+
+
+                inputSize[0] = minibatch;
+                INDArray f = Nd4j.rand(Nd4j.defaultFloatingPointType(), inputSize);
+                INDArray l = TestUtils.randomOneHot(minibatch, 10);
+
+                MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                        .updater(new Adam(0.01))
+                        .convolutionMode(cm)
+                        .list()
+                        .layer(new ConvolutionLayer.Builder().activation(Activation.TANH)
+                                .kernelSize(kernel)
+                                .stride(stride)
+                                .padding(0, 0)
+                                .nOut(3)
+                                .build())
+                        .layer(new LocalResponseNormalization.Builder()
+                                .alpha(a[i])
+                                .beta(b[i])
+                                .n(n[i])
+                                .k(k[i])
+                                .cudnnAllowFallback(false).build())
+                        .layer(new ConvolutionLayer.Builder().activation(Activation.TANH)
+                                .kernelSize(kernel)
+                                .stride(stride)
+                                .padding(0, 0)
+                                .nOut(3)
+                                .build())
+                        .layer(new OutputLayer.Builder().nOut(10).activation(Activation.SOFTMAX).lossFunction(LossFunctions.LossFunction.MCXENT).build())
+                        .setInputType(InputType.convolutional(inputSize[2], inputSize[3], inputSize[1]))
+                        .build();
+
+                MultiLayerNetwork netWith = new MultiLayerNetwork(conf.clone());
+                netWith.init();
+
+                MultiLayerNetwork netWithout = new MultiLayerNetwork(conf.clone());
+                netWithout.init();
+
+                LayerHelperValidationUtil.TestCase tc = LayerHelperValidationUtil.TestCase.builder()
+                        .allowHelpersForClasses(Arrays.<Class<?>>asList(org.deeplearning4j.nn.layers.normalization.LocalResponseNormalization.class))
+                        .testForward(true)
+                        .testScore(true)
+                        .testBackward(true)
+                        .testTraining(true)
+                        .features(f)
+                        .labels(l)
+                        .data(new SingletonDataSetIterator(new DataSet(f, l)))
+                        .build();
+
+                LayerHelperValidationUtil.validateMLN(netWith, tc);
+            }
         }
     }
 }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.mkldnn;
+
+import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.LayerHelperValidationUtil;
+import org.deeplearning4j.TestUtils;
+import org.deeplearning4j.nn.conf.ConvolutionMode;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.learning.config.Adam;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import java.util.Arrays;
+
+import static org.junit.Assume.assumeTrue;
+
+public class ValidateMKLDNN extends BaseDL4JTest {
+
+    @Test
+    public void validateConvSubsampling() throws Exception {
+        //Only run test if using nd4j-native backend
+        assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
+
+        int[] inputSize = {-1, 3, 10, 10};
+
+        for(int minibatch : new int[]{1,3}) {
+            for (ConvolutionMode cm : ConvolutionMode.values()) {
+                for (int[] kernel : new int[][]{{2, 2}, {2, 3}}) {
+                    for (int[] stride : new int[][]{{1, 1}, {2, 2}}) {
+
+                        inputSize[0] = minibatch;
+                        INDArray f = Nd4j.rand(Nd4j.defaultFloatingPointType(), inputSize);
+                        INDArray l = TestUtils.randomOneHot(minibatch, 10);
+
+                        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                                .updater(new Adam(0.01))
+                                .convolutionMode(cm)
+                                .list()
+                                .layer(new ConvolutionLayer.Builder().activation(Activation.TANH)
+                                        .kernelSize(kernel)
+                                        .stride(stride)
+                                        .padding(0,0)
+                                        .nOut(3)
+                                        .build())
+                                .layer(new SubsamplingLayer.Builder()
+                                        .kernelSize(kernel)
+                                        .stride(stride)
+                                        .padding(0,0)
+                                        .build())
+                                .layer(new ConvolutionLayer.Builder().activation(Activation.TANH)
+                                        .kernelSize(kernel)
+                                        .stride(stride)
+                                        .padding(0,0)
+                                        .nOut(3)
+                                        .build())
+                                .layer(new OutputLayer.Builder().nOut(10).activation(Activation.SOFTMAX).lossFunction(LossFunctions.LossFunction.MCXENT).build())
+                                .setInputType(InputType.convolutional(inputSize[2], inputSize[3], inputSize[1]))
+                                .build();
+
+                        MultiLayerNetwork netWith = new MultiLayerNetwork(conf.clone());
+                        netWith.init();
+
+                        MultiLayerNetwork netWithout = new MultiLayerNetwork(conf.clone());
+                        netWithout.init();
+
+                        LayerHelperValidationUtil.TestCase tc = LayerHelperValidationUtil.TestCase.builder()
+                                .allowHelpersForClasses(Arrays.<Class<?>>asList(org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingLayer.class))
+                                .testForward(true)
+                                .testScore(true)
+                                .testBackward(true)
+                                .testTraining(true)
+                                .features(f)
+                                .labels(l)
+                                .build();
+
+                        LayerHelperValidationUtil.validateMLN(netWith, tc);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.nn.mkldnn;
 import org.deeplearning4j.BaseDL4JTest;
 import org.deeplearning4j.LayerHelperValidationUtil;
 import org.deeplearning4j.TestUtils;
+import org.deeplearning4j.datasets.iterator.impl.SingletonDataSetIterator;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -30,9 +31,11 @@ import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.Test;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.Adam;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.nativeblas.Nd4jCpu;
 
 import java.util.Arrays;
 
@@ -45,10 +48,10 @@ public class ValidateMKLDNN extends BaseDL4JTest {
         //Only run test if using nd4j-native backend
         assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
 
-        int[] inputSize = {-1, 3, 10, 10};
+        int[] inputSize = {-1, 3, 16, 16};
 
         for(int minibatch : new int[]{1,3}) {
-            for (ConvolutionMode cm : ConvolutionMode.values()) {
+            for (ConvolutionMode cm : new ConvolutionMode[]{ConvolutionMode.Same, ConvolutionMode.Truncate}) {
                 for (int[] kernel : new int[][]{{2, 2}, {2, 3}}) {
                     for (int[] stride : new int[][]{{1, 1}, {2, 2}}) {
 
@@ -95,6 +98,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
                                 .testTraining(true)
                                 .features(f)
                                 .labels(l)
+                                .data(new SingletonDataSetIterator(new DataSet(f,l)))
                                 .build();
 
                         LayerHelperValidationUtil.validateMLN(netWith, tc);

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -175,7 +175,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
         }
     }
 
-    @Test
+    @Test @Ignore   //https://github.com/deeplearning4j/deeplearning4j/issues/7272
     public void validateLRN() {
 
         //Only run test if using nd4j-native backend

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -158,7 +158,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
             netWithout.init();
 
             LayerHelperValidationUtil.TestCase tc = LayerHelperValidationUtil.TestCase.builder()
-                    .allowHelpersForClasses(Arrays.<Class<?>>asList(org.deeplearning4j.nn.layers.normalization.BatchNormalization.class))
+                    .allowHelpersForClasses(Collections.<Class<?>>singletonList(org.deeplearning4j.nn.layers.normalization.BatchNormalization.class))
                     .testForward(true)
                     .testScore(true)
                     .testBackward(true)
@@ -172,9 +172,8 @@ public class ValidateMKLDNN extends BaseDL4JTest {
         }
     }
 
-    @Test @Ignore
+    @Test
     public void validateLRN() {
-        //2019-02-14 AB - Ignored: LRN backprop is broken: https://github.com/deeplearning4j/deeplearning4j/issues/6958 issue 20
 
         //Only run test if using nd4j-native backend
         assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
@@ -188,7 +187,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
         double[] a = new double[]{1e-4, 1e-4, 1e-3, 1e-3};
         double[] b = new double[]{0.75, 0.9, 0.6, 0.75};
         double[] n = new double[]{5, 3, 2, 4};
-        double[] k = new double[]{2, 3, 1.5, 2};
+        double[] k = new double[]{2, 2.5, 1.5, 2};
 
         for (int minibatch : new int[]{1, 3}) {
             for( int i=0; i<a.length; i++ ) {
@@ -236,11 +235,13 @@ public class ValidateMKLDNN extends BaseDL4JTest {
                         .labels(l)
                         .data(new SingletonDataSetIterator(new DataSet(f, l)))
                         //Very infrequent minor differences - as far as I can tell, just numerical precision issues...
-                        .minAbsError(1e-4)
-                        .maxRelError(2e-4)
+                        .minAbsError(1e-3)
+                        .maxRelError(1e-2)
                         .build();
 
                 LayerHelperValidationUtil.validateMLN(netWith, tc);
+
+                System.out.println("/////////////////////////////////////////////////////////////////////////////");
             }
         }
     }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -189,17 +189,18 @@ public class ValidateMKLDNN extends BaseDL4JTest {
         ConvolutionMode cm = ConvolutionMode.Truncate;
 
         double[] a = new double[]{1e-4, 1e-4, 1e-3, 1e-3};
-        double[] b = new double[]{0.75, 0.9, 0.6, 0.75};
-        double[] n = new double[]{5, 3, 2, 4};
-        double[] k = new double[]{2, 2.5, 1.5, 2};
+        double[] b = new double[]{0.75, 0.9, 0.75, 0.75};
+        double[] n = new double[]{5, 3, 3, 4};
+        double[] k = new double[]{2, 2.5, 2.75, 2};
 
         for (int minibatch : new int[]{1, 3}) {
             for( int i=0; i<a.length; i++ ) {
+                System.out.println("+++++ MINIBATCH = " + minibatch + ", TEST=" + i + " +++++");
 
 
                 inputSize[0] = minibatch;
-                INDArray f = Nd4j.rand(Nd4j.defaultFloatingPointType(), inputSize).muli(4);
-                INDArray l = TestUtils.randomOneHot(minibatch, 10);
+                INDArray f = Nd4j.rand(Nd4j.defaultFloatingPointType(), inputSize);
+                INDArray l = TestUtils.randomOneHot(minibatch, 10).castTo(DataType.FLOAT);
 
                 MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                         .updater(new Adam(0.01))

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/mkldnn/ValidateMKLDNN.java
@@ -30,6 +30,7 @@ import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
@@ -48,6 +49,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
     public void validateConvSubsampling() throws Exception {
         //Only run test if using nd4j-native backend
         assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
+        Nd4j.setDefaultDataTypes(DataType.FLOAT, DataType.FLOAT);
         Nd4j.getRandom().setSeed(12345);
 
         int[] inputSize = {-1, 3, 16, 16};
@@ -58,8 +60,8 @@ public class ValidateMKLDNN extends BaseDL4JTest {
                     for (int[] stride : new int[][]{{1, 1}, {2, 2}}) {
 
                         inputSize[0] = minibatch;
-                        INDArray f = Nd4j.rand(Nd4j.defaultFloatingPointType(), inputSize);
-                        INDArray l = TestUtils.randomOneHot(minibatch, 10);
+                        INDArray f = Nd4j.rand(DataType.FLOAT, inputSize);
+                        INDArray l = TestUtils.randomOneHot(minibatch, 10).castTo(DataType.FLOAT);
 
                         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                                 .updater(new Adam(0.01))
@@ -116,6 +118,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
     public void validateBatchNorm() {
         //Only run test if using nd4j-native backend
         assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
+        Nd4j.setDefaultDataTypes(DataType.FLOAT, DataType.FLOAT);
         Nd4j.getRandom().setSeed(12345);
 
         int[] inputSize = {-1, 3, 16, 16};
@@ -177,6 +180,7 @@ public class ValidateMKLDNN extends BaseDL4JTest {
 
         //Only run test if using nd4j-native backend
         assumeTrue(Nd4j.getBackend().getClass().getName().toLowerCase().contains("native"));
+        Nd4j.setDefaultDataTypes(DataType.FLOAT, DataType.FLOAT);
         Nd4j.getRandom().setSeed(12345);
 
         int[] inputSize = {-1, 3, 16, 16};

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/RegressionTest100a.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/regressiontest/RegressionTest100a.java
@@ -30,6 +30,7 @@ import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.weights.WeightInitXavier;
 import org.deeplearning4j.regressiontest.customlayer100a.CustomLayer;
+import org.junit.Before;
 import org.junit.Test;
 import org.nd4j.linalg.activations.impl.*;
 import org.nd4j.linalg.api.buffer.DataType;

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
@@ -128,10 +128,10 @@ public class CudnnConvolutionHelper extends BaseCudnnHelper implements Convoluti
     private CudnnConvolutionContext cudnnContext = new CudnnConvolutionContext();
 
     @Override
-    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray delta, int[] kernel,
-                    int[] strides, int[] pad, INDArray biasGradView, INDArray weightGradView, IActivation afn,
-                    AlgoMode mode, BwdFilterAlgo bwdFilterAlgo, BwdDataAlgo bwdDataAlgo,
-                    ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr) {
+    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray bias, INDArray delta, int[] kernel,
+                                                     int[] strides, int[] pad, INDArray biasGradView, INDArray weightGradView, IActivation afn,
+                                                     AlgoMode mode, BwdFilterAlgo bwdFilterAlgo, BwdDataAlgo bwdDataAlgo,
+                                                     ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr) {
         int code;
 
         val miniBatch = input.size(0);

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/convolution/CudnnConvolutionHelper.java
@@ -529,7 +529,7 @@ public class CudnnConvolutionHelper extends BaseCudnnHelper implements Convoluti
     }
 
     @Override
-    public INDArray activate(INDArray z, IActivation afn) {
+    public INDArray activate(INDArray z, IActivation afn, boolean training) {
         if (Nd4j.getExecutioner() instanceof GridExecutioner)
             ((GridExecutioner) Nd4j.getExecutioner()).flushQueue();
 

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnBatchNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/nn/layers/normalization/CudnnBatchNormalizationHelper.java
@@ -114,7 +114,7 @@ public class CudnnBatchNormalizationHelper extends BaseCudnnHelper implements Ba
     private INDArray varCache;
     private double eps;
 
-    public boolean checkSupported(double eps) {
+    public boolean checkSupported(double eps, boolean isFixedGammaBeta) {
         boolean supported = checkSupported();
         if (eps < CUDNN_BN_MIN_EPSILON) {
             supported = false;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
@@ -36,10 +36,10 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 public interface ConvolutionHelper extends LayerHelper {
     boolean checkSupported();
 
-    Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray delta, int[] kernel,
-                    int[] strides, int[] pad, INDArray biasGradView, INDArray weightGradView, IActivation afn,
-                    AlgoMode mode, BwdFilterAlgo bwdFilterAlgo, BwdDataAlgo bwdDataAlgo,
-                    ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr);
+    Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray bias, INDArray delta, int[] kernel,
+                                              int[] strides, int[] pad, INDArray biasGradView, INDArray weightGradView, IActivation afn,
+                                              AlgoMode mode, BwdFilterAlgo bwdFilterAlgo, BwdDataAlgo bwdDataAlgo,
+                                              ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr);
 
     INDArray preOutput(INDArray input, INDArray weights, INDArray bias, int[] kernel, int[] strides, int[] pad,
                        AlgoMode mode, FwdAlgo fwdAlgo, ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionHelper.java
@@ -44,5 +44,5 @@ public interface ConvolutionHelper extends LayerHelper {
     INDArray preOutput(INDArray input, INDArray weights, INDArray bias, int[] kernel, int[] strides, int[] pad,
                        AlgoMode mode, FwdAlgo fwdAlgo, ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr);
 
-    INDArray activate(INDArray z, IActivation afn);
+    INDArray activate(INDArray z, IActivation afn, boolean training);
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -18,16 +18,15 @@ package org.deeplearning4j.nn.layers.convolution;
 
 
 import org.deeplearning4j.exception.DL4JInvalidInputException;
-import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.MaskState;
 import org.deeplearning4j.nn.conf.CacheMode;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
-import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.layers.BaseLayer;
 import org.deeplearning4j.nn.layers.LayerHelper;
+import org.deeplearning4j.nn.layers.mkldnn.MKLDNNConvHelper;
 import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.activations.IActivation;
@@ -44,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.Properties;
 
 
 /**
@@ -93,6 +91,10 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                             + "For more information, please refer to: https://deeplearning4j.org/docs/latest/deeplearning4j-config-cudnn", t);
                 }
             }
+        } else if("CPU".equalsIgnoreCase(backend)){
+            //TODO check if MKL-DNN is supported
+            helper = new MKLDNNConvHelper();
+            log.info("Created MKLDNNConvHelper");
         }
     }
 
@@ -105,6 +107,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
     public Pair<Gradient, INDArray> backpropGradient(INDArray epsilon, LayerWorkspaceMgr workspaceMgr) {
         assertInputSet(true);
         INDArray weights = getParamWithNoise(ConvolutionParamInitializer.WEIGHT_KEY, true, workspaceMgr);
+        INDArray bias = getParamWithNoise(ConvolutionParamInitializer.BIAS_KEY, true, workspaceMgr);
 
         // FIXME: int cast
         int miniBatch = (int) input.size(0);
@@ -159,10 +162,10 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
 
             Pair<Gradient, INDArray> ret = null;
             try {
-                ret = helper.backpropGradient(input, weights, delta, kernel, strides, pad,
-                        biasGradView, weightGradView, afn, layerConf().getCudnnAlgoMode(),
-                        layerConf().getCudnnBwdFilterAlgo(), layerConf().getCudnnBwdDataAlgo(), convolutionMode,
-                        dilation, workspaceMgr);
+                ret = helper.backpropGradient(input, weights, bias, delta, kernel, strides,
+                        pad, biasGradView, weightGradView, afn,
+                        layerConf().getCudnnAlgoMode(), layerConf().getCudnnBwdFilterAlgo(), layerConf().getCudnnBwdDataAlgo(),
+                        convolutionMode, dilation, workspaceMgr);
             } catch (Exception e){
                 if(e.getMessage().contains("Failed to allocate")){
                    //This is a memory exception - don't fallback to built-in implementation
@@ -347,7 +350,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                 ret = helper.preOutput(input, weights, bias, kernel, strides, pad, layerConf().getCudnnAlgoMode(),
                         layerConf().getCudnnFwdAlgo(), convolutionMode, dilation, workspaceMgr);
             } catch (Exception e){
-                if(e.getMessage().contains("Failed to allocate")){
+                if(e.getMessage() != null && e.getMessage().contains("Failed to allocate")){
                     //This is a memory exception - don't fallback to built-in implementation
                     throw e;
                 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -96,6 +96,10 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
             helper = new MKLDNNConvHelper();
             log.info("Created MKLDNNConvHelper");
         }
+        if (helper != null && !helper.checkSupported()) {
+            log.debug("Removed helper {} as not supported", helper.getClass());
+            helper = null;
+        }
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -435,7 +435,7 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
         IActivation afn = layerConf().getActivationFn();
 
         if (helper != null && Shape.strideDescendingCAscendingF(z)) {
-            INDArray ret = helper.activate(z, layerConf().getActivationFn());
+            INDArray ret = helper.activate(z, layerConf().getActivationFn(), training);
             if (ret != null) {
                 return ret;
             }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/ConvolutionLayer.java
@@ -92,9 +92,8 @@ public class ConvolutionLayer extends BaseLayer<org.deeplearning4j.nn.conf.layer
                 }
             }
         } else if("CPU".equalsIgnoreCase(backend)){
-            //TODO check if MKL-DNN is supported
             helper = new MKLDNNConvHelper();
-            log.info("Created MKLDNNConvHelper");
+            log.debug("Created MKLDNNConvHelper, layer {}", layerConf().getLayerName());
         }
         if (helper != null && !helper.checkSupported()) {
             log.debug("Removed helper {} as not supported", helper.getClass());

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/Deconvolution2DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/Deconvolution2DLayer.java
@@ -23,11 +23,9 @@ import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
-import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.params.DeconvolutionParamInitializer;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.activations.IActivation;
-import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.CustomOp;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
@@ -261,7 +259,7 @@ public class Deconvolution2DLayer extends ConvolutionLayer {
         IActivation afn = layerConf().getActivationFn();
 
         if (helper != null && Shape.strideDescendingCAscendingF(z)) {
-            INDArray ret = helper.activate(z, layerConf().getActivationFn());
+            INDArray ret = helper.activate(z, layerConf().getActivationFn(), training);
             if (ret != null) {
                 return ret;
             }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -93,7 +93,8 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                             + "For more information, please refer to: https://deeplearning4j.org/docs/latest/deeplearning4j-config-cudnn", t);
                 }
             }
-        } else if("CPU".equalsIgnoreCase(backend)){
+        } else if("CPU".equalsIgnoreCase(backend) ){
+
             //TODO check if native libraries are available
             helper = new MKLDNNSubsamplingHelper();
             log.info("Created MKL-DNN helper");

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -94,10 +94,13 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                 }
             }
         } else if("CPU".equalsIgnoreCase(backend) ){
-
             //TODO check if native libraries are available
             helper = new MKLDNNSubsamplingHelper();
-            log.info("Created MKL-DNN helper");
+            log.info("Created MKL-DNN helper: MKLDNNSubsamplingHelper");
+        }
+        if (helper != null && !helper.checkSupported()) {
+            log.debug("Removed helper {} as not supported", helper.getClass());
+            helper = null;
         }
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -27,6 +27,7 @@ import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.AbstractLayer;
 import org.deeplearning4j.nn.layers.LayerHelper;
+import org.deeplearning4j.nn.layers.mkldnn.MKLDNNSubsamplingHelper;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
@@ -92,6 +93,10 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                             + "For more information, please refer to: https://deeplearning4j.org/docs/latest/deeplearning4j-config-cudnn", t);
                 }
             }
+        } else if("CPU".equalsIgnoreCase(backend)){
+            //TODO check if native libraries are available
+            helper = new MKLDNNSubsamplingHelper();
+            log.info("Created MKL-DNN helper");
         }
     }
 
@@ -138,7 +143,7 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                 ret = helper.backpropGradient(input, epsilon, kernel, strides, pad,
                         layerConf().getPoolingType(), convolutionMode, dilation, workspaceMgr);
             } catch (Exception e){
-                if(e.getMessage().contains("Failed to allocate")){
+                if(e.getMessage() != null && e.getMessage().contains("Failed to allocate")){
                     //This is a memory exception - don't fallback to built-in implementation
                     throw e;
                 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -94,9 +94,8 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                 }
             }
         } else if("CPU".equalsIgnoreCase(backend) ){
-            //TODO check if native libraries are available
             helper = new MKLDNNSubsamplingHelper();
-            log.info("Created MKL-DNN helper: MKLDNNSubsamplingHelper");
+            log.debug("Created MKL-DNN helper: MKLDNNSubsamplingHelper, layer {}", layerConf().getLayerName());
         }
         if (helper != null && !helper.checkSupported()) {
             log.debug("Removed helper {} as not supported", helper.getClass());

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/BaseMKLDNNHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/BaseMKLDNNHelper.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.layers.mkldnn;
+
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BaseMKLDNNHelper {
+
+    private static AtomicBoolean BACKEND_OK = null;
+    private static AtomicBoolean FAILED_CHECK = null;
+
+    public static boolean mklDnnEnabled(){
+        if(BACKEND_OK == null){
+            String backend = Nd4j.getExecutioner().getEnvironmentInformation().getProperty("backend");
+            BACKEND_OK = new AtomicBoolean("CPU".equalsIgnoreCase(backend));
+        }
+
+        if(!BACKEND_OK.get() || (FAILED_CHECK != null && FAILED_CHECK.get())){
+            //Wrong backend or already failed trying to check
+            return false;
+        }
+
+        try{
+            Class<?> c = Class.forName("org.nd4j.nativeblas.Nd4jCpu$Environment");
+            Method m = c.getMethod("getInstance");
+            Object instance = m.invoke(null);
+            Method m2 = c.getMethod("isUseMKLDNN");
+            boolean b = (Boolean)m2.invoke(instance);
+            return b;
+        } catch (Throwable t ){
+            FAILED_CHECK = new AtomicBoolean(true);
+            return false;
+        }
+    }
+
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/BaseMKLDNNHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/BaseMKLDNNHelper.java
@@ -21,6 +21,10 @@ import org.nd4j.linalg.factory.Nd4j;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Base class for MLK-DNN Helpers
+ * @author Alex Black
+ */
 public class BaseMKLDNNHelper {
 
     private static AtomicBoolean BACKEND_OK = null;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
@@ -40,7 +40,7 @@ public class MKLDNNBatchNormHelper implements BatchNormalizationHelper {
 
     @Override
     public boolean checkSupported(double eps) {
-        return true;
+        return BaseMKLDNNHelper.mklDnnEnabled();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
@@ -31,6 +31,11 @@ import org.nd4j.linalg.primitives.Pair;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * MKL-DNN batch normalization helper implementation
+ *
+ * @author Alex Black
+ */
 public class MKLDNNBatchNormHelper implements BatchNormalizationHelper {
     private static final int[] RANK2_DIMS = {0};
     private static final int[] RANK4_DIMS = {0,2,3};
@@ -46,6 +51,8 @@ public class MKLDNNBatchNormHelper implements BatchNormalizationHelper {
     @Override
     public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, int[] shape, INDArray gamma,
                                                      INDArray dGammaView, INDArray dBetaView, double eps, LayerWorkspaceMgr workspaceMgr) {
+        //2019-02-14: Backprop disabled pending fixes. https://github.com/deeplearning4j/deeplearning4j/issues/7166
+        //Also no MKL-DNN implemented for backprop anyway
         /*
         INDArray[] in = gamma == null ? new INDArray[]{input, mean, var, epsilon} : new INDArray[]{input, mean, var, gamma, beta, epsilon};
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.layers.mkldnn;
+
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.normalization.BatchNormalizationHelper;
+import org.deeplearning4j.nn.workspace.ArrayType;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.BatchNorm;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.BatchNormDerivative;
+import org.nd4j.linalg.api.ops.impl.summarystats.Variance;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MKLDNNBatchNormHelper implements BatchNormalizationHelper {
+    private static final int[] RANK2_DIMS = {0};
+    private static final int[] RANK4_DIMS = {0,2,3};
+
+    private INDArray meanCache;
+    private INDArray varCache;
+
+    @Override
+    public boolean checkSupported(double eps) {
+        return true;
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, int[] shape, INDArray gamma,
+                                                     INDArray dGammaView, INDArray dBetaView, double eps, LayerWorkspaceMgr workspaceMgr) {
+        /*
+        INDArray[] in = gamma == null ? new INDArray[]{input, mean, var, epsilon} : new INDArray[]{input, mean, var, gamma, beta, epsilon};
+
+        INDArray gradAtInput = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, input.dataType(), input.shape());
+
+        INDArray[] out = gamma == null ? new INDArray[]{gradAtInput, }
+
+        BatchNormDerivative bn = BatchNormDerivative.derivativeBuilder()
+                .applyBeta(gamma != null)
+                .applyGamma(gamma != null)
+                .axis(new int[]{1})     //4d: is channels: NCHW; 2d: is nIn - axis 1 in both cases
+                .epsilon(eps)
+                .inputArrays(in)
+                .outputArrays(new INDArray[]{out})
+                .build();
+        Nd4j.exec(bn);
+        */
+
+        return null;
+    }
+
+    @Override
+    public INDArray preOutput(INDArray x, boolean training, int[] shape, INDArray gamma, INDArray beta, INDArray mean, INDArray var,
+                              double decay, double eps, LayerWorkspaceMgr workspaceMgr) {
+
+        //Mean and variance: args here are *global*. Depending on train/test mode we might need to use batch mean/var
+        INDArray m, v;
+        if(training){
+            if(meanCache == null){
+                try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
+                    meanCache = Nd4j.createUninitialized(x.dataType(), x.size(1));
+                    varCache = Nd4j.createUninitialized(x.dataType(), x.size(1));
+                }
+            }
+            x.mean(meanCache, x.rank() == 2 ? RANK2_DIMS : RANK4_DIMS);
+            Nd4j.exec(new Variance(x, varCache, false, x.rank() == 2 ? RANK2_DIMS : RANK4_DIMS));
+
+            m = meanCache;
+            v = varCache;
+        } else {
+            m = mean.reshape(mean.length());
+            v = var.reshape(var.length());
+        }
+
+        //Note: batchnorm op expects rank 1 inputs for mean/var etc, not rank 2 shape [1,x]
+        INDArray[] input = gamma == null ? new INDArray[]{x, m, v} : new INDArray[]{x, m, v, gamma.reshape(gamma.length()), beta.reshape(beta.length())};
+        INDArray out = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, x.dataType(), x.shape());
+
+        BatchNorm bn = BatchNorm.builder()
+                .applyBeta(beta != null)
+                .applyGamma(gamma != null)
+                .axis(new int[]{1})     //4d: is channels: NCHW; 2d: is nIn - axis 1 in both cases
+                .epsilon(eps)
+                .inputArrays(input)
+                .outputArrays(new INDArray[]{out})
+                .build();
+        Nd4j.exec(bn);
+        return out;
+    }
+
+    @Override
+    public INDArray getMeanCache() {
+        return meanCache;
+    }
+
+    @Override
+    public INDArray getVarCache() {
+        return varCache;
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        return Collections.emptyMap();
+    }
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
@@ -24,7 +24,6 @@ import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.BatchNorm;
-import org.nd4j.linalg.api.ops.impl.layers.convolution.BatchNormDerivative;
 import org.nd4j.linalg.api.ops.impl.summarystats.Variance;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.Pair;
@@ -47,8 +46,8 @@ public class MKLDNNBatchNormHelper implements BatchNormalizationHelper {
     private INDArray varCache;
 
     @Override
-    public boolean checkSupported(double eps) {
-        return BaseMKLDNNHelper.mklDnnEnabled();
+    public boolean checkSupported(double eps, boolean fixedGammaBeta) {
+        return !fixedGammaBeta && BaseMKLDNNHelper.mklDnnEnabled();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
@@ -20,6 +20,7 @@ import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.normalization.BatchNormalizationHelper;
 import org.deeplearning4j.nn.workspace.ArrayType;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
+import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
@@ -79,6 +80,8 @@ public class MKLDNNBatchNormHelper implements BatchNormalizationHelper {
     @Override
     public INDArray preOutput(INDArray x, boolean training, int[] shape, INDArray gamma, INDArray beta, INDArray mean, INDArray var,
                               double decay, double eps, LayerWorkspaceMgr workspaceMgr) {
+        if(x.dataType() != DataType.FLOAT)
+            return null;    //MKL-DNN only supports float
 
         if(context == null){
             context = Nd4j.getExecutioner().buildContext();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.layers.mkldnn;
+
+import org.deeplearning4j.nn.conf.ConvolutionMode;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.convolution.ConvolutionHelper;
+import org.deeplearning4j.nn.params.ConvolutionParamInitializer;
+import org.deeplearning4j.nn.workspace.ArrayType;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
+import org.deeplearning4j.util.ConvolutionUtils;
+import org.nd4j.linalg.activations.IActivation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.Conv2D;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.Conv2DDerivative;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.config.Conv2DConfig;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MKLDNNConvHelper implements ConvolutionHelper {
+    @Override
+    public boolean checkSupported() {
+        return true;
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray weights, INDArray bias, INDArray delta, int[] kernel, int[] strides, int[] pad,
+                                                     INDArray biasGradView, INDArray weightGradView, IActivation afn, ConvolutionLayer.AlgoMode mode,
+                                                     ConvolutionLayer.BwdFilterAlgo bwdFilterAlgo, ConvolutionLayer.BwdDataAlgo bwdDataAlgo, ConvolutionMode convolutionMode,
+                                                     int[] dilation, LayerWorkspaceMgr workspaceMgr) {
+        //Note: conv2d op expects [kH, kW, iC, oC] weights... DL4J conv uses [oC, iC, kH, kW]
+        INDArray weightsPermute = weights.permute(2,3,1,0);
+        INDArray weightGradViewPermute = weightGradView.permute(2,3,1,0);
+
+        if (convolutionMode == ConvolutionMode.Same) {
+            pad = ConvolutionUtils.getSameModeTopLeftPadding(new int[]{(int)delta.size(2), (int)delta.size(3)}, new int[] {(int) input.size(2), (int) input.size(3)},
+                    kernel, strides, dilation);
+        }
+
+        Conv2DConfig conf = Conv2DConfig.builder()
+                .dataFormat(Conv2DConfig.NCHW)
+                .kH(kernel[0]).kW(kernel[1])
+                .sH(strides[0]).sW(strides[1])
+                .pH(pad[0]).pW(pad[1])
+                .dH(dilation[0]).dH(dilation[1])
+                .isSameMode(convolutionMode == ConvolutionMode.Same)
+                .build();
+
+        INDArray gradAtInput = workspaceMgr.createUninitialized(ArrayType.ACTIVATION_GRAD, input.dataType(), input.shape());
+
+        INDArray[] inputsArr = biasGradView == null ? new INDArray[]{input, weightsPermute, delta} : new INDArray[]{input, weightsPermute, bias, delta};
+        INDArray[] outputArr = biasGradView == null ? new INDArray[]{gradAtInput, weightGradViewPermute} : new INDArray[]{gradAtInput, weightGradViewPermute, biasGradView};
+        DynamicCustomOp op = Conv2DDerivative.builder()
+                .config(conf)
+                .inputArrays(inputsArr)
+                .outputs(outputArr)
+                .build();
+        Nd4j.exec(op);
+
+        Gradient g = new DefaultGradient();
+        if(biasGradView != null) {
+            g.gradientForVariable().put(ConvolutionParamInitializer.BIAS_KEY, biasGradView);
+        }
+        g.gradientForVariable().put(ConvolutionParamInitializer.WEIGHT_KEY, weightGradView);
+
+        return new Pair<>(g, gradAtInput);
+    }
+
+    @Override
+    public INDArray preOutput(INDArray input, INDArray weights, INDArray bias, int[] kernel, int[] strides, int[] pad, ConvolutionLayer.AlgoMode mode, ConvolutionLayer.FwdAlgo fwdAlgo, ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr) {
+
+        int inH = (int)input.size(2);
+        int inW = (int)input.size(3);
+        int[] outSize;
+        if (convolutionMode == ConvolutionMode.Same) {
+            outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, null, convolutionMode, dilation); //Also performs validation
+            pad = ConvolutionUtils.getSameModeTopLeftPadding(outSize, new int[] {inH, inW}, kernel, strides, dilation);
+        } else {
+            outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, pad, convolutionMode, dilation); //Also performs validation
+        }
+
+        int outDepth = (int) weights.size(0);
+        INDArray out = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, input.dataType(), input.size(0), outDepth, outSize[0], outSize[1]);
+
+        //Note: conv2d op expects [kH, kW, iC, oC] weights... DL4J conv uses [oC, iC, kH, kW]
+        weights = weights.permute(2,3,1,0);
+
+        Conv2DConfig conf = Conv2DConfig.builder()
+                .dataFormat(Conv2DConfig.NCHW)
+                .kH(kernel[0]).kW(kernel[1])
+                .sH(strides[0]).sW(strides[1])
+                .pH(pad[0]).pW(pad[1])
+                .dH(dilation[0]).dH(dilation[1])
+                .isSameMode(convolutionMode == ConvolutionMode.Same)
+                .build();
+
+        INDArray[] inputsArr = bias == null ? new INDArray[]{input, weights} : new INDArray[]{input, weights, bias};
+        DynamicCustomOp op = Conv2D.builder()
+                .config(conf)
+                .inputArrays(inputsArr)
+                .outputs(new INDArray[]{out})
+                .build();
+        Nd4j.exec(op);
+
+        return out;
+    }
+
+    @Override
+    public INDArray activate(INDArray z, IActivation afn) {
+        return afn.getActivation(z, false); //TODO train/test mode
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        return Collections.emptyMap();
+    }
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
@@ -70,7 +70,7 @@ public class MKLDNNConvHelper implements ConvolutionHelper {
 
         INDArray[] inputsArr = biasGradView == null ? new INDArray[]{input, weightsPermute, delta} : new INDArray[]{input, weightsPermute, bias, delta};
         INDArray[] outputArr = biasGradView == null ? new INDArray[]{gradAtInput, weightGradViewPermute} : new INDArray[]{gradAtInput, weightGradViewPermute, biasGradView};
-        DynamicCustomOp op = Conv2DDerivative.builder()
+        DynamicCustomOp op = Conv2DDerivative.derivativeBuilder()
                 .config(conf)
                 .inputArrays(inputsArr)
                 .outputs(outputArr)
@@ -126,8 +126,8 @@ public class MKLDNNConvHelper implements ConvolutionHelper {
     }
 
     @Override
-    public INDArray activate(INDArray z, IActivation afn) {
-        return afn.getActivation(z, false); //TODO train/test mode
+    public INDArray activate(INDArray z, IActivation afn, boolean training) {
+        return afn.getActivation(z, training);
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
@@ -37,6 +37,11 @@ import org.nd4j.linalg.primitives.Pair;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * MKL-DNN Convolution (2d) helper
+ *
+ * @author Alex Black
+ */
 public class MKLDNNConvHelper implements ConvolutionHelper {
     @Override
     public boolean checkSupported() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class MKLDNNConvHelper implements ConvolutionHelper {
     @Override
     public boolean checkSupported() {
-        return true;
+        return BaseMKLDNNHelper.mklDnnEnabled();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
@@ -27,15 +27,12 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.activations.IActivation;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.Conv2D;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.Conv2DDerivative;
-import org.nd4j.linalg.api.ops.impl.layers.convolution.config.Conv2DConfig;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.util.ArrayUtil;
-import org.nd4j.nativeblas.Nd4jCpu;
 
 import java.util.Collections;
 import java.util.Map;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNConvHelper.java
@@ -26,6 +26,7 @@ import org.deeplearning4j.nn.workspace.ArrayType;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.util.ConvolutionUtils;
 import org.nd4j.linalg.activations.IActivation;
+import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.impl.layers.convolution.Conv2D;
@@ -57,6 +58,9 @@ public class MKLDNNConvHelper implements ConvolutionHelper {
                                                      INDArray biasGradView, INDArray weightGradView, IActivation afn, ConvolutionLayer.AlgoMode mode,
                                                      ConvolutionLayer.BwdFilterAlgo bwdFilterAlgo, ConvolutionLayer.BwdDataAlgo bwdDataAlgo, ConvolutionMode convolutionMode,
                                                      int[] dilation, LayerWorkspaceMgr workspaceMgr) {
+        if(input.dataType() != DataType.FLOAT || weights.dataType() != DataType.FLOAT)
+            return null;    //MKL-DNN only supports floating point dtype
+
         //Note: conv2d op expects [kH, kW, iC, oC] weights... DL4J conv uses [oC, iC, kH, kW]
         INDArray weightsPermute = weights.permute(2,3,1,0);
         INDArray weightGradViewPermute = weightGradView.permute(2,3,1,0);
@@ -106,6 +110,8 @@ public class MKLDNNConvHelper implements ConvolutionHelper {
 
     @Override
     public INDArray preOutput(INDArray input, INDArray weights, INDArray bias, int[] kernel, int[] strides, int[] pad, ConvolutionLayer.AlgoMode mode, ConvolutionLayer.FwdAlgo fwdAlgo, ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr) {
+        if(input.dataType() != DataType.FLOAT || weights.dataType() != DataType.FLOAT)
+            return null;    //MKL-DNN only supports floating point dtype
 
         int inH = (int)input.size(2);
         int inW = (int)input.size(3);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLocalResponseNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLocalResponseNormalizationHelper.java
@@ -31,6 +31,11 @@ import org.nd4j.linalg.primitives.Pair;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * MKL-DNN Local response normalization helper
+ *
+ * @author Alex Black
+ */
 public class MKLDNNLocalResponseNormalizationHelper extends BaseMKLDNNHelper implements LocalResponseNormalizationHelper {
     @Override
     public boolean checkSupported(double k, double n, double alpha, double beta) {
@@ -39,7 +44,8 @@ public class MKLDNNLocalResponseNormalizationHelper extends BaseMKLDNNHelper imp
 
     @Override
     public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, double k, double n, double alpha, double beta, LayerWorkspaceMgr workspaceMgr) {
-        INDArray gradAtInput = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, input.dataType(), input.shape());
+        INDArray gradAtInput = workspaceMgr.createUninitialized(ArrayType.ACTIVATION_GRAD, input.dataType(), input.shape());
+        gradAtInput.assign(0);
 
         LocalResponseNormalizationConfig conf = LocalResponseNormalizationConfig.builder()
                 .alpha(alpha)

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLocalResponseNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLocalResponseNormalizationHelper.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.layers.mkldnn;
+
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.normalization.LocalResponseNormalizationHelper;
+import org.deeplearning4j.nn.workspace.ArrayType;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.LocalResponseNormalization;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.LocalResponseNormalizationDerivative;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.config.LocalResponseNormalizationConfig;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MKLDNNLocalResponseNormalizationHelper extends BaseMKLDNNHelper implements LocalResponseNormalizationHelper {
+    @Override
+    public boolean checkSupported(double k, double n, double alpha, double beta) {
+        return BaseMKLDNNHelper.mklDnnEnabled();
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, double k, double n, double alpha, double beta, LayerWorkspaceMgr workspaceMgr) {
+        INDArray gradAtInput = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, input.dataType(), input.shape());
+
+        LocalResponseNormalizationConfig conf = LocalResponseNormalizationConfig.builder()
+                .alpha(alpha)
+                .beta(beta)
+                .bias(k)
+                .depth((int)n)   //Adjacent kernel maps
+                .build();
+
+        LocalResponseNormalizationDerivative op = LocalResponseNormalizationDerivative.derivativeBuilder()
+                .config(conf)
+                .inputs(new INDArray[]{input, epsilon})
+                .outputs(new INDArray[]{gradAtInput})
+                .build();
+
+        Nd4j.exec(op);
+        Gradient g = new DefaultGradient();
+        return new Pair<>(g, gradAtInput);
+    }
+
+    @Override
+    public INDArray activate(INDArray x, boolean training, double k, double n, double alpha, double beta, LayerWorkspaceMgr workspaceMgr) {
+        INDArray out = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, x.dataType(), x.shape());
+
+        LocalResponseNormalizationConfig conf = LocalResponseNormalizationConfig.builder()
+                .alpha(alpha)
+                .beta(beta)
+                .bias(k)
+                .depth((int)n)   //Adjacent kernel maps
+                .build();
+
+        LocalResponseNormalization op = LocalResponseNormalization.builder()
+                .config(conf)
+                .inputs(new INDArray[]{x})
+                .outputs(new INDArray[]{out})
+                .build();
+
+        Nd4j.exec(op);
+        return out;
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        return Collections.emptyMap();
+    }
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class MKLDNNSubsamplingHelper implements SubsamplingHelper {
     @Override
     public boolean checkSupported() {
-        return true;
+        return BaseMKLDNNHelper.mklDnnEnabled();
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
@@ -54,6 +54,9 @@ public class MKLDNNSubsamplingHelper implements SubsamplingHelper {
             pad = ConvolutionUtils.getSameModeTopLeftPadding(new int[]{(int)epsilon.size(2), (int)epsilon.size(3)}, new int[] {(int)input.size(2), (int)input.size(3)}, kernel, strides, dilation);
         }
 
+        input = input.dup();
+        epsilon = epsilon.dup();
+
         Pooling2DConfig conf = Pooling2DConfig.builder()
                 .isSameMode(convolutionMode == ConvolutionMode.Same)
                 .kH(kernel[0]).kW(kernel[1])
@@ -92,6 +95,8 @@ public class MKLDNNSubsamplingHelper implements SubsamplingHelper {
 
         long[] outShape = new long[]{input.size(0), input.size(1), outSize[0], outSize[1]};
         INDArray output = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, input.dataType(), outShape);
+
+        input = input.dup();
 
         Pooling2DConfig conf = Pooling2DConfig.builder()
                 .isSameMode(convolutionMode == ConvolutionMode.Same)

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.layers.mkldnn;
+
+import org.deeplearning4j.nn.conf.ConvolutionMode;
+import org.deeplearning4j.nn.conf.layers.PoolingType;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.nn.layers.convolution.subsampling.SubsamplingHelper;
+import org.deeplearning4j.nn.workspace.ArrayType;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
+import org.deeplearning4j.util.ConvolutionUtils;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.AvgPooling2D;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.MaxPooling2D;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.Pooling2D;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.Pooling2DDerivative;
+import org.nd4j.linalg.api.ops.impl.layers.convolution.config.Pooling2DConfig;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.primitives.Pair;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class MKLDNNSubsamplingHelper implements SubsamplingHelper {
+    @Override
+    public boolean checkSupported() {
+        return true;
+    }
+
+    @Override
+    public Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, int[] kernel, int[] strides, int[] pad, PoolingType poolingType, ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr) {
+        if(poolingType == PoolingType.SUM || poolingType == PoolingType.PNORM)
+            return null;
+
+        INDArray gradAtInput = workspaceMgr.createUninitialized(ArrayType.ACTIVATION_GRAD, input.dataType(), input.shape());
+
+        if (convolutionMode == ConvolutionMode.Same) {
+            pad = ConvolutionUtils.getSameModeTopLeftPadding(new int[]{(int)epsilon.size(2), (int)epsilon.size(3)}, new int[] {(int)input.size(2), (int)input.size(3)}, kernel, strides, dilation);
+        }
+
+        Pooling2DConfig conf = Pooling2DConfig.builder()
+                .isSameMode(convolutionMode == ConvolutionMode.Same)
+                .kH(kernel[0]).kW(kernel[1])
+                .sH(strides[0]).sW(strides[1])
+                .dH(dilation[0]).dW(dilation[1])
+                .pH(pad[0]).pW(pad[1])
+                .isNHWC(false)
+                .build();
+
+        switch (poolingType){
+            case MAX:
+                conf.setType(Pooling2D.Pooling2DType.MAX);
+            case AVG:
+                conf.setType(Pooling2D.Pooling2DType.AVG);
+        }
+
+        Pooling2DDerivative d = Pooling2DDerivative.derivativeBuilder()
+                .config(conf)
+                .arrayInputs(new INDArray[]{input, epsilon})
+                .arrayOutputs(new INDArray[]{gradAtInput})
+                .build();
+
+        Nd4j.exec(d);
+        return new Pair<Gradient,INDArray>(new DefaultGradient(), gradAtInput);
+    }
+
+    @Override
+    public INDArray activate(INDArray input, boolean training, int[] kernel, int[] strides, int[] pad, PoolingType poolingType, ConvolutionMode convolutionMode, int[] dilation, LayerWorkspaceMgr workspaceMgr) {
+        int[] outSize;
+        if (convolutionMode == ConvolutionMode.Same) {
+            outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, null, convolutionMode, dilation); //Also performs validation
+            pad = ConvolutionUtils.getSameModeTopLeftPadding(outSize, new int[] {(int)input.size(2), (int)input.size(3)}, kernel, strides, dilation);
+        } else {
+            outSize = ConvolutionUtils.getOutputSize(input, kernel, strides, pad, convolutionMode, dilation); //Also performs validation
+        }
+
+        long[] outShape = new long[]{input.size(0), input.size(1), outSize[0], outSize[1]};
+        INDArray output = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, input.dataType(), outShape);
+
+        Pooling2DConfig conf = Pooling2DConfig.builder()
+                .isSameMode(convolutionMode == ConvolutionMode.Same)
+                .kH(kernel[0]).kW(kernel[1])
+                .sH(strides[0]).sW(strides[1])
+                .dH(dilation[0]).dW(dilation[1])
+                .pH(pad[0]).pW(pad[1])
+                .isNHWC(false)
+                .build();
+
+        DynamicCustomOp op;
+        switch (poolingType){
+            case MAX:
+                conf.setType(Pooling2D.Pooling2DType.MAX);
+                op = MaxPooling2D.builder()
+                        .arrayInput(input)
+                        .arrayOutput(output)
+                        .config(conf)
+                        .build();
+                break;
+            case AVG:
+                conf.setType(Pooling2D.Pooling2DType.AVG);
+                op = AvgPooling2D.builder()
+                        .arrayInput(input)
+                        .arrayOutput(output)
+                        .config(conf)
+                        .build();
+                break;
+            case SUM:
+            case PNORM:
+            default:
+                return null;
+        }
+
+        Nd4j.getExecutioner().exec(op);
+        return output;
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        return Collections.emptyMap();
+    }
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
@@ -69,8 +69,10 @@ public class MKLDNNSubsamplingHelper implements SubsamplingHelper {
         switch (poolingType){
             case MAX:
                 conf.setType(Pooling2D.Pooling2DType.MAX);
+                break;
             case AVG:
                 conf.setType(Pooling2D.Pooling2DType.AVG);
+                break;
         }
 
         Pooling2DDerivative d = Pooling2DDerivative.derivativeBuilder()

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNSubsamplingHelper.java
@@ -37,6 +37,11 @@ import org.nd4j.linalg.primitives.Pair;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * MKL-DNN Subsampling (2d) helper
+ *
+ * @author Alex Black
+ */
 public class MKLDNNSubsamplingHelper implements SubsamplingHelper {
     @Override
     public boolean checkSupported() {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -78,9 +78,6 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
                 helper = Class.forName("org.deeplearning4j.nn.layers.normalization.CudnnBatchNormalizationHelper")
                         .asSubclass(BatchNormalizationHelper.class).newInstance();
                 log.debug("CudnnBatchNormalizationHelper successfully initialized");
-                if (!helper.checkSupported(layerConf().getEps())) {
-                    helper = null;
-                }
             } catch (Throwable t) {
                 if (!(t instanceof ClassNotFoundException)) {
                     log.warn("Could not initialize CudnnBatchNormalizationHelper", t);
@@ -92,7 +89,11 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
             }
         } else if("CPU".equalsIgnoreCase(backend)){
             helper = new MKLDNNBatchNormHelper();
-            log.info("Created MKLDNNBatchNormHelper");
+            log.debug("Created MKLDNNBatchNormHelper");
+        }
+        if (helper != null && !helper.checkSupported(layerConf().getEps())) {
+            log.debug("Removed helper {} as not supported with epsilon {}", helper.getClass(), layerConf().getEps());
+            helper = null;
         }
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -89,7 +89,7 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
             }
         } else if("CPU".equalsIgnoreCase(backend)){
             helper = new MKLDNNBatchNormHelper();
-            log.debug("Created MKLDNNBatchNormHelper");
+            log.debug("Created MKLDNNBatchNormHelper, layer {}", layerConf().getLayerName());
         }
         if (helper != null && !helper.checkSupported(layerConf().getEps(), layerConf().isLockGammaBeta())) {
             log.debug("Removed helper {} as not supported with epsilon {}, lockGammaBeta={}", helper.getClass(), layerConf().getEps(), layerConf().isLockGammaBeta());

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalizationHelper.java
@@ -28,7 +28,7 @@ import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
  * @author saudet
  */
 public interface BatchNormalizationHelper extends LayerHelper {
-    boolean checkSupported(double eps);
+    boolean checkSupported(double eps, boolean fixedGammaBeta);
 
     Pair<Gradient, INDArray> backpropGradient(INDArray input, INDArray epsilon, int[] shape, INDArray gamma,
                     INDArray dGammaView, INDArray dBetaView, double eps, LayerWorkspaceMgr workspaceMgr);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
@@ -104,10 +104,13 @@ public class LocalResponseNormalization
                             + "For more information, please refer to: https://deeplearning4j.org/docs/latest/deeplearning4j-config-cudnn", t);
                 }
             }
-        } else if("CPU".equalsIgnoreCase(backend)){
+        }
+        /*
+        //2019-02-14 AB - MKL-DNN helper disabled: LRN backprop is broken: https://github.com/deeplearning4j/deeplearning4j/issues/6958 issue 20
+        else if("CPU".equalsIgnoreCase(backend)){
             helper = new MKLDNNLocalResponseNormalizationHelper();
             log.debug("Created MKLDNNLocalResponseNormalizationHelper");
-        }
+        }*/
         if (helper != null && !helper.checkSupported(layerConf().getK(), layerConf().getN(), layerConf().getAlpha(), layerConf().getBeta())) {
             log.debug("Removed helper {} as not supported (k={}, n={}, alpha={}, beta={})", helper.getClass(), layerConf().getK(), layerConf().getN(), layerConf().getAlpha(), layerConf().getBeta());
             helper = null;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
@@ -105,12 +105,11 @@ public class LocalResponseNormalization
                 }
             }
         }
-        /*
         //2019-02-14 AB - MKL-DNN helper disabled: LRN backprop is broken: https://github.com/deeplearning4j/deeplearning4j/issues/6958 issue 20
         else if("CPU".equalsIgnoreCase(backend)){
             helper = new MKLDNNLocalResponseNormalizationHelper();
             log.debug("Created MKLDNNLocalResponseNormalizationHelper");
-        }*/
+        }
         if (helper != null && !helper.checkSupported(layerConf().getK(), layerConf().getN(), layerConf().getAlpha(), layerConf().getBeta())) {
             log.debug("Removed helper {} as not supported (k={}, n={}, alpha={}, beta={})", helper.getClass(), layerConf().getK(), layerConf().getN(), layerConf().getAlpha(), layerConf().getBeta());
             helper = null;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
@@ -105,11 +105,11 @@ public class LocalResponseNormalization
                 }
             }
         }
-        //2019-02-14 AB - MKL-DNN helper disabled: LRN backprop is broken: https://github.com/deeplearning4j/deeplearning4j/issues/6958 issue 20
-        else if("CPU".equalsIgnoreCase(backend)){
-            helper = new MKLDNNLocalResponseNormalizationHelper();
-            log.debug("Created MKLDNNLocalResponseNormalizationHelper");
-        }
+        //2019-03-09 AB - MKL-DNN helper disabled: https://github.com/deeplearning4j/deeplearning4j/issues/7272
+//        else if("CPU".equalsIgnoreCase(backend)){
+//            helper = new MKLDNNLocalResponseNormalizationHelper();
+//            log.debug("Created MKLDNNLocalResponseNormalizationHelper");
+//        }
         if (helper != null && !helper.checkSupported(layerConf().getK(), layerConf().getN(), layerConf().getAlpha(), layerConf().getBeta())) {
             log.debug("Removed helper {} as not supported (k={}, n={}, alpha={}, beta={})", helper.getClass(), layerConf().getK(), layerConf().getN(), layerConf().getAlpha(), layerConf().getBeta());
             helper = null;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Conv2D.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/convolution/Conv2D.java
@@ -69,8 +69,10 @@ public class Conv2D extends DynamicCustomOp {
                                     INVALID_CONFIGURATION,
                                     config.getSH(), config.getPH(), config.getDW());
         addArgs();
-        sameDiff.putFunctionForId(this.getOwnName(), this);    //Normally called in DynamicCustomOp constructor, via setInstanceId - but sameDiff field is null at that point
-        sameDiff.addArgsFor(inputFunctions, this);
+        if(sameDiff != null) {
+            sameDiff.putFunctionForId(this.getOwnName(), this);    //Normally called in DynamicCustomOp constructor, via setInstanceId - but sameDiff field is null at that point
+            sameDiff.addArgsFor(inputFunctions, this);
+        }
     }
 
     protected void addArgs() {


### PR DESCRIPTION
Adds MKL-DNN support for DL4J layers.

MKL-DNN support for:
* Subsampling layer. Implemented and passing tests.
* ConvolutionLayer: Implemented and passing tests.
* Batch norm: forward pass only implemented (passing tests). No backprop on account of this: https://github.com/deeplearning4j/deeplearning4j/issues/7166

Note that conv3d is already using conv3dnew op, hence already supports MKL-DNN by default.

Previous performance issues with MKL-DNN have been resolved.

LRN is implemented but is disabled on account of this: https://github.com/deeplearning4j/deeplearning4j/issues/7272

LSTM is not implemneted here - we don't yet have MKL-DNN support at libnd4j blockLSTM op (or similar) level.