### PR TITLE
fix deeplearning4j-modelexport-solr ScoringModelTest failure

### DIFF
--- a/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
+++ b/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
@@ -127,7 +127,7 @@ public class ScoringModel extends AdapterModel {
    * Uses the {@link NetworkUtils#output(Model, INDArray)} method.
    */
   public static float outputScore(Model model, float[] modelFeatureValuesNormalized) {
-    final INDArray input = Nd4j.create(modelFeatureValuesNormalized);
+    final INDArray input = Nd4j.create(new float[][]{ modelFeatureValuesNormalized });
     final INDArray output = NetworkUtils.output(model, input);
     return output.getFloat(0);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To fix a test failure that arose:
```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.049 sec <<< FAILURE! - in org.deeplearning4j.nn.modelexport.solr.ltr.model.ScoringModelTest
test(org.deeplearning4j.nn.modelexport.solr.ltr.model.ScoringModelTest)  Time elapsed: 2 sec  <<< ERROR!
org.apache.solr.ltr.model.ModelException: score(...) test failed for model myModel
	at org.deeplearning4j.nn.modelexport.solr.ltr.model.ScoringModelTest.doTest(ScoringModelTest.java:148)
	at org.deeplearning4j.nn.modelexport.solr.ltr.model.ScoringModelTest.test(ScoringModelTest.java:122)
Caused by: org.deeplearning4j.exception.DL4JInvalidInputException: Input that is not a matrix; expected matrix (rank 2), got rank 1 array with shape [3]. Missing preprocessor or wrong input type? (layer name: layer0, layer index: 0, layer type: OutputLayer)
	at org.deeplearning4j.nn.modelexport.solr.ltr.model.ScoringModelTest.doTest(ScoringModelTest.java:148)
	at org.deeplearning4j.nn.modelexport.solr.ltr.model.ScoringModelTest.test(ScoringModelTest.java:122)


Results :

Tests in error: 
  ScoringModelTest.test:122->doTest:148 » Model score(...) test failed for model...
```

## How was this patch tested?
```
cd deeplearning4j/deeplearning4j-modelexport-solr
mvn test
```
