### PR TITLE
Several fixes for new SameDiff Backprop behavior

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -3509,6 +3509,9 @@ public class SameDiff extends SDBaseOps {
                             leafFPVars.add(s);
                         }
                     }
+                    if(v.getVariable().getVariableType() == VariableType.CONSTANT || v.getVariable().getVariableType() == VariableType.PLACEHOLDER){
+                        leafFPVars.add(s);
+                    }
                 }
 
                 while(!leafFPVars.isEmpty()){
@@ -3658,7 +3661,7 @@ public class SameDiff extends SDBaseOps {
                         // need to differentiate OpY too
                         //Note that just because we *need to* doesn't mean we *can* yet
 
-                        boolean isRequiredOp = true;
+                        boolean isRequiredOp = false;
                         SameDiffOp op = ops.get(opName);
                         if(op.getInputsToOp() != null){
                             List<String> opInputs = op.getInputsToOp();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -3556,12 +3556,12 @@ public class SameDiff extends SDBaseOps {
                         " graph does not contain any trainable SDVariables (floating point VARIABLE type SDVariables) that the loss function depend on.", lossVariables);
 
                 //At this point: we know the set of variables that are connected to the loss - these all (and only) need gradients
-                Queue<DifferentialFunction> availableForDiff = new LinkedList<>();
+                Queue<String> availableForDiff = new LinkedList<>();
                 for(SDVariable lossVar : finalOutputs){
                     Variable v = sameDiff.variables.get(lossVar.getVarName());
                     if(v.getOutputOfOp() != null){
                         String opName = v.getOutputOfOp();
-                        availableForDiff.add(sameDiff.ops.get(opName).getOp());
+                        availableForDiff.add(opName);
                     }
                 }
 
@@ -3601,7 +3601,8 @@ public class SameDiff extends SDBaseOps {
 
                 Set<String> differentiatedOps = new HashSet<>();
                 while(!availableForDiff.isEmpty()){
-                    DifferentialFunction df = availableForDiff.remove();
+                    String dfName = availableForDiff.remove();
+                    DifferentialFunction df = sameDiff.ops.get(dfName).getOp();
 
                     //Get the inputs and outputs of the op
                     List<String> inputsToOp;
@@ -3714,8 +3715,8 @@ public class SameDiff extends SDBaseOps {
                             }
                         }
 
-                        if(allAvailable && !availableForDiff.contains(o.getOp())){
-                            availableForDiff.add(o.getOp());
+                        if(allAvailable && !availableForDiff.contains(o.getOp().getOwnName())){
+                            availableForDiff.add(o.getOp().getOwnName());
                         }
                     }
                 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/ExternalErrorsFunction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/ExternalErrorsFunction.java
@@ -22,7 +22,6 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
-import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.factory.Nd4j;
@@ -62,7 +61,7 @@ public class ExternalErrorsFunction extends DifferentialFunction {
     public SDVariable[] outputVariables(String baseName) {
         if(out == null){
             String name = sameDiff.generateNewVarName("dummyOutput", 0);
-            out = sameDiff.zero(name, DataType.FLOAT, 1);
+            out = sameDiff.zero(name, Nd4j.dataType(), 1);
             sameDiff.getOps().get(getOwnName()).setOutputsOfOp(Collections.singletonList(out.getVarName()));
             sameDiff.getVariables().get(name).setOutputOfOp(getOwnName());
         }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
@@ -3021,6 +3021,20 @@ public class SameDiffTests {
     }
 
     @Test
+    public void testSameDiffBackprop1(){
+        SameDiff sd = SameDiff.create();
+        final SDVariable a = sd.var("a", Nd4j.rand(4, 4));
+        final SDVariable b = sd.var("b", Nd4j.rand(4, 4));
+        final SDVariable c = sd.var("c", Nd4j.rand(4, 4));
+        final SDVariable d = sd.var("d", Nd4j.rand(4, 4));
+
+        final SDVariable out = a.mmul(b).add(c.mmul(d)).sum();
+        out.markAsLoss();
+
+        sd.execBackwards(null);
+    }
+
+    @Test
     public void testSameDiffNoGradForConstantAndPlaceholder(){
         SameDiff sd = SameDiff.create();
         final SDVariable a = sd.var("a", Nd4j.rand(4, 4));

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/samediff/SameDiffTests.java
@@ -3019,4 +3019,19 @@ public class SameDiffTests {
 
         assertNull(err);
     }
+
+    @Test
+    public void testSameDiffNoGradForConstantAndPlaceholder(){
+        SameDiff sd = SameDiff.create();
+        final SDVariable a = sd.var("a", Nd4j.rand(4, 4));
+        final SDVariable b = sd.constant("b", Nd4j.rand(4, 4));
+        final SDVariable c = sd.placeHolder("c", Nd4j.dataType(), 4, 4);
+
+        a.add(b.add(c)).sum().markAsLoss();
+
+        sd.execBackwards(Collections.singletonMap("c", Nd4j.rand(4,4 )));
+        assertNotNull(sd.grad("a"));
+        assertNull(sd.grad("b"));
+        assertNull(sd.grad("c"));
+    }
 }


### PR DESCRIPTION
1. Use the configured default data type when creating the external errors function
2. Skip differentiating ops that have only constant / placeholder type inputs
3. Use op name instead of flawed equality to check if an op is alreday in the queue to be differentiated 