### PR TITLE
Shyrma broadcast

### DIFF
--- a/libnd4j/blas/cpu/NDArray.cpp
+++ b/libnd4j/blas/cpu/NDArray.cpp
@@ -2980,7 +2980,7 @@ template void NDArray::applyScalar(nd4j::scalar::Ops op, const bool scalar, NDAr
             throw std::runtime_error("NDArray::applyBroadcast method: tad length mismatch !");
 
         auto tadPackX = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
-        auto tadPackZ = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(target->_shapeInfo, copy);
+        auto tadPackZ = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(result->_shapeInfo, copy);
 
         if(max == this)
             NativeOpExcutioner::execBroadcast(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPackX.primaryShapeInfo(), tadPackX.primaryOffsets(), tadPackZ.primaryShapeInfo(), tadPackZ.primaryOffsets());
@@ -3035,7 +3035,7 @@ template void NDArray::applyScalar(nd4j::scalar::Ops op, const bool scalar, NDAr
             throw std::runtime_error("Tad length mismatch");
 
         auto tadPackX = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
-        auto tadPackZ = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
+        auto tadPackZ = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(result->_shapeInfo, copy);
 
         // TODO: eventually we want separate tads here
         if(this == max)

--- a/libnd4j/blas/cpu/NDArray.cpp
+++ b/libnd4j/blas/cpu/NDArray.cpp
@@ -2979,12 +2979,13 @@ template void NDArray::applyScalar(nd4j::scalar::Ops op, const bool scalar, NDAr
         if (tadLength != min->lengthOf())
             throw std::runtime_error("NDArray::applyBroadcast method: tad length mismatch !");
 
-        auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
+        auto tadPackX = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
+        auto tadPackZ = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(target->_shapeInfo, copy);
 
         if(max == this)
-            NativeOpExcutioner::execBroadcast(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets());
+            NativeOpExcutioner::execBroadcast(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPackX.primaryShapeInfo(), tadPackX.primaryOffsets(), tadPackZ.primaryShapeInfo(), tadPackZ.primaryOffsets());
         else
-            NativeOpExcutioner::execInverseBroadcast(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets());
+            NativeOpExcutioner::execInverseBroadcast(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPackX.primaryShapeInfo(), tadPackX.primaryOffsets(), tadPackZ.primaryShapeInfo(), tadPackZ.primaryOffsets());
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -3033,13 +3034,14 @@ template void NDArray::applyScalar(nd4j::scalar::Ops op, const bool scalar, NDAr
         if (tadLength != min->lengthOf())
             throw std::runtime_error("Tad length mismatch");
 
-        auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
+        auto tadPackX = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
+        auto tadPackZ = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(max->_shapeInfo, copy);
 
         // TODO: eventually we want separate tads here
         if(this == max)
-            NativeOpExcutioner::execBroadcastBool(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets());
+            NativeOpExcutioner::execBroadcastBool(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPackX.primaryShapeInfo(), tadPackX.primaryOffsets(), tadPackZ.primaryShapeInfo(), tadPackZ.primaryOffsets());
         else
-            NativeOpExcutioner::execInverseBroadcastBool(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets());
+            NativeOpExcutioner::execInverseBroadcastBool(op, this->_buffer, this->_shapeInfo, other->_buffer, other->_shapeInfo, result->_buffer, result->_shapeInfo, copy.data(), (int)copy.size(), tadPackX.primaryShapeInfo(), tadPackX.primaryOffsets(), tadPackZ.primaryShapeInfo(), tadPackZ.primaryOffsets());
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/libnd4j/blas/cpu/NativeOpExcutioner.cpp
+++ b/libnd4j/blas/cpu/NativeOpExcutioner.cpp
@@ -59,7 +59,7 @@
 * @param xShapeInfo
 * @param extraParams
 * @param result
-* @param resultShapeInfo
+* @param zShapeInfo
 */
 void NativeOpExcutioner::execIndexReduceScalar(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *vz, Nd4jLong *zShapeInfo) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
@@ -90,11 +90,11 @@ void NativeOpExcutioner::execIndexReduce(int opNum,
         int *dimension,
         int dimensionLength,
         Nd4jLong *tadShapeInfo,
-        Nd4jLong *tadOffsets) {
+        Nd4jLong *xTadOffsets) {
 
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
 
-    BUILD_SINGLE_SELECTOR(xType, functions::indexreduce::IndexReduce, ::exec(opNum, x, xShapeInfo, extraParams, result, resultShapeInfoBuffer, dimension, dimensionLength, tadShapeInfo, tadOffsets), LIBND4J_TYPES);
+    BUILD_SINGLE_SELECTOR(xType, functions::indexreduce::IndexReduce, ::exec(opNum, x, xShapeInfo, extraParams, result, resultShapeInfoBuffer, dimension, dimensionLength, tadShapeInfo, xTadOffsets), LIBND4J_TYPES);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -106,15 +106,15 @@ void NativeOpExcutioner::execIndexReduce(int opNum,
  * @param y
  * @param yShapeInfo
  * @param result
- * @param resultShapeInfo
+ * @param zShapeInfo
  * @param dimension
  * @param dimensionLength
  */
 
-void NativeOpExcutioner::execBroadcast(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadOnlyShapeInfo, Nd4jLong *tadOffsets, Nd4jLong *tadOnlyShapeInfoZ, Nd4jLong *tadOffsetsZ) {
+void NativeOpExcutioner::execBroadcast(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *xTadShapeInfo, Nd4jLong *xTadOffsets, Nd4jLong *zTadShapeInfo, Nd4jLong *zTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(yShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
     if (!nd4j::Environment::getInstance()->isExperimentalBuild())
     if ((yType != xType && yType != nd4j::DataType::BOOL) || xType != zType)
@@ -122,15 +122,15 @@ void NativeOpExcutioner::execBroadcast(int opNum, void *x, Nd4jLong *xShapeInfo,
 
     auto xRank = shape::rank(xShapeInfo);
     auto yRank = shape::rank(yShapeInfo);
-    auto zRank = shape::rank(resultShapeInfo);
+    auto zRank = shape::rank(zShapeInfo);
 
     auto xOrder = shape::order(xShapeInfo);
     auto yOrder = shape::order(yShapeInfo);
-    auto zOrder = shape::order(resultShapeInfo);
+    auto zOrder = shape::order(zShapeInfo);
 
     auto xEws = shape::elementWiseStride(xShapeInfo);
     auto yEws = shape::elementWiseStride(yShapeInfo);
-    auto zEws = shape::elementWiseStride(resultShapeInfo);
+    auto zEws = shape::elementWiseStride(zShapeInfo);
 
     int axis = 0;
     auto isVector = shape::isCommonVector(yShapeInfo, axis);
@@ -144,9 +144,9 @@ void NativeOpExcutioner::execBroadcast(int opNum, void *x, Nd4jLong *xShapeInfo,
         auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(xShapeInfo, newDim);
 
 #ifdef __ND4J_EXPERIMENTAL__
-        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, resultShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES, LIBND4J_TYPES);
+        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, zShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES, LIBND4J_TYPES);
 #else
-        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, resultShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES);
+        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, zShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES);
 #endif
 
     } else if (xOrder == 'f' && zOrder == 'f' && xEws == 1 && zEws == 1 && yEws == 1 && xRank == 2 && isVector && dimensionLength == 1 && dimension[0] == 1 && isConvertible) {
@@ -156,62 +156,62 @@ void NativeOpExcutioner::execBroadcast(int opNum, void *x, Nd4jLong *xShapeInfo,
         auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(xShapeInfo, newDim);
 
 #ifdef __ND4J_EXPERIMENTAL__
-        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, resultShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES, LIBND4J_TYPES);
+        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, zShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES, LIBND4J_TYPES);
 #else
-        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, resultShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES);
+        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::scalar::ScalarTransform, ::transform(scalarOp, x, xShapeInfo, nullptr, result, zShapeInfo, y, &newDim, dimensionLength, tadPack.primaryShapeInfo(), tadPack.primaryOffsets(), tadPack.primaryShapeInfo(), tadPack.primaryOffsets()), LIBND4J_TYPES);
 #endif
 
     }else {
         // default case
 
 #ifdef __ND4J_EXPERIMENTAL__
-        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::broadcast::Broadcast, ::exec(opNum, x, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ, tadOffsetsZ), LIBND4J_TYPES, LIBND4J_TYPES);
+        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::broadcast::Broadcast, ::exec(opNum, x, xShapeInfo, y, yShapeInfo, result, zShapeInfo, dimension, dimensionLength, xTadShapeInfo, xTadOffsets, zTadShapeInfo, zTadOffsets), LIBND4J_TYPES, LIBND4J_TYPES);
 #else
-        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::broadcast::Broadcast, ::exec(opNum, x, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ,tadOffsetsZ), LIBND4J_TYPES);
+        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::broadcast::Broadcast, ::exec(opNum, x, xShapeInfo, y, yShapeInfo, result, zShapeInfo, dimension, dimensionLength, xTadShapeInfo, xTadOffsets, zTadShapeInfo,zTadOffsets), LIBND4J_TYPES);
 #endif
     }
 }
 
 
-void NativeOpExcutioner::execInverseBroadcast(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadOnlyShapeInfo, Nd4jLong *tadOffsets, Nd4jLong *tadOnlyShapeInfoZ, Nd4jLong *tadOffsetsZ) {
+void NativeOpExcutioner::execInverseBroadcast(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *xTadShapeInfo, Nd4jLong *xTadOffsets, Nd4jLong *zTadShapeInfo, Nd4jLong *zTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(yShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
     if (!nd4j::Environment::getInstance()->isExperimentalBuild())
         if ((yType != xType && yType != nd4j::DataType::BOOL) || xType != zType)
             throw nd4j::datatype_exception::build("NativeOps::execBroadcast both operands must have same data type", xType, yType);
 
 #ifdef __ND4J_EXPERIMENTAL__
-        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::broadcast::Broadcast, ::execInverse(opNum, x, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ, tadOffsetsZ), LIBND4J_TYPES, LIBND4J_TYPES);
+        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::broadcast::Broadcast, ::execInverse(opNum, x, xShapeInfo, y, yShapeInfo, result, zShapeInfo, dimension, dimensionLength, xTadShapeInfo, xTadOffsets, zTadShapeInfo, zTadOffsets), LIBND4J_TYPES, LIBND4J_TYPES);
 #else
-        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::broadcast::Broadcast, ::execInverse(opNum, x, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ,tadOffsetsZ), LIBND4J_TYPES);
+        BUILD_SINGLE_SELECTOR_THRICE(xType, functions::broadcast::Broadcast, ::execInverse(opNum, x, xShapeInfo, y, yShapeInfo, result, zShapeInfo, dimension, dimensionLength, xTadShapeInfo, xTadOffsets, zTadShapeInfo,zTadOffsets), LIBND4J_TYPES);
 #endif
 
 }
 
-void NativeOpExcutioner::execBroadcastBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadOnlyShapeInfo, Nd4jLong *tadOffsets, Nd4jLong *tadOnlyShapeInfoZ, Nd4jLong *tadOffsetsZ) {
+void NativeOpExcutioner::execBroadcastBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *xTadShapeInfo, Nd4jLong *xTadOffsets, Nd4jLong *zTadShapeInfo, Nd4jLong *zTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(yShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
     if (!nd4j::Environment::getInstance()->isExperimentalBuild())
         if (yType != xType || nd4j::DataType::BOOL != zType)
             throw nd4j::datatype_exception::build("NativeOps::execBroadcastBool both operands must have same data type", xType, yType);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::broadcast::BroadcastBool, ::exec(opNum, x, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ, tadOffsetsZ), LIBND4J_TYPES, BOOL_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::broadcast::BroadcastBool, ::exec(opNum, x, xShapeInfo, y, yShapeInfo, result, zShapeInfo, dimension, dimensionLength, xTadShapeInfo, xTadOffsets, zTadShapeInfo, zTadOffsets), LIBND4J_TYPES, BOOL_TYPES);
 }
 
-void NativeOpExcutioner::execInverseBroadcastBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadOnlyShapeInfo, Nd4jLong *tadOffsets, Nd4jLong *tadOnlyShapeInfoZ, Nd4jLong *tadOffsetsZ) {
+void NativeOpExcutioner::execInverseBroadcastBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *xTadShapeInfo, Nd4jLong *xTadOffsets, Nd4jLong *zTadShapeInfo, Nd4jLong *zTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(yShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
     if (!nd4j::Environment::getInstance()->isExperimentalBuild())
         if (yType != xType || nd4j::DataType::BOOL != zType)
             throw nd4j::datatype_exception::build("NativeOps::execInverseBroadcastBool both operands must have same data type", xType, yType);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::broadcast::BroadcastBool, ::execInverse(opNum, x, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ, tadOffsetsZ), LIBND4J_TYPES, BOOL_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::broadcast::BroadcastBool, ::execInverse(opNum, x, xShapeInfo, y, yShapeInfo, result, zShapeInfo, dimension, dimensionLength, xTadShapeInfo, xTadOffsets, zTadShapeInfo, zTadOffsets), LIBND4J_TYPES, BOOL_TYPES);
 }
 
 
@@ -228,10 +228,10 @@ void NativeOpExcutioner::execInverseBroadcastBool(int opNum, void *x, Nd4jLong *
 * @param extraParams
 * @param n
 */
-void NativeOpExcutioner::execPairwiseTransform(int opNum, void *dx, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *extraParams) {
+void NativeOpExcutioner::execPairwiseTransform(int opNum, void *dx, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *zShapeInfo, void *extraParams) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(yShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
     if (!nd4j::Environment::getInstance()->isExperimentalBuild()) {
         if ((yType != xType && yType != nd4j::DataType::BOOL))
@@ -242,16 +242,16 @@ void NativeOpExcutioner::execPairwiseTransform(int opNum, void *dx, Nd4jLong *xS
     }
 
 #ifdef __ND4J_EXPERIMENTAL__
-    BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::pairwise_transforms::PairWiseTransform, ::exec(opNum, dx, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, extraParams), LIBND4J_TYPES, LIBND4J_TYPES);
+    BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::pairwise_transforms::PairWiseTransform, ::exec(opNum, dx, xShapeInfo, y, yShapeInfo, result, zShapeInfo, extraParams), LIBND4J_TYPES, LIBND4J_TYPES);
 #else
-    BUILD_SINGLE_SELECTOR_THRICE(xType, functions::pairwise_transforms::PairWiseTransform, ::exec(opNum, dx, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, extraParams), LIBND4J_TYPES);
+    BUILD_SINGLE_SELECTOR_THRICE(xType, functions::pairwise_transforms::PairWiseTransform, ::exec(opNum, dx, xShapeInfo, y, yShapeInfo, result, zShapeInfo, extraParams), LIBND4J_TYPES);
 #endif
 }
 
-void NativeOpExcutioner::execPairwiseBoolTransform(int opNum, void *dx, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *extraParams) {
+void NativeOpExcutioner::execPairwiseBoolTransform(int opNum, void *dx, Nd4jLong *xShapeInfo, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *zShapeInfo, void *extraParams) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(yShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
     if (!nd4j::Environment::getInstance()->isExperimentalBuild()) {
         if (yType != xType)
@@ -262,7 +262,7 @@ void NativeOpExcutioner::execPairwiseBoolTransform(int opNum, void *dx, Nd4jLong
             throw nd4j::datatype_exception::build("NativeOps::execPairwiseBoolTransform result must have bool type", zType);
     }
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::pairwise_transforms::PairWiseBoolTransform, ::exec(opNum, dx, xShapeInfo, y, yShapeInfo, result, resultShapeInfo, extraParams), LIBND4J_TYPES, BOOL_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::pairwise_transforms::PairWiseBoolTransform, ::exec(opNum, dx, xShapeInfo, y, yShapeInfo, result, zShapeInfo, extraParams), LIBND4J_TYPES, BOOL_TYPES);
 }
 
 
@@ -275,34 +275,34 @@ void NativeOpExcutioner::execPairwiseBoolTransform(int opNum, void *dx, Nd4jLong
 * @param xShapeInfo
 * @param extraParams
 * @param result
-* @param resultShapeInfo
+* @param zShapeInfo
 */
-void NativeOpExcutioner::execReduceFloat(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execReduceFloat(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceFloatFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, resultShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets), LIBND4J_TYPES, FLOAT_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceFloatFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, zShapeInfo, dimension, dimensionLength, tadShapeInfo, xTadOffsets), LIBND4J_TYPES, FLOAT_TYPES);
 }
 
-void NativeOpExcutioner::execReduceSame(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execReduceSame(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_SINGLE_SELECTOR(xType, functions::reduce::ReduceSameFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, resultShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets), LIBND4J_TYPES);
+    BUILD_SINGLE_SELECTOR(xType, functions::reduce::ReduceSameFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, zShapeInfo, dimension, dimensionLength, tadShapeInfo, xTadOffsets), LIBND4J_TYPES);
 }
 
-void NativeOpExcutioner::execReduceBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execReduceBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceBoolFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, resultShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets), LIBND4J_TYPES, BOOL_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceBoolFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, zShapeInfo, dimension, dimensionLength, tadShapeInfo, xTadOffsets), LIBND4J_TYPES, BOOL_TYPES);
 }
 
-void NativeOpExcutioner::execReduceLong(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *resultShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execReduceLong(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *zShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceLongFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, resultShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets), LIBND4J_TYPES, LONG_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceLongFunction, ::exec(opNum, x, xShapeInfo, extraParams, result, zShapeInfo, dimension, dimensionLength, tadShapeInfo, xTadOffsets), LIBND4J_TYPES, LONG_TYPES);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -374,13 +374,13 @@ void NativeOpExcutioner::execReduce3Scalar(int opNum, void *x, Nd4jLong *xShapeI
 * @param y
 * @param yShapeInfo
 * @param result
-* @param resultShapeInfo
+* @param zShapeInfo
 */
-void NativeOpExcutioner::execReduce3(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParamsVals, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfo) {
+void NativeOpExcutioner::execReduce3(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParamsVals, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *zShapeInfo) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce3::Reduce3, ::exec(opNum, x, xShapeInfo, extraParamsVals, y, yShapeInfo, result, resultShapeInfo, nullptr, 1), LIBND4J_TYPES, FLOAT_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce3::Reduce3, ::exec(opNum, x, xShapeInfo, extraParamsVals, y, yShapeInfo, result, zShapeInfo, nullptr, 1), LIBND4J_TYPES, FLOAT_TYPES);
 
 }
 
@@ -393,11 +393,11 @@ void NativeOpExcutioner::execReduce3All(int opNum, void *x, Nd4jLong *xShapeInfo
 }
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExcutioner::execReduce3TAD(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParamsVals, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfoBuffer, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execReduce3TAD(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParamsVals, void *y, Nd4jLong *yShapeInfo, void *result, Nd4jLong *resultShapeInfoBuffer, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto zType = nd4j::ArrayOptions::dataType(resultShapeInfoBuffer);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce3::Reduce3, ::exec(opNum, x, xShapeInfo, extraParamsVals, y, yShapeInfo, result, resultShapeInfoBuffer, dimension, dimensionLength, tadShapeInfo, tadOffsets), LIBND4J_TYPES, FLOAT_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce3::Reduce3, ::exec(opNum, x, xShapeInfo, extraParamsVals, y, yShapeInfo, result, resultShapeInfoBuffer, dimension, dimensionLength, tadShapeInfo, xTadOffsets), LIBND4J_TYPES, FLOAT_TYPES);
 }
 
 
@@ -413,10 +413,10 @@ void NativeOpExcutioner::execReduce3TAD(int opNum, void *x, Nd4jLong *xShapeInfo
 * @param extraParams
 * @param n
 */
-void NativeOpExcutioner::execScalar(int opNum, void *x, Nd4jLong *xShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *scalar, Nd4jLong *scalarShapeInfo, void *extraParams) {
+void NativeOpExcutioner::execScalar(int opNum, void *x, Nd4jLong *xShapeInfo, void *result, Nd4jLong *zShapeInfo, void *scalar, Nd4jLong *scalarShapeInfo, void *extraParams) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(scalarShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
     if (!nd4j::Environment::getInstance()->isExperimentalBuild()) {
         if ((yType != xType && yType != nd4j::DataType::BOOL) || zType != xType){
             throw nd4j::datatype_exception::build("NativeOpExecutioner::execScalar both operands must have same data type", xType, yType);
@@ -424,17 +424,17 @@ void NativeOpExcutioner::execScalar(int opNum, void *x, Nd4jLong *xShapeInfo, vo
     }
 
 #ifdef __ND4J_EXPERIMENTAL__
-        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(opNum, x, xShapeInfo, result, resultShapeInfo, scalar, extraParams), LIBND4J_TYPES, LIBND4J_TYPES);
+        BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(opNum, x, xShapeInfo, result, zShapeInfo, scalar, extraParams), LIBND4J_TYPES, LIBND4J_TYPES);
 #else
         BUILD_SINGLE_SELECTOR_THRICE(xType, functions::scalar::ScalarTransform,
-                                     ::transform(opNum, x, xShapeInfo, result, resultShapeInfo, scalar, extraParams),
+                                     ::transform(opNum, x, xShapeInfo, result, zShapeInfo, scalar, extraParams),
                                      LIBND4J_TYPES);
 #endif
 }
 
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExcutioner::execScalar(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *z, Nd4jLong *zShapeInfo, void *scalars, Nd4jLong *scalarShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets, Nd4jLong *tadShapeInfoZ, Nd4jLong *tadOffsetsZ) {
+void NativeOpExcutioner::execScalar(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *z, Nd4jLong *zShapeInfo, void *scalars, Nd4jLong *scalarShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets, Nd4jLong *tadShapeInfoZ, Nd4jLong *zTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(scalarShapeInfo);
     auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
@@ -444,22 +444,22 @@ void NativeOpExcutioner::execScalar(int opNum, void *x, Nd4jLong *xShapeInfo, vo
             throw nd4j::datatype_exception::build("NativeOpExecutioner::execScalar both operands must have same data type", xType, yType);
 
 #ifdef __ND4J_EXPERIMENTAL__
-    BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(opNum, x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength, tadShapeInfo, tadOffsets, tadShapeInfoZ, tadOffsetsZ), LIBND4J_TYPES, LIBND4J_TYPES);
+    BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform, ::transform(opNum, x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength, tadShapeInfo, xTadOffsets, tadShapeInfoZ, zTadOffsets), LIBND4J_TYPES, LIBND4J_TYPES);
 #else
-    BUILD_SINGLE_SELECTOR_THRICE(xType, functions::scalar::ScalarTransform, ::transform(opNum, x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength, tadShapeInfo, tadOffsets, tadShapeInfoZ, tadOffsetsZ), LIBND4J_TYPES);
+    BUILD_SINGLE_SELECTOR_THRICE(xType, functions::scalar::ScalarTransform, ::transform(opNum, x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength, tadShapeInfo, xTadOffsets, tadShapeInfoZ, zTadOffsets), LIBND4J_TYPES);
 #endif
 }
 
-void NativeOpExcutioner::execScalarBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *scalar, Nd4jLong *scalarShapeInfo, void *extraParams) {
+void NativeOpExcutioner::execScalarBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *result, Nd4jLong *zShapeInfo, void *scalar, Nd4jLong *scalarShapeInfo, void *extraParams) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::scalar::ScalarBoolTransform, ::transform(opNum, x, xShapeInfo, result, resultShapeInfo, scalar, extraParams), LIBND4J_TYPES, BOOL_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::scalar::ScalarBoolTransform, ::transform(opNum, x, xShapeInfo, result, zShapeInfo, scalar, extraParams), LIBND4J_TYPES, BOOL_TYPES);
 }
 
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExcutioner::execScalarBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *z, Nd4jLong *zShapeInfo, void *scalars, Nd4jLong *scalarShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets, Nd4jLong *tadShapeInfoZ, Nd4jLong *tadOffsetsZ) {
+void NativeOpExcutioner::execScalarBool(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *z, Nd4jLong *zShapeInfo, void *scalars, Nd4jLong *scalarShapeInfo, int *dimension, int dimensionLength, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets, Nd4jLong *tadShapeInfoZ, Nd4jLong *zTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
     auto yType = nd4j::ArrayOptions::dataType(scalarShapeInfo);
     auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
@@ -468,7 +468,7 @@ void NativeOpExcutioner::execScalarBool(int opNum, void *x, Nd4jLong *xShapeInfo
         if (yType != xType || nd4j::DataType::BOOL != zType)
             throw nd4j::datatype_exception::build("NativeOpExecutioner::execScalarBool both operands must have same data type", xType, yType);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::scalar::ScalarBoolTransform, ::transform(opNum, x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength, tadShapeInfo, tadOffsets, tadShapeInfoZ, tadOffsetsZ), LIBND4J_TYPES, BOOL_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::scalar::ScalarBoolTransform, ::transform(opNum, x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength, tadShapeInfo, xTadOffsets, tadShapeInfoZ, zTadOffsets), LIBND4J_TYPES, BOOL_TYPES);
 }
 
 
@@ -480,13 +480,13 @@ void NativeOpExcutioner::execScalarBool(int opNum, void *x, Nd4jLong *xShapeInfo
 * @param xShapeInfo
 * @param extraParams
 * @param result
-* @param resultShapeInfo
+* @param zShapeInfo
 */
-void NativeOpExcutioner::execSummaryStats(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *resultShapeInfo, bool biasCorrected) {
+void NativeOpExcutioner::execSummaryStats(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *zShapeInfo, bool biasCorrected) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::summarystats::SummaryStatsReduce, ::exec(opNum, biasCorrected, x, xShapeInfo, extraParams, result, resultShapeInfo, nullptr, 1), LIBND4J_TYPES, FLOAT_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::summarystats::SummaryStatsReduce, ::exec(opNum, biasCorrected, x, xShapeInfo, extraParams, result, zShapeInfo, nullptr, 1), LIBND4J_TYPES, FLOAT_TYPES);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -497,13 +497,13 @@ void NativeOpExcutioner::execSummaryStats(int opNum, void *x, Nd4jLong *xShapeIn
 * @param xShapeInfo
 * @param extraParams
 * @param result
-* @param resultShapeInfo
+* @param zShapeInfo
 */
-void NativeOpExcutioner::execSummaryStatsScalar(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *resultShapeInfo, bool biasCorrected) {
+void NativeOpExcutioner::execSummaryStatsScalar(int opNum, void *x, Nd4jLong *xShapeInfo, void *extraParams, void *result, Nd4jLong *zShapeInfo, bool biasCorrected) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::summarystats::SummaryStatsReduce, ::execScalar(opNum, biasCorrected, x, xShapeInfo, extraParams, result, resultShapeInfo), LIBND4J_TYPES, FLOAT_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::summarystats::SummaryStatsReduce, ::execScalar(opNum, biasCorrected, x, xShapeInfo, extraParams, result, zShapeInfo), LIBND4J_TYPES, FLOAT_TYPES);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -537,43 +537,43 @@ void NativeOpExcutioner::execSummaryStats(int opNum, void *x, Nd4jLong *xShapeIn
 * @param extraParams
 * @param n
 */
-void NativeOpExcutioner::execTransformFloat(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execTransformFloat(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *zShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformFloat, ::exec(opNum, dx, xShapeInfo, result, resultShapeInfo, extraParams, tadShapeInfo, tadOffsets), LIBND4J_TYPES, FLOAT_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformFloat, ::exec(opNum, dx, xShapeInfo, result, zShapeInfo, extraParams, tadShapeInfo, xTadOffsets), LIBND4J_TYPES, FLOAT_TYPES);
 }
 
-void NativeOpExcutioner::execTransformBool(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execTransformBool(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *zShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformBool, ::exec(opNum, dx, xShapeInfo, result, resultShapeInfo, extraParams, tadShapeInfo, tadOffsets), LIBND4J_TYPES, BOOL_TYPES);
+    BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformBool, ::exec(opNum, dx, xShapeInfo, result, zShapeInfo, extraParams, tadShapeInfo, xTadOffsets), LIBND4J_TYPES, BOOL_TYPES);
 }
 
-void NativeOpExcutioner::execTransformAny(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execTransformAny(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *zShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    if (opNum == nd4j::transform::Assign && xType == zType && shape::elementWiseStride(xShapeInfo) == 1 && shape::elementWiseStride(resultShapeInfo) == 1 && shape::order(xShapeInfo) == shape::order(resultShapeInfo) && shape::equalsTypesAndShapesSoft(xShapeInfo, resultShapeInfo)) {
+    if (opNum == nd4j::transform::Assign && xType == zType && shape::elementWiseStride(xShapeInfo) == 1 && shape::elementWiseStride(zShapeInfo) == 1 && shape::order(xShapeInfo) == shape::order(zShapeInfo) && shape::equalsTypesAndShapesSoft(xShapeInfo, zShapeInfo)) {
         memcpy(result, dx, nd4j::DataTypeUtils::sizeOf(xType) * shape::length(xShapeInfo));
     } else {
-        BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformAny, ::exec(opNum, dx, xShapeInfo, result, resultShapeInfo, extraParams, tadShapeInfo, tadOffsets), LIBND4J_TYPES, LIBND4J_TYPES);
+        BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformAny, ::exec(opNum, dx, xShapeInfo, result, zShapeInfo, extraParams, tadShapeInfo, xTadOffsets), LIBND4J_TYPES, LIBND4J_TYPES);
     }
 }
 
-void NativeOpExcutioner::execTransformSame(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execTransformSame(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *zShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_SINGLE_SELECTOR(xType, functions::transform::TransformSame, ::exec(opNum, dx, xShapeInfo, result, resultShapeInfo, extraParams, tadShapeInfo, tadOffsets), LIBND4J_TYPES);
+    BUILD_SINGLE_SELECTOR(xType, functions::transform::TransformSame, ::exec(opNum, dx, xShapeInfo, result, zShapeInfo, extraParams, tadShapeInfo, xTadOffsets), LIBND4J_TYPES);
 }
 
-void NativeOpExcutioner::execTransformStrict(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *resultShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *tadOffsets) {
+void NativeOpExcutioner::execTransformStrict(int opNum, void *dx, Nd4jLong *xShapeInfo, void *result, Nd4jLong *zShapeInfo, void *extraParams, Nd4jLong *tadShapeInfo, Nd4jLong *xTadOffsets) {
     auto xType = nd4j::ArrayOptions::dataType(xShapeInfo);
-    auto zType = nd4j::ArrayOptions::dataType(resultShapeInfo);
+    auto zType = nd4j::ArrayOptions::dataType(zShapeInfo);
 
-    BUILD_SINGLE_SELECTOR(xType, functions::transform::TransformStrict, ::exec(opNum, dx, xShapeInfo, result, resultShapeInfo, extraParams, tadShapeInfo, tadOffsets), FLOAT_TYPES);
+    BUILD_SINGLE_SELECTOR(xType, functions::transform::TransformStrict, ::exec(opNum, dx, xShapeInfo, result, zShapeInfo, extraParams, tadShapeInfo, xTadOffsets), FLOAT_TYPES);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/loops/cpu/broadcasting.hpp
+++ b/libnd4j/include/loops/cpu/broadcasting.hpp
@@ -36,25 +36,25 @@ namespace functions {
                                       void *y,
                                       Nd4jLong *yShapeInfo,
                                       void *z,
-                                      Nd4jLong *resultShapeInfo,
+                                      Nd4jLong *zShapeInfo,
                                       int *dimension,
                                       int dimensionLength,
-                                      Nd4jLong *tadShapeInfo,
-                                      Nd4jLong *tadOffset,
-                                      Nd4jLong *tadShapeInfoZ,
-                                      Nd4jLong *tadOffsetZ) {
+                                      Nd4jLong *xTadShapeInfo,
+                                      Nd4jLong *xTadOffset,
+                                      Nd4jLong *zTadShapeInfo,
+                                      Nd4jLong *zTadOffset) {
             DISPATCH_BY_OPNUM_TTT(execInverse, PARAMS(x,
                                                xShapeInfo,
                                                y,
                                                yShapeInfo,
                                                z,
-                                               resultShapeInfo,
+                                               zShapeInfo,
                                                dimension,
                                                dimensionLength,
-                                               tadShapeInfo,
-                                               tadOffset,
-                                               tadShapeInfoZ,
-                                               tadOffsetZ), BROADCAST_OPS);
+                                               xTadShapeInfo,
+                                               xTadOffset,
+                                               zTadShapeInfo,
+                                               zTadOffset), BROADCAST_OPS);
         }
 
         template <typename X, typename Y, typename Z>
@@ -64,25 +64,25 @@ namespace functions {
                              void *y,
                              Nd4jLong *yShapeInfo,
                              void *z,
-                             Nd4jLong *resultShapeInfo,
+                             Nd4jLong *zShapeInfo,
                              int *dimension,
                              int dimensionLength,
-                             Nd4jLong *tadShapeInfo,
-                             Nd4jLong *tadOffset,
-                             Nd4jLong *tadShapeInfoZ,
-                             Nd4jLong *tadOffsetZ) {
+                             Nd4jLong *xTadShapeInfo,
+                             Nd4jLong *xTadOffset,
+                             Nd4jLong *zTadShapeInfo,
+                             Nd4jLong *zTadOffset) {
             DISPATCH_BY_OPNUM_TTT(exec, PARAMS(x,
                                                xShapeInfo,
                                                y,
                                                yShapeInfo,
                                                z,
-                                               resultShapeInfo,
+                                               zShapeInfo,
                                                dimension,
                                                dimensionLength,
-                                               tadShapeInfo,
-                                               tadOffset,
-                                               tadShapeInfoZ,
-                                               tadOffsetZ), BROADCAST_OPS);
+                                               xTadShapeInfo,
+                                               xTadOffset,
+                                               zTadShapeInfo,
+                                               zTadOffset), BROADCAST_OPS);
         }
 
         template <typename X, typename  Y, typename Z>
@@ -92,13 +92,13 @@ namespace functions {
                              void *vy,
                              Nd4jLong *yShapeInfo,
                              void *vz,
-                             Nd4jLong *resultShapeInfo,
+                             Nd4jLong *zShapeInfo,
                              int *dimension,
                              int dimensionLength,
-                             Nd4jLong *tadShapeInfo,
-                             Nd4jLong *tadOffset,
-                             Nd4jLong *tadShapeInfoZ,
-                             Nd4jLong *tadOffsetZ) {
+                             Nd4jLong *xTadShapeInfo,
+                             Nd4jLong *xTadOffset,
+                             Nd4jLong *zTadShapeInfo,
+                             Nd4jLong *zTadOffset) {
 
                 auto x = reinterpret_cast<X *>(vx);
                 auto y = reinterpret_cast<Y *>(vy);
@@ -108,134 +108,134 @@ namespace functions {
                 //moving all dimensions (in sorted order)
                 //to the back.
                 //permuted version of the x shape info for setting up the tad problem
-                auto tadShapeShapeInfo = tadShapeInfo;
-                auto tadOffsets = tadOffset;
+                auto xTadShapeShapeInfo = xTadShapeInfo;
+                auto tadOffsets = xTadOffset;
 
-                if (tadShapeInfo == nullptr || tadOffsets == nullptr) {
+                if (xTadShapeInfo == nullptr || tadOffsets == nullptr) {
                     auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(xShapeInfo, dimension, dimensionLength);
 
-                    tadShapeShapeInfo = tadPack.primaryShapeInfo();
+                    xTadShapeShapeInfo = tadPack.primaryShapeInfo();
                     tadOffsets = tadPack.primaryOffsets();
                 }
 
-                //int *resultStride = shape::stride(tadShapeShapeInfo);                
-                unsigned int tadLength = shape::length(tadShapeShapeInfo);
+                //int *resultStride = shape::stride(xTadShapeShapeInfo);                
+                unsigned int tadLength = shape::length(xTadShapeShapeInfo);
                 unsigned int tads = shape::length(xShapeInfo) / tadLength;
 
-                if (tadShapeInfoZ == nullptr) {
-                    tadShapeInfoZ = tadShapeShapeInfo;
-                    tadOffsetZ = tadOffsets;
+                if (zTadShapeInfo == nullptr) {
+                    zTadShapeInfo = xTadShapeShapeInfo;
+                    zTadOffset = tadOffsets;
                 }
 
-                auto lenZ = shape::length(tadShapeInfoZ);
+                auto lenZ = shape::length(zTadShapeInfo);
                 auto lenY = shape::length(yShapeInfo);
 
                 int tadsPerThread = tads / TAD_THRESHOLD;
-                int _threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
-                _threads = nd4j::math::nd4j_min<int>(_threads, omp_get_max_threads());
-                auto xEws = shape::elementWiseStride(tadShapeShapeInfo);
+                int threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
+                threads = nd4j::math::nd4j_min<int>(threads, omp_get_max_threads());
+                auto xEws = shape::elementWiseStride(xTadShapeShapeInfo);
                 auto yEws = shape::elementWiseStride(yShapeInfo);
-                auto zEws = shape::elementWiseStride(tadShapeInfoZ);
+                auto zEws = shape::elementWiseStride(zTadShapeInfo);
 
-                if (shape::order(tadShapeShapeInfo) == shape::order(yShapeInfo) && shape::order(tadShapeInfoZ) == shape::order(yShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
+                if (shape::order(xTadShapeShapeInfo) == shape::order(yShapeInfo) && shape::order(zTadShapeInfo) == shape::order(yShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
 
                     if (xEws == 1 && yEws == 1 && zEws == 1) {
-                        PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                        PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                         for (int i = 0; i < tads; i++) {
                             auto oX = x + tadOffsets[i];
-                            auto oZ = z + tadOffsetZ[i];
+                            auto oZ = z + zTadOffset[i];
 
                             PRAGMA_OMP_SIMD
                             for (unsigned int f = 0; f < tadLength; f++)
                                 oZ[f] = OpType::op(oX[f], y[f]);
                         }
                     } else {
-                        PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                        PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                         for (int i = 0; i < tads; i++) {
                             auto oX = x + tadOffsets[i];
-                            auto oZ = z + tadOffsetZ[i];
+                            auto oZ = z + zTadOffset[i];
 
                             PRAGMA_OMP_SIMD
                             for (unsigned int f = 0; f < tadLength; f++)
                                 oZ[f * zEws] = OpType::op(oX[f * xEws], y[f * yEws]);
                         }
                     }
-                } else if(shape::haveSameOffsets(tadShapeShapeInfo, yShapeInfo) && shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+                } else if(shape::haveSameOffsets(xTadShapeShapeInfo, yShapeInfo) && shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                         
                         auto oX = x + tadOffsets[i];
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
 
                         PRAGMA_OMP_SIMD
                         for (unsigned int f = 0; f < tadLength; f++) {
-                            auto offset = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto offset = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             oZ[offset] = OpType::op(oX[offset], y[offset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(tadShapeShapeInfo, yShapeInfo)) {
+                else if(shape::haveSameOffsets(xTadShapeShapeInfo, yShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint tadShapeInfoZCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
-                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
-                            auto zOffset = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                            auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto zOffset = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                             oZ[zOffset] = OpType::op(oX[offset], y[offset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+                else if(shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint yShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
                     bool canCastY = nd4j::DataTypeUtils::castShapeInfo(yShapeInfo, yShapeInfoCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             auto yOffset = shape::indexOffset(f, yShapeInfo, yShapeInfoCast, lenY, canCastY);
                             oZ[offset] = OpType::op(oX[offset], y[yOffset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(yShapeInfo, tadShapeInfoZ)) {
+                else if(shape::haveSameOffsets(yShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint yShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
                     bool canCastY = nd4j::DataTypeUtils::castShapeInfo(yShapeInfo, yShapeInfoCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto xOffset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto xOffset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             auto offset = shape::indexOffset(f, yShapeInfo, yShapeInfoCast, lenY, canCastY);
                             oZ[offset] = OpType::op(oX[xOffset], y[offset]);
                         }
@@ -246,21 +246,21 @@ namespace functions {
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint tadShapeInfoZCast[MAX_RANK];
                     uint yShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
                     bool canCastY = nd4j::DataTypeUtils::castShapeInfo(yShapeInfo, yShapeInfoCast);
-                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto xOffset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto xOffset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             auto yOffset = shape::indexOffset(f, yShapeInfo, yShapeInfoCast, lenY, canCastY);
-                            auto zOffset  = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                            auto zOffset  = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                             oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
                         }
                     }
@@ -276,13 +276,13 @@ namespace functions {
                                       void *vy,
                                       Nd4jLong *yShapeInfo,
                                       void *vz,
-                                      Nd4jLong *resultShapeInfo,
+                                      Nd4jLong *zShapeInfo,
                                       int *dimension,
                                       int dimensionLength,
-                                      Nd4jLong *tadShapeInfo,
-                                      Nd4jLong *tadOffset,
-                                      Nd4jLong *tadShapeInfoZ,
-                                      Nd4jLong *tadOffsetZ) {
+                                      Nd4jLong *xTadShapeInfo,
+                                      Nd4jLong *xTadOffset,
+                                      Nd4jLong *zTadShapeInfo,
+                                      Nd4jLong *zTadOffset) {
 
             auto x = reinterpret_cast<X *>(vx);
             auto y = reinterpret_cast<Y *>(vy);
@@ -292,134 +292,134 @@ namespace functions {
             //moving all dimensions (in sorted order)
             //to the back.
             //permuted version of the x shape info for setting up the tad problem
-            auto tadShapeShapeInfo = tadShapeInfo;
-            auto tadOffsets = tadOffset;
+            auto xTadShapeShapeInfo = xTadShapeInfo;
+            auto tadOffsets = xTadOffset;
 
-            if (tadShapeInfo == nullptr || tadOffsets == nullptr) {
+            if (xTadShapeInfo == nullptr || tadOffsets == nullptr) {
                 auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(yShapeInfo, dimension, dimensionLength);
 
-                tadShapeShapeInfo = tadPack.primaryShapeInfo();
+                xTadShapeShapeInfo = tadPack.primaryShapeInfo();
                 tadOffsets = tadPack.primaryOffsets();
             }
 
-            //int *resultStride = shape::stride(tadShapeShapeInfo);
-            unsigned int tadLength = shape::length(tadShapeShapeInfo);
+            //int *resultStride = shape::stride(xTadShapeShapeInfo);
+            unsigned int tadLength = shape::length(xTadShapeShapeInfo);
             unsigned int tads = shape::length(yShapeInfo) / tadLength;
 
-            if (tadShapeInfoZ == nullptr) {
-                tadShapeInfoZ = tadShapeShapeInfo;
-                tadOffsetZ = tadOffsets;
+            if (zTadShapeInfo == nullptr) {
+                zTadShapeInfo = xTadShapeShapeInfo;
+                zTadOffset = tadOffsets;
             }
 
-            auto lenZ = shape::length(tadShapeInfoZ);
+            auto lenZ = shape::length(zTadShapeInfo);
             auto lenX = shape::length(xShapeInfo);
 
             int tadsPerThread = tads / TAD_THRESHOLD;
-            int _threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
-            _threads = nd4j::math::nd4j_min<int>(_threads, omp_get_max_threads());
-            auto yEws = shape::elementWiseStride(tadShapeShapeInfo);
+            int threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
+            threads = nd4j::math::nd4j_min<int>(threads, omp_get_max_threads());
+            auto yEws = shape::elementWiseStride(xTadShapeShapeInfo);
             auto xEws = shape::elementWiseStride(yShapeInfo);
-            auto zEws = shape::elementWiseStride(tadShapeInfoZ);
+            auto zEws = shape::elementWiseStride(zTadShapeInfo);
 
-            if (shape::order(tadShapeShapeInfo) == shape::order(xShapeInfo) && shape::order(tadShapeInfoZ) == shape::order(xShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
+            if (shape::order(xTadShapeShapeInfo) == shape::order(xShapeInfo) && shape::order(zTadShapeInfo) == shape::order(xShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
 
                 if (xEws == 1 && yEws == 1 && zEws == 1) {
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (unsigned int i = 0; i < tads; i++) {
                         auto oY = y + tadOffsets[i];
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
 
                         PRAGMA_OMP_SIMD
                         for (unsigned int f = 0; f < tadLength; f++)
                             oZ[f] = OpType::op(x[f], oY[f]);
                     }
                 } else {
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                         auto oY = y + tadOffsets[i];
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
 
                         PRAGMA_OMP_SIMD
                         for (unsigned int f = 0; f < tadLength; f++)
                             oZ[f * zEws] = OpType::op(x[f * xEws], oY[f * yEws]);
                     }
                 }
-            } else if(shape::haveSameOffsets(tadShapeShapeInfo, xShapeInfo) && shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+            } else if(shape::haveSameOffsets(xTadShapeShapeInfo, xShapeInfo) && shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                 uint tadShapeShapeInfoCast[MAX_RANK];
-                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
 
-                PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                 for (int i = 0; i < tads; i++) {
 
                     auto oY = x + tadOffsets[i];
-                    auto oZ = z + tadOffsetZ[i];
+                    auto oZ = z + zTadOffset[i];
 
                     PRAGMA_OMP_SIMD
                     for (unsigned int f = 0; f < tadLength; f++) {
-                        auto offset = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                        auto offset = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
                         oZ[offset] = OpType::op(x[offset], oY[offset]);
                     }
                 }
             }
-            else if(shape::haveSameOffsets(tadShapeShapeInfo, xShapeInfo)) {
+            else if(shape::haveSameOffsets(xTadShapeShapeInfo, xShapeInfo)) {
 
                 uint tadShapeShapeInfoCast[MAX_RANK];
                 uint tadShapeInfoZCast[MAX_RANK];
-                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
-                bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
+                bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                 for (int i = 0; i < tads; i++) {
 
-                    auto oZ = z + tadOffsetZ[i];
+                    auto oZ = z + zTadOffset[i];
                     auto oY = y + tadOffsets[i];
 
                     PRAGMA_OMP_SIMD
                     for (int f = 0; f < tadLength; f++) {
-                        auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
-                        auto zOffset = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                        auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                        auto zOffset = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                         oZ[zOffset] = OpType::op(x[offset], oY[offset]);
                     }
                 }
             }
-            else if(shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+            else if(shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                 uint tadShapeShapeInfoCast[MAX_RANK];
                 uint xShapeInfoCast[MAX_RANK];
                 bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xShapeInfo, xShapeInfoCast);
-                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
 
-                PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                 for (int i = 0; i < tads; i++) {
 
-                    auto oZ = z + tadOffsetZ[i];
+                    auto oZ = z + zTadOffset[i];
                     auto oY = y + tadOffsets[i];
 
                     PRAGMA_OMP_SIMD
                     for (int f = 0; f < tadLength; f++) {
-                        auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                        auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
                         auto xOffset = shape::indexOffset(f, yShapeInfo, xShapeInfoCast, lenX, canCastX);
                         oZ[offset] = OpType::op(x[xOffset], oY[offset]);
                     }
                 }
             }
-            else if(shape::haveSameOffsets(xShapeInfo, tadShapeInfoZ)) {
+            else if(shape::haveSameOffsets(xShapeInfo, zTadShapeInfo)) {
 
                 uint tadShapeShapeInfoCast[MAX_RANK];
                 uint xShapeInfoCast[MAX_RANK];
                 bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xShapeInfo, xShapeInfoCast);
-                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
 
-                PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                 for (int i = 0; i < tads; i++) {
 
-                    auto oZ = z + tadOffsetZ[i];
+                    auto oZ = z + zTadOffset[i];
                     auto oY = y + tadOffsets[i];
 
                     PRAGMA_OMP_SIMD
                     for (int f = 0; f < tadLength; f++) {
-                        auto yOffset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                        auto yOffset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
                         auto offset = shape::indexOffset(f, xShapeInfo, xShapeInfoCast, lenX, canCastX);
                         oZ[offset] = OpType::op(x[offset], oY[yOffset]);
                     }
@@ -431,20 +431,20 @@ namespace functions {
                 uint tadShapeInfoZCast[MAX_RANK];
                 uint xShapeInfoCast[MAX_RANK];
                 bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xShapeInfo, xShapeInfoCast);
-                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
-                bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
+                bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                 for (int i = 0; i < tads; i++) {
 
-                    auto oZ = z + tadOffsetZ[i];
+                    auto oZ = z + zTadOffset[i];
                     auto oY = y + tadOffsets[i];
 
                     PRAGMA_OMP_SIMD
                     for (int f = 0; f < tadLength; f++) {
                         auto xOffset = shape::indexOffset(f, xShapeInfo, xShapeInfoCast, lenX, canCastX);
-                        auto yOffset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
-                        auto zOffset  = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                        auto yOffset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                        auto zOffset  = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                         oZ[zOffset] = OpType::op(x[xOffset], oY[yOffset]);
                     }
                 }

--- a/libnd4j/include/loops/cpu/broadcasting_bool.cpp
+++ b/libnd4j/include/loops/cpu/broadcasting_bool.cpp
@@ -39,10 +39,10 @@ namespace functions {
                              Nd4jLong *zShapeInfo,
                              int *dimension,
                              int dimensionLength,
-                             Nd4jLong *tadShapeInfo,
-                             Nd4jLong *tadOffset,
-                             Nd4jLong *tadShapeInfoZ,
-                             Nd4jLong *tadOffsetZ) {
+                             Nd4jLong *xTadShapeInfo,
+                             Nd4jLong *xTadOffset,
+                             Nd4jLong *zTadShapeInfo,
+                             Nd4jLong *zTadOffset) {
             DISPATCH_BY_OPNUM_TT(exec, PARAMS(x,
                                                xShapeInfo,
                                                y,
@@ -51,10 +51,10 @@ namespace functions {
                                                zShapeInfo,
                                                dimension,
                                                dimensionLength,
-                                               tadShapeInfo,
-                                               tadOffset,
-                                               tadShapeInfoZ,
-                                               tadOffsetZ), BROADCAST_BOOL_OPS);
+                                               xTadShapeInfo,
+                                               xTadOffset,
+                                               zTadShapeInfo,
+                                               zTadOffset), BROADCAST_BOOL_OPS);
         }
 
         template <typename X, typename Y>
@@ -67,10 +67,10 @@ namespace functions {
                              Nd4jLong *zShapeInfo,
                              int *dimension,
                              int dimensionLength,
-                             Nd4jLong *tadShapeInfo,
-                             Nd4jLong *tadOffset,
-                             Nd4jLong *tadShapeInfoZ,
-                             Nd4jLong *tadOffsetZ) {
+                             Nd4jLong *xTadShapeInfo,
+                             Nd4jLong *xTadOffset,
+                             Nd4jLong *zTadShapeInfo,
+                             Nd4jLong *zTadOffset) {
             DISPATCH_BY_OPNUM_TT(execInverse, PARAMS(x,
                                                xShapeInfo,
                                                y,
@@ -79,10 +79,10 @@ namespace functions {
                                                zShapeInfo,
                                                dimension,
                                                dimensionLength,
-                                               tadShapeInfo,
-                                               tadOffset,
-                                               tadShapeInfoZ,
-                                               tadOffsetZ), BROADCAST_BOOL_OPS);
+                                               xTadShapeInfo,
+                                               xTadOffset,
+                                               zTadShapeInfo,
+                                               zTadOffset), BROADCAST_BOOL_OPS);
         }
 
         template <typename X, typename Z>
@@ -95,10 +95,10 @@ namespace functions {
                              Nd4jLong *zShapeInfo,
                              int *dimension,
                              int dimensionLength,
-                             Nd4jLong *tadShapeInfo,
-                             Nd4jLong *tadOffset,
-                             Nd4jLong *tadShapeInfoZ,
-                             Nd4jLong *tadOffsetZ) {
+                             Nd4jLong *xTadShapeInfo,
+                             Nd4jLong *xTadOffset,
+                             Nd4jLong *zTadShapeInfo,
+                             Nd4jLong *zTadOffset) {
 
                 auto x = reinterpret_cast<X *>(vx);
                 auto y = reinterpret_cast<X *>(vy);
@@ -108,137 +108,137 @@ namespace functions {
                 //moving all dimensions (in sorted order)
                 //to the back.
                 //permuted version of the x shape info for setting up the tad problem
-                auto tadShapeShapeInfo = tadShapeInfo;
-                auto tadOffsets = tadOffset;
+                auto xTadShapeShapeInfo = xTadShapeInfo;
+                auto tadOffsets = xTadOffset;
 
-                if (tadShapeInfo == nullptr || tadOffsets == nullptr) {
+                if (xTadShapeInfo == nullptr || tadOffsets == nullptr) {
                     auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(xShapeInfo, dimension, dimensionLength);
 
-                    tadShapeShapeInfo = tadPack.primaryShapeInfo();
+                    xTadShapeShapeInfo = tadPack.primaryShapeInfo();
                     tadOffsets = tadPack.primaryOffsets();
                 }
 
-                //int *resultStride = shape::stride(tadShapeShapeInfo);
-                unsigned int tadLength = shape::length(tadShapeShapeInfo);
+                //int *resultStride = shape::stride(xTadShapeShapeInfo);
+                unsigned int tadLength = shape::length(xTadShapeShapeInfo);
                 unsigned int tads = shape::length(xShapeInfo) / tadLength;
 
-                if (tadShapeInfoZ == nullptr) {
-                    tadShapeInfoZ = tadShapeShapeInfo;
-                    tadOffsetZ = tadOffsets;
+                if (zTadShapeInfo == nullptr) {
+                    zTadShapeInfo = xTadShapeShapeInfo;
+                    zTadOffset = tadOffsets;
                 }                                
 
-                auto lenZ = shape::length(tadShapeInfoZ);
+                auto lenZ = shape::length(zTadShapeInfo);
                 auto lenY = shape::length(yShapeInfo);
 
                 int tadsPerThread = tads / TAD_THRESHOLD;
-                int _threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
-                _threads = nd4j::math::nd4j_min<int>(_threads, omp_get_max_threads());
+                int threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
+                threads = nd4j::math::nd4j_min<int>(threads, omp_get_max_threads());
 
-                auto xEws = shape::elementWiseStride(tadShapeShapeInfo);
+                auto xEws = shape::elementWiseStride(xTadShapeShapeInfo);
                 auto yEws = shape::elementWiseStride(yShapeInfo);
-                auto zEws = shape::elementWiseStride(tadShapeInfoZ);
+                auto zEws = shape::elementWiseStride(zTadShapeInfo);
 
-                if (shape::order(tadShapeShapeInfo) == shape::order(yShapeInfo) && shape::order(tadShapeInfoZ) == shape::order(yShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
+                if (shape::order(xTadShapeShapeInfo) == shape::order(yShapeInfo) && shape::order(zTadShapeInfo) == shape::order(yShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
 
                     if (xEws == 1 && yEws == 1 && zEws == 1) {
-                        PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                        PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                         for (int i = 0; i < tads; i++) {
                             auto oX = x + tadOffsets[i];
-                            auto oZ = z + tadOffsetZ[i];
+                            auto oZ = z + zTadOffset[i];
 
                             PRAGMA_OMP_SIMD
                             for (unsigned int f = 0; f < tadLength; f++)
                                 oZ[f] = OpType::op(oX[f], y[f]);
                         }
                     } else {
-                        PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                        PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                         for (int i = 0; i < tads; i++) {
                             auto oX = x + tadOffsets[i];
-                            auto oZ = z + tadOffsetZ[i];
+                            auto oZ = z + zTadOffset[i];
 
                             PRAGMA_OMP_SIMD
                             for (unsigned int f = 0; f < tadLength; f++)
                                 oZ[f * zEws] = OpType::op(oX[f * xEws], y[f * yEws]);
                         }
                     }
-                } else if(shape::haveSameOffsets(tadShapeShapeInfo, yShapeInfo) && shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+                } else if(shape::haveSameOffsets(xTadShapeShapeInfo, yShapeInfo) && shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
                                         
                         // TODO: cover this codebranch with tests
                         // all this stuff already happens within thread
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto offset = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             oZ[offset] = OpType::op(oX[offset], y[offset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(tadShapeShapeInfo, yShapeInfo)) {
+                else if(shape::haveSameOffsets(xTadShapeShapeInfo, yShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint tadShapeInfoZCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
-                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
-                            auto zOffset = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                            auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto zOffset = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                             oZ[zOffset] = OpType::op(oX[offset], y[offset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+                else if(shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint yShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
                     bool canCastY = nd4j::DataTypeUtils::castShapeInfo(yShapeInfo, yShapeInfoCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             auto yOffset = shape::indexOffset(f, yShapeInfo, yShapeInfoCast, lenY, canCastY);
                             oZ[offset] = OpType::op(oX[offset], y[yOffset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(yShapeInfo, tadShapeInfoZ)) {
+                else if(shape::haveSameOffsets(yShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint yShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
                     bool canCastY = nd4j::DataTypeUtils::castShapeInfo(yShapeInfo, yShapeInfoCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto xOffset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto xOffset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             auto offset = shape::indexOffset(f, yShapeInfo, yShapeInfoCast, lenY, canCastY);
                             oZ[offset] = OpType::op(oX[xOffset], y[offset]);
                         }
@@ -249,21 +249,21 @@ namespace functions {
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint tadShapeInfoZCast[MAX_RANK];
                     uint yShapeInfoCast[MAX_RANK];
-                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
                     bool canCastY = nd4j::DataTypeUtils::castShapeInfo(yShapeInfo, yShapeInfoCast);
-                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oX = x + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto xOffset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
+                            auto xOffset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastX);
                             auto yOffset = shape::indexOffset(f, yShapeInfo, yShapeInfoCast, lenY, canCastY);
-                            auto zOffset  = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                            auto zOffset  = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                             oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
                         }
                     }
@@ -281,10 +281,10 @@ namespace functions {
                              Nd4jLong *zShapeInfo,
                              int *dimension,
                              int dimensionLength,
-                             Nd4jLong *tadShapeInfo,
-                             Nd4jLong *tadOffset,
-                             Nd4jLong *tadShapeInfoZ,
-                             Nd4jLong *tadOffsetZ) {
+                             Nd4jLong *xTadShapeInfo,
+                             Nd4jLong *xTadOffset,
+                             Nd4jLong *zTadShapeInfo,
+                             Nd4jLong *zTadOffset) {
 
                 auto x = reinterpret_cast<X *>(vx);
                 auto y = reinterpret_cast<X *>(vy);
@@ -294,137 +294,137 @@ namespace functions {
                 //moving all dimensions (in sorted order)
                 //to the back.
                 //permuted version of the x shape info for setting up the tad problem
-                auto tadShapeShapeInfo = tadShapeInfo;
-                auto tadOffsets = tadOffset;
+                auto xTadShapeShapeInfo = xTadShapeInfo;
+                auto tadOffsets = xTadOffset;
 
-                if (tadShapeInfo == nullptr || tadOffsets == nullptr) {
+                if (xTadShapeInfo == nullptr || tadOffsets == nullptr) {
                     auto tadPack = nd4j::ConstantTadHelper::getInstance()->tadForDimensions(yShapeInfo, dimension, dimensionLength);
 
-                    tadShapeShapeInfo = tadPack.primaryShapeInfo();
+                    xTadShapeShapeInfo = tadPack.primaryShapeInfo();
                     tadOffsets = tadPack.primaryOffsets();
                 }
 
-                //int *resultStride = shape::stride(tadShapeShapeInfo);
-                unsigned int tadLength = shape::length(tadShapeShapeInfo);
+                //int *resultStride = shape::stride(xTadShapeShapeInfo);
+                unsigned int tadLength = shape::length(xTadShapeShapeInfo);
                 unsigned int tads = shape::length(yShapeInfo) / tadLength;
 
-                if (tadShapeInfoZ == nullptr) {
-                    tadShapeInfoZ = tadShapeShapeInfo;
-                    tadOffsetZ = tadOffsets;
+                if (zTadShapeInfo == nullptr) {
+                    zTadShapeInfo = xTadShapeShapeInfo;
+                    zTadOffset = tadOffsets;
                 }                                
 
-                auto lenZ = shape::length(tadShapeInfoZ);
+                auto lenZ = shape::length(zTadShapeInfo);
                 auto lenX = shape::length(xShapeInfo);
 
                 int tadsPerThread = tads / TAD_THRESHOLD;
-                int _threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
-                _threads = nd4j::math::nd4j_min<int>(_threads, omp_get_max_threads());
+                int threads = nd4j::math::nd4j_max<int>(1, tadsPerThread);
+                threads = nd4j::math::nd4j_min<int>(threads, omp_get_max_threads());
 
-                auto yEws = shape::elementWiseStride(tadShapeShapeInfo);
+                auto yEws = shape::elementWiseStride(xTadShapeShapeInfo);
                 auto xEws = shape::elementWiseStride(xShapeInfo);
-                auto zEws = shape::elementWiseStride(tadShapeInfoZ);
+                auto zEws = shape::elementWiseStride(zTadShapeInfo);
 
-                if (shape::order(tadShapeShapeInfo) == shape::order(xShapeInfo) && shape::order(tadShapeInfoZ) == shape::order(xShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
+                if (shape::order(xTadShapeShapeInfo) == shape::order(xShapeInfo) && shape::order(zTadShapeInfo) == shape::order(xShapeInfo) && xEws > 0 && yEws > 0 && zEws > 0) {
 
                     if (xEws == 1 && yEws == 1 && zEws == 1) {
-                        PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                        PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                         for (int i = 0; i < tads; i++) {
                             auto oY = y + tadOffsets[i];
-                            auto oZ = z + tadOffsetZ[i];
+                            auto oZ = z + zTadOffset[i];
 
                             PRAGMA_OMP_SIMD
                             for (unsigned int f = 0; f < tadLength; f++)
                                 oZ[f] = OpType::op(x[f], oY[f]);
                         }
                     } else {
-                        PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                        PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                         for (int i = 0; i < tads; i++) {
                             auto oY = y + tadOffsets[i];
-                            auto oZ = z + tadOffsetZ[i];
+                            auto oZ = z + zTadOffset[i];
 
                             PRAGMA_OMP_SIMD
                             for (uint f = 0; f < tadLength; f++)
                                 oZ[f * zEws] = OpType::op(x[f * xEws], oY[f * yEws]);
                         }
                     }
-                } else if(shape::haveSameOffsets(tadShapeShapeInfo, xShapeInfo) && shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+                } else if(shape::haveSameOffsets(xTadShapeShapeInfo, xShapeInfo) && shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
-                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
                         auto oY = y + tadOffsets[i];
-                        auto oZ = z + tadOffsetZ[i];                        
+                        auto oZ = z + zTadOffset[i];                        
                                         
                         // TODO: cover this codebranch with tests
                         // all this stuff already happens within thread
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                            auto offset = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
                             oZ[offset] = OpType::op(x[offset], oY[offset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(tadShapeShapeInfo, xShapeInfo)) {
+                else if(shape::haveSameOffsets(xTadShapeShapeInfo, xShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint tadShapeInfoZCast[MAX_RANK];
-                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
-                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oY = y + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
-                            auto zOffset = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                            auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                            auto zOffset = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                             oZ[zOffset] = OpType::op(x[offset], oY[offset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(tadShapeShapeInfo, tadShapeInfoZ)) {
+                else if(shape::haveSameOffsets(xTadShapeShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint xShapeInfoCast[MAX_RANK];
                     bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xShapeInfo, xShapeInfoCast);
-                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);                    
+                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);                    
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oY = y + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto offset  = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                            auto offset  = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
                             auto xOffset = shape::indexOffset(f, xShapeInfo, xShapeInfoCast, lenX, canCastX);
                             oZ[offset] = OpType::op(x[xOffset], oY[offset]);
                         }
                     }
                 }
-                else if(shape::haveSameOffsets(xShapeInfo, tadShapeInfoZ)) {
+                else if(shape::haveSameOffsets(xShapeInfo, zTadShapeInfo)) {
 
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint xShapeInfoCast[MAX_RANK];
                     bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xShapeInfo, xShapeInfoCast);
-                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);
+                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);
                     
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oY = y + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
-                            auto yOffset = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
+                            auto yOffset = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);
                             auto offset  = shape::indexOffset(f, xShapeInfo, xShapeInfoCast, lenX, canCastX);
                             oZ[offset] = OpType::op(x[offset], oY[yOffset]);
                         }
@@ -436,20 +436,20 @@ namespace functions {
                     uint tadShapeShapeInfoCast[MAX_RANK];
                     uint tadShapeInfoZCast[MAX_RANK];                    
                     bool canCastX = nd4j::DataTypeUtils::castShapeInfo(xShapeInfo, xShapeInfoCast);
-                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(tadShapeShapeInfo, tadShapeShapeInfoCast);                
-                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(tadShapeInfoZ, tadShapeInfoZCast);
+                    bool canCastY = nd4j::DataTypeUtils::castShapeInfo(xTadShapeShapeInfo, tadShapeShapeInfoCast);                
+                    bool canCastZ = nd4j::DataTypeUtils::castShapeInfo(zTadShapeInfo, tadShapeInfoZCast);
 
-                    PRAGMA_OMP_PARALLEL_FOR_THREADS(_threads)
+                    PRAGMA_OMP_PARALLEL_FOR_THREADS(threads)
                     for (int i = 0; i < tads; i++) {
                     
-                        auto oZ = z + tadOffsetZ[i];
+                        auto oZ = z + zTadOffset[i];
                         auto oY = y + tadOffsets[i];
 
                         PRAGMA_OMP_SIMD
                         for (int f = 0; f < tadLength; f++) {
                             auto xOffset = shape::indexOffset(f, xShapeInfo, xShapeInfoCast, lenX, canCastX);
-                            auto yOffset = shape::indexOffset(f, tadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);                            
-                            auto zOffset = shape::indexOffset(f, tadShapeInfoZ, tadShapeInfoZCast, lenZ, canCastZ);
+                            auto yOffset = shape::indexOffset(f, xTadShapeShapeInfo, tadShapeShapeInfoCast, tadLength, canCastY);                            
+                            auto zOffset = shape::indexOffset(f, zTadShapeInfo, tadShapeInfoZCast, lenZ, canCastZ);
                             oZ[zOffset] = OpType::op(x[xOffset], oY[yOffset]);
                         }
                     }

--- a/libnd4j/tests_cpu/layers_tests/NDArrayTests2.cpp
+++ b/libnd4j/tests_cpu/layers_tests/NDArrayTests2.cpp
@@ -1234,18 +1234,19 @@ TEST_F(NDArrayTest2, reshapei_2) {
 }
 
 //////////////////////////////////////////////////////////////////////
-TEST_F(NDArrayTest2, Test_apply_true_scalar_1) {
+TEST_F(NDArrayTest2, trueBroadcast_1) {
+
     NDArray x('f', {2, 3}, {1., 2., 3., 4., 5., 6.});
-    NDArray y('f', {2, 3}, {5., 4., 3., 2., 1., 0.});
+    NDArray y('f', {1, 3}, {5., 4., 3.});
     NDArray z('c', {2, 3}, nd4j::DataType::DOUBLE);
 
-    auto expected = x - y;
+    auto exp = x - y;
+    x.applyTrueBroadcast(nd4j::BroadcastOpsTuple::Subtract(), &y, &z, true);
 
-    x.applyTrueBroadcast(nd4j::BroadcastOpsTuple::Subtract(), &y, &z, true);    
-    // expected.printIndexedBuffer();
+    // exp.printIndexedBuffer();
     // z.printIndexedBuffer();
 
-    ASSERT_TRUE(expected.equalsTo(z));
+    ASSERT_TRUE(exp.equalsTo(z));
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
correct bug in NDArray::applyBroadcast - we gave same input tad shapeInfo both for input and output arrays, now 2 shapeInfos are given: input tad for input array and output tad for output array
