### PR TITLE
ND4J: Fix build for linux-arm64

### DIFF
--- a/libnd4j/blas/CMakeLists.txt
+++ b/libnd4j/blas/CMakeLists.txt
@@ -44,10 +44,6 @@ if(WIN32)
     SET(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "@")
 
     SET(CMAKE_NINJA_FORCE_RESPONSE_FILE 1 CACHE INTERNAL "")
-else()
-    if (CUDA_BLAS)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcmodel=medium")
-    endif()
 endif()
 
 

--- a/libnd4j/buildnativeoperations.sh
+++ b/libnd4j/buildnativeoperations.sh
@@ -169,6 +169,12 @@ case "$OS" in
     fi
     ;;
 
+    linux-arm64)
+    if [ -z "$ARCH" ]; then
+        ARCH="armv8-a"
+    fi
+    ;;
+
     android-arm)
     if [ -z "$ARCH" ]; then
         ARCH="armv7-a"

--- a/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -421,6 +421,20 @@
           </properties>
         </profile>
         <profile>
+          <id>linux-arm64-default</id>
+          <activation>
+            <property>
+              <name>javacpp.platform</name>
+              <value>linux-arm64</value>
+            </property>
+          </activation>
+          <properties>
+            <javacpp.platform.properties>linux-arm64</javacpp.platform.properties>
+            <javacpp.platform.compiler>aarch64-linux-gnu-g++</javacpp.platform.compiler>
+            <dependency.platform2></dependency.platform2>
+          </properties>
+        </profile>
+        <profile>
           <id>linux-ppc64le-default</id>
           <activation>
             <property>


### PR DESCRIPTION
Fixes #7687

## What changes were proposed in this pull request?

Add missing profile to pom.xml file for build to succeed on linux-arm64

## How was this patch tested?

Untested on linux-arm64, but build still passes on other platforms

@kwatters Could you try with `mvn clean install -Dmaven.test.skip -Djavacpp.platform=linux-arm64`?