### PR TITLE
nd4j-jackson: exclude java.xml.stream.XML*Factory from service loader

### DIFF
--- a/nd4j/nd4j-shade/jackson/pom.xml
+++ b/nd4j/nd4j-shade/jackson/pom.xml
@@ -240,6 +240,17 @@
                         </relocation>
                     </relocations>
 
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/services/javax.xml.stream.XMLOutputFactory</exclude>
+                                <exclude>META-INF/services/javax.xml.stream.XMLInputFactory</exclude>
+                                <exclude>META-INF/services/javax.xml.stream.XMLEventFactory</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
To avoid clashes with other non-shaded jackson etc on classpath

Fixes: https://github.com/eclipse/deeplearning4j/issues/8437
