### PR TITLE
Corrected capital case for Activations, changed from "Tanh" To "TanH"

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/Activation.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/Activation.java
@@ -50,9 +50,9 @@ public enum Activation {
             case LEAKYRELU:
                 return new ActivationLReLU();
             case RATIONALTANH:
-                return new ActivationRationalTanh();
+                return new ActivationRationalTanH();
             case RECTIFIEDTANH:
-                return new ActivationRectifiedTanh();
+                return new ActivationRectifiedTanH();
             case RELU:
                 return new ActivationReLU();
             case RELU6:

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationRationalTanh.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationRationalTanh.java
@@ -37,7 +37,7 @@ import org.nd4j.linalg.primitives.Pair;
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
-public class ActivationRationalTanh extends BaseActivationFunction {
+public class ActivationRationalTanH extends BaseActivationFunction {
 
     @Override
     public INDArray getActivation(INDArray in, boolean training) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationRectifiedTanh.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/activations/impl/ActivationRectifiedTanh.java
@@ -34,7 +34,7 @@ import org.nd4j.linalg.primitives.Pair;
  */
 @EqualsAndHashCode(callSuper = false)
 @Getter
-public class ActivationRectifiedTanh extends BaseActivationFunction {
+public class ActivationRectifiedTanH extends BaseActivationFunction {
 
     @Override
     public INDArray getActivation(INDArray in, boolean training) {


### PR DESCRIPTION
Signed-off-by: yptheangel <choowilson93@gmail.com>

## What changes were proposed in this pull request?

Changes are targeted to issue "DL4J: Standardize activation function class capitalization #8279"
Changed the the "h" to "H" for "ActivationRationalTanh" and "ActivationRectifiedTanh" only in relevant files.

## How was this patch tested?

No additional test was done.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.

Note: I am uncertain on how to test the changes because I usually use the compiled jar files from Maven, I am willing to try to build from source if you could share some steps. 