### PR TITLE
upgrade Apache Lucene/Solr version from 7.7.1 to 8.3.1

### DIFF
--- a/deeplearning4j/deeplearning4j-dataimport-solrj/src/main/java/org/deeplearning4j/nn/dataimport/solr/client/solrj/io/stream/TupleStreamDataSetIterator.java
+++ b/deeplearning4j/deeplearning4j-dataimport-solrj/src/main/java/org/deeplearning4j/nn/dataimport/solr/client/solrj/io/stream/TupleStreamDataSetIterator.java
@@ -39,8 +39,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
-  * A {@link DataSetIterator} which uses a <a href="https://lucene.apache.org/solr/guide/7_7/streaming-expressions.html">streaming expression</a>
- * to fetch data from Apache Solr and/or one of the sources (e.g. <code>jdbc</code>) supported as a <a href="https://lucene.apache.org/solr/guide/7_7/stream-source-reference.html">stream source</a>.
+  * A {@link DataSetIterator} which uses a <a href="https://lucene.apache.org/solr/guide/8_3/streaming-expressions.html">streaming expression</a>
+ * to fetch data from Apache Solr and/or one of the sources (e.g. <code>jdbc</code>) supported as a <a href="https://lucene.apache.org/solr/guide/8_3/stream-source-reference.html">stream source</a>.
  * <p>
  * Example code snippet:
 <pre>{

--- a/deeplearning4j/deeplearning4j-dataimport-solrj/src/test/resources/solr/configsets/mini/conf/solrconfig.xml
+++ b/deeplearning4j/deeplearning4j-dataimport-solrj/src/test/resources/solr/configsets/mini/conf/solrconfig.xml
@@ -17,10 +17,10 @@
 
 <!--
   This file is a minimal test configuration. For comprehensive information about solrconfig.xml please refer to
-  http://lucene.apache.org/solr/guide/7_7/configuring-solrconfig-xml.html
+  http://lucene.apache.org/solr/guide/8_3/configuring-solrconfig-xml.html
   and the well-commented example files in the Apache Solr release's server/solr/configsets directories.
 -->
 
 <config>
-  <luceneMatchVersion>7.7.1</luceneMatchVersion>
+  <luceneMatchVersion>8.3.1</luceneMatchVersion>
 </config>

--- a/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/handler/ModelTupleStream.java
+++ b/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/handler/ModelTupleStream.java
@@ -43,9 +43,9 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
- * A <a href="https://lucene.apache.org/solr/7_7_1/solr-solrj/org/apache/solr/client/solrj/io/stream/TupleStream.html">
+ * A <a href="https://lucene.apache.org/solr/8_3_1/solr-solrj/org/apache/solr/client/solrj/io/stream/TupleStream.html">
  * org.apache.solr.client.solrj.io.stream.TupleStream</a> that uses a {@link Model} to compute output scores.
- * <a href="https://lucene.apache.org/solr/7_7_1/solr-solrj/org/apache/solr/client/solrj/io/Tuple.html">Tuple</a>
+ * <a href="https://lucene.apache.org/solr/8_3_1/solr-solrj/org/apache/solr/client/solrj/io/Tuple.html">Tuple</a>
  * fields are the model inputs and the model output(s) are added to the returned tuple.
  * <p>
  * Illustrative configuration snippet:
@@ -67,7 +67,7 @@ import org.nd4j.linalg.factory.Nd4j;
  * <p>
  * Apache Solr Reference Guide:
  * <ul>
- * <li> <a href="https://lucene.apache.org/solr/guide/7_7/streaming-expressions.html">Streaming Expressions</a>
+ * <li> <a href="https://lucene.apache.org/solr/guide/8_3/streaming-expressions.html">Streaming Expressions</a>
  * </ul>
  */
 public class ModelTupleStream extends TupleStream implements Expressible {

--- a/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
+++ b/deeplearning4j/deeplearning4j-modelexport-solr/src/main/java/org/deeplearning4j/nn/modelexport/solr/ltr/model/ScoringModel.java
@@ -38,7 +38,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
- * An <a href="https://lucene.apache.org/solr/7_7_1/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
+ * An <a href="https://lucene.apache.org/solr/8_3_1/solr-ltr/org/apache/solr/ltr/model/LTRScoringModel.html">
  * org.apache.solr.ltr.model.LTRScoringModel</a> that computes scores using a {@link MultiLayerNetwork} or
  * {@link ComputationGraph} model.
  * <p>
@@ -58,7 +58,7 @@ import org.nd4j.linalg.factory.Nd4j;
  * <p>
  * Apache Solr Reference Guide:
  * <ul>
- * <li> <a href="https://lucene.apache.org/solr/guide/7_7/learning-to-rank.html">Learning To Rank</a>
+ * <li> <a href="https://lucene.apache.org/solr/guide/8_3/learning-to-rank.html">Learning To Rank</a>
  * </ul>
  */
 public class ScoringModel extends AdapterModel {

--- a/deeplearning4j/deeplearning4j-modelexport-solr/src/test/resources/solr/configsets/mini-expressible/conf/solrconfig.xml
+++ b/deeplearning4j/deeplearning4j-modelexport-solr/src/test/resources/solr/configsets/mini-expressible/conf/solrconfig.xml
@@ -17,12 +17,12 @@
 
 <!--
   This file is a minimal test configuration. For comprehensive information about solrconfig.xml please refer to
-  http://lucene.apache.org/solr/guide/7_7/configuring-solrconfig-xml.html
+  http://lucene.apache.org/solr/guide/8_3/configuring-solrconfig-xml.html
   and the well-commented example files in the Apache Solr release's server/solr/configsets directories.
 -->
 
 <config>
-  <luceneMatchVersion>7.7.1</luceneMatchVersion>
+  <luceneMatchVersion>8.3.1</luceneMatchVersion>
 
   <expressible name="modelTuple" class="org.deeplearning4j.nn.modelexport.solr.handler.ModelTupleStream"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <geo.jackson.version>2.8.7</geo.jackson.version>
         <lombok.version>1.18.2</lombok.version>
         <cleartk.version>2.0.0</cleartk.version>
-        <lucene-solr.version>7.7.1</lucene-solr.version>
+        <lucene-solr.version>8.3.1</lucene-solr.version>
         <json.version>20131018</json.version>
         <google.protobuf.version>2.6.1</google.protobuf.version>
         <failIfNoTests>false</failIfNoTests>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Apache Lucene/Solr version from 7.7.1 to 8.3.1 release.

http://lucene.apache.org/core/8_3_1/changes/Changes.html
http://lucene.apache.org/solr/8_3_1/changes/Changes.html

The lucene-solr.version pom.xml property is currently used by two modules:
* deeplearning4j/deeplearning4j-dataimport-solrj
* deeplearning4j/deeplearning4j-modelexport-solr

## How was this patch tested?

Not yet.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.