### PR TITLE
Fix#8383，getMostPopulatedClusters should sort by cluster's points siz…

### DIFF
--- a/deeplearning4j/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterSet.java
+++ b/deeplearning4j/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/main/java/org/deeplearning4j/clustering/cluster/ClusterSet.java
@@ -234,7 +234,7 @@ public class ClusterSet implements Serializable {
         List<Cluster> mostPopulated = new ArrayList<>(clusters);
         Collections.sort(mostPopulated, new Comparator<Cluster>() {
             public int compare(Cluster o1, Cluster o2) {
-                return new Integer(o1.getPoints().size()).compareTo(new Integer(o2.getPoints().size()));
+                return Integer.compare(o2.getPoints().size(), o1.getPoints().size());
             }
         });
         return mostPopulated.subList(0, count);

--- a/deeplearning4j/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/cluster/ClusterSetTest.java
+++ b/deeplearning4j/deeplearning4j-nearestneighbors-parent/nearestneighbor-core/src/test/java/org/deeplearning4j/clustering/cluster/ClusterSetTest.java
@@ -1,0 +1,26 @@
+package org.deeplearning4j.clustering.cluster;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClusterSetTest {
+    @Test
+    public void testGetMostPopulatedClusters() {
+        ClusterSet clusterSet = new ClusterSet(false);
+        List<Cluster> clusters = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Cluster cluster = new Cluster();
+            cluster.setPoints(Point.toPoints(Nd4j.randn(i + 1, 5)));
+            clusters.add(cluster);
+        }
+        clusterSet.setClusters(clusters);
+        List<Cluster> mostPopulatedClusters = clusterSet.getMostPopulatedClusters(5);
+        for (int i = 0; i < 5; i++) {
+            Assert.assertEquals(5 - i, mostPopulatedClusters.get(i).getPoints().size());
+        }
+    }
+}


### PR DESCRIPTION

## What changes were proposed in this pull request?

Fix#8383，getMostPopulatedClusters should sort by cluster's points size desc.

## How was this patch tested?

Unit tests tested.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [Y] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [Y] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [Y] Created tests for any significant new code additions.
- [Y] Relevant tests for your changes are passing.
