### PR TITLE
Fix Nadam updater clone missing schedule

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/Nadam.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/learning/config/Nadam.java
@@ -101,7 +101,7 @@ public class Nadam implements IUpdater {
 
     @Override
     public Nadam clone() {
-        return new Nadam(learningRate, beta1, beta2, epsilon);
+        return new Nadam(learningRate, learningRateSchedule, beta1, beta2, epsilon);
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Nadam.clone()` did not include the `learningRateSchedule`. 

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing. (The [Nadam](https://github.com/steven-lang/deeplearning4j/blob/276caeee4797f3b5db1c80edc08abf041850addf/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/learning/UpdaterTest.java#L135) test does not make use of `clone()` so I don't see any relevant tests)
