### PR TITLE
[Docs] Fix command to install OpenBLAS on OS X

### DIFF
--- a/docs/deeplearning4j/templates/build-from-source.md
+++ b/docs/deeplearning4j/templates/build-from-source.md
@@ -143,11 +143,10 @@ For more complete instructions, [go here](http://www.cyberciti.biz/faq/centos-li
 
 ##### OS X
 
-You can install OpenBLAS on OS X with Home
-Science:
+You can install OpenBLAS on OS X with Homebrew:
 
 ```
-brew install homebrew/science/openblas
+brew install openblas
 ```
 
 ##### Windows


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix command to install OpenBLAS on OS X

## How was this patch tested?

N/A

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Reviewed the [Contributing Guidelines](https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
- [ ] Ran mvn formatter:format (see [formatter instructions](http://code.revelc.net/formatter-maven-plugin/examples.html#Setting_Source_Files) for targeting your specific files).

## Reason
```console
$ brew install homebrew/science/openblas
Error: homebrew/science was deprecated. This tap is now empty as all its formulae were migrated.
```
And
```console
$ brew install brewsci/science/openblas
Updating Homebrew...
Warning: Use openblas instead of deprecated brewsci/science/openblas
```