### PR TITLE
libnd4j: Add reorder operations to MKL-DNN streams

### DIFF
--- a/libnd4j/include/helpers/MKLDNNStream.h
+++ b/libnd4j/include/helpers/MKLDNNStream.h
@@ -40,7 +40,7 @@ namespace nd4j {
 
         mkldnn::engine _engine = mkldnn::engine(mkldnn::engine::cpu, 0);
         std::vector<mkldnn::memory> _memory;
-        mkldnn::primitive _operation;
+        std::vector<mkldnn::primitive> _operations;
 
     public:
         template <typename X, typename Y>
@@ -66,7 +66,7 @@ namespace nd4j {
                 _outputs = outputs;
                 _floatArguments = floatArguments;
                 _intArguments = intArguments;
-                _operation.reset(nullptr);
+                _operations.clear();
                 _memory.clear();
                 return true;
             }
@@ -78,15 +78,17 @@ namespace nd4j {
 
         const std::vector<mkldnn::memory> &getMemory() { return _memory; }
         void setMemory(const std::vector<mkldnn::memory> &memory) { _memory = memory; }
+        void addMemory(const mkldnn::memory &memory) { _memory.push_back(memory); }
 
-        const mkldnn::primitive &getOperation() { return _operation; }
-        void setOperation(const mkldnn::primitive &operation) { _operation = operation; }
+        const std::vector<mkldnn::primitive> &getOperations() { return _operations; }
+        void setOperations(const std::vector<mkldnn::primitive> &operations) { _operations = operations; }
+        void addOperation(const mkldnn::primitive &operation) { _operations.push_back(operation); }
 
         bool submitAndWait(mkldnn::stream::kind kind = mkldnn::stream::kind::eager) {
             nd4j_debug("Executing %s with MKL-DNN\n", _opName.c_str());
             // need to create a new one because already executed streams become unusable
             mkldnn::stream stream(kind);
-            return stream.submit({_operation}).wait();
+            return stream.submit(_operations).wait();
         }
     };
 }

--- a/libnd4j/include/ops/declarable/generic/convo/conv3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/conv3d.cpp
@@ -102,10 +102,10 @@ CUSTOM_OP_IMPL(conv3dnew, 2, 1, false, 0, 13) {
             if (bias != nullptr) {
                 auto conv_bias_memory = mkldnn::memory(conv_prim_desc.bias_primitive_desc(), bias->buffer());
                 streams[0].setMemory({conv_src_memory, conv_weights_memory, conv_bias_memory, conv_dst_memory});
-                streams[0].setOperation(convolution_forward(conv_prim_desc, conv_src_memory, conv_weights_memory, conv_bias_memory, conv_dst_memory));
+                streams[0].addOperation(convolution_forward(conv_prim_desc, conv_src_memory, conv_weights_memory, conv_bias_memory, conv_dst_memory));
             } else {
                 streams[0].setMemory({conv_src_memory, conv_weights_memory, conv_dst_memory});
-                streams[0].setOperation(convolution_forward(conv_prim_desc, conv_src_memory, conv_weights_memory, conv_dst_memory));
+                streams[0].addOperation(convolution_forward(conv_prim_desc, conv_src_memory, conv_weights_memory, conv_dst_memory));
             }
         }
 
@@ -310,10 +310,10 @@ CUSTOM_OP_IMPL(conv3dnew_bp, 3, 2, false, 0, 13) {
                 if (gradB != nullptr) {
                     auto convW_bias_memory = mkldnn::memory(convW_prim_desc.diff_bias_primitive_desc(), gradB->buffer());
                     streams[0].setMemory({convW_src_memory, convW_dst_memory, convW_weights_memory, convW_bias_memory});
-                    streams[0].setOperation(convolution_backward_weights(convW_prim_desc, convW_src_memory, convW_dst_memory, convW_weights_memory, convW_bias_memory));
+                    streams[0].addOperation(convolution_backward_weights(convW_prim_desc, convW_src_memory, convW_dst_memory, convW_weights_memory, convW_bias_memory));
                 } else {
                     streams[0].setMemory({convW_src_memory, convW_dst_memory, convW_weights_memory});
-                    streams[0].setOperation(convolution_backward_weights(convW_prim_desc, convW_src_memory, convW_dst_memory, convW_weights_memory));
+                    streams[0].addOperation(convolution_backward_weights(convW_prim_desc, convW_src_memory, convW_dst_memory, convW_weights_memory));
                 }
             }
 
@@ -328,7 +328,7 @@ CUSTOM_OP_IMPL(conv3dnew_bp, 3, 2, false, 0, 13) {
                 auto convI_weights_memory = mkldnn::memory(convI_prim_desc.weights_primitive_desc(), weights->buffer());
                 auto convI_dst_memory = mkldnn::memory(convI_prim_desc.diff_dst_primitive_desc(), gradO->buffer());
                 streams[1].setMemory({convI_dst_memory, convI_weights_memory, convI_src_memory});
-                streams[1].setOperation(convolution_backward_data(convI_prim_desc, convI_dst_memory, convI_weights_memory, convI_src_memory));
+                streams[1].addOperation(convolution_backward_data(convI_prim_desc, convI_dst_memory, convI_weights_memory, convI_src_memory));
             }
         }
 

--- a/libnd4j/include/ops/declarable/generic/convo/conv3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/convo/conv3d.cpp
@@ -80,11 +80,13 @@ CUSTOM_OP_IMPL(conv3dnew, 2, 1, false, 0, 13) {
         if (streams[0].checkAndReset({input, weights, bias}, {output}, {}, {kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, isSameMode, isNCDHW})) {
             mkldnn_memory_desc_t empty;
             mkldnn::memory::desc conv_src_md(empty), conv_weights_md(empty), conv_bias_md(empty), conv_dst_md(empty);
+            mkldnn::memory::desc user_src_md(empty), user_weights_md(empty), user_bias_md(empty), user_dst_md(empty);
             mkldnn::memory::dims conv_strides, conv_padding, conv_padding_r;
 
             ConvolutionUtils::getMKLDNNMemoryDescConv3d(kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, isSameMode, isNCDHW,
                     bS, iC, iD, iH, iW, oC, oD, oH, oW, input, nullptr, weights, nullptr, bias, output,
                     &conv_src_md, nullptr, &conv_weights_md, nullptr, &conv_bias_md, &conv_dst_md,
+                    &user_src_md, nullptr, &user_weights_md, nullptr, &user_bias_md, &user_dst_md,
                     conv_strides, conv_padding, conv_padding_r);
 
             auto conv_desc = bias != nullptr
@@ -95,17 +97,49 @@ CUSTOM_OP_IMPL(conv3dnew, 2, 1, false, 0, 13) {
                             convolution_direct, conv_src_md, conv_weights_md,
                             conv_dst_md, conv_strides, conv_padding, conv_padding_r, padding_kind::zero);
 
-            auto conv_prim_desc = convolution_forward::primitive_desc(conv_desc, streams[0].getEngine());
-            auto conv_src_memory = mkldnn::memory(conv_prim_desc.src_primitive_desc(), input->buffer());
-            auto conv_weights_memory = mkldnn::memory(conv_prim_desc.weights_primitive_desc(), weights->buffer());
-            auto conv_dst_memory = mkldnn::memory(conv_prim_desc.dst_primitive_desc(), output->buffer());
+            auto engine = streams[0].getEngine();
+            auto conv_prim_desc = convolution_forward::primitive_desc(conv_desc, engine);
+            auto user_src_memory = mkldnn::memory({user_src_md, engine}, const_cast<NDArray*>(input)->buffer());
+            auto user_weights_memory = mkldnn::memory({user_weights_md, engine}, const_cast<NDArray*>(weights)->buffer());
+            auto user_dst_memory = mkldnn::memory({user_dst_md, engine}, output->buffer());
+
+            auto conv_src_memory = user_src_memory;
+            streams[0].addMemory(user_src_memory);
+            if (mkldnn::memory::primitive_desc(conv_prim_desc.src_primitive_desc())
+                    != user_src_memory.get_primitive_desc()) {
+                conv_src_memory = mkldnn::memory(conv_prim_desc.src_primitive_desc());
+                streams[0].addMemory(conv_src_memory);
+                streams[0].addOperation(reorder(user_src_memory, conv_src_memory));
+            }
+
+            auto conv_weights_memory = user_weights_memory;
+            streams[0].addMemory(user_weights_memory);
+            if (mkldnn::memory::primitive_desc(conv_prim_desc.weights_primitive_desc())
+                    != user_weights_memory.get_primitive_desc()) {
+                conv_weights_memory = mkldnn::memory(conv_prim_desc.weights_primitive_desc());
+                streams[0].addMemory(conv_weights_memory);
+                streams[0].addOperation(reorder(user_weights_memory, conv_weights_memory));
+            }
+
+            auto conv_dst_memory = user_dst_memory;
+            streams[0].addMemory(user_dst_memory);
+            if (mkldnn::memory::primitive_desc(conv_prim_desc.dst_primitive_desc())
+                    != user_dst_memory.get_primitive_desc()) {
+                conv_dst_memory = mkldnn::memory(conv_prim_desc.dst_primitive_desc());
+                streams[0].addMemory(conv_dst_memory);
+            }
+
             if (bias != nullptr) {
                 auto conv_bias_memory = mkldnn::memory(conv_prim_desc.bias_primitive_desc(), bias->buffer());
-                streams[0].setMemory({conv_src_memory, conv_weights_memory, conv_bias_memory, conv_dst_memory});
+                streams[0].addMemory(conv_bias_memory);
                 streams[0].addOperation(convolution_forward(conv_prim_desc, conv_src_memory, conv_weights_memory, conv_bias_memory, conv_dst_memory));
             } else {
-                streams[0].setMemory({conv_src_memory, conv_weights_memory, conv_dst_memory});
                 streams[0].addOperation(convolution_forward(conv_prim_desc, conv_src_memory, conv_weights_memory, conv_dst_memory));
+            }
+
+            if (mkldnn::memory::primitive_desc(conv_prim_desc.dst_primitive_desc())
+                    != user_dst_memory.get_primitive_desc()) {
+                streams[0].addOperation(reorder(conv_dst_memory, user_dst_memory));
             }
         }
 
@@ -277,11 +311,14 @@ CUSTOM_OP_IMPL(conv3dnew_bp, 3, 2, false, 0, 13) {
             mkldnn_memory_desc_t empty;
             mkldnn::memory::desc conv_src_md(empty), conv_diff_src_md(empty), conv_weights_md(empty),
                                  conv_diff_weights_md(empty), conv_bias_md(empty), conv_dst_md(empty);
+            mkldnn::memory::desc user_src_md(empty), user_diff_src_md(empty), user_weights_md(empty),
+                                 user_diff_weights_md(empty), user_bias_md(empty), user_dst_md(empty);
             mkldnn::memory::dims conv_strides, conv_padding, conv_padding_r;
 
             ConvolutionUtils::getMKLDNNMemoryDescConv3d(kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, isSameMode, isNDHWC,
                     bS, iC, iD, iH, iW, oC, oD, oH, oW, input, gradI, weights, gradW, gradB, gradO,
                     &conv_src_md, &conv_diff_src_md, &conv_weights_md, &conv_diff_weights_md, &conv_bias_md, &conv_dst_md,
+                    &user_src_md, &user_diff_src_md, &user_weights_md, &user_diff_weights_md, &user_bias_md, &user_dst_md,
                     conv_strides, conv_padding, conv_padding_r);
 
             auto conv_desc = gradB != nullptr
@@ -303,17 +340,49 @@ CUSTOM_OP_IMPL(conv3dnew_bp, 3, 2, false, 0, 13) {
                                 convolution_direct, conv_src_md, conv_diff_weights_md,
                                 conv_dst_md, conv_strides, conv_padding, conv_padding_r, padding_kind::zero);
 
-                auto convW_prim_desc = convolution_backward_weights::primitive_desc(convW_desc, streams[0].getEngine(), conv_prim_desc);
-                auto convW_src_memory = mkldnn::memory(convW_prim_desc.src_primitive_desc(), input->buffer());
-                auto convW_weights_memory = mkldnn::memory(convW_prim_desc.diff_weights_primitive_desc(), gradW->buffer());
-                auto convW_dst_memory = mkldnn::memory(convW_prim_desc.diff_dst_primitive_desc(), gradO->buffer());
+                auto engine = streams[0].getEngine();
+                auto convW_prim_desc = convolution_backward_weights::primitive_desc(convW_desc, engine, conv_prim_desc);
+                auto userW_src_memory = mkldnn::memory({user_src_md, engine}, const_cast<NDArray*>(input)->buffer());
+                auto userW_weights_memory = mkldnn::memory({user_diff_weights_md, engine}, gradW->buffer());
+                auto userW_dst_memory = mkldnn::memory({user_dst_md, engine}, const_cast<NDArray*>(gradO)->buffer());
+
+                auto convW_src_memory = userW_src_memory;
+                streams[0].addMemory(userW_src_memory);
+                if (mkldnn::memory::primitive_desc(convW_prim_desc.src_primitive_desc())
+                        != userW_src_memory.get_primitive_desc()) {
+                    convW_src_memory = mkldnn::memory(convW_prim_desc.src_primitive_desc());
+                    streams[0].addMemory(convW_src_memory);
+                    streams[0].addOperation(reorder(userW_src_memory, convW_src_memory));
+                }
+
+                auto convW_weights_memory = userW_weights_memory;
+                streams[0].addMemory(userW_weights_memory);
+                if (mkldnn::memory::primitive_desc(convW_prim_desc.diff_weights_primitive_desc())
+                        != userW_weights_memory.get_primitive_desc()) {
+                    convW_weights_memory = mkldnn::memory(convW_prim_desc.diff_weights_primitive_desc());
+                    streams[0].addMemory(convW_weights_memory);
+                }
+
+                auto convW_dst_memory = userW_dst_memory;
+                streams[0].addMemory(userW_dst_memory);
+                if (mkldnn::memory::primitive_desc(convW_prim_desc.diff_dst_primitive_desc())
+                        != userW_dst_memory.get_primitive_desc()) {
+                    convW_dst_memory = mkldnn::memory(convW_prim_desc.diff_dst_primitive_desc());
+                    streams[0].addMemory(convW_dst_memory);
+                    streams[0].addOperation(reorder(userW_dst_memory, convW_dst_memory));
+                }
+
                 if (gradB != nullptr) {
                     auto convW_bias_memory = mkldnn::memory(convW_prim_desc.diff_bias_primitive_desc(), gradB->buffer());
-                    streams[0].setMemory({convW_src_memory, convW_dst_memory, convW_weights_memory, convW_bias_memory});
+                    streams[0].addMemory(convW_bias_memory);
                     streams[0].addOperation(convolution_backward_weights(convW_prim_desc, convW_src_memory, convW_dst_memory, convW_weights_memory, convW_bias_memory));
                 } else {
-                    streams[0].setMemory({convW_src_memory, convW_dst_memory, convW_weights_memory});
                     streams[0].addOperation(convolution_backward_weights(convW_prim_desc, convW_src_memory, convW_dst_memory, convW_weights_memory));
+                }
+
+                if (mkldnn::memory::primitive_desc(convW_prim_desc.diff_weights_primitive_desc())
+                        != userW_weights_memory.get_primitive_desc()) {
+                    streams[0].addOperation(reorder(convW_weights_memory, userW_weights_memory));
                 }
             }
 
@@ -323,12 +392,44 @@ CUSTOM_OP_IMPL(conv3dnew_bp, 3, 2, false, 0, 13) {
                                 convolution_direct, conv_diff_src_md, conv_weights_md,
                                 conv_dst_md, conv_strides, conv_padding, conv_padding_r, padding_kind::zero);
 
-                auto convI_prim_desc = convolution_backward_data::primitive_desc(convI_desc, streams[1].getEngine(), conv_prim_desc);
-                auto convI_src_memory = mkldnn::memory(convI_prim_desc.diff_src_primitive_desc(), gradI->buffer());
-                auto convI_weights_memory = mkldnn::memory(convI_prim_desc.weights_primitive_desc(), weights->buffer());
-                auto convI_dst_memory = mkldnn::memory(convI_prim_desc.diff_dst_primitive_desc(), gradO->buffer());
-                streams[1].setMemory({convI_dst_memory, convI_weights_memory, convI_src_memory});
+                auto engine = streams[1].getEngine();
+                auto convI_prim_desc = convolution_backward_data::primitive_desc(convI_desc, engine, conv_prim_desc);
+                auto userI_src_memory = mkldnn::memory({user_diff_src_md, engine}, gradI->buffer());
+                auto userI_weights_memory = mkldnn::memory({user_weights_md, engine}, const_cast<NDArray*>(weights)->buffer());
+                auto userI_dst_memory = mkldnn::memory({user_dst_md, engine}, const_cast<NDArray*>(gradO)->buffer());
+
+                auto convI_src_memory = userI_src_memory;
+                streams[1].addMemory(userI_src_memory);
+                if (mkldnn::memory::primitive_desc(convI_prim_desc.diff_src_primitive_desc())
+                        != userI_src_memory.get_primitive_desc()) {
+                    convI_src_memory = mkldnn::memory(convI_prim_desc.diff_src_primitive_desc());
+                    streams[1].addMemory(convI_src_memory);
+                }
+
+                auto convI_weights_memory = userI_weights_memory;
+                streams[1].addMemory(userI_weights_memory);
+                if (mkldnn::memory::primitive_desc(convI_prim_desc.weights_primitive_desc())
+                        != userI_weights_memory.get_primitive_desc()) {
+                    convI_weights_memory = mkldnn::memory(convI_prim_desc.weights_primitive_desc());
+                    streams[1].addMemory(convI_weights_memory);
+                    streams[1].addOperation(reorder(userI_weights_memory, convI_weights_memory));
+                }
+
+                auto convI_dst_memory = userI_dst_memory;
+                streams[1].addMemory(userI_dst_memory);
+                if (mkldnn::memory::primitive_desc(convI_prim_desc.diff_dst_primitive_desc())
+                        != userI_dst_memory.get_primitive_desc()) {
+                    convI_dst_memory = mkldnn::memory(convI_prim_desc.diff_dst_primitive_desc());
+                    streams[1].addMemory(convI_dst_memory);
+                    streams[1].addOperation(reorder(userI_dst_memory, convI_dst_memory));
+                }
+
                 streams[1].addOperation(convolution_backward_data(convI_prim_desc, convI_dst_memory, convI_weights_memory, convI_src_memory));
+
+                if (mkldnn::memory::primitive_desc(convI_prim_desc.diff_src_primitive_desc())
+                        != userI_src_memory.get_primitive_desc()) {
+                    streams[1].addOperation(reorder(convI_src_memory, userI_src_memory));
+                }
             }
         }
 

--- a/libnd4j/include/ops/declarable/generic/helpers/convolutions.h
+++ b/libnd4j/include/ops/declarable/generic/helpers/convolutions.h
@@ -71,6 +71,8 @@ namespace nd4j {
                     const NDArray* weights, const NDArray* diff_weights, const NDArray* bias, const NDArray* dst,
                     mkldnn::memory::desc* conv_src_md, mkldnn::memory::desc* conv_diff_src_md, mkldnn::memory::desc* conv_weights_md,
                     mkldnn::memory::desc* conv_diff_weights_md, mkldnn::memory::desc* conv_bias_md, mkldnn::memory::desc* conv_dst_md,
+                    mkldnn::memory::desc* user_src_md, mkldnn::memory::desc* user_diff_src_md, mkldnn::memory::desc* user_weights_md,
+                    mkldnn::memory::desc* user_diff_weights_md, mkldnn::memory::desc* user_bias_md, mkldnn::memory::desc* user_dst_md,
                     mkldnn::memory::dims& conv_strides, mkldnn::memory::dims& conv_padding, mkldnn::memory::dims& conv_padding_r);
 #endif
             static void conv2d(nd4j::graph::Context& block, const NDArray* input, const NDArray* weights, const NDArray* bias, NDArray* output, const int kH, const int kW, const int sH, const int sW, int pH, int pW, const int dH, const int dW, const int isSameMode, const int isNCHW);
@@ -95,15 +97,17 @@ namespace nd4j {
             static void getMKLDNNMemoryDescPool2d(
                     int kH, int kW, int sH, int sW, int pH, int pW, int dH, int dW, int poolingMode, int extraParam0, bool isNCHW,
                     int bS, int iC, int iH, int iW, int oC, int oH, int oW,
-                    const NDArray* src, const NDArray* diff_src, const NDArray* dst,
-                    mkldnn::memory::desc* pool_src_md, mkldnn::memory::desc* conv_diff_src_md, mkldnn::memory::desc* pool_dst_md, mkldnn::algorithm& algorithm,
+                    const NDArray* src, const NDArray* diff_src, const NDArray* dst, mkldnn::algorithm& algorithm,
+                    mkldnn::memory::desc* pool_src_md, mkldnn::memory::desc* pool_diff_src_md, mkldnn::memory::desc* pool_dst_md,
+                    mkldnn::memory::desc* user_src_md, mkldnn::memory::desc* user_diff_src_md, mkldnn::memory::desc* user_dst_md,
                     mkldnn::memory::dims& pool_strides, mkldnn::memory::dims& pool_kernel, mkldnn::memory::dims& pool_padding, mkldnn::memory::dims& pool_padding_r);
 
             static void getMKLDNNMemoryDescPool3d(
                     int kD, int kH, int kW, int sD, int sH, int sW, int pD, int pH, int pW, int dD, int dH, int dW, int poolingMode, int extraParam0, bool isNCDHW,
                     int bS, int iC, int iD, int iH, int iW, int oC, int oD, int oH, int oW,
-                    const NDArray* src, const NDArray* diff_src, const NDArray* dst,
-                    mkldnn::memory::desc* pool_src_md, mkldnn::memory::desc* conv_diff_src_md, mkldnn::memory::desc* pool_dst_md, mkldnn::algorithm& algorithm,
+                    const NDArray* src, const NDArray* diff_src, const NDArray* dst, mkldnn::algorithm& algorithm,
+                    mkldnn::memory::desc* pool_src_md, mkldnn::memory::desc* pool_diff_src_md, mkldnn::memory::desc* pool_dst_md,
+                    mkldnn::memory::desc* user_src_md, mkldnn::memory::desc* user_diff_src_md, mkldnn::memory::desc* user_dst_md,
                     mkldnn::memory::dims& pool_strides, mkldnn::memory::dims& pool_kernel, mkldnn::memory::dims& pool_padding, mkldnn::memory::dims& pool_padding_r);
 #endif
             static void upsampling2d(const NDArray& input, NDArray& output, const int factorH, const int factorW, const bool isNCHW);

--- a/libnd4j/include/ops/declarable/generic/helpers/convolutions.h
+++ b/libnd4j/include/ops/declarable/generic/helpers/convolutions.h
@@ -61,6 +61,8 @@ namespace nd4j {
                     const NDArray* weights, const NDArray* diff_weights, const NDArray* bias, const NDArray* dst,
                     mkldnn::memory::desc* conv_src_md, mkldnn::memory::desc* conv_diff_src_md, mkldnn::memory::desc* conv_weights_md,
                     mkldnn::memory::desc* conv_diff_weights_md, mkldnn::memory::desc* conv_bias_md, mkldnn::memory::desc* conv_dst_md,
+                    mkldnn::memory::desc* user_src_md, mkldnn::memory::desc* user_diff_src_md, mkldnn::memory::desc* user_weights_md,
+                    mkldnn::memory::desc* user_diff_weights_md, mkldnn::memory::desc* user_bias_md, mkldnn::memory::desc* user_dst_md,
                     mkldnn::memory::dims& conv_strides, mkldnn::memory::dims& conv_padding, mkldnn::memory::dims& conv_padding_r);
 
             static void getMKLDNNMemoryDescConv3d(

--- a/libnd4j/include/ops/declarable/generic/nn/batchnorm.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/batchnorm.cpp
@@ -225,11 +225,11 @@ CUSTOM_OP_IMPL(batchnorm_new, 3, 1, false, 1, 2) {
             if (applyScale || applyOffset) {
                 auto batchnorm_weights_memory = mkldnn::memory(batchnorm_prim_desc.weights_primitive_desc(), weights.buffer());
                 streams[0].setMemory({batchnorm_src_memory, batchnorm_mean_memory, batchnorm_variance_memory, batchnorm_weights_memory, batchnorm_dst_memory});
-                streams[0].setOperation(batch_normalization_forward(batchnorm_prim_desc, (mkldnn::primitive::at)batchnorm_src_memory,
+                streams[0].addOperation(batch_normalization_forward(batchnorm_prim_desc, (mkldnn::primitive::at)batchnorm_src_memory,
                         (mkldnn::primitive::at)batchnorm_mean_memory, (mkldnn::primitive::at)batchnorm_variance_memory, (mkldnn::primitive::at)batchnorm_weights_memory, batchnorm_dst_memory));
             } else {
                 streams[0].setMemory({batchnorm_src_memory, batchnorm_mean_memory, batchnorm_variance_memory, batchnorm_dst_memory});
-                streams[0].setOperation(batch_normalization_forward(batchnorm_prim_desc, (mkldnn::primitive::at)batchnorm_src_memory,
+                streams[0].addOperation(batch_normalization_forward(batchnorm_prim_desc, (mkldnn::primitive::at)batchnorm_src_memory,
                         (mkldnn::primitive::at)batchnorm_mean_memory, (mkldnn::primitive::at)batchnorm_variance_memory, batchnorm_dst_memory));
             }
         }

--- a/libnd4j/include/ops/declarable/generic/nn/batchnorm.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/batchnorm.cpp
@@ -32,7 +32,8 @@ namespace ops {
 using namespace mkldnn;
 
 static void getMKLDNNMemoryDescBatchNorm(const NDArray* src, const NDArray* diff_src,
-        mkldnn::memory::desc* batchnorm_src_md, mkldnn::memory::desc* batchnorm_diff_src_md, int axis) {
+        mkldnn::memory::desc* batchnorm_src_md, mkldnn::memory::desc* batchnorm_diff_src_md,
+        mkldnn::memory::desc* user_src_md, mkldnn::memory::desc* user_diff_src_md,int axis) {
     const Nd4jLong* shape = src->getShapeInfo();
     Nd4jLong rank = shape[0];
     Nd4jLong dim1 = axis; // MKL-DNN supports only 1 axis, which has to be the "channel" one
@@ -42,23 +43,26 @@ static void getMKLDNNMemoryDescBatchNorm(const NDArray* src, const NDArray* diff
 
     auto type = mkldnn::memory::data_type::f32;
     auto format = mkldnn::memory::format::nchw;
+    auto supposed_to_be_any_format = mkldnn::memory::format::nChw8c; // doesn't work with "any"
 
     if (src != nullptr && src->getBuffer() != nullptr && batchnorm_src_md != nullptr) {
-        *batchnorm_src_md = mkldnn::memory::desc({ batchnorm_src_tz }, type, format);
-        batchnorm_src_md->data.format = mkldnn_blocked; // overrides format
-        batchnorm_src_md->data.layout_desc.blocking.strides[0][0] = src->stridesOf()[0];
-        batchnorm_src_md->data.layout_desc.blocking.strides[0][1] = src->stridesOf()[dim1];
-        batchnorm_src_md->data.layout_desc.blocking.strides[0][2] = rank > 2 ? src->stridesOf()[dim2] : 1;
-        batchnorm_src_md->data.layout_desc.blocking.strides[0][3] = rank > 3 ? src->stridesOf()[dim3] : 1;
+        *batchnorm_src_md = mkldnn::memory::desc({ batchnorm_src_tz }, type, supposed_to_be_any_format);
+        *user_src_md = mkldnn::memory::desc({ batchnorm_src_tz }, type, format);
+        user_src_md->data.format = mkldnn_blocked; // overrides format
+        user_src_md->data.layout_desc.blocking.strides[0][0] = src->stridesOf()[0];
+        user_src_md->data.layout_desc.blocking.strides[0][1] = src->stridesOf()[dim1];
+        user_src_md->data.layout_desc.blocking.strides[0][2] = rank > 2 ? src->stridesOf()[dim2] : 1;
+        user_src_md->data.layout_desc.blocking.strides[0][3] = rank > 3 ? src->stridesOf()[dim3] : 1;
     }
 
     if (diff_src != nullptr && diff_src->getBuffer() != nullptr && batchnorm_diff_src_md != nullptr) {
-        *batchnorm_diff_src_md = mkldnn::memory::desc({ batchnorm_src_tz }, type, format);
-        batchnorm_diff_src_md->data.format = mkldnn_blocked; // overrides format
-        batchnorm_diff_src_md->data.layout_desc.blocking.strides[0][0] = diff_src->stridesOf()[0];
-        batchnorm_diff_src_md->data.layout_desc.blocking.strides[0][1] = diff_src->stridesOf()[dim1];
-        batchnorm_diff_src_md->data.layout_desc.blocking.strides[0][2] = rank > 2 ? diff_src->stridesOf()[dim2] : 1;
-        batchnorm_diff_src_md->data.layout_desc.blocking.strides[0][3] = rank > 3 ? diff_src->stridesOf()[dim3] : 1;
+        *batchnorm_diff_src_md = mkldnn::memory::desc({ batchnorm_src_tz }, type, supposed_to_be_any_format);
+        *user_diff_src_md = mkldnn::memory::desc({ batchnorm_src_tz }, type, format);
+        user_diff_src_md->data.format = mkldnn_blocked; // overrides format
+        user_diff_src_md->data.layout_desc.blocking.strides[0][0] = diff_src->stridesOf()[0];
+        user_diff_src_md->data.layout_desc.blocking.strides[0][1] = diff_src->stridesOf()[dim1];
+        user_diff_src_md->data.layout_desc.blocking.strides[0][2] = rank > 2 ? diff_src->stridesOf()[dim2] : 1;
+        user_diff_src_md->data.layout_desc.blocking.strides[0][3] = rank > 3 ? diff_src->stridesOf()[dim3] : 1;
     }
 }
 #endif
@@ -196,7 +200,7 @@ CUSTOM_OP_IMPL(batchnorm_new, 3, 1, false, 1, 2) {
     for(int i = 1; i < block.width(); ++i)
         REQUIRE_TRUE(INPUT_VARIABLE(0)->dataType() == INPUT_VARIABLE(i)->dataType(), 0, "BATCHNORM_NEW op: types of all input arrays should be the same !");
 
-#ifdef HAVE_MKLDNN    
+#ifdef HAVE_MKLDNN
     if (block.isUseMKLDNN() && nd4j::MKLDNNStream::isSupported({input, mean, variance, gamma, beta, output}) && numOfAxes == 1) {
         std::vector<nd4j::MKLDNNStream>& streams = block.getMKLDNNStreams();
         if (streams.empty()) {
@@ -210,27 +214,53 @@ CUSTOM_OP_IMPL(batchnorm_new, 3, 1, false, 1, 2) {
 
         if (streams[0].checkAndReset({input, mean, variance, gamma, beta}, {output}, {epsilon}, axes)) {
             mkldnn_memory_desc_t empty;
-            mkldnn::memory::desc batchnorm_src_md(empty);
+            mkldnn::memory::desc batchnorm_src_md(empty), user_src_md(empty);
 
-            getMKLDNNMemoryDescBatchNorm(input, nullptr, &batchnorm_src_md, nullptr, axes[0]);
+            getMKLDNNMemoryDescBatchNorm(input, nullptr, &batchnorm_src_md, nullptr, &user_src_md, nullptr, axes[0]);
 
             auto batchnorm_desc = batch_normalization_forward::desc(prop_kind::forward_inference, batchnorm_src_md, epsilon,
                             use_global_stats | (applyScale || applyOffset ? use_scale_shift : 0));
 
-            auto batchnorm_prim_desc = batch_normalization_forward::primitive_desc(batchnorm_desc, streams[0].getEngine());
-            auto batchnorm_src_memory = mkldnn::memory(mkldnn::memory::primitive_desc(batchnorm_src_md, streams[0].getEngine()), input->buffer());
-            auto batchnorm_dst_memory = mkldnn::memory(batchnorm_prim_desc.dst_primitive_desc(), output->buffer());
+            auto engine = streams[0].getEngine();
+            auto batchnorm_prim_desc = batch_normalization_forward::primitive_desc(batchnorm_desc, engine);
+            auto user_src_memory = mkldnn::memory({user_src_md, engine}, input->buffer());
+            auto user_dst_memory = mkldnn::memory({user_src_md, engine}, output->buffer());
             auto batchnorm_mean_memory = mkldnn::memory(batchnorm_prim_desc.mean_primitive_desc(), mean->buffer());
             auto batchnorm_variance_memory = mkldnn::memory(batchnorm_prim_desc.variance_primitive_desc(), variance->buffer());
+
+            auto batchnorm_src_memory = user_src_memory;
+            streams[0].addMemory(user_src_memory);
+            if (mkldnn::memory::primitive_desc(batchnorm_prim_desc.src_primitive_desc())
+                    != user_src_memory.get_primitive_desc()) {
+                batchnorm_src_memory = mkldnn::memory(batchnorm_prim_desc.src_primitive_desc());
+                streams[0].addMemory(batchnorm_src_memory);
+                streams[0].addOperation(reorder(user_src_memory, batchnorm_src_memory));
+            }
+
+            auto batchnorm_dst_memory = user_dst_memory;
+            streams[0].addMemory(user_dst_memory);
+            if (mkldnn::memory::primitive_desc(batchnorm_prim_desc.dst_primitive_desc())
+                    != user_dst_memory.get_primitive_desc()) {
+                batchnorm_dst_memory = mkldnn::memory(batchnorm_prim_desc.dst_primitive_desc());
+                streams[0].addMemory(batchnorm_dst_memory);
+            }
+
+            streams[0].addMemory(batchnorm_mean_memory);
+            streams[0].addMemory(batchnorm_variance_memory);
+
             if (applyScale || applyOffset) {
                 auto batchnorm_weights_memory = mkldnn::memory(batchnorm_prim_desc.weights_primitive_desc(), weights.buffer());
-                streams[0].setMemory({batchnorm_src_memory, batchnorm_mean_memory, batchnorm_variance_memory, batchnorm_weights_memory, batchnorm_dst_memory});
+                streams[0].addMemory(batchnorm_weights_memory);
                 streams[0].addOperation(batch_normalization_forward(batchnorm_prim_desc, (mkldnn::primitive::at)batchnorm_src_memory,
                         (mkldnn::primitive::at)batchnorm_mean_memory, (mkldnn::primitive::at)batchnorm_variance_memory, (mkldnn::primitive::at)batchnorm_weights_memory, batchnorm_dst_memory));
             } else {
-                streams[0].setMemory({batchnorm_src_memory, batchnorm_mean_memory, batchnorm_variance_memory, batchnorm_dst_memory});
                 streams[0].addOperation(batch_normalization_forward(batchnorm_prim_desc, (mkldnn::primitive::at)batchnorm_src_memory,
                         (mkldnn::primitive::at)batchnorm_mean_memory, (mkldnn::primitive::at)batchnorm_variance_memory, batchnorm_dst_memory));
+            }
+
+            if (mkldnn::memory::primitive_desc(batchnorm_prim_desc.dst_primitive_desc())
+                    != user_dst_memory.get_primitive_desc()) {
+                streams[0].addOperation(reorder(batchnorm_dst_memory, user_dst_memory));
             }
         }
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/lrn.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/lrn.cpp
@@ -87,7 +87,7 @@ static void getMKLDNNMemoryDescLrn(const NDArray* src, const NDArray* diff_src,
             auto lrn_src_memory = mkldnn::memory(lrn_prim_desc.src_primitive_desc(), input->buffer());
             auto lrn_dst_memory = mkldnn::memory(lrn_prim_desc.dst_primitive_desc(), output->buffer());
             streams[0].setMemory({lrn_src_memory, lrn_dst_memory});
-            streams[0].setOperation(lrn_forward(lrn_prim_desc, lrn_src_memory, lrn_dst_memory));
+            streams[0].addOperation(lrn_forward(lrn_prim_desc, lrn_src_memory, lrn_dst_memory));
         }
 
         streams[0].submitAndWait();
@@ -189,7 +189,7 @@ static void getMKLDNNMemoryDescLrn(const NDArray* src, const NDArray* diff_src,
             auto lrn_src_memory = mkldnn::memory(lrn_prim_desc.src_primitive_desc(), input->buffer());
             auto lrn_dst_memory = mkldnn::memory(lrn_prim_desc.dst_primitive_desc(), output->buffer());
             streams[0].setMemory({lrn_src_memory, lrn_dst_memory});
-            streams[0].setOperation(lrn_forward(lrn_prim_desc, lrn_src_memory, lrn_dst_memory));
+            streams[0].addOperation(lrn_forward(lrn_prim_desc, lrn_src_memory, lrn_dst_memory));
         }
 
         streams[0].submitAndWait();
@@ -294,7 +294,7 @@ static void getMKLDNNMemoryDescLrn(const NDArray* src, const NDArray* diff_src,
             auto lrn_dst_memory = mkldnn::memory(lrn_back_prim_desc.diff_dst_primitive_desc(), scale->buffer());
             auto lrn_diff_src_memory = mkldnn::memory(lrn_back_prim_desc.diff_src_primitive_desc(), output->buffer());
             streams[0].setMemory({lrn_src_memory, lrn_dst_memory, lrn_diff_src_memory});
-            streams[0].setOperation(lrn_backward(lrn_back_prim_desc, lrn_src_memory, lrn_dst_memory, lrn_diff_src_memory));
+            streams[0].addOperation(lrn_backward(lrn_back_prim_desc, lrn_src_memory, lrn_dst_memory, lrn_diff_src_memory));
         }
 
         streams[0].submitAndWait();

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests10.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests10.cpp
@@ -2598,15 +2598,15 @@ TEST_F(DeclarableOpsTests10, FakeQuantWithMinMaxVars_Test_2) {
 }
 
 ////////////////////////////////////////////////////////////////////
-TEST_F(DeclarableOpsTests10, batchnorm_new_test1) {
+TYPED_TEST(TypedDeclarableOpsTests10, batchnorm_new_test1) {
 
-    auto input    = NDArrayFactory::create<double>('c', {2,3,4});
-    auto mean     = NDArrayFactory::create<double>('c', {4});
-    auto variance = NDArrayFactory::create<double>('c', {4});
-    auto gamma    = NDArrayFactory::create<double>('c', {4});
-    auto beta     = NDArrayFactory::create<double>('c', {4});
+    auto input    = NDArrayFactory::create<TypeParam>('c', {2,3,4});
+    auto mean     = NDArrayFactory::create<TypeParam>('c', {4});
+    auto variance = NDArrayFactory::create<TypeParam>('c', {4});
+    auto gamma    = NDArrayFactory::create<TypeParam>('c', {4});
+    auto beta     = NDArrayFactory::create<TypeParam>('c', {4});
 
-    auto expected = NDArrayFactory::create<double>('c', {2,3,4}, {-0.52733537,-0.35763144,-0.18792751,-0.01822358, 0.15148035, 0.32118428, 0.49088821, 0.66059214, 0.83029607, 1.        , 1.16970393, 1.33940786,
+    auto expected = NDArrayFactory::create<TypeParam>('c', {2,3,4}, {-0.52733537,-0.35763144,-0.18792751,-0.01822358, 0.15148035, 0.32118428, 0.49088821, 0.66059214, 0.83029607, 1.        , 1.16970393, 1.33940786,
                                             1.50911179, 1.67881572, 1.84851965, 2.01822358, 2.18792751, 2.35763144, 2.52733537, 2.6970393 , 2.86674323, 3.03644717, 3.2061511 , 3.37585503});
 
     input.linspace(0.1, 0.1);
@@ -2630,15 +2630,15 @@ TEST_F(DeclarableOpsTests10, batchnorm_new_test1) {
 }
 
 ////////////////////////////////////////////////////////////////////
-TEST_F(DeclarableOpsTests10, batchnorm_new_test2) {
+TYPED_TEST(TypedDeclarableOpsTests10, batchnorm_new_test2) {
 
-    auto input    = NDArrayFactory::create<double>('c', {2,3,4});
-    auto mean     = NDArrayFactory::create<double>('c', {3}, {1.05, 1.1, 1.15});
-    auto variance = NDArrayFactory::create<double>('c', {3}, {0.5, 0.6, 0.7});
-    auto gamma    = NDArrayFactory::create<double>('c', {3}, {1.2, 1.3, 1.4});
-    auto beta     = NDArrayFactory::create<double>('c', {3}, {0.1, 0.2, 0.3});
+    auto input    = NDArrayFactory::create<TypeParam>('c', {2,3,4});
+    auto mean     = NDArrayFactory::create<TypeParam>('c', {3}, {1.05, 1.1, 1.15});
+    auto variance = NDArrayFactory::create<TypeParam>('c', {3}, {0.5, 0.6, 0.7});
+    auto gamma    = NDArrayFactory::create<TypeParam>('c', {3}, {1.2, 1.3, 1.4});
+    auto beta     = NDArrayFactory::create<TypeParam>('c', {3}, {0.1, 0.2, 0.3});
 
-    auto expected = NDArrayFactory::create<double>('c', {2,3,4}, {-1.51218734,-1.34248341,-1.17277948,-1.00307555,-0.80696728,-0.6391394 ,-0.47131152,-0.30348364,-0.11832703, 0.04900378, 0.21633459, 0.38366541,
+    auto expected = NDArrayFactory::create<TypeParam>('c', {2,3,4}, {-1.51218734,-1.34248341,-1.17277948,-1.00307555,-0.80696728,-0.6391394 ,-0.47131152,-0.30348364,-0.11832703, 0.04900378, 0.21633459, 0.38366541,
                                             0.52425983, 0.69396376, 0.86366769, 1.03337162, 1.20696728, 1.37479516, 1.54262304, 1.71045092, 1.8896427 , 2.05697351, 2.22430432, 2.39163513,});
 
     input.linspace(0.1, 0.1);
@@ -2658,15 +2658,15 @@ TEST_F(DeclarableOpsTests10, batchnorm_new_test2) {
 }
 
 ////////////////////////////////////////////////////////////////////
-TEST_F(DeclarableOpsTests10, batchnorm_new_test3) {
+TYPED_TEST(TypedDeclarableOpsTests10, batchnorm_new_test3) {
 
-    auto input    = NDArrayFactory::create<double>('c', {2,3,4});
-    auto mean     = NDArrayFactory::create<double>('c', {2,1,4}, {1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4});
-    auto variance = NDArrayFactory::create<double>('c', {2,1,4}, {0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.1, 1.2});
-    auto gamma    = NDArrayFactory::create<double>('c', {2,1,4}, {1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9});
-    auto beta     = NDArrayFactory::create<double>('c', {2,1,4}, {0.1, 0.2, 0.3, 0.4, 0.5, 0.66, 0.7, 0.8});
+    auto input    = NDArrayFactory::create<TypeParam>('c', {2,3,4});
+    auto mean     = NDArrayFactory::create<TypeParam>('c', {2,1,4}, {1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4});
+    auto variance = NDArrayFactory::create<TypeParam>('c', {2,1,4}, {0.5, 0.6, 0.7, 0.8, 0.9, 1., 1.1, 1.2});
+    auto gamma    = NDArrayFactory::create<TypeParam>('c', {2,1,4}, {1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9});
+    auto beta     = NDArrayFactory::create<TypeParam>('c', {2,1,4}, {0.1, 0.2, 0.3, 0.4, 0.5, 0.66, 0.7, 0.8});
 
-    auto expected = NDArrayFactory::create<double>('c', {2,3,4}, {-1.51218734,-1.31045092,-1.12231189,-0.9416324 ,-0.83337162,-0.6391394 ,-0.45298865,-0.2708162 ,-0.1545559 , 0.03217212, 0.21633459, 0.4,
+    auto expected = NDArrayFactory::create<TypeParam>('c', {2,3,4}, {-1.51218734,-1.31045092,-1.12231189,-0.9416324 ,-0.83337162,-0.6391394 ,-0.45298865,-0.2708162 ,-0.1545559 , 0.03217212, 0.21633459, 0.4,
                                             0.58432694, 0.82999915, 0.95743373, 1.14688951, 1.25894242, 1.50999575, 1.64392367, 1.84066852, 1.93355791, 2.18999235, 2.33041362, 2.53444754});
 
     input.linspace(0.1, 0.1);


### PR DESCRIPTION
Fixes #7192

## What changes were proposed in this pull request?

We need to add reorder() operations manually to MKL-DNN streams or it falls back on reference implementations (non-JIT) of the other operations.

## How was this patch tested?

Unit tests of libnd4j pass and confirmed the improved performance with a few benchmarks.