### PR TITLE
RL4J - Fix for setTarget() (issue #8107)

### DIFF
--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
@@ -232,15 +232,14 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
         INDArray dqnOutputAr = dqnOutput(obs);
 
         INDArray dqnOutputNext = dqnOutput(nextObs);
-        INDArray targetDqnOutputNext = null;
+        INDArray targetDqnOutputNext = targetDqnOutput(nextObs);
 
         INDArray tempQ = null;
         INDArray getMaxAction = null;
         if (getConfiguration().isDoubleDQN()) {
-            targetDqnOutputNext = targetDqnOutput(nextObs);
             getMaxAction = Nd4j.argMax(dqnOutputNext, 1);
         } else {
-            tempQ = Nd4j.max(dqnOutputNext, 1);
+            tempQ = Nd4j.max(targetDqnOutputNext, 1);
         }
 
 
@@ -257,8 +256,6 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
 
             }
 
-
-
             double previousV = dqnOutputAr.getDouble(i, actions[i]);
             double lowB = previousV - getConfiguration().getErrorClamp();
             double highB = previousV + getConfiguration().getErrorClamp();
@@ -269,5 +266,4 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
 
         return new Pair(obs, dqnOutputAr);
     }
-
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/CartpoleNative.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/CartpoleNative.java
@@ -1,0 +1,159 @@
+package org.deeplearning4j.rl4j.mdp;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.space.ArrayObservationSpace;
+import org.deeplearning4j.rl4j.space.DiscreteSpace;
+import org.deeplearning4j.rl4j.space.Encodable;
+import org.deeplearning4j.rl4j.space.ObservationSpace;
+
+import java.util.Random;
+
+/*
+    With the setup below, it should hit max score (200) after 4000-5000 iterations
+
+    public static QLearning.QLConfiguration CARTPOLE_QL =
+            new QLearning.QLConfiguration(
+                    123,    //Random seed
+                    200,    //Max step By epoch
+                    10000, //Max step
+                    10000, //Max size of experience replay
+                    64,     //size of batches
+                    50,    //target update (hard)
+                    0,     //num step noop warmup
+                    1.0,   //reward scaling
+                    0.99,   //gamma
+                    Double.MAX_VALUE,    //td-error clipping
+                    0.1f,   //min epsilon
+                    3000,   //num step for eps greedy anneal
+                    true    //double DQN
+            );
+
+    public static DQNFactoryStdDense.Configuration CARTPOLE_NET =
+            DQNFactoryStdDense.Configuration.builder()
+                    .l2(0.001).updater(new Adam(0.0005)).numHiddenNodes(16).numLayer(3).build();
+
+ */
+
+public class CartpoleNative implements MDP<CartpoleNative.State, Integer, DiscreteSpace> {
+    public enum KinematicsIntegrators { Euler, SemiImplicitEuler };
+
+    private static final int NUM_ACTIONS = 2;
+    private static final int ACTION_LEFT = 0;
+    private static final int ACTION_RIGHT = 1;
+    private static final int OBSERVATION_NUM_FEATURES = 4;
+
+    private static final double gravity = 9.8;
+    private static final double massCart = 1.0;
+    private static final double massPole = 0.1;
+    private static final double totalMass = massPole + massCart;
+    private static final double length = 0.5; // actually half the pole's length
+    private static final double polemassLength = massPole * length;
+    private static final double forceMag = 10.0;
+    private static final double tau = 0.02;  // seconds between state updates
+
+    // Angle at which to fail the episode
+    private static final double thetaThresholdRadians = 12.0 * 2.0 * Math.PI / 360.0;
+    private static final double xThreshold = 2.4;
+
+    private final Random rnd = new Random();
+
+    @Getter @Setter
+    private KinematicsIntegrators kinematicsIntegrator = KinematicsIntegrators.Euler;
+
+    @Getter
+    private boolean done = false;
+
+    private double x;
+    private double xDot;
+    private double theta;
+    private double thetaDot;
+    private Integer stepsBeyondDone;
+
+    @Getter
+    private DiscreteSpace actionSpace = new DiscreteSpace(NUM_ACTIONS);
+    @Getter
+    private ObservationSpace<CartpoleNative.State> observationSpace = new ArrayObservationSpace(new int[] { OBSERVATION_NUM_FEATURES });
+
+    @Override
+    public State reset() {
+
+        x = 0.1 * rnd.nextDouble() - 0.05;
+        xDot = 0.1 * rnd.nextDouble() - 0.05;
+        theta = 0.1 * rnd.nextDouble() - 0.05;
+        thetaDot = 0.1 * rnd.nextDouble() - 0.05;
+        stepsBeyondDone = null;
+
+        return new State(new double[] { x, xDot, theta, thetaDot });
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public StepReply<State> step(Integer action) {
+        double force = action == ACTION_RIGHT ? forceMag : -forceMag;
+        double cosTheta = Math.cos(theta);
+        double sinTheta = Math.sin(theta);
+        double temp = (force + polemassLength * thetaDot * thetaDot * sinTheta) / totalMass;
+        double thetaAcc = (gravity * sinTheta - cosTheta* temp) / (length * (4.0/3.0 - massPole * cosTheta * cosTheta / totalMass));
+        double xAcc = temp - polemassLength * thetaAcc * cosTheta / totalMass;
+
+        switch(kinematicsIntegrator) {
+            case Euler:
+                x += tau * xDot;
+                xDot += tau * xAcc;
+                theta += tau * thetaDot;
+                thetaDot += tau * thetaAcc;
+                break;
+
+            case SemiImplicitEuler:
+                xDot += tau * xAcc;
+                x += tau * xDot;
+                thetaDot += tau * thetaAcc;
+                theta += tau * thetaDot;
+                break;
+        }
+
+        boolean done =  x < -xThreshold || x > xThreshold
+                || theta < -thetaThresholdRadians || theta > thetaThresholdRadians;
+
+        double reward;
+        if(!done) {
+            reward = 1.0;
+        }
+        else if(stepsBeyondDone == null) {
+            stepsBeyondDone = 0;
+            reward = 1.0;
+        }
+        else {
+            ++stepsBeyondDone;
+            reward = 0;
+        }
+
+        return new StepReply<>(new State(new double[] { x, xDot, theta, thetaDot }), reward, done, null);
+    }
+
+    @Override
+    public MDP<State, Integer, DiscreteSpace> newInstance() {
+        return new CartpoleNative();
+    }
+
+    public static class State  implements Encodable {
+
+        private final double[] state;
+
+        State(double[] state) {
+
+            this.state = state;
+        }
+
+        @Override
+        public double[] toArray() {
+            return state;
+        }
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

See issue #8107 

After reading again "_Playing Atari with Deep Reinforcement Learning_" (http://arxiv.org/abs/1312.5602), I still think there is a problem with the current implementation of standard DQN, but I don't think that the target-network should be used for `dqnOutputAr`.

I have also read the section 3 "_Understanding Deep Q-Network_" of "A _Theoretical Analysis of Deep Q-Learning_" (https://arxiv.org/pdf/1901.00137.pdf).
And also https://medium.com/@qempsil0914/deep-q-learning-part2-double-deep-q-network-double-dqn-b8fc9212bbb2 which has a good overview of DQN.
Plus I reviewed a few DQN implementations on github. For example, Google's TensorLayer (https://github.com/tensorlayer/tensorlayer/blob/72666dbf23718e8710dc1069dbcf3231d131dff2/examples/reinforcement_learning/tutorial_DQN_variants.py).

First, the target-network should be used to compute `tempQ` in the standard DQN algorithm.
This can be seen in the equation 3.1 (and the one above in the text) of https://arxiv.org/pdf/1901.00137.pdf and also from lines 6-8 of `tutorial_DQN_variants.py`:
```
	The max operator in standard DQN uses the same values both to select and to evaluate an action by
	Q(s_t, a_t) = R_{t+1} + \gamma * max_{a}Q_{tar}(s_{t+1}, a)
```
We can see that the target-network (`Q_{tar}`) should be used.

Second, the target-network is only used as a stable base to compute the loss function, and not "to obtain the labels" as @flyheroljg says. This means that the Q-Network should used for `dqnOutputAr`. This can be seen on line 8 of `tutorial_DQN_variants.py` and also on lines 322-325:
```
                # calculate loss
                with tf.GradientTape() as q_tape:
                    b_q = tf.reduce_sum(qnet(b_o) * tf.one_hot(b_a, out_dim), 1)
                    loss = tf.reduce_mean(huber_loss(b_q - (b_r + reward_gamma * b_q_)))
```
The above snippet is used for Double-DQN, but only the td-target part (`(b_r + reward_gamma * b_q_)` above) is different between standard and double DQN in the computation of the loss function.
This can also be seen in the section "_Double Q-Learning Algorithm_" of https://medium.com/@qempsil0914/deep-q-learning-part2-double-deep-q-network-double-dqn-b8fc9212bbb2, as well as equation 3.3 of https://arxiv.org/pdf/1901.00137.pdf


## How was this patch tested?

With cartpole-v0 (re-written in java because couldn't make gym's version to work; can add it to this PR if requested)

