### PR TITLE
Wait for all gradients to become available

### DIFF
--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
@@ -2862,7 +2862,7 @@ public class SameDiffTests {
         SDVariable t = sd.concat(2, outputSlices);
         t.norm2("out");
         String err = OpValidation.validate(new TestCase(sd)
-                .testFlatBufferSerialization(TestCase.TestSerialization.NONE)
+                .testFlatBufferSerialization(TestCase.TestSerialization.BOTH)
                 .expectedOutput("out", out)
                 .gradientCheck(true));
 


### PR DESCRIPTION
The current way of checking if the gradient for a variable is available will by satisfied if any one gradient for a variable is available. In a recurrent usage case, this may result in not all gradients being actually considered.

I've changed it to collect all the ways a gradient may come from, and then check if all of them have been differentiated yet before adding an op or variable to the list of available ops for differentiation. 

Orthogonal to the original issue of failing gradient checks, but also uncovered there, was the issue with serialization order. By making both SameDiff.ops and SameDiff.variables a LinkedHashMap, thereby preserving the order of insertion, the serialization checks now also pass. 

Fixes
https://github.com/deeplearning4j/deeplearning4j/issues/7346
https://github.com/deeplearning4j/deeplearning4j/issues/7354