### PR TITLE
[WIP] ModelAdapter for ParallelInference

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/adapters/YoloModelAdapter.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/adapters/YoloModelAdapter.java
@@ -44,7 +44,7 @@ public class YoloModelAdapter implements ModelAdapter<List<DetectedObject>> {
     @Builder.Default private double detectionThreshold = 0.5;
 
     @Override
-    public List<DetectedObject> apply(Model model, INDArray[] inputs, INDArray[] masks) {
+    public List<DetectedObject> apply(Model model, INDArray[] inputs, INDArray[] masks, INDArray[] labelsMasks) {
         if (model instanceof ComputationGraph) {
             val blindLayer = ((ComputationGraph) model).getOutputLayer(outputLayerIndex);
             if (blindLayer instanceof Yolo2OutputLayer) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/adapters/YoloModelAdapter.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/adapters/YoloModelAdapter.java
@@ -48,7 +48,7 @@ public class YoloModelAdapter implements ModelAdapter<List<DetectedObject>> {
         if (model instanceof ComputationGraph) {
             val blindLayer = ((ComputationGraph) model).getOutputLayer(outputLayerIndex);
             if (blindLayer instanceof Yolo2OutputLayer) {
-                val output = ((ComputationGraph) model).output(false, inputs, masks);
+                val output = ((ComputationGraph) model).output(false, inputs, masks, labelsMasks);
                 return ((Yolo2OutputLayer) blindLayer).getPredictedObjects(output[outputIndex], detectionThreshold);
             } else {
                 throw new ND4JIllegalStateException("Output layer with index [" + outputLayerIndex + "] is NOT Yolo2OutputLayer");

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/adapters/YoloModelAdapter.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/adapters/YoloModelAdapter.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.adapters;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.val;
+import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.nn.api.ModelAdapter;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.layers.objdetect.DetectedObject;
+import org.deeplearning4j.nn.layers.objdetect.Yolo2OutputLayer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
+
+import java.util.List;
+
+/**
+ * This ModelAdapter implementation is suited for use of Yolo2 model with ParallelInference
+ *
+ * @author raver119@gmail.com
+ */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class YoloModelAdapter implements ModelAdapter<List<DetectedObject>> {
+    @Builder.Default private int outputLayerIndex = 0;
+    @Builder.Default private int outputIndex = 0;
+    @Builder.Default private double detectionThreshold = 0.5;
+
+    @Override
+    public List<DetectedObject> apply(Model model, INDArray[] inputs, INDArray[] masks) {
+        if (model instanceof ComputationGraph) {
+            val blindLayer = ((ComputationGraph) model).getOutputLayer(outputLayerIndex);
+            if (blindLayer instanceof Yolo2OutputLayer) {
+                val output = ((ComputationGraph) model).output(false, inputs, masks);
+                return ((Yolo2OutputLayer) blindLayer).getPredictedObjects(output[outputIndex], detectionThreshold);
+            } else {
+                throw new ND4JIllegalStateException("Output layer with index [" + outputLayerIndex + "] is NOT Yolo2OutputLayer");
+            }
+        } else
+            throw new ND4JIllegalStateException("Yolo2 model must be ComputationGraph");
+    }
+
+    @Override
+    public List<DetectedObject> apply(INDArray... outputs) {
+        throw new UnsupportedOperationException("Please use apply(Model, INDArray[], INDArray[]) signature");
+    }
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/ModelAdapter.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/ModelAdapter.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2018 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.nn.api;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * This interface describes abstraction that uses provided model to convert INDArrays to some specific output
+ *
+ * @param <T>
+ */
+public interface ModelAdapter<T> extends OutputAdapter<T> {
+    /**
+     * This method
+     * @return
+     */
+    T apply(Model model, INDArray[] inputs, INDArray[] masks);
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/ModelAdapter.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/api/ModelAdapter.java
@@ -25,8 +25,8 @@ import org.nd4j.linalg.api.ndarray.INDArray;
  */
 public interface ModelAdapter<T> extends OutputAdapter<T> {
     /**
-     * This method
+     * This method invokes model internally, and does convertion to T
      * @return
      */
-    T apply(Model model, INDArray[] inputs, INDArray[] masks);
+    T apply(Model model, INDArray[] inputs, INDArray[] inputMasks, INDArray[] labelsMasks);
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -1694,7 +1694,10 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
      */
     public synchronized <T> T output(@NonNull INDArray[] inputs, INDArray[] inputMasks, INDArray[] labelMasks, @NonNull OutputAdapter<T> outputAdapter) {
         try (val ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(WS_ALL_LAYERS_ACT_CONFIG, WS_OUTPUT_MEM)) {
-            return outputAdapter.apply(output(false, inputs, inputMasks, labelMasks, ws));
+            if (outputAdapter instanceof ModelAdapter)
+                return ((ModelAdapter<T>) outputAdapter).apply(this, inputs, inputMasks, labelMasks);
+            else
+                return outputAdapter.apply(output(false, inputs, inputMasks, labelMasks, ws));
         }
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -2336,7 +2336,10 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
      */
     public synchronized <T> T output(@NonNull INDArray inputs, INDArray inputMasks, INDArray labelMasks, @NonNull OutputAdapter<T> outputAdapter) {
         try (val ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(WS_ALL_LAYERS_ACT_CONFIG, WS_OUTPUT_MEM)) {
-            return outputAdapter.apply(output(inputs, false, inputMasks, labelMasks, ws));
+            if (outputAdapter instanceof ModelAdapter)
+                return ((ModelAdapter<T>) outputAdapter).apply(this, new INDArray[]{inputs}, new INDArray[]{ inputMasks}, new INDArray[]{labelMasks});
+            else
+                return outputAdapter.apply(output(inputs, false, inputMasks, labelMasks, ws));
         }
     }
 

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/InplaceParallelInference.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/InplaceParallelInference.java
@@ -20,10 +20,13 @@ package org.deeplearning4j.parallelism;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.nn.api.ModelAdapter;
+import org.deeplearning4j.nn.api.OutputAdapter;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.parallelism.inference.InferenceMode;
 import org.deeplearning4j.parallelism.inference.LoadBalanceMode;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
@@ -93,6 +96,31 @@ public class InplaceParallelInference extends ParallelInference {
     @Override
     public INDArray[] output(INDArray[] input, INDArray[] inputMasks) {
         return selector.output(input, inputMasks);
+    }
+
+    /**
+     * This method does forward pass and returns output provided by OutputAdapter
+     *
+     * @param adapter
+     * @param input
+     * @param inputMasks
+     * @param <T>
+     * @return
+     */
+    public <T> T output(@NonNull ModelAdapter<T> adapter, INDArray[] input, INDArray[] inputMasks) {
+        val holder = selector.getModelForThisThread();
+        Model model = null;
+        boolean acquired = false;
+        try {
+            model = holder.acquireModel();
+            acquired = true;
+            return adapter.apply(model, input, inputMasks);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (model != null && acquired)
+                holder.releaseModel(model);
+        }
     }
 
 

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
@@ -19,7 +19,10 @@ package org.deeplearning4j.parallelism;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.nn.api.ModelAdapter;
+import org.deeplearning4j.nn.api.OutputAdapter;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
@@ -32,6 +35,7 @@ import org.deeplearning4j.parallelism.inference.observers.BasicInferenceObserver
 import org.deeplearning4j.parallelism.inference.observers.BatchedInferenceObservable;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.primitives.Pair;
 
@@ -258,6 +262,30 @@ public class ParallelInference {
         }
 
         return observable.getOutput();
+    }
+
+    /**
+     * This method does forward pass and returns output provided by OutputAdapter
+     *
+     * @param adapter
+     * @param inputs
+     * @return
+     */
+    public <T> T output(@NonNull ModelAdapter<T> adapter, INDArray... inputs) {
+        return output(adapter, inputs, null);
+    }
+
+    /**
+     * This method does forward pass and returns output provided by OutputAdapter
+     *
+     * @param adapter
+     * @param input
+     * @param inputMasks
+     * @param <T>
+     * @return
+     */
+    public <T> T output(@NonNull ModelAdapter<T> adapter,INDArray[] input, INDArray[] inputMasks) {
+        throw new ND4JIllegalStateException("Adapted mode requires Inplace inference mode");
     }
 
 


### PR DESCRIPTION
This PR adds ModelAdapter abstraction to make use of ParallelInference for models that require special access to outputs or models. Like Yolo2 or Seq2Seq models.

Addresses #6916 