### PR TITLE
[WIP] SameDiff fixes

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunctionFactory.java
@@ -179,10 +179,6 @@ public class DifferentialFunctionFactory {
         return new Constant(sameDiff(), input, (shape != null && shape.length > 0 ? shape : null)).outputVariable();
     }
 
-    public SDVariable linspace(double lower, double upper, long count) {
-        return new Linspace(sameDiff(), lower, upper, count).outputVariable();
-    }
-
     public SDVariable linspace(SDVariable lower, SDVariable upper, SDVariable count, DataType dt) {
         return new org.nd4j.linalg.api.ops.impl.shape.Linspace(sameDiff(), lower, upper, count, dt).outputVariable();
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -2574,7 +2574,7 @@ public class SameDiff extends SDBaseOps {
 
 
     /**
-     * Create a new scalar (rank 0) SDVariable with the specified value
+     * Create a new double scalar (rank 0) SDVariable with the specified value
      * @param name  Name of the SDVariable
      * @param value Value to initialize the variable with
      * @return SDVariable
@@ -2585,8 +2585,41 @@ public class SameDiff extends SDBaseOps {
         }
     }
 
+    /**
+     * Create a new float scalar (rank 0) SDVariable with the specified value
+     * @param name  Name of the SDVariable
+     * @param value Value to initialize the variable with
+     * @return SDVariable
+     */
+    public SDVariable scalar(String name, float value) {
+        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
+            return var(name, Nd4j.scalar(value));
+        }
+    }
 
+    /**
+     * Create a new integer scalar (rank 0) SDVariable with the specified value
+     * @param name  Name of the SDVariable
+     * @param value Value to initialize the variable with
+     * @return SDVariable
+     */
+    public SDVariable scalar(String name, int value) {
+        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
+            return var(name, Nd4j.scalar(value));
+        }
+    }
 
+    /**
+     * Create a new long scalar (rank 0) SDVariable with the specified value
+     * @param name  Name of the SDVariable
+     * @param value Value to initialize the variable with
+     * @return SDVariable
+     */
+    public SDVariable scalar(String name, long value) {
+        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
+            return var(name, Nd4j.scalar(value));
+        }
+    }
 
 
     /**
@@ -2988,6 +3021,10 @@ public class SameDiff extends SDBaseOps {
         execBackwards(placeholders, vargradNamesList);
     }
 
+    public void execBackwards(Map<String,INDArray> placeholders, String... variableGradNamesList){
+        execBackwards(placeholders, Arrays.asList(variableGradNamesList));
+    }
+
     /**
      * As per {@link #execBackwards(Map)}, but the set of gradients to calculate can be specified manually.<br>
      * For example, to calculate the gradient for placeholder variable "myPlaceholder", use
@@ -3122,6 +3159,7 @@ public class SameDiff extends SDBaseOps {
                 }
                 SDVariable initialGrad = sameDiff.var("one-var", initGradArr);
                 for(SDVariable v : finalOutputs) {
+                    v = v.sum();    //If output is not a scalar: we'll use loss = v.sum(), same as adding loss for multiple outputs
                     if(v.dataType() == initialGrad.dataType()){
                         sameDiff.setGradientForVariableName(v.getVarName(), initialGrad);
                     } else {
@@ -3200,7 +3238,8 @@ public class SameDiff extends SDBaseOps {
                     }
                 }
 
-                Preconditions.checkState(numProcessed == ops.size(), "Only differentiated %s of %s ops", numProcessed, ops.size());
+                Preconditions.checkState(numProcessed == ops.size() + finalOutputs.size(), "Only differentiated %s of %s ops",
+                        numProcessed, ops.size() + finalOutputs.size());    //+finalOutputs due to sum() on each output for non-scalar outputs
 
                 return new SDVariable[]{sameDiff.var("grad", org.nd4j.linalg.api.buffer.DataType.FLOAT, 1)};
             }
@@ -3347,6 +3386,12 @@ public class SameDiff extends SDBaseOps {
         varToUpdate.setVarName(newVarName);
         updateVariableName(oldVarName, newVarName);
         return varToUpdate;
+    }
+
+    @Override
+    protected SameDiff sd() {
+        //Helper method for SDBaseOps etc
+        return this;
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
@@ -3,6 +3,7 @@ package org.nd4j.autodiff.samediff.ops;
 import lombok.NonNull;
 import org.nd4j.autodiff.functions.DifferentialFunctionFactory;
 import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ops.impl.shape.OneHot;
@@ -42,6 +43,8 @@ public abstract class SDBaseOps {
     protected abstract DifferentialFunctionFactory f();
 
     protected abstract SDVariable updateVariableNameAndReference(SDVariable varToUpdate, String newVarName);
+
+    protected abstract SameDiff sd();
 
     /**
      * Argmax array reduction operation, optionally along specified dimensions.<br>
@@ -790,8 +793,24 @@ public abstract class SDBaseOps {
      * @param number Number of values to generate
      * @return SDVariable with linearly spaced elements
      */
-    public SDVariable linspace(double start, double stop, long number) {
-        return linspace(null, start, stop, number);
+    public SDVariable linspace(DataType dataType, double start, double stop, long number) {
+        return linspace(dataType, start, stop, number);
+    }
+
+    /**
+     * Create a new 1d array with values evenly spaced between values 'start' and 'stop'
+     * For example, linspace(start=3.0, stop=4.0, number=3) will generate [3.0, 3.5, 4.0]
+     *
+     * @param name     Name of the new variable
+     * @param dataType Data type of the output array
+     * @param start    Start value
+     * @param stop     Stop value
+     * @param number   Number of values to generate
+     * @return SDVariable with linearly spaced elements
+     */
+    public SDVariable linspace(String name, DataType dataType, double start, double stop, long number) {
+        SDVariable ret = f().linspace(sd().scalar(null, start), sd().scalar(null, stop), sd().scalar(null, number), dataType);
+        return updateVariableNameAndReference(ret, name);
     }
 
     /**
@@ -799,16 +818,12 @@ public abstract class SDBaseOps {
      * For example, linspace(start=3.0, stop=4.0, number=3) will generate [3.0, 3.5, 4.0]
      *
      * @param name   Name of the new variable
-     * @param start  Start value
-     * @param stop   Stop value
-     * @param number Number of values to generate
+     * @param from   Start value
+     * @param to     Stop value
+     * @param length Number of values to generate
+     * @param dt     Data type of the output array
      * @return SDVariable with linearly spaced elements
      */
-    public SDVariable linspace(String name, double start, double stop, long number) {
-        SDVariable ret = f().linspace(start, stop, number);
-        return updateVariableNameAndReference(ret, name);
-    }
-
     public SDVariable linspace(String name, SDVariable from, SDVariable to, SDVariable length, DataType dt) {
         SDVariable ret = f().linspace(from, to, length, dt);
         return updateVariableNameAndReference(ret, name);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/validation/GradCheckUtil.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/validation/GradCheckUtil.java
@@ -113,12 +113,12 @@ public class GradCheckUtil {
         List<String> outputs = sd.outputs();
         Preconditions.checkState(outputs.size() == 1, "Expected 1 output for gradient check, got %s", outputs);
         String outName = outputs.get(0);
-        Map<String,INDArray> outMap = sd.exec(placeholderValues, outName);
-        Preconditions.checkState(outMap.size() == 1, "Expected 1 output, got %s", outMap.keySet());
-        INDArray out = outMap.get(outName);
-        if(out.length() != 1){
-            throw new IllegalStateException("Output variable is not a scalar - has shape " + Arrays.toString(out.shape()));
-        }
+//        Map<String,INDArray> outMap = sd.exec(placeholderValues, outName);
+//        Preconditions.checkState(outMap.size() == 1, "Expected 1 output, got %s", outMap.keySet());
+//        INDArray out = outMap.get(outName);
+//        if(out.length() != 1){
+//            throw new IllegalStateException("Output variable is not a scalar - has shape " + Arrays.toString(out.shape()));
+//        }
 
         //TODO also check that all inputs are non-zero (otherwise: consider out = sum(x * y) with all x and y being 0
         // in this case, gradients of x and y are all 0 too
@@ -204,9 +204,9 @@ public class GradCheckUtil {
                 totalCount++;
                 double orig = a.getDouble(idx);
                 a.putScalar(idx, orig+eps);
-                double scorePlus = sd.exec(placeholderValues, outputs.get(0)).get(outName).getDouble(0);
+                double scorePlus = sd.exec(placeholderValues, outputs.get(0)).get(outName).sumNumber().doubleValue();
                 a.putScalar(idx, orig-eps);
-                double scoreMinus = sd.exec(placeholderValues, outputs.get(0)).get(outName).getDouble(0);
+                double scoreMinus = sd.exec(placeholderValues, outputs.get(0)).get(outName).sumNumber().doubleValue();
                 a.putScalar(idx, orig);
 
                 double numericalGrad = (scorePlus - scoreMinus) / (2 * eps);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -1299,11 +1299,16 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public Number prodNumber() {
+        if(isScalar())
+            return getNumber(0);
         return prod(Integer.MAX_VALUE).getDouble(0);
     }
 
     @Override
     public Number meanNumber() {
+        validateNumericalArray("meanNumber", false);
+        if(isScalar())
+            return getNumber(0);
         return mean(Integer.MAX_VALUE).getDouble(0);
     }
 
@@ -1319,6 +1324,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public Number maxNumber() {
+        if(isScalar())
+            return getNumber(0);
         return max(Integer.MAX_VALUE).getDouble(0);
     }
 
@@ -1329,6 +1336,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public Number minNumber() {
+        if(isScalar())
+            return getNumber(0);
         return min(Integer.MAX_VALUE).getDouble(0);
     }
 
@@ -1346,6 +1355,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     public Number sumNumber() {
         validateNumericalArray("sum", false);
+        if(isScalar())
+            return getNumber(0);
         val scalar = sum(Integer.MAX_VALUE);
         Nd4j.getExecutioner().commit();
         return scalar.getDouble(0);
@@ -4374,9 +4385,51 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             return assign(toPut);
         }
         return put(new INDArrayIndex[] {NDArrayIndex.all(), NDArrayIndex.point(column)}, toPut);
-
     }
 
+    @Override
+    public Number getNumber(long i){
+        switch (dataType()){
+            case DOUBLE:
+            case FLOAT:
+            case HALF:
+                return getDouble(i);
+            case LONG:
+            case INT:
+            case SHORT:
+            case UBYTE:
+            case BYTE:
+            case BOOL:
+                return getLong(i);
+            case UTF8:
+            case COMPRESSED:
+            case UNKNOWN:
+            default:
+                throw new UnsupportedOperationException("Cannot get number from array of datatype: " + dataType());
+        }
+    }
+
+    @Override
+    public Number getNumber(long... idx){
+        switch (dataType()){
+            case DOUBLE:
+            case FLOAT:
+            case HALF:
+                return getDouble(idx);
+            case LONG:
+            case INT:
+            case SHORT:
+            case UBYTE:
+            case BYTE:
+            case BOOL:
+                return getLong(idx);
+            case UTF8:
+            case COMPRESSED:
+            case UNKNOWN:
+            default:
+                throw new UnsupportedOperationException("Cannot get number from array of datatype: " + dataType());
+        }
+    }
 
     @Override
     public double getDouble(long i) {
@@ -6255,6 +6308,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     public Number medianNumber() {
         validateNumericalArray("medianNumber", false);
+        if(isScalar())
+            return getNumber(0);
         return percentileNumber(50);
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -5026,6 +5026,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 throw new IllegalArgumentException("Too many indices for array. Number of indexes must be <= rank(): rank " +
                         rank() + " array with indices " + Arrays.toString(indexes));
             }
+        } else if(indexes.length < rank()){
+            throw new IllegalStateException("Expected " + rank() + " indices for array of rank " + rank() + ", got " + indexes.length + " indices");
         }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseSparseNDArray.java
@@ -1323,6 +1323,16 @@ public abstract class BaseSparseNDArray implements ISparseNDArray {
     }
 
     @Override
+    public Number getNumber(long index) {
+        return null;
+    }
+
+    @Override
+    public Number getNumber(long... indices) {
+        return null;
+    }
+
+    @Override
     public INDArray getScalar(int... indices) {
         return null;
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/INDArray.java
@@ -1868,6 +1868,10 @@ public interface INDArray extends Serializable, AutoCloseable {
 
     long getLong(long... indices);
 
+    Number getNumber(long index);
+
+    Number getNumber(long... indices);
+
     /**
      * Get a double value at the specified indices.
      * @param indices Indices to get the double at. Number of indices must match the array rank.

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
@@ -782,7 +782,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray zeros(long columns) {
-        return zeros(new long[] {1, columns});
+        return zeros(new long[] {columns});
     }
 
     /**
@@ -811,10 +811,10 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
     public INDArray create(int[] shape, int[] stride, long offset, char ordering) {
         Shape.assertValidOrder(ordering);
         //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
-        return create(Nd4j.createBuffer(ArrayUtil.prodLong(shape)), shape, stride, offset, ordering);
+        long length = ArrayUtil.prodLong(shape);
+        if(length == 0)
+            return scalar(0.0);
+        return create(Nd4j.createBuffer(length), shape, stride, offset, ordering);
     }
 
     /**
@@ -852,16 +852,15 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray ones(long columns) {
-        return ones(new long[] {1, columns});
+        return ones(new long[] {columns});
     }
 
     @Override
     public INDArray create(float[] data, int[] shape, char ordering) {
         Shape.assertValidOrder(ordering);
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
+        long length = ArrayUtil.prodLong(shape);
+        if(length == 0)
+            return scalar(0.0);
         return create(Nd4j.createBuffer(data), shape, Nd4j.getStrides(shape, ordering), 0, ordering);
     }
 
@@ -1009,12 +1008,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray ones(int[] shape) {
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
-
-        INDArray ret = create(shape);
+        INDArray ret = createUninitialized(shape, Nd4j.order());
         ret.assign(1);
         return ret;
     }
@@ -1022,7 +1016,6 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
     @Override
     public INDArray ones(long[] shape) {
         //ensure shapes that wind up being scalar end up with the write shape
-
         INDArray ret = createUninitialized(shape, Nd4j.order());
         ret.assign(1);
         return ret;
@@ -1078,28 +1071,16 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray create(float[] data, int[] shape) {
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
         return create(data, shape, Nd4j.getStrides(shape), 0);
     }
 
     @Override
     public INDArray create(float[] data, long[] shape) {
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new long[] {1, 1};
-        }
         return create(data, shape, Nd4j.getStrides(shape), 0);
     }
 
     @Override
     public INDArray create(double[] data, long[] shape) {
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new long[] {1, 1};
-        }
         return create(data, shape, Nd4j.getStrides(shape), 0);
     }
 
@@ -1174,21 +1155,12 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray create(int[] shape, int[] stride, long offset) {
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
         DataBuffer buffer = Nd4j.createBuffer(ArrayUtil.prodLong(shape));
         return create(buffer, shape, stride, offset);
     }
 
     @Override
     public INDArray create(long[] shape, long[] stride, long offset) {
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new long[] {1, 1};
-        }
-
         DataBuffer buffer = Nd4j.createBuffer(ArrayUtil.prodLong(shape));
         return create(buffer, shape, stride, offset);
     }
@@ -1215,9 +1187,6 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
     @Override
     public INDArray create(long[] shape, long[] stride, long offset, char ordering) {
         Shape.assertValidOrder(ordering);
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new long[] {1, 1};
-        }
         return create(Nd4j.createBuffer(ArrayUtil.prodLong(shape)), shape, stride, offset, ordering);
     }
 
@@ -1268,10 +1237,6 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray create(int[] shape) {
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
         return create(shape, Nd4j.getStrides(shape), 0);
     }
 
@@ -1304,7 +1269,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray scalar(float value, long offset) {
-        return create(new float[] {value}, new int[] {1, 1}, new int[] {1, 1}, offset);
+        return create(new float[] {value}, new int[0], new int[0], offset);
     }
 
     /**
@@ -1316,7 +1281,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
      */
     @Override
     public INDArray scalar(double value, long offset) {
-        return create(new double[] {value}, new int[] {1, 1}, new int[] {1, 1}, offset);
+        return create(new double[] {value}, new int[0], new int[0], offset);
     }
 
     @Override
@@ -1438,7 +1403,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
     @Override
     public INDArray scalar(float value) {
         if (Nd4j.dataType() == DataType.FLOAT || Nd4j.dataType() == DataType.HALF)
-            return create(new float[] {value}, new int[] {1, 1}, new int[] {1, 1}, 0);
+            return create(new float[] {value}, new int[0], new int[0], 0);
         else if (Nd4j.dataType() == DataType.DOUBLE)
             return scalar((double) value);
         else
@@ -1454,7 +1419,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
     @Override
     public INDArray scalar(double value) {
         if (Nd4j.dataType() == DataType.DOUBLE)
-            return create(new double[] {value}, new int[] {1, 1}, new int[] {1, 1}, 0);
+            return create(new double[] {value}, new int[0], new int[0], 0);
         else
             return scalar((float) value);
     }
@@ -1494,20 +1459,12 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
     @Override
     public INDArray create(DataBuffer buffer, int[] shape, int[] stride, char order, long offset) {
         Shape.assertValidOrder(order);
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
         return create(buffer, shape, stride, offset, order);
     }
 
     @Override
     public INDArray create(int[] data, int[] shape, int[] stride, char order, long offset) {
         Shape.assertValidOrder(order);
-        //ensure shapes that wind up being scalar end up with the write shape
-        if (shape.length == 1 && shape[0] == 0) {
-            shape = new int[] {1, 1};
-        }
         return create(Nd4j.createBuffer(data), shape, stride, order, offset);
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/ShapeOffsetResolution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/ShapeOffsetResolution.java
@@ -89,7 +89,7 @@ public class ShapeOffsetResolution implements Serializable {
 
 
 
-        if (arr.isVector()) {
+        if (arr.isVector() && arr.rank() == 2) {
             //return the whole vector
             if (indexes[0] instanceof NDArrayIndexAll && indexes.length == 1) {
 
@@ -355,7 +355,7 @@ public class ShapeOffsetResolution implements Serializable {
         for (int i = 0; i < indexes.length; i++) {
             INDArrayIndex idx = indexes[i];
             // On vectors, the first dimension can be ignored when indexing them with a single point index
-            if (idx instanceof PointIndex && (arr.isVector() && indexes.length == 1 ? idx.current() >= shape[i + 1]
+            if (idx instanceof PointIndex && (arr.isVector() && arr.rank() == 2 && indexes.length == 1 ? idx.current() >= shape[i + 1]
                     : idx.current() >= shape[i])) {
                 throw new IllegalArgumentException(
                         "INDArrayIndex[" + i + "] is out of bounds (value: " + idx.current() + ")");

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/MiscOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/MiscOpValidation.java
@@ -1188,7 +1188,7 @@ public class MiscOpValidation extends BaseOpValidation {
     @Test
     public void testLinspace(){
         SameDiff sd = SameDiff.create();
-        SDVariable out = sd.linspace("linspace", 1,10,10).castTo(DataType.DOUBLE);
+        SDVariable out = sd.linspace("linspace", DataType.DOUBLE, 1,10,10);
         SDVariable loss = out.std(true);
 
         String err = OpValidation.validate(new TestCase(sd)

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/ShapeOpValidation.java
@@ -1515,10 +1515,10 @@ public class ShapeOpValidation extends BaseOpValidation {
         SDVariable idxs = sameDiff.var("idxs", arr2);
         SDVariable result = sameDiff.gatherNd(x, idxs);
         // build expected output array
-        INDArray expected  = Nd4j.zeros(3);
+        INDArray expected  = Nd4j.zeros(1, 3);
         for (int i=0; i<3; i++){
-            INDArray idx = arr2.get(point(i));
-            expected.get(point(i)).assign(
+            INDArray idx = arr2.get(point(i), NDArrayIndex.all());
+            expected.get(NDArrayIndex.point(0), point(i)).assign(
                     arr1.get(point(idx.getInt(0)),
                             point(idx.getInt(1)),
                             point(idx.getInt(2))));

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/LoneTest.java
@@ -113,8 +113,8 @@ public class LoneTest extends BaseNd4jTest {
             j = i + 1;
             assertEquals(i + 1,colVector.getRow(i).getInt(0));
             assertEquals(i + 1,rowVector.getColumn(i).getInt(0));
-            assertEquals(i + 1,rowVector.get(NDArrayIndex.interval(i, j)).getInt(0));
-            assertEquals(i + 1,colVector.get(NDArrayIndex.interval(i, j)).getInt(0));
+            assertEquals(i + 1,rowVector.get(NDArrayIndex.point(0), NDArrayIndex.interval(i, j)).getInt(0));
+            assertEquals(i + 1,colVector.get(NDArrayIndex.interval(i, j), NDArrayIndex.point(0)).getInt(0));
             System.out.println("Making sure index interval will not crash with begin/end vals...");
             jj = colVector.get(NDArrayIndex.interval(i, i + 10));
             jj = colVector.get(NDArrayIndex.interval(i, i + 10));

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/Nd4jTestsC.java
@@ -3102,7 +3102,7 @@ public class Nd4jTestsC extends BaseNd4jTest {
     @Test
     public void testSoftmaxRow() {
         for (int i = 0; i < 20; i++) {
-            INDArray arr1 = Nd4j.zeros(100);
+            INDArray arr1 = Nd4j.zeros(1, 100);
             Nd4j.getExecutioner().execAndReturn(new OldSoftMax(arr1));
             System.out.println(Arrays.toString(arr1.data().asFloat()));
         }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/indexing/IndexingTestsC.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/shape/indexing/IndexingTestsC.java
@@ -166,7 +166,7 @@ public class IndexingTestsC extends BaseNd4jTest {
     @Test
     public void testRowVectorInterval() {
         int len = 30;
-        INDArray row = Nd4j.zeros(len);
+        INDArray row = Nd4j.zeros(1, len);
         for (int i = 0; i < len; i++) {
             row.putScalar(i, i);
         }


### PR DESCRIPTION

Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/7421
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/7405
Fixes one part of: https://github.com/deeplearning4j/deeplearning4j/issues/7401 (not the reduce_sqnorm_bp issue)

Allows non-scalar outputs for SameDiff instances. Now non-scalar outputs basically do loss = arrayOutput.sum()

Adds INDArray.getNumber(long), .getNumber(long[])
Switches SameDiff.linspace no new custom op, adds datatype arg. New SameDiff.scalar(float/int/long) overloads.