### PR TITLE
FEATURE: change API of WordVectorSerializer. Add posibility to read m…

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/TsneTest.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/TsneTest.java
@@ -77,7 +77,7 @@ public class TsneTest extends BaseDL4JTest {
                 log.info("Load & Vectorize data....");
                 File wordFile = new ClassPathResource("deeplearning4j-tsne/words.txt").getFile();   //Open the file
                 //Get the data of all unique word vectors
-                Pair<InMemoryLookupTable, VocabCache> vectors = WordVectorSerializer.loadTxt(wordFile);
+                Pair<InMemoryLookupTable, VocabCache> vectors = WordVectorSerializer.loadTxt(new FileInputStream(wordFile));
                 VocabCache cache = vectors.getSecond();
                 weights = vectors.getFirst().getSyn0();    //seperate weights of unique words into their own list
 
@@ -129,7 +129,7 @@ public class TsneTest extends BaseDL4JTest {
                 log.info("Load & Vectorize data....");
                 File wordFile = new ClassPathResource("deeplearning4j-tsne/words.txt").getFile();   //Open the file
                 //Get the data of all unique word vectors
-                Pair<InMemoryLookupTable, VocabCache> vectors = WordVectorSerializer.loadTxt(wordFile);
+                Pair<InMemoryLookupTable, VocabCache> vectors = WordVectorSerializer.loadTxt(new FileInputStream(wordFile));
                 VocabCache cache = vectors.getSecond();
                 weights = vectors.getFirst().getSyn0();    //seperate weights of unique words into their own list
 

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializerTest.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializerTest.java
@@ -14,16 +14,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package org.deeplearning4j.models.sequencevectors.serialization;
+package org.deeplearning4j.models.embeddings.loader;
 
 import lombok.val;
-import org.apache.commons.lang.StringUtils;
 import org.deeplearning4j.BaseDL4JTest;
 import org.deeplearning4j.models.embeddings.WeightLookupTable;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
 import org.deeplearning4j.models.embeddings.learning.impl.elements.CBOW;
-import org.deeplearning4j.models.embeddings.loader.VectorsConfiguration;
-import org.deeplearning4j.models.embeddings.loader.WordVectorSerializer;
 import org.deeplearning4j.models.embeddings.reader.impl.BasicModelUtils;
 import org.deeplearning4j.models.embeddings.reader.impl.FlatModelUtils;
 import org.deeplearning4j.models.fasttext.FastText;
@@ -46,7 +43,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class WordVectorSerializerTest extends BaseDL4JTest {
     private AbstractCache<VocabWord> cache;
@@ -76,10 +77,11 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
                 syn1 = Nd4j.rand(DataType.FLOAT, 10, 2),
                 syn1Neg = Nd4j.rand(DataType.FLOAT, 10, 2);
 
-        InMemoryLookupTable<VocabWord> lookupTable =
-                (InMemoryLookupTable<VocabWord>) new InMemoryLookupTable.Builder<VocabWord>()
-                        .useAdaGrad(false).cache(cache)
-                        .build();
+        InMemoryLookupTable<VocabWord> lookupTable = new InMemoryLookupTable
+                .Builder<VocabWord>()
+                .useAdaGrad(false)
+                .cache(cache)
+                .build();
 
         lookupTable.setSyn0(syn0);
         lookupTable.setSyn1(syn1);
@@ -90,7 +92,6 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
                 lookupTable(lookupTable).
                 build();
         SequenceVectors<VocabWord> deser = null;
-        String json = StringUtils.EMPTY;
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             WordVectorSerializer.writeSequenceVectors(vectors, baos);
@@ -124,10 +125,11 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
                 syn1 = Nd4j.rand(DataType.FLOAT, 10, 2),
                 syn1Neg = Nd4j.rand(DataType.FLOAT, 10, 2);
 
-        InMemoryLookupTable<VocabWord> lookupTable =
-                (InMemoryLookupTable<VocabWord>) new InMemoryLookupTable.Builder<VocabWord>()
-                        .useAdaGrad(false).cache(cache)
-                        .build();
+        InMemoryLookupTable<VocabWord> lookupTable = new InMemoryLookupTable
+                .Builder<VocabWord>()
+                .useAdaGrad(false)
+                .cache(cache)
+                .build();
 
         lookupTable.setSyn0(syn0);
         lookupTable.setSyn1(syn1);
@@ -202,10 +204,11 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
                 syn1 = Nd4j.rand(DataType.FLOAT, 10, 2),
                 syn1Neg = Nd4j.rand(DataType.FLOAT, 10, 2);
 
-        InMemoryLookupTable<VocabWord> lookupTable =
-                (InMemoryLookupTable<VocabWord>) new InMemoryLookupTable.Builder<VocabWord>()
-                        .useAdaGrad(false).cache(cache)
-                        .build();
+        InMemoryLookupTable<VocabWord> lookupTable = new InMemoryLookupTable
+                .Builder<VocabWord>()
+                .useAdaGrad(false)
+                .cache(cache)
+                .build();
 
         lookupTable.setSyn0(syn0);
         lookupTable.setSyn1(syn1);
@@ -250,10 +253,11 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
                 syn1 = Nd4j.rand(DataType.FLOAT, 10, 2),
                 syn1Neg = Nd4j.rand(DataType.FLOAT, 10, 2);
 
-        InMemoryLookupTable<VocabWord> lookupTable =
-                (InMemoryLookupTable<VocabWord>) new InMemoryLookupTable.Builder<VocabWord>()
-                        .useAdaGrad(false).cache(cache)
-                        .build();
+        InMemoryLookupTable<VocabWord> lookupTable = new InMemoryLookupTable
+                .Builder<VocabWord>()
+                .useAdaGrad(false)
+                .cache(cache)
+                .build();
 
         lookupTable.setSyn0(syn0);
         lookupTable.setSyn1(syn1);
@@ -265,7 +269,6 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
         WeightLookupTable<VocabWord> deser = null;
         try {
             WordVectorSerializer.writeLookupTable(lookupTable, file);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
             deser = WordVectorSerializer.readLookupTable(file);
         } catch (Exception e) {
             e.printStackTrace();
@@ -303,7 +306,6 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
 
         FastText deser = null;
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
             deser = WordVectorSerializer.readWordVectors(new File(dir, "some.data"));
         } catch (Exception e) {
             e.printStackTrace();
@@ -320,5 +322,33 @@ public class WordVectorSerializerTest extends BaseDL4JTest {
         assertEquals(fastText.isQuantize(), deser.isQuantize());
         assertEquals(fastText.getInputFile(), deser.getInputFile());
         assertEquals(fastText.getOutputFile(), deser.getOutputFile());
+    }
+
+    @Test
+    public void testIsHeader_withValidHeader () {
+
+        /* Given */
+        AbstractCache<VocabWord> cache = new AbstractCache<>();
+        String line = "48 100";
+
+        /* When */
+        boolean isHeader = WordVectorSerializer.isHeader(line, cache);
+
+        /* Then */
+        assertTrue(isHeader);
+    }
+
+    @Test
+    public void testIsHeader_notHeader () {
+
+        /* Given */
+        AbstractCache<VocabWord> cache = new AbstractCache<>();
+        String line = "your -0.0017603 0.0030831 0.00069072 0.0020581 -0.0050952 -2.2573e-05 -0.001141";
+
+        /* When */
+        boolean isHeader = WordVectorSerializer.isHeader(line, cache);
+
+        /* Then */
+        assertFalse(isHeader);
     }
 }

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/fasttext/FastTextTest.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/models/fasttext/FastTextTest.java
@@ -1,14 +1,11 @@
 package org.deeplearning4j.models.fasttext;
 
-import com.github.jfasttext.JFastText;
 import lombok.extern.slf4j.Slf4j;
-import org.deeplearning4j.models.embeddings.loader.WordVectorSerializer;
-import org.deeplearning4j.models.embeddings.reader.impl.BasicModelUtils;
-import org.deeplearning4j.models.word2vec.Word2Vec;
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.models.embeddings.loader.WordVectorSerializer;
+import org.deeplearning4j.models.word2vec.Word2Vec;
 import org.deeplearning4j.text.sentenceiterator.BasicLineIterator;
 import org.deeplearning4j.text.sentenceiterator.SentenceIterator;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -17,13 +14,11 @@ import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.resources.Resources;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Arrays;
-
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-
 
 @Slf4j
 public class FastTextTest extends BaseDL4JTest {
@@ -35,7 +30,6 @@ public class FastTextTest extends BaseDL4JTest {
     private File supModelFile = Resources.asFile("models/fasttext/supervised.model.bin");
     private File cbowModelFile = Resources.asFile("models/fasttext/cbow.model.bin");
     private File supervisedVectors = Resources.asFile("models/fasttext/supervised.model.vec");
-
 
     @Rule
     public TemporaryFolder testDir = new TemporaryFolder();
@@ -94,7 +88,7 @@ public class FastTextTest extends BaseDL4JTest {
     }
 
     @Test
-    public void tesLoadCBOWModel() throws IOException {
+    public void tesLoadCBOWModel() {
 
         FastText fastText = new FastText(cbowModelFile);
         fastText.test(cbowModelFile);
@@ -144,7 +138,7 @@ public class FastTextTest extends BaseDL4JTest {
     }
 
     @Test
-    public void testVocabulary() throws IOException {
+    public void testVocabulary() {
         FastText fastText = new FastText(supModelFile);
         assertEquals(48, fastText.vocab().numWords());
         assertEquals(48, fastText.vocabSize());
@@ -175,7 +169,7 @@ public class FastTextTest extends BaseDL4JTest {
     @Test(expected=IllegalStateException.class)
     public void testState() {
         FastText fastText = new FastText();
-        String label = fastText.predict("something");
+        fastText.predict("something");
     }
 
     @Test
@@ -204,7 +198,8 @@ public class FastTextTest extends BaseDL4JTest {
         log.info("\nTraining supervised model ...\n");
         fastText.fit();
 
-        Word2Vec word2Vec = WordVectorSerializer.readAsCsv(new File(output.getAbsolutePath() + ".vec"));
+        Word2Vec word2Vec = WordVectorSerializer.readAsCsv(
+                new FileInputStream(new File(output.getAbsolutePath() + ".vec")));
 
         assertEquals(48,  word2Vec.getVocab().numWords());
 
@@ -216,9 +211,7 @@ public class FastTextTest extends BaseDL4JTest {
 
 
     @Test
-    public void testWordsNativeStatistics() throws IOException {
-
-        File output = testDir.newFile();
+    public void testWordsNativeStatistics() {
 
         FastText fastText = new FastText();
         fastText.loadPretrainedVectors(supervisedVectors);


### PR DESCRIPTION
Add possibility to read Word2Vec models from any InputStream. Not only from files.

The goal of present modification is to allow read Word2Vec models from any InputStream: network connections, data stores, etc.

(Please fill in changes proposed in this fix)

## How was this patch tested?

All existing testes are passing. Two new testes was added.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
