### PR TITLE
RL4J - Added ObservationHandler

### DIFF
--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/HistoryProcessor.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/HistoryProcessor.java
@@ -107,6 +107,13 @@ public class HistoryProcessor implements IHistoryProcessor {
         return array;
     }
 
+    public boolean isHistoryReady() {
+        return history.size() == conf.getHistoryLength();
+    }
+
+    public void reset() {
+        history.clear();
+    }
 
     private INDArray transform(INDArray raw) {
         long[] shape = raw.shape();

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/IHistoryProcessor.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/IHistoryProcessor.java
@@ -46,6 +46,9 @@ public interface IHistoryProcessor {
 
     boolean isMonitoring();
 
+    boolean isHistoryReady();
+    void reset();
+
     /** Returns the scale of the arrays returned by {@link #getHistory()}, typically 255. */
     double getScale();
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/ObservationHandler.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/ObservationHandler.java
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation;
+
+import lombok.Setter;
+import org.apache.commons.lang3.NotImplementedException;
+import org.deeplearning4j.rl4j.learning.IHistoryProcessor;
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+import org.deeplearning4j.rl4j.observation.prefiltering.PreFilter;
+import org.deeplearning4j.rl4j.observation.recorder.DataRecorder;
+import org.nd4j.base.Preconditions;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.DataSet;
+import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A handler that can create and record {@link Observation Observations} from raw environment data.
+ *
+ * When building, the observation should contain exactly one data channel (presently only single-channel observations are supported)
+ * The observation is built this way:
+ * <ol>
+ *     <li>The channel data is recorded (if at least one {@link DataRecorder DataRecorder} has been added)</li>
+ *     <li>The observation is filtered (if at least one {@link PreFilter PreFilter}  has been added). The observation must pass <b>all</b> filters, otherwise it is skipped</li>
+ *     <li>The observation is pre-processed (if a {@link DataSetPreProcessor DataSetPreProcessor} has been set)</li>
+ *     <li>The observation is assembled with past observation if a IHistoryProcessor has been set (this is subject to change in the future)</li>
+ * </ol>
+ *
+ * @author Alexandre Boulanger
+ */
+public class ObservationHandler {
+
+    private int currentEpisodeStep;
+
+    /**
+     * A {@link DataSetPreProcessor DataSetPreProcessor} that will be applied to non-skipped observations.
+     * {@link org.nd4j.linalg.dataset.api.preprocessor.CompositeDataSetPreProcessor CompositeDataSetPreProcessor} can be used to apply multiple processors
+     */
+    @Setter
+    private DataSetPreProcessor dataSetPreProcessor;
+
+    private final List<PreFilter> preFilters = new ArrayList<PreFilter>();
+    private final List<DataRecorder> dataRecorders = new ArrayList<DataRecorder>();
+
+    @Setter
+    private IHistoryProcessor historyProcessor; // FIXME: to be removed eventually
+
+    /**
+     * Starts the creation of an {@link Observation Observation} in a fluent way
+     * @return an {@link ObservationBuilder ObservationBuilder}
+     */
+    public ObservationBuilder newObservation() {
+        return new ObservationBuilder(this, currentEpisodeStep++);
+    }
+
+    /**
+     * Add a {@link PreFilter PreFilter} to the pre-filters list. PreFilters are invoked in the same order that they are added.
+     * @param preFilter a PreFilter
+     */
+    public void addPreFilter(PreFilter preFilter) {
+        Preconditions.checkNotNull(preFilter, "preFilter should not be null");
+        preFilters.add(preFilter);
+    }
+
+    /**
+     * Add a {@link DataRecorder DataRecorder} to the recorders list.
+     * @param dataRecorder a DataRecorder
+     */
+    public void addDataRecorder(DataRecorder dataRecorder) {
+        Preconditions.checkNotNull(dataRecorder, "dataRecorder should not be null");
+        dataRecorders.add(dataRecorder);
+    }
+
+    /**
+     * Resets the ObservationHandler's state to how it should be at the start of an episode.
+     */
+    public void reset() {
+        currentEpisodeStep = 0;
+        if(historyProcessor != null) {
+            historyProcessor.reset();
+        }
+    }
+
+    private Observation buildObservation(List<ChannelData> channelDataList, int observationEpisodeStep, boolean isFinalObservation) {
+        // Record
+        recordData(channelDataList);
+
+        // Filter
+        boolean isPassing = preFilterObservation(channelDataList, observationEpisodeStep, isFinalObservation);
+        if(!isPassing) {
+            return Observation.SkippedObservation;
+        }
+
+        DataSet dataSet = createDataSet(channelDataList);
+
+        // Pre-Process
+        DataSetPreProcessor preProcessor = dataSetPreProcessor;
+        if(preProcessor != null) {
+            preProcessor.preProcess(dataSet);
+        }
+
+        // Assemble (currently only necessary with HistoryProcessor)
+        // TODO: refac history stacking
+        if(historyProcessor != null) {
+            historyProcessor.add(dataSet.getFeatures());
+
+            if(!historyProcessor.isHistoryReady()) {
+                return Observation.SkippedObservation;
+            }
+            INDArray[] frames = historyProcessor.getHistory();
+            INDArray stackedFrames = Nd4j.concat(0, frames);
+            dataSet.setFeatures(stackedFrames);
+
+            enforceObservationShape(dataSet);
+        }
+
+        return new Observation(dataSet);
+    }
+
+    private DataSet createDataSet(List<ChannelData> channelDataList) {
+        // FIXME: Only single channel observation supported right now.
+        INDArray features = channelDataList.get(0).toINDArray();
+        DataSet dataSet = new org.nd4j.linalg.dataset.DataSet(features, null);
+        enforceObservationShape(dataSet);
+
+        return dataSet;
+    }
+
+    private boolean preFilterObservation(List<ChannelData> channelDataList, int observationEpisodeStep, boolean isFinalObservation) {
+        boolean isPassing = true;
+        Iterator<PreFilter> preFilterIterator = preFilters.iterator();
+        while (preFilterIterator.hasNext() && isPassing) {
+            isPassing &= preFilterIterator.next().isPassing(channelDataList, observationEpisodeStep, isFinalObservation);
+        }
+        return isPassing;
+    }
+
+    private void recordData(List<ChannelData> channelDataList) {
+        for(DataRecorder recorder : dataRecorders) {
+            recorder.record(channelDataList);
+        }
+    }
+
+    private void enforceObservationShape(DataSet dataSet) {
+        INDArray features = dataSet.getFeatures();
+        long[] shape = features.shape();
+        if(shape[0] != 1) {
+            long[] nshape = new long[shape.length + 1];
+            nshape[0] = 1;
+            System.arraycopy(shape, 0, nshape, 1, shape.length);
+
+            dataSet.setFeatures(features.reshape(nshape));
+        }
+    }
+
+    public static class ObservationBuilder {
+        private final ObservationHandler observationHandler;
+        private final int observationEpisodeStep;
+        private List<ChannelData> channelDataList = new ArrayList<ChannelData>();
+        private boolean isFinalObservation;
+
+        public ObservationBuilder(ObservationHandler observationHandler, int observationEpisodeStep) {
+            this.observationHandler = observationHandler;
+            this.observationEpisodeStep = observationEpisodeStep;
+        }
+
+        /**
+         * Indicates whether the observation is the last of the episode
+         * @param value true if it's the last observation
+         * @return
+         */
+        public ObservationBuilder isFinalObservation(boolean value) {
+            isFinalObservation = value;
+            return this;
+        }
+
+        /**
+         * Mandatory. Adds a data channel to the observation
+         * Note: Presently, only single-channel observations are supported.
+         *
+         * @param channelData a {@link ChannelData ChannelData} instance.
+         * @return
+         */
+        public ObservationBuilder addChannelData(ChannelData channelData) {
+            if(!channelDataList.isEmpty()) {
+                throw new NotImplementedException("More than one data channel is not yet implemented.");
+            }
+
+            channelDataList.add(channelData);
+            return this;
+        }
+
+        /**
+         * Builds the {@link Observation}
+         * @return an Observation instance
+         */
+        public Observation build() {
+            Preconditions.checkArgument(!channelDataList.isEmpty(), "Channel data not supplied");
+
+            return observationHandler.buildObservation(channelDataList, observationEpisodeStep, isFinalObservation);
+        }
+
+
+    }
+
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/channel/ChannelData.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/channel/ChannelData.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation.channel;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * An interface that carries the raw data of a single channel of an observation
+ */
+public interface ChannelData {
+    /**
+     * Reformats the raw data into a INDArray
+     * @return A INDArray containing the raw data
+     */
+    INDArray toINDArray();
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/channel/legacy/LegacyChannelData.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/channel/legacy/LegacyChannelData.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation.channel.legacy;
+
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+import org.deeplearning4j.rl4j.space.Encodable;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+/**
+ * A {@link ChannelData ChannelData} used with legacy MDPs (those that uses Encodable)
+ *
+ * @author Alexandre Boulanger
+ */
+public class LegacyChannelData implements ChannelData {
+
+    private final INDArray data;
+
+    /**
+     * Creates a LegacyChannelData
+     * @param input An Encodable that contains the data
+     * @param observationShape The target shape of the INDArray
+     */
+    public LegacyChannelData(Encodable input, long[] observationShape) {
+        data = getInput(input, observationShape);
+    }
+
+    @Override
+    public INDArray toINDArray() {
+        return data;
+    }
+
+    protected static INDArray getInput(Encodable obs, long[] observationShape) {
+        INDArray arr = Nd4j.create(obs.toArray());
+        if (observationShape.length == 1)
+            return arr.reshape(new long[] {1, arr.length()});
+        else
+            return arr.reshape(observationShape);
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/channel/legacy/LegacyChannelDataFactory.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/channel/legacy/LegacyChannelDataFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation.channel.legacy;
+
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+import org.deeplearning4j.rl4j.space.Encodable;
+
+/**
+ * A factory used to create {@link LegacyChannelData LegacyChannelData}
+ *
+ * @author Alexandre Boulanger
+ */
+public class LegacyChannelDataFactory {
+    private final long[] observationShape;
+
+    /**
+     * Create an instance used to create {@link LegacyChannelData LegacyChannelData} instances
+     * @param observationShape the target shape of the created LegacyChannelData's INDArray
+     */
+    public LegacyChannelDataFactory(long[] observationShape) {
+        this.observationShape = observationShape;
+    }
+
+    /**
+     * Create a {@link LegacyChannelData LegacyChannelData} instance with the factory's configured shape
+     * @param input the data of the LegacyChannelData
+     * @return the created LegacyChannelData
+     */
+    public ChannelData create(Encodable input) {
+        return new LegacyChannelData(input, observationShape);
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/prefiltering/PreFilter.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/prefiltering/PreFilter.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation.prefiltering;
+
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+
+import java.util.List;
+
+/**
+ * Used by {@link org.deeplearning4j.rl4j.observation.ObservationHandler ObservationHandler} to determine if
+ * it should consider the observation as skipped.
+ *
+ * @author Alexandre Boulanger
+ */
+public interface PreFilter {
+    /**
+     * Determines if the observation should be skipped.
+     * @param channelDataList A list of channel data for the current observation
+     * @param currentObservationStep The step, relative to the start of the episode, of the current observation
+     * @param isFinalObservation true if it's the last observation of the episode
+     * @return true if it passes the filter; false if the observation should be skipped
+     */
+    boolean isPassing(List<ChannelData> channelDataList, int currentObservationStep, boolean isFinalObservation);
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/prefiltering/UniformSkippingPreFilter.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/prefiltering/UniformSkippingPreFilter.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation.prefiltering;
+
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+import org.nd4j.base.Preconditions;
+
+import java.util.List;
+
+/**
+ * A {@link PreFilter PreFilter} that will let pass 1 observation every _skipFrame_ observations.
+ * With an exception: the last frame of an episode always pass.
+ *
+ * @author Alexandre Boulanger
+ */
+public class UniformSkippingPreFilter implements PreFilter {
+
+    private final int skipFrame;
+
+    /**
+     * Creates a {@link PreFilter PreFilter} instance
+     * @param skipFrame the PreFilter will let pass 1 observation every _skipFrame_ observations.
+     */
+    public UniformSkippingPreFilter(int skipFrame) {
+        Preconditions.checkArgument(skipFrame > 0, "skipFrame should be greater than 0");
+
+        this.skipFrame = skipFrame;
+    }
+
+    /**
+     * @return always true if it's the final observation; true once every _skipFrame_ observations; otherwise false
+     */
+    public boolean isPassing(List<ChannelData> channelDataList, int currentObservationStep, boolean isFinalObservation) {
+        return isFinalObservation || (currentObservationStep % skipFrame == 0);
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/recorder/DataRecorder.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/recorder/DataRecorder.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation.recorder;
+
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+
+import java.util.List;
+
+/**
+ * An interface used by {@link org.deeplearning4j.rl4j.observation.ObservationHandler ObservationHandler} to record observations
+ *
+ * @author Alexandre Boulanger
+ */
+public interface DataRecorder {
+    /**
+     * Records the observation. Each implementing class should only record the channel(s) it is designed to record and ignore the others.
+     * @param channelDataList a list of channel data to be recorded
+     */
+    void record(List<ChannelData> channelDataList);
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/recorder/LegacyVideoDataRecorder.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/observation/recorder/LegacyVideoDataRecorder.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Skymind, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.rl4j.observation.recorder;
+
+import org.deeplearning4j.rl4j.learning.IHistoryProcessor;
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.List;
+
+/**
+ * A {@link DataRecorder DataRecorder} that will record the video channel of legacy MDPs (those using Encodable)
+ *
+ * @author Alexandre Boulanger
+ */
+public class LegacyVideoDataRecorder implements DataRecorder {
+
+    private final IHistoryProcessor historyProcessor;
+
+    /**
+     * Creates an instance of LegacyVideoDataRecorder
+     * @param historyProcessor
+     */
+    public LegacyVideoDataRecorder(IHistoryProcessor historyProcessor) {
+        // TODO: Use VideoRecorder instead of HistoryProcessor
+        this.historyProcessor = historyProcessor;
+    }
+
+    /**
+     * Records an observation into a video frame.
+     * @param channelDataList currently uses the first channel as the video channel
+     */
+    @Override
+    public void record(List<ChannelData> channelDataList) {
+        INDArray features = channelDataList.get(0).toINDArray();
+        historyProcessor.record(features);
+    }
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/observation/ObservationHandlerTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/observation/ObservationHandlerTest.java
@@ -1,0 +1,234 @@
+package org.deeplearning4j.rl4j.observation;
+
+import org.deeplearning4j.rl4j.observation.channel.ChannelData;
+import org.deeplearning4j.rl4j.observation.prefiltering.PreFilter;
+import org.deeplearning4j.rl4j.observation.recorder.DataRecorder;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.DataSet;
+import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ObservationHandlerTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void when_buildingObservationWithoutData_expect_Exception() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+
+        // Act
+        sut.newObservation().build();
+    }
+
+    @Test
+    public void when_buildingObservationWithRecorder_expect_dataIsRecorded() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+        MockDataRecorder dataRecorderMock = new MockDataRecorder();
+        sut.addDataRecorder(dataRecorderMock);
+
+        // Act
+        sut.newObservation()
+                .addChannelData(new MockChannelData(123.0))
+                .build();
+
+        // Assert
+        assertEquals(1, dataRecorderMock.recordedChannelDataList.size());
+        List<ChannelData> channelDataList = dataRecorderMock.recordedChannelDataList.get(0);
+        assertEquals(1, channelDataList.size());
+        assertEquals(123.0, channelDataList.get(0).toINDArray().getDouble(0), 0.00001);
+    }
+
+    @Test
+    public void when_observationIsFilteredOut_expect_skippedObservation() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+        sut.addPreFilter(new MockPreFilter(false));
+
+        // Act
+        Observation result = sut.newObservation()
+                .addChannelData(new MockChannelData(123.0))
+                .build();
+
+        // Assert
+        assertTrue(result.isSkipped());
+    }
+
+    @Test
+    public void when_dataWithDimension0Is1_expect_shapeUnchanged() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+        sut.addPreFilter(new MockPreFilter(true));
+
+        // Act
+        Observation result = sut.newObservation()
+                .addChannelData(new MockChannelData(123.0))
+                .build();
+
+        // Assert
+        assertFalse(result.isSkipped());
+        long[] expectedShape = new long[] { 1 };
+        assertArrayEquals(expectedShape, result.getData().shape());
+        assertEquals(123.0, result.getData().getDouble(0), 0.00001);
+    }
+
+    @Test
+    public void when_dataWithDimension0IsNot1_expect_dimension0Is1() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+        sut.addPreFilter(new MockPreFilter(true));
+
+        // Act
+        Observation result = sut.newObservation()
+                .addChannelData(new MockChannelData(new double[] { 1.0, 2.0, 3.0, 4.0 }, new long[] { 2, 2}))
+                .build();
+
+        // Assert
+        assertFalse(result.isSkipped());
+        long[] expectedShape = new long[] { 1, 2, 2 };
+        assertArrayEquals(expectedShape, result.getData().shape());
+
+        assertEquals(1.0, result.getData().getDouble(0, 0, 0), 0.00001);
+        assertEquals(2.0, result.getData().getDouble(0, 0, 1), 0.00001);
+        assertEquals(3.0, result.getData().getDouble(0, 1, 0), 0.00001);
+        assertEquals(4.0, result.getData().getDouble(0, 1, 1), 0.00001);
+    }
+
+    @Test
+    public void when_preProcessorIsSet_expect_dataPreProcessed() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+        sut.addPreFilter(new MockPreFilter(true));
+        MockPreProcessor preProcessorMock = new MockPreProcessor();
+        sut.setDataSetPreProcessor(preProcessorMock);
+
+
+        // Act
+        Observation result = sut.newObservation()
+                .addChannelData(new MockChannelData(new double[] { 1.0, 2.0, 3.0, 4.0 }, new long[] { 2, 2}))
+                .build();
+
+        // Assert
+        assertFalse(result.isSkipped());
+        assertEquals(1, preProcessorMock.preProcessed.size());
+        DataSet preProcessedDataSet = preProcessorMock.preProcessed.get(0);
+        assertNotNull(preProcessedDataSet);
+        assertFalse(preProcessedDataSet.isEmpty());
+
+        assertEquals(1.0, preProcessedDataSet.getFeatures().getDouble(0, 0, 0), 0.00001);
+        assertEquals(2.0, preProcessedDataSet.getFeatures().getDouble(0, 0, 1), 0.00001);
+        assertEquals(3.0, preProcessedDataSet.getFeatures().getDouble(0, 1, 0), 0.00001);
+        assertEquals(4.0, preProcessedDataSet.getFeatures().getDouble(0, 1, 1), 0.00001);
+    }
+
+    @Test
+    public void when_buildingObservation_expect_observation() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+        sut.addPreFilter(new MockPreFilter(true));
+
+
+        // Act
+        Observation result = sut.newObservation()
+                .addChannelData(new MockChannelData(new double[] { 1.0, 2.0, 3.0, 4.0 }, new long[] { 2, 2}))
+                .build();
+
+        // Assert
+        assertFalse(result.isSkipped());
+        INDArray data = result.getData();
+        assertEquals(1.0, data.getDouble(0, 0, 0), 0.00001);
+        assertEquals(2.0, data.getDouble(0, 0, 1), 0.00001);
+        assertEquals(3.0, data.getDouble(0, 1, 0), 0.00001);
+        assertEquals(4.0, data.getDouble(0, 1, 1), 0.00001);
+    }
+
+    @Test
+    public void when_observationHandlerIsReset_expect_observationStepReset() {
+        // Assemble
+        ObservationHandler sut = new ObservationHandler();
+        MockPreFilter filter = new MockPreFilter(true);
+        sut.addPreFilter(filter);
+
+        // Act
+        sut.newObservation()
+                .addChannelData(new MockChannelData(1.0))
+                .build();
+        sut.newObservation()
+                .addChannelData(new MockChannelData(2.0))
+                .build();
+        int stepBeforeReset = filter.callCurrentObservationStep;
+
+        sut.reset();
+
+        sut.newObservation()
+                .addChannelData(new MockChannelData(3.0))
+                .build();
+
+        // Assert
+        assertEquals(1, stepBeforeReset);
+        assertEquals(0, filter.callCurrentObservationStep);
+    }
+
+    private static class MockChannelData implements ChannelData {
+
+        private final double[] values;
+        private final long[] shape;
+
+        public MockChannelData(double value) {
+            this(new double[] { value }, new long[] { 1 });
+        }
+
+        public MockChannelData(double[] values, long[] shape) {
+            this.values = values;
+            this.shape = shape;
+        }
+
+        @Override
+        public INDArray toINDArray() {
+            return Nd4j.create(values).reshape(shape);
+        }
+    }
+
+    private static class MockDataRecorder implements DataRecorder {
+
+        public ArrayList<List<ChannelData>> recordedChannelDataList = new ArrayList<List<ChannelData>>();
+
+        @Override
+        public void record(List<ChannelData> channelDataList) {
+            recordedChannelDataList.add(channelDataList);
+        }
+    }
+
+    private static class MockPreFilter implements PreFilter {
+
+        private final boolean isPassing;
+
+        private int callCurrentObservationStep = Integer.MIN_VALUE;
+
+        public MockPreFilter(boolean isPassing) {
+
+            this.isPassing = isPassing;
+        }
+
+        @Override
+        public boolean isPassing(List<ChannelData> channelDataList, int currentObservationStep, boolean isFinalObservation) {
+            this.callCurrentObservationStep = currentObservationStep;
+            return isPassing;
+        }
+    }
+
+    private static class MockPreProcessor implements DataSetPreProcessor {
+
+        private List<DataSet> preProcessed = new ArrayList<DataSet>();
+
+        @Override
+        public void preProcess(DataSet dataSet) {
+            preProcessed.add(dataSet);
+        }
+    }
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/observation/channel/LegacyChannelDataTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/observation/channel/LegacyChannelDataTest.java
@@ -1,0 +1,70 @@
+package org.deeplearning4j.rl4j.observation.channel;
+
+import org.deeplearning4j.rl4j.observation.channel.legacy.LegacyChannelData;
+import org.deeplearning4j.rl4j.space.Encodable;
+import org.deeplearning4j.rl4j.support.MockEncodable;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import static org.junit.Assert.assertEquals;
+
+public class LegacyChannelDataTest {
+
+    @Test
+    public void when_supplying1DData_expect_2DINDArray() {
+        // Assemble
+        Encodable data = new MockEncodable(new double[] { 1.0, 2.0, 3.0 });
+        long[] shape = new long[] { 3 };
+        LegacyChannelData sut = new LegacyChannelData(data, shape);
+
+        // Act
+        INDArray result = sut.toINDArray();
+
+        // Assert
+        long[] resultShape = result.shape();
+        assertEquals(2, resultShape.length);
+        assertEquals(1, resultShape[0]);
+        assertEquals(3, resultShape[1]);
+
+        assertEquals(1.0, result.getDouble(0, 0), 0.00001);
+        assertEquals(2.0, result.getDouble(0, 1), 0.00001);
+        assertEquals(3.0, result.getDouble(0, 2), 0.00001);
+    }
+
+    @Test
+    public void when_supplying2DData_expect_2DINDArray() {
+        // Assemble
+        Encodable data = new MockEncodable(new double[] { 1.0, 2.0, 3.0, 4.0 });
+        long[] shape = new long[] { 2, 2 };
+        LegacyChannelData sut = new LegacyChannelData(data, shape);
+
+        // Act
+        INDArray result = sut.toINDArray();
+
+        // Assert
+        long[] resultShape = result.shape();
+        assertEquals(2, resultShape.length);
+        assertEquals(2, resultShape[0]);
+        assertEquals(2, resultShape[1]);
+
+        assertEquals(1.0, result.getDouble(0, 0), 0.00001);
+        assertEquals(2.0, result.getDouble(0, 1), 0.00001);
+        assertEquals(3.0, result.getDouble(1, 0), 0.00001);
+        assertEquals(4.0, result.getDouble(1, 1), 0.00001);
+    }
+
+    private static class MockEncodable implements Encodable {
+
+        private final double[] data;
+
+        public MockEncodable(double[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public double[] toArray() {
+            return data;
+        }
+    }
+
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/observation/prefiltering/UniformSkippingPreFilterTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/observation/prefiltering/UniformSkippingPreFilterTest.java
@@ -1,0 +1,51 @@
+package org.deeplearning4j.rl4j.observation.prefiltering;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UniformSkippingPreFilterTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void when_skipFrameIs0OrLess_expect_IllegalArgumentException() {
+        // Assemble
+        UniformSkippingPreFilter sut = new UniformSkippingPreFilter(0);
+    }
+
+    @Test
+    public void when_frameIsMultipleOfSkippedFrame_expect_passingFilter() {
+        // Assemble
+        UniformSkippingPreFilter sut = new UniformSkippingPreFilter(2);
+
+        // Act
+        boolean result = sut.isPassing(null, 0, false);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    public void when_frameShouldBeSkipped_expect_notPassingFilter() {
+        // Assemble
+        UniformSkippingPreFilter sut = new UniformSkippingPreFilter(2);
+
+        // Act
+        boolean result = sut.isPassing(null, 1, false);
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    public void when_frameIsLast_expect_passingFilter() {
+        // Assemble
+        UniformSkippingPreFilter sut = new UniformSkippingPreFilter(2);
+
+        // Act
+        boolean result = sut.isPassing(null, 1, true);
+
+        // Assert
+        assertTrue(result);
+    }
+
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/support/MockHistoryProcessor.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/support/MockHistoryProcessor.java
@@ -19,6 +19,8 @@ public class MockHistoryProcessor implements IHistoryProcessor {
     public final ArrayList<INDArray> recordCalls;
     public final ArrayList<INDArray> addCalls;
 
+    private int currentHistorySize = 0;
+
     public MockHistoryProcessor(Configuration config) {
 
         this.config = config;
@@ -43,13 +45,14 @@ public class MockHistoryProcessor implements IHistoryProcessor {
 
     @Override
     public void record(INDArray image) {
-        recordCalls.add(image);
+        recordCalls.add(image.dup());
     }
 
     @Override
     public void add(INDArray image) {
-        addCalls.add(image);
+        addCalls.add(image.dup());
         history.add(image);
+        ++currentHistorySize;
     }
 
     @Override
@@ -65,6 +68,16 @@ public class MockHistoryProcessor implements IHistoryProcessor {
     @Override
     public boolean isMonitoring() {
         return false;
+    }
+
+    @Override
+    public boolean isHistoryReady() {
+        return currentHistorySize >= config.getHistoryLength();
+    }
+
+    @Override
+    public void reset() {
+        currentHistorySize = 0;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

What we need now is a way to build the Observations. In this PR, I add a few classes that I'll need. 
Note: They're not connected to the rest of RL4J in this PR in order to stay below the 1000 lines limit.

What we'll need ultimately is an Observation able to contain several data 'channels'.
A use case of this would be an observation that contains a video channel with a left and right audio channels and a LIDAR channel.
Another use case would be a multi-player environment where each player's observation would be a channel with some shared observation as an additional channel.

For now, I am adding a single-channel `ObservationHandler` class, to be used in the environment to build and process the observations.
It's usage looks something like this:
```
Observation observation = observationHandler.newObservation()
      .addChannelData(legacyChannelDataFactory.create(rawData))
      .isFinalObservation(isFinalObservation)
      .build();
```
The `ObservationHandler` will handle the raw data this way: Recording -> Filtering -> Processing -> Assembly.

During the recording step, the `DataChannels` are passed to instances of `DataRecorder` that can record the data. For example, a LidarRecorder could render a point cloud channel to a video, while another recorder could create a video from the video and audio channels.

The filtering step determines if an observation should be skipped or not. With this, different approaches can be used, for example a 3/4 frame skipping, or a random frame skipping. This can also be used to skip the first few frames of an episode if needed.

The processing step is where normalization, cropping, resizing, RGBtoGrayscale, etc... is done

And finally the assembly step, where the final packaging of the observation is done. Currently, this step is not fully implemented and is just calling `HistoryProcessor.getHistory()` (if set). It will need to change to support other ways to track motion. For example, instead of stacking the last X observations, one can flatten the stack by using the max of corresponding pixels in the stack or adding (or subtracting) the corresponding pixel values of the frames. 

## How was this patch tested?

unit tests and manual tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [X] Relevant tests for your changes are passing.