### PR TITLE
Minor edits to README for pydatavec and pydl4j

### DIFF
--- a/pydatavec/LICENSE
+++ b/pydatavec/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pydatavec/README.md
+++ b/pydatavec/README.md
@@ -1,5 +1,6 @@
 # PyDataVec : Python interface for DataVec
 
+[![Join the chat at https://gitter.im/deeplearning4j/deeplearning4j](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/deeplearning4j/deeplearning4j?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![PyPI version](https://badge.fury.io/py/pydatavec.svg)](https://badge.fury.io/py/pydatavec)
 

--- a/pydatavec/README.md
+++ b/pydatavec/README.md
@@ -1,5 +1,8 @@
 # PyDataVec : Python interface for DataVec
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![PyPI version](https://badge.fury.io/py/pydatavec.svg)](https://badge.fury.io/py/pydatavec)
+
 ## Installation
 
 ```bash
@@ -13,13 +16,13 @@ Examples are in the [dl4j-examples repo](https://www.github.com/eclipse/deeplear
 Clone dl4j-examples:
 
 ```bash
-git clone https://www.github.com/deeplearning4j.dl4j-examples.git
+git clone https://www.github.com/eclipse/deeplearning4j-examples.git
 ```
 
 Run examples in `pydatavec-examples` directory
 
 ```bash
-cd pydatavec-examples
+cd deeplearning4j-examples/pydatavec-examples
 python basic.py
 python iris.py
 python reduction.py

--- a/pydl4j/README.md
+++ b/pydl4j/README.md
@@ -10,11 +10,8 @@ can use PyDL4J for the following tasks:
 
 ---------
 
-[![Build Status](https://jenkins.ci.skymind.io/buildStatus/icon?job=deeplearing4j/pydl4j/master)](https: // jenkins.ci.skymind.io/blue/organizations/jenkins/deeplearing4j % 2Fpydl4j/activity)
-[![License](https://img.shields.io/badge/License-Apache % 202.0-blue.svg)](https: // github.com/deeplearning4j/pydl4j/blob/master/LICENSE)
-[![PyPI version](https://badge.fury.io/py/pydl4j.svg)](https: // badge.fury.io/py/pydl4j)
-
-![PyDL4J](https: // github.com/deeplearning4j/pydl4j/blob/master/python_in_java.png)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![PyPI version](https://badge.fury.io/py/pydl4j.svg)](https://badge.fury.io/py/pydl4j)
 
 # Installation
 
@@ -27,8 +24,8 @@ pip install pydl4j
 Alternatively, you can build the project locally as follows:
 
 ```bash
-git clone https: // www.github.com/deeplearning4j/pydl4j.git
-cd pydl4j
+git clone https://www.github.com/eclipse/deeplearning4j.git
+cd deeplearning4j/pydl4j
 python setup.py install
 ```
 
@@ -41,7 +38,7 @@ Skymind use PyDL4J under the hood and will install this dependency for you.
 Installing PyDL4J exposes a command line tool called `pydl4j`. You can use this tool to configure
 your PyDL4J environment. If you don't use the CLI, a default configuration that will be used instead.
 
-**Note: ** If you intend to use the CLI, make sure to have[`docker` installed](https: // docs.docker.com/install/)
+**Note:** If you intend to use the CLI, make sure to have [`docker` installed](https://docs.docker.com/install/)
 on your machine.
 
 To initialize a new PyDL4j configuration, type

--- a/pydl4j/README.md
+++ b/pydl4j/README.md
@@ -1,5 +1,6 @@
 # PyDL4J - Java dependency management for Python applications
 
+[![Join the chat at https://gitter.im/deeplearning4j/deeplearning4j](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/deeplearning4j/deeplearning4j?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![PyPI version](https://badge.fury.io/py/pydl4j.svg)](https://badge.fury.io/py/pydl4j)
 

--- a/pydl4j/README.md
+++ b/pydl4j/README.md
@@ -3,13 +3,13 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![PyPI version](https://badge.fury.io/py/pydl4j.svg)](https://badge.fury.io/py/pydl4j)
 
-PyDL4J is a lightweight package manager for the DL4J ecosystem whick allows you to focus
+PyDL4J is a lightweight package manager for the DL4J ecosystem which allows you to focus
 on building Python applications on top of `pyjnius` without worrying about the details. You
 can use PyDL4J for the following tasks:
 
 - Automatically manage JARs for your Python projects, such as `jumpy` or `pydatavec`.
-- Configure your Python DL4J environment through the PyDL4J command line interface.
-- use PyDL4J as a replacement for Maven for basic tasks, from Python.
+- Configure your Python DL4J environment through the PyDL4J command line interface,
+- Use PyDL4J as a replacement for Maven for basic tasks, from Python.
 
 ---------
 
@@ -37,12 +37,12 @@ Skymind use PyDL4J under the hood and will install this dependency for you.
 # PyDL4J command line interface (CLI)
 
 Installing PyDL4J exposes a command line tool called `pydl4j`. You can use this tool to configure
-your PyDL4J environment. If you don't use the CLI, a default configuration that will be used instead.
+your PyDL4J environment. If you don't use the CLI, a default configuration will be used instead.
 
 **Note:** If you intend to use the CLI, make sure to have [`docker` installed](https://docs.docker.com/install/)
 on your machine.
 
-To initialize a new PyDL4j configuration, type
+To initialize a new PyDL4J configuration, type
 
 ```bash
 pydl4j init
@@ -82,7 +82,7 @@ Does this look good? (default 'y')[y/n]:
 
 If not configured otherwise, this configuration file will be stored at `~/.deeplearning4j/pydl4j/config.json`. This
 configuration file is a lightweight version for Python users to avoid the cognitive load of the widely used
-Project Object Model(POM) widely used in Java. PyDL4J will translate your configuration into the right format
+Project Object Model (POM) widely used in Java. PyDL4J will translate your configuration into the right format
 internally to provide you with the tools you need.
 
 Finally, to install the Java dependencies configured in your `config.json` you use the following command:
@@ -92,7 +92,7 @@ pydl4j install
 ```
 
 This tool will install all necessary JARs into `~/.deeplearning4j/pydl4j` for you, by running `mvn` in a
-docker container, and setting your classpath so that your `pyjnius` Python applications can access them.
+Docker container, and setting your classpath so that your `pyjnius` Python applications can access them.
 
 # PyDL4J API
 

--- a/pydl4j/README.md
+++ b/pydl4j/README.md
@@ -1,5 +1,8 @@
 # PyDL4J - Java dependency management for Python applications
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![PyPI version](https://badge.fury.io/py/pydl4j.svg)](https://badge.fury.io/py/pydl4j)
+
 PyDL4J is a lightweight package manager for the DL4J ecosystem whick allows you to focus
 on building Python applications on top of `pyjnius` without worrying about the details. You
 can use PyDL4J for the following tasks:
@@ -10,8 +13,6 @@ can use PyDL4J for the following tasks:
 
 ---------
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![PyPI version](https://badge.fury.io/py/pydl4j.svg)](https://badge.fury.io/py/pydl4j)
 
 # Installation
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restore badges for PyPi and Apache license; and edit spaces in links. Removed badge for build status as build status for Deeplearning4j overall is not meaningful here. Embedded coffee image removed as we (probably) don't want to be pointing to the old repo (let me know if I should add this back).

Apache LICENSE file added for pydatavec as it was not previously included.

## How was this patch tested?

n/a

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
