### PR TITLE
[WIP] Fixed use deprecated method INDArray.lengthLong()

### DIFF
--- a/datavec/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
+++ b/datavec/datavec-data/datavec-data-image/src/main/java/org/datavec/image/loader/NativeImageLoader.java
@@ -368,7 +368,7 @@ public class NativeImageLoader extends BaseImageLoader {
         long cols = image.cols();
         long channels = image.channels();
 
-        if (ret.lengthLong() != rows * cols * channels) {
+        if (ret.length() != rows * cols * channels) {
             throw new ND4JIllegalStateException("INDArray provided to store image not equal to image: {channels: "
                             + channels + ", rows: " + rows + ", columns: " + cols + "}");
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -4503,8 +4503,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
         long prod = ArrayUtil.prodLong(shape);
 
-        if (prod != this.lengthLong()){
-            throw new ND4JIllegalStateException("New shape length doesn't match original length: [" + prod + "] vs [" + this.lengthLong() + "]. Original shape: "+Arrays.toString(this.shape())+" New Shape: "+Arrays.toString(newShape));
+        if (prod != this.length()){
+            throw new ND4JIllegalStateException("New shape length doesn't match original length: [" + prod + "] vs [" + this.length() + "]. Original shape: "+Arrays.toString(this.shape())+" New Shape: "+Arrays.toString(newShape));
         }
 
 
@@ -5981,7 +5981,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (Nd4j.getMemoryManager().getCurrentWorkspace() == null) {
             if (!isView()) {
                 Nd4j.getExecutioner().commit();
-                DataBuffer buffer = Nd4j.createBuffer(this.lengthLong(), false);
+                DataBuffer buffer = Nd4j.createBuffer(this.length(), false);
 
                 Nd4j.getMemoryManager().memcpy(buffer, this.data());
 
@@ -6000,7 +6000,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
             if (!isView()) {
                 Nd4j.getExecutioner().commit();
-                DataBuffer buffer = Nd4j.createBuffer(this.lengthLong(), false);
+                DataBuffer buffer = Nd4j.createBuffer(this.length(), false);
 
                 //Pointer.memcpy(buffer.pointer(), this.data.pointer(), this.lengthLong() * Nd4j.sizeOfDataType(this.data.dataType()));
                 Nd4j.getMemoryManager().memcpy(buffer, this.data());
@@ -6056,7 +6056,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             INDArray copy = null;
             if (!this.isView()) {
                 Nd4j.getExecutioner().commit();
-                DataBuffer buffer = Nd4j.createBuffer(this.lengthLong(), false);
+                DataBuffer buffer = Nd4j.createBuffer(this.length(), false);
                 Nd4j.getMemoryManager().memcpy(buffer, this.data());
 
                 copy = Nd4j.createArrayFromShapeBuffer(buffer, this.shapeInfoDataBuffer());
@@ -6122,7 +6122,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         INDArray copy = null;
         if (!this.isView()) {
             Nd4j.getExecutioner().commit();
-            DataBuffer buffer = Nd4j.createBuffer(this.dataType(), this.lengthLong(), false);
+            DataBuffer buffer = Nd4j.createBuffer(this.dataType(), this.length(), false);
             Nd4j.getMemoryManager().memcpy(buffer, this.data());
 
             copy = Nd4j.createArrayFromShapeBuffer(buffer, this.shapeInfoDataBuffer());
@@ -6199,7 +6199,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
         if (!this.isView()) {
             Nd4j.getExecutioner().commit();
-            DataBuffer buffer = Nd4j.createBuffer(this.lengthLong(), false);
+            DataBuffer buffer = Nd4j.createBuffer(this.length(), false);
             Nd4j.getMemoryManager().memcpy(buffer, this.data());
 
             copy = Nd4j.createArrayFromShapeBuffer(buffer, this.shapeInfoDataBuffer());

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
@@ -1668,7 +1668,7 @@ public abstract class BaseSparseNDArray implements ISparseNDArray {
 
         INDArray n = (INDArray) o;
 
-        if (this.lengthLong() != n.lengthLong())
+        if (this.length() != n.length())
             return false;
 
         if (isScalar() && n.isScalar()) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/ScatterUpdate.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/ScatterUpdate.java
@@ -59,7 +59,7 @@ public class ScatterUpdate implements CustomOp {
         for (val v: indices)
             iargs.add(v);
 
-        if (updates.tensorAlongDimension(0, dimension).lengthLong() != original.tensorAlongDimension(0, dimension).lengthLong())
+        if (updates.tensorAlongDimension(0, dimension).length() != original.tensorAlongDimension(0, dimension).length())
             throw new ND4JIllegalStateException("ScatterUpdate requires equal shaped tensors for operation along given dimension(s)");
 
         long numTensors = original.tensorsAlongDimension(dimension);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BernoulliDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BernoulliDistribution.java
@@ -71,9 +71,9 @@ public class BernoulliDistribution extends BaseRandomOp {
         if (prob.elementWiseStride() != 1)
             throw new ND4JIllegalStateException("Probabilities should have ElementWiseStride of 1");
 
-        if (prob.lengthLong() != z.lengthLong())
-            throw new ND4JIllegalStateException("Length of probabilities array [" + prob.lengthLong()
-                            + "] doesn't match length of output array [" + z.lengthLong() + "]");
+        if (prob.length() != z.length())
+            throw new ND4JIllegalStateException("Length of probabilities array [" + prob.length()
+                            + "] doesn't match length of output array [" + z.length() + "]");
         this.prob = 0.0;
         this.extraArgs = new Object[] {this.prob};
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistribution.java
@@ -71,7 +71,7 @@ public class BinomialDistribution extends BaseRandomOp {
      */
     public BinomialDistribution(@NonNull INDArray z, int trials, @NonNull INDArray probabilities) {
         super(z, probabilities, z);
-        if (trials > probabilities.lengthLong())
+        if (trials > probabilities.length())
             throw new IllegalStateException("Number of trials is > then amount of probabilities provided");
 
         if (probabilities.elementWiseStride() < 1)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistributionEx.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistributionEx.java
@@ -61,7 +61,7 @@ public class BinomialDistributionEx extends BaseRandomOp {
      */
     public BinomialDistributionEx(@NonNull INDArray z, int trials, @NonNull INDArray probabilities) {
         super(z, probabilities, z);
-        if (z.lengthLong() != probabilities.lengthLong())
+        if (z.length() != probabilities.length())
             throw new IllegalStateException("Length of probabilities array should match length of target array");
 
         if (probabilities.elementWiseStride() < 1)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/GaussianDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/GaussianDistribution.java
@@ -66,7 +66,7 @@ public class GaussianDistribution extends BaseRandomOp {
 
     public GaussianDistribution(@NonNull INDArray z, @NonNull INDArray means, double stddev) {
         super(z, means, z);
-        if (z.lengthLong() != means.lengthLong())
+        if (z.length() != means.length())
             throw new IllegalStateException("Result length should be equal to provided Means length");
 
         if (means.elementWiseStride() < 1)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/LogNormalDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/LogNormalDistribution.java
@@ -66,7 +66,7 @@ public class LogNormalDistribution extends BaseRandomOp {
 
     public LogNormalDistribution(@NonNull INDArray z, @NonNull INDArray means, double stddev) {
         super(z,means,z);
-        if (z.lengthLong() != means.lengthLong())
+        if (z.length() != means.length())
             throw new IllegalStateException("Result length should be equal to provided Means length");
 
         if (means.elementWiseStride() < 1)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/TruncatedNormalDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/TruncatedNormalDistribution.java
@@ -64,7 +64,7 @@ public class TruncatedNormalDistribution extends BaseRandomOp {
 
     public TruncatedNormalDistribution(@NonNull INDArray z, @NonNull INDArray means, double stddev) {
         super(z, means, z);
-        if (z.lengthLong() != means.lengthLong())
+        if (z.length() != means.length())
             throw new IllegalStateException("Result length should be equal to provided Means length");
 
         if (means.elementWiseStride() < 1)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -1317,10 +1317,10 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      */
     @Override
     public long getMemoryFootprint() {
-        long reqMem = features.lengthLong() * Nd4j.sizeOfDataType();
-        reqMem += labels == null ? 0 : labels.lengthLong() * Nd4j.sizeOfDataType();
-        reqMem += featuresMask == null ? 0 : featuresMask.lengthLong() * Nd4j.sizeOfDataType();
-        reqMem += labelsMask == null ? 0 : labelsMask.lengthLong() * Nd4j.sizeOfDataType();
+        long reqMem = features.length() * Nd4j.sizeOfDataType();
+        reqMem += labels == null ? 0 : labels.length() * Nd4j.sizeOfDataType();
+        reqMem += featuresMask == null ? 0 : featuresMask.length() * Nd4j.sizeOfDataType();
+        reqMem += labelsMask == null ? 0 : labelsMask.length() * Nd4j.sizeOfDataType();
 
         return reqMem;
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
@@ -604,19 +604,19 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
         long reqMem = 0;
 
         for (INDArray f : features)
-            reqMem += f == null ? 0 : f.lengthLong() * Nd4j.sizeOfDataType();
+            reqMem += f == null ? 0 : f.length() * Nd4j.sizeOfDataType();
 
         if (featuresMaskArrays != null)
             for (INDArray f : featuresMaskArrays)
-                reqMem += f == null ? 0 : f.lengthLong() * Nd4j.sizeOfDataType();
+                reqMem += f == null ? 0 : f.length() * Nd4j.sizeOfDataType();
 
         if (labelsMaskArrays != null)
             for (INDArray f : labelsMaskArrays)
-                reqMem += f == null ? 0 : f.lengthLong() * Nd4j.sizeOfDataType();
+                reqMem += f == null ? 0 : f.length() * Nd4j.sizeOfDataType();
 
         if (labels != null)
             for (INDArray f : labels)
-                reqMem += f == null ? 0 : f.lengthLong() * Nd4j.sizeOfDataType();
+                reqMem += f == null ? 0 : f.length() * Nd4j.sizeOfDataType();
 
         return reqMem;
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
@@ -51,7 +51,7 @@ public class BooleanIndexing {
         if (cond instanceof BaseCondition) {
             long val = (long) Nd4j.getExecutioner().exec(new MatchCondition(n, cond)).getDouble(0);
 
-            if (val == n.lengthLong())
+            if (val == n.length())
                 return true;
             else
                 return false;
@@ -157,7 +157,7 @@ public class BooleanIndexing {
         if (!(condition instanceof BaseCondition))
             throw new UnsupportedOperationException("Only static Conditions are supported");
 
-        if (to.lengthLong() != from.lengthLong())
+        if (to.length() != from.length())
             throw new IllegalStateException("Mis matched length for to and from");
 
         Nd4j.getExecutioner().exec(new CompareAndSet(to, from, condition));
@@ -175,7 +175,7 @@ public class BooleanIndexing {
         if (!(condition instanceof BaseCondition))
             throw new UnsupportedOperationException("Only static Conditions are supported");
 
-        if (to.lengthLong() != from.lengthLong())
+        if (to.length() != from.length())
             throw new IllegalStateException("Mis matched length for to and from");
 
         Nd4j.getExecutioner().exec(new CompareAndReplace(to, from, condition));

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDeltaUpdater.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDeltaUpdater.java
@@ -81,7 +81,7 @@ public class AdaDeltaUpdater implements GradientUpdater<AdaDelta> {
         double epsilon = config.getEpsilon();
 
         //Line 4 of Algorithm 1: https://arxiv.org/pdf/1212.5701v1.pdf
-        //E[g^2]_t = rho * E[g^2]_{tâ?’1} + (1-rho)*g^2_t
+        //E[g^2]_t = rho * E[g^2]_{tâˆ’1} + (1-rho)*g^2_t
         msg.muli(rho).addi(gradient.mul(gradient).muli(1 - rho));
 
         //Calculate update:

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDeltaUpdater.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/AdaDeltaUpdater.java
@@ -81,7 +81,7 @@ public class AdaDeltaUpdater implements GradientUpdater<AdaDelta> {
         double epsilon = config.getEpsilon();
 
         //Line 4 of Algorithm 1: https://arxiv.org/pdf/1212.5701v1.pdf
-        //E[g^2]_t = rho * E[g^2]_{tâˆ’1} + (1-rho)*g^2_t
+        //E[g^2]_t = rho * E[g^2]_{tâ?’1} + (1-rho)*g^2_t
         msg.muli(rho).addi(gradient.mul(gradient).muli(1 - rho));
 
         //Calculate update:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated use deprecated method in two modules (datavec-data-image and nd4j-api)
from org.nd4j.linalg.api.ndarray.INDArray#lengthLong
to org.nd4j.linalg.api.ndarray.INDArray#length

## How was this patch tested?

Ran all tests again.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).
