### PR TITLE
RL4J - Added Agent and Environment classes

### DIFF
--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -1944,7 +1944,7 @@ void NDArray::tilei(const std::vector<Nd4jLong>& reps) {
 Nd4jLong NDArray::sizeAt(const int dim) const {
 
     if (dim >= this->rankOf() || dim < -this->rankOf())
-        throw std::runtime_error("Bad size index requested");
+        throw std::runtime_error("NDArray::sizeAt: bad size index requested");
 
     if (dim >= 0)
         return shape::shapeOf(_shapeInfo)[dim];

--- a/libnd4j/include/helpers/LoopKind.h
+++ b/libnd4j/include/helpers/LoopKind.h
@@ -35,16 +35,16 @@ namespace sd {
 
 
 class ND4J_EXPORT LoopKind {
-    
+
     public:
         enum Kind { SMALLARR2DX, EWS1, EWSNONZERO, RANK1, RANK2, RANK3, RANK4, RANK5, X_EWSNONZERO, Y_EWSNONZERO, Z_EWSNONZERO, COMMON, BROADCAST_SCALAR_X, BROADCAST_SCALAR_Y, BROADCAST_3D, BROADCAST_4D, BROADCAST_5D };
 
         static FORCEINLINE Kind deduceKindOfLoopXZ(const Nd4jLong* xShapeInfo, const Nd4jLong* zShapeInfo);
         static FORCEINLINE Kind deduceKindOfLoopXYZ(const Nd4jLong* xShapeInfo, const Nd4jLong* yShapeInfo, const Nd4jLong* zShapeInfo);
-        static FORCEINLINE Kind deduceKindOfLoopTadXZ(const Nd4jLong* xShapeInfo, const Nd4jLong* zShapeInfo, const Nd4jLong* tadShapeInfo);        
+        static FORCEINLINE Kind deduceKindOfLoopTadXZ(const Nd4jLong* xShapeInfo, const Nd4jLong* zShapeInfo, const Nd4jLong* tadShapeInfo);
         static FORCEINLINE Kind deduceKindOfLoopTadXYZ(const Nd4jLong* xTadShapeInfo, const Nd4jLong* yTadShapeInfo, const Nd4jLong* zShapeInfo);
         static FORCEINLINE Kind deduceKindOfLoopBroadcast(const Nd4jLong* xShapeInfo, const Nd4jLong* yShapeInfo, const Nd4jLong* zShapeInfo);
-    
+
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -59,8 +59,8 @@ LoopKind::Kind LoopKind::deduceKindOfLoopXZ(const Nd4jLong* xShapeInfo, const Nd
 
     int temp;
     const bool xVectorOrC     = shape::isCommonVector(xShapeInfo, temp)    || xOrder == 'c';
-    const bool zVectorOrC     = shape::isCommonVector(zShapeInfo, temp)    || zOrder == 'c';    
-    const bool shapesSame     = shape::shapeEquals(xShapeInfo, zShapeInfo);    
+    const bool zVectorOrC     = shape::isCommonVector(zShapeInfo, temp)    || zOrder == 'c';
+    const bool shapesSame     = shape::shapeEquals(xShapeInfo, zShapeInfo);
 
     if (xEws == 1 && zEws == 1 && xOrder == zOrder && (shapesSame || xOrder == 'c'))
         return EWS1;
@@ -160,7 +160,7 @@ LoopKind::Kind LoopKind::deduceKindOfLoopXYZ(const Nd4jLong* xShapeInfo, const N
     const bool xVectorOrC = shape::isCommonVector(xShapeInfo, temp)                || xOrder == 'c';
     const bool yVectorOrC = shape::isCommonVector(yShapeInfo, temp)                || yOrder == 'c';
     const bool zVectorOrC = shape::isCommonVector(zShapeInfo, temp)                || zOrder == 'c';
-    const bool shapesSame = shape::shapeEquals(xShapeInfo, yShapeInfo, zShapeInfo);    
+    const bool shapesSame = shape::shapeEquals(xShapeInfo, yShapeInfo, zShapeInfo);
 
     if (xEws == 1 && yEws == 1 && zEws == 1 && xOrder == yOrder && xOrder == zOrder && (shapesSame || xOrder == 'c'))
         return EWS1;
@@ -206,7 +206,7 @@ LoopKind::Kind LoopKind::deduceKindOfLoopTadXZ(const Nd4jLong* xShapeInfo, const
     const bool tVectorOrC = shape::isCommonVector(tadShapeInfo, temp) || tOrder == 'c';
     const bool zVectorOrC = shape::isCommonVector(zShapeInfo, temp)   || zOrder == 'c';;
 
-    if(shape::length(tadShapeInfo) * shape::length(zShapeInfo) <= Environment::getInstance()->elementwiseThreshold() && shape::rank(xShapeInfo) == 2 && xEws == 1 && xOrder == 'c' && xRank == 2 &&
+    if(shape::length(tadShapeInfo) * shape::length(zShapeInfo) <= Environment::getInstance()->elementwiseThreshold() && xEws == 1 && xOrder == 'c' && xRank == 2 &&
         tEws > 1 && zEws == 1 && (allC || (tVectorOrC && zVectorOrC)))
         return SMALLARR2DX;
     if(tEws == 1 && zEws == 1 && (allC || (tVectorOrC && zVectorOrC)))
@@ -233,18 +233,18 @@ LoopKind::Kind LoopKind::deduceKindOfLoopTadXZ(const Nd4jLong* xShapeInfo, const
 //////////////////////////////////////////////////////////////////////////////
 LoopKind::Kind LoopKind::deduceKindOfLoopTadXYZ(const Nd4jLong* xTadShapeInfo, const Nd4jLong* yTadShapeInfo, const Nd4jLong* zShapeInfo) {
 
-    // both tad shapes are the same, but strides and ews may be different    
+    // both tad shapes are the same, but strides and ews may be different
 
     const int tadRank = shape::rank(xTadShapeInfo);
 
     const Nd4jLong xTadEws = shape::elementWiseStride(xTadShapeInfo);
-    const Nd4jLong yTadEws = shape::elementWiseStride(yTadShapeInfo);    
-    const Nd4jLong zEws    = shape::elementWiseStride(zShapeInfo);    
+    const Nd4jLong yTadEws = shape::elementWiseStride(yTadShapeInfo);
+    const Nd4jLong zEws    = shape::elementWiseStride(zShapeInfo);
 
     const char xTadOrder = shape::order(xTadShapeInfo);
     const char yTadOrder = shape::order(xTadShapeInfo);
     const char zOrder    = shape::order(zShapeInfo);
-    
+
     int position;
     const bool xTadVectorOrC = shape::isCommonVector(xTadShapeInfo, position) || xTadOrder == 'c';
     const bool yTadVectorOrC = shape::isCommonVector(yTadShapeInfo, position) || yTadOrder == 'c';
@@ -265,7 +265,7 @@ LoopKind::Kind LoopKind::deduceKindOfLoopTadXYZ(const Nd4jLong* xTadShapeInfo, c
         return RANK4;
     if(tadRank == 5 && zEws > 0 && zVectorOrC)
         return RANK5;
-    return COMMON;  
+    return COMMON;
 }
 
 

--- a/libnd4j/include/ops/declarable/generic/broadcastable/floormod.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/floormod.cpp
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-//
-//  @author raver119@gmail.com
-//  modified by sgazeos@gmail.com with backprop implementation.
-//
+ //
+ //  @author raver119@gmail.com
+ //  modified by sgazeos@gmail.com with backprop implementation.
+ //
 #include <system/op_boilerplate.h>
 #if NOT_EXCLUDED(OP_floormod)
 
@@ -31,7 +31,7 @@ namespace sd {
             auto y = INPUT_VARIABLE(1);
             auto z = OUTPUT_VARIABLE(0);
 
-            BROADCAST_CHECK_EMPTY(x,y,z);
+            BROADCAST_CHECK_EMPTY(x, y, z);
 
             REQUIRE_TRUE(!y->isB(), 0, "FLOORMOD OP: you can't divide by bool array!");
             auto tZ = BroadcastHelper::broadcastApply(BROADCAST(FloorMod), x, y, z);
@@ -46,15 +46,15 @@ namespace sd {
 
         DECLARE_TYPES(floormod) {
             getOpDescriptor()
-                    ->setAllowedInputTypes(0, DataType::ANY)
-                    ->setAllowedInputTypes(1, DataType::ANY)
-                    ->setAllowedOutputTypes(0, DataType::INHERIT);
+                ->setAllowedInputTypes(0, DataType::ANY)
+                ->setAllowedInputTypes(1, DataType::ANY)
+                ->setAllowedOutputTypes(0, DataType::INHERIT);
         }
 
         DECLARE_TYPES(floormod_bp) {
             getOpDescriptor()
-                    ->setAllowedInputTypes(DataType::ANY)
-                    ->setAllowedOutputTypes({ALL_FLOATS});
+                ->setAllowedInputTypes(DataType::ANY)
+                ->setAllowedOutputTypes({ ALL_FLOATS });
         }
 
         CUSTOM_OP_IMPL(floormod_bp, 3, 2, false, 0, 0) {
@@ -66,11 +66,11 @@ namespace sd {
             auto gradY = OUTPUT_VARIABLE(1);
             gradX->assign(epsNext);
 
-            sd::ops::floormod op;
-            auto tmpResult(op.evaluate({x, y}));
+            NDArray temp(*epsNext);
+            BroadcastHelper::broadcastApply(BROADCAST(FloorMod), x, y, &temp);
 
             if (gradY->rankOf() == gradX->rankOf())
-                epsNext->applyPairwiseTransform(pairwise::Multiply, *tmpResult.at(0), *gradY);
+                epsNext->applyPairwiseTransform(pairwise::Multiply, temp, *gradY);
             else // epsNext is greater than gradY
             {
                 std::vector<Nd4jLong> dims(epsNext->rankOf() * 2);
@@ -78,7 +78,7 @@ namespace sd {
                 for (Nd4jLong d = 0; d < gap; d++) {
                     dims[d * 2 + 1] = 1;
                 }
-                auto tempIn((*tmpResult.at(0))(dims));
+                auto tempIn((temp)(dims));
                 (*epsNext)(dims).applyPairwiseTransform(pairwise::Multiply, tempIn, *gradY);
             }
             return Status::OK();
@@ -92,8 +92,8 @@ namespace sd {
             // eps always has shape of x
             // grad always has shape of y
 
-            Nd4jLong *shapeE;
-            Nd4jLong *shapeG;
+            Nd4jLong* shapeE;
+            Nd4jLong* shapeG;
 
             COPY_SHAPE(x, shapeE);
             COPY_SHAPE(y, shapeG);

--- a/libnd4j/include/ops/declarable/generic/compat/compat_string_split.cpp
+++ b/libnd4j/include/ops/declarable/generic/compat/compat_string_split.cpp
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-//
-//  @author raver119@gmail.com
-//
+ //
+ //  @author raver119@gmail.com
+ //
 
 #include <system/op_boilerplate.h>
 #if NOT_EXCLUDED(OP_split_string)
@@ -60,7 +60,7 @@ namespace sd {
 
                 // filling output indices
                 for (uint64_t f = 0; f < cnt; f++) {
-                    for (auto v: icoords)
+                    for (auto v : icoords)
                         indices->p(ic++, v);
 
                     // last index
@@ -75,12 +75,12 @@ namespace sd {
             for (auto e = 0L; e < input->lengthOf(); e++) {
                 auto split = StringUtils::split(input->e<std::string>(e), d);
 
-                for (const auto &s:split)
+                for (const auto& s : split)
                     strings.emplace_back(s);
             }
 
             // now once we have all strings in single vector time to fill
-            auto tmp = NDArrayFactory::string({(Nd4jLong) strings.size()}, strings);
+            auto tmp = NDArrayFactory::string({ (Nd4jLong)strings.size() }, strings, input->dataType(), block.launchContext());
             auto blen = StringUtils::byteLength(tmp) + ShapeUtils::stringBufferHeaderRequirements(strings.size());
 
             // for CUDA mostly
@@ -129,9 +129,9 @@ namespace sd {
 
         DECLARE_TYPES(compat_string_split) {
             getOpDescriptor()
-                    ->setAllowedInputTypes({ALL_STRINGS})
-                    ->setAllowedOutputTypes(0, {ALL_INDICES})
-                    ->setAllowedOutputTypes(1, {ALL_STRINGS});
+                ->setAllowedInputTypes({ ALL_STRINGS })
+                ->setAllowedOutputTypes(0, { ALL_INDICES })
+                ->setAllowedOutputTypes(1, { ALL_STRINGS });
         }
     }
 }

--- a/libnd4j/include/ops/declarable/generic/loss/hingeLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/hingeLoss.cpp
@@ -68,6 +68,7 @@ namespace sd {
                 }
                 case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
                     NDArray sum;
+                    sum.setContext(block.launchContext());
                     if (weights->isScalar())
                         sum = *weights * E.lengthOf();
                     else
@@ -201,6 +202,7 @@ namespace sd {
                 case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 
                     NDArray sum;
+                    sum.setContext(block.launchContext());
                     if (weights->isScalar())
                         sum = (*weights) * E.lengthOf();
                     else

--- a/libnd4j/include/ops/declarable/generic/loss/huberLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/huberLoss.cpp
@@ -73,6 +73,7 @@ CUSTOM_OP_IMPL(huber_loss, 3, 1, false, 1, 1) {
 		}
 		case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 			NDArray sum;
+			sum.setContext(block.launchContext());
 			if (weights->isScalar())
 				sum = *weights * E.lengthOf();
 			else
@@ -216,6 +217,7 @@ DECLARE_SHAPE_FN(huber_loss) {
 				case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 
 					NDArray sum;
+					sum.setContext(block.launchContext());
 					if (weights->isScalar())
 						sum = (*weights) * E.lengthOf();
 					else

--- a/libnd4j/include/ops/declarable/generic/loss/logLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/logLoss.cpp
@@ -70,6 +70,7 @@ CUSTOM_OP_IMPL(log_loss, 3, 1, false, 1, 1) {
 		}
 		case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 			NDArray sum;
+			sum.setContext(block.launchContext());
 			if (weights->isScalar())
 				sum = *weights * E.lengthOf();
 			else
@@ -206,6 +207,7 @@ CUSTOM_OP_IMPL(log_loss_grad, 3, 3, false, 1, 1) {
 		case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 
 			NDArray sum;
+			sum.setContext(block.launchContext());
 			if (weights->isScalar())
 				sum = (*weights) * E.lengthOf();
 			else

--- a/libnd4j/include/ops/declarable/generic/loss/log_poisson_loss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/log_poisson_loss.cpp
@@ -74,6 +74,7 @@ namespace ops {
             }
             case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
                 NDArray sum;
+                sum.setContext(block.launchContext());
                 if (weights->isScalar())
                     sum = *weights * E.lengthOf();
                 else
@@ -209,6 +210,7 @@ namespace ops {
             case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 
                 NDArray sum;
+                sum.setContext(block.launchContext());
                 if (weights->isScalar())
                     sum = (*weights) * E.lengthOf();
                 else

--- a/libnd4j/include/ops/declarable/generic/loss/meanPairWsSqErr.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/meanPairWsSqErr.cpp
@@ -143,6 +143,7 @@ namespace sd {
                 }
                 case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
                     NDArray sum;
+                    sum.setContext(block.launchContext());
                     if (weights->isScalar())
                         sum = (*weights) * E.lengthOf();
                     else
@@ -282,6 +283,7 @@ namespace sd {
                 case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 
                     NDArray sum;
+                    sum.setContext(block.launchContext());
                     if (weights->isScalar())
                         sum = (*weights) * E.lengthOf();
                     else

--- a/libnd4j/include/ops/declarable/generic/loss/meanSqErr.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/meanSqErr.cpp
@@ -67,6 +67,7 @@ CUSTOM_OP_IMPL(mean_sqerr_loss, 3, 1, false, 0, 1) {
 		}
 		case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 			NDArray sum;
+			sum.setContext(block.launchContext());
 			if (weights->isScalar())
 				sum = (*weights) * E.lengthOf();
 			else
@@ -200,6 +201,7 @@ CUSTOM_OP_IMPL(mean_sqerr_loss_grad, 3, 3, false, 0, 1) {
 		case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 
 			NDArray sum;
+			sum.setContext(block.launchContext());
 			if (weights->isScalar())
 				sum = (*weights) * E.lengthOf();
 			else

--- a/libnd4j/include/ops/declarable/generic/loss/sigmCrossEntropy.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/sigmCrossEntropy.cpp
@@ -78,6 +78,7 @@ CUSTOM_OP_IMPL(sigm_cross_entropy_loss, 3, 1, false, 1, 1) {
 		}
 		case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 			NDArray sum;
+			sum.setContext(block.launchContext());
 			if (weights->isScalar())
 				sum = (*weights) * E.lengthOf();
 			else
@@ -219,6 +220,7 @@ CUSTOM_OP_IMPL(sigm_cross_entropy_loss_grad, 3, 3, false, 1, 1) {
 		}
 		case 2: {											// 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of all elements of weightsBroad array
 			NDArray sum;
+			sum.setContext(block.launchContext());
 			if (weights->isScalar())
 				sum = (*weights) * E.lengthOf();
 			else

--- a/libnd4j/include/ops/declarable/generic/nn/xw_plus_b.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/xw_plus_b.cpp
@@ -14,10 +14,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-//
-//  xw_plus_b op. Created by GS <george@skymind.io> 31.01.2018
-//
-//
+ //
+ //  xw_plus_b op. Created by GS <george@skymind.io> 31.01.2018
+ //  @author Oleg Semeniv <oleg.semeniv@gmail.com>
+ //
+ //
 
 #include <system/op_boilerplate.h>
 #if NOT_EXCLUDED(OP_xw_plus_b)
@@ -29,34 +30,113 @@
 namespace sd {
     namespace ops {
         CUSTOM_OP_IMPL(xw_plus_b, 3, 1, false, 0, 0) {
+
             auto x = INPUT_VARIABLE(0);
-            auto y = INPUT_VARIABLE(1);
+
             auto b = INPUT_VARIABLE(2);
             auto z = OUTPUT_VARIABLE(0);
 
-            REQUIRE_TRUE(x->rankOf() <= 2 && y->rankOf() <= 2 && z->rankOf() <= 2, 0, "xw_plus_b: Input and Output NDArrays should have rank less or equal to 2");
-            REQUIRE_TRUE(b->isVector() && b->lengthOf() == z->sizeAt(-1), 0, "xw_plus_b: Input vector should have proper dimension 1x%i. "
-                "But %i != %i.", z->sizeAt(-1), b->lengthOf(), z->sizeAt(-1));
+            if (x->isEmpty() || INPUT_VARIABLE(1)->isEmpty() || b->isEmpty())
+                return Status::OK();
+
+            const bool bTranspose = (block.getIArguments()->size() > 0 ? INT_ARG(0) == 1 : false);
+
+            auto w = bTranspose ? new NDArray(INPUT_VARIABLE(1)->transpose()) : INPUT_VARIABLE(1);
+
+            REQUIRE_TRUE(x->rankOf() == 2, 0, "xw_plus_b: Input x array should have rank equal 2, but got instead %i!", x->rankOf());
+            REQUIRE_TRUE(w->rankOf() == 2, 0, "xw_plus_b: Input weights array should have rank equal 2, but got instead %i!", w->rankOf());
+            REQUIRE_TRUE(z->rankOf() == 2, 0, "xw_plus_b: Output array should have rank equal 2, but got instead %i!", z->rankOf());
+
+            REQUIRE_TRUE(1 == b->rankOf() && b->lengthOf() == z->sizeAt(-1), 0, "xw_plus_b: Input bias vector should be 1D and have proper dimension 1x%i."
+                " But got rank %i, and got length %i instead %i.", z->sizeAt(-1), b->rankOf(), b->lengthOf(), z->sizeAt(-1));
+
             // multiply x to y
-            MmulHelper::mmul(x, y, z, 1.0, 0.0);
+            MmulHelper::mmul(x, w, z, 1.0, 0.0);
 
             // adding b vector
             z->addiRowVector(*b);
+
+            if (bTranspose)
+                delete w;
 
             return Status::OK();
         }
 
         DECLARE_SHAPE_FN(xw_plus_b) {
-            auto outputShape = ShapeUtils::matrixProductShape(inputShape->at(0), inputShape->at(1), false, false,
-                    ArrayOptions::dataType(inputShape->at(0)), block.getWorkspace());
+
+            auto weights = INPUT_VARIABLE(1);
+
+            const int nWeightsFormat = block.getIArguments()->size() > 0 ? INT_ARG(0) : 0;
+
+            auto weightsShape = (1 == nWeightsFormat) ? ShapeUtils::evalTranspShapeInfo(*weights, block.getWorkspace()) : inputShape->at(1);
+
+            auto outputShape = ShapeUtils::matrixProductShape(inputShape->at(0), weightsShape, false, false,
+                ArrayOptions::dataType(inputShape->at(0)), block.getWorkspace());
 
             return SHAPELIST(CONSTANT(outputShape));
         }
 
         DECLARE_TYPES(xw_plus_b) {
             getOpDescriptor()
-                    ->setAllowedInputTypes(sd::DataType::ANY)
-                    ->setAllowedOutputTypes({ALL_FLOATS});
+                ->setAllowedInputTypes(sd::DataType::ANY)
+                ->setAllowedOutputTypes({ ALL_FLOATS });
+        }
+
+
+        CUSTOM_OP_IMPL(xw_plus_b_bp, 4, 3, false, 0, 0) {
+
+            auto x = INPUT_VARIABLE(0);
+            auto b = INPUT_VARIABLE(2);
+            auto dLdz = INPUT_VARIABLE(3);
+
+            auto dLdx = OUTPUT_VARIABLE(0);
+            auto dLdb = OUTPUT_VARIABLE(2);
+
+            if (x->isEmpty() || INPUT_VARIABLE(1)->isEmpty() || b->isEmpty() || dLdz->isEmpty())
+                return Status::OK();
+
+            const bool bTranspose = (block.getIArguments()->size() > 0 ? INT_ARG(0) == 1 : false);
+
+            auto w = bTranspose ? new NDArray(INPUT_VARIABLE(1)->transpose()) : INPUT_VARIABLE(1);
+
+            REQUIRE_TRUE(x->rankOf() == 2, 0, "xw_plus_b BP: Input x array should have rank equal 2, but got instead %i!", x->rankOf());
+            REQUIRE_TRUE(w->rankOf() == 2, 0, "xw_plus_b BP: Input weights array should have rank equal 2, but got instead %i!", w->rankOf());
+            REQUIRE_TRUE(dLdz->rankOf() == 2, 0, "xw_plus_b BP: Output array should have rank equal 2, but got instead %i!", dLdz->rankOf());
+            REQUIRE_TRUE(1 == b->rankOf() && b->lengthOf() == dLdz->sizeAt(-1), 0, "xw_plus_b BP: Input bias vector should be 1D and have proper dimension 1x%i."
+                " But got rank %i, and got length %i instead %i.", dLdz->sizeAt(-1), b->rankOf(), b->lengthOf(), dLdz->sizeAt(-1));
+
+            auto dLdw = (bTranspose) ? new NDArray(OUTPUT_VARIABLE(1)->transpose()) : OUTPUT_VARIABLE(1);
+
+            // dLdb
+            dLdb->assign(dLdz->reduceAlongDimension(reduce::Sum, { 0 }));
+
+            matmul_bp mmul_bp;
+            mmul_bp.execute({ x, w, dLdz }, std::vector<NDArray*>{dLdx, dLdw}, {}, {}, {});
+
+            if (bTranspose) {
+                delete w;
+                delete dLdw;
+            }
+            return Status::OK();
+        }
+
+        DECLARE_SHAPE_FN(xw_plus_b_bp) {
+
+            Nd4jLong* xShapeInfo;
+            Nd4jLong* wShapeInfo;
+            Nd4jLong* bShapeInfo;
+
+            COPY_SHAPE(inputShape->at(0), xShapeInfo);
+            COPY_SHAPE(inputShape->at(1), wShapeInfo);
+            COPY_SHAPE(inputShape->at(2), bShapeInfo);
+
+            return SHAPELIST(CONSTANT(xShapeInfo), CONSTANT(wShapeInfo), CONSTANT(bShapeInfo));
+        }
+
+        DECLARE_TYPES(xw_plus_b_bp) {
+            getOpDescriptor()
+                ->setAllowedInputTypes(sd::DataType::ANY)
+                ->setAllowedOutputTypes({ ALL_FLOATS });
         }
     }
 }

--- a/libnd4j/include/ops/declarable/generic/parity_ops/compare_and_bitpack.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/compare_and_bitpack.cpp
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-//
-// @author sgazeos@gmail.com
-//
+ //
+ // @author sgazeos@gmail.com
+ //
 
 #include <ops/declarable/generic/helpers/BroadcastHelper.h>
 #include <ops/declarable/headers/parity_ops.h>
@@ -29,24 +29,24 @@ namespace sd {
             auto x = INPUT_VARIABLE(0);
             auto y = INPUT_VARIABLE(1);
             auto z = OUTPUT_VARIABLE(0);
-            auto z0 = NDArrayFactory::create<bool>(x->ordering(), x->getShapeAsVector());
+            auto z0 = NDArrayFactory::create<bool>(x->ordering(), x->getShapeAsVector(), block.launchContext());
             BROADCAST_CHECK_EMPTY(x, y, (&z0));
-            
+
             auto tZ = BroadcastHelper::broadcastApply(BROADCAST_BOOL(GreaterThan), x, y, &z0);
             bitcast res;
-            auto status = res.execute({tZ}, {z}, {}, {DataType::UINT8}, {}, {}, false);
+            auto status = res.execute({ tZ }, { z }, {}, { DataType::UINT8 }, {}, {}, false);
             if (tZ != &z0) {
                 delete tZ;
             }
-            
+
             return status;
         }
 
         DECLARE_TYPES(compare_and_bitpack) {
             getOpDescriptor()
-                    ->setAllowedInputTypes(0, DataType::ANY)
-                    ->setAllowedInputTypes(1, DataType::ANY)
-                    ->setAllowedOutputTypes(0, DataType::UINT8);
+                ->setAllowedInputTypes(0, DataType::ANY)
+                ->setAllowedInputTypes(1, DataType::ANY)
+                ->setAllowedOutputTypes(0, DataType::UINT8);
         }
 
         DECLARE_SHAPE_FN(compare_and_bitpack) {

--- a/libnd4j/include/ops/declarable/generic/parity_ops/normalize_moments.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/normalize_moments.cpp
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-//
-// Created by george@skymind.io on 26.01.2018.
-//
+ //
+ // Created by george@skymind.io on 26.01.2018.
+ //
 
 #include <system/op_boilerplate.h>
 #if NOT_EXCLUDED(OP_normalize_moments)
@@ -34,7 +34,7 @@ namespace sd {
             auto resVariances = OUTPUT_VARIABLE(1);
 
             // FIXME: double?
-            NDArray shift = NDArrayFactory::create<double>(0.);
+            NDArray shift = NDArrayFactory::create<double>(0., block.launchContext());
 
             if (block.getTArguments()->size() > 0) {
                 shift.assign(T_ARG(0));
@@ -47,7 +47,7 @@ namespace sd {
 
             squareMeans.applyTransform(transform::Square, squareMeans, nullptr);
             variances->applyScalarArr(scalar::Divide, *counts, tempVariances);
-//            tempVariances.printIndexedBuffer("varianced divided by count");
+            //            tempVariances.printIndexedBuffer("varianced divided by count");
             tempVariances.applyPairwiseTransform(pairwise::Subtract, squareMeans, *resVariances);
 
             if (shift.e<double>(0) != 0) {
@@ -75,8 +75,8 @@ namespace sd {
 
         DECLARE_TYPES(normalize_moments) {
             getOpDescriptor()
-                    ->setAllowedInputTypes(sd::DataType::ANY)
-                    ->setAllowedOutputTypes({ALL_FLOATS});
+                ->setAllowedInputTypes(sd::DataType::ANY)
+                ->setAllowedOutputTypes({ ALL_FLOATS });
         }
     }
 

--- a/libnd4j/include/ops/declarable/generic/random/uniform.cpp
+++ b/libnd4j/include/ops/declarable/generic/random/uniform.cpp
@@ -49,8 +49,8 @@ namespace sd {
             bool disposable = false;
 
             if (min == nullptr && max == nullptr && block.numT() >= 2) {
-                min = NDArrayFactory::create_(dtype);
-                max = NDArrayFactory::create_(dtype);
+                min = NDArrayFactory::create_(dtype, block.launchContext());
+                max = NDArrayFactory::create_(dtype, block.launchContext());
                 min->p(0, T_ARG(0));
                 max->p(0, T_ARG(1));
                 disposable = true;

--- a/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
+++ b/libnd4j/include/ops/declarable/generic/shape/reshape.cpp
@@ -35,111 +35,19 @@ CUSTOM_OP_IMPL(reshape, 1, 1, false, 0, -2) {
     auto z = OUTPUT_VARIABLE(0);
 
     //Special case: empty.reshape(<other empty shape>) -> return empty
-        if (x->isEmpty()) {
-            REQUIRE_TRUE(z->isEmpty(), 0, "Reshape: when input is empty, output must also be empty");
-            return Status::OK();    //No op
-        }
-
-    if (block.width() == 1) {
-
-        auto arguments = block.getIArguments();
-        int argsSize = arguments->size();
-
-
-
-        int e = 1;
-        char order = (char) -(*arguments)[0];
-        if (order != 'c' && order != 'f') {
-            order = 'c'; //x->ordering();
-            e = 0;
-        }
-
-        REQUIRE_TRUE(argsSize - e >= 1, 0, "Reshape arguments should have at least 1 dimension");
-
-        std::vector<Nd4jLong> shapeNew;
-        int e2 = e;
-        for (; e < (int) arguments->size(); e++) {
-            if (arguments->at(e) == -1){
-                Nd4jLong shapeLength = 1;
-                for(; e2 < e; e2++){
-                    shapeLength *= arguments->at(e2);
-                }
-                for(e2 = e + 1; e2 < arguments->size(); e2++){
-                    shapeLength *= arguments->at(e2);
-                }
-                Nd4jLong realShape = x->lengthOf() / shapeLength;
-                shapeNew.push_back(realShape);
-            }
-            else{
-                shapeNew.push_back(arguments->at(e));
-            }
-
-        }
-
-        auto len = shape::prodLong(shapeNew.data(), shapeNew.size());
-        REQUIRE_TRUE(len == x->lengthOf(), 0, "Reshape: lengths before and after reshape should match, but got %i vs %i", x->lengthOf(), len);
-
-        if (Environment::getInstance()->isDebugAndVerbose()) {
-            nd4j_printv("Reshape: new shape", shapeNew);
-        }
-
-        auto xr = x->reshape(order, shapeNew);
-        z->assign(xr);
-        STORE_RESULT(*z);
-
-        return Status::OK();
-
-    } else if (block.width() == 2) {
-
-        auto s = INPUT_VARIABLE(1);
-
-        char order = 'c';
-        if (block.numI() > 0)
-            order = (char) -INT_ARG(0);
-
-        std::vector<Nd4jLong> shapeNew(s->lengthOf());
-
-        for (int e = 0; e < (int) s->lengthOf(); e++) {
-            auto dim = s->e<Nd4jLong >(e);
-            if (dim == -1){
-                Nd4jLong shapeLength = 1;
-                for(int e2 = 0; e2 < e; e2++){
-                    shapeLength *= s->e<Nd4jLong>(e2);
-                }
-                for(int e2 = e + 1; e2 < (int) s->lengthOf(); e2++){
-                    REQUIRE_TRUE(s->e<Nd4jLong>(e2) != -1, 0, "Reshape : Only one unknown dimension (-1) is allowed.");
-                    shapeLength *= s->e<Nd4jLong>(e2);
-                }
-                Nd4jLong realShape = x->lengthOf() / shapeLength;
-                shapeNew[e] = realShape;
-            }
-            else{
-                shapeNew[e] = dim;
-            }
-        }
-
-        if (Environment::getInstance()->isDebugAndVerbose()) {
-            nd4j_printv("Reshape: new shape", shapeNew);
-        }
-
-        if (s->isScalar()) {
-            // just a scalar
-            z->assign(x);
-        } else {
-            // in some cases we might go away with simple memcpy call instead of assign call
-            if (x->ordering() == 'c' && z->ordering() == x->ordering() && shape::reshapeC(x->shapeInfo(), z->shapeInfo())) {
-                z->dataBuffer()->copyBufferFrom(*x->dataBuffer().get(), z->lengthOf() * DataTypeUtils::sizeOfElement(z->dataType()), 0, x->bufferOffset());
-            } else {
-                auto xr = x->reshape(order, shapeNew);
-                z->assign(xr);
-            }
-        }
-
-        return Status::OK();
-
+    if (x->isEmpty()) {
+        REQUIRE_TRUE(z->isEmpty(), 0, "Reshape: when input is empty, output must also be empty");
+        return Status::OK();    //No op
     }
 
-    return ND4J_STATUS_BAD_INPUT;
+    REQUIRE_TRUE(x->lengthOf() == z->lengthOf(), 0, "Reshape: lengths before and after reshape should match, but got %i vs %i", x->lengthOf(), z->lengthOf());
+
+    if (Environment::getInstance()->isDebugAndVerbose())
+        nd4j_printv("Reshape: new shape", z->getShapeAsVector());
+
+    z->assign(x->reshape(z->ordering(), z->getShapeAsVector()));
+
+    return Status::OK();
 }
 
 
@@ -151,117 +59,73 @@ DECLARE_TYPES(reshape) {
 }
 
 DECLARE_SHAPE_FN(reshape) {
-    auto inp = inputShape->at(0);
 
-    // we can launch op using Int arguments
-    if (inputShape->size() == 1) {
-        REQUIRE_TRUE(block.numI() > 0, 0, "Reshape: new shape should be provided as NDArray or int arguments, but nothing was defined");
-        std::vector<int> *arguments = block.getIArguments();
+    const auto x = INPUT_VARIABLE(0);
 
-        int e = 1;
-        char order = (char) -(*arguments)[0];
-        if (order != 'c' && order != 'f') {
-            order = shape::order(inp);
-            e = 0;
+    std::vector<int> reshapeArgs;
+    std::vector<Nd4jLong> shapeNew;
+    char orderNew = 'c';
+
+    if (block.width() == 1) {
+        reshapeArgs = *block.getIArguments();
+        if(!reshapeArgs.empty()) {
+            orderNew = (char) -reshapeArgs[0];
+            if(orderNew == 'c' || orderNew == 'f')
+                reshapeArgs.erase(reshapeArgs.begin());   // remove first element being order in this case
         }
-
-        std::vector<Nd4jLong> shapeNew;
-
-        int e2 = e;
-        for (; e < (int) arguments->size(); e++) {
-            if ((int) arguments->at(e) == -1){
-
-                Nd4jLong shapeLength = 1;
-                for(; e2 < e; e2 ++){
-                    shapeLength *= arguments->at(e2);
-                }
-                for(e2 = e + 1; e2 < arguments->size(); e2++){
-                    REQUIRE_TRUE(arguments->at(e2) != -1, 0, "Reshape : Only one unknown dimension (-1) is allowed.");
-                    shapeLength *= arguments->at(e2);
-                }
-
-                if(shapeLength == 0){
-                    //Edge case for empty:
-                    shapeNew.push_back(0);
-                } else {
-                    //Standard case
-                    Nd4jLong realShape = shape::length(inp) / shapeLength;
-                    shapeNew.push_back(realShape);
-                }
-            }
-            else{
-                shapeNew.push_back(arguments->at(e));
-            }
-        }
-
-        return SHAPELIST(ConstantShapeHelper::getInstance()->createShapeInfo(ShapeDescriptor(ArrayOptions::dataType(inp), order, shapeNew)));
-    } else {
-        // or, with second input "as shape"
-        auto x = INPUT_VARIABLE(0);
-        auto y = INPUT_VARIABLE(1);
-
-        // special case here
-        if (y->isEmpty()) {
-            REQUIRE_TRUE(x->lengthOf() == 1, 0, "Reshape: new length doesn't match existing array");
-            return SHAPELIST(ConstantShapeHelper::getInstance()->scalarShapeInfo(ArrayOptions::dataType(inp)));
-        }
-        //Special case: empty.reshape(-1) -> return empty
-        if (x->isEmpty()) {
-            //REQUIRE_TRUE(y->lengthOf() == 1 && y->e<Nd4jLong>(0) == -1, 0, "Reshape: when input is empty, shape must be [-1]");
-            auto shapeOf = y->getBufferAsVector<Nd4jLong>();
-            Nd4jLong prod = 1;
-            bool hasNegs = false;
-            for (auto v:shapeOf) {
-                if (v < 0) {
-                    hasNegs = true;
-                    v = 0;
-                }
-
-                prod *= v;
-            }
-
-            REQUIRE_TRUE(prod == 0, 0, "Reshape: in case of empty arrays reshape must return empty array as well");
-
-            // if there are -1s - we turn them into zeros
-            if (hasNegs) {
-                for (int e = 0; e < shapeOf.size(); e++)
-                    if (shapeOf[e] < 0)
-                        shapeOf[e] = 0;
-            }
-
-            auto newShape = ShapeBuilders::createShapeInfo(ArrayOptions::dataType(inp), shape::order(inp), y->lengthOf(), shapeOf.data());
-            return SHAPELIST(CONSTANT(newShape));
-        }
-
-        std::vector<Nd4jLong> shapeNew(y->lengthOf());
-
-        for (int e = 0; e < (int) y->lengthOf(); e++) {
-            auto dim = y->e<Nd4jLong>(e);
-            if (dim == -1){
-                Nd4jLong shapeLength = 1;
-                for(int e2 = 0; e2 < e; e2++){
-                    shapeLength *= y->e<Nd4jLong>(e2);
-                }
-                for(int e2 = e + 1; e2 < (int)y->lengthOf(); e2++){
-                    REQUIRE_TRUE(y->e<Nd4jLong>(e2) != -1, 0, "Reshape : Only one unknown dimension (-1) is allowed.");
-                    shapeLength *= y->e<Nd4jLong>(e2);
-                }
-
-                if(shapeLength == 0){
-                    //Edge case for empty:
-                    shapeNew[e] = 0;
-                } else {
-                    Nd4jLong realShape = shape::length(inp) / shapeLength;
-                    shapeNew[e] = realShape;
-                }
-            }else {
-                shapeNew[e] = dim;
-            }
-        }
-
-        return SHAPELIST(ConstantShapeHelper::getInstance()->createShapeInfo(ArrayOptions::dataType(inp), 'c', shapeNew));
     }
+    else {
+        reshapeArgs = INPUT_VARIABLE(1)->getBufferAsVector<int>();
+        orderNew = block.numI() > 0 ? (char) -INT_ARG(0) : 'c';
+    }
+
+    REQUIRE_TRUE(!reshapeArgs.empty() || x->lengthOf() == 1, 0, "Reshape buffer should have at least 1 dimension !");
+
+    Nd4jLong xLen = x->lengthOf();
+    if(x->isEmpty()) {
+        xLen = 1;
+        for (uint i = 0; i < x->rankOf(); ++i)                            // take into account possible empty shapes
+            if(x->sizeAt(i) != 0)
+                xLen *= x->sizeAt(i);
+    }
+
+    for (uint i = 0; i < reshapeArgs.size(); ++i) {
+
+        if (reshapeArgs[i] == -1) {
+
+            uint shapeLength = 1, numOfZeros = 0;
+
+            for(uint j = 0; j < i; ++j)
+                if(reshapeArgs[j] != 0)
+                    shapeLength *= reshapeArgs[j];
+                else
+                    ++numOfZeros;
+
+            for(uint j = i + 1; j < reshapeArgs.size(); ++j) {
+                REQUIRE_TRUE(reshapeArgs[j] != -1, 0, "Reshape : Only one unknown dimension (-1) is allowed.");
+                if(reshapeArgs[j] != 0)
+                    shapeLength *= reshapeArgs[j];
+                else
+                    ++numOfZeros;
+            }
+
+            const auto dim = xLen / shapeLength;
+
+            if(x->isEmpty() && (1 == dim || 0 == numOfZeros))
+                shapeNew.push_back(0);
+            else
+                shapeNew.push_back(dim);
+        }
+        else
+            shapeNew.push_back(reshapeArgs[i]);
+    }
+
+    auto len = shape::prodLong(shapeNew.data(), shapeNew.size());
+    REQUIRE_TRUE(x->lengthOf() == len, 0, "Reshape: lengths before and after reshape should match, but got %i vs %i", x->lengthOf(), len);
+
+    return SHAPELIST(ConstantShapeHelper::getInstance()->createShapeInfo(x->dataType(), orderNew, shapeNew));
 }
+
 }
 }
 

--- a/libnd4j/include/ops/declarable/generic/tsne/symmetrized.cpp
+++ b/libnd4j/include/ops/declarable/generic/tsne/symmetrized.cpp
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-//
-// @author George A. Shulinok <sgazeos@gmail.com>, created on 4/18/2019.
-//
+ //
+ // @author George A. Shulinok <sgazeos@gmail.com>, created on 4/18/2019.
+ //
 
 #include <system/op_boilerplate.h>
 #if NOT_EXCLUDED(OP_barnes_symmetrized)
@@ -25,20 +25,20 @@
 #include <ops/declarable/helpers/BarnesHutTsne.h>
 
 namespace sd {
-namespace ops  {
-		NDArray* rowCountsPtr = nullptr;
+    namespace ops {
+        NDArray* rowCountsPtr = nullptr;
 
-		CUSTOM_OP_IMPL(barnes_symmetrized, 3, 3, false, 0, -1) {
-    		auto rowP  = INPUT_VARIABLE(0);
-            auto colP  = INPUT_VARIABLE(1);
-            auto valP  = INPUT_VARIABLE(2);
+        CUSTOM_OP_IMPL(barnes_symmetrized, 3, 3, false, 0, -1) {
+            auto rowP = INPUT_VARIABLE(0);
+            auto colP = INPUT_VARIABLE(1);
+            auto valP = INPUT_VARIABLE(2);
             auto N = rowP->lengthOf() - 1;
-    		auto outputRows = OUTPUT_VARIABLE(0);
+            auto outputRows = OUTPUT_VARIABLE(0);
             auto outputCols = OUTPUT_VARIABLE(1);
             auto outputVals = OUTPUT_VARIABLE(2);
 
-    		if (block.getIArguments()->size() > 0)
-    		    N = INT_ARG(0);
+            if (block.getIArguments()->size() > 0)
+                N = INT_ARG(0);
 
             if (rowCountsPtr) {
                 helpers::barnes_symmetrize(rowP, colP, valP, N, outputRows, outputCols, outputVals, rowCountsPtr);
@@ -46,33 +46,33 @@ namespace ops  {
                 return Status::OK();
             }
             return Status::THROW("barnes_symmetrized: Cannot loop due wrong input data.");
-		}
+        }
 
-		DECLARE_TYPES(barnes_symmetrized) {
-			getOpDescriptor()
-				->setAllowedInputTypes(0, {DataType::INT32})
-                ->setAllowedInputTypes(1, {DataType::INT32})
-                ->setAllowedInputTypes(2, {ALL_INTS, ALL_FLOATS})
-                ->setAllowedOutputTypes(1, {DataType::INT32})
-                ->setAllowedOutputTypes(1, {DataType::INT32})
-                ->setAllowedOutputTypes(2, {ALL_INTS, ALL_FLOATS})
-				->setSameMode(false);
-		}
+        DECLARE_TYPES(barnes_symmetrized) {
+            getOpDescriptor()
+                ->setAllowedInputTypes(0, { DataType::INT32 })
+                ->setAllowedInputTypes(1, { DataType::INT32 })
+                ->setAllowedInputTypes(2, { ALL_INTS, ALL_FLOATS })
+                ->setAllowedOutputTypes(1, { DataType::INT32 })
+                ->setAllowedOutputTypes(1, { DataType::INT32 })
+                ->setAllowedOutputTypes(2, { ALL_INTS, ALL_FLOATS })
+                ->setSameMode(false);
+        }
 
-		DECLARE_SHAPE_FN(barnes_symmetrized) {
-    		auto valPShapeInfo = inputShape->at(2);
+        DECLARE_SHAPE_FN(barnes_symmetrized) {
+            auto valPShapeInfo = inputShape->at(2);
             Nd4jLong* outShapeInfo;
-            auto rowP  = INPUT_VARIABLE(0);
-            auto colP  = INPUT_VARIABLE(1);
+            auto rowP = INPUT_VARIABLE(0);
+            auto colP = INPUT_VARIABLE(1);
             auto N = rowP->lengthOf() - 1;
             if (block.getIArguments()->size() > 0)
                 N = INT_ARG(0);
             auto dataType = rowP->dataType(); //ArrayOptions::dataType(inputShape->at(0));
-            NDArray* rowCounts = NDArrayFactory::create_<int>('c', {N}); //rowP->dup();
+            NDArray* rowCounts = NDArrayFactory::create_<int>('c', { N }, block.launchContext()); //rowP->dup();
             //srowCounts->assign(0);
             Nd4jLong len = helpers::barnes_row_count(rowP, colP, N, *rowCounts);
             rowCounts->syncToHost();
-//            rowCounts->printBuffer("Row Counts");
+            //            rowCounts->printBuffer("Row Counts");
             if (len <= 0) throw std::runtime_error("barnes_symmetrized: Cannot allocate shape due non-positive len.");
             rowCountsPtr = rowCounts;
             //ALLOCATE(outShapeInfo, block.workspace(), shape::shapeInfoLength(2), Nd4jLong);
@@ -80,13 +80,13 @@ namespace ops  {
 //            outShapeInfo[2] = len;
            // ShapeUtils::updateStridesAndType(outShapeInfo, ArrayOptions::dataType(valPShapeInfo), 'c');
             //outShapeInfo = ShapeBuilders::createVectorShapeInfo(ArrayOptions::dataType(valPShapeInfo), len, block.workspace());
-            outShapeInfo = sd::ShapeBuilders::createShapeInfo(ArrayOptions::dataType(valPShapeInfo), 'c', {1, len}, block.getWorkspace());
-            auto outColsShapeInfo = sd::ShapeBuilders::createShapeInfo(dataType, 'c', {1, len}, block.getWorkspace());
-            auto outRowsShapeInfo = sd::ShapeBuilders::createShapeInfo(dataType, 'c', {1, N + 1}, block.getWorkspace());
-    		return SHAPELIST(CONSTANT(outRowsShapeInfo), CONSTANT(outColsShapeInfo), CONSTANT(outShapeInfo));
-		}
+            outShapeInfo = sd::ShapeBuilders::createShapeInfo(ArrayOptions::dataType(valPShapeInfo), 'c', { 1, len }, block.getWorkspace());
+            auto outColsShapeInfo = sd::ShapeBuilders::createShapeInfo(dataType, 'c', { 1, len }, block.getWorkspace());
+            auto outRowsShapeInfo = sd::ShapeBuilders::createShapeInfo(dataType, 'c', { 1, N + 1 }, block.getWorkspace());
+            return SHAPELIST(CONSTANT(outRowsShapeInfo), CONSTANT(outColsShapeInfo), CONSTANT(outShapeInfo));
+        }
 
-}
+    }
 }
 
 #endif

--- a/libnd4j/include/ops/declarable/headers/parity_ops.h
+++ b/libnd4j/include/ops/declarable/headers/parity_ops.h
@@ -867,9 +867,12 @@ namespace sd {
          *   - 2D matrix MxN
          *   - 1D vector with N elements
          * output value - 2D matrix NxN as multiply of matrixes and add vector
+         * Int args:
+         *      0 - optional switcher of weights format, if int arg == 1 - mkldnn, else mmul
          */
         #if NOT_EXCLUDED(OP_xw_plus_b)
-        DECLARE_CUSTOM_OP(xw_plus_b, 3, 1, false, 0, 0);
+                DECLARE_CUSTOM_OP(xw_plus_b, 3, 1, false, 0, 0);
+                DECLARE_CUSTOM_OP(xw_plus_b_bp, 4, 3, false, 0, 0);
         #endif
 
         /**

--- a/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
@@ -142,7 +142,7 @@ namespace helpers {
         const int rowNum = input->rows();
         const int columnNum = input->columns();
 
-        NDArray determinant = NDArrayFactory::create<T>(1.f);
+        NDArray determinant = NDArrayFactory::create<T>(1.f, context);
         NDArray compoundMatrix = *input; // copy
         NDArray permutationMatrix(input, false, context); // has same shape as input and contiguous strides
         permutationMatrix.setIdentity();

--- a/libnd4j/include/ops/declarable/helpers/cpu/qr.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/qr.cpp
@@ -39,7 +39,7 @@ namespace helpers {
     template <typename T>
     NDArray vmul(NDArray const& v, int n)
     {
-        NDArray res('c', {n,n}, v.dataType()); // x = matrix_new(n, n);
+        NDArray res('c', {n,n}, v.dataType(), v.getContext()); // x = matrix_new(n, n);
         T const* vBuf = v.getDataBuffer()->primaryAsT<T>();
         T* resBuf = res.dataBuffer()->primaryAsT<T>();
         auto interloop = PRAGMA_THREADS_FOR_2D {
@@ -61,7 +61,7 @@ namespace helpers {
         std::vector<NDArray> q(M);
 
         NDArray z = *matrix;
-        NDArray e('c', {M}, DataTypeUtils::fromT<T>()); // two internal buffers and scalar for squared norm
+        NDArray e('c', {M}, DataTypeUtils::fromT<T>(), Q->getContext()); // two internal buffers and scalar for squared norm
 
         for (Nd4jLong k = 0; k < N && k < M - 1; k++) { // loop for columns, but not further then row number
             e.nullify();

--- a/libnd4j/include/ops/declarable/helpers/cpu/top_k.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/top_k.cpp
@@ -69,9 +69,9 @@ namespace helpers {
                     auto trial = (*input)(e, dimsToExclude);
 
                     // fill up the first k elements
-                    NDArray topValues = NDArrayFactory::create<T>('c', {k});
-                    NDArray sortedVals = NDArrayFactory::create<T>('c', {k});
-                    NDArray topIndices = NDArrayFactory::create<Nd4jLong>('c', {k});
+                    NDArray topValues = NDArrayFactory::create<T>('c', {k}, input->getContext());
+                    NDArray sortedVals = NDArrayFactory::create<T>('c', {k}, input->getContext());
+                    NDArray topIndices = NDArrayFactory::create<Nd4jLong>('c', {k}, input->getContext());
                     for (uint pos = 0; pos < k; ++pos) {
                         topIndices.t<Nd4jLong>(pos) = pos;
                         topValues.t<T>(pos) = trial.t<T>(pos);
@@ -144,7 +144,7 @@ namespace helpers {
             for (int i = 0; i < input->rankOf() - 1; i++)
                 shapeI[i] = input->sizeAt(i);
             shapeI[input->rankOf() - 1] = k;
-            std::unique_ptr<NDArray> indices(NDArrayFactory::create_<Nd4jLong>(input->ordering(), shapeI));
+            std::unique_ptr<NDArray> indices(NDArrayFactory::create_<Nd4jLong>(input->ordering(), shapeI, context));
             NDArray* values = nullptr;
             int status = topKFunctor(context, input, values, indices.get(), k, true);
             result->assign(0);

--- a/libnd4j/include/ops/declarable/helpers/cuda/histogram.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/histogram.cu
@@ -112,7 +112,7 @@ namespace sd {
                 int numThreads = 256;
                 int numBlocks = sd::math::nd4j_max<int>(256, sd::math::nd4j_min<int>(1, shape::length(xShapeInfo) / numThreads));
                 int workspaceSize = numBlocks * numBins;
-                auto tmp = NDArrayFactory::create<Z>('c', {workspaceSize});
+                auto tmp = NDArrayFactory::create<Z>('c', {workspaceSize}, context);
 
                 histogramKernel<X, Z><<<numBlocks, numThreads, 32768, *context->getCudaStream()>>>(xBuffer, dxShapeInfo, zBuffer, zShapeInfo, tmp.getSpecialBuffer(), context->getReductionPointer(), numBins, reinterpret_cast<X*>(min_val), reinterpret_cast<X*>(max_val));
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/image_draw_bounding_boxes.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/image_draw_bounding_boxes.cu
@@ -25,7 +25,7 @@ namespace ops {
 namespace helpers {
 
     typedef NDArray ColorTable_t;
-    static NDArray DefaultColorTable(int depth) {
+    static NDArray DefaultColorTable(int depth, sd::LaunchContext* context) {
         //std::vector<std::vector<float>> colorTable;
         const Nd4jLong kDefaultTableLength = 10;
         const Nd4jLong kDefaultChannelLength = 4;
@@ -40,7 +40,7 @@ namespace helpers {
                 0, 0, 0.5, 1,    // 7: navy blue
                 0, 1, 1, 1,      // 8: aqua
                 1, 0, 1, 1       // 9: fuchsia
-        }, DataType::FLOAT32);
+        }, DataType::FLOAT32, context);
 
         if (depth == 1) {
             colorTable.assign(1.f); // all to white when black and white colors
@@ -144,7 +144,7 @@ namespace helpers {
         auto channels = images->sizeAt(3);
         auto stream = context->getCudaStream();
         auto boxSize = boxes->sizeAt(1);
-        NDArray colorsTable = DefaultColorTable(channels);
+        NDArray colorsTable = DefaultColorTable(channels, context);
         if ((colors != nullptr && colors->lengthOf() > 0)) {
             colorsTable = *colors;
         }

--- a/libnd4j/include/ops/declarable/helpers/cuda/image_suppression.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/image_suppression.cu
@@ -188,7 +188,7 @@ namespace helpers {
     static void nonMaxSuppressionV2_(sd::LaunchContext* context, NDArray* boxes, NDArray* scales, int maxSize, double threshold, double scoreThreshold, NDArray* output) {
         auto stream = context->getCudaStream();
         NDArray::prepareSpecialUse({output}, {boxes, scales});
-        std::unique_ptr<NDArray> indices(NDArrayFactory::create_<I>('c', {scales->lengthOf()})); // - 1, scales->lengthOf()); //, scales->getContext());
+        std::unique_ptr<NDArray> indices(NDArrayFactory::create_<I>('c', {scales->lengthOf()}, context)); // - 1, scales->lengthOf()); //, scales->getContext());
 
         NDArray scores(*scales);
         Nd4jPointer extras[2] = {nullptr, stream};
@@ -198,7 +198,7 @@ namespace helpers {
         indices->tickWriteDevice();
         sortByValue(extras, indices->buffer(), indices->shapeInfo(), indices->specialBuffer(), indices->specialShapeInfo(), scores.buffer(), scores.shapeInfo(), scores.specialBuffer(), scores.specialShapeInfo(), true);
         indices->tickWriteDevice();
-        NDArray selectedIndices = NDArrayFactory::create<I>('c', {output->lengthOf()});
+        NDArray selectedIndices = NDArrayFactory::create<I>('c', {output->lengthOf()}, context);
         int numSelected = 0;
         int numBoxes = boxes->sizeAt(0);
         auto boxesBuf = reinterpret_cast<T*>(boxes->specialBuffer());
@@ -347,8 +347,8 @@ namespace helpers {
                 scores->syncToDevice();
         }
 
-        NDArray indices = NDArrayFactory::create<I>('c', {scores->lengthOf()}); // - 1, scales->lengthOf()); //, scales->getContext());
-        NDArray startPositions = NDArrayFactory::create<I>('c', {scores->lengthOf()});
+        NDArray indices = NDArrayFactory::create<I>('c', {scores->lengthOf()}, context); // - 1, scales->lengthOf()); //, scales->getContext());
+        NDArray startPositions = NDArrayFactory::create<I>('c', {scores->lengthOf()}, context);
         NDArray selectedScores(*scores);
         Nd4jPointer extras[2] = {nullptr, stream};
         auto indexBuf = indices.dataBuffer()->specialAsT<I>();///reinterpret_cast<I*>(indices->specialBuffer());

--- a/libnd4j/include/ops/declarable/helpers/cuda/lup.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/lup.cu
@@ -598,7 +598,7 @@ namespace helpers {
     static void lu_(LaunchContext * context, NDArray* input, NDArray* output, NDArray* permutationVectors) {
         auto n = input->sizeAt(-1);
         auto stream = context->getCudaStream();
-        NDArray iota('c', {n}, permutationVectors->dataType());// = NDArrayFactory::create(); // <int>('c', {n});
+        NDArray iota('c', {n}, permutationVectors->dataType(), context);// = NDArrayFactory::create(); // <int>('c', {n});
         iota.linspace(0); iota.syncToDevice();
 
         output->assign(input); // fill up output tensor with zeros
@@ -631,7 +631,7 @@ namespace helpers {
 //        if (dtype != DataType::DOUBLE)
 //            dtype = DataType::FLOAT32;
         auto matrix = NDArrayFactory::create(input->ordering(), {n, n}, DataTypeUtils::fromT<T>(), context); //, block.getWorkspace());
-        auto det = NDArrayFactory::create<T>(1);
+        auto det = NDArrayFactory::create<T>(1, context);
         auto stream = context->getCudaStream();
         NDArray::prepareSpecialUse({output}, {input});
         dim3 launchDims(256, 256, 1024);
@@ -677,7 +677,7 @@ namespace helpers {
                 dtype = DataType::FLOAT32;
 
             auto matrix = NDArrayFactory::create(input->ordering(), {n, n}, dtype, context); //, block.getWorkspace());
-            auto det = NDArrayFactory::create<T>(1);
+            auto det = NDArrayFactory::create<T>(1, context);
             auto stream = context->getCudaStream();
             NDArray::prepareSpecialUse({output}, {input});
             dim3 launchDims(256, 256, 1024);

--- a/libnd4j/include/ops/declarable/helpers/cuda/qr.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/qr.cu
@@ -110,7 +110,7 @@ namespace helpers {
         auto resR = fullMatricies?R->ulike():matrix->ulike();
         std::vector<NDArray> q(M);
         NDArray z = *matrix;
-        NDArray e('c', {M}, DataTypeUtils::fromT<T>()); // two internal buffers and scalar for squared norm
+        NDArray e('c', {M}, DataTypeUtils::fromT<T>(), context); // two internal buffers and scalar for squared norm
         for (auto k = 0; k < N && k < M - 1; k++) { // loop for columns, but not further then row number
             e.nullify();
             z = matrixMinor<T>(context, z, k); // minor computing for current column with given matrix z (initally is a input matrix)
@@ -177,4 +177,3 @@ namespace helpers {
 }
 }
 }
-

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_max.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_max.cu
@@ -167,8 +167,8 @@ namespace sd {
                 auto stream = context->getCudaStream();
                 indices->syncToHost();
                 Nd4jLong numOfClasses = indices->e<Nd4jLong>(indices->lengthOf() - 1) + 1;
-                NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses});
-                NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses});
+                NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses}, context);
+                NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses}, context);
 
                 classesRangesBegs.assign(indices->lengthOf());
                 classesRangesLens.assign(0);
@@ -209,8 +209,8 @@ namespace sd {
 //        NDArray classes = NDArrayFactory::create<int>('c', {numOfClasses, 2});
                 output->assign(DataTypeUtils::infOrMax<T>());
 
-                NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses});
-                NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses});
+                NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses}, context);
+                NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses}, context);
 //        NDArray row = NDArrayFactory::create<int>('c', {1, 2}, {(int)indices->lengthOf(), (int)0});
 //        classes.applyTrueBroadcast(sd::BroadcastOpsTuple::Assign(), row, classes);
                 classesRangesBegs.assign(indices->lengthOf());

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_mean.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_mean.cu
@@ -158,8 +158,8 @@ namespace helpers {
     static void segmentMeanFunctor_(LaunchContext* context, NDArray* input, NDArray* indices, NDArray* output) {
         auto stream = context->getCudaStream();
         Nd4jLong numClasses = indices->e<Nd4jLong>(indices->lengthOf() - 1) + 1;
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses});
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses}, context);
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses}, context);
 
         classesRangesBegs.assign(indices->lengthOf());
         classesRangesLens.assign(0);
@@ -198,8 +198,8 @@ namespace helpers {
         auto stream = context->getCudaStream();
 //        NDArray classes = NDArrayFactory::create<int>('c', {numOfClasses, 2});
 
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses});
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses});
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses}, context);
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses}, context);
 //        NDArray row = NDArrayFactory::create<int>('c', {1, 2}, {(int)indices->lengthOf(), (int)0});
 //        classes.applyTrueBroadcast(sd::BroadcastOpsTuple::Assign(), &row, &classes);
         classesRangesBegs.assign(indices->lengthOf());
@@ -314,8 +314,8 @@ namespace helpers {
         auto stream = context->getCudaStream();
         NDArray::prepareSpecialUse({output}, {input, indices, gradOut});
         auto numClasses = indices->e<int>(indices->lengthOf() - 1) + 1;
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses});
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses}, context);
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses}, context);
 
         classesRangesBegs.assign(indices->lengthOf());
         classesRangesLens.assign(0);
@@ -367,8 +367,8 @@ namespace helpers {
         auto stream = context->getCudaStream();
         NDArray::prepareSpecialUse({output}, {input, indices, gradOut});
         auto numClasses = indices->e<int>(indices->lengthOf() - 1) + 1;
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses});
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses}, context);
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses}, context);
 
         classesRangesBegs.assign(indices->lengthOf());
         classesRangesLens.assign(0);

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_min.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_min.cu
@@ -161,8 +161,8 @@ namespace helpers {
     static void segmentMinFunctor_(LaunchContext* context, NDArray* input, NDArray* indices, NDArray* output) {
         auto stream = context->getCudaStream();
         Nd4jLong numClasses = indices->e<Nd4jLong>(indices->lengthOf() - 1) + 1;
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses});
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses}, context);
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses}, context);
         output->assign(DataTypeUtils::infOrMax<T>());
         classesRangesBegs.assign(indices->lengthOf());
         classesRangesLens.assign(0);
@@ -202,8 +202,8 @@ namespace helpers {
     static void unsortedSegmentMinFunctor_(sd::LaunchContext* context, NDArray* input, NDArray* indices, Nd4jLong numOfClasses, NDArray* output) {
         auto stream = context->getCudaStream();
 //        NDArray classes = NDArrayFactory::create<int>('c', {numOfClasses, 2});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses});
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses});
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses}, context);
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses}, context);
 //        NDArray row = NDArrayFactory::create<int>('c', {1, 2}, {(int)indices->lengthOf(), (int)0});
 //        classes.applyTrueBroadcast(sd::BroadcastOpsTuple::Assign(), &row, &classes);
         output->assign(DataTypeUtils::infOrMax<T>());

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_prod.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_prod.cu
@@ -122,8 +122,8 @@ namespace helpers {
     static void segmentProdFunctor_(sd::LaunchContext* context, NDArray* input, NDArray* indices, NDArray* output) {
         auto stream = context->getCudaStream();
         Nd4jLong numClasses = indices->e<Nd4jLong>(indices->lengthOf() - 1) + 1;
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses});
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses}, context);
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses}, context);
         output->assign(1);
         classesRangesBegs.assign(indices->lengthOf());
         classesRangesLens.assign(0);
@@ -160,8 +160,8 @@ namespace helpers {
     static void unsortedSegmentProdFunctor_(sd::LaunchContext* context, NDArray* input, NDArray* indices, Nd4jLong numOfClasses, NDArray* output) {
         auto stream = context->getCudaStream();
 //        NDArray classes = NDArrayFactory::create<int>('c', {numOfClasses, 2});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses});
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses});
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses}, context);
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses}, context);
 //        NDArray row = NDArrayFactory::create<int>('c', {1, 2}, {(int)indices->lengthOf(), (int)0});
 //        classes.applyTrueBroadcast(sd::BroadcastOpsTuple::Assign(), &row, &classes);
         classesRangesBegs.assign(indices->lengthOf());

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_sqrtn.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_sqrtn.cu
@@ -86,8 +86,8 @@ namespace helpers {
     static void unsortedSegmentSqrtNFunctor_(sd::LaunchContext* context, NDArray* input, NDArray* indices, Nd4jLong numOfClasses, NDArray* output) {
         auto stream = context->getCudaStream();
 //        NDArray classes = NDArrayFactory::create<int>('c', {numOfClasses, 2});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses});
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses});
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses}, context);
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses}, context);
 //        NDArray row = NDArrayFactory::create<int>('c', {1, 2}, {(int)indices->lengthOf(), (int)0});
 //        classes.applyTrueBroadcast(sd::BroadcastOpsTuple::Assign(), &row, &classes);
         classesRangesBegs.assign(indices->lengthOf());
@@ -207,8 +207,8 @@ namespace helpers {
         auto stream = context->getCudaStream();
         NDArray::prepareSpecialUse({output}, {input, indices, gradOut});
         auto numClasses = indices->e<int>(indices->lengthOf() - 1) + 1;
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses});
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses}, context);
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses}, context);
 
         classesRangesBegs.assign(indices->lengthOf());
         classesRangesLens.assign(0);

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
@@ -162,8 +162,8 @@ namespace helpers {
     static void segmentSumFunctor_(sd::LaunchContext* context, NDArray* input, NDArray* indices, NDArray* output) {
         auto stream = context->getCudaStream();
         Nd4jLong numClasses = indices->e<Nd4jLong>(indices->lengthOf() - 1) + 1;
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses});
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numClasses}, context);
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numClasses}, context);
 
         classesRangesBegs.assign(indices->lengthOf());
         classesRangesLens.assign(0);
@@ -201,8 +201,8 @@ namespace helpers {
     static void unsortedSegmentSumFunctor_(sd::LaunchContext* context, NDArray* input, NDArray* indices, Nd4jLong numOfClasses, NDArray* output) {
         auto stream = context->getCudaStream();
 //        NDArray classes = NDArrayFactory::create<int>('c', {numOfClasses, 2});
-        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses});
-        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses});
+        NDArray classesRangesBegs = NDArrayFactory::create<int>('c', {numOfClasses}, context);
+        NDArray classesRangesLens = NDArrayFactory::create<int>('c', {numOfClasses}, context);
 //        NDArray row = NDArrayFactory::create<int>('c', {1, 2}, {(int)indices->lengthOf(), (int)0});
 //        classes.applyTrueBroadcast(sd::BroadcastOpsTuple::Assign(), &row, &classes);
         classesRangesBegs.assign(indices->lengthOf());

--- a/libnd4j/include/ops/declarable/helpers/impl/multiUnique.cpp
+++ b/libnd4j/include/ops/declarable/helpers/impl/multiUnique.cpp
@@ -41,7 +41,7 @@ namespace helpers {
             length += array->lengthOf();
             pos++;
         }
-        NDArray arrayFull('c', {length}, sd::DataType::INT32);
+        NDArray arrayFull('c', {length}, sd::DataType::INT32, inputList[0]->getContext());
         cContext.setOutputArray(0, &arrayFull);
         cContext.setIArguments(&axis, 1);
 

--- a/libnd4j/include/ops/declarable/platform/mkldnn/mkldnnUtils.h
+++ b/libnd4j/include/ops/declarable/platform/mkldnn/mkldnnUtils.h
@@ -96,6 +96,10 @@ namespace sd {
 
             DECLARE_PLATFORM(tanh_bp, ENGINE_CPU);
 
+            DECLARE_PLATFORM(xw_plus_b, ENGINE_CPU);
+
+            DECLARE_PLATFORM(xw_plus_b_bp, ENGINE_CPU);
+
         }
     }
 

--- a/libnd4j/include/ops/declarable/platform/mkldnn/xw_plus_b.cpp
+++ b/libnd4j/include/ops/declarable/platform/mkldnn/xw_plus_b.cpp
@@ -1,0 +1,426 @@
+/*******************************************************************************
+ * Copyright (c) 2019-2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+ //
+ //  @author Oleg Semeniv <oleg.semeniv@gmail.com>
+ //
+ //
+
+#include <ops/declarable/PlatformHelper.h>
+#include <ops/declarable/OpRegistrator.h>
+#include <system/platform_boilerplate.h>
+#include <helpers/MKLDNNStream.h>
+#include "mkldnnUtils.h"
+
+using namespace dnnl;
+
+namespace sd {
+    namespace ops {
+        namespace platforms {
+
+            //////////////////////////////////////////////////////////////////////
+            static void xwPlusBiasMKLDNN(const NDArray* x, const NDArray* weights, const NDArray* bias, NDArray* z, const bool bShouldTransp) {
+
+                // mkl works with following
+                // [M,K]     x [N,K]^T  + [N]   = [M,N]
+                const auto xRank = x->rankOf();
+
+                // [M,K] x [K,N] = [M,N]
+                const int M = x->sizeAt(0);
+                const int K = x->sizeAt(1); // K == wK
+                const int N = z->sizeAt(1);
+
+                dnnl::memory::dims xShape = dnnl::memory::dims({ M, K });
+                dnnl::memory::dims wShape = dnnl::memory::dims({ N, K });
+                dnnl::memory::dims zShape = dnnl::memory::dims({ M, N });
+                dnnl::memory::dims bShape = dnnl::memory::dims({ N });
+
+                dnnl::memory::format_tag format = dnnl::memory::format_tag::ab;
+
+                // x type
+                dnnl::memory::data_type xType = dnnl::memory::data_type::f32;
+                if (x->dataType() == DataType::UINT8)
+                    xType = dnnl::memory::data_type::u8;
+                else if (x->dataType() == DataType::INT8)
+                    xType = dnnl::memory::data_type::s8;
+
+                // weights type
+                dnnl::memory::data_type wType = (weights->dataType() == DataType::FLOAT32) ?
+                    wType = dnnl::memory::data_type::f32 : wType = dnnl::memory::data_type::s8;
+
+                // bias type need add description for bias
+                dnnl::memory::data_type bType = dnnl::memory::data_type::f32;
+                if (bias->dataType() == DataType::INT32)
+                    bType = dnnl::memory::data_type::s32;
+                else if (bias->dataType() == DataType::UINT8)
+                    bType = dnnl::memory::data_type::u8;
+                else if (bias->dataType() == DataType::INT8)
+                    bType = dnnl::memory::data_type::s8;
+
+                // z type
+                dnnl::memory::data_type zType = dnnl::memory::data_type::f32;
+                if (z->dataType() == DataType::INT32)
+                    zType = dnnl::memory::data_type::s32;
+                else if (z->dataType() == DataType::UINT8)
+                    zType = dnnl::memory::data_type::u8;
+                else if (z->dataType() == DataType::INT8)
+                    zType = dnnl::memory::data_type::s8;
+
+                // memory descriptors for arrays
+                // x
+                dnnl::memory::desc x_mkl_md = dnnl::memory::desc(xShape, xType, dnnl::memory::format_tag::any);
+                dnnl::memory::desc x_user_md = dnnl::memory::desc(xShape, xType, format);
+                mkldnnUtils::setBlockStrides(x, x_user_md);
+
+                // weights
+                dnnl::memory::desc weights_mkl_md = dnnl::memory::desc(wShape, wType, dnnl::memory::format_tag::any);
+                dnnl::memory::desc weights_user_md = dnnl::memory::desc(wShape, wType, format);
+                if (weights->ews() != 1 || weights->ordering() != 'c' || bShouldTransp) {
+
+                    weights_user_md.data.format_kind = dnnl_blocked;    // overrides format
+                    if (bShouldTransp) {
+                        weights_user_md.data.format_desc.blocking.strides[0] = weights->strideAt(1);
+                        weights_user_md.data.format_desc.blocking.strides[1] = weights->strideAt(0);
+                    }
+                    else {
+                        weights_user_md.data.format_desc.blocking.strides[0] = weights->strideAt(0);
+                        weights_user_md.data.format_desc.blocking.strides[1] = weights->strideAt(1);
+                    }
+                }
+                // bias
+                dnnl::memory::desc bias_mkl_md = dnnl::memory::desc(bShape, bType, dnnl::memory::format_tag::x);
+                dnnl::memory::desc bias_user_md = dnnl::memory::desc(bShape, bType, dnnl::memory::format_tag::x);
+                mkldnnUtils::setBlockStrides(bias, bias_user_md);
+
+                // z
+                dnnl::memory::desc z_mkl_md = dnnl::memory::desc(zShape, zType, dnnl::memory::format_tag::any);
+                dnnl::memory::desc z_user_md = dnnl::memory::desc(zShape, zType, format);
+                mkldnnUtils::setBlockStrides(z, z_user_md);
+
+                auto engine = mkldnnUtils::getEngine(LaunchContext::defaultContext()->engine());
+
+                // operation primitive description
+                dnnl::inner_product_forward::desc op_desc(dnnl::prop_kind::forward_inference, x_mkl_md, weights_mkl_md, bias_mkl_md, z_mkl_md);
+
+                dnnl::inner_product_forward::primitive_desc op_prim_desc(op_desc, engine);
+
+                // arguments (memory buffers) necessary for calculations
+                std::unordered_map<int, dnnl::memory> args;
+
+                dnnl::stream stream(engine);
+
+                // provide memory buffers and check whether reorder is required
+
+                // input
+                mkldnnUtils::loadDataToMklStream(x, engine, stream, x_user_md, op_prim_desc.src_desc(), args[DNNL_ARG_SRC]);
+
+                // weights
+                mkldnnUtils::loadDataToMklStream(weights, engine, stream, weights_user_md, op_prim_desc.weights_desc(), args[DNNL_ARG_WEIGHTS]);
+
+                // bias
+                auto bias_mkl_mem = dnnl::memory(bias_mkl_md, engine, bias->getBuffer());
+                args[DNNL_ARG_BIAS] = bias_mkl_mem;
+
+                // z
+                auto z_user_mem = dnnl::memory(z_user_md, engine, z->getBuffer());
+                const bool zReorder = op_prim_desc.dst_desc() != z_user_mem.get_desc();
+                auto z_mkl_mem = zReorder ? dnnl::memory(op_prim_desc.dst_desc(), engine) : z_user_mem;
+                args[DNNL_ARG_DST] = z_mkl_mem;
+
+                // run calculations
+                dnnl::inner_product_forward(op_prim_desc).execute(stream, args);
+
+                // reorder outputs if necessary
+                if (zReorder)
+                    dnnl::reorder(z_mkl_mem, z_user_mem).execute(stream, z_mkl_mem, z_user_mem);
+
+                stream.wait();
+            }
+
+            //////////////////////////////////////////////////////////////////////
+            static void xwPlusBiasBp(const NDArray* x, const NDArray* weights, const NDArray* bias, const NDArray* dLdz,
+                NDArray* dLdx, NDArray* dLdw, NDArray* dLdb, const bool bShouldTransp) {
+
+                // mkl works with following
+                // [M,K]     x [N,K]^T  + [N]   = [M,N]
+                const auto xRank = x->rankOf();
+
+                // [M,K] x [K,N] = [M,N]
+                const int M = x->sizeAt(0);
+                const int K = x->sizeAt(1); // K == wK               
+                const int N = dLdz->sizeAt(1);
+                // input dims
+                dnnl::memory::dims xShape = dnnl::memory::dims({ M, K });
+                dnnl::memory::dims wShape = dnnl::memory::dims({ N, K });
+                dnnl::memory::dims dLdzShape = dnnl::memory::dims({ M, N });
+
+                dnnl::memory::dims bShape = dnnl::memory::dims({ N });
+                // output dims
+                dnnl::memory::dims dLdxShape = xShape;
+                dnnl::memory::dims dLdwShape = wShape;
+
+                dnnl::memory::format_tag format = dnnl::memory::format_tag::ab;
+                dnnl::memory::data_type dataType = dnnl::memory::data_type::f32;
+
+                // memory descriptors for arrays
+                // x
+                dnnl::memory::desc x_mkl_md = dnnl::memory::desc(xShape, dataType, dnnl::memory::format_tag::any);
+                dnnl::memory::desc x_user_md = dnnl::memory::desc(xShape, dataType, format);
+                mkldnnUtils::setBlockStrides(x, x_user_md);
+
+                // weights
+                dnnl::memory::desc weights_mkl_md = dnnl::memory::desc(wShape, dataType, dnnl::memory::format_tag::any);
+                dnnl::memory::desc weights_user_md = dnnl::memory::desc(wShape, dataType, format);
+                if (weights->ews() != 1 || weights->ordering() != 'c' || bShouldTransp) {
+
+                    weights_user_md.data.format_kind = dnnl_blocked;    // overrides format
+                    if (bShouldTransp) {
+                        weights_user_md.data.format_desc.blocking.strides[0] = weights->strideAt(1);
+                        weights_user_md.data.format_desc.blocking.strides[1] = weights->strideAt(0);
+                    }
+                    else {
+                        weights_user_md.data.format_desc.blocking.strides[0] = weights->strideAt(0);
+                        weights_user_md.data.format_desc.blocking.strides[1] = weights->strideAt(1);
+                    }
+                }
+                // bias
+                dnnl::memory::desc bias_mkl_md = dnnl::memory::desc(bShape, dataType, dnnl::memory::format_tag::x);
+                dnnl::memory::desc bias_user_md = dnnl::memory::desc(bShape, dataType, dnnl::memory::format_tag::x);
+                mkldnnUtils::setBlockStrides(bias, bias_user_md);
+
+                // dLdz
+                dnnl::memory::desc dLdz_mkl_md = dnnl::memory::desc(dLdzShape, dataType, dnnl::memory::format_tag::any);
+                dnnl::memory::desc dLdz_user_md = dnnl::memory::desc(dLdzShape, dataType, format);
+                mkldnnUtils::setBlockStrides(dLdz, dLdz_user_md);
+
+                // dLdw
+                dnnl::memory::desc dLdw_mkl_md = dnnl::memory::desc(wShape, dataType, format);
+                dnnl::memory::desc dLdw_user_md = dnnl::memory::desc(wShape, dataType, format);
+                if (dLdw->ews() != 1 || dLdw->ordering() != 'c' || bShouldTransp) {
+
+                    dLdw_user_md.data.format_kind = dnnl_blocked;    // overrides format
+                    if (bShouldTransp) {
+                        dLdw_user_md.data.format_desc.blocking.strides[0] = dLdw->strideAt(1);
+                        dLdw_user_md.data.format_desc.blocking.strides[1] = dLdw->strideAt(0);
+                    }
+                    else {
+                        dLdw_user_md.data.format_desc.blocking.strides[0] = dLdw->strideAt(0);
+                        dLdw_user_md.data.format_desc.blocking.strides[1] = dLdw->strideAt(1);
+                    }
+                }
+
+                // dLdb
+                dnnl::memory::desc dLdb_mkl_md = dnnl::memory::desc(bShape, dataType, dnnl::memory::format_tag::x);
+                dnnl::memory::desc dLdb_user_md = dnnl::memory::desc(bShape, dataType, dnnl::memory::format_tag::x);
+                mkldnnUtils::setBlockStrides(dLdb, dLdb_user_md);
+
+                // dLdx
+                dnnl::memory::desc dLdx_mkl_md = dnnl::memory::desc(xShape, dataType, dnnl::memory::format_tag::any);
+                dnnl::memory::desc dLdx_user_md = dnnl::memory::desc(xShape, dataType, format);
+                mkldnnUtils::setBlockStrides(dLdx, dLdx_user_md);
+
+                auto engine = mkldnnUtils::getEngine(LaunchContext::defaultContext()->engine());
+                // forward
+                // operation primitive description
+                dnnl::inner_product_forward::desc op_ff_desc(dnnl::prop_kind::forward_inference, x_mkl_md, weights_mkl_md, bias_mkl_md, dLdz_mkl_md);
+                dnnl::inner_product_forward::primitive_desc op_ff_prim_desc(op_ff_desc, engine);
+
+                // backprob
+                // dLdw
+                auto op_bpdw_desc = inner_product_backward_weights::desc(x_mkl_md, dLdw_mkl_md, dLdb_mkl_md, dLdz_mkl_md);
+                auto op_bpdw_prim_desc = inner_product_backward_weights::primitive_desc(op_bpdw_desc, engine, op_ff_prim_desc);
+
+                // backprob
+                // dLdx
+                auto op_bpdx_desc = inner_product_backward_data::desc(dLdx_mkl_md, weights_mkl_md, dLdz_mkl_md);
+                auto op_bpdx_prim_desc = inner_product_backward_data::primitive_desc(op_bpdx_desc, engine, op_ff_prim_desc);
+
+                // arguments (memory buffers) necessary for calculations
+                std::unordered_map<int, dnnl::memory> argsDw, argsDx;
+
+                dnnl::stream stream(engine);
+
+                // dLdz dw
+                mkldnnUtils::loadDataToMklStream(dLdz, engine, stream, dLdz_user_md, op_bpdw_prim_desc.diff_dst_desc(), argsDw[DNNL_ARG_DIFF_DST]);
+
+                // dLdz - dx
+                mkldnnUtils::loadDataToMklStream(dLdz, engine, stream, dLdz_user_md, op_bpdx_prim_desc.diff_dst_desc(), argsDx[DNNL_ARG_DIFF_DST]);
+
+                // input x for dw
+                mkldnnUtils::loadDataToMklStream(x, engine, stream, x_user_md, op_bpdw_prim_desc.src_desc(), argsDw[DNNL_ARG_SRC]);
+
+                // weights - dx
+                mkldnnUtils::loadDataToMklStream(weights, engine, stream, weights_user_md, op_bpdx_prim_desc.weights_desc(), argsDx[DNNL_ARG_WEIGHTS]);
+
+                // dLdw 
+                auto dLdw_user_mem = dnnl::memory(dLdw_user_md, engine, dLdw->getBuffer());
+                const bool dLdwReorder = op_bpdw_prim_desc.diff_weights_desc() != dLdw_user_mem.get_desc();
+                auto dLdw_mkl_mem = dLdwReorder ? dnnl::memory(op_bpdw_prim_desc.diff_weights_desc(), engine) : dLdw_user_mem;
+                argsDw[DNNL_ARG_DIFF_WEIGHTS] = dLdw_mkl_mem;
+
+                // dLdx 
+                auto dLdx_user_mem = dnnl::memory(dLdx_user_md, engine, dLdx->getBuffer());
+                const bool dLdxReorder = op_bpdx_prim_desc.diff_src_desc() != dLdx_user_mem.get_desc();
+                auto dLdx_mkl_mem = dLdxReorder ? dnnl::memory(op_bpdx_prim_desc.diff_src_desc(), engine) : dLdx_user_mem;
+                argsDx[DNNL_ARG_DIFF_SRC] = dLdx_mkl_mem;
+
+                // dLdb
+                auto dLdb_user_mem = dnnl::memory(dLdb_user_md, engine, dLdb->getBuffer());
+                const bool dLdbReorder = op_bpdw_prim_desc.diff_bias_desc() != dLdb_user_mem.get_desc();
+                auto dLdb_mkl_mem = dLdbReorder ? dnnl::memory(op_bpdw_prim_desc.diff_bias_desc(), engine) : dLdb_user_mem;
+                argsDw[DNNL_ARG_DIFF_BIAS] = dLdb_mkl_mem;
+
+                // run calculations dw
+                dnnl::inner_product_backward_weights(op_bpdw_prim_desc).execute(stream, argsDw);
+                // run calculations dx
+                dnnl::inner_product_backward_data(op_bpdx_prim_desc).execute(stream, argsDx);
+
+                // reorder outputs if necessary
+                if (dLdxReorder)
+                    dnnl::reorder(dLdx_mkl_mem, dLdx_user_mem).execute(stream, dLdx_mkl_mem, dLdx_user_mem);
+
+                if (dLdwReorder)
+                    dnnl::reorder(dLdw_mkl_mem, dLdw_user_mem).execute(stream, dLdw_mkl_mem, dLdw_user_mem);
+
+                if (dLdbReorder)
+                    dnnl::reorder(dLdb_mkl_mem, dLdb_user_mem).execute(stream, dLdb_mkl_mem, dLdb_user_mem);
+
+                stream.wait();
+            }
+
+            PLATFORM_IMPL(xw_plus_b, ENGINE_CPU) {
+
+                auto x = INPUT_VARIABLE(0);
+                auto w = INPUT_VARIABLE(1);
+                auto b = INPUT_VARIABLE(2);
+                auto z = OUTPUT_VARIABLE(0);
+
+                if (x->isEmpty() || w->isEmpty() || b->isEmpty())
+                    return Status::OK();
+
+                const int xRank = x->rankOf();
+                const int wRank = w->rankOf();
+                const int zRank = z->rankOf();
+
+                const bool bShouldTransp = block.getIArguments()->size() > 0 ? (1 != INT_ARG(0)) : true; // [M,K] * [K,N] -> [M, N], mkl -> [M,K] * [N, K]^T -> [M, N] 
+
+                REQUIRE_TRUE(xRank == 2, 0, "xw_plus_b MKL: Input x array should have rank equal 2, but got instead %i!", xRank);
+                REQUIRE_TRUE(wRank == 2, 0, "xw_plus_b MKL: Input weights array should have rank equal 2, but got instead %i!", wRank);
+                REQUIRE_TRUE(zRank == 2, 0, "xw_plus_b MKL: Output array should have rank equal 2, but got instead %i!", zRank);
+
+                REQUIRE_TRUE(1 == b->rankOf() && b->lengthOf() == z->sizeAt(-1), 0, "xw_plus_b MKL: Input bias vector should be 1D and have proper dimension 1x%i."
+                    " But got rank %i, and got length %i instead %i.", z->sizeAt(-1), b->rankOf(), b->lengthOf(), z->sizeAt(-1));
+
+                // mkldnnInerPorductss
+                xwPlusBiasMKLDNN(x, w, b, z, bShouldTransp);
+
+                return Status::OK();
+            }
+
+            PLATFORM_CHECK(xw_plus_b, ENGINE_CPU) {
+
+                auto x = INPUT_VARIABLE(0);
+                auto w = INPUT_VARIABLE(1);
+                auto b = INPUT_VARIABLE(2);
+                auto z = OUTPUT_VARIABLE(0);
+
+                const DataType xType = x->dataType();
+                const DataType wType = w->dataType();
+                const DataType bType = b->dataType();
+                const DataType zType = z->dataType();
+
+                /*
+                Source    Weights   Destination         Bias
+                f32 	    f32 	f32 	            f32
+                u8, s8  	s8 	    u8, s8, s32, f32 	u8, s8, s32, f32
+                */
+                return block.isUseMKLDNN() &&
+                    ((xType == DataType::FLOAT32 && wType == DataType::FLOAT32 && bType == DataType::FLOAT32 && zType == DataType::FLOAT32) ||
+                        ( // x
+                            (xType == DataType::UINT8 || xType == DataType::INT8) &&
+                            // w
+                            (wType == DataType::UINT8 || wType == DataType::INT8) &&
+                            // b
+                            (bType == DataType::UINT8 || bType == DataType::INT8 || bType == DataType::INT32 || bType == DataType::FLOAT32) &&
+                            // z
+                            (zType == DataType::UINT8 || zType == DataType::INT8 || zType == DataType::INT32 || zType == DataType::FLOAT32)
+                            ));
+            }
+
+            PLATFORM_IMPL(xw_plus_b_bp, ENGINE_CPU) {
+
+                auto x = INPUT_VARIABLE(0);
+                auto w = INPUT_VARIABLE(1);
+                auto b = INPUT_VARIABLE(2);
+                auto dLdz = INPUT_VARIABLE(3);
+
+                auto dLdx = OUTPUT_VARIABLE(0);
+                auto dLdw = OUTPUT_VARIABLE(1);
+                auto dLdb = OUTPUT_VARIABLE(2);
+
+                if (x->isEmpty() || w->isEmpty() || b->isEmpty() || dLdz->isEmpty())
+                    return Status::OK();
+
+                const int xRank = x->rankOf();
+                const int wRank = w->rankOf();
+                const int dLdzRank = dLdz->rankOf();
+
+                const bool bShouldTransp = block.getIArguments()->size() > 0 ? (1 != INT_ARG(0)) : true; // [M,K] * [K,N] -> [M, N], mkl -> [M,K] * [N, K]^T -> [M, N] 
+
+                REQUIRE_TRUE(x->rankOf() == 2, 0, "xw_plus_b BP MKL: Input x array should have rank equal 2, but got instead %i!", x->rankOf());
+                REQUIRE_TRUE(w->rankOf() == 2, 0, "xw_plus_b BP MKL: Input weights array should have rank equal 2, but got instead %i!", w->rankOf());
+                REQUIRE_TRUE(dLdz->rankOf() == 2, 0, "xw_plus_b BP MKL: Output array should have rank equal 2, but got instead %i!", dLdz->rankOf());
+                REQUIRE_TRUE(1 == b->rankOf() && b->lengthOf() == dLdz->sizeAt(1), 0, "xw_plus_b BP MKL: Input bias vector should be 1D and have proper dimension 1x%i."
+                    " But got rank %i, and got length %i instead %i.", dLdz->sizeAt(1), b->rankOf(), b->lengthOf(), dLdz->sizeAt(1));
+
+                xwPlusBiasBp(x, w, b, dLdz, dLdx, dLdw, dLdb, bShouldTransp);
+
+                return Status::OK();
+            }
+
+            PLATFORM_CHECK(xw_plus_b_bp, ENGINE_CPU) {
+
+                auto x = INPUT_VARIABLE(0);
+                auto w = INPUT_VARIABLE(1);
+                auto b = INPUT_VARIABLE(2);
+                auto dLdz = INPUT_VARIABLE(3);
+
+                auto dLdx = OUTPUT_VARIABLE(0);
+                auto dLdw = OUTPUT_VARIABLE(1);
+                auto dLdb = OUTPUT_VARIABLE(2);
+
+                const DataType xType = x->dataType();
+                const DataType wType = w->dataType();
+                const DataType bType = b->dataType();
+                const DataType dLdzType = dLdz->dataType();
+                const DataType dLdxType = dLdx->dataType();
+                const DataType dLdwType = dLdw->dataType();
+                const DataType dLdbType = dLdb->dataType();
+
+                /*
+                Source    Weights   Destination         Bias
+                f32 	    f32 	f32 	            f32
+                */
+                return block.isUseMKLDNN() &&
+                    (xType == DataType::FLOAT32 && wType == DataType::FLOAT32 &&
+                        bType == DataType::FLOAT32 && dLdzType == DataType::FLOAT32 &&
+                        dLdbType == DataType::FLOAT32 && dLdxType == DataType::FLOAT32 &&
+                        dLdwType == DataType::FLOAT32);
+            }
+
+        }
+    }
+}

--- a/libnd4j/tests_cpu/layers_tests/ArrayOptionsTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ArrayOptionsTests.cpp
@@ -40,16 +40,15 @@ TEST_F(ArrayOptionsTests, TestShape_Basic_0) {
 
 TEST_F(ArrayOptionsTests, TestShape_Basic_1) {
     shape[5] = 2;
-    
+
 
     ASSERT_TRUE(ArrayOptions::isNewFormat(shape));
     ASSERT_TRUE(ArrayOptions::isSparseArray(shape));
 }
 
-
 TEST_F(ArrayOptionsTests, TestShape_Basic_2) {
     shape[5] = 258;
-    
+
     ASSERT_TRUE(ArrayOptions::isNewFormat(shape));
 
     ASSERT_TRUE(ArrayOptions::isSparseArray(shape));
@@ -58,7 +57,7 @@ TEST_F(ArrayOptionsTests, TestShape_Basic_2) {
 
 TEST_F(ArrayOptionsTests, TestShape_Basic_3) {
     ASSERT_EQ(0, shape::extra(shape));
-    
+
     ASSERT_EQ(SpaceType::CONTINUOUS, ArrayOptions::spaceType(shape));
 }
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
@@ -166,7 +166,7 @@ TEST_F(DeclarableOpsTests1, ApplyGradientDescent_1) {
     auto z = result.at(0);
 
     ASSERT_TRUE(z->equalsTo(exp));
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -180,7 +180,7 @@ TEST_F(DeclarableOpsTests1, AssignBroadcastTest_1) {
     auto z = result.at(0);
 
     ASSERT_TRUE(z->equalsTo(exp));
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -198,7 +198,7 @@ TEST_F(DeclarableOpsTests1, AssignBroadcastTest_2) {
 
     ASSERT_TRUE(z1->equalsTo(exp1));
     ASSERT_TRUE(z2->equalsTo(exp2));
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -213,7 +213,7 @@ TEST_F(DeclarableOpsTests1, AXpY_Test_1) {
     auto z = result.at(0);
 
     ASSERT_TRUE(z->equalsTo(exp));
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, BasicInitialization3) {
@@ -258,7 +258,7 @@ TEST_F(DeclarableOpsTests1, TestTensorMmul1) {
     ASSERT_TRUE(exp.isSameShape(out));
     ASSERT_TRUE(exp.equalsTo(out));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, TestTensorDot2) {
@@ -278,7 +278,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot2) {
     ASSERT_TRUE(exp.isSameShape(out));
     ASSERT_TRUE(exp.equalsTo(out));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, TestTensorDot3) {
@@ -298,7 +298,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot3) {
     ASSERT_TRUE(exp.isSameShape(out));
     ASSERT_TRUE(exp.equalsTo(out));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, TestTensorDot4) {
@@ -318,7 +318,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot4) {
     ASSERT_TRUE(exp.isSameShape(out));
     ASSERT_TRUE(exp.equalsTo(out));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -338,7 +338,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot5) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -360,7 +360,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot6) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -381,7 +381,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot7) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -402,7 +402,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot8) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -431,7 +431,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot9) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 
@@ -452,7 +452,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot10) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -474,7 +474,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot11) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -495,7 +495,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot12) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -516,7 +516,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot13) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -537,7 +537,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot14) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -558,7 +558,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot15) {
     ASSERT_TRUE(expected.isSameShape(result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 
 }
 
@@ -579,7 +579,7 @@ TEST_F(DeclarableOpsTests1, TestTensorDot16) {
     ASSERT_TRUE(exp.isSameShape(result));
     ASSERT_TRUE(exp.equalsTo(result));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -786,7 +786,7 @@ TEST_F(DeclarableOpsTests1, SubtractTest_2) {
 
     ASSERT_TRUE(res.at(0)->equalsTo(&exp));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, TestRng1) {
@@ -1046,7 +1046,7 @@ TEST_F(DeclarableOpsTests1, ReverseSubtractTest_1) {
     ASSERT_TRUE(res.status() == ND4J_STATUS_OK);
     ASSERT_TRUE(res.at(0)->equalsTo(&exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1071,7 +1071,7 @@ TEST_F(DeclarableOpsTests1, ReverseSubtractTest_2) {
     ASSERT_TRUE(res.status() == ND4J_STATUS_OK);
     ASSERT_TRUE(res.at(0)->equalsTo(&exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1093,7 +1093,7 @@ TEST_F(DeclarableOpsTests1, ReverseSubtractTest_3) {
     ASSERT_TRUE(res.status() == ND4J_STATUS_OK);
     ASSERT_TRUE(res.at(0)->equalsTo(&exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1121,7 +1121,7 @@ TEST_F(DeclarableOpsTests1, ReverseModTest_1) {
     ASSERT_TRUE(res.at(0)->equalsTo(&exp));
     ASSERT_TRUE(exp.equalsTo(&z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1147,7 +1147,7 @@ TEST_F(DeclarableOpsTests1, ReverseModTest_2) {
     ASSERT_TRUE(res.status() == ND4J_STATUS_OK);
     ASSERT_TRUE(res.at(0)->equalsTo(&exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1402,7 +1402,7 @@ TEST_F(DeclarableOpsTests1, BroadcastDivideTest_1) {
     ASSERT_EQ(res.status(), ND4J_STATUS_OK);
     ASSERT_TRUE(res.at(0)->equalsTo(exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1421,7 +1421,7 @@ TEST_F(DeclarableOpsTests1, BroadcastDivideTest_2) {
     ASSERT_EQ(res.status(), ND4J_STATUS_OK);
     ASSERT_TRUE(res.at(0)->equalsTo(exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1437,7 +1437,7 @@ TEST_F(DeclarableOpsTests1, BroadcastDivideTest_3) {
     ASSERT_EQ(res.status(), ND4J_STATUS_OK);
     ASSERT_TRUE(res.at(0)->equalsTo(exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1463,7 +1463,7 @@ TEST_F(DeclarableOpsTests1, BroadcastReverseDivideTest_1) {
 
     ASSERT_TRUE(z.equalsTo(&exp));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1676,31 +1676,6 @@ TEST_F(DeclarableOpsTests1, ReverseDivideScalarScalar1) {
     delete block;
 }
 
-//////////////////////////////////////////////////////////////////////
-TEST_F(DeclarableOpsTests1, Reshapeas1) {
-    const std::vector<Nd4jLong> xShape = { 5,4,3 };
-    const std::vector<Nd4jLong> yShape = { 3,5,4 };
-
-    auto x = NDArrayFactory::create_<float>('f', xShape);
-    auto y = NDArrayFactory::create_<float>('f', yShape);
-
-
-    auto variableSpace = new VariableSpace();
-    variableSpace->putVariable(-1, x);
-    variableSpace->putVariable(-2, y);
-    auto block = new Context(1, variableSpace, true);
-    block->fillInputs({ -1, -2 });
-
-    sd::ops::reshapeas reshape;
-
-    reshape.execute(block);
-
-    ASSERT_TRUE(x->isSameShape(y));
-
-    delete variableSpace;
-    delete block;
-}
-
 TEST_F(DeclarableOpsTests1, Test_Cast_1) {
     // TODO: right now there's no real cast implementation, but genera idea should be the same: arrays equality to be expected
     auto x = NDArrayFactory::create<float>('c', { 5, 5 });
@@ -1715,7 +1690,7 @@ TEST_F(DeclarableOpsTests1, Test_Cast_1) {
     auto z = result.at(0);
     ASSERT_TRUE(yExp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1848,113 +1823,6 @@ TEST_F(DeclarableOpsTests1, TestGemv1) {
 
 #endif
 
-//////////////////////////////////////////////////////////////////////
-TEST_F(DeclarableOpsTests1, Reshape2) {
-    const std::vector<Nd4jLong> xShape = { 5,4,3 };
-    const std::vector<Nd4jLong> yShape = { 3,5,4 };
-
-    auto x = NDArrayFactory::create_<float>('c', xShape);
-    auto y = NDArrayFactory::create_<float>('c', yShape);
-
-    auto variableSpace = new VariableSpace();
-    variableSpace->putVariable(-1, x);
-    variableSpace->putVariable(1, new Variable());
-
-    auto block = new Context(1, variableSpace, false);
-    block->fillInputs({ -1 });
-    std::vector<int>* arguments = block->getIArguments();
-    arguments->push_back(-y->ordering());
-    arguments->push_back(3);
-    arguments->push_back(5);
-    arguments->push_back(4);
-
-    sd::ops::reshape reshape;
-
-    Nd4jStatus status = reshape.execute(block);
-    ASSERT_EQ(ND4J_STATUS_OK, status);
-    auto result = variableSpace->getVariable(block->getNodeId())->getNDArray();
-
-    ASSERT_TRUE(result->isSameShape(y));
-
-    delete y;
-    delete block;
-    delete variableSpace;
-}
-
-TEST_F(DeclarableOpsTests1, Reshape3) {
-    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({ &x }, {}, { -99, 3, 4, 5 });
-
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(x.isSameShape(z));
-
-    
-}
-
-TEST_F(DeclarableOpsTests1, Reshape4) {
-    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({ &x }, {}, { 3, 4, 5 });
-
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(x.isSameShape(z));
-
-    
-}
-
-TEST_F(DeclarableOpsTests1, Reshape5) {
-    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({ &x }, {}, { 5, 4, 3 });
-
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    
-}
-
-TEST_F(DeclarableOpsTests1, Reshape6) {
-    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
-    auto exp = NDArrayFactory::create<float>('c', { 4, 15 });
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({ &x }, {}, { 4, -1 });
-
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(z->isSameShape(exp));
-
-    
-
-}
-
-TEST_F(DeclarableOpsTests1, Reshape7) {
-    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
-    auto exp = NDArrayFactory::create<float>('c', { 60 });
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({ &x }, {}, { -1 });
-
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(z->isSameShape(exp));
-
-    
-
-}
 
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, Transpose1) {
@@ -1982,7 +1850,6 @@ TEST_F(DeclarableOpsTests1, Transpose1) {
     delete block;
     delete variableSpace;
 }
-
 
 //////////////////////////////////////////////////////////////////////
 // not-in-place
@@ -2259,7 +2126,7 @@ TEST_F(DeclarableOpsTests1, IsMax1) {
     //res->printIndexedBuffer("IS_MAX");
     ASSERT_TRUE(exp.equalsTo(res));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2281,7 +2148,7 @@ TEST_F(DeclarableOpsTests1, IsMax2) {
     //res->printIndexedBuffer("IS_MAX");
     ASSERT_TRUE(exp.equalsTo(res));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2303,7 +2170,7 @@ TEST_F(DeclarableOpsTests1, IsMax3) {
     //res->printIndexedBuffer("IS_MAX");
     ASSERT_TRUE(exp.equalsTo(res));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2352,7 +2219,7 @@ TEST_F(DeclarableOpsTests1, IsMax4) {
 //     ASSERT_TRUE(expState.equalsTo(state));
 //     ASSERT_TRUE(expOut.equalsTo(output));
 
-//     
+//
 // }
 
 //////////////////////////////////////////////////////////////////
@@ -2386,7 +2253,7 @@ TEST_F(DeclarableOpsTests1, sru_test1) {
     ASSERT_TRUE(expState.equalsTo(state));
     ASSERT_TRUE(expOut.equalsTo(output));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2438,7 +2305,7 @@ TEST_F(DeclarableOpsTests1, sru_bp) {
     ASSERT_TRUE(expGradB.equalsTo(gradB));
     ASSERT_TRUE(expGradInit.equalsTo(gradInit));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////
@@ -2474,7 +2341,7 @@ TEST_F(DeclarableOpsTests1, sru_bi_1) {
     ASSERT_TRUE(expState.equalsTo(state));
     ASSERT_TRUE(expOut.equalsTo(output));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, sru_bi_bp_1) {
@@ -2527,7 +2394,7 @@ TEST_F(DeclarableOpsTests1, sru_bi_bp_1) {
     ASSERT_TRUE(expGradB.equalsTo(gradB));
     ASSERT_TRUE(expGradInit.equalsTo(gradInit));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, ArgMax1) {
@@ -2547,7 +2414,7 @@ TEST_F(DeclarableOpsTests1, ArgMax1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -2568,7 +2435,7 @@ TEST_F(DeclarableOpsTests1, ArgMax2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -2590,7 +2457,7 @@ TEST_F(DeclarableOpsTests1, ArgMax3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, ArgMax4) {
@@ -2611,7 +2478,7 @@ TEST_F(DeclarableOpsTests1, ArgMax4) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -2633,7 +2500,7 @@ TEST_F(DeclarableOpsTests1, ArgMax5) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, ArgMax6) {
@@ -2676,7 +2543,7 @@ TEST_F(DeclarableOpsTests1, ArgMin1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -2697,7 +2564,7 @@ TEST_F(DeclarableOpsTests1, SquareTests1) {
 
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, OneHotTests_1) {
@@ -2717,7 +2584,7 @@ TEST_F(DeclarableOpsTests1, OneHotTests_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, OneHotTests_2) {
@@ -2736,7 +2603,7 @@ TEST_F(DeclarableOpsTests1, OneHotTests_2) {
 
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, OneHotTests_3) {
@@ -2756,7 +2623,7 @@ TEST_F(DeclarableOpsTests1, OneHotTests_3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, OneHotTests_4) {
@@ -2775,7 +2642,7 @@ TEST_F(DeclarableOpsTests1, OneHotTests_4) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, OneHotTests_5) {
@@ -2796,7 +2663,7 @@ TEST_F(DeclarableOpsTests1, OneHotTests_5) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, OneHotTests_6) {
@@ -2809,7 +2676,7 @@ TEST_F(DeclarableOpsTests1, OneHotTests_6) {
 
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, OneHotTests_7) {
@@ -2822,7 +2689,7 @@ TEST_F(DeclarableOpsTests1, OneHotTests_7) {
 
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, FillAs_1) {
@@ -2840,7 +2707,7 @@ TEST_F(DeclarableOpsTests1, FillAs_1) {
 
     ASSERT_NEAR(scalar, result.at(0)->meanNumber().e<float>(0), 1e-5f);
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2866,7 +2733,7 @@ TEST_F(DeclarableOpsTests1, Test_Range_Integer_1) {
     ASSERT_TRUE(exp.isSameShape(array));
     ASSERT_TRUE(exp.equalsTo(array));
 
-    
+
 }
 
 
@@ -2893,7 +2760,7 @@ TEST_F(DeclarableOpsTests1, Test_Range_Integer_2) {
     ASSERT_TRUE(exp.isSameShape(array));
     ASSERT_TRUE(exp.equalsTo(array));
 
-    
+
 }
 
 
@@ -2913,7 +2780,7 @@ TEST_F(DeclarableOpsTests1, Test_Range_Integer_3) {
     ASSERT_TRUE(exp.isSameShape(array));
     ASSERT_TRUE(exp.equalsTo(array));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2931,7 +2798,7 @@ TEST_F(DeclarableOpsTests1, softmax_test1) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2947,7 +2814,7 @@ TEST_F(DeclarableOpsTests1, softmax_test2) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2963,7 +2830,7 @@ TEST_F(DeclarableOpsTests1, softmax_test3) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2979,7 +2846,7 @@ TEST_F(DeclarableOpsTests1, softmax_test4) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2995,7 +2862,7 @@ TEST_F(DeclarableOpsTests1, softmax_test5) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3011,7 +2878,7 @@ TEST_F(DeclarableOpsTests1, softmax_test6) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3027,7 +2894,7 @@ TEST_F(DeclarableOpsTests1, softmax_test7) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3043,7 +2910,7 @@ TEST_F(DeclarableOpsTests1, softmax_test8) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3059,7 +2926,7 @@ TEST_F(DeclarableOpsTests1, softmax_test9) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, softmax_test10) {
@@ -3074,7 +2941,7 @@ TEST_F(DeclarableOpsTests1, softmax_test10) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, softmax_test11) {
@@ -3089,7 +2956,7 @@ TEST_F(DeclarableOpsTests1, softmax_test11) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3108,7 +2975,7 @@ TEST_F(DeclarableOpsTests1, softmax_test12) {
     ASSERT_TRUE(expOutput.isSameShape(z));
     ASSERT_TRUE(expOutput.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, Reverse_1) {
@@ -3132,7 +2999,7 @@ TEST_F(DeclarableOpsTests1, Reverse_1) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3157,7 +3024,7 @@ TEST_F(DeclarableOpsTests1, Reverse_2) {
     ASSERT_TRUE(expected.isSameShapeStrict(input));
     ASSERT_TRUE(expected.equalsTo(&input));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3183,7 +3050,7 @@ TEST_F(DeclarableOpsTests1, Reverse_3) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3209,7 +3076,7 @@ TEST_F(DeclarableOpsTests1, Reverse_4) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3234,7 +3101,7 @@ TEST_F(DeclarableOpsTests1, Reverse_5) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -3260,7 +3127,7 @@ TEST_F(DeclarableOpsTests1, Reverse_6) {
     ASSERT_TRUE(expected.isSameShapeStrict(input));
     ASSERT_TRUE(expected.equalsTo(&input));
 
-    
+
 }
 
 
@@ -3288,7 +3155,7 @@ TEST_F(DeclarableOpsTests1, Reverse_7) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 
@@ -3316,7 +3183,7 @@ TEST_F(DeclarableOpsTests1, Reverse_8) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -3341,7 +3208,7 @@ TEST_F(DeclarableOpsTests1, Reverse_9) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, Reverse_10) {
@@ -3357,7 +3224,7 @@ TEST_F(DeclarableOpsTests1, Reverse_10) {
     ASSERT_TRUE(e.isSameShape(z));
     ASSERT_TRUE(e.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3380,7 +3247,7 @@ TEST_F(DeclarableOpsTests1, Reverse_11) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3402,7 +3269,7 @@ TEST_F(DeclarableOpsTests1, Reverse_12) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3423,7 +3290,7 @@ TEST_F(DeclarableOpsTests1, Reverse_13) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -3444,7 +3311,7 @@ TEST_F(DeclarableOpsTests1, Reverse_14) {
     ASSERT_TRUE(expected.isSameShapeStrict(*result));
     ASSERT_TRUE(expected.equalsTo(result));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, Test_Expose_1) {
@@ -3463,7 +3330,7 @@ TEST_F(DeclarableOpsTests1, Test_Expose_1) {
     ASSERT_TRUE(input0.equalsTo(z0));
     ASSERT_TRUE(input1.equalsTo(z1));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests1, Test_Expose_2) {

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests14.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests14.cpp
@@ -51,23 +51,7 @@ TEST_F(DeclarableOpsTests14, Test_Validation_Edge_1) {
 
     ASSERT_EQ(exp, *z);
 
-    
-}
 
-TEST_F(DeclarableOpsTests14, Test_Reshape_CF_1) {
-    auto x = NDArrayFactory::create<double>('f', {2, 3}, {1.0, 4.0, 2.0, 5.0, 3.0, 6.0});
-    auto e = NDArrayFactory::create<double>('f', {3, 2}, {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
-
-    auto r = x.reshape('c', {3, 2});;
-    r.streamline('f');
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&x}, {3, 2});
-    ASSERT_EQ(Status::OK(), result.status());
-
-    auto z = result.at(0);
-
-    
 }
 
 TEST_F(DeclarableOpsTests14, Test_Inf_Comparison_1) {
@@ -108,7 +92,7 @@ TEST_F(DeclarableOpsTests14, Multiply_test) {
         ASSERT_EQ(e, r);
         ASSERT_EQ(e, *f);
 
-        
+
     }
 }
 
@@ -124,7 +108,7 @@ TEST_F(DeclarableOpsTests14, Test_EvalReductionShape_1) {
     auto z = result.at(0);
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Test_EvalReductionShape_2) {
@@ -139,7 +123,7 @@ TEST_F(DeclarableOpsTests14, Test_EvalReductionShape_2) {
     auto z = result.at(0);
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Test_Reduce_Min_Small_0) {
@@ -193,7 +177,7 @@ TEST_F(DeclarableOpsTests14, Test_scalar_broadcast_1) {
 
     ASSERT_EQ(e, *result.at(0));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Test_scalar_broadcast_2) {
@@ -210,7 +194,7 @@ TEST_F(DeclarableOpsTests14, Test_scalar_broadcast_2) {
 
     ASSERT_EQ(e, *result.at(0));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, test_empty_fill_1) {
@@ -224,7 +208,7 @@ TEST_F(DeclarableOpsTests14, test_empty_fill_1) {
     auto z = result.at(0);
     ASSERT_EQ(y, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, test_lstmBlockCell_1) {
@@ -259,7 +243,7 @@ TEST_F(DeclarableOpsTests14, test_empty_reduce_min_1) {
     auto out = res2.at(0);
 
     ASSERT_EQ(out->e<float>(0), DataTypeUtils::infOrMax<float>());
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, test_empty_reduce_max_1) {
@@ -271,7 +255,7 @@ TEST_F(DeclarableOpsTests14, test_empty_reduce_max_1) {
     auto out = res2.at(0);
 
     ASSERT_EQ(out->e<float>(0), -DataTypeUtils::infOrMax<float>());
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, test_empty_reduce_sum_1) {
@@ -286,7 +270,7 @@ TEST_F(DeclarableOpsTests14, test_empty_reduce_sum_1) {
     ASSERT_EQ(res2.status(), Status::OK());
     auto out = res2.at(0);
     ASSERT_EQ(out->e<float>(0), 0.f);
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, test_empty_reduce_mean_1) {
@@ -303,7 +287,7 @@ TEST_F(DeclarableOpsTests14, test_empty_reduce_mean_1) {
     // out->printShapeInfo("ReduceMean empty shape with keep dims");
     // out->printIndexedBuffer("ReduceMean scalar");
     ASSERT_TRUE(std::isnan(out->e<float>(0)));
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Test_StridedSliceZeros_1) {
@@ -324,7 +308,7 @@ TEST_F(DeclarableOpsTests14, Test_StridedSliceZeros_1) {
 
     ASSERT_TRUE(exp.isSameShape(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Test_StridedSliceZeros_2) {
@@ -345,7 +329,7 @@ TEST_F(DeclarableOpsTests14, Test_StridedSliceZeros_2) {
 
     ASSERT_TRUE(exp.isSameShape(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, test_empty_argmax_1) {
@@ -363,7 +347,7 @@ TEST_F(DeclarableOpsTests14, test_empty_argmax_1) {
 
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, test_empty_argmax_2) {
@@ -391,7 +375,7 @@ TEST_F(DeclarableOpsTests14, test_empty_tanh_5) {
     ASSERT_TRUE(x.isSameShape(z));
     ASSERT_EQ(x, *z);
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -409,7 +393,7 @@ TEST_F(DeclarableOpsTests14, repeat_1) {
     ASSERT_TRUE(e.isSameShape(z));
     ASSERT_TRUE(e.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -427,7 +411,7 @@ TEST_F(DeclarableOpsTests14, repeat_2) {
     ASSERT_TRUE(e.isSameShape(z));
     ASSERT_TRUE(e.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -445,7 +429,7 @@ TEST_F(DeclarableOpsTests14, repeat_3) {
     ASSERT_TRUE(e.isSameShape(z));
     ASSERT_TRUE(e.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -463,7 +447,7 @@ TEST_F(DeclarableOpsTests14, repeat_4) {
     ASSERT_TRUE(e.isSameShape(z));
     ASSERT_TRUE(e.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -481,7 +465,7 @@ TEST_F(DeclarableOpsTests14, repeat_5) {
     ASSERT_TRUE(e.isSameShape(z));
     ASSERT_TRUE(e.equalsTo(z));
 
-    
+
 }
 /////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, Test_broadcast_SpecialCaseTest) {
@@ -502,7 +486,7 @@ TEST_F(DeclarableOpsTests14, Test_broadcast_SpecialCaseTest) {
 
     ASSERT_EQ(e, res);
 
-    
+
 }
 /////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, Test_broadcast_SpecialCaseTest2) {
@@ -523,7 +507,7 @@ TEST_F(DeclarableOpsTests14, Test_broadcast_SpecialCaseTest2) {
 
     ASSERT_EQ(e, res);
 
-    
+
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -639,7 +623,7 @@ TEST_F(DeclarableOpsTests14, matmul_test1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -661,7 +645,7 @@ TEST_F(DeclarableOpsTests14, matmul_test2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -682,7 +666,7 @@ TEST_F(DeclarableOpsTests14, matmul_test3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -704,7 +688,7 @@ TEST_F(DeclarableOpsTests14, matmul_test4) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -726,7 +710,7 @@ TEST_F(DeclarableOpsTests14, matmul_test5) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -747,7 +731,7 @@ TEST_F(DeclarableOpsTests14, matmul_test6) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -770,7 +754,7 @@ TEST_F(DeclarableOpsTests14, matmul_test7) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -795,7 +779,7 @@ TEST_F(DeclarableOpsTests14, matmul_test8) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -820,7 +804,7 @@ TEST_F(DeclarableOpsTests14, matmul_test9) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, matmul_test10) {
@@ -876,7 +860,7 @@ TEST_F(DeclarableOpsTests14, matmul_test11) {
 
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, matmul_test12) {
@@ -894,7 +878,7 @@ TEST_F(DeclarableOpsTests14, matmul_test12) {
     ASSERT_TRUE(exp.equalsTo(z));
 
 
-    
+
 }
 
 
@@ -914,7 +898,7 @@ TEST_F(DeclarableOpsTests14, matmul_test13) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, matmul_test14) {
@@ -933,7 +917,7 @@ TEST_F(DeclarableOpsTests14, matmul_test14) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, matmul_test15) {
@@ -952,7 +936,7 @@ TEST_F(DeclarableOpsTests14, matmul_test15) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, matmul_test16) {
@@ -971,7 +955,7 @@ TEST_F(DeclarableOpsTests14, matmul_test16) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, matmul_test17) {
@@ -985,7 +969,7 @@ TEST_F(DeclarableOpsTests14, matmul_test17) {
 
     ASSERT_EQ(exp, *result.at(0));
 
-    
+
 }
 
 
@@ -1007,7 +991,7 @@ TEST_F(DeclarableOpsTests14, matmul_test18) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1027,7 +1011,7 @@ TEST_F(DeclarableOpsTests14, matmul_test19) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1048,7 +1032,7 @@ TEST_F(DeclarableOpsTests14, matmul_test20) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1069,7 +1053,7 @@ TEST_F(DeclarableOpsTests14, matmul_test21) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1090,7 +1074,7 @@ TEST_F(DeclarableOpsTests14, matmul_test22) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1111,7 +1095,7 @@ TEST_F(DeclarableOpsTests14, matmul_test23) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1135,7 +1119,7 @@ TEST_F(DeclarableOpsTests14, matmul_test24) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1156,7 +1140,7 @@ TEST_F(DeclarableOpsTests14, matmul_test25) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1177,7 +1161,7 @@ TEST_F(DeclarableOpsTests14, matmul_test26) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1198,7 +1182,7 @@ TEST_F(DeclarableOpsTests14, matmul_test27) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -1220,7 +1204,7 @@ TEST_F(DeclarableOpsTests14, matmul_test28) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -1242,7 +1226,7 @@ TEST_F(DeclarableOpsTests14, matmul_test29) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test30) {
@@ -1262,7 +1246,7 @@ TEST_F(DeclarableOpsTests14, matmul_test30) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test31) {
@@ -1282,7 +1266,7 @@ TEST_F(DeclarableOpsTests14, matmul_test31) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test32) {
@@ -1299,7 +1283,7 @@ TEST_F(DeclarableOpsTests14, matmul_test32) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 /////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test33) {
@@ -1319,7 +1303,7 @@ TEST_F(DeclarableOpsTests14, matmul_test33) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test34) {
@@ -1336,7 +1320,7 @@ TEST_F(DeclarableOpsTests14, matmul_test34) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test35) {
@@ -1353,7 +1337,7 @@ TEST_F(DeclarableOpsTests14, matmul_test35) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test36) {
@@ -1370,7 +1354,7 @@ TEST_F(DeclarableOpsTests14, matmul_test36) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests14, matmul_test37) {
@@ -1617,7 +1601,7 @@ TEST_F(DeclarableOpsTests14, Stack_1) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 
 }
 
@@ -1645,7 +1629,7 @@ TEST_F(DeclarableOpsTests14, Stack_2) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 
@@ -1673,7 +1657,7 @@ TEST_F(DeclarableOpsTests14, Stack_3) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1700,7 +1684,7 @@ TEST_F(DeclarableOpsTests14, Stack_4) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1727,7 +1711,7 @@ TEST_F(DeclarableOpsTests14, Stack_5) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1754,7 +1738,7 @@ TEST_F(DeclarableOpsTests14, Stack_6) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 
@@ -1778,7 +1762,7 @@ TEST_F(DeclarableOpsTests14, Stack_7) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1801,7 +1785,7 @@ TEST_F(DeclarableOpsTests14, Stack_8) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1824,7 +1808,7 @@ TEST_F(DeclarableOpsTests14, Stack_9) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1850,7 +1834,7 @@ TEST_F(DeclarableOpsTests14, Stack_10) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Stack_11) {
@@ -1872,7 +1856,7 @@ TEST_F(DeclarableOpsTests14, Stack_11) {
     ASSERT_TRUE(expected.isSameShapeStrict(*output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 
@@ -1895,7 +1879,7 @@ TEST_F(DeclarableOpsTests14, Stack_12) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1917,7 +1901,7 @@ TEST_F(DeclarableOpsTests14, Stack_13) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1941,7 +1925,7 @@ TEST_F(DeclarableOpsTests14, Stack_14) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Stack_15) {
@@ -1959,7 +1943,7 @@ TEST_F(DeclarableOpsTests14, Stack_15) {
 
     ASSERT_TRUE(exp.isSameShape(z));
 
-    
+
 }
 
 
@@ -1978,7 +1962,7 @@ TEST_F(DeclarableOpsTests14, Stack_16) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Stack_17) {
@@ -1999,7 +1983,7 @@ TEST_F(DeclarableOpsTests14, Stack_17) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Stack_18) {
@@ -2018,8 +2002,8 @@ TEST_F(DeclarableOpsTests14, Stack_18) {
     auto out = res2.at(0);
 
     ASSERT_EQ(out->e<float>(0), DataTypeUtils::infOrMax<float>());
-    
-    
+
+
 }
 
 TEST_F(DeclarableOpsTests14, Stack_19) {
@@ -2033,7 +2017,7 @@ TEST_F(DeclarableOpsTests14, Stack_19) {
     auto z = result.at(0);
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Stack_20) {
@@ -2047,7 +2031,7 @@ TEST_F(DeclarableOpsTests14, Stack_20) {
     auto z = result.at(0);
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests14, Stack_21) {
@@ -2073,7 +2057,363 @@ TEST_F(DeclarableOpsTests14, Stack_21) {
 
     ASSERT_TRUE(outStack->isSameShape(outConcat));
     ASSERT_TRUE(outStack->equalsTo(outConcat));
+}
+
+//////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests14, Reshape1) {
+    const std::vector<Nd4jLong> xShape = { 5,4,3 };
+    const std::vector<Nd4jLong> yShape = { 3,5,4 };
+
+    auto x = NDArrayFactory::create_<float>('f', xShape);
+    auto y = NDArrayFactory::create_<float>('f', yShape);
+
+
+    auto variableSpace = new VariableSpace();
+    variableSpace->putVariable(-1, x);
+    variableSpace->putVariable(-2, y);
+    auto block = new Context(1, variableSpace, true);
+    block->fillInputs({ -1, -2 });
+
+    sd::ops::reshapeas reshape;
+
+    reshape.execute(block);
+
+    ASSERT_TRUE(x->isSameShape(y));
+
+    delete variableSpace;
+    delete block;
+}
+
+//////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests14, Reshape2) {
+    const std::vector<Nd4jLong> xShape = { 5,4,3 };
+    const std::vector<Nd4jLong> yShape = { 3,5,4 };
+
+    auto x = NDArrayFactory::create_<float>('c', xShape);
+    auto y = NDArrayFactory::create_<float>('c', yShape);
+
+    auto variableSpace = new VariableSpace();
+    variableSpace->putVariable(-1, x);
+    variableSpace->putVariable(1, new Variable());
+
+    auto block = new Context(1, variableSpace, false);
+    block->fillInputs({ -1 });
+    std::vector<int>* arguments = block->getIArguments();
+    arguments->push_back(-y->ordering());
+    arguments->push_back(3);
+    arguments->push_back(5);
+    arguments->push_back(4);
+
+    sd::ops::reshape reshape;
+
+    Nd4jStatus status = reshape.execute(block);
+    ASSERT_EQ(ND4J_STATUS_OK, status);
+    auto result = variableSpace->getVariable(block->getNodeId())->getNDArray();
+
+    ASSERT_TRUE(result->isSameShape(y));
+
+    delete y;
+    delete block;
+    delete variableSpace;
+}
+
+TEST_F(DeclarableOpsTests14, Reshape3) {
+    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({ &x }, {}, { -99, 3, 4, 5 });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(x.isSameShape(z));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape4) {
+    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({ &x }, {}, { 3, 4, 5 });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(x.isSameShape(z));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape5) {
+    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({ &x }, {}, { 5, 4, 3 });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+}
+
+TEST_F(DeclarableOpsTests14, Reshape6) {
+    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
+    auto exp = NDArrayFactory::create<float>('c', { 4, 15 });
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({ &x }, {}, { 4, -1 });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(z->isSameShape(exp));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape7) {
+    auto x = NDArrayFactory::create<float>('c', { 3, 4, 5 });
+    auto exp = NDArrayFactory::create<float>('c', { 60 });
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({ &x }, {}, { -1 });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(z->isSameShape(exp));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape8) {
+    auto x = NDArrayFactory::create<double>('f', {2, 3}, {1.0, 4.0, 2.0, 5.0, 3.0, 6.0});
+    auto e = NDArrayFactory::create<double>('f', {3, 2}, {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
+
+    auto r = x.reshape('c', {3, 2});;
+    r.streamline('f');
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&x}, {3, 2});
+    ASSERT_EQ(Status::OK(), result.status());
+
+    auto z = result.at(0);
+}
+
+TEST_F(DeclarableOpsTests14, Reshape9) {
+    auto array = NDArrayFactory::create<float>(119.f);
+    auto e = NDArrayFactory::create<float>('c', {1, 1}, {119.f});
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&array}, {}, {1, 1});
+    ASSERT_EQ(Status::OK(), result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_EQ(e, *z);
+}
+
+TEST_F(DeclarableOpsTests14, Reshape10) {
+    auto array = NDArrayFactory::create<float>(119.f);
+    auto e = NDArrayFactory::create<float>('c', {1, 1}, {119.f});
+    auto z = NDArrayFactory::create<float>('c', {1, 1});
+
+    sd::ops::reshape op;
+    auto result = op.execute({&array}, {&z}, {}, {1, 1}, {});
+    ASSERT_EQ(Status::OK(), result);
+    ASSERT_EQ(e, z);
+}
+
+TEST_F(DeclarableOpsTests14, Reshape11) {
+    auto x = NDArrayFactory::create<double>('c', {4, 3});
+    auto exp = NDArrayFactory::create<double>('c', {4, 3});
+
+    x.linspace(1);
+    exp.linspace(1);
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&x}, {-99, 4, 3});
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(z));
+    ASSERT_TRUE(exp.equalsTo(z));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape12) {
+    auto x = NDArrayFactory::create<double>('c', {2, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8});
+    auto shape = NDArrayFactory::create<Nd4jLong>('c', {2}, {-1, 2});
+    auto exp = NDArrayFactory::create<double>('c', {4, 2}, {1, 2, 3, 4, 5, 6, 7, 8});
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&x, &shape});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(z));
+    ASSERT_TRUE(exp.equalsTo(z));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape13) {
+    auto vector = NDArrayFactory::create<float>('c', {1}, {119.0f});
+    auto exp = NDArrayFactory::create<float>(119.f);
+    auto empty = NDArrayFactory::empty_<int>();
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&vector, empty}, {}, {});
+
+    ASSERT_EQ(Status::OK(), result.status());
+
+    ASSERT_EQ(exp, *result.at(0));
+
+    delete empty;
+}
+
+TEST_F(DeclarableOpsTests14, Reshape14) {
+    auto x = NDArrayFactory::create<float>('c', {1, 0, 0, 2});
+    auto y = NDArrayFactory::create<int>('c', {2}, {10, 0});
+    auto e = NDArrayFactory::create<float>('c', {10, 0});
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&x, &y}, {}, {});
+    ASSERT_EQ(Status::OK(), result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(e.isSameShape(z));
+    ASSERT_EQ(e, *z);
 
 }
 
+TEST_F(DeclarableOpsTests14, Reshape15) {
 
+    auto x0 = NDArrayFactory::create<float>('c', {2, 0});
+    auto x1 = NDArrayFactory::create<float>('c', {0, 1, 2});
+
+    auto shape0 = NDArrayFactory::create<Nd4jLong>('c', {3}, {2, 0, -1});
+    auto shape1 = NDArrayFactory::create<Nd4jLong>('c', {2}, {-1, 1});
+
+    auto e0 = NDArrayFactory::create<float>('c', {2, 0, 0});
+    auto e1 = NDArrayFactory::create<float>('c', {0, 1});
+
+    sd::ops::reshape op;
+    auto result0 = op.evaluate({&x0, &shape0}, {}, {});
+    ASSERT_EQ(Status::OK(), result0.status());
+    auto z0 = result0.at(0);
+    ASSERT_EQ(e0, *z0);
+
+    auto result1 = op.evaluate({&x1, &shape1}, {}, {});
+    ASSERT_EQ(Status::OK(), result1.status());
+    auto z1 = result1.at(0);
+    ASSERT_EQ(e1, *z1);
+}
+
+TEST_F(DeclarableOpsTests14, Reshape16) {
+    auto x = NDArrayFactory::create<int>('c', {2, 2}, {1, 2, 3, 4});
+    auto shape = NDArrayFactory::create<int>('c', {1, 3}, {1, 2, 2});
+
+    auto exp = NDArrayFactory::create<int>('c', {1, 2, 2}, {1, 2, 3, 4});
+
+    sd::ops::reshape op;
+
+    auto result = op.evaluate({&x, &shape}, {}, {});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(z));
+    ASSERT_TRUE(exp.equalsTo(z));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape17) {
+    auto x = NDArrayFactory::create<float>(2.0f);
+    auto exp = NDArrayFactory::create<float>('c', {1, 1, 1}, {2.0f});
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&x}, {}, {-99, 1, 1, 1});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(z));
+    ASSERT_TRUE(exp.equalsTo(z));
+}
+
+TEST_F(DeclarableOpsTests14, Reshape18) {
+    auto x = NDArrayFactory::create<float>('c', {1, 3}, {1, 2, 3});
+    auto exp = NDArrayFactory::create<float>('c', {3}, {1, 2, 3});
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&x}, {}, {-99, 3});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(z));
+    ASSERT_TRUE(exp.equalsTo(z));
+
+
+}
+
+TEST_F(DeclarableOpsTests14, Reshape19) {
+    auto x = NDArrayFactory::create<float>('c', {3}, {1, 2, 3});
+    auto exp = NDArrayFactory::create<float>('c', {1, 3}, {1, 2, 3});
+
+    sd::ops::reshape op;
+    auto result = op.evaluate({&x}, {}, {-99, 1, 3});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto z = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(z));
+    ASSERT_TRUE(exp.equalsTo(z));
+}
+
+
+TEST_F(DeclarableOpsTests14, Reshape20) {
+
+    NDArray x1('c', {2,0}, sd::DataType::FLOAT32);
+    NDArray x2('c', {10,0}, sd::DataType::FLOAT32);
+    NDArray x3('c', {2,0,0,10}, sd::DataType::FLOAT32);
+    NDArray x4('c', {0,0,10}, sd::DataType::FLOAT32);
+    NDArray x5('c', {0,2,10}, sd::DataType::FLOAT32);
+    NDArray x6('c', {0,10,0}, sd::DataType::FLOAT32);
+    NDArray x7('c', {0,1,2}, sd::DataType::FLOAT32);
+
+    sd::ops::reshape op;
+
+    auto result = op.evaluate({&x1}, {}, {2, -1});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({2,0}));
+
+    result = op.evaluate({&x2}, {}, {2, 0, -1});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({2,0,5}));
+
+    result = op.evaluate({&x2}, {}, {5, 2, -1});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({5,2,0}));
+
+    result = op.evaluate({&x2}, {}, {-1, 2, 0});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({5,2,0}));
+
+    result = op.evaluate({&x3}, {}, {2, 0, -1});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({2,0,10}));
+
+    result = op.evaluate({&x4}, {}, {2, -1, 0});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({2,5,0}));
+
+    result = op.evaluate({&x5}, {}, {2, 0, 0, 0, -1});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({2,0,0,0,10}));
+
+    result = op.evaluate({&x6}, {}, {-1, 2, 0});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({5, 2, 0}));
+
+    result = op.evaluate({&x7}, {}, {-1, 0});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({2, 0}));
+
+    result = op.evaluate({&x7}, {}, {10,0,50,100});
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+    ASSERT_TRUE(result.at(0)->isSameShape({10,0,50,100}));
+}

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests15.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests15.cpp
@@ -89,7 +89,7 @@ TEST_F(DeclarableOpsTests15, Test_standarize_bp_1) {
     sd::ops::standardize_bp op;
     auto result = op.evaluate({&x, &eps}, {0});
     ASSERT_EQ(Status::OK(), result.status());
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_AdjustContrast_1) {
@@ -108,7 +108,7 @@ TEST_F(DeclarableOpsTests15, Test_AdjustContrast_1) {
     auto out = result.at(0);
 
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_AdjustContrast_2) {
@@ -126,7 +126,7 @@ TEST_F(DeclarableOpsTests15, Test_AdjustContrast_2) {
     auto out = result.at(0);
 //    out->printIndexedBuffer("Adjusted Constrast");
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_AdjustContrast_3) {
@@ -144,7 +144,7 @@ TEST_F(DeclarableOpsTests15, Test_AdjustContrast_3) {
     auto out = result.at(0);
 //    out->printIndexedBuffer("Adjusted Constrast");
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_AdjustContrast_4) {
@@ -162,7 +162,7 @@ TEST_F(DeclarableOpsTests15, Test_AdjustContrast_4) {
     auto out = result.at(0);
 //    out->printIndexedBuffer("Adjusted Constrast");
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_AdjustContrast_5) {
@@ -177,7 +177,7 @@ TEST_F(DeclarableOpsTests15, Test_AdjustContrast_5) {
     auto out = result.at(0);
 //    out->printIndexedBuffer("Adjusted Constrast");
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 /*
@@ -308,7 +308,7 @@ TEST_F(DeclarableOpsTests15, Test_AdjustContrast_6) {
 //    out->printBuffer("Adjusted Constrast6");
 //    e.printBuffer("Adjusted Expected 6");
 //    ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_AdjustContrast_7) {
@@ -415,7 +415,7 @@ TEST_F(DeclarableOpsTests15, Test_AdjustContrast_7) {
     auto diff = e - *out;
 //    diff.printBuffer("Adjusted subtract 7");
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_BitCast_1) {
@@ -429,7 +429,7 @@ TEST_F(DeclarableOpsTests15, Test_BitCast_1) {
     auto out = result.at(0);
 //    out->printIndexedBuffer("Casted result");
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_BitCast_2) {
@@ -444,7 +444,7 @@ TEST_F(DeclarableOpsTests15, Test_BitCast_2) {
     auto out = result.at(0);
 
     ASSERT_TRUE(e.equalsTo(out));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_BitCast_3) {
@@ -487,7 +487,7 @@ TEST_F(DeclarableOpsTests15, Test_BitCast_4_1) {
     //    e.printIndexedBuffer("Double to int64");
     auto res = result.at(0);
     ASSERT_EQ(*res, e);
-    
+
 }
 
 
@@ -508,7 +508,7 @@ TEST_F(DeclarableOpsTests15, Test_BitCast_5) {
 
 //    res->printIndexedBuffer("BITCAST5");
     ASSERT_TRUE(e.equalsTo(res));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_BitCast_6) {
@@ -528,7 +528,7 @@ TEST_F(DeclarableOpsTests15, Test_BitCast_6) {
 
 //    res->printIndexedBuffer("BITCAST6");
     ASSERT_TRUE(e.equalsTo(res));
-    
+
 }
 TEST_F(DeclarableOpsTests15, Test_BitCast_7) {
     auto x = NDArrayFactory::create<float16>('c', {4, 4}, {
@@ -547,7 +547,7 @@ TEST_F(DeclarableOpsTests15, Test_BitCast_7) {
 
 //    res->printIndexedBuffer("BITCAST7");
     ASSERT_TRUE(e.equalsTo(res));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, test_matmul_bp_1) {
@@ -637,7 +637,7 @@ TEST_F(DeclarableOpsTests15, Test_layer_norm_1) {
     sd::ops::layer_norm op;
     auto result = op.evaluate({&x, &g, &b}, {}, {0}, {false});
     ASSERT_EQ(Status::OK(), result.status());
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Test_layer_norm_bp_1) {
@@ -649,7 +649,7 @@ TEST_F(DeclarableOpsTests15, Test_layer_norm_bp_1) {
     sd::ops::layer_norm_bp op;
     auto result = op.evaluate({&x, &g, &b, &eps}, {}, {0}, {false});
     ASSERT_EQ(Status::OK(), result.status());
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -710,30 +710,6 @@ TEST_F(DeclarableOpsTests15, test_hashCode_2) {
     ASSERT_NE(*resultA0.at(0), *resultB0.at(0));
 }
 
-TEST_F(DeclarableOpsTests15, test_reshape_to_scalar_1) {
-    auto array = NDArrayFactory::create<float>(119.f);
-    auto e = NDArrayFactory::create<float>('c', {1, 1}, {119.f});
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&array}, {}, {1, 1});
-    ASSERT_EQ(Status::OK(), result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_EQ(e, *z);
-}
-
-TEST_F(DeclarableOpsTests15, test_reshape_to_scalar_2) {
-    auto array = NDArrayFactory::create<float>(119.f);
-    auto e = NDArrayFactory::create<float>('c', {1, 1}, {119.f});
-    auto z = NDArrayFactory::create<float>('c', {1, 1});
-
-    sd::ops::reshape op;
-    auto result = op.execute({&array}, {&z}, {}, {1, 1}, {});
-    ASSERT_EQ(Status::OK(), result);
-    ASSERT_EQ(e, z);
-}
-
 TEST_F(DeclarableOpsTests15, test_rank_1) {
     auto array = NDArrayFactory::create<float>('c', {4, 64});
     auto e = NDArrayFactory::create<int>('c', {}, {2});
@@ -757,7 +733,7 @@ TEST_F(DeclarableOpsTests15, test_rank_2) {
 
     ASSERT_EQ(e, *z);
 
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, test_lstmBlock_1) {
@@ -800,7 +776,7 @@ TEST_F(DeclarableOpsTests15, test_lstmBlock_2) {
     ASSERT_EQ(Status::OK(), result.status());
 
     auto z = result.at(0);
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, test_lstmBlock_3) {
@@ -969,7 +945,7 @@ TEST_F(DeclarableOpsTests15, test_rgb_to_grs_8) {
         sd::ops::rgb_to_grs op;
         auto result = op.evaluate({ &rgbs }, {}, {});
         ASSERT_EQ(Status::THROW(), result.status());
-        
+
     } catch (std::exception& e) {
         nd4j_printf("Error should be here `%s'. It's OK.\n", e.what());
     }
@@ -1063,7 +1039,7 @@ TEST_F(DeclarableOpsTests15, test_rgb_to_yuv_5) {
     ASSERT_EQ(Status::OK(), result.status());
     ASSERT_TRUE(expected.isSameShape(output));
     ASSERT_TRUE(expected.equalsTo(output));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1074,7 +1050,7 @@ TEST_F(DeclarableOpsTests15, test_rgb_to_yuv_6) {
         sd::ops::rgb_to_yuv op;
         auto result = op.evaluate({ &rgbs }, {}, {});
         ASSERT_EQ(Status::THROW(), result.status());
-        
+
     }
     catch (std::exception & e) {
         nd4j_printf("Error should be here `%s'. It's OK.\n", e.what());
@@ -1109,7 +1085,7 @@ TEST_F(DeclarableOpsTests15, test_yuv_to_rgb_1) {
     ASSERT_TRUE(expected.isSameShape(output));
     ASSERT_TRUE(expected.equalsTo(output));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1168,7 +1144,7 @@ TEST_F(DeclarableOpsTests15, test_yuv_to_rgb_5) {
     ASSERT_EQ(Status::OK(), result.status());
     ASSERT_TRUE(expected.isSameShape(output));
     ASSERT_TRUE(expected.equalsTo(output));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1179,7 +1155,7 @@ TEST_F(DeclarableOpsTests15, test_yuv_to_rgb_6) {
         sd::ops::yuv_to_rgb op;
         auto result = op.evaluate({ &yuv }, {}, {});
         ASSERT_EQ(Status::THROW(), result.status());
-        
+
     }
     catch (std::exception & e) {
         nd4j_printf("Error should be here `%s'. It's OK.\n", e.what());
@@ -1423,7 +1399,7 @@ TEST_F(DeclarableOpsTests15, Pow_BP_Test8) {
     ASSERT_TRUE(dLdxExp.equalsTo(dLdx));
     ASSERT_TRUE(dLdyExp.isSameShape(dLdy));
     ASSERT_TRUE(dLdyExp.equalsTo(dLdy));
-    
+
 }
 
 TEST_F(DeclarableOpsTests15, Pow_BP_Test9) {
@@ -1515,7 +1491,7 @@ TEST_F(DeclarableOpsTests15, Pow_BP_Test11) {
             ASSERT_NEAR(dLdyB->e<float>(i), dLdyExpB.e<float>(i), 0.00001);
     }
 
-    
+
 }
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests15, TestTensorMmul_BP1) {
@@ -1532,10 +1508,10 @@ TEST_F(DeclarableOpsTests15, TestTensorMmul_BP1) {
     auto resultsBP = op_bp.evaluate({ &A, &B, &dLdC }, {}, { 2,0,1, 2,0,1 }, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, resultsBP.status());
-    
+
     auto* dLdAbp = resultsBP.at(0);
     auto* dLdBbp = resultsBP.at(1);
-    
+
     ASSERT_TRUE(dLdA.isSameShape(*dLdAbp));
     ASSERT_TRUE(dLdA.equalsTo(*dLdAbp));
 
@@ -1554,10 +1530,10 @@ TEST_F(DeclarableOpsTests15, TestTensorMmul_BP2) {
     auto resultsBP = op_bp.evaluate({ &A, &B, &dLdC }, {}, { 2,1,2, 2,1,2 }, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, resultsBP.status());
-    
+
     auto* dLdAbp = resultsBP.at(0);
     auto* dLdBbp = resultsBP.at(1);
-    
+
     ASSERT_TRUE(B.isSameShape(*dLdAbp));
     ASSERT_TRUE(B.equalsTo(*dLdAbp));
 
@@ -1606,7 +1582,7 @@ TEST_F(DeclarableOpsTests15, TestTensorMmul_BP4) {
     auto resultsBP = op_bp.evaluate({ &A, &B, &dLdC }, {}, { 2,1,2, 2,1,2 }, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, resultsBP.status());
-    
+
     auto* dLdAbp = resultsBP.at(0);
     auto* dLdBbp = resultsBP.at(1);
 
@@ -1632,7 +1608,7 @@ TEST_F(DeclarableOpsTests15, TestTensorMmul_BP5) {
     auto resultsBP = op_bp.evaluate({ &A, &B, &dLdC }, {}, { 2,1,2, 2,1,2 }, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, resultsBP.status());
-    
+
     auto* dLdAbp = resultsBP.at(0);
     auto* dLdBbp = resultsBP.at(1);
 
@@ -1655,7 +1631,7 @@ TEST_F(DeclarableOpsTests15, TestTensorMmul_BP6) {
     auto resultsBP = op_bp.evaluate({ &A, &B, &dLdC }, {}, { 3,0,1,2, 3,0,1,2 }, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, resultsBP.status());
-    
+
     auto* dLdAbp = resultsBP.at(0);
     auto* dLdBbp = resultsBP.at(1);
 
@@ -1706,7 +1682,7 @@ TEST_F(DeclarableOpsTests15, TestTensorMmul_BP8) {
     auto resultsBP = op_bp.evaluate({ &A, &B, &dLdC }, {}, { 3,0,1,2, 3,0,1,2 }, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, resultsBP.status());
-    
+
     auto* dLdAbp = resultsBP.at(0);
     auto* dLdBbp = resultsBP.at(1);
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests4.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests4.cpp
@@ -791,24 +791,6 @@ TEST_F(DeclarableOpsTests4, Test_FloorTests_1) {
 
 }
 
-TEST_F(DeclarableOpsTests4, Test_Reshape_Again) {
-    auto x = NDArrayFactory::create<double>('c', {4, 3});
-    auto exp = NDArrayFactory::create<double>('c', {4, 3});
-
-    x.linspace(1);
-    exp.linspace(1);
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&x}, {-99, 4, 3});
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(exp.isSameShape(z));
-    ASSERT_TRUE(exp.equalsTo(z));
-
-
-}
-
 TEST_F(DeclarableOpsTests4, Test_Split_1) {
     auto x = NDArrayFactory::create<double>('c', {5, 30});
     auto sizes = NDArrayFactory::create<int>('c', {1, 3}, {4, 15, 11});
@@ -1204,23 +1186,6 @@ TEST_F(DeclarableOpsTests4, Test_Add_119) {
     auto z = result.at(0);
 
     ASSERT_EQ(2, z->rankOf());
-
-    ASSERT_TRUE(exp.isSameShape(z));
-    ASSERT_TRUE(exp.equalsTo(z));
-
-
-}
-
-TEST_F(DeclarableOpsTests4, Test_Reshape_Negative_1) {
-    auto x = NDArrayFactory::create<double>('c', {2, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8});
-    auto shape = NDArrayFactory::create<Nd4jLong>('c', {2}, {-1, 2});
-    auto exp = NDArrayFactory::create<double>('c', {4, 2}, {1, 2, 3, 4, 5, 6, 7, 8});
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&x, &shape});
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests5.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests5.cpp
@@ -2432,18 +2432,36 @@ TEST_F(DeclarableOpsTests5, ZeroFraction_3) {
 
     
 }
-
 ////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests5, XWPlusB_1) {
 
-    auto x = NDArrayFactory::create<double>('c', {2,3}, { 1.f, 11.f,  3.f, 14.f,  5.f,  6.f});
-    auto y = NDArrayFactory::create<double>('c', {3,2}, { 11.f,  3.f, 4.f,  5.f, 6.f,  2.f});
-    auto b = NDArrayFactory::create<double>({100.f, 200.f});
+    auto x = NDArrayFactory::create<float>('c', { 2,3 }, { 1.f, 11.f,  3.f, 14.f,  5.f,  6.f });
+    auto y = NDArrayFactory::create<float>('c', { 3,2 }, { 11.f,  3.f, 4.f,  5.f, 6.f,  2.f });
+    auto b = NDArrayFactory::create<float>({ 100.f, 200.f });
 
-    auto exp = NDArrayFactory::create<double>('c', {2,2}, {173.f, 264.f, 310.f, 279.f});
+    auto exp = NDArrayFactory::create<float>('c', { 2,2 }, { 173.f, 264.f, 310.f, 279.f });
 
     sd::ops::xw_plus_b op;
-    auto result = op.evaluate({&x, &y, &b}, {}, {});
+    auto result = op.evaluate({ &x, &y, &b });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto output = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+}
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests5, XWPlusB_2) {
+
+    auto x = NDArrayFactory::create<float>('c', { 1, 2 }, { 1.f, 11.f });
+    auto y = NDArrayFactory::create<float>('c', { 2, 3 }, { 11.f,  3.f, 4.f,  5.f, 6.f,  2.f });
+    auto b = NDArrayFactory::create<float>({ 100.f, 200.f, 300.f });
+
+    auto exp = NDArrayFactory::create<float>('c', { 1, 3 }, { 166.f, 269.f, 326.f });
+
+    sd::ops::xw_plus_b op;
+    auto result = op.evaluate({ &x, &y, &b }, {}, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, result.status());
 
@@ -2452,9 +2470,107 @@ TEST_F(DeclarableOpsTests5, XWPlusB_1) {
     ASSERT_TRUE(exp.isSameShape(output));
     ASSERT_TRUE(exp.equalsTo(output));
 
-    
 }
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests5, XWPlusB_3) {
 
+    auto x = NDArrayFactory::create<float>('c', { 1, 2 }, { 1.f, 11.f });
+    auto y = NDArrayFactory::create<float>('c', { 2, 1 }, { 11.f,  3.f });
+    auto b = NDArrayFactory::create<float>('c', { 1 }, { 200.f });
+
+    auto exp = NDArrayFactory::create<float>('c', { 1,1 }, { 244.f });
+
+    sd::ops::xw_plus_b op;
+    auto result = op.evaluate({ &x, &y, &b });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto output = result.at(0);
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+}
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests5, XWPlusB_4) {
+
+    auto x = NDArrayFactory::create<float>('f', { 2,3 }, { 1.f, 11.f,  3.f, 14.f,  5.f,  6.f });
+    auto y = NDArrayFactory::create<float>('f', { 3,2 }, { 11.f,  3.f, 4.f,  5.f, 6.f,  2.f });
+    auto b = NDArrayFactory::create<float>({ 100.f, 200.f });
+
+    auto exp = NDArrayFactory::create<float>('f', { 2,2 }, { 140.f, 287.f, 233.f,  351.f });
+
+    sd::ops::xw_plus_b op;
+    auto result = op.evaluate({ &x, &y, &b });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto output = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+}
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests5, XWPlusB_5) {
+
+    auto x = NDArrayFactory::create<float>('c', { 2,3 }, { 1.f, 11.f,  3.f, 14.f,  5.f,  6.f });
+    auto y = NDArrayFactory::create<float>('c', { 3,2 }, { 11.f,  3.f, 4.f,  5.f, 6.f,  2.f });
+
+    y = y.transpose();
+
+    auto b = NDArrayFactory::create<float>({ 100.f, 200.f });
+
+    auto exp = NDArrayFactory::create<float>('c', { 2,2 }, { 173.f, 264.f, 310.f, 279.f });
+
+
+    sd::ops::xw_plus_b op;
+    auto result = op.evaluate({ &x, &y, &b }, {}, { 1 });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto output = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+}
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests5, XWPlusB_6) {
+
+    auto x = NDArrayFactory::create<float>('c', { 3, 2 }, { 1.f, 11.f,  3.f, 14.f,  5.f,  6.f });
+    auto y = NDArrayFactory::create<float>('c', { 2, 1 }, { 11.f,  3.f });
+
+    auto b = NDArrayFactory::create<float>('c', { 1 }, { 100.f });
+
+    auto exp = NDArrayFactory::create<float>('c', { 3, 1 }, { 144.f, 175.f, 173.f });
+
+    sd::ops::xw_plus_b op;
+    auto result = op.evaluate({ &x, &y, &b });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto output = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+}
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests5, XWPlusB_7) {
+
+    auto x = NDArrayFactory::create<float>('c', { 3, 4 }, { 1.f, 11.f,  3.f, 14.f,  5.f,  6.f, 1.f, 11.f,  3.f, 14.f,  5.f,  6.f });
+    auto y = NDArrayFactory::create<float>('c', { 4, 5 }, { 11.f,  3.f, 11.f,  3.f, 11.f,  3.f, 11.f,  3.f, 11.f,  3.f, 11.f,  3.f, 11.f,  3.f, 11.f,  3.f, 3.f, 11.f, 3.f, 11.f });
+
+    auto b = NDArrayFactory::create<float>('c', { 5 }, { 100.f, 200.f, 300.f, 400.f, 500.f });
+
+    auto exp = NDArrayFactory::create<float>('c', { 3, 5 }, { 219.f, 375.f, 531.f, 575.f, 731.f, 217.f, 317.f, 505.f, 517.f, 705.f, 248.f, 396.f, 496.f, 596.f, 696.f });
+
+    sd::ops::xw_plus_b op;
+    auto result = op.evaluate({ &x, &y, &b });
+
+    ASSERT_EQ(ND4J_STATUS_OK, result.status());
+
+    auto output = result.at(0);
+
+    ASSERT_TRUE(exp.isSameShape(output));
+    ASSERT_TRUE(exp.equalsTo(output));
+}
 ////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests5, StopGradient_1) {
 

--- a/libnd4j/tests_cpu/layers_tests/EmptyTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/EmptyTests.cpp
@@ -140,37 +140,6 @@ TEST_F(EmptyTests, Test_Concat_4) {
     ASSERT_EQ(exp, *z);
 }
 
-TEST_F(EmptyTests, Test_Reshape_1) {
-    auto vector = NDArrayFactory::create<float>('c', {1}, {119.0f});
-    auto exp = NDArrayFactory::create<float>(119.f);
-    auto empty = NDArrayFactory::empty_<int>();
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&vector, empty}, {}, {});
-
-    ASSERT_EQ(Status::OK(), result.status());
-
-    ASSERT_EQ(exp, *result.at(0));
-
-    delete empty;
-}
-
-TEST_F(EmptyTests, Test_Reshape_3) {
-    auto x = NDArrayFactory::create<float>('c', {1, 0, 0, 2});
-    auto y = NDArrayFactory::create<int>('c', {2}, {10, 0});
-    auto e = NDArrayFactory::create<float>('c', {10, 0});
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&x, &y}, {}, {});
-    ASSERT_EQ(Status::OK(), result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(e.isSameShape(z));
-    ASSERT_EQ(e, *z);
-
-}
-
 TEST_F(EmptyTests, Test_dup_1) {
     auto empty = NDArrayFactory::empty<int>();
     auto dup = new NDArray(empty.dup());
@@ -254,41 +223,6 @@ TEST_F(EmptyTests, test_shaped_empty_4) {
     ASSERT_TRUE(array.isEmpty());
     ASSERT_EQ(1, array.rankOf());
     ASSERT_EQ(shapeOf, array.getShapeAsVector());
-}
-
-TEST_F(EmptyTests, test_empty_reshape_1) {
-    /*
-    INDArray arr0 = Nd4j.create(DataType.FLOAT, 2, 0);
-    INDArray arr1 = Nd4j.create(DataType.FLOAT, 0, 1, 2);
-
-    INDArray out0 = Nd4j.exec(new Reshape(arr0, Nd4j.createFromArray(2, 0, -1), Nd4j.create(DataType.FLOAT, 2, 0, 0)))[0];
-    INDArray out1 = Nd4j.exec(new Reshape(arr1, Nd4j.createFromArray(-1, 1), Nd4j.create(DataType.FLOAT, 0, 1)))[0];
-    INDArray out2 = Nd4j.exec(new Reshape(arr1, Nd4j.createFromArray(10, -1), Nd4j.create(DataType.FLOAT, 10, 0)))[0];
-
-    assertArrayEquals(new long[]{2, 0, 0}, out0.shape());
-    assertArrayEquals(new long[]{0, 1}, out1.shape());
-    assertArrayEquals(new long[]{10, 0}, out2.shape());
-     */
-    auto x0 = NDArrayFactory::create<float>('c', {2, 0});
-    auto x1 = NDArrayFactory::create<float>('c', {0, 1, 2});
-
-    auto shape0 = NDArrayFactory::create<Nd4jLong>('c', {3}, {2, 0, -1});
-    auto shape1 = NDArrayFactory::create<Nd4jLong>('c', {2}, {-1, 1});
-
-    auto e0 = NDArrayFactory::create<float>('c', {2, 0, 0});
-    auto e1 = NDArrayFactory::create<float>('c', {0, 1});
-
-    sd::ops::reshape op;
-    auto result0 = op.evaluate({&x0, &shape0}, {}, {});
-    ASSERT_EQ(Status::OK(), result0.status());
-    auto z0 = result0.at(0);
-    ASSERT_EQ(e0, *z0);
-
-    auto result1 = op.evaluate({&x1, &shape1}, {}, {});
-    ASSERT_EQ(Status::OK(), result1.status());
-    auto z1 = result1.at(0);
-    ASSERT_EQ(e1, *z1);
-
 }
 
 

--- a/libnd4j/tests_cpu/layers_tests/MklDnnTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/MklDnnTests.cpp
@@ -76,8 +76,13 @@ TEST_F(MklDnnTests, helpers_includer) {
     sd::ops::platforms::PLATFORM_tanh_ENGINE_CPU tanh;
 
     sd::ops::platforms::PLATFORM_tanh_ENGINE_CPU tanh_bp;
+   
+    sd::ops::platforms::PLATFORM_xw_plus_b_ENGINE_CPU xw_plus_b;
 
-    printer({&conv2d, &conv2d_bp, &conv3d, &conv3d_bp, &avgpool2d, &avgpool2d_bp, &maxpool2d, &maxpool2d_bp, &avgpool3d, &avgpool3d_bp, &maxpool3d, &maxpool3d_bp, &lrn, &batchnorm, &matmul, &softmax, &softmax_bp, &tanh, &tanh_bp });
+    sd::ops::platforms::PLATFORM_xw_plus_b_bp_ENGINE_CPU xw_plus_b_bp;
 
+
+    printer({&conv2d, &conv2d_bp, &conv3d, &conv3d_bp, &avgpool2d, &avgpool2d_bp, &maxpool2d, &maxpool2d_bp, &avgpool3d, &avgpool3d_bp, &maxpool3d, &maxpool3d_bp, &lrn, &batchnorm, &matmul, &softmax, &softmax_bp, &tanh, &tanh_bp, &xw_plus_b, &xw_plus_b_bp });
+    
 #endif
 }

--- a/libnd4j/tests_cpu/layers_tests/ParityOpsTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ParityOpsTests.cpp
@@ -48,7 +48,7 @@ TEST_F(ParityOpsTests, TestZeroAs1) {
     ASSERT_TRUE(z->isSameShape(&x));
     ASSERT_TRUE(z->equalsTo(&exp));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestMaximum1) {
@@ -66,7 +66,7 @@ TEST_F(ParityOpsTests, TestMaximum1) {
 
     ASSERT_TRUE(y.equalsTo(z));
 
-    
+
 }
 
 
@@ -86,7 +86,7 @@ TEST_F(ParityOpsTests, TestMinimum1) {
 
     ASSERT_TRUE(y.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestTear1) {
@@ -106,7 +106,7 @@ TEST_F(ParityOpsTests, TestTear1) {
     for (int e = 0; e < result.size(); e++)
         ASSERT_TRUE(tads.at(e)->equalsTo(result.at(e)));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack1) {
@@ -126,7 +126,7 @@ TEST_F(ParityOpsTests, TestUnstack1) {
     for (int e = 0; e < result.size(); e++)
         ASSERT_TRUE(tads.at(e)->equalsTo(result.at(e)));
 
-    
+
 }
 
 
@@ -148,7 +148,7 @@ TEST_F(ParityOpsTests, TestUnstack2) {
     for (int e = 0; e < result.size(); e++)
         ASSERT_TRUE(tads.at(e)->equalsTo(result.at(e)));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack3) {
@@ -166,7 +166,7 @@ TEST_F(ParityOpsTests, TestUnstack3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -185,7 +185,7 @@ TEST_F(ParityOpsTests, TestUnstack4) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack5) {
@@ -203,7 +203,7 @@ TEST_F(ParityOpsTests, TestUnstack5) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack6) {
@@ -221,7 +221,7 @@ TEST_F(ParityOpsTests, TestUnstack6) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack7) {
@@ -239,7 +239,7 @@ TEST_F(ParityOpsTests, TestUnstack7) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack8) {
@@ -257,7 +257,7 @@ TEST_F(ParityOpsTests, TestUnstack8) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack9) {
@@ -275,7 +275,7 @@ TEST_F(ParityOpsTests, TestUnstack9) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -293,7 +293,7 @@ TEST_F(ParityOpsTests, TestUnstack10) {
     ASSERT_TRUE(exp.isSameShape(result.at(1)));
     ASSERT_TRUE(exp.isSameShape(result.at(2)));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -310,7 +310,7 @@ TEST_F(ParityOpsTests, TestUnstack11) {
     ASSERT_TRUE(exp.isSameShape(result.at(0)));
     ASSERT_TRUE(exp.isSameShape(result.at(1)));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -325,7 +325,7 @@ TEST_F(ParityOpsTests, TestUnstack12) {
 
     ASSERT_TRUE(result.size() == 0);
 
-    
+
 }
 
 TEST_F(ParityOpsTests, TestUnstack13) {
@@ -361,7 +361,7 @@ TEST_F(ParityOpsTests, ExpandDimsTest1) {
     ASSERT_TRUE(reshaped.isSameShape(z));
     ASSERT_TRUE(reshaped.equalsTo(z));
 
-    
+
 }
 
 
@@ -380,7 +380,7 @@ TEST_F(ParityOpsTests, ExpandDimsTest2) {
     ASSERT_TRUE(reshaped.isSameShape(z));
     ASSERT_TRUE(reshaped.equalsTo(z));
 
-    
+
 }
 
 
@@ -399,7 +399,7 @@ TEST_F(ParityOpsTests, ExpandDimsTest3) {
     ASSERT_TRUE(reshaped.isSameShape(z));
     ASSERT_TRUE(reshaped.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, ExpandDimsTest4) {
@@ -417,7 +417,7 @@ TEST_F(ParityOpsTests, ExpandDimsTest4) {
     ASSERT_TRUE(reshaped.isSameShape(z));
     ASSERT_TRUE(reshaped.equalsTo(z));
 
-    
+
 }
 
 
@@ -434,7 +434,7 @@ TEST_F(ParityOpsTests, Test_Shape_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -452,7 +452,7 @@ TEST_F(ParityOpsTests, Test_Equals_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -470,7 +470,7 @@ TEST_F(ParityOpsTests, Test_NotEquals_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Less_1) {
@@ -487,7 +487,7 @@ TEST_F(ParityOpsTests, Test_Less_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_LessEquals_1) {
@@ -504,7 +504,7 @@ TEST_F(ParityOpsTests, Test_LessEquals_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_GreaterEquals_1) {
@@ -521,7 +521,7 @@ TEST_F(ParityOpsTests, Test_GreaterEquals_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_GreaterEquals_2) {
@@ -538,7 +538,7 @@ TEST_F(ParityOpsTests, Test_GreaterEquals_2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Greater_1) {
@@ -555,7 +555,7 @@ TEST_F(ParityOpsTests, Test_Greater_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Where_1) {
@@ -575,7 +575,7 @@ TEST_F(ParityOpsTests, Test_Where_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Where_2) {
@@ -593,7 +593,7 @@ TEST_F(ParityOpsTests, Test_Where_2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -612,7 +612,7 @@ TEST_F(ParityOpsTests, Test_Where_3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Select_1) {
@@ -630,7 +630,7 @@ TEST_F(ParityOpsTests, Test_Select_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Select_2) {
@@ -648,7 +648,7 @@ TEST_F(ParityOpsTests, Test_Select_2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Select_3) {
@@ -666,25 +666,7 @@ TEST_F(ParityOpsTests, Test_Select_3) {
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
-    
-}
 
-TEST_F(ParityOpsTests, Test_Reshape_TF_1) {
-    auto x = NDArrayFactory::create<int>('c', {2, 2}, {1, 2, 3, 4});
-    auto shape = NDArrayFactory::create<int>('c', {1, 3}, {1, 2, 2});
-
-    auto exp = NDArrayFactory::create<int>('c', {1, 2, 2}, {1, 2, 3, 4});
-
-    sd::ops::reshape op;
-
-    auto result = op.evaluate({&x, &shape}, {}, {});
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(exp.isSameShape(z));
-    ASSERT_TRUE(exp.equalsTo(z));
-    
 }
 
 TEST_F(ParityOpsTests, Test_Bias_Add_1) {
@@ -702,7 +684,7 @@ TEST_F(ParityOpsTests, Test_Bias_Add_1) {
     for (int e = 0; e < tads.size(); e++) {
         ASSERT_TRUE(bias.equalsTo(tads.at(e)));
     }
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Scatter_Add_1) {
@@ -718,7 +700,7 @@ TEST_F(ParityOpsTests, Test_Scatter_Add_1) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Scatter_Add_2) {
@@ -735,7 +717,7 @@ TEST_F(ParityOpsTests, Test_Scatter_Add_2) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Scatter_Add_3) {
@@ -751,7 +733,7 @@ TEST_F(ParityOpsTests, Test_Scatter_Add_3) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Scatter_Add_4) {
@@ -767,7 +749,7 @@ TEST_F(ParityOpsTests, Test_Scatter_Add_4) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Scatter_Add_5) {
@@ -784,7 +766,7 @@ TEST_F(ParityOpsTests, Test_Scatter_Add_5) {
     // z->printBuffer();
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Scatter_Add_6) {
@@ -800,7 +782,7 @@ TEST_F(ParityOpsTests, Test_Scatter_Add_6) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, Test_Scatter_Add_7) {
@@ -816,7 +798,7 @@ TEST_F(ParityOpsTests, Test_Scatter_Add_7) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -864,7 +846,7 @@ TEST_F(ParityOpsTests, scatterMax_test1) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMax_test2) {
@@ -880,7 +862,7 @@ TEST_F(ParityOpsTests, scatterMax_test2) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMax_test3) {
@@ -897,7 +879,7 @@ TEST_F(ParityOpsTests, scatterMax_test3) {
 
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMax_test4) {
@@ -913,7 +895,7 @@ TEST_F(ParityOpsTests, scatterMax_test4) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMax_test5) {
@@ -929,7 +911,7 @@ TEST_F(ParityOpsTests, scatterMax_test5) {
     auto z = result.at(0);
 
    ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMax_test6) {
@@ -945,7 +927,7 @@ TEST_F(ParityOpsTests, scatterMax_test6) {
     auto z = result.at(0);
 
    ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 
@@ -963,7 +945,7 @@ TEST_F(ParityOpsTests, scatterMin_test1) {
 
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMin_test2) {
@@ -979,7 +961,7 @@ TEST_F(ParityOpsTests, scatterMin_test2) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMin_test3) {
@@ -995,7 +977,7 @@ TEST_F(ParityOpsTests, scatterMin_test3) {
     auto z = result.at(0);
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 TEST_F(ParityOpsTests, scatterMin_test4) {
@@ -1012,7 +994,7 @@ TEST_F(ParityOpsTests, scatterMin_test4) {
     // z->printBuffer();
 
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1044,7 +1026,7 @@ TEST_F(ParityOpsTests, scatterND_test1) {
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1064,7 +1046,7 @@ TEST_F(ParityOpsTests, scatterND_test2) {
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1088,7 +1070,7 @@ TEST_F(ParityOpsTests, scatterND_test3) {
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1107,7 +1089,7 @@ TEST_F(ParityOpsTests, scatterND_test4) {
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1127,7 +1109,7 @@ TEST_F(ParityOpsTests, scatterND_test5) {
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1154,7 +1136,7 @@ TEST_F(ParityOpsTests, scatterND_test6) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1181,7 +1163,7 @@ TEST_F(ParityOpsTests, scatterND_test7) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1202,7 +1184,7 @@ TEST_F(ParityOpsTests, scatterND_test8) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1236,7 +1218,7 @@ TEST_F(ParityOpsTests, scatterND_add_test1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1260,7 +1242,7 @@ TEST_F(ParityOpsTests, scatterND_add_test2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1283,7 +1265,7 @@ TEST_F(ParityOpsTests, scatterND_add_test3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1310,7 +1292,7 @@ TEST_F(ParityOpsTests, scatterND_add_test4) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1346,7 +1328,7 @@ TEST_F(ParityOpsTests, scatterND_add_test5) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1379,7 +1361,7 @@ TEST_F(ParityOpsTests, scatterND_sub_test1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1404,7 +1386,7 @@ TEST_F(ParityOpsTests, scatterND_sub_test2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1427,7 +1409,7 @@ TEST_F(ParityOpsTests, scatterND_sub_test3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1454,7 +1436,7 @@ TEST_F(ParityOpsTests, scatterND_sub_test4) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1490,7 +1472,7 @@ TEST_F(ParityOpsTests, scatterND_sub_test5) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -1511,7 +1493,7 @@ TEST_F(ParityOpsTests, scatterND_update_test1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1535,7 +1517,7 @@ TEST_F(ParityOpsTests, scatterND_update_test2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1559,7 +1541,7 @@ TEST_F(ParityOpsTests, scatterND_update_test3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1586,7 +1568,7 @@ TEST_F(ParityOpsTests, scatterND_update_test4) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1622,7 +1604,7 @@ TEST_F(ParityOpsTests, scatterND_update_test5) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1655,7 +1637,7 @@ TEST_F(ParityOpsTests, scatter_update_1) {
     ASSERT_TRUE(exp.isSameShape(x));
     ASSERT_TRUE(exp.equalsTo(x));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1674,7 +1656,7 @@ TEST_F(ParityOpsTests, scatter_update_2) {
     ASSERT_TRUE(exp.isSameShape(x));
     ASSERT_TRUE(exp.equalsTo(x));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1693,7 +1675,7 @@ TEST_F(ParityOpsTests, scatter_update_3) {
     ASSERT_TRUE(exp.isSameShape(x));
     ASSERT_TRUE(exp.equalsTo(x));
 
-    
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1712,5 +1694,5 @@ TEST_F(ParityOpsTests, scatter_update_4) {
     ASSERT_TRUE(exp.isSameShape(x));
     ASSERT_TRUE(exp.equalsTo(x));
 
-    
+
 }

--- a/libnd4j/tests_cpu/layers_tests/ScalarTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ScalarTests.cpp
@@ -103,7 +103,7 @@ TEST_F(ScalarTests, Test_Concat_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -124,7 +124,7 @@ TEST_F(ScalarTests, Test_Concat_2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -146,7 +146,7 @@ TEST_F(ScalarTests, Test_Concat_3) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ScalarTests, Test_ExpandDims_1) {
@@ -163,7 +163,7 @@ TEST_F(ScalarTests, Test_ExpandDims_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ScalarTests, Test_Squeeze_1) {
@@ -179,26 +179,8 @@ TEST_F(ScalarTests, Test_Squeeze_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
-
-
-TEST_F(ScalarTests, Test_Reshape_1) {
-    auto x = NDArrayFactory::create<float>(2.0f);
-    auto exp = NDArrayFactory::create<float>('c', {1, 1, 1}, {2.0f});
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&x}, {}, {-99, 1, 1, 1});
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(exp.isSameShape(z));
-    ASSERT_TRUE(exp.equalsTo(z));
-
-    
-}
-
 
 TEST_F(ScalarTests, Test_Permute_1) {
     auto x = NDArrayFactory::create<float>(3.0f);
@@ -213,7 +195,7 @@ TEST_F(ScalarTests, Test_Permute_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(ScalarTests, Test_Concat_Scalar_1) {

--- a/libnd4j/tests_cpu/layers_tests/SingleDimTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/SingleDimTests.cpp
@@ -77,7 +77,7 @@ TEST_F(SingleDimTests, Test_Concat_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(SingleDimTests, Test_Reduce_1) {
@@ -111,7 +111,7 @@ TEST_F(SingleDimTests, Test_ExpandDims_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -129,7 +129,7 @@ TEST_F(SingleDimTests, Test_ExpandDims_2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 
@@ -149,7 +149,7 @@ TEST_F(SingleDimTests, Test_Squeeze_1) {
     ASSERT_EQ(exp.rankOf(), z->rankOf());
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
 
 TEST_F(SingleDimTests, Test_Squeeze_2) {
@@ -165,41 +165,8 @@ TEST_F(SingleDimTests, Test_Squeeze_2) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }
-
-TEST_F(SingleDimTests, Test_Reshape_1) {
-    auto x = NDArrayFactory::create<float>('c', {1, 3}, {1, 2, 3});
-    auto exp = NDArrayFactory::create<float>('c', {3}, {1, 2, 3});
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&x}, {}, {-99, 3});
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(exp.isSameShape(z));
-    ASSERT_TRUE(exp.equalsTo(z));
-
-    
-}
-
-TEST_F(SingleDimTests, Test_Reshape_2) {
-    auto x = NDArrayFactory::create<float>('c', {3}, {1, 2, 3});
-    auto exp = NDArrayFactory::create<float>('c', {1, 3}, {1, 2, 3});
-
-    sd::ops::reshape op;
-    auto result = op.evaluate({&x}, {}, {-99, 1, 3});
-    ASSERT_EQ(ND4J_STATUS_OK, result.status());
-
-    auto z = result.at(0);
-
-    ASSERT_TRUE(exp.isSameShape(z));
-    ASSERT_TRUE(exp.equalsTo(z));
-
-    
-}
-
 
 TEST_F(SingleDimTests, Test_Permute_1) {
     auto x = NDArrayFactory::create<float>('c', {3}, {1, 2, 3});
@@ -214,5 +181,5 @@ TEST_F(SingleDimTests, Test_Permute_1) {
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
 
-    
+
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/Agent.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/Agent.java
@@ -1,0 +1,210 @@
+package org.deeplearning4j.rl4j.agent;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import org.deeplearning4j.rl4j.agent.listener.AgentListener;
+import org.deeplearning4j.rl4j.agent.listener.AgentListenerList;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.environment.StepResult;
+import org.deeplearning4j.rl4j.observation.Observation;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.deeplearning4j.rl4j.policy.IPolicy;
+import org.nd4j.base.Preconditions;
+
+import java.util.Map;
+
+public class Agent<ACTION> {
+    @Getter
+    private final String id;
+
+    @Getter
+    private final Environment<ACTION> environment;
+
+    @Getter
+    private final IPolicy<ACTION> policy;
+
+    private final TransformProcess transformProcess;
+
+    protected final AgentListenerList<ACTION> listeners;
+
+    private final Integer maxEpisodeSteps;
+
+    @Getter(AccessLevel.PROTECTED)
+    private Observation observation;
+
+    @Getter(AccessLevel.PROTECTED)
+    private ACTION lastAction;
+
+    @Getter
+    private int episodeStepNumber;
+
+    @Getter
+    private double reward;
+
+    protected boolean canContinue;
+
+    private Agent(Builder<ACTION> builder) {
+        this.environment = builder.environment;
+        this.transformProcess = builder.transformProcess;
+        this.policy = builder.policy;
+        this.maxEpisodeSteps = builder.maxEpisodeSteps;
+        this.id = builder.id;
+
+        listeners = buildListenerList();
+    }
+
+    protected AgentListenerList<ACTION> buildListenerList() {
+        return new AgentListenerList<ACTION>();
+    }
+
+    public void addListener(AgentListener listener) {
+        listeners.add(listener);
+    }
+
+    public void run() {
+        runEpisode();
+    }
+
+    protected void onBeforeEpisode() {
+        // Do Nothing
+    }
+
+    protected void onAfterEpisode() {
+        // Do Nothing
+    }
+
+    protected void runEpisode() {
+        reset();
+        onBeforeEpisode();
+
+        canContinue = listeners.notifyBeforeEpisode(this);
+
+        while (canContinue && !environment.isEpisodeFinished() && (maxEpisodeSteps == null || episodeStepNumber < maxEpisodeSteps)) {
+            performStep();
+        }
+
+        if(!canContinue) {
+            return;
+        }
+
+        onAfterEpisode();
+    }
+
+    protected void reset() {
+        resetEnvironment();
+        resetPolicy();
+        reward = 0;
+        lastAction = getInitialAction();
+        canContinue = true;
+    }
+
+    protected void resetEnvironment() {
+        episodeStepNumber = 0;
+        Map<String, Object> channelsData = environment.reset();
+        this.observation = transformProcess.transform(channelsData, episodeStepNumber, false);
+    }
+
+    protected void resetPolicy() {
+        policy.reset();
+    }
+
+    protected ACTION getInitialAction() {
+        return environment.getSchema().getActionSchema().getNoOp();
+    }
+
+    protected void performStep() {
+
+        onBeforeStep();
+
+        ACTION action = decideAction(observation);
+
+        canContinue = listeners.notifyBeforeStep(this, observation, action);
+        if(!canContinue) {
+            return;
+        }
+
+        StepResult stepResult = act(action);
+        handleStepResult(stepResult);
+
+        onAfterStep(stepResult);
+
+        canContinue = listeners.notifyAfterStep(this, stepResult);
+        if(!canContinue) {
+            return;
+        }
+
+        incrementEpisodeStepNumber();
+    }
+
+    protected void incrementEpisodeStepNumber() {
+        ++episodeStepNumber;
+    }
+
+    protected ACTION decideAction(Observation observation) {
+        if (!observation.isSkipped()) {
+            lastAction = policy.nextAction(observation);
+        }
+
+        return lastAction;
+    }
+
+    protected StepResult act(ACTION action) {
+        return environment.step(action);
+    }
+
+    protected void handleStepResult(StepResult stepResult) {
+        observation = convertChannelDataToObservation(stepResult, episodeStepNumber + 1);
+        reward +=computeReward(stepResult);
+    }
+
+    protected Observation convertChannelDataToObservation(StepResult stepResult, int episodeStepNumberOfObs) {
+        return transformProcess.transform(stepResult.getChannelsData(), episodeStepNumberOfObs, stepResult.isTerminal());
+    }
+
+    protected double computeReward(StepResult stepResult) {
+        return stepResult.getReward();
+    }
+
+    protected void onAfterStep(StepResult stepResult) {
+        // Do Nothing
+    }
+
+    protected void onBeforeStep() {
+        // Do Nothing
+    }
+
+    public static <ACTION> Builder<ACTION> builder(@NonNull Environment<ACTION> environment, @NonNull TransformProcess transformProcess, @NonNull IPolicy<ACTION> policy) {
+        return new Builder<>(environment, transformProcess, policy);
+    }
+
+    public static class Builder<ACTION> {
+        private final Environment<ACTION> environment;
+        private final TransformProcess transformProcess;
+        private final IPolicy<ACTION> policy;
+        private Integer maxEpisodeSteps = null; // Default, no max
+        private String id;
+
+        public Builder(@NonNull Environment<ACTION> environment, @NonNull TransformProcess transformProcess, @NonNull IPolicy<ACTION> policy) {
+            this.environment = environment;
+            this.transformProcess = transformProcess;
+            this.policy = policy;
+        }
+
+        public Builder<ACTION> maxEpisodeSteps(int maxEpisodeSteps) {
+            Preconditions.checkArgument(maxEpisodeSteps > 0, "maxEpisodeSteps must be greater than 0, got", maxEpisodeSteps);
+            this.maxEpisodeSteps = maxEpisodeSteps;
+
+            return this;
+        }
+
+        public Builder<ACTION> id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Agent build() {
+            return new Agent(this);
+        }
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListener.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListener.java
@@ -1,0 +1,23 @@
+package org.deeplearning4j.rl4j.agent.listener;
+
+import org.deeplearning4j.rl4j.agent.Agent;
+import org.deeplearning4j.rl4j.environment.StepResult;
+import org.deeplearning4j.rl4j.observation.Observation;
+
+public interface AgentListener<ACTION> {
+    enum ListenerResponse {
+        /**
+         * Tell the learning process to continue calling the listeners and the training.
+         */
+        CONTINUE,
+
+        /**
+         * Tell the learning process to stop calling the listeners and terminate the training.
+         */
+        STOP,
+    }
+
+    AgentListener.ListenerResponse onBeforeEpisode(Agent agent);
+    AgentListener.ListenerResponse onBeforeStep(Agent agent, Observation observation, ACTION action);
+    AgentListener.ListenerResponse onAfterStep(Agent agent, StepResult stepResult);
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListenerList.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListenerList.java
@@ -1,0 +1,50 @@
+package org.deeplearning4j.rl4j.agent.listener;
+
+import org.deeplearning4j.rl4j.agent.Agent;
+import org.deeplearning4j.rl4j.environment.StepResult;
+import org.deeplearning4j.rl4j.observation.Observation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AgentListenerList<ACTION> {
+    protected final List<AgentListener<ACTION>> listeners = new ArrayList<>();
+
+    /**
+     * Add a listener at the end of the list
+     * @param listener The listener to be added
+     */
+    public void add(AgentListener<ACTION> listener) {
+        listeners.add(listener);
+    }
+
+    public boolean notifyBeforeEpisode(Agent<ACTION> agent) {
+        for (AgentListener<ACTION> listener : listeners) {
+            if (listener.onBeforeEpisode(agent) == AgentListener.ListenerResponse.STOP) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public boolean notifyBeforeStep(Agent<ACTION> agent, Observation observation, ACTION action) {
+        for (AgentListener<ACTION> listener : listeners) {
+            if (listener.onBeforeStep(agent, observation, action) == AgentListener.ListenerResponse.STOP) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public boolean notifyAfterStep(Agent<ACTION> agent, StepResult stepResult) {
+        for (AgentListener<ACTION> listener : listeners) {
+            if (listener.onAfterStep(agent, stepResult) == AgentListener.ListenerResponse.STOP) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/ActionSchema.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/ActionSchema.java
@@ -1,0 +1,9 @@
+package org.deeplearning4j.rl4j.environment;
+
+import lombok.Value;
+
+@Value
+public class ActionSchema<ACTION> {
+    private ACTION noOp;
+    //FIXME ACTION randomAction();
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/Environment.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/Environment.java
@@ -1,0 +1,11 @@
+package org.deeplearning4j.rl4j.environment;
+
+import java.util.Map;
+
+public interface Environment<ACTION> {
+    Schema<ACTION> getSchema();
+    Map<String, Object> reset();
+    StepResult step(ACTION action);
+    boolean isEpisodeFinished();
+    void close();
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/Schema.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/Schema.java
@@ -1,0 +1,8 @@
+package org.deeplearning4j.rl4j.environment;
+
+import lombok.Value;
+
+@Value
+public class Schema<ACTION> {
+    private ActionSchema<ACTION> actionSchema;
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/StepResult.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/StepResult.java
@@ -1,0 +1,12 @@
+package org.deeplearning4j.rl4j.environment;
+
+import lombok.Value;
+
+import java.util.Map;
+
+@Value
+public class StepResult {
+    private Map<String, Object> channelsData;
+    private double reward;
+    private boolean terminal;
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/ILearning.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/ILearning.java
@@ -28,7 +28,7 @@ import org.deeplearning4j.rl4j.space.Encodable;
  */
 public interface ILearning<O, A, AS extends ActionSpace<A>> {
 
-    IPolicy<O, A> getPolicy();
+    IPolicy<A> getPolicy();
 
     void train();
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThread.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThread.java
@@ -199,7 +199,7 @@ public abstract class AsyncThread<O, A, AS extends ActionSpace<A>, NN extends Ne
 
     protected abstract AsyncConfiguration getConf();
 
-    protected abstract IPolicy<O, A> getPolicy(NN net);
+    protected abstract IPolicy<A> getPolicy(NN net);
 
     protected abstract SubEpochReturn trainSubEpoch(Observation obs, int nstep);
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscrete.java
@@ -66,7 +66,7 @@ public abstract class AsyncThreadDiscrete<O, NN extends NeuralNet>
         Stack<MiniTrans<Integer>> rewards = new Stack<>();
 
         Observation obs = sObs;
-        IPolicy<O, Integer> policy = getPolicy(current);
+        IPolicy<Integer> policy = getPolicy(current);
 
         Integer action;
         Integer lastAction = getMdp().getActionSpace().noOp();

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/a3c/discrete/A3CThreadDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/a3c/discrete/A3CThreadDiscrete.java
@@ -69,7 +69,7 @@ public class A3CThreadDiscrete<O extends Encodable> extends AsyncThreadDiscrete<
     }
 
     @Override
-    protected Policy<O, Integer> getPolicy(IActorCritic net) {
+    protected Policy<Integer> getPolicy(IActorCritic net) {
         return new ACPolicy(net, rnd);
     }
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/nstep/discrete/AsyncNStepQLearningDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/nstep/discrete/AsyncNStepQLearningDiscrete.java
@@ -58,7 +58,7 @@ public abstract class AsyncNStepQLearningDiscrete<O extends Encodable>
         return asyncGlobal.getCurrent();
     }
 
-    public IPolicy<O, Integer> getPolicy() {
+    public IPolicy<Integer> getPolicy() {
         return new DQNPolicy<O>(getNeuralNet());
     }
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/nstep/discrete/AsyncNStepQLearningThreadDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/nstep/discrete/AsyncNStepQLearningThreadDiscrete.java
@@ -65,7 +65,7 @@ public class AsyncNStepQLearningThreadDiscrete<O extends Encodable> extends Asyn
         }
     }
 
-    public Policy<O, Integer> getPolicy(IDQN nn) {
+    public Policy<Integer> getPolicy(IDQN nn) {
         return new EpsGreedy(new DQNPolicy(nn), getMdp(), conf.getUpdateStart(), conf.getEpsilonNbStep(),
                 rnd, conf.getMinEpsilon(), this);
     }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/CartpoleEnvironment.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/CartpoleEnvironment.java
@@ -1,0 +1,129 @@
+package org.deeplearning4j.rl4j.mdp;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.deeplearning4j.rl4j.environment.ActionSchema;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.environment.Schema;
+import org.deeplearning4j.rl4j.environment.StepResult;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+public class CartpoleEnvironment implements Environment<Integer> {
+    private static final int NUM_ACTIONS = 2;
+    private static final int ACTION_LEFT = 0;
+    private static final int ACTION_RIGHT = 1;
+
+    private static final Schema<Integer> schema = new Schema<>(new ActionSchema<>(ACTION_LEFT));
+
+    public enum KinematicsIntegrators { Euler, SemiImplicitEuler };
+
+    private static final double gravity = 9.8;
+    private static final double massCart = 1.0;
+    private static final double massPole = 0.1;
+    private static final double totalMass = massPole + massCart;
+    private static final double length = 0.5; // actually half the pole's length
+    private static final double polemassLength = massPole * length;
+    private static final double forceMag = 10.0;
+    private static final double tau = 0.02;  // seconds between state updates
+
+    // Angle at which to fail the episode
+    private static final double thetaThresholdRadians = 12.0 * 2.0 * Math.PI / 360.0;
+    private static final double xThreshold = 2.4;
+
+    private final Random rnd;
+
+    @Getter @Setter
+    private KinematicsIntegrators kinematicsIntegrator = KinematicsIntegrators.Euler;
+
+    @Getter
+    private boolean episodeFinished = false;
+
+    private double x;
+    private double xDot;
+    private double theta;
+    private double thetaDot;
+    private Integer stepsBeyondDone;
+
+    public CartpoleEnvironment() {
+        rnd = new Random();
+    }
+
+    public CartpoleEnvironment(int seed) {
+        rnd = new Random(seed);
+    }
+
+    @Override
+    public Schema<Integer> getSchema() {
+        return schema;
+    }
+
+    @Override
+    public Map<String, Object> reset() {
+
+        x = 0.1 * rnd.nextDouble() - 0.05;
+        xDot = 0.1 * rnd.nextDouble() - 0.05;
+        theta = 0.1 * rnd.nextDouble() - 0.05;
+        thetaDot = 0.1 * rnd.nextDouble() - 0.05;
+        stepsBeyondDone = null;
+        episodeFinished = false;
+
+        return new HashMap<>() {{
+            put("data", new double[]{x, xDot, theta, thetaDot});
+        }};
+    }
+
+    @Override
+    public StepResult step(Integer action) {
+        double force = action == ACTION_RIGHT ? forceMag : -forceMag;
+        double cosTheta = Math.cos(theta);
+        double sinTheta = Math.sin(theta);
+        double temp = (force + polemassLength * thetaDot * thetaDot * sinTheta) / totalMass;
+        double thetaAcc = (gravity * sinTheta - cosTheta* temp) / (length * (4.0/3.0 - massPole * cosTheta * cosTheta / totalMass));
+        double xAcc = temp - polemassLength * thetaAcc * cosTheta / totalMass;
+
+        switch(kinematicsIntegrator) {
+            case Euler:
+                x += tau * xDot;
+                xDot += tau * xAcc;
+                theta += tau * thetaDot;
+                thetaDot += tau * thetaAcc;
+                break;
+
+            case SemiImplicitEuler:
+                xDot += tau * xAcc;
+                x += tau * xDot;
+                thetaDot += tau * thetaAcc;
+                theta += tau * thetaDot;
+                break;
+        }
+
+        episodeFinished |=  x < -xThreshold || x > xThreshold
+                || theta < -thetaThresholdRadians || theta > thetaThresholdRadians;
+
+        double reward;
+        if(!episodeFinished) {
+            reward = 1.0;
+        }
+        else if(stepsBeyondDone == null) {
+            stepsBeyondDone = 0;
+            reward = 1.0;
+        }
+        else {
+            ++stepsBeyondDone;
+            reward = 0;
+        }
+
+        Map<String, Object> channelsData = new HashMap<>() {{
+            put("data", new double[]{x, xDot, theta, thetaDot});
+        }};
+        return new StepResult(channelsData, reward, episodeFinished);
+    }
+
+    @Override
+    public void close() {
+        // Do nothing
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/ACPolicy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/ACPolicy.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * the softmax output of the actor critic, but objects constructed
  * with a {@link Random} argument of null return the max only.
  */
-public class ACPolicy<O extends Encodable> extends Policy<O, Integer> {
+public class ACPolicy<O extends Encodable> extends Policy<Integer> {
 
     final private IActorCritic actorCritic;
     Random rnd;

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/BoltzmannQ.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/BoltzmannQ.java
@@ -30,7 +30,7 @@ import static org.nd4j.linalg.ops.transforms.Transforms.exp;
  * Boltzmann exploration is a stochastic policy wrt to the
  * exponential Q-values as evaluated by the dqn model.
  */
-public class BoltzmannQ<O extends Encodable> extends Policy<O, Integer> {
+public class BoltzmannQ<O extends Encodable> extends Policy<Integer> {
 
     final private IDQN dqn;
     final private Random rnd;

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/DQNPolicy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/DQNPolicy.java
@@ -32,8 +32,10 @@ import java.io.IOException;
  * DQN policy returns the action with the maximum Q-value as evaluated
  * by the dqn model
  */
+
+// FIXME: Should we rename this "GreedyPolicy"?
 @AllArgsConstructor
-public class DQNPolicy<O extends Encodable> extends Policy<O, Integer> {
+public class DQNPolicy<O> extends Policy<Integer> {
 
     final private IDQN dqn;
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
@@ -39,9 +39,9 @@ import org.nd4j.linalg.api.rng.Random;
  */
 @AllArgsConstructor
 @Slf4j
-public class EpsGreedy<O, A, AS extends ActionSpace<A>> extends Policy<O, A> {
+public class EpsGreedy<O, A, AS extends ActionSpace<A>> extends Policy<A> {
 
-    final private Policy<O, A> policy;
+    final private Policy<A> policy;
     final private MDP<O, A, AS> mdp;
     final private int updateStart;
     final private int epsilonNbStep;

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/IPolicy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/IPolicy.java
@@ -7,8 +7,14 @@ import org.deeplearning4j.rl4j.space.ActionSpace;
 import org.deeplearning4j.rl4j.space.Encodable;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
-public interface IPolicy<O, A> {
-    <AS extends ActionSpace<A>> double play(MDP<O, A, AS> mdp, IHistoryProcessor hp);
-    A nextAction(INDArray input);
-    A nextAction(Observation observation);
+public interface IPolicy<ACTION> {
+    @Deprecated
+    <O, AS extends ActionSpace<ACTION>> double play(MDP<O, ACTION, AS> mdp, IHistoryProcessor hp);
+
+    @Deprecated
+    ACTION nextAction(INDArray input);
+
+    ACTION nextAction(Observation observation);
+
+    void reset();
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/Policy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/Policy.java
@@ -36,22 +36,22 @@ import org.deeplearning4j.rl4j.util.LegacyMDPWrapper;
  *
  * A Policy responsability is to choose the next action given a state
  */
-public abstract class Policy<O, A> implements IPolicy<O, A> {
+public abstract class Policy<A> implements IPolicy<A> {
 
     public abstract NeuralNet getNeuralNet();
 
     public abstract A nextAction(Observation obs);
 
-    public <AS extends ActionSpace<A>> double play(MDP<O, A, AS> mdp) {
+    public <O, AS extends ActionSpace<A>> double play(MDP<O, A, AS> mdp) {
         return play(mdp, (IHistoryProcessor)null);
     }
 
-    public <AS extends ActionSpace<A>> double play(MDP<O, A, AS> mdp, HistoryProcessor.Configuration conf) {
+    public <O, AS extends ActionSpace<A>> double play(MDP<O, A, AS> mdp, HistoryProcessor.Configuration conf) {
         return play(mdp, new HistoryProcessor(conf));
     }
 
     @Override
-    public <AS extends ActionSpace<A>> double play(MDP<O, A, AS> mdp, IHistoryProcessor hp) {
+    public <O, AS extends ActionSpace<A>> double play(MDP<O, A, AS> mdp, IHistoryProcessor hp) {
         resetNetworks();
 
         RefacEpochStepCounter epochStepCounter = new RefacEpochStepCounter();
@@ -89,7 +89,11 @@ public abstract class Policy<O, A> implements IPolicy<O, A> {
         getNeuralNet().reset();
     }
 
-    protected <AS extends ActionSpace<A>> Learning.InitMdp<Observation> refacInitMdp(LegacyMDPWrapper<O, A, AS> mdpWrapper, IHistoryProcessor hp, RefacEpochStepCounter epochStepCounter) {
+    public void reset() {
+        resetNetworks();
+    }
+
+    protected <O, AS extends ActionSpace<A>> Learning.InitMdp<Observation> refacInitMdp(LegacyMDPWrapper<O, A, AS> mdpWrapper, IHistoryProcessor hp, RefacEpochStepCounter epochStepCounter) {
         epochStepCounter.setCurrentEpochStep(0);
 
         double reward = 0;

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/AgentTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/AgentTest.java
@@ -1,0 +1,479 @@
+package org.deeplearning4j.rl4j.agent;
+
+import org.deeplearning4j.rl4j.agent.listener.AgentListener;
+import org.deeplearning4j.rl4j.environment.ActionSchema;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.environment.Schema;
+import org.deeplearning4j.rl4j.environment.StepResult;
+import org.deeplearning4j.rl4j.observation.Observation;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.deeplearning4j.rl4j.policy.IPolicy;
+import org.junit.Rule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.mockito.*;
+import org.mockito.junit.*;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class AgentTest {
+
+    @Mock Environment environmentMock;
+    @Mock TransformProcess transformProcessMock;
+    @Mock IPolicy policyMock;
+    @Mock AgentListener listenerMock;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Test
+    public void when_buildingWithNullEnvironment_expect_exception() {
+        Exception exception = assertThrows(NullPointerException.class, () -> {
+            Agent.builder(null, null, null).build();
+        });
+
+        String expectedMessage = "environment is marked @NonNull but is null";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void when_buildingWithNullTransformProcess_expect_exception() {
+        Exception exception = assertThrows(NullPointerException.class, () -> {
+            Agent.builder(environmentMock, null, null).build();
+        });
+
+        String expectedMessage = "transformProcess is marked @NonNull but is null";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void when_buildingWithNullPolicy_expect_exception() {
+        Exception exception = assertThrows(NullPointerException.class, () -> {
+            Agent.builder(environmentMock, transformProcessMock, null).build();
+        });
+
+        String expectedMessage = "policy is marked @NonNull but is null";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void when_buildingWithInvalidMaxSteps_expect_exception() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Agent.builder(environmentMock, transformProcessMock, policyMock)
+                    .maxEpisodeSteps(0)
+                    .build();
+        });
+
+        String expectedMessage = "maxEpisodeSteps must be greater than 0, got [0]";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void when_buildingWithId_expect_idSetInAgent() {
+        // Arrange
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .id("TestAgent")
+                .build();
+
+        // Assert
+        assertEquals("TestAgent", sut.getId());
+    }
+
+    @Test
+    public void when_runIsCalled_expect_agentIsReset() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+        when(policyMock.nextAction(any(Observation.class))).thenReturn(1);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .build();
+
+        when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), anyInt())).thenReturn(AgentListener.ListenerResponse.STOP);
+        sut.addListener(listenerMock);
+
+        // Act
+        sut.run();
+
+        // Assert
+        assertEquals(0, sut.getEpisodeStepNumber());
+        verify(transformProcessMock).transform(envResetResult, 0, false);
+        verify(policyMock, times(1)).reset();
+        assertEquals(0.0, sut.getReward(), 0.00001);
+        verify(environmentMock, times(1)).reset();
+    }
+
+    @Test
+    public void when_runIsCalled_expect_onBeforeAndAfterEpisodeCalled() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+        when(environmentMock.isEpisodeFinished()).thenReturn(true);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock).build();
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy, times(1)).onBeforeEpisode();
+        verify(spy, times(1)).onAfterEpisode();
+    }
+
+    @Test
+    public void when_onBeforeEpisodeReturnsStop_expect_performStepAndOnAfterEpisodeNotCalled() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock).build();
+
+        when(listenerMock.onBeforeEpisode(any(Agent.class))).thenReturn(AgentListener.ListenerResponse.STOP);
+        sut.addListener(listenerMock);
+
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy, times(1)).onBeforeEpisode();
+        verify(spy, never()).performStep();
+        verify(spy, never()).onAfterStep(any(StepResult.class));
+        verify(spy, never()).onAfterEpisode();
+    }
+
+    @Test
+    public void when_runIsCalledWithoutMaxStep_expect_agentRunUntilEpisodeIsFinished() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .build();
+
+        final Agent spy = Mockito.spy(sut);
+
+        doAnswer(invocation -> {
+            ((Agent)invocation.getMock()).incrementEpisodeStepNumber();
+            return null;
+        }).when(spy).performStep();
+        when(environmentMock.isEpisodeFinished()).thenAnswer(invocation -> spy.getEpisodeStepNumber() >= 5 );
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy, times(1)).onBeforeEpisode();
+        verify(spy, times(5)).performStep();
+        verify(spy, times(1)).onAfterEpisode();
+    }
+
+    @Test
+    public void when_maxStepsIsReachedBeforeEposideEnds_expect_runTerminated() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .maxEpisodeSteps(3)
+                .build();
+
+        final Agent spy = Mockito.spy(sut);
+
+        doAnswer(invocation -> {
+            ((Agent)invocation.getMock()).incrementEpisodeStepNumber();
+            return null;
+        }).when(spy).performStep();
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy, times(1)).onBeforeEpisode();
+        verify(spy, times(3)).performStep();
+        verify(spy, times(1)).onAfterEpisode();
+    }
+
+    @Test
+    public void when_initialObservationsAreSkipped_expect_performNoOpAction() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(Observation.SkippedObservation);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .build();
+
+        when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), any())).thenReturn(AgentListener.ListenerResponse.STOP);
+        sut.addListener(listenerMock);
+
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(listenerMock).onBeforeStep(any(), any(), eq(-1));
+    }
+
+    @Test
+    public void when_initialObservationsAreSkipped_expect_performNoOpActionAnd() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(Observation.SkippedObservation);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .build();
+
+        when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), any())).thenReturn(AgentListener.ListenerResponse.STOP);
+        sut.addListener(listenerMock);
+
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(listenerMock).onBeforeStep(any(), any(), eq(-1));
+    }
+
+    @Test
+    public void when_observationsIsSkipped_expect_performLastAction() {
+        // Arrange
+        Map<String, Object> envResetResult = new HashMap<>();
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(envResetResult);
+        when(environmentMock.step(any(Integer.class))).thenReturn(new StepResult(envResetResult, 0.0, false));
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(policyMock.nextAction(any(Observation.class)))
+                .thenAnswer(invocation -> (int)((Observation)invocation.getArgument(0)).getData().getDouble(0));
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .maxEpisodeSteps(3)
+                .build();
+
+        Agent spy = Mockito.spy(sut);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean()))
+                .thenAnswer(invocation -> {
+                    int stepNumber = (int)invocation.getArgument(1);
+                    return stepNumber  % 2 == 1 ? Observation.SkippedObservation
+                            : new Observation(Nd4j.create(new double[] {  stepNumber }));
+                });
+
+        sut.addListener(listenerMock);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(policyMock, times(2)).nextAction(any(Observation.class));
+
+        ArgumentCaptor<Agent> agentCaptor = ArgumentCaptor.forClass(Agent.class);
+        ArgumentCaptor<Observation> observationCaptor = ArgumentCaptor.forClass(Observation.class);
+        ArgumentCaptor<Integer> actionCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(listenerMock, times(3)).onBeforeStep(agentCaptor.capture(), observationCaptor.capture(), actionCaptor.capture());
+        List<Integer> capturedActions = actionCaptor.getAllValues();
+        assertEquals(0, (int)capturedActions.get(0));
+        assertEquals(0, (int)capturedActions.get(1));
+        assertEquals(2, (int)capturedActions.get(2));
+    }
+
+    @Test
+    public void when_onBeforeStepReturnsStop_expect_performStepAndOnAfterEpisodeNotCalled() {
+        // Arrange
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(new HashMap<>());
+        when(environmentMock.getSchema()).thenReturn(schema);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock).build();
+
+        when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), any())).thenReturn(AgentListener.ListenerResponse.STOP);
+        sut.addListener(listenerMock);
+
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy, times(1)).onBeforeEpisode();
+        verify(spy, times(1)).onBeforeStep();
+        verify(spy, never()).act(any());
+        verify(spy, never()).onAfterStep(any(StepResult.class));
+        verify(spy, never()).onAfterEpisode();
+    }
+
+    @Test
+    public void when_observationIsNotSkipped_expect_policyActionIsSentToEnvironment() {
+        // Arrange
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(new HashMap<>());
+        when(environmentMock.getSchema()).thenReturn(schema);
+        when(environmentMock.step(any(Integer.class))).thenReturn(new StepResult(new HashMap<>(), 0.0, false));
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .maxEpisodeSteps(1)
+                .build();
+
+        // Act
+        sut.run();
+
+        // Assert
+        verify(environmentMock, times(1)).step(123);
+    }
+
+    @Test
+    public void when_stepResultIsReceived_expect_observationAndRewardUpdated() {
+        // Arrange
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(new HashMap<>());
+        when(environmentMock.getSchema()).thenReturn(schema);
+        when(environmentMock.step(any(Integer.class))).thenReturn(new StepResult(new HashMap<>(), 234.0, false));
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .maxEpisodeSteps(1)
+                .build();
+
+        // Act
+        sut.run();
+
+        // Assert
+        assertEquals(123.0, sut.getObservation().getData().getDouble(0), 0.00001);
+        assertEquals(234.0, sut.getReward(), 0.00001);
+    }
+
+    @Test
+    public void when_stepIsDone_expect_onAfterStepAndWithStepResult() {
+        // Arrange
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(new HashMap<>());
+        when(environmentMock.getSchema()).thenReturn(schema);
+        StepResult stepResult = new StepResult(new HashMap<>(), 234.0, false);
+        when(environmentMock.step(any(Integer.class))).thenReturn(stepResult);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .maxEpisodeSteps(1)
+                .build();
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy).onAfterStep(stepResult);
+    }
+
+    @Test
+    public void when_onAfterStepReturnsStop_expect_onAfterEpisodeNotCalled() {
+        // Arrange
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(new HashMap<>());
+        when(environmentMock.getSchema()).thenReturn(schema);
+        StepResult stepResult = new StepResult(new HashMap<>(), 234.0, false);
+        when(environmentMock.step(any(Integer.class))).thenReturn(stepResult);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .maxEpisodeSteps(1)
+                .build();
+        when(listenerMock.onAfterStep(any(Agent.class), any(StepResult.class))).thenReturn(AgentListener.ListenerResponse.STOP);
+        sut.addListener(listenerMock);
+
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy, never()).onAfterEpisode();
+    }
+
+    @Test
+    public void when_runIsCalled_expect_onAfterEpisodeIsCalled() {
+        // Arrange
+        Schema schema = new Schema(new ActionSchema<>(-1));
+        when(environmentMock.reset()).thenReturn(new HashMap<>());
+        when(environmentMock.getSchema()).thenReturn(schema);
+        StepResult stepResult = new StepResult(new HashMap<>(), 234.0, false);
+        when(environmentMock.step(any(Integer.class))).thenReturn(stepResult);
+
+        when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
+
+        when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
+
+        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+                .maxEpisodeSteps(1)
+                .build();
+
+        Agent spy = Mockito.spy(sut);
+
+        // Act
+        spy.run();
+
+        // Assert
+        verify(spy, times(1)).onAfterEpisode();
+    }
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/async/AsyncLearningTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/async/AsyncLearningTest.java
@@ -84,9 +84,9 @@ public class AsyncLearningTest {
     public static class TestAsyncLearning extends AsyncLearning<MockEncodable, Integer, DiscreteSpace, MockNeuralNet> {
         private final AsyncConfiguration conf;
         private final IAsyncGlobal asyncGlobal;
-        private final IPolicy<MockEncodable, Integer> policy;
+        private final IPolicy<Integer> policy;
 
-        public TestAsyncLearning(AsyncConfiguration conf, IAsyncGlobal asyncGlobal, IPolicy<MockEncodable, Integer> policy) {
+        public TestAsyncLearning(AsyncConfiguration conf, IAsyncGlobal asyncGlobal, IPolicy<Integer> policy) {
             this.conf = conf;
             this.asyncGlobal = asyncGlobal;
             this.policy = policy;

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscreteTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscreteTest.java
@@ -178,7 +178,7 @@ public class AsyncThreadDiscreteTest {
         }
 
         @Override
-        protected IPolicy<MockEncodable, Integer> getPolicy(MockNeuralNet net) {
+        protected IPolicy<Integer> getPolicy(MockNeuralNet net) {
             return policy;
         }
 

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/policy/PolicyTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/policy/PolicyTest.java
@@ -212,7 +212,7 @@ public class PolicyTest {
         assertEquals(0, dqn.outputParams.size());
     }
 
-    public static class MockRefacPolicy extends Policy<MockEncodable, Integer> {
+    public static class MockRefacPolicy extends Policy<Integer> {
 
         private NeuralNet neuralNet;
         private final int[] shape;
@@ -242,7 +242,7 @@ public class PolicyTest {
         }
 
         @Override
-        protected <AS extends ActionSpace<Integer>> Learning.InitMdp<Observation> refacInitMdp(LegacyMDPWrapper<MockEncodable, Integer, AS> mdpWrapper, IHistoryProcessor hp, RefacEpochStepCounter epochStepCounter) {
+        protected <O, AS extends ActionSpace<Integer>> Learning.InitMdp<Observation> refacInitMdp(LegacyMDPWrapper<O, Integer, AS> mdpWrapper, IHistoryProcessor hp, RefacEpochStepCounter epochStepCounter) {
             mdpWrapper.setTransformProcess(MockMDP.buildTransformProcess(shape, skipFrame, historyLength));
             return super.refacInitMdp(mdpWrapper, hp, epochStepCounter);
         }

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/support/MockPolicy.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/support/MockPolicy.java
@@ -10,13 +10,13 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MockPolicy implements IPolicy<MockEncodable, Integer> {
+public class MockPolicy implements IPolicy<Integer> {
 
     public int playCallCount = 0;
     public List<INDArray> actionInputs = new ArrayList<INDArray>();
 
     @Override
-    public <AS extends ActionSpace<Integer>> double play(MDP<MockEncodable, Integer, AS> mdp, IHistoryProcessor hp) {
+    public <O, AS extends ActionSpace<Integer>> double play(MDP<O, Integer, AS> mdp, IHistoryProcessor hp) {
         ++playCallCount;
         return 0;
     }
@@ -30,5 +30,10 @@ public class MockPolicy implements IPolicy<MockEncodable, Integer> {
     @Override
     public Integer nextAction(Observation observation) {
         return nextAction(observation.getData());
+    }
+
+    @Override
+    public void reset() {
+
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A PR introducing `Agent` and `Environment` in RL4J. Refactoring the legacy code is becoming increasingly difficult without breaking the code for existing users. Instead, new code will be added to RL4J and legacy code will be deprecated.

Environment:
 - Instead of `ActionSpace` and `ObservationSpace`, I wanted to do something similar to DataVec's schema. I'd like to be able to have metadata in this schema for example to help normalization or describe the data channel (describe it's the left audio channel or the right one for example)
 - `step()` now returns a StepResult that contains a Map<String, Object> (same thing for `reset()`). Maybe we should define a container class instead using directly a map.

I added a test environment (`CartpoleEnvironment`) in `org.deeplearning4j.rl4j.mdp` to help for the development and tests
 
Agent:
 - First iteration that can presently only play an episode with a pre-trained model.
 - The number of protected methods seems overkill but I plan to make the LearnerAgent extend Agent and it'll be much easier.

## How was this patch tested?

unit tests and manual tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
- [ ] Javadoc
- [ ] Headers