### PR TITLE
DataVec: Avoid sampling bias in RandomPathFilter.filter()

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/io/filters/RandomPathFilter.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/io/filters/RandomPathFilter.java
@@ -17,6 +17,7 @@
 package org.datavec.api.io.filters;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Random;
@@ -64,8 +65,12 @@ public class RandomPathFilter implements PathFilter {
 
     @Override
     public URI[] filter(URI[] paths) {
+        // shuffle before to avoid sampling bias
+        ArrayList<URI> paths2 = new ArrayList<URI>(Arrays.asList(paths));
+        Collections.shuffle(paths2, random);
+
         ArrayList<URI> newpaths = new ArrayList<URI>();
-        for (URI path : paths) {
+        for (URI path : paths2) {
             if (accept(path.toString())) {
                 newpaths.add(path);
             }
@@ -73,7 +78,6 @@ public class RandomPathFilter implements PathFilter {
                 break;
             }
         }
-        Collections.shuffle(newpaths, random);
         return newpaths.toArray(new URI[newpaths.size()]);
     }
 }

--- a/datavec/datavec-api/src/test/java/org/datavec/api/split/InputSplitTests.java
+++ b/datavec/datavec-api/src/test/java/org/datavec/api/split/InputSplitTests.java
@@ -24,6 +24,7 @@ import org.datavec.api.io.labels.PatternPathLabelGenerator;
 import org.junit.Test;
 
 import java.io.*;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Random;
@@ -127,6 +128,27 @@ public class InputSplitTests {
         assertTrue(boostrap.needsBootstrapForWrite());
         boostrap.bootStrapForWrite();
         assertTrue(tmpDir.listFiles() != null);
+    }
+
+    @Test
+    public void testSampleNoBias() throws URISyntaxException {
+        Random random = new Random(7);
+        RandomPathFilter randomPathFilter = new RandomPathFilter(random, null, 100);
+
+        URI[] paths = new URI[1000];
+        for (int i = 0; i < paths.length; i++) {
+            paths[i] = new URI("file:///label" + (i/100) + "/image" + i);
+        }
+
+        boolean notOnlyFirstLabel = false;
+        URI[] paths2 = randomPathFilter.filter(paths);
+        assertEquals(100, paths2.length);
+        for (int i = 0; i < paths2.length; i++) {
+            if (!paths2[i].toString().startsWith("file:///label0/")) {
+                notOnlyFirstLabel = true;
+            }
+        }
+        assertTrue(notOnlyFirstLabel);
     }
 
 }


### PR DESCRIPTION
Fixes #7738

@AlexDBlack Is there already a set of images somewhere in the test resources that we could use to create a test for this?

## What changes were proposed in this pull request?

Shuffles the input array before filtering to avoid sampling bias.

## How was this patch tested?

Existing unit tests pass
