### PR TITLE
Support multiple use of computation graph vertex as input to other vertices

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -52,7 +52,6 @@ import org.deeplearning4j.nn.modelimport.keras.preprocessors.PermutePreprocessor
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.nn.multilayer.MultiLayerTest;
 import org.deeplearning4j.nn.transferlearning.TransferLearning;
-import org.deeplearning4j.nn.updater.UpdaterBlock;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
@@ -75,6 +74,7 @@ import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.nd4j.linalg.io.ClassPathResource;
 import org.nd4j.linalg.learning.config.AdaGrad;
 import org.nd4j.linalg.learning.config.Adam;
+import org.nd4j.linalg.learning.config.NoOp;
 import org.nd4j.linalg.learning.config.Sgd;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
 import org.nd4j.linalg.primitives.Pair;
@@ -2083,5 +2083,36 @@ public class TestComputationGraphNetwork extends BaseDL4JTest {
         Nd4j.getExecutioner().setProfilingMode(OpExecutioner.ProfilingMode.NAN_PANIC);
         cg.fit(new DataSet(in, lbl));
         Nd4j.getExecutioner().setProfilingMode(OpExecutioner.ProfilingMode.SCOPE_PANIC);
+    }
+
+    @Test
+    public void testCompGraphInputReuse() {
+        int inputSize = 5;
+        int outputSize = 6;
+        int layerSize = 3;
+
+        ComputationGraphConfiguration conf = new NeuralNetConfiguration.Builder()
+                .seed(12345)
+                .weightInit(WeightInit.XAVIER)
+                .updater(new NoOp())
+                .graphBuilder()
+                .addInputs("in")
+                .setOutputs("out")
+                .addLayer("0",new DenseLayer.Builder().nIn(inputSize).nOut(layerSize).build(),"in")
+                .addVertex("combine", new MergeVertex(), "0", "0", "0")
+                .addLayer("out",new OutputLayer.Builder(LossFunctions.LossFunction.XENT).nIn(3*layerSize).nOut(outputSize)
+                        .activation(Activation.SIGMOID).build(),"combine")
+                .build();
+
+        ComputationGraph net = new ComputationGraph(conf);
+        net.init();
+
+
+        int dataSize = 11;
+        INDArray features = Nd4j.rand(new int[] {dataSize, inputSize});
+        INDArray labels = Nd4j.rand(new int[] {dataSize, outputSize});
+
+        DataSet dataSet1 = new DataSet(features, labels);
+        net.fit(dataSet1);
     }
 }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/graph/TestComputationGraphNetwork.java
@@ -30,6 +30,7 @@ import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.SingletonMultiDataSetIterator;
 import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.exception.DL4JException;
+import org.deeplearning4j.gradientcheck.GradientCheckUtil;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.*;
 import org.deeplearning4j.nn.conf.distribution.UniformDistribution;
@@ -2087,6 +2088,8 @@ public class TestComputationGraphNetwork extends BaseDL4JTest {
 
     @Test
     public void testCompGraphInputReuse() {
+        Nd4j.setDefaultDataTypes(DataType.DOUBLE, DataType.DOUBLE);
+
         int inputSize = 5;
         int outputSize = 6;
         int layerSize = 3;
@@ -2112,7 +2115,8 @@ public class TestComputationGraphNetwork extends BaseDL4JTest {
         INDArray features = Nd4j.rand(new int[] {dataSize, inputSize});
         INDArray labels = Nd4j.rand(new int[] {dataSize, outputSize});
 
-        DataSet dataSet1 = new DataSet(features, labels);
-        net.fit(dataSet1);
+        boolean gradOK = GradientCheckUtil.checkGradients(net, 1e-6, 1e-3,
+                1e-8, false, true, new INDArray[]{features}, new INDArray[]{labels}, null, null);
+        assertTrue(gradOK);
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -16,8 +16,11 @@
 
 package org.deeplearning4j.nn.graph;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bytedeco.javacpp.Pointer;
@@ -56,7 +59,6 @@ import org.deeplearning4j.util.ModelSerializer;
 import org.deeplearning4j.util.NetworkUtils;
 import org.deeplearning4j.util.OutputLayerUtil;
 import org.nd4j.base.Preconditions;
-import org.nd4j.evaluation.EvaluationUtils;
 import org.nd4j.evaluation.IEvaluation;
 import org.nd4j.evaluation.classification.Evaluation;
 import org.nd4j.evaluation.classification.ROC;
@@ -644,15 +646,17 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                 continue; //Output vertex
             VertexIndices[] outputIndices = new VertexIndices[thisVertexOutputsTo.size()];
             int j = 0;
-            for (String s : thisVertexOutputsTo) {
+            for (String s : new HashSet<>(thisVertexOutputsTo)) {
                 //First, we have gv -> s
                 //Which input in s does gv connect to? s may in general have multiple inputs...
                 List<String> nextVertexInputNames = vertexInputs.get(s);
 
-                int outputVertexInputNumber = nextVertexInputNames.indexOf(vertexName);
-
-                int outputVertexIndex = allNamesReverse.get(s);
-                outputIndices[j++] = new VertexIndices(outputVertexIndex, outputVertexInputNumber);
+                for (int k = 0; k < nextVertexInputNames.size(); k++) {
+                    if(vertexName.equals(nextVertexInputNames.get(k))){
+                        int outputVertexIndex = allNamesReverse.get(s);
+                        outputIndices[j++] = new VertexIndices(outputVertexIndex, k);
+                    }
+                }
             }
             gv.setOutputVertices(outputIndices);
         }


### PR DESCRIPTION
While building a test case for the attention vertex, I've stumbled across the use case were I needed to use the same vertex output three times as the input. 

In that specific case it was that I was using the output of an lstm for queries, keys and values. 

The reason why it was failing was that `indexOf` will always only find the first appearance of an entry within a list.
