### PR TITLE
Fix result shape datatype calculation for Variance based Ops

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/summarystats/Variance.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/summarystats/Variance.java
@@ -24,9 +24,6 @@ import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseReduceOp;
-import org.nd4j.linalg.api.ops.executioner.OpExecutioner;
-import org.nd4j.linalg.api.ops.impl.reduce.floating.Bias;
-import org.nd4j.linalg.api.ops.impl.reduce.floating.Mean;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
@@ -134,6 +131,10 @@ public class Variance extends BaseReduceOp {
     public DataType resultType() {
         if (this.x() != null && this.x().isR())
             return this.x().dataType();
+
+        if(this.arg() != null){
+            return this.arg().dataType();
+        }
 
         return Nd4j.defaultFloatingPointType();
     }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LossOpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/autodiff/opvalidation/LossOpValidation.java
@@ -421,10 +421,9 @@ public class LossOpValidation extends BaseOpValidation {
 
     @Test
     public void testNonZeroResult() {
-        OpValidationSuite.ignoreFailing(); //TEMPORARY - Waiting on PR #7082
-        INDArray predictions = Nd4j.rand(org.nd4j.graph.DataType.DOUBLE, 10, 4);
+        INDArray predictions = Nd4j.rand(DataType.DOUBLE, 10, 5);
         INDArray w = Nd4j.scalar(1.0);
-        INDArray label = Nd4j.rand(org.nd4j.graph.DataType.DOUBLE, 10, 5);
+        INDArray label = Nd4j.rand(DataType.DOUBLE, 10, 5);
         final INDArray zero = Nd4j.scalar(0.);
         final INDArray zeroBp = Nd4j.zerosLike(predictions);
 
@@ -476,5 +475,15 @@ public class LossOpValidation extends BaseOpValidation {
                 assertNotEquals(lossOp + "_grad returns zero result. Reduction Mode " + reductionMode, outBP, zeroBp);
             }
         }
+    }
+
+    @Test
+    public void TestStdLossMixedDataType(){
+        // Default Data Type in this test suite is Double.
+        // This test used to throw an Exception that we have mixed data types.
+
+        SameDiff sd = SameDiff.create();
+        SDVariable v = sd.placeHolder("x", DataType.FLOAT, 3,4);
+        SDVariable loss = v.std(true);
     }
 }


### PR DESCRIPTION
Fixes #7697 

And also fixes wrong use of DataType in previously ignored test that passes now.