### PR TITLE
Modify regex for scheme detection

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/split/NumberedFileInputSplit.java
@@ -122,7 +122,7 @@ public class NumberedFileInputSplit implements InputSplit {
     public URI[] locations() {
         URI[] uris = new URI[(int) length()];
         int x = 0;
-        if(baseString.matches(".*:/.*")){
+        if(baseString.matches(".{2,}:/.*")){
             //URI (has scheme)
             for (int i = minIdx; i <= maxIdx; i++) {
                 uris[x++] = URI.create(String.format(baseString, i));


### PR DESCRIPTION
Modified regex expression for scheme detection from
`if(baseString.matches(".*:/.*")){`
to
`if(baseString.matches(".{2,}:/.*")){`
i.e. there must be at least 2 characters before the ":/".

This prevents the string
"C:/path/" 
from being matched (contrary to before), whilst matching e.g.
"file:/C:/path" and "file:/path".

Additionally, with the proposed modification the string ":/path" which matched previously no longer matches (which I assume is desired behaviour).