### PR TITLE
libnd4j: Link with MKL-DNN or OpenBLAS when available for GEMM

### DIFF
--- a/libnd4j/include/helpers/impl/BlasHelper.cpp
+++ b/libnd4j/include/helpers/impl/BlasHelper.cpp
@@ -74,7 +74,7 @@ namespace nd4j {
 
     template <>
     bool BlasHelper::hasGEMV<float>() {
-#ifdef __EXTERNAL_BLAS__
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
         return true;
 #else
         return _hasSgemv;
@@ -83,7 +83,7 @@ namespace nd4j {
 
     template <>
     bool BlasHelper::hasGEMV<double>() {
-#ifdef __EXTERNAL_BLAS__
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
         return true;
 #else
     return _hasDgemv;
@@ -132,14 +132,14 @@ namespace nd4j {
 
     bool BlasHelper::hasGEMV(const nd4j::DataType dtype) const {
         if(dtype == DataType::FLOAT32) {
-            #ifdef __EXTERNAL_BLAS__
+            #if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
                 return true;
             #else
                 return _hasSgemv;
             #endif
         }
         if(dtype == DataType::DOUBLE) {
-            #ifdef __EXTERNAL_BLAS__
+            #if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
                 return true;
             #else
                 return _hasDgemv;
@@ -150,7 +150,7 @@ namespace nd4j {
 
     template <>
     bool BlasHelper::hasGEMM<float>() {
-#ifdef __EXTERNAL_BLAS__
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
         return true;
 #else
     return _hasSgemm;
@@ -159,7 +159,7 @@ namespace nd4j {
 
     template <>
     bool BlasHelper::hasGEMM<double>() {
-#ifdef __EXTERNAL_BLAS__
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
         return true;
 #else
     return _hasDgemm;
@@ -208,14 +208,14 @@ namespace nd4j {
 
     bool BlasHelper:: hasGEMM(const nd4j::DataType dtype) const {
         if(dtype == DataType::FLOAT32) {
-            #ifdef __EXTERNAL_BLAS__
+            #if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
                 return true;
             #else
                 return _hasSgemm;
             #endif
         }
         if(dtype == DataType::DOUBLE) {
-            #ifdef __EXTERNAL_BLAS__
+            #if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
                 return true;
             #else
                 return _hasDgemm;
@@ -275,31 +275,31 @@ namespace nd4j {
     }
 
     CblasSgemv BlasHelper::sgemv() {
-#ifdef __EXTERNAL_BLAS__
-        return &cblas_sgemv;
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
+        return (CblasSgemv)&cblas_sgemv;
 #else
         return this->cblasSgemv;
 #endif
     }
     CblasDgemv BlasHelper::dgemv() {
-#ifdef __EXTERNAL_BLAS__
-        return &cblas_dgemv;
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
+        return (CblasDgemv)&cblas_dgemv;
 #else
         return this->cblasDgemv;
 #endif
     }
 
     CblasSgemm BlasHelper::sgemm() {
-#ifdef __EXTERNAL_BLAS__
-        return &cblas_sgemm;
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
+        return (CblasSgemm)&cblas_sgemm;
 #else
         return this->cblasSgemm;
 #endif
     }
 
     CblasDgemm BlasHelper::dgemm() {
-#ifdef __EXTERNAL_BLAS__
-        return &cblas_dgemm;
+#if defined(__EXTERNAL_BLAS__) || defined(HAVE_MKLDNN) || defined(HAVE_OPENBLAS)
+        return (CblasDgemm)&cblas_dgemm;
 #else
         return this->cblasDgemm;
 #endif


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allows libnd4j to use BLAS from MKL-DNN or OpenBLAS on its own, without help from ND4J in Java.

## How was this patch tested?

All unit tests for libnd4j pass