### PR TITLE
Added swish activation function in mapToActivation

### DIFF
--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
@@ -334,6 +334,7 @@ public class KerasLayerConfiguration {
     private final String KERAS_ACTIVATION_SIGMOID = "sigmoid";
     private final String KERAS_ACTIVATION_HARD_SIGMOID = "hard_sigmoid";
     private final String KERAS_ACTIVATION_LINEAR = "linear";
+    private final String KERAS_ACTIVATION_SWISH = "swish";
     private final String KERAS_ACTIVATION_ELU = "elu"; // keras 2 only
     private final String KERAS_ACTIVATION_SELU = "selu"; // keras 2 only
 

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasActivationUtils.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasActivationUtils.java
@@ -63,6 +63,8 @@ public class KerasActivationUtils {
             dl4jActivation = Activation.HARDSIGMOID;
         } else if (kerasActivation.equals(conf.getKERAS_ACTIVATION_LINEAR())) {
             dl4jActivation = Activation.IDENTITY;
+        } else if (kerasActivation.equals(conf.getKERAS_ACTIVATION_SWISH())) {
+            dl4jActivation = Activation.SWISH;
         } else {
             throw new UnsupportedKerasConfigurationException(
                     "Unknown Keras activation function " + kerasActivation);


### PR DESCRIPTION
Swish function already implemented, and accounted for in getActivationFunction, just not for in the if-else chain of mapToActivation

## What changes were proposed in this pull request?

When importing a Keras model that uses the `swish` activation function (such as EfficientNet), a `UnsupportedKerasConfigurationException` is thrown in `KerasActivationUtils.java` (line 67), as the `swish` activation function is not included in the if-else chain.

The swish activation function is already implemented in DL4J, however, (see `Activation.java`, line 62-63) so this PR simply includes that implementation in the if-else chain, so it can actually be used (at the moment the `swish` function cannot be used for a Keras model).

## How was this patch tested?

No additional testing was done.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
