### PR TITLE
Add quotes to cd command in nd4j build script, necessary for windows dirs w/ spaces

### DIFF
--- a/libnd4j/buildnativeoperations.sh
+++ b/libnd4j/buildnativeoperations.sh
@@ -19,7 +19,7 @@ set -eu
 
 # cd to the directory containing this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $DIR
+cd "$DIR"
 
 export CMAKE_COMMAND="cmake"
 if which cmake3 &> /dev/null; then


### PR DESCRIPTION
Add quotes to cd command in nd4j `buildnativeoperations.sh` script.  Necessary for windows dirs w/ spaces.