### PR TITLE
upgrade Apache Lucene/Solr version from 7.5.0 to 7.7.1

### DIFF
--- a/deeplearning4j/deeplearning4j-dataimport-solrj/src/main/java/org/deeplearning4j/nn/dataimport/solr/client/solrj/io/stream/TupleStreamDataSetIterator.java
+++ b/deeplearning4j/deeplearning4j-dataimport-solrj/src/main/java/org/deeplearning4j/nn/dataimport/solr/client/solrj/io/stream/TupleStreamDataSetIterator.java
@@ -39,8 +39,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
-  * A {@link DataSetIterator} which uses a <a href="https://lucene.apache.org/solr/guide/7_5/streaming-expressions.html">streaming expression</a>
- * to fetch data from Apache Solr and/or one of the sources (e.g. <code>jdbc</code>) supported as a <a href="https://lucene.apache.org/solr/guide/7_5/stream-source-reference.html">stream source</a>.
+  * A {@link DataSetIterator} which uses a <a href="https://lucene.apache.org/solr/guide/7_7/streaming-expressions.html">streaming expression</a>
+ * to fetch data from Apache Solr and/or one of the sources (e.g. <code>jdbc</code>) supported as a <a href="https://lucene.apache.org/solr/guide/7_7/stream-source-reference.html">stream source</a>.
  * <p>
  * Example code snippet:
 <pre>{

--- a/deeplearning4j/deeplearning4j-dataimport-solrj/src/test/resources/solr/configsets/mini/conf/solrconfig.xml
+++ b/deeplearning4j/deeplearning4j-dataimport-solrj/src/test/resources/solr/configsets/mini/conf/solrconfig.xml
@@ -17,10 +17,10 @@
 
 <!--
   This file is a minimal test configuration. For comprehensive information about solrconfig.xml please refer to
-  http://lucene.apache.org/solr/guide/7_5/configuring-solrconfig-xml.html
+  http://lucene.apache.org/solr/guide/7_7/configuring-solrconfig-xml.html
   and the well-commented example files in the Apache Solr release's server/solr/configsets directories.
 -->
 
 <config>
-  <luceneMatchVersion>7.5.0</luceneMatchVersion>
+  <luceneMatchVersion>7.7.1</luceneMatchVersion>
 </config>

--- a/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
+++ b/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
@@ -38,7 +38,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
- * An <a href="https://lucene.apache.org/solr/7_5_0/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
+ * An <a href="https://lucene.apache.org/solr/7_7_1/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
  * org.apache.solr.ltr.model.LTRScoringModel</a> that computes scores using a {@link MultiLayerNetwork} or
  * {@link ComputationGraph} model.
  * <p>
@@ -58,7 +58,7 @@ import org.nd4j.linalg.factory.Nd4j;
  * <p>
  * Apache Solr Reference Guide:
  * <ul>
- * <li> <a href="https://lucene.apache.org/solr/guide/7_5/learning-to-rank.html">Learning To Rank</a>
+ * <li> <a href="https://lucene.apache.org/solr/guide/7_7/learning-to-rank.html">Learning To Rank</a>
  * </ul>
  */
 public class ScoringModel extends AdapterModel {

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
         <geo.jackson.version>2.8.7</geo.jackson.version>
         <lombok.version>1.18.2</lombok.version>
         <cleartk.version>2.0.0</cleartk.version>
-        <lucene-solr.version>7.5.0</lucene-solr.version>
+        <lucene-solr.version>7.7.1</lucene-solr.version>
         <json.version>20131018</json.version>
         <google.protobuf.version>2.6.1</google.protobuf.version>
         <failIfNoTests>false</failIfNoTests>


### PR DESCRIPTION
http://lucene.apache.org/core/7_7_1/changes/Changes.html
http://lucene.apache.org/solr/7_7_1/changes/Changes.html

The lucene-solr.version pom.xml property is currently used by two modules:
* deeplearning4j/deeplearning4j-dataimport-solrj
* deeplearning4j/deeplearning4j-modelexport-solr
