### PR TITLE
Invert stride in IntervalIndex.reverse()

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/IntervalIndex.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/IntervalIndex.java
@@ -89,6 +89,7 @@ public class IntervalIndex implements INDArrayIndex {
         long oldBegin = begin;
         this.end = oldBegin;
         this.begin = oldEnd;
+        this.stride = -stride;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Invert stride in IntervalIndex.reverse()

Fixes #7276

## How was this patch tested?

N/A