### PR TITLE
Fix misused WeakHashMap in UI multisession I18N and TrainModule

### DIFF
--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/i18n/DefaultI18N.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/i18n/DefaultI18N.java
@@ -24,7 +24,11 @@ import org.deeplearning4j.ui.api.UIModule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Collections;
+import java.util.ServiceLoader;
 
 /**
  * Default internationalization implementation.<br>
@@ -50,9 +54,11 @@ public class DefaultI18N implements I18N {
     public static final String FALLBACK_LANGUAGE = "en"; //use this if the specified language doesn't have the requested message
 
     private static DefaultI18N instance;
-    private static Map<String, I18N> sessionInstances = Collections.synchronizedMap(new WeakHashMap<>());
+    private static Map<String, I18N> sessionInstances = Collections.synchronizedMap(new HashMap<>());
     private static Throwable languageLoadingException = null;
 
+
+    private String currentLanguage = DEFAULT_LANGUAGE;
     private Map<String, Map<String, String>> messagesByLanguage = new HashMap<>();
 
     /**
@@ -87,8 +93,6 @@ public class DefaultI18N implements I18N {
         return sessionInstances.remove(sessionId);
     }
 
-
-    private String currentLanguage = DEFAULT_LANGUAGE;
 
     private DefaultI18N() {
         loadLanguages();

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
@@ -57,7 +57,16 @@ import play.mvc.Results;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -88,7 +97,7 @@ public class TrainModule implements UIModule {
     }
 
     private final int maxChartPoints; //Technically, the way it's set up: won't exceed 2*maxChartPoints
-    private Map<String, StatsStorage> knownSessionIDs = Collections.synchronizedMap(new WeakHashMap<>());
+    private Map<String, StatsStorage> knownSessionIDs = Collections.synchronizedMap(new HashMap<>());
     private String currentSessionID;
     private int currentWorkerIdx;
     private Map<String, AtomicInteger> workerIdxCount = new ConcurrentHashMap<>(); //Key: session ID

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
@@ -309,7 +309,6 @@ public class TrainModule implements UIModule {
                         addressSupplier.get(), s, statsStorage);
             }
             lastUpdateForSession.remove(s);
-            I18NProvider.removeInstance(s);
         }
         getDefaultSession();
     }

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/PlayUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-play/src/main/java/org/deeplearning4j/ui/play/PlayUIServer.java
@@ -46,7 +46,6 @@ import org.deeplearning4j.ui.storage.InMemoryStatsStorage;
 import org.deeplearning4j.ui.storage.impl.QueueStatsStorageListener;
 import org.deeplearning4j.util.DL4JFileUtils;
 import org.nd4j.linalg.function.Function;
-import org.nd4j.linalg.function.Supplier;
 import org.nd4j.linalg.primitives.Pair;
 import play.Mode;
 import play.api.routing.Router;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This will fix #7335 i.e.: changing misused `WeakHashMap` to `HashMap` in `DefaultI18N` and `TrainModule`.

## How was this patch tested?

I have manually tested the solution by running TestPlayUIMultiSession.testUIAutoAttachDetach(), opening a session in the browser, changing language, and refreshing the page for 1 minute.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
