### PR TITLE
Model/format validation utilities + tests + npz fixes

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelValidatorTests.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelValidatorTests.java
@@ -7,6 +7,7 @@ import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.Rule;
 import org.junit.Test;
@@ -158,6 +159,124 @@ public class ModelValidatorTests extends BaseDL4JTest {
     }
 
 
+    @Test
+    public void testComputationGraphNetworkValidation() throws Exception {
+        File f = testDir.newFolder();
+
+        //Test non-existent file
+        File f0 = new File(f, "doesntExist.bin");
+        ValidationResult vr0 = DL4JModelValidator.isValidComputationGraph(f0);
+        assertFalse(vr0.isValid());
+        assertTrue(vr0.getIssues().get(0).contains("exist"));
+        assertEquals("ComputationGraph", vr0.getFormatType());
+        assertEquals(ComputationGraph.class, vr0.getFormatClass());
+        assertNull(vr0.getException());
+        System.out.println(vr0.toString());
+
+        //Test empty file
+        File f1 = new File(f, "empty.bin");
+        f1.createNewFile();
+        assertTrue(f1.exists());
+        ValidationResult vr1 = DL4JModelValidator.isValidComputationGraph(f1);
+        assertFalse(vr1.isValid());
+        assertTrue(vr1.getIssues().get(0).contains("empty"));
+        assertEquals("ComputationGraph", vr1.getFormatType());
+        assertEquals(ComputationGraph.class, vr1.getFormatClass());
+        assertNull(vr1.getException());
+        System.out.println(vr1.toString());
+
+        //Test invalid zip file
+        File f2 = new File(f, "notReallyZip.zip");
+        FileUtils.writeStringToFile(f2, "This isn't actually a zip file", StandardCharsets.UTF_8);
+        ValidationResult vr2 = DL4JModelValidator.isValidComputationGraph(f2);
+        assertFalse(vr2.isValid());
+        String s = vr2.getIssues().get(0);
+        assertTrue(s, s.contains("zip") && s.contains("corrupt"));
+        assertEquals("ComputationGraph", vr2.getFormatType());
+        assertEquals(ComputationGraph.class, vr2.getFormatClass());
+        assertNotNull(vr2.getException());
+        System.out.println(vr2.toString());
+
+        //Test valid zip, but missing configuration
+        File f3 = new File(f, "modelNoConfig.zip");
+        getSimpleNet().save(f3);
+        try (FileSystem zipfs = FileSystems.newFileSystem(URI.create("jar:" + f3.toURI().toString()), Collections.singletonMap("create", "false"))) {
+            Path p = zipfs.getPath(ModelSerializer.CONFIGURATION_JSON);
+            Files.delete(p);
+        }
+        ValidationResult vr3 = DL4JModelValidator.isValidComputationGraph(f3);
+        assertFalse(vr3.isValid());
+        s = vr3.getIssues().get(0);
+        assertEquals(1, vr3.getIssues().size());
+        assertTrue(s, s.contains("missing") && s.contains("configuration"));
+        assertEquals("ComputationGraph", vr3.getFormatType());
+        assertEquals(ComputationGraph.class, vr3.getFormatClass());
+        assertNull(vr3.getException());
+        System.out.println(vr3.toString());
+
+
+        //Test valid sip, but missing params
+        File f4 = new File(f, "modelNoParams.zip");
+        getSimpleNet().save(f4);
+        try (FileSystem zipfs = FileSystems.newFileSystem(URI.create("jar:" + f4.toURI().toString()), Collections.singletonMap("create", "false"))) {
+            Path p = zipfs.getPath(ModelSerializer.COEFFICIENTS_BIN);
+            Files.delete(p);
+        }
+        ValidationResult vr4 = DL4JModelValidator.isValidComputationGraph(f4);
+        assertFalse(vr4.isValid());
+        s = vr4.getIssues().get(0);
+        assertEquals(1, vr4.getIssues().size());
+        assertTrue(s, s.contains("missing") && s.contains("coefficients"));
+        assertEquals("ComputationGraph", vr4.getFormatType());
+        assertEquals(ComputationGraph.class, vr4.getFormatClass());
+        assertNull(vr4.getException());
+        System.out.println(vr4.toString());
+
+
+        //Test valid model
+        File f5 = new File(f, "modelValid.zip");
+        getSimpleNet().save(f5);
+        ValidationResult vr5 = DL4JModelValidator.isValidComputationGraph(f5);
+        assertTrue(vr5.isValid());
+        assertNull(vr5.getIssues());
+        assertEquals("ComputationGraph", vr5.getFormatType());
+        assertEquals(ComputationGraph.class, vr5.getFormatClass());
+        assertNull(vr5.getException());
+        System.out.println(vr5.toString());
+
+
+        //Test valid model with corrupted JSON
+        File f6 = new File(f, "modelBadJson.zip");
+        getSimpleNet().save(f6);
+        try(ZipFile zf = new ZipFile(f5); ZipOutputStream zo = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(f6)))){
+            Enumeration<? extends ZipEntry> e = zf.entries();
+            while(e.hasMoreElements()){
+                ZipEntry ze = e.nextElement();
+                zo.putNextEntry(new ZipEntry(ze.getName()));
+                if(ze.getName().equals(ModelSerializer.CONFIGURATION_JSON)){
+                    zo.write("totally not valid json! - {}".getBytes(StandardCharsets.UTF_8));
+                } else {
+                    byte[] bytes;
+                    try(ZipInputStream zis = new ZipInputStream(zf.getInputStream(ze))){
+                        bytes = IOUtils.toByteArray(zis);
+                    }
+                    zo.write(bytes);
+                    System.out.println("WROTE: " + ze.getName());
+                }
+            }
+        }
+        ValidationResult vr6 = DL4JModelValidator.isValidComputationGraph(f6);
+        assertFalse(vr6.isValid());
+        s = vr6.getIssues().get(0);
+        assertEquals(1, vr6.getIssues().size());
+        assertTrue(s, s.contains("JSON") && s.contains("valid") && s.contains("ComputationGraphConfiguration"));
+        assertEquals("ComputationGraph", vr6.getFormatType());
+        assertEquals(ComputationGraph.class, vr6.getFormatClass());
+        assertNotNull(vr6.getException());
+        System.out.println(vr6.toString());
+    }
+
+
 
     public static MultiLayerNetwork getSimpleNet(){
 
@@ -174,5 +293,9 @@ public class ModelValidatorTests extends BaseDL4JTest {
         net.init();
 
         return net;
+    }
+
+    public static ComputationGraph getSimpleCG(){
+        return getSimpleNet().toComputationGraph();
     }
 }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelValidatorTests.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelValidatorTests.java
@@ -1,0 +1,139 @@
+package org.deeplearning4j.util;
+
+import org.apache.commons.io.FileUtils;
+import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.nd4j.linalg.learning.config.Adam;
+import org.nd4j.validation.ValidationResult;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.*;
+
+public class ModelValidatorTests extends BaseDL4JTest {
+
+    @Rule
+    public TemporaryFolder testDir = new TemporaryFolder();
+
+    @Test
+    public void testMultiLayerNetworkValidation() throws Exception {
+        File f = testDir.newFolder();
+
+        //Test non-existent file
+        File f0 = new File(f, "doesntExist.bin");
+        ValidationResult vr0 = DL4JModelValidator.isValidMultiLayerNetwork(f0);
+        assertFalse(vr0.isValid());
+        assertTrue(vr0.getIssues().get(0).contains("exist"));
+        assertEquals("MultiLayerNetwork", vr0.getFormatType());
+        assertEquals(MultiLayerNetwork.class, vr0.getFormatClass());
+        assertNull(vr0.getException());
+        System.out.println(vr0.toString());
+
+        //Test empty file
+        File f1 = new File(f, "empty.bin");
+        f1.createNewFile();
+        assertTrue(f1.exists());
+        ValidationResult vr1 = DL4JModelValidator.isValidMultiLayerNetwork(f1);
+        assertFalse(vr1.isValid());
+        assertTrue(vr1.getIssues().get(0).contains("empty"));
+        assertEquals("MultiLayerNetwork", vr1.getFormatType());
+        assertEquals(MultiLayerNetwork.class, vr1.getFormatClass());
+        assertNull(vr1.getException());
+        System.out.println(vr1.toString());
+
+        //Test invalid zip file
+        File f2 = new File(f, "notReallyZip.zip");
+        FileUtils.writeStringToFile(f2, "This isn't actually a zip file", StandardCharsets.UTF_8);
+        ValidationResult vr2 = DL4JModelValidator.isValidMultiLayerNetwork(f2);
+        assertFalse(vr2.isValid());
+        String s = vr2.getIssues().get(0);
+        assertTrue(s, s.contains("zip") && s.contains("corrupt"));
+        assertEquals("MultiLayerNetwork", vr2.getFormatType());
+        assertEquals(MultiLayerNetwork.class, vr2.getFormatClass());
+        assertNotNull(vr2.getException());
+        System.out.println(vr2.toString());
+
+        //Test valid zip, but missing configuration
+        File f3 = new File(f, "modelNoConfig.zip");
+        getSimpleNet().save(f3);
+        try (FileSystem zipfs = FileSystems.newFileSystem(URI.create("jar:" + f3.toURI().toString()), Collections.singletonMap("create", "false"))) {
+            Path p = zipfs.getPath(ModelSerializer.CONFIGURATION_JSON);
+            Files.delete(p);
+        }
+        ValidationResult vr3 = DL4JModelValidator.isValidMultiLayerNetwork(f3);
+        assertFalse(vr3.isValid());
+        s = vr3.getIssues().get(0);
+        assertEquals(1, vr3.getIssues().size());
+        assertTrue(s, s.contains("missing") && s.contains("configuration"));
+        assertEquals("MultiLayerNetwork", vr3.getFormatType());
+        assertEquals(MultiLayerNetwork.class, vr3.getFormatClass());
+        assertNull(vr3.getException());
+        System.out.println(vr3.toString());
+
+
+        //Test valid sip, but missing params
+        File f4 = new File(f, "modelNoParams.zip");
+        getSimpleNet().save(f4);
+        try (FileSystem zipfs = FileSystems.newFileSystem(URI.create("jar:" + f4.toURI().toString()), Collections.singletonMap("create", "false"))) {
+            Path p = zipfs.getPath(ModelSerializer.COEFFICIENTS_BIN);
+            Files.delete(p);
+        }
+        ValidationResult vr4 = DL4JModelValidator.isValidMultiLayerNetwork(f4);
+        assertFalse(vr4.isValid());
+        s = vr4.getIssues().get(0);
+        assertEquals(1, vr4.getIssues().size());
+        assertTrue(s, s.contains("missing") && s.contains("coefficients"));
+        assertEquals("MultiLayerNetwork", vr4.getFormatType());
+        assertEquals(MultiLayerNetwork.class, vr4.getFormatClass());
+        assertNull(vr4.getException());
+        System.out.println(vr4.toString());
+
+
+        //Test valid model
+        File f5 = new File(f, "modelValid.zip");
+        getSimpleNet().save(f5);
+        ValidationResult vr5 = DL4JModelValidator.isValidMultiLayerNetwork(f5);
+        assertTrue(vr5.isValid());
+        assertNull(vr5.getIssues());
+        assertEquals("MultiLayerNetwork", vr5.getFormatType());
+        assertEquals(MultiLayerNetwork.class, vr5.getFormatClass());
+        assertNull(vr5.getException());
+        System.out.println(vr5.toString());
+    }
+
+
+
+    public static MultiLayerNetwork getSimpleNet(){
+
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .seed(12345)
+                .updater(new Adam(0.01))
+                .list()
+                .layer(new DenseLayer.Builder().nIn(10).nOut(10).build())
+                .layer(new DenseLayer.Builder().nIn(10).nOut(10).build())
+                .layer(new OutputLayer.Builder().nIn(10).nOut(10).build())
+                .build();
+
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+
+        return net;
+    }
+}

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelValidatorTests.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/util/ModelValidatorTests.java
@@ -26,8 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
@@ -47,7 +45,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
 
         //Test non-existent file
         File f0 = new File(f, "doesntExist.bin");
-        ValidationResult vr0 = DL4JModelValidator.isValidMultiLayerNetwork(f0);
+        ValidationResult vr0 = DL4JModelValidator.validateMultiLayerNetwork(f0);
         assertFalse(vr0.isValid());
         assertTrue(vr0.getIssues().get(0).contains("exist"));
         assertEquals("MultiLayerNetwork", vr0.getFormatType());
@@ -59,7 +57,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
         File f1 = new File(f, "empty.bin");
         f1.createNewFile();
         assertTrue(f1.exists());
-        ValidationResult vr1 = DL4JModelValidator.isValidMultiLayerNetwork(f1);
+        ValidationResult vr1 = DL4JModelValidator.validateMultiLayerNetwork(f1);
         assertFalse(vr1.isValid());
         assertTrue(vr1.getIssues().get(0).contains("empty"));
         assertEquals("MultiLayerNetwork", vr1.getFormatType());
@@ -70,7 +68,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
         //Test invalid zip file
         File f2 = new File(f, "notReallyZip.zip");
         FileUtils.writeStringToFile(f2, "This isn't actually a zip file", StandardCharsets.UTF_8);
-        ValidationResult vr2 = DL4JModelValidator.isValidMultiLayerNetwork(f2);
+        ValidationResult vr2 = DL4JModelValidator.validateMultiLayerNetwork(f2);
         assertFalse(vr2.isValid());
         String s = vr2.getIssues().get(0);
         assertTrue(s, s.contains("zip") && s.contains("corrupt"));
@@ -86,7 +84,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
             Path p = zipfs.getPath(ModelSerializer.CONFIGURATION_JSON);
             Files.delete(p);
         }
-        ValidationResult vr3 = DL4JModelValidator.isValidMultiLayerNetwork(f3);
+        ValidationResult vr3 = DL4JModelValidator.validateMultiLayerNetwork(f3);
         assertFalse(vr3.isValid());
         s = vr3.getIssues().get(0);
         assertEquals(1, vr3.getIssues().size());
@@ -104,7 +102,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
             Path p = zipfs.getPath(ModelSerializer.COEFFICIENTS_BIN);
             Files.delete(p);
         }
-        ValidationResult vr4 = DL4JModelValidator.isValidMultiLayerNetwork(f4);
+        ValidationResult vr4 = DL4JModelValidator.validateMultiLayerNetwork(f4);
         assertFalse(vr4.isValid());
         s = vr4.getIssues().get(0);
         assertEquals(1, vr4.getIssues().size());
@@ -118,7 +116,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
         //Test valid model
         File f5 = new File(f, "modelValid.zip");
         getSimpleNet().save(f5);
-        ValidationResult vr5 = DL4JModelValidator.isValidMultiLayerNetwork(f5);
+        ValidationResult vr5 = DL4JModelValidator.validateMultiLayerNetwork(f5);
         assertTrue(vr5.isValid());
         assertNull(vr5.getIssues());
         assertEquals("MultiLayerNetwork", vr5.getFormatType());
@@ -147,7 +145,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
                 }
             }
         }
-        ValidationResult vr6 = DL4JModelValidator.isValidMultiLayerNetwork(f6);
+        ValidationResult vr6 = DL4JModelValidator.validateMultiLayerNetwork(f6);
         assertFalse(vr6.isValid());
         s = vr6.getIssues().get(0);
         assertEquals(1, vr6.getIssues().size());
@@ -165,7 +163,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
 
         //Test non-existent file
         File f0 = new File(f, "doesntExist.bin");
-        ValidationResult vr0 = DL4JModelValidator.isValidComputationGraph(f0);
+        ValidationResult vr0 = DL4JModelValidator.validateComputationGraph(f0);
         assertFalse(vr0.isValid());
         assertTrue(vr0.getIssues().get(0).contains("exist"));
         assertEquals("ComputationGraph", vr0.getFormatType());
@@ -177,7 +175,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
         File f1 = new File(f, "empty.bin");
         f1.createNewFile();
         assertTrue(f1.exists());
-        ValidationResult vr1 = DL4JModelValidator.isValidComputationGraph(f1);
+        ValidationResult vr1 = DL4JModelValidator.validateComputationGraph(f1);
         assertFalse(vr1.isValid());
         assertTrue(vr1.getIssues().get(0).contains("empty"));
         assertEquals("ComputationGraph", vr1.getFormatType());
@@ -188,7 +186,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
         //Test invalid zip file
         File f2 = new File(f, "notReallyZip.zip");
         FileUtils.writeStringToFile(f2, "This isn't actually a zip file", StandardCharsets.UTF_8);
-        ValidationResult vr2 = DL4JModelValidator.isValidComputationGraph(f2);
+        ValidationResult vr2 = DL4JModelValidator.validateComputationGraph(f2);
         assertFalse(vr2.isValid());
         String s = vr2.getIssues().get(0);
         assertTrue(s, s.contains("zip") && s.contains("corrupt"));
@@ -204,7 +202,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
             Path p = zipfs.getPath(ModelSerializer.CONFIGURATION_JSON);
             Files.delete(p);
         }
-        ValidationResult vr3 = DL4JModelValidator.isValidComputationGraph(f3);
+        ValidationResult vr3 = DL4JModelValidator.validateComputationGraph(f3);
         assertFalse(vr3.isValid());
         s = vr3.getIssues().get(0);
         assertEquals(1, vr3.getIssues().size());
@@ -222,7 +220,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
             Path p = zipfs.getPath(ModelSerializer.COEFFICIENTS_BIN);
             Files.delete(p);
         }
-        ValidationResult vr4 = DL4JModelValidator.isValidComputationGraph(f4);
+        ValidationResult vr4 = DL4JModelValidator.validateComputationGraph(f4);
         assertFalse(vr4.isValid());
         s = vr4.getIssues().get(0);
         assertEquals(1, vr4.getIssues().size());
@@ -236,7 +234,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
         //Test valid model
         File f5 = new File(f, "modelValid.zip");
         getSimpleNet().save(f5);
-        ValidationResult vr5 = DL4JModelValidator.isValidComputationGraph(f5);
+        ValidationResult vr5 = DL4JModelValidator.validateComputationGraph(f5);
         assertTrue(vr5.isValid());
         assertNull(vr5.getIssues());
         assertEquals("ComputationGraph", vr5.getFormatType());
@@ -265,7 +263,7 @@ public class ModelValidatorTests extends BaseDL4JTest {
                 }
             }
         }
-        ValidationResult vr6 = DL4JModelValidator.isValidComputationGraph(f6);
+        ValidationResult vr6 = DL4JModelValidator.validateComputationGraph(f6);
         assertFalse(vr6.isValid());
         s = vr6.getIssues().get(0);
         assertEquals(1, vr6.getIssues().size());

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/DL4JKerasModelValidator.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/DL4JKerasModelValidator.java
@@ -1,0 +1,105 @@
+package org.deeplearning4j.nn.modelimport.keras.utils;
+
+import lombok.NonNull;
+import org.apache.commons.io.IOUtils;
+import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.modelimport.keras.Hdf5Archive;
+import org.deeplearning4j.nn.modelimport.keras.KerasModel;
+import org.deeplearning4j.nn.modelimport.keras.config.KerasModelConfiguration;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.validation.Nd4jCommonValidator;
+import org.nd4j.validation.ValidationResult;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * A utility for validating serialized Keras sequential and functional models for import into DL4J
+ *
+ * @author Alex Black
+ */
+public class DL4JKerasModelValidator {
+
+    private DL4JKerasModelValidator(){ }
+
+    /**
+     * Validate whether the file represents a valid Keras Sequential model (HDF5 archive)
+     *
+     * @param f File that should represent an saved Keras Sequential model (HDF5 archive)
+     * @return Result of validation
+     */
+    public static ValidationResult validateKerasSequential(@NonNull File f){
+        return validateKeras(f, "Keras Sequential Model HDF5", MultiLayerNetwork.class);
+    }
+
+    /**
+     * Validate whether the file represents a valid Keras Functional model (HDF5 archive)
+     *
+     * @param f File that should represent an saved Keras Functional model (HDF5 archive)
+     * @return Result of validation
+     */
+    public static ValidationResult validateKerasFunctional(@NonNull File f){
+        return validateKeras(f, "Keras Functional Model HDF5", ComputationGraph.class);
+    }
+
+    protected static ValidationResult validateKeras(@NonNull File f, String format, Class<?> cl){
+        ValidationResult vr = Nd4jCommonValidator.isValidFile(f, format, false);
+        if(vr != null && !vr.isValid()) {
+            return vr;
+        }
+
+        KerasModelConfiguration c = new KerasModelConfiguration();
+        Hdf5Archive archive = null;
+        try{
+            archive = new Hdf5Archive(f.getPath());
+
+            //Check JSON
+            try{
+                String json = archive.readAttributeAsJson(c.getTrainingModelConfigAttribute());
+                vr = Nd4jCommonValidator.isValidJSON(json);
+                if(vr != null && !vr.isValid()){
+                    vr.setFormatType(format);
+                    return vr;
+                }
+            } catch (Throwable t){
+                return ValidationResult.builder()
+                        .formatType(format)
+                        .formatClass(cl)
+                        .valid(false)
+                        .path(Nd4jCommonValidator.getPath(f))
+                        .issues(Collections.singletonList("Unable to read JSON configuration from Keras Sequential model HDF5 file"))
+                        .exception(t)
+                        .build();
+            }
+
+        } catch (Throwable t){
+            return ValidationResult.builder()
+                    .formatType(format)
+                    .formatClass(cl)
+                    .valid(false)
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("Unable to read from " + format + " file - file is corrupt or not a valid Keras HDF5 archive?"))
+                    .exception(t)
+                    .build();
+        }
+
+
+        return ValidationResult.builder()
+                .formatType(format)
+                .formatClass(cl)
+                .valid(true)
+                .path(Nd4jCommonValidator.getPath(f))
+                .build();
+    }
+}

--- a/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/MiscTests.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/MiscTests.java
@@ -16,16 +16,21 @@
 
 package org.deeplearning4j.nn.modelimport.keras;
 
+import org.apache.commons.io.FileUtils;
+import org.deeplearning4j.nn.modelimport.keras.utils.DL4JKerasModelValidator;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.nd4j.linalg.io.ClassPathResource;
+import org.nd4j.linalg.util.Nd4jValidator;
+import org.nd4j.validation.ValidationResult;
 
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -94,5 +99,142 @@ public class MiscTests {
             MultiLayerNetwork model = KerasModelImport.importKerasSequentialModelAndWeights(is);
             assertNotNull(model);
         }
+    }
+
+    @Test(timeout = 60000L)
+    public void testModelValidatorSequential() throws Exception {
+        File f = testDir.newFolder();
+
+        //Test not existent file:
+        File fNonExistent = new File("doesntExist.h5");
+        ValidationResult vr0 = DL4JKerasModelValidator.validateKerasSequential(fNonExistent);
+        assertFalse(vr0.isValid());
+        assertEquals("Keras Sequential Model HDF5", vr0.getFormatType());
+        assertTrue(vr0.getIssues().get(0), vr0.getIssues().get(0).contains("exist"));
+        System.out.println(vr0.toString());
+
+        //Test empty file:
+        File fEmpty = new File(f, "empty.h5");
+        fEmpty.createNewFile();
+        assertTrue(fEmpty.exists());
+        ValidationResult vr1 = DL4JKerasModelValidator.validateKerasSequential(fEmpty);
+        assertEquals("Keras Sequential Model HDF5", vr1.getFormatType());
+        assertFalse(vr1.isValid());
+        assertTrue(vr1.getIssues().get(0), vr1.getIssues().get(0).contains("empty"));
+        System.out.println(vr1.toString());
+
+        //Test directory (not zip file)
+        File directory = new File(f, "dir");
+        boolean created = directory.mkdir();
+        assertTrue(created);
+        ValidationResult vr2 = DL4JKerasModelValidator.validateKerasSequential(directory);
+        assertEquals("Keras Sequential Model HDF5", vr2.getFormatType());
+        assertFalse(vr2.isValid());
+        assertTrue(vr2.getIssues().get(0), vr2.getIssues().get(0).contains("directory"));
+        System.out.println(vr2.toString());
+
+        //Test Keras HDF5 format:
+        File fText = new File(f, "text.txt");
+        FileUtils.writeStringToFile(fText, "Not a hdf5 file :)", StandardCharsets.UTF_8);
+        ValidationResult vr3 = DL4JKerasModelValidator.validateKerasSequential(fText);
+        assertEquals("Keras Sequential Model HDF5", vr3.getFormatType());
+        assertFalse(vr3.isValid());
+        String s = vr3.getIssues().get(0);
+        assertTrue(s, s.contains("Keras") && s.contains("Sequential") && s.contains("corrupt"));
+        System.out.println(vr3.toString());
+
+        //Test corrupted npy format:
+        File fValid = new ClassPathResource("modelimport/keras/examples/mnist_mlp/mnist_mlp_tf_keras_1_model.h5").getFile();
+        byte[] numpyBytes = FileUtils.readFileToByteArray(fValid);
+        for( int i=0; i<30; i++ ){
+            numpyBytes[i] = 0;
+        }
+        File fCorrupt = new File(f, "corrupt.h5");
+        FileUtils.writeByteArrayToFile(fCorrupt, numpyBytes);
+
+        ValidationResult vr4 = DL4JKerasModelValidator.validateKerasSequential(fCorrupt);
+        assertEquals("Keras Sequential Model HDF5", vr4.getFormatType());
+        assertFalse(vr4.isValid());
+        s = vr4.getIssues().get(0);
+        assertTrue(s, s.contains("Keras") && s.contains("Sequential") && s.contains("corrupt"));
+        System.out.println(vr4.toString());
+
+
+        //Test valid npy format:
+        ValidationResult vr5 = DL4JKerasModelValidator.validateKerasSequential(fValid);
+        assertEquals("Keras Sequential Model HDF5", vr5.getFormatType());
+        assertTrue(vr5.isValid());
+        assertNull(vr5.getIssues());
+        assertNull(vr5.getException());
+        System.out.println(vr4.toString());
+    }
+
+    @Test(timeout = 60000L)
+    public void testModelValidatorFunctional() throws Exception {
+        File f = testDir.newFolder();
+        //String modelPath = "modelimport/keras/examples/functional_lstm/lstm_functional_tf_keras_2.h5";
+
+        //Test not existent file:
+        File fNonExistent = new File("doesntExist.h5");
+        ValidationResult vr0 = DL4JKerasModelValidator.validateKerasFunctional(fNonExistent);
+        assertFalse(vr0.isValid());
+        assertEquals("Keras Functional Model HDF5", vr0.getFormatType());
+        assertTrue(vr0.getIssues().get(0), vr0.getIssues().get(0).contains("exist"));
+        System.out.println(vr0.toString());
+
+        //Test empty file:
+        File fEmpty = new File(f, "empty.h5");
+        fEmpty.createNewFile();
+        assertTrue(fEmpty.exists());
+        ValidationResult vr1 = DL4JKerasModelValidator.validateKerasFunctional(fEmpty);
+        assertEquals("Keras Functional Model HDF5", vr1.getFormatType());
+        assertFalse(vr1.isValid());
+        assertTrue(vr1.getIssues().get(0), vr1.getIssues().get(0).contains("empty"));
+        System.out.println(vr1.toString());
+
+        //Test directory (not zip file)
+        File directory = new File(f, "dir");
+        boolean created = directory.mkdir();
+        assertTrue(created);
+        ValidationResult vr2 = DL4JKerasModelValidator.validateKerasFunctional(directory);
+        assertEquals("Keras Functional Model HDF5", vr2.getFormatType());
+        assertFalse(vr2.isValid());
+        assertTrue(vr2.getIssues().get(0), vr2.getIssues().get(0).contains("directory"));
+        System.out.println(vr2.toString());
+
+        //Test Keras HDF5 format:
+        File fText = new File(f, "text.txt");
+        FileUtils.writeStringToFile(fText, "Not a hdf5 file :)", StandardCharsets.UTF_8);
+        ValidationResult vr3 = DL4JKerasModelValidator.validateKerasFunctional(fText);
+        assertEquals("Keras Functional Model HDF5", vr3.getFormatType());
+        assertFalse(vr3.isValid());
+        String s = vr3.getIssues().get(0);
+        assertTrue(s, s.contains("Keras") && s.contains("Functional") && s.contains("corrupt"));
+        System.out.println(vr3.toString());
+
+        //Test corrupted npy format:
+        File fValid = new ClassPathResource("modelimport/keras/examples/mnist_mlp/mnist_mlp_tf_keras_1_model.h5").getFile();
+        byte[] numpyBytes = FileUtils.readFileToByteArray(fValid);
+        for( int i=0; i<30; i++ ){
+            numpyBytes[i] = 0;
+        }
+        File fCorrupt = new File(f, "corrupt.h5");
+        FileUtils.writeByteArrayToFile(fCorrupt, numpyBytes);
+
+        ValidationResult vr4 = DL4JKerasModelValidator.validateKerasFunctional(fCorrupt);
+        assertEquals("Keras Functional Model HDF5", vr4.getFormatType());
+        assertFalse(vr4.isValid());
+        s = vr4.getIssues().get(0);
+        assertTrue(s, s.contains("Keras") && s.contains("Functional") && s.contains("corrupt"));
+        System.out.println(vr4.toString());
+
+
+        //Test valid npy format:
+        ValidationResult vr5 = DL4JKerasModelValidator.validateKerasFunctional(fValid);
+        assertEquals("Keras Functional Model HDF5", vr5.getFormatType());
+        assertTrue(vr5.isValid());
+        assertNull(vr5.getIssues());
+        assertNull(vr5.getException());
+        System.out.println(vr4.toString());
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
@@ -1,0 +1,23 @@
+package org.deeplearning4j.util;
+
+import lombok.NonNull;
+import org.nd4j.validation.Nd4jCommonValidator;
+import org.nd4j.validation.ValidationResult;
+
+import java.io.File;
+
+public class DL4JModelValidator {
+
+    private DL4JModelValidator(){ }
+
+    public static ValidationResult isValidMultiLayerNetwork(@NonNull File f){
+
+        ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "MultiLayerNetwork", false);
+        if(vr != null)
+            return vr;
+
+
+
+    }
+
+}

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
@@ -1,14 +1,23 @@
 package org.deeplearning4j.util;
 
 import lombok.NonNull;
+import org.apache.commons.io.IOUtils;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.nd4j.validation.Nd4jCommonValidator;
 import org.nd4j.validation.ValidationResult;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 public class DL4JModelValidator {
 
@@ -26,7 +35,42 @@ public class DL4JModelValidator {
         }
 
         //Check that configuration (JSON) can actually be deserialized correctly...
+        String config;
+        try(ZipFile zf = new ZipFile(f)){
+            ZipEntry ze = zf.getEntry(ModelSerializer.CONFIGURATION_JSON);
+            config = IOUtils.toString(new BufferedReader(new InputStreamReader(zf.getInputStream(ze), StandardCharsets.UTF_8)));
+        } catch (IOException e){
+            return ValidationResult.builder()
+                    .formatType("MultiLayerNetwork")
+                    .formatClass(MultiLayerNetwork.class)
+                    .valid(false)
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("Unable to read configuration from model zip file"))
+                    .exception(e)
+                    .build();
+        }
 
+        try{
+            MultiLayerConfiguration.fromJson(config);
+        } catch (Throwable t){
+            return ValidationResult.builder()
+                    .formatType("MultiLayerNetwork")
+                    .formatClass(MultiLayerNetwork.class)
+                    .valid(false)
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("Zip file JSON model configuration does not appear to represent a valid MultiLayerConfiguration"))
+                    .exception(t)
+                    .build();
+        }
+
+        //TODO should we check params too?
+
+        return ValidationResult.builder()
+                .formatType("MultiLayerNetwork")
+                .formatClass(MultiLayerNetwork.class)
+                .valid(true)
+                .path(Nd4jCommonValidator.getPath(f))
+                .build();
     }
 
     public static ValidationResult isValidComputationGraph(@NonNull File f){
@@ -41,7 +85,44 @@ public class DL4JModelValidator {
         }
 
         //Check that configuration (JSON) can actually be deserialized correctly...
+        String config;
+        try(ZipFile zf = new ZipFile(f)){
+            ZipEntry ze = zf.getEntry(ModelSerializer.CONFIGURATION_JSON);
+            config = IOUtils.toString(new BufferedReader(new InputStreamReader(zf.getInputStream(ze), StandardCharsets.UTF_8)));
+        } catch (IOException e){
+            return ValidationResult.builder()
+                    .formatType("ComputationGraph")
+                    .formatClass(ComputationGraph.class)
+                    .valid(false)
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("Unable to read configuration from model zip file"))
+                    .exception(e)
+                    .build();
+        }
 
+        try{
+            MultiLayerConfiguration.fromJson(config);
+        } catch (Throwable t){
+            return ValidationResult.builder()
+                    .formatType("ComputationGraph")
+                    .formatClass(ComputationGraph.class)
+                    .valid(false)
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("Zip file JSON model configuration does not appear to represent a valid ComputationGraphConfiguration"))
+                    .exception(t)
+                    .build();
+        }
+
+        //TODO should we check params too? (a) that it can be read, and (b) that it matches config (number of parameters, etc)
+
+        return ValidationResult.builder()
+                .formatType("ComputationGraph")
+                .formatClass(ComputationGraph.class)
+                .valid(true)
+                .path(Nd4jCommonValidator.getPath(f))
+                .build();
     }
+
+    //TODO also check if updater is valid?
 
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
@@ -78,7 +78,7 @@ public class DL4JModelValidator {
         List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params
 
         ValidationResult vr = Nd4jCommonValidator.isValidZipFile(f, false, requiredEntries);
-        if(vr != null) {
+        if(vr != null && !vr.isValid()) {
             vr.setFormatClass(ComputationGraph.class);
             vr.setFormatType("ComputationGraph");
             return vr;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
@@ -2,6 +2,7 @@ package org.deeplearning4j.util;
 
 import lombok.NonNull;
 import org.apache.commons.io.IOUtils;
+import org.deeplearning4j.nn.api.Model;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
@@ -19,13 +20,25 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+/**
+ * A utility for validating Deeplearning4j Serialized model file formats
+ *
+ * @author Alex Black
+ */
 public class DL4JModelValidator {
 
     private DL4JModelValidator(){ }
 
-    public static ValidationResult isValidMultiLayerNetwork(@NonNull File f){
+    /**
+     * Validate whether the file represents a valid MultiLayerNetwork saved previously with {@link MultiLayerNetwork#save(File)}
+     * or {@link ModelSerializer#writeModel(Model, File, boolean)}, to be read with {@link MultiLayerNetwork#load(File, boolean)}
+     *
+     * @param f File that should represent an saved MultiLayerNetwork
+     * @return Result of validation
+     */
+    public static ValidationResult validateMultiLayerNetwork(@NonNull File f){
 
-        List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params
+        List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params, but basically useless in practice
 
         ValidationResult vr = Nd4jCommonValidator.isValidZipFile(f, false, requiredEntries);
         if(vr != null && !vr.isValid()) {
@@ -73,9 +86,16 @@ public class DL4JModelValidator {
                 .build();
     }
 
-    public static ValidationResult isValidComputationGraph(@NonNull File f){
+    /**
+     * Validate whether the file represents a valid ComputationGraph saved previously with {@link ComputationGraph#save(File)}
+     * or {@link ModelSerializer#writeModel(Model, File, boolean)}, to be read with {@link ComputationGraph#load(File, boolean)}
+     *
+     * @param f File that should represent an saved MultiLayerNetwork
+     * @return Result of validation
+     */
+    public static ValidationResult validateComputationGraph(@NonNull File f){
 
-        List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params
+        List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params, but basically useless in practice
 
         ValidationResult vr = Nd4jCommonValidator.isValidZipFile(f, false, requiredEntries);
         if(vr != null && !vr.isValid()) {
@@ -122,7 +142,4 @@ public class DL4JModelValidator {
                 .path(Nd4jCommonValidator.getPath(f))
                 .build();
     }
-
-    //TODO also check if updater is valid?
-
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
@@ -28,7 +28,7 @@ public class DL4JModelValidator {
         List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params
 
         ValidationResult vr = Nd4jCommonValidator.isValidZipFile(f, false, requiredEntries);
-        if(vr != null) {
+        if(vr != null && !vr.isValid()) {
             vr.setFormatClass(MultiLayerNetwork.class);
             vr.setFormatType("MultiLayerNetwork");
             return vr;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/DL4JModelValidator.java
@@ -1,10 +1,14 @@
 package org.deeplearning4j.util;
 
 import lombok.NonNull;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.nd4j.validation.Nd4jCommonValidator;
 import org.nd4j.validation.ValidationResult;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 public class DL4JModelValidator {
 
@@ -12,11 +16,31 @@ public class DL4JModelValidator {
 
     public static ValidationResult isValidMultiLayerNetwork(@NonNull File f){
 
-        ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "MultiLayerNetwork", false);
-        if(vr != null)
+        List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params
+
+        ValidationResult vr = Nd4jCommonValidator.isValidZipFile(f, false, requiredEntries);
+        if(vr != null) {
+            vr.setFormatClass(MultiLayerNetwork.class);
+            vr.setFormatType("MultiLayerNetwork");
             return vr;
+        }
 
+        //Check that configuration (JSON) can actually be deserialized correctly...
 
+    }
+
+    public static ValidationResult isValidComputationGraph(@NonNull File f){
+
+        List<String> requiredEntries = Arrays.asList(ModelSerializer.CONFIGURATION_JSON, ModelSerializer.COEFFICIENTS_BIN);     //TODO no-params models... might be OK to have no params
+
+        ValidationResult vr = Nd4jCommonValidator.isValidZipFile(f, false, requiredEntries);
+        if(vr != null) {
+            vr.setFormatClass(ComputationGraph.class);
+            vr.setFormatType("ComputationGraph");
+            return vr;
+        }
+
+        //Check that configuration (JSON) can actually be deserialized correctly...
 
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/tensorflow/TensorFlowImportValidator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/tensorflow/TensorFlowImportValidator.java
@@ -1,5 +1,6 @@
 package org.nd4j.imports.tensorflow;
 
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.nd4j.base.Preconditions;
@@ -12,17 +13,17 @@ import java.io.*;
 import java.util.*;
 
 /**
- * A simple utility that analyzes TensorFlow graphs and reports details about the models:
- * - The path of the model file(s)
- * - The path of the model(s) that can't be imported due to missing ops
- * - The path of model files that couldn't be read for some reason (corrupt file?)
- * - The total number of ops in all graphs
- * - The number of unique ops in all graphs
- * - The (unique) names of all ops encountered in all graphs
- * - The (unique) names of all ops that were encountered, and can be imported, in all graphs
- * - The (unique) names of all ops that were encountered, and can NOT be imported (lacking import mapping)
- *
- * Note that an op is considered to be importable if has an import mapping specified for that op name in SameDiff.
+ * A simple utility that analyzes TensorFlow graphs and reports details about the models:<br>
+ * - The path of the model file(s)<br>
+ * - The path of the model(s) that can't be imported due to missing ops<br>
+ * - The path of model files that couldn't be read for some reason (corrupt file?)<br>
+ * - The total number of ops in all graphs<br>
+ * - The number of unique ops in all graphs<br>
+ * - The (unique) names of all ops encountered in all graphs<br>
+ * - The (unique) names of all ops that were encountered, and can be imported, in all graphs<br>
+ * - The (unique) names of all ops that were encountered, and can NOT be imported (lacking import mapping)<br>
+ *<br>
+ * Note that an op is considered to be importable if has an import mapping specified for that op name in SameDiff.<br>
  * This alone does not guarantee that the op can be imported successfully.
  *
  * @author Alex Black
@@ -31,9 +32,9 @@ import java.util.*;
 public class TensorFlowImportValidator {
 
     /**
-     * Recursively scan the specified directory for .pb files, and evaluate
-     * @param directory
-     * @return
+     * Recursively scan the specified directory for .pb files, and evaluate which operations/graphs can/can't be imported
+     * @param directory Directory to scan
+     * @return Status for TensorFlow import for all models in
      * @throws IOException
      */
     public static TFImportStatus checkAllModelsForImport(File directory) throws IOException {
@@ -53,7 +54,21 @@ public class TensorFlowImportValidator {
         return status;
     }
 
-    public static TFImportStatus checkModelForImport(File file) throws IOException {
+    /**
+     * See {@link #checkModelForImport(File)}. Defaults to exceptionOnRead = false
+     */
+    public static TFImportStatus checkModelForImport(@NonNull File file) throws IOException {
+        return checkModelForImport(file, false);
+    }
+
+    /**
+     * Check whether the TensorFlow frozen model (protobuf format) can be imported into SameDiff or not
+     * @param file            Protobuf file
+     * @param exceptionOnRead If true, and the file can't be read, throw an exception. If false, return an "empty" TFImportStatus
+     * @return Status for importing the file
+     * @throws IOException If error
+     */
+    public static TFImportStatus checkModelForImport(@NonNull File file, boolean exceptionOnRead) throws IOException {
         TFGraphMapper m = TFGraphMapper.getInstance();
 
         try {
@@ -94,7 +109,10 @@ public class TensorFlowImportValidator {
                     importSupportedOpNames,
                     unsupportedOpNames);
         } catch (Throwable t){
-            log.warn("Failed to import model: " + file.getPath(), t);
+            if(exceptionOnRead) {
+                throw new IOException("Error reading model from path " + file.getPath() + " - not a TensorFlow frozen model in ProtoBuf format?", t);
+            }
+            log.warn("Failed to import model from file: " + file.getPath() + " - not a TensorFlow frozen model in ProtoBuf format?", t);
             return new TFImportStatus(
                     Collections.<String>emptyList(),
                     Collections.<String>emptyList(),

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2578,6 +2578,11 @@ public class Nd4j {
         } finally {
             LineIterator.closeQuietly(it);
         }
+
+        if(newArr == null){
+            throw new IllegalStateException("Cannot parse file: file does not appear to represent a text serialized INDArray file");
+        }
+
         return newArr;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -96,6 +96,8 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -2376,8 +2378,12 @@ public class Nd4j {
      * @param split    the split separator
      * @return the read txt method
      */
-    public static INDArray readNumpy(InputStream filePath, String split) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(filePath));
+    public static INDArray readNumpy(@NonNull InputStream filePath, @NonNull String split) throws IOException {
+        return readNumpy(DataType.FLOAT, filePath, split, StandardCharsets.UTF_8);
+    }
+
+    public static INDArray readNumpy(@NonNull DataType dataType, @NonNull InputStream filePath, @NonNull String split, @NonNull Charset charset) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(filePath, charset));
         String line;
         List<float[]> data2 = new ArrayList<>();
         int numColumns = -1;
@@ -2393,10 +2399,10 @@ public class Nd4j {
 
 
         }
-        ret = Nd4j.create(Nd4j.defaultFloatingPointType(), data2.size(), numColumns);
+        ret = Nd4j.create(dataType, data2.size(), numColumns);
         for (int i = 0; i < data2.size(); i++) {
             float[] row = data2.get(i);
-            INDArray arr = Nd4j.create(row, new long[]{1, row.length}, Nd4j.defaultFloatingPointType());
+            INDArray arr = Nd4j.create(row, new long[]{1, row.length}, dataType);
             ret.putRow(i, arr);
         }
         return ret;
@@ -2433,8 +2439,12 @@ public class Nd4j {
      * @return the read txt method
      */
     public static INDArray readNumpy(String filePath, String split) throws IOException {
+        return readNumpy(DataType.FLOAT, filePath, split);
+    }
+
+    public static INDArray readNumpy(DataType dataType, String filePath, String split) throws IOException {
         try(InputStream is = new FileInputStream(filePath)) {
-            return readNumpy(is, split);
+            return readNumpy(dataType, is, split, StandardCharsets.UTF_8);
         }
     }
 
@@ -2445,7 +2455,11 @@ public class Nd4j {
      * @return the read txt method
      */
     public static INDArray readNumpy(String filePath) throws IOException {
-        return readNumpy(filePath, "\t");
+        return readNumpy(DataType.FLOAT, filePath);
+    }
+
+    public static INDArray readNumpy(DataType dataType, String filePath) throws IOException {
+        return readNumpy(dataType, filePath, " ");
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
@@ -1,0 +1,102 @@
+package org.nd4j.linalg.util;
+
+import lombok.NonNull;
+import org.apache.commons.lang3.ArrayUtils;
+import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.validation.Nd4jCommonValidator;
+import org.nd4j.validation.ValidationResult;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+public class Nd4jValidator {
+
+    private Nd4jValidator(){ }
+
+    public static ValidationResult validateINDArrayFile(@NonNull File f) {
+        return validateINDArrayFile(f, (DataType[])null);
+    }
+
+    public static ValidationResult validateINDArrayFile(@NonNull File f, DataType... allowableDataTypes){
+
+        ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray File", false);
+        if(vr != null)
+            return vr;
+
+        //TODO let's do this without reading the whole thing into memory - check header + length...
+        try (INDArray arr = Nd4j.readBinary(f)) {   //Using the fact that INDArray.close() exists -> deallocate memory as soon as reading is done
+            if(allowableDataTypes != null){
+                ArrayUtils.contains(allowableDataTypes, arr.dataType());
+            }
+        } catch (IOException e) {
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType("INDArray File")
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("Unable to read file (IOException)"))
+                    .exception(e)
+                    .build();
+        } catch (Throwable t) {
+            if (t instanceof OutOfMemoryError || t.getMessage().toLowerCase().contains("failed to allocate")) {
+                //This is a memory exception during reading... result is indeterminant (might be valid, might not be, can't tell here)
+                return ValidationResult.builder()
+                        .valid(true)
+                        .formatType("INDArray File")
+                        .path(Nd4jCommonValidator.getPath(f))
+                        .build();
+            }
+
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType("INDArray File")
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("File may be corrupt or is not a binary INDArray file"))
+                    .exception(t)
+                    .build();
+        }
+
+        return ValidationResult.builder()
+                .valid(true)
+                .formatType("INDArray File")
+                .path(Nd4jCommonValidator.getPath(f))
+                .build();
+    }
+
+    public static ValidationResult validateINDArrayTextFile(@NonNull File f){
+
+        ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray Text File", false);
+        if(vr != null)
+            return vr;
+
+        //TODO let's do this without reading the whole thing into memory - check header + length...
+        try (INDArray arr = Nd4j.readTxt(f.getPath())) {   //Using the fact that INDArray.close() exists -> deallocate memory as soon as reading is done
+        } catch (Throwable t) {
+            if (t instanceof OutOfMemoryError || t.getMessage().toLowerCase().contains("failed to allocate")) {
+                //This is a memory exception during reading... result is indeterminant (might be valid, might not be, can't tell here)
+                return ValidationResult.builder()
+                        .valid(true)
+                        .formatType("INDArray Text File")
+                        .path(Nd4jCommonValidator.getPath(f))
+                        .build();
+            }
+
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType("INDArray Text File")
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("File may be corrupt or is not a binary INDArray file"))
+                    .exception(t)
+                    .build();
+        }
+
+        return ValidationResult.builder()
+                .valid(true)
+                .formatType("INDArray Text File")
+                .path(Nd4jCommonValidator.getPath(f))
+                .build();
+    }
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
@@ -17,14 +17,33 @@ import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A utility for validating multiple file formats that ND4J and SameDiff can read
+ * @author Alex Black
+ */
 public class Nd4jValidator {
 
     private Nd4jValidator(){ }
 
+    /**
+     * Validate whether the file represents a valid INDArray (of any data type) saved previously with {@link Nd4j#saveBinary(INDArray, File)}
+     * to be read with {@link Nd4j#readBinary(File)}
+     *
+     * @param f File that should represent an INDArray saved with Nd4j.saveBinary
+     * @return Result of validation
+     */
     public static ValidationResult validateINDArrayFile(@NonNull File f) {
         return validateINDArrayFile(f, (DataType[])null);
     }
 
+    /**
+     * Validate whether the file represents a valid INDArray (of one of the allowed/specified data types) saved previously
+     * with {@link Nd4j#saveBinary(INDArray, File)} to be read with {@link Nd4j#readBinary(File)}
+     *
+     * @param f File that should represent an INDArray saved with Nd4j.saveBinary
+     * @param allowableDataTypes May be null. If non-null, the file must represent one of the specified data types
+     * @return Result of validation
+     */
     public static ValidationResult validateINDArrayFile(@NonNull File f, DataType... allowableDataTypes){
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray File", false);
@@ -70,6 +89,14 @@ public class Nd4jValidator {
                 .build();
     }
 
+    /**
+     * Validate whether the file represents a valid INDArray text file (of any data type) saved previously with
+     * {@link Nd4j#writeTxt(INDArray, String)}
+     * to be read with {@link Nd4j#readBinary(File)}
+     *
+     * @param f File that should represent an INDArray saved with Nd4j.saveBinary
+     * @return Result of validation
+     */
     public static ValidationResult validateINDArrayTextFile(@NonNull File f){
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray Text File", false);
@@ -78,6 +105,7 @@ public class Nd4jValidator {
 
         //TODO let's do this without reading the whole thing into memory - check header + length...
         try (INDArray arr = Nd4j.readTxt(f.getPath())) {   //Using the fact that INDArray.close() exists -> deallocate memory as soon as reading is done
+            System.out.println();
         } catch (Throwable t) {
             if (t instanceof OutOfMemoryError || t.getMessage().toLowerCase().contains("failed to allocate")) {
                 //This is a memory exception during reading... result is indeterminant (might be valid, might not be, can't tell here)
@@ -92,7 +120,7 @@ public class Nd4jValidator {
                     .valid(false)
                     .formatType("INDArray Text File")
                     .path(Nd4jCommonValidator.getPath(f))
-                    .issues(Collections.singletonList("File may be corrupt or is not a binary INDArray file"))
+                    .issues(Collections.singletonList("File may be corrupt or is not a text INDArray file"))
                     .exception(t)
                     .build();
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
@@ -19,11 +19,13 @@ import java.util.Map;
 
 /**
  * A utility for validating multiple file formats that ND4J and SameDiff can read
+ *
  * @author Alex Black
  */
 public class Nd4jValidator {
 
-    private Nd4jValidator(){ }
+    private Nd4jValidator() {
+    }
 
     /**
      * Validate whether the file represents a valid INDArray (of any data type) saved previously with {@link Nd4j#saveBinary(INDArray, File)}
@@ -33,26 +35,26 @@ public class Nd4jValidator {
      * @return Result of validation
      */
     public static ValidationResult validateINDArrayFile(@NonNull File f) {
-        return validateINDArrayFile(f, (DataType[])null);
+        return validateINDArrayFile(f, (DataType[]) null);
     }
 
     /**
      * Validate whether the file represents a valid INDArray (of one of the allowed/specified data types) saved previously
      * with {@link Nd4j#saveBinary(INDArray, File)} to be read with {@link Nd4j#readBinary(File)}
      *
-     * @param f File that should represent an INDArray saved with Nd4j.saveBinary
+     * @param f                  File that should represent an INDArray saved with Nd4j.saveBinary
      * @param allowableDataTypes May be null. If non-null, the file must represent one of the specified data types
      * @return Result of validation
      */
-    public static ValidationResult validateINDArrayFile(@NonNull File f, DataType... allowableDataTypes){
+    public static ValidationResult validateINDArrayFile(@NonNull File f, DataType... allowableDataTypes) {
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray File", false);
-        if(vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid())
             return vr;
 
         //TODO let's do this without reading the whole thing into memory - check header + length...
         try (INDArray arr = Nd4j.readBinary(f)) {   //Using the fact that INDArray.close() exists -> deallocate memory as soon as reading is done
-            if(allowableDataTypes != null){
+            if (allowableDataTypes != null) {
                 ArrayUtils.contains(allowableDataTypes, arr.dataType());
             }
         } catch (IOException e) {
@@ -91,16 +93,15 @@ public class Nd4jValidator {
 
     /**
      * Validate whether the file represents a valid INDArray text file (of any data type) saved previously with
-     * {@link Nd4j#writeTxt(INDArray, String)}
-     * to be read with {@link Nd4j#readBinary(File)}
+     * {@link Nd4j#writeTxt(INDArray, String)} to be read with {@link Nd4j#readTxt(String)} }
      *
-     * @param f File that should represent an INDArray saved with Nd4j.saveBinary
+     * @param f File that should represent an INDArray saved with Nd4j.writeTxt
      * @return Result of validation
      */
-    public static ValidationResult validateINDArrayTextFile(@NonNull File f){
+    public static ValidationResult validateINDArrayTextFile(@NonNull File f) {
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray Text File", false);
-        if(vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid())
             return vr;
 
         //TODO let's do this without reading the whole thing into memory - check header + length...
@@ -132,11 +133,16 @@ public class Nd4jValidator {
                 .build();
     }
 
-
-    public static ValidationResult validateNpyFile(@NonNull File f){
+    /**
+     * Validate whether the file represents a valid Numpy .npy file to be read with {@link Nd4j#createFromNpyFile(File)} }
+     *
+     * @param f File that should represent a Numpy .npy file written with Numpy save method
+     * @return Result of validation
+     */
+    public static ValidationResult validateNpyFile(@NonNull File f) {
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "Numpy .npy File", false);
-        if(vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid())
             return vr;
 
         //TODO let's do this without reading whole thing into memory
@@ -167,15 +173,21 @@ public class Nd4jValidator {
                 .build();
     }
 
-    public static ValidationResult validateNpzFile(@NonNull File f){
+    /**
+     * Validate whether the file represents a valid Numpy .npz file to be read with {@link Nd4j#createFromNpyFile(File)} }
+     *
+     * @param f File that should represent a Numpy .npz file written with Numpy savez method
+     * @return Result of validation
+     */
+    public static ValidationResult validateNpzFile(@NonNull File f) {
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "Numpy .npz File", false);
-        if(vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid())
             return vr;
 
-        Map<String,INDArray> m = null;
-        try{
+        Map<String, INDArray> m = null;
+        try {
             m = Nd4j.createFromNpzFile(f);
-        } catch (Throwable t){
+        } catch (Throwable t) {
             return ValidationResult.builder()
                     .valid(false)
                     .formatType("Numpy .npz File")
@@ -185,9 +197,9 @@ public class Nd4jValidator {
                     .build();
         } finally {
             //Deallocate immediately
-            if(m != null){
-                for(INDArray arr : m.values()){
-                    if(arr != null){
+            if (m != null) {
+                for (INDArray arr : m.values()) {
+                    if (arr != null) {
                         arr.close();
                     }
                 }
@@ -201,15 +213,22 @@ public class Nd4jValidator {
                 .build();
     }
 
-    public static ValidationResult validateNumpyTxtFile(@NonNull File f, @NonNull String delimiter, @NonNull Charset charset){
+    /**
+     * Validate whether the file represents a valid Numpy text file (written using numpy.savetxt) to be read with
+     * {@link Nd4j#readNumpy(String)} }
+     *
+     * @param f File that should represent a Numpy text file written with Numpy savetxt method
+     * @return Result of validation
+     */
+    public static ValidationResult validateNumpyTxtFile(@NonNull File f, @NonNull String delimiter, @NonNull Charset charset) {
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "Numpy text file", false);
-        if(vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid())
             return vr;
 
         String s;
-        try{
+        try {
             s = FileUtils.readFileToString(f, charset);
-        } catch (Throwable t){
+        } catch (Throwable t) {
             return ValidationResult.builder()
                     .valid(false)
                     .formatType("Numpy text file")
@@ -221,12 +240,12 @@ public class Nd4jValidator {
 
         String[] lines = s.split("\n");
         int countPerLine = 0;
-        for(int i=0; i<lines.length; i++ ){
+        for (int i = 0; i < lines.length; i++) {
             String[] lineSplit = lines[i].split(delimiter);
-            if(i == 0 ){
+            if (i == 0) {
                 countPerLine = lineSplit.length;
-            } else if(!lines[i].isEmpty()){
-                if(countPerLine != lineSplit.length){
+            } else if (!lines[i].isEmpty()) {
+                if (countPerLine != lineSplit.length) {
                     return ValidationResult.builder()
                             .valid(false)
                             .formatType("Numpy text file")
@@ -236,10 +255,10 @@ public class Nd4jValidator {
                 }
             }
 
-            for( int j=0; j<lineSplit.length; j++ ){
-                try{
+            for (int j = 0; j < lineSplit.length; j++) {
+                try {
                     Double.parseDouble(lineSplit[j]);
-                } catch (NumberFormatException e){
+                } catch (NumberFormatException e) {
                     return ValidationResult.builder()
                             .valid(false)
                             .formatType("Numpy text file")
@@ -258,12 +277,19 @@ public class Nd4jValidator {
     }
 
 
-    public static ValidationResult validateSameDiffFlatBuffers(@NonNull File f){
+    /**
+     * Validate whether the file represents a valid SameDiff FlatBuffers file, previously saved with {@link org.nd4j.autodiff.samediff.SameDiff#asFlatFile(File)} )
+     * to be read with {@link org.nd4j.autodiff.samediff.SameDiff#fromFlatFile(File)} }
+     *
+     * @param f File that should represent a SameDiff FlatBuffers file
+     * @return Result of validation
+     */
+    public static ValidationResult validateSameDiffFlatBuffers(@NonNull File f) {
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "SameDiff FlatBuffers file", false);
-        if(vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid())
             return vr;
 
-        try{
+        try {
             byte[] bytes;
             try (InputStream is = new BufferedInputStream(new FileInputStream(f))) {
                 bytes = IOUtils.toByteArray(is);
@@ -274,7 +300,7 @@ public class Nd4jValidator {
             int vl = fg.variablesLength();
             int ol = fg.nodesLength();
             System.out.println();
-        } catch (Throwable t){
+        } catch (Throwable t) {
             return ValidationResult.builder()
                     .valid(false)
                     .formatType("SameDiff FlatBuffers file")

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
@@ -4,6 +4,7 @@ import lombok.NonNull;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.graph.FlatGraph;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -49,8 +50,10 @@ public class Nd4jValidator {
     public static ValidationResult validateINDArrayFile(@NonNull File f, DataType... allowableDataTypes) {
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray File", false);
-        if (vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid()) {
+            vr.setFormatClass(INDArray.class);
             return vr;
+        }
 
         //TODO let's do this without reading the whole thing into memory - check header + length...
         try (INDArray arr = Nd4j.readBinary(f)) {   //Using the fact that INDArray.close() exists -> deallocate memory as soon as reading is done
@@ -61,6 +64,7 @@ public class Nd4jValidator {
             return ValidationResult.builder()
                     .valid(false)
                     .formatType("INDArray File")
+                    .formatClass(INDArray.class)
                     .path(Nd4jCommonValidator.getPath(f))
                     .issues(Collections.singletonList("Unable to read file (IOException)"))
                     .exception(e)
@@ -71,6 +75,7 @@ public class Nd4jValidator {
                 return ValidationResult.builder()
                         .valid(true)
                         .formatType("INDArray File")
+                        .formatClass(INDArray.class)
                         .path(Nd4jCommonValidator.getPath(f))
                         .build();
             }
@@ -78,6 +83,7 @@ public class Nd4jValidator {
             return ValidationResult.builder()
                     .valid(false)
                     .formatType("INDArray File")
+                    .formatClass(INDArray.class)
                     .path(Nd4jCommonValidator.getPath(f))
                     .issues(Collections.singletonList("File may be corrupt or is not a binary INDArray file"))
                     .exception(t)
@@ -87,6 +93,7 @@ public class Nd4jValidator {
         return ValidationResult.builder()
                 .valid(true)
                 .formatType("INDArray File")
+                .formatClass(INDArray.class)
                 .path(Nd4jCommonValidator.getPath(f))
                 .build();
     }
@@ -101,8 +108,10 @@ public class Nd4jValidator {
     public static ValidationResult validateINDArrayTextFile(@NonNull File f) {
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray Text File", false);
-        if (vr != null && !vr.isValid())
+        if (vr != null && !vr.isValid()) {
+            vr.setFormatClass(INDArray.class);
             return vr;
+        }
 
         //TODO let's do this without reading the whole thing into memory - check header + length...
         try (INDArray arr = Nd4j.readTxt(f.getPath())) {   //Using the fact that INDArray.close() exists -> deallocate memory as soon as reading is done
@@ -113,6 +122,7 @@ public class Nd4jValidator {
                 return ValidationResult.builder()
                         .valid(true)
                         .formatType("INDArray Text File")
+                        .formatClass(INDArray.class)
                         .path(Nd4jCommonValidator.getPath(f))
                         .build();
             }
@@ -120,6 +130,7 @@ public class Nd4jValidator {
             return ValidationResult.builder()
                     .valid(false)
                     .formatType("INDArray Text File")
+                    .formatClass(INDArray.class)
                     .path(Nd4jCommonValidator.getPath(f))
                     .issues(Collections.singletonList("File may be corrupt or is not a text INDArray file"))
                     .exception(t)
@@ -129,6 +140,7 @@ public class Nd4jValidator {
         return ValidationResult.builder()
                 .valid(true)
                 .formatType("INDArray Text File")
+                .formatClass(INDArray.class)
                 .path(Nd4jCommonValidator.getPath(f))
                 .build();
     }
@@ -304,6 +316,7 @@ public class Nd4jValidator {
             return ValidationResult.builder()
                     .valid(false)
                     .formatType("SameDiff FlatBuffers file")
+                    .formatClass(SameDiff.class)
                     .path(Nd4jCommonValidator.getPath(f))
                     .issues(Collections.singletonList("File may be corrupt or is not a SameDiff file in FlatBuffers format"))
                     .exception(t)
@@ -313,6 +326,7 @@ public class Nd4jValidator {
         return ValidationResult.builder()
                 .valid(true)
                 .formatType("SameDiff FlatBuffers file")
+                .formatClass(SameDiff.class)
                 .path(Nd4jCommonValidator.getPath(f))
                 .build();
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
@@ -23,7 +23,7 @@ public class Nd4jValidator {
     public static ValidationResult validateINDArrayFile(@NonNull File f, DataType... allowableDataTypes){
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray File", false);
-        if(vr != null)
+        if(vr != null && !vr.isValid())
             return vr;
 
         //TODO let's do this without reading the whole thing into memory - check header + length...
@@ -68,7 +68,7 @@ public class Nd4jValidator {
     public static ValidationResult validateINDArrayTextFile(@NonNull File f){
 
         ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "INDArray Text File", false);
-        if(vr != null)
+        if(vr != null && !vr.isValid())
             return vr;
 
         //TODO let's do this without reading the whole thing into memory - check header + length...
@@ -95,6 +95,41 @@ public class Nd4jValidator {
         return ValidationResult.builder()
                 .valid(true)
                 .formatType("INDArray Text File")
+                .path(Nd4jCommonValidator.getPath(f))
+                .build();
+    }
+
+
+    public static ValidationResult validateNpyFile(@NonNull File f){
+
+        ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "Numpy .npy File", false);
+        if(vr != null && !vr.isValid())
+            return vr;
+
+        //TODO let's do this without reading whole thing into memory
+        try (INDArray arr = Nd4j.createFromNpyFile(f)) {   //Using the fact that INDArray.close() exists -> deallocate memory as soon as reading is done
+        } catch (Throwable t) {
+            if (t instanceof OutOfMemoryError || t.getMessage().toLowerCase().contains("failed to allocate")) {
+                //This is a memory exception during reading... result is indeterminant (might be valid, might not be, can't tell here)
+                return ValidationResult.builder()
+                        .valid(true)
+                        .formatType("Numpy .npy File")
+                        .path(Nd4jCommonValidator.getPath(f))
+                        .build();
+            }
+
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType("Numpy .npy File")
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("File may be corrupt or is not a Numpy .npy file"))
+                    .exception(t)
+                    .build();
+        }
+
+        return ValidationResult.builder()
+                .valid(true)
+                .formatType("Numpy .npy File")
                 .path(Nd4jCommonValidator.getPath(f))
                 .build();
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/util/Nd4jValidator.java
@@ -11,6 +11,7 @@ import org.nd4j.validation.ValidationResult;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 
 public class Nd4jValidator {
 
@@ -134,4 +135,37 @@ public class Nd4jValidator {
                 .build();
     }
 
+    public static ValidationResult validateNpzFile(@NonNull File f){
+        ValidationResult vr = Nd4jCommonValidator.isValidFile(f, "Numpy .npz File", false);
+        if(vr != null && !vr.isValid())
+            return vr;
+
+        Map<String,INDArray> m = null;
+        try{
+            m = Nd4j.createFromNpzFile(f);
+        } catch (Throwable t){
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType("Numpy .npz File")
+                    .path(Nd4jCommonValidator.getPath(f))
+                    .issues(Collections.singletonList("File may be corrupt or is not a Numpy .npz file"))
+                    .exception(t)
+                    .build();
+        } finally {
+            //Deallocate immediately
+            if(m != null){
+                for(INDArray arr : m.values()){
+                    if(arr != null){
+                        arr.close();
+                    }
+                }
+            }
+        }
+
+        return ValidationResult.builder()
+                .valid(true)
+                .formatType("Numpy .npz File")
+                .path(Nd4jCommonValidator.getPath(f))
+                .build();
+    }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
@@ -285,7 +285,11 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
             byte[] localHeader = new byte[30];
             is.read(localHeader);
             if ((int)localHeader[2] != 3 || (int)localHeader[3] != 4){
-                break;
+                if(map.isEmpty()) {
+                    throw new IllegalStateException("Found malformed NZP file header: File is not a npz file? " + file.getPath());
+                } else {
+                    break;
+                }
             }
             int fNameLength = localHeader[26];
             byte[] fNameBytes = new byte[fNameLength];

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
@@ -306,16 +306,42 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
                 headerStr += (char)b;
             }
 
-            int idx = headerStr.indexOf("'<") + 2;
-            String typeStr = headerStr.substring(idx, idx + 2);
+            int idx;
+            String typeStr;
+            if(headerStr.contains("<")){
+                idx = headerStr.indexOf("'<") + 2;
+            } else {
+                idx = headerStr.indexOf("'|") + 2;
+            }
+            typeStr = headerStr.substring(idx, idx + 2);
+
             int elemSize;
+            DataType dt;
             if (typeStr.equals("f8")){
                 elemSize = 8;
-            }
-            else if (typeStr.equals("f4")){
+                dt = DataType.DOUBLE;
+            } else if (typeStr.equals("f4")){
                 elemSize = 4;
-            }
-            else{
+                dt = DataType.FLOAT;
+            } else if(typeStr.equals("f2")){
+                elemSize = 2;
+                dt = DataType.HALF;
+            } else if(typeStr.equals("i8")){
+                elemSize = 8;
+                dt = DataType.LONG;
+            } else if (typeStr.equals("i4")){
+                elemSize = 4;
+                dt = DataType.INT;
+            } else if(typeStr.equals("i2")){
+                elemSize = 2;
+                dt = DataType.SHORT;
+            } else if(typeStr.equals("i1")){
+                elemSize = 1;
+                dt = DataType.BYTE;
+            } else if(typeStr.equals("u1")){
+                elemSize = 1;
+                dt = DataType.UBYTE;
+            } else{
                 throw new Exception("Unsupported data type: " + typeStr);
             }
             idx = headerStr.indexOf("'fortran_order': ");
@@ -341,21 +367,65 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
             is.read(data);
             ByteBuffer bb = ByteBuffer.wrap(data);
 
-            if (elemSize == 8){
+            if (dt == DataType.DOUBLE){
                 double[] doubleData = new double[(int)size];
                 for (int i=0; i<size; i++){
-                    doubleData[i] = bb.getDouble(i);
+                    long l = bb.getLong(8*i);
+                    l = Long.reverseBytes(l);
+                    doubleData[i] = Double.longBitsToDouble(l);
                 }
                 map.put(fName, Nd4j.create(doubleData, shape, order));
-
-            }
-            else{
-                double[] floatData = new double[(int)size];
+            } else if(dt == DataType.FLOAT){
+                float[] floatData = new float[(int)size];
                 for (int i=0; i<size; i++){
-                    floatData[i] = bb.getFloat(i);
+                    int i2 = bb.getInt(4*i);
+                    i2 = Integer.reverseBytes(i2);
+                    float f = Float.intBitsToFloat(i2);
+                    floatData[i] = f;
                 }
                 map.put(fName, Nd4j.create(floatData, shape, order));
-
+            } else if(dt == DataType.HALF){
+                INDArray arr = Nd4j.create(DataType.HALF, size);
+                ByteBuffer bb2 = arr.data().pointer().asByteBuffer();
+                for( int i=0; i<size; i++ ) {
+                    short s = bb.getShort(2*i);
+                    bb2.put((byte)((s >> 8) & 0xff));
+                    bb2.put((byte)(s & 0xff));
+                }
+                map.put(fName, arr.reshape(order, shape));
+            } else if(dt == DataType.LONG){
+                long[] d = new long[(int)size];
+                for (int i=0; i<size; i++){
+                    long l = bb.getLong(8*i);
+                    l = Long.reverseBytes(l);
+                    d[i] = l;
+                }
+                map.put(fName, Nd4j.createFromArray(d).reshape(order, shape));
+            } else if(dt == DataType.INT){
+                int[] d = new int[(int)size];
+                for (int i=0; i<size; i++){
+                    int l = bb.getInt(4*i);
+                    l = Integer.reverseBytes(l);
+                    d[i] = l;
+                }
+                map.put(fName, Nd4j.createFromArray(d).reshape(order, shape));
+            } else if(dt == DataType.SHORT){
+                short[] d = new short[(int)size];
+                for (int i=0; i<size; i++){
+                    short l = bb.getShort(2*i);
+                    l = Short.reverseBytes(l);
+                    d[i] = l;
+                }
+                map.put(fName, Nd4j.createFromArray(d).reshape(order, shape));
+            } else if(dt == DataType.BYTE){
+                map.put(fName, Nd4j.createFromArray(data).reshape(order, shape));
+            } else if(dt == DataType.UBYTE){
+                short[] d = new short[(int)size];
+                for (int i=0; i<size; i++){
+                    short l = ((short) (bb.get(i) & (short) 0xff));
+                    d[i] = l;
+                }
+                map.put(fName, Nd4j.createFromArray(d).reshape(order, shape).castTo(DataType.UBYTE));
             }
 
         }

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/serde/NumpyFormatTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/serde/NumpyFormatTests.java
@@ -16,6 +16,8 @@ import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.io.ClassPathResource;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -119,6 +121,24 @@ public class NumpyFormatTests extends BaseNd4jTest {
         }
 
         assertTrue(cnt > 0);
+    }
+
+    @Test
+    public void testTxtReading() throws Exception {
+        File f = new ClassPathResource("numpy_arrays/txt/arange_3,4_float32.txt").getFile();
+        INDArray arr = Nd4j.readNumpy(DataType.FLOAT, f.getPath());
+
+        INDArray exp = Nd4j.arange(12).castTo(DataType.FLOAT).reshape(3,4);
+        assertEquals(exp, arr);
+
+        arr = Nd4j.readNumpy(DataType.DOUBLE, f.getPath());
+
+        assertEquals(exp.castTo(DataType.DOUBLE), arr);
+
+        f = new ClassPathResource("numpy_arrays/txt_tab/arange_3,4_float32.txt").getFile();
+        arr = Nd4j.readNumpy(DataType.FLOAT, f.getPath(), "\t");
+
+        assertEquals(exp, arr);
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/serde/NumpyFormatTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/serde/NumpyFormatTests.java
@@ -17,7 +17,9 @@ import org.nd4j.linalg.io.ClassPathResource;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
@@ -32,8 +34,6 @@ public class NumpyFormatTests extends BaseNd4jTest {
 
     @Test
     public void testToNpyFormat() throws Exception {
-
-        //File dir = new File("C:\\develop\\dl4j-test-resources\\src\\main\\resources\\numpy_arrays");
 
         val dir = testDir.newFolder();
         new ClassPathResource("numpy_arrays/").copyDirectory(dir);
@@ -75,6 +75,46 @@ public class NumpyFormatTests extends BaseNd4jTest {
 */
 
             assertArrayEquals("Failed with file [" + f.getName() + "]", expected, bytes);
+            cnt++;
+        }
+
+        assertTrue(cnt > 0);
+    }
+
+    @Test
+    public void testNpzReading() throws Exception {
+
+        val dir = testDir.newFolder();
+        new ClassPathResource("numpy_arrays/npz/").copyDirectory(dir);
+
+        File[] files = dir.listFiles();
+        int cnt = 0;
+
+        for(File f : files){
+            if(!f.getPath().endsWith(".npz")){
+                log.warn("Skipping: {}", f);
+                continue;
+            }
+
+            String path = f.getAbsolutePath();
+            int lastDot = path.lastIndexOf('.');
+            int lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+            String dtype = path.substring(lastSlash+1, lastDot);
+            System.out.println(path + " : " + dtype);
+
+            DataType dt = DataType.fromNumpy(dtype);
+            //System.out.println(dt);
+
+            INDArray arr = Nd4j.arange(12).castTo(dt).reshape(3,4);
+            INDArray arr2 = Nd4j.linspace(DataType.FLOAT, 0, 3, 10);
+
+            Map<String,INDArray> m = Nd4j.createFromNpzFile(f);
+            assertEquals(2, m.size());
+            assertTrue(m.containsKey("firstArr"));
+            assertTrue(m.containsKey("secondArr"));
+
+            assertEquals(arr, m.get("firstArr"));
+            assertEquals(arr2, m.get("secondArr"));
             cnt++;
         }
 

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/ValidationUtilTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/ValidationUtilTests.java
@@ -5,6 +5,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.io.ClassPathResource;
 import org.nd4j.validation.Nd4jCommonValidator;
@@ -112,6 +115,77 @@ public class ValidationUtilTests extends BaseNd4jTest {
         assertTrue(s, s.contains("someFile1.bin") && s.contains("someFile2.bin"));
         assertFalse(s, s.contains("content.txt"));
         System.out.println(vr4.toString());
+    }
+
+
+    @Test
+    public void testNpyValidation() throws Exception {
+
+        File f = testDir.newFolder();
+
+        //Test not existent file:
+        File fNonExistent = new File("doesntExist.npy");
+        ValidationResult vr0 = Nd4jValidator.validateNpyFile(fNonExistent);
+        assertFalse(vr0.isValid());
+        assertEquals("Numpy .npy File", vr0.getFormatType());
+        assertTrue(vr0.getIssues().get(0), vr0.getIssues().get(0).contains("exist"));
+        System.out.println(vr0.toString());
+
+        //Test empty file:
+        File fEmpty = new File(f, "empty.npy");
+        fEmpty.createNewFile();
+        assertTrue(fEmpty.exists());
+        ValidationResult vr1 = Nd4jValidator.validateNpyFile(fEmpty);
+        assertEquals("Numpy .npy File", vr1.getFormatType());
+        assertFalse(vr1.isValid());
+        assertTrue(vr1.getIssues().get(0), vr1.getIssues().get(0).contains("empty"));
+        System.out.println(vr1.toString());
+
+        //Test directory (not zip file)
+        File directory = new File(f, "dir");
+        boolean created = directory.mkdir();
+        assertTrue(created);
+        ValidationResult vr2 = Nd4jValidator.validateNpyFile(directory);
+        assertEquals("Numpy .npy File", vr2.getFormatType());
+        assertFalse(vr2.isValid());
+        assertTrue(vr2.getIssues().get(0), vr2.getIssues().get(0).contains("directory"));
+        System.out.println(vr2.toString());
+
+        //Test non-numpy format:
+        File fText = new File(f, "text.txt");
+        FileUtils.writeStringToFile(fText, "Not a numpy .npy file", StandardCharsets.UTF_8);
+        ValidationResult vr3 = Nd4jValidator.validateNpyFile(fText);
+        assertEquals("Numpy .npy File", vr3.getFormatType());
+        assertFalse(vr3.isValid());
+        String s = vr3.getIssues().get(0);
+        assertTrue(s, s.contains("npy") && s.toLowerCase().contains("numpy") && s.contains("corrupt"));
+        System.out.println(vr3.toString());
+
+        //Test corrupted npy format:
+        File fValid = new ClassPathResource("numpy_arrays/arange_3,4_float32.npy").getFile();
+        byte[] numpyBytes = FileUtils.readFileToByteArray(fValid);
+        for( int i=0; i<30; i++ ){
+            numpyBytes[i] = 0;
+        }
+        File fCorrupt = new File(f, "corrupt.npy");
+        FileUtils.writeByteArrayToFile(fCorrupt, numpyBytes);
+
+        ValidationResult vr4 = Nd4jValidator.validateNpyFile(fCorrupt);
+        assertEquals("Numpy .npy File", vr4.getFormatType());
+        assertFalse(vr4.isValid());
+        s = vr4.getIssues().get(0);
+        assertTrue(s, s.contains("npy") && s.toLowerCase().contains("numpy") && s.contains("corrupt"));
+        System.out.println(vr4.toString());
+
+
+        //Test valid npy format:
+        ValidationResult vr5 = Nd4jValidator.validateNpyFile(fValid);
+        assertEquals("Numpy .npy File", vr5.getFormatType());
+        assertTrue(vr5.isValid());
+        assertNull(vr5.getIssues());
+        assertNull(vr5.getException());
+        System.out.println(vr4.toString());
+
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/ValidationUtilTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/util/ValidationUtilTests.java
@@ -1,0 +1,122 @@
+package org.nd4j.linalg.util;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.nd4j.linalg.BaseNd4jTest;
+import org.nd4j.linalg.factory.Nd4jBackend;
+import org.nd4j.linalg.io.ClassPathResource;
+import org.nd4j.validation.Nd4jCommonValidator;
+import org.nd4j.validation.ValidationResult;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.*;
+
+public class ValidationUtilTests extends BaseNd4jTest {
+
+    @Rule
+    public TemporaryFolder testDir = new TemporaryFolder();
+
+    public ValidationUtilTests(Nd4jBackend backend) {
+        super(backend);
+    }
+
+    @Test
+    public void testFileValidation() throws Exception {
+        File f = testDir.newFolder();
+
+        //Test not existent file:
+        File fNonExistent = new File("doesntExist.bin");
+        ValidationResult vr0 = Nd4jCommonValidator.isValidFile(fNonExistent);
+        assertFalse(vr0.isValid());
+        assertTrue(vr0.getIssues().get(0), vr0.getIssues().get(0).contains("exist"));
+        System.out.println(vr0.toString());
+
+        //Test empty file:
+        File fEmpty = new File(f, "0.bin");
+        fEmpty.createNewFile();
+        ValidationResult vr1 = Nd4jCommonValidator.isValidFile(fEmpty);
+        assertFalse(vr1.isValid());
+        assertTrue(vr1.getIssues().get(0), vr1.getIssues().get(0).contains("empty"));
+        System.out.println(vr1.toString());
+
+        //Test directory
+        File directory = new File(f, "dir");
+        boolean created = directory.mkdir();
+        assertTrue(created);
+        ValidationResult vr2 = Nd4jCommonValidator.isValidFile(directory);
+        assertFalse(vr2.isValid());
+        assertTrue(vr2.getIssues().get(0), vr2.getIssues().get(0).contains("directory"));
+        System.out.println(vr2.toString());
+
+        //Test valid non-empty file - valid
+        File f3 = new File(f, "1.txt");
+        FileUtils.writeStringToFile(f3, "Test", StandardCharsets.UTF_8);
+        ValidationResult vr3 = Nd4jCommonValidator.isValidFile(f3);
+        assertTrue(vr3.isValid());
+        System.out.println(vr3.toString());
+    }
+
+    @Test
+    public void testZipValidation() throws Exception {
+        File f = testDir.newFolder();
+
+        //Test not existent file:
+        File fNonExistent = new File("doesntExist.zip");
+        ValidationResult vr0 = Nd4jCommonValidator.isValidZipFile(fNonExistent, false);
+        assertFalse(vr0.isValid());
+        assertTrue(vr0.getIssues().get(0), vr0.getIssues().get(0).contains("exist"));
+        System.out.println(vr0.toString());
+
+        //Test empty zip:
+        File fEmpty = new ClassPathResource("validation/empty_zip.zip").getFile();
+        assertTrue(fEmpty.exists());
+        ValidationResult vr1 = Nd4jCommonValidator.isValidZipFile(fEmpty, false);
+        assertFalse(vr1.isValid());
+        assertTrue(vr1.getIssues().get(0), vr1.getIssues().get(0).contains("empty"));
+        System.out.println(vr1.toString());
+
+        //Test directory (not zip file)
+        File directory = new File(f, "dir");
+        boolean created = directory.mkdir();
+        assertTrue(created);
+        ValidationResult vr2 = Nd4jCommonValidator.isValidFile(directory);
+        assertFalse(vr2.isValid());
+        assertTrue(vr2.getIssues().get(0), vr2.getIssues().get(0).contains("directory"));
+        System.out.println(vr2.toString());
+
+        //Test non-empty zip - valid
+        File f3 = new File(f, "1.zip");
+        try(ZipOutputStream z = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(f3)))){
+            ZipEntry ze = new ZipEntry("content.txt");
+            z.putNextEntry(ze);
+            z.write("Text content".getBytes());
+        }
+        ValidationResult vr3 = Nd4jCommonValidator.isValidZipFile(f3, false);
+        assertTrue(vr3.isValid());
+        System.out.println(vr3.toString());
+
+        //Test non-empty zip - but missing required entries
+        ValidationResult vr4 = Nd4jCommonValidator.isValidZipFile(f3, false, "content.txt", "someFile1.bin", "someFile2.bin");
+        assertFalse(vr4.isValid());
+        assertEquals(1, vr4.getIssues().size());
+        String s = vr4.getIssues().get(0);
+        assertTrue(s, s.contains("someFile1.bin") && s.contains("someFile2.bin"));
+        assertFalse(s, s.contains("content.txt"));
+        System.out.println(vr4.toString());
+    }
+
+
+    @Override
+    public char ordering() {
+        return 'c';
+    }
+}

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/validation/Nd4jCommonValidator.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/validation/Nd4jCommonValidator.java
@@ -1,0 +1,63 @@
+package org.nd4j.validation;
+
+import lombok.NonNull;
+
+import java.io.File;
+import java.util.Collections;
+
+public class Nd4jCommonValidator {
+
+    private Nd4jCommonValidator(){ }
+
+    protected ValidationResult isValidFile(@NonNull File f, String formatType, boolean allowEmpty){
+        String path;
+        try{
+            //Very occasionally: getAbsolutePath not possible (files in JARs etc)
+            path = f.getAbsolutePath();
+        } catch (Throwable t ){
+            path = f.getPath();
+        }
+
+        if(!f.exists() || !f.isFile()){
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType(formatType)
+                    .path(path)
+                    .issues(Collections.singletonList("File does not exist"))
+                    .build();
+        }
+
+        if(!f.isFile()){
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType(formatType)
+                    .path(path)
+                    .issues(Collections.singletonList(f.isDirectory() ? "Specified path is a directory" : "Specified path is not a file"))
+                    .build();
+        }
+
+        if(f.length() <= 0){
+            return ValidationResult.builder()
+                    .valid(false)
+                    .formatType(formatType)
+                    .path(path)
+                    .issues(Collections.singletonList("File is empty (length 0)"))
+                    .build();
+        }
+
+        return null;    //OK
+    }
+
+    public ValidationResult isValidJSON(@NonNull File f){
+
+        //ValidationResult vr = isValidFile()
+
+        return null;
+    }
+
+    public ValidationResult isValidJSON(String s){
+
+        return null;
+    }
+
+}

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/validation/Nd4jCommonValidator.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/validation/Nd4jCommonValidator.java
@@ -2,7 +2,6 @@ package org.nd4j.validation;
 
 import lombok.NonNull;
 import org.apache.commons.io.FileUtils;
-import org.nd4j.shade.jackson.core.JsonProcessingException;
 import org.nd4j.shade.jackson.databind.JavaType;
 import org.nd4j.shade.jackson.databind.ObjectMapper;
 
@@ -10,7 +9,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -189,7 +191,7 @@ public class Nd4jCommonValidator {
     }
 
 
-    private static String getPath(File f){
+    public static String getPath(File f){
         if(f == null)
             return null;
         try{

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/validation/Nd4jCommonValidator.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/validation/Nd4jCommonValidator.java
@@ -143,7 +143,7 @@ public class Nd4jCommonValidator {
                     .valid(false)
                     .formatType("Zip File")
                     .path(getPath(f))
-                    .issues(Collections.singletonList("File does not appear to be valid zip file"))
+                    .issues(Collections.singletonList("File does not appear to be valid zip file (not a zip file or content is corrupt)"))
                     .exception(e)
                     .build();
         }

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/validation/ValidationResult.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/validation/ValidationResult.java
@@ -26,7 +26,7 @@ public class ValidationResult implements Serializable {
     private String path;             //Path of file (if applicable)
     private boolean valid;           //Whether the file/model is valid
     private List<String> issues;     //List of issues (generally only present if not valid)
-    private Exception exception;     //Exception, if applicable
+    private Throwable exception;     //Exception, if applicable
 
 
 

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/validation/ValidationResult.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/validation/ValidationResult.java
@@ -1,0 +1,78 @@
+package org.nd4j.validation;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a standard way of validating models, files, etc before attempting to load them.
+ *
+ * @author Alex Black
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class ValidationResult implements Serializable {
+
+    private String formatType;       //Human readable format/model type
+    private Class<?> formatClass;    //Actual class the format/model is (or should be)
+    private String path;             //Path of file (if applicable)
+    private boolean valid;           //Whether the file/model is valid
+    private List<String> issues;     //List of issues (generally only present if not valid)
+    private Exception exception;     //Exception, if applicable
+
+
+
+    @Override
+    public String toString(){
+        List<String> lines = new ArrayList<>();
+        if(formatType != null) {
+            lines.add("Format type: " + formatType);
+        }
+        if(formatClass != null){
+            lines.add("Format class: " + formatClass.getName());
+        }
+        if(path != null){
+            lines.add("Path: " + path);
+        }
+        lines.add("Model valid: " + valid);
+        if(issues != null && !issues.isEmpty()){
+            lines.add("Issues:\n");
+            for(String s : issues){
+                addWithIndent(s, lines, "- ", "  ");
+            }
+        }
+        if(exception != null){
+            String ex = ExceptionUtils.getStackTrace(exception);
+            lines.add("Stack Trace:\n");
+            addWithIndent(ex, lines, "  ", "  ");
+        }
+        //Would use String.join but that's Java 8...
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for(String s : lines){
+            if(!first)
+                sb.append("\n");
+            sb.append(s);
+            first = false;
+        }
+        return sb.toString();
+    }
+
+    protected static void addWithIndent(String toAdd, List<String> list, String firstLineIndent, String laterLineIndent){
+        String[] split = toAdd.split("\n");
+        boolean first = true;
+        for(String issueLine : split){
+            list.add((first ? firstLineIndent : laterLineIndent) + issueLine);
+            first = false;
+        }
+    }
+
+}

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/validation/ValidationResult.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/validation/ValidationResult.java
@@ -42,16 +42,20 @@ public class ValidationResult implements Serializable {
         if(path != null){
             lines.add("Path: " + path);
         }
-        lines.add("Model valid: " + valid);
+        lines.add("Format valid: " + valid);
         if(issues != null && !issues.isEmpty()){
-            lines.add("Issues:\n");
-            for(String s : issues){
-                addWithIndent(s, lines, "- ", "  ");
+            if(issues.size() == 1){
+                addWithIndent(issues.get(0), lines, "Issue: ", "       ");
+            } else {
+                lines.add("Issues:");
+                for (String s : issues) {
+                    addWithIndent(s, lines, "- ", "  ");
+                }
             }
         }
         if(exception != null){
             String ex = ExceptionUtils.getStackTrace(exception);
-            lines.add("Stack Trace:\n");
+            lines.add("Stack Trace:");
             addWithIndent(ex, lines, "  ", "  ");
         }
         //Would use String.join but that's Java 8...


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/deeplearning4j/issues/7503

Adds numerous validation utils for checking if most common serialized formats are valid:
* DL4JModelValidator
* DL4JKerasModelValidator
* Nd4jValidator
* Nd4jCommonValidator

In most (but not all) cases, it should be cheaper/faster to use these validation tools to detect invalid formats than simply trying to load the format to see if it works or not.

Validation tools have common return format - ValidationResult object with the following information:
* formatType: Human readable format/model type
* formatClass; Actual class the format/model is (or should be)
* path: Path of file (if applicable)
* valid: Whether the file/model is valid
* issues: List of issues/problems making format invalid (generally only present if not valid)
* exception: Exception, if applicable

Also fixes and better tests for npz file reading.

Eventually we should integrate these better into actual loading, but we'll look at that separately