### PR TITLE
[ComputationGraph] Calculate topologicalOrder if its null when summary is called

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -4195,6 +4195,11 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
             maxLength[i] = header[i].length();
         }
 
+        if(topologicalOrder == null){
+            GraphIndices indices = calculateIndices();
+            topologicalOrder = indices.getTopologicalSortOrder();
+        }
+
         for (int currVertexIdx : topologicalOrder) {
 
             GraphVertex currentVertex = vertices[currVertexIdx];


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #7350.  If `summary()` is called before `init()` it will calculate `topologicalOrder()`.

## How was this patch tested?

N/A

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
- [x] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
