### PR TITLE
[WIP] Fixed use deprecated method FileUtils.writeStringToFile 

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/transform/ui/HtmlAnalysis.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/transform/ui/HtmlAnalysis.java
@@ -40,6 +40,7 @@ import org.nd4j.shade.jackson.databind.SerializationFeature;
 import java.io.File;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -234,7 +235,7 @@ public class HtmlAnalysis {
 
         String str = createHtmlAnalysisString(dataAnalysis);
 
-        FileUtils.writeStringToFile(output, str);
+        FileUtils.writeStringToFile(output, str, StandardCharsets.UTF_8);
     }
 
 }

--- a/datavec/datavec-api/src/main/java/org/datavec/api/transform/ui/HtmlSequencePlotting.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/transform/ui/HtmlSequencePlotting.java
@@ -39,6 +39,7 @@ import org.nd4j.shade.jackson.databind.SerializationFeature;
 import java.io.File;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -206,6 +207,6 @@ public class HtmlSequencePlotting {
     public static void createHtmlSequencePlotFile(String title, Schema schema, List<List<Writable>> sequence,
                     File output) throws Exception {
         String s = createHtmlSequencePlots(title, schema, sequence);
-        FileUtils.writeStringToFile(output, s);
+        FileUtils.writeStringToFile(output, s, StandardCharsets.UTF_8);
     }
 }

--- a/datavec/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVLineSequenceRecordReaderTest.java
+++ b/datavec/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVLineSequenceRecordReaderTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +45,7 @@ public class CSVLineSequenceRecordReaderTest {
         File f = testDir.newFolder();
         File source = new File(f, "temp.csv");
         String str = "a,b,c\n1,2,3,4";
-        FileUtils.writeStringToFile(source, str);
+        FileUtils.writeStringToFile(source, str, StandardCharsets.UTF_8);
 
         SequenceRecordReader rr = new CSVLineSequenceRecordReader();
         rr.initialize(new FileSplit(source));

--- a/datavec/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVMultiSequenceRecordReaderTest.java
+++ b/datavec/datavec-api/src/test/java/org/datavec/api/records/reader/impl/CSVMultiSequenceRecordReaderTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,7 +51,7 @@ public class CSVMultiSequenceRecordReaderTest {
 
             String str = "a,b,c\n1,2,3,4\nx,y\n" + seqSep + "\nA,B,C";
             File f = testDir.newFile();
-            FileUtils.writeStringToFile(f, str);
+            FileUtils.writeStringToFile(f, str, StandardCharsets.UTF_8);
 
             SequenceRecordReader seqRR = new CSVMultiSequenceRecordReader(seqSepRegex, CSVMultiSequenceRecordReader.Mode.CONCAT);
             seqRR.initialize(new FileSplit(f));
@@ -104,7 +105,7 @@ public class CSVMultiSequenceRecordReaderTest {
 
             String str = "a,b\n1,2\nx,y\n" + seqSep + "\nA\nB\nC";
             File f = testDir.newFile();
-            FileUtils.writeStringToFile(f, str);
+            FileUtils.writeStringToFile(f, str, StandardCharsets.UTF_8);
 
             SequenceRecordReader seqRR = new CSVMultiSequenceRecordReader(seqSepRegex, CSVMultiSequenceRecordReader.Mode.EQUAL_LENGTH);
             seqRR.initialize(new FileSplit(f));
@@ -154,7 +155,7 @@ public class CSVMultiSequenceRecordReaderTest {
 
             String str = "a,b\n1\nx\n" + seqSep + "\nA\nB\nC";
             File f = testDir.newFile();
-            FileUtils.writeStringToFile(f, str);
+            FileUtils.writeStringToFile(f, str, StandardCharsets.UTF_8);
 
             SequenceRecordReader seqRR = new CSVMultiSequenceRecordReader(seqSepRegex, CSVMultiSequenceRecordReader.Mode.PAD, new Text("PAD"));
             seqRR.initialize(new FileSplit(f));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated use deprecated method 
from org.apache.commons.io.FileUtils#writeStringToFile(java.io.File, java.lang.String) 
to org.apache.commons.io.FileUtils#writeStringToFile(java.io.File, java.lang.String, java.nio.charset.Charset)

## How was this patch tested?

Ran all tests again.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
