### PR TITLE
RL4J: Fix HistoryProcessor now using castTo() to perform "compression"

### DIFF
--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/HistoryProcessor.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/HistoryProcessor.java
@@ -21,8 +21,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.bytedeco.javacv.*;
 import org.datavec.image.loader.NativeImageLoader;
+import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.compression.BasicNDArrayCompressor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.io.IOException;
 
@@ -46,9 +47,6 @@ public class HistoryProcessor implements IHistoryProcessor {
     final private OpenCVFrameConverter openCVFrameConverter = new OpenCVFrameConverter.ToMat();
     private CircularFifoQueue<INDArray> history;
     private FFmpegFrameRecorder fmpegFrameRecorder = null;
-    public static BasicNDArrayCompressor compressor =
-                    BasicNDArrayCompressor.getInstance().setDefaultCompression("UINT8");
-
 
     public HistoryProcessor(Configuration conf) {
         this.conf = conf;
@@ -110,7 +108,7 @@ public class HistoryProcessor implements IHistoryProcessor {
     public INDArray[] getHistory() {
         INDArray[] array = new INDArray[getConf().getHistoryLength()];
         for (int i = 0; i < conf.getHistoryLength(); i++) {
-            array[i] = history.get(i);
+            array[i] = history.get(i).castTo(Nd4j.dataType());
         }
         return array;
     }
@@ -139,7 +137,7 @@ public class HistoryProcessor implements IHistoryProcessor {
         }
         //System.out.println(out.shapeInfoToString());
         out = out.reshape(1, conf.getCroppingHeight(), conf.getCroppingWidth());
-        INDArray compressed = compressor.compress(out);
+        INDArray compressed = out.castTo(DataType.UBYTE);
         return compressed;
     }
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/IHistoryProcessor.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/IHistoryProcessor.java
@@ -53,25 +53,14 @@ public interface IHistoryProcessor {
     @Builder
     @Value
     public static class Configuration {
-        int historyLength;
-        int rescaledWidth;
-        int rescaledHeight;
-        int croppingWidth;
-        int croppingHeight;
-        int offsetX;
-        int offsetY;
-        int skipFrame;
-
-        public Configuration() {
-            historyLength = 4;
-            rescaledWidth = 84;
-            rescaledHeight = 84;
-            croppingWidth = 84;
-            croppingHeight = 84;
-            offsetX = 0;
-            offsetY = 0;
-            skipFrame = 4;
-        }
+        @Builder.Default int historyLength = 4;
+        @Builder.Default int rescaledWidth = 84;
+        @Builder.Default int rescaledHeight = 84;
+        @Builder.Default int croppingWidth = 84;
+        @Builder.Default int croppingHeight = 84;
+        @Builder.Default int offsetX = 0;
+        @Builder.Default int offsetY = 0;
+        @Builder.Default int skipFrame = 4;
 
         public int[] getShape() {
             return new int[] {getHistoryLength(), getCroppingHeight(), getCroppingWidth()};

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/HistoryProcessorTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/HistoryProcessorTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2015-2019 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.learning;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author saudet
+ */
+public class HistoryProcessorTest {
+
+    @Test
+    public void testHistoryProcessor() throws Exception {
+        HistoryProcessor.Configuration conf = HistoryProcessor.Configuration.builder()
+                .croppingHeight(2).croppingWidth(2).rescaledHeight(2).rescaledWidth(2).build();
+        IHistoryProcessor hp = new HistoryProcessor(conf);
+        INDArray a = Nd4j.createFromArray(new float[][][] {{{0.1f, 0.1f, 0.1f}, {0.2f, 0.2f, 0.2f}}, {{0.3f, 0.3f, 0.3f}, {0.4f, 0.4f, 0.4f}}});
+        hp.add(a);
+        hp.add(a);
+        hp.add(a);
+        hp.add(a);
+        INDArray[] h = hp.getHistory();
+        assertEquals(4, h.length);
+        System.out.println(Arrays.toString(a.shape()));
+        System.out.println(Arrays.toString(h[0].shape()));
+        assertEquals(           1, h[0].shape()[0]);
+        assertEquals(a.shape()[0], h[0].shape()[1]);
+        assertEquals(a.shape()[1], h[0].shape()[2]);
+        assertEquals(0.1f * hp.getScale(), h[0].getDouble(0, 0, 0), 1);
+        assertEquals(0.2f * hp.getScale(), h[0].getDouble(0, 0, 1), 1);
+        assertEquals(0.3f * hp.getScale(), h[0].getDouble(0, 1, 0), 1);
+        assertEquals(0.4f * hp.getScale(), h[0].getDouble(0, 1, 1), 1);
+    }
+}


### PR DESCRIPTION
Fixes #7806

## What changes were proposed in this pull request?

ND4J has deprecated NDArray "compression" in favor of casting to different DataType, so we need to change this in RL4J as well.

## How was this patch tested?

Added a new unit test that fails without this change.