### PR TITLE
Fix UIServer features in multi-session mode, synchronous start and stop

### DIFF
--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
@@ -75,10 +75,6 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
 
     private TrainModule trainModule;
 
-    public static VertxUIServer getInstance() {
-        return getInstance(null, multiSession.get(), null);
-    }
-
     public static VertxUIServer getInstance(Integer port, boolean multiSession, Function<String, StatsStorage> statsStorageProvider){
         if (instance == null || instance.isStopped()) {
             VertxUIServer.multiSession.set(multiSession);

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
@@ -89,17 +89,20 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
             //Launch UI server verticle and wait for it to start
             CountDownLatch l = new CountDownLatch(1);
             vertx.deployVerticle(VertxUIServer.class.getName(), res -> {
+                if (res.failed()) {
+                    log.error("UI server failed to start.", res.cause());
+                }
                 l.countDown();
             });
             try {
                 l.await(5000, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e){ } //Ignore
         } else if (!instance.isStopped()) {
-            if (instance.multiSession.get() && !instance.isMultiSession()) {
+            if (multiSession && !instance.isMultiSession()) {
                 throw new RuntimeException("Cannot return multi-session instance." +
                         " UIServer has already started in single-session mode at " + instance.getAddress() +
                         " You may stop the UI server instance, and start a new one.");
-            } else if (!instance.multiSession.get() && instance.isMultiSession()) {
+            } else if (!multiSession && instance.isMultiSession()) {
                 throw new RuntimeException("Cannot return single-session instance." +
                         " UIServer has already started in multi-session mode at " + instance.getAddress() +
                         " You may stop the UI server instance, and start a new one.");
@@ -306,7 +309,6 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
         server.close();
         shutdown.set(true);
     }
-
 
     @Override
     public boolean isStopped() {

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
@@ -37,6 +37,7 @@ import org.deeplearning4j.api.storage.StatsStorageEvent;
 import org.deeplearning4j.api.storage.StatsStorageListener;
 import org.deeplearning4j.api.storage.StatsStorageRouter;
 import org.deeplearning4j.config.DL4JSystemProperties;
+import org.deeplearning4j.exception.DL4JException;
 import org.deeplearning4j.ui.api.Route;
 import org.deeplearning4j.ui.api.UIModule;
 import org.deeplearning4j.ui.api.UIServer;
@@ -79,7 +80,7 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
 
     public static VertxUIServer getInstance(Integer port, boolean multiSession,
                                             Function<String, StatsStorage> statsStorageProvider)
-            throws RuntimeException, InterruptedException {
+            throws DL4JException, InterruptedException {
         if (instance == null || instance.isStopped()) {
             VertxUIServer.multiSession.set(multiSession);
             VertxUIServer.setStatsStorageProvider(statsStorageProvider);
@@ -88,11 +89,11 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
             deploy();
         } else if (!instance.isStopped()) {
             if (multiSession && !instance.isMultiSession()) {
-                throw new RuntimeException("Cannot return multi-session instance." +
+                throw new DL4JException("Cannot return multi-session instance." +
                         " UIServer has already started in single-session mode at " + instance.getAddress() +
                         " You may stop the UI server instance, and start a new one.");
             } else if (!multiSession && instance.isMultiSession()) {
-                throw new RuntimeException("Cannot return single-session instance." +
+                throw new DL4JException("Cannot return single-session instance." +
                         " UIServer has already started in multi-session mode at " + instance.getAddress() +
                         " You may stop the UI server instance, and start a new one.");
             }
@@ -103,10 +104,10 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
 
     /**
      * Deploy (start) {@link VertxUIServer}, waiting until starting is complete.
-     * @throws RuntimeException if UI server failed to start
+     * @throws DL4JException if UI server failed to start
      * @throws InterruptedException if interrupted while waiting for completion
      */
-    private static void deploy() throws RuntimeException, InterruptedException {
+    private static void deploy() throws DL4JException, InterruptedException {
         CountDownLatch l = new CountDownLatch(1);
         Promise<String> promise = Promise.promise();
         promise.future().compose(
@@ -119,7 +120,7 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
 
         Future<String> future = promise.future();
         if (future.failed()) {
-            throw new RuntimeException("Deeplearning4j UI server failed to start.", future.cause());
+            throw new DL4JException("Deeplearning4j UI server failed to start.", future.cause());
         }
     }
 

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
@@ -144,7 +144,9 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
     public void autoAttachStatsStorageBySessionId(Function<String, StatsStorage> statsStorageProvider) {
         if (statsStorageProvider != null) {
             this.statsStorageLoader = new StatsStorageLoader(statsStorageProvider);
-            this.trainModule.setSessionLoader(this.statsStorageLoader);
+            if (trainModule != null) {
+                this.trainModule.setSessionLoader(this.statsStorageLoader);
+            }
         }
     }
 
@@ -191,6 +193,9 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
             });
         }
 
+        if (VertxUIServer.statsStorageProvider != null) {
+            autoAttachStatsStorageBySessionId(VertxUIServer.statsStorageProvider);
+        }
 
         uiModules.add(new DefaultModule(isMultiSession())); //For: navigation page "/"
         trainModule = new TrainModule(isMultiSession(), statsStorageLoader, this::getAddress);

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
@@ -408,13 +408,18 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
                 successEvent -> Future.future(prom -> l.countDown()),
                 failureEvent -> Future.future(prom -> l.countDown())
         );
+        stopAsync(promise);
+        // synchronous function should wait until the server is stopped
+        l.await();
+    }
+
+    @Override
+    public void stopAsync(Promise<Void> stopCallback) {
         /**
          * Stop Vertx instance and release any resources held by it.
          * Pass promise to {@link #stop(Promise)}.
          */
-        vertx.close(ar -> promise.handle(ar));
-        // synchronous function should wait until the server is stopped
-        l.await();
+        vertx.close(ar -> stopCallback.handle(ar));
     }
 
     @Override

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
@@ -20,6 +20,7 @@ package org.deeplearning4j.ui.api;
 import io.vertx.core.Promise;
 import org.deeplearning4j.api.storage.StatsStorage;
 import org.deeplearning4j.api.storage.StatsStorageRouter;
+import org.deeplearning4j.exception.DL4JException;
 import org.deeplearning4j.ui.VertxUIServer;
 import org.nd4j.linalg.function.Function;
 
@@ -37,11 +38,11 @@ public interface UIServer {
      * Singleton pattern - all calls to getInstance() will return the same UI instance.
      *
      * @return UI instance for this JVM
-     * @throws RuntimeException if UI server failed to start;
+     * @throws DL4JException if UI server failed to start;
      * if the instance has already started in a different mode (multi/single-session)
      * @throws InterruptedException if interrupted while waiting for completion
      */
-    static UIServer getInstance() throws RuntimeException, InterruptedException {
+    static UIServer getInstance() throws DL4JException, InterruptedException {
         if (VertxUIServer.getInstance() != null) {
             return VertxUIServer.getInstance();
         } else {
@@ -59,12 +60,12 @@ public interface UIServer {
      *                             <br/>Use this to auto-attach StatsStorage if an unknown session ID is passed
      *                             as URL path parameter in multi-session mode, or leave it {@code null}.
      * @return UI instance for this JVM
-     * @throws RuntimeException if UI server failed to start;
+     * @throws DL4JException if UI server failed to start;
      * if the instance has already started in a different mode (multi/single-session)
      * @throws InterruptedException if interrupted while waiting for completion
      */
     static UIServer getInstance(boolean multiSession, Function<String, StatsStorage> statsStorageProvider)
-            throws RuntimeException, InterruptedException {
+            throws DL4JException, InterruptedException {
         return VertxUIServer.getInstance(null, multiSession, statsStorageProvider);
     }
 

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
@@ -39,7 +39,11 @@ public interface UIServer {
      * @throws RuntimeException if the instance has already started in a different mode (multi/single-session)
      */
     static UIServer getInstance() throws RuntimeException {
-        return getInstance(false, null);
+        if (VertxUIServer.getInstance() != null) {
+            return VertxUIServer.getInstance();
+        } else {
+            return getInstance(false, null);
+        }
     }
 
     /**

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
@@ -39,10 +39,10 @@ public interface UIServer {
      *
      * @return UI instance for this JVM
      * @throws DL4JException if UI server failed to start;
-     * if the instance has already started in a different mode (multi/single-session)
-     * @throws InterruptedException if interrupted while waiting for completion
+     * if the instance has already started in a different mode (multi/single-session);
+     * if interrupted while waiting for completion
      */
-    static UIServer getInstance() throws DL4JException, InterruptedException {
+    static UIServer getInstance() throws DL4JException {
         if (VertxUIServer.getInstance() != null && !VertxUIServer.getInstance().isStopped()) {
             return VertxUIServer.getInstance();
         } else {
@@ -61,11 +61,11 @@ public interface UIServer {
      *                             as URL path parameter in multi-session mode, or leave it {@code null}.
      * @return UI instance for this JVM
      * @throws DL4JException if UI server failed to start;
-     * if the instance has already started in a different mode (multi/single-session)
-     * @throws InterruptedException if interrupted while waiting for completion
+     * if the instance has already started in a different mode (multi/single-session);
+     * if interrupted while waiting for completion
      */
     static UIServer getInstance(boolean multiSession, Function<String, StatsStorage> statsStorageProvider)
-            throws DL4JException, InterruptedException {
+            throws DL4JException {
         return VertxUIServer.getInstance(null, multiSession, statsStorageProvider);
     }
 

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
@@ -17,6 +17,7 @@
 
 package org.deeplearning4j.ui.api;
 
+import io.vertx.core.Promise;
 import org.deeplearning4j.api.storage.StatsStorage;
 import org.deeplearning4j.api.storage.StatsStorageRouter;
 import org.deeplearning4j.ui.VertxUIServer;
@@ -32,13 +33,15 @@ import java.util.List;
 public interface UIServer {
 
     /**
-     * Get (and, initialize if necessary) the UI server.
+     * Get (and, initialize if necessary) the UI server. This synchronous function will wait until the server started.
      * Singleton pattern - all calls to getInstance() will return the same UI instance.
      *
      * @return UI instance for this JVM
-     * @throws RuntimeException if the instance has already started in a different mode (multi/single-session)
+     * @throws RuntimeException if UI server failed to start;
+     * if the instance has already started in a different mode (multi/single-session)
+     * @throws InterruptedException if interrupted while waiting for completion
      */
-    static UIServer getInstance() throws RuntimeException {
+    static UIServer getInstance() throws RuntimeException, InterruptedException {
         if (VertxUIServer.getInstance() != null) {
             return VertxUIServer.getInstance();
         } else {
@@ -47,7 +50,7 @@ public interface UIServer {
     }
 
     /**
-     * Get (and, initialize if necessary) the UI server.
+     * Get (and, initialize if necessary) the UI server. This synchronous function will wait until the server started.
      * Singleton pattern - all calls to getInstance() will return the same UI instance.
      *
      * @param multiSession         in multi-session mode, multiple training sessions can be visualized in separate browser tabs.
@@ -56,16 +59,19 @@ public interface UIServer {
      *                             <br/>Use this to auto-attach StatsStorage if an unknown session ID is passed
      *                             as URL path parameter in multi-session mode, or leave it {@code null}.
      * @return UI instance for this JVM
-     * @throws RuntimeException if the instance has already started in a different mode (multi/single-session)
+     * @throws RuntimeException if UI server failed to start;
+     * if the instance has already started in a different mode (multi/single-session)
+     * @throws InterruptedException if interrupted while waiting for completion
      */
-    static UIServer getInstance(boolean multiSession, Function<String, StatsStorage> statsStorageProvider) throws RuntimeException {
+    static UIServer getInstance(boolean multiSession, Function<String, StatsStorage> statsStorageProvider)
+            throws RuntimeException, InterruptedException {
         return VertxUIServer.getInstance(null, multiSession, statsStorageProvider);
     }
 
     /**
      * Stop UIServer instance, if already running
      */
-    static void stopInstance() {
+    static void stopInstance() throws Exception {
         VertxUIServer.stopInstance();
     }
 
@@ -148,8 +154,15 @@ public interface UIServer {
     boolean isRemoteListenerEnabled();
 
     /**
-     * Stop/shut down the UI server.
+     * Stop/shut down the UI server. This synchronous function should wait until the server is stopped.
      */
-    void stop();
+    void stop() throws Exception;
 
+    /**
+     * Stop/shut down the UI server.
+     * This asynchronous function should immediately return, and notify the callback {@link Promise} on completion:
+     * either call {@link Promise#complete} or {@link io.vertx.core.Promise#fail}.
+     * @param stopCallback callback {@link Promise} to notify on completion
+     */
+    void stop(Promise<Void> stopCallback);
 }

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
@@ -43,7 +43,7 @@ public interface UIServer {
      * @throws InterruptedException if interrupted while waiting for completion
      */
     static UIServer getInstance() throws DL4JException, InterruptedException {
-        if (VertxUIServer.getInstance() != null) {
+        if (VertxUIServer.getInstance() != null && !VertxUIServer.getInstance().isStopped()) {
             return VertxUIServer.getInstance();
         } else {
             return getInstance(false, null);

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
@@ -165,5 +165,5 @@ public interface UIServer {
      * either call {@link Promise#complete} or {@link io.vertx.core.Promise#fail}.
      * @param stopCallback callback {@link Promise} to notify on completion
      */
-    void stop(Promise<Void> stopCallback);
+    void stopAsync(Promise<Void> stopCallback);
 }

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/i18n/DefaultI18N.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/i18n/DefaultI18N.java
@@ -69,15 +69,19 @@ public class DefaultI18N implements I18N {
     }
 
     /**
-     * Get instance for session (used in multi-session mode)
-     * @param sessionId session
-     * @return instance for session
+     * Get instance for session
+     * @param sessionId session ID for multi-session mode, leave it {@code null} for global instance
+     * @return instance for session, or global instance
      */
     public static synchronized I18N getInstance(String sessionId) {
-        if (!sessionInstances.containsKey(sessionId)) {
-            sessionInstances.put(sessionId, new DefaultI18N());
+        if (sessionId == null) {
+            return getInstance();
+        } else {
+            if (!sessionInstances.containsKey(sessionId)) {
+                sessionInstances.put(sessionId, new DefaultI18N());
+            }
+            return sessionInstances.get(sessionId);
         }
-        return sessionInstances.get(sessionId);
     }
 
     /**

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
@@ -226,7 +226,9 @@ public class TrainModule implements UIModule {
      * @param rc   Routing context
      */
     private void renderFtl(String file, RoutingContext rc) {
-        Map<String, String> input = DefaultI18N.getInstance().getMessages(DefaultI18N.getInstance().getDefaultLanguage());
+        String sessionId = rc.request().getParam("sessionID");
+        String langCode = DefaultI18N.getInstance(sessionId).getDefaultLanguage();
+        Map<String, String> input = DefaultI18N.getInstance().getMessages(langCode);
         String html;
         try {
             String content = FileUtils.readFileToString(Resources.asFile("templates/" + file), StandardCharsets.UTF_8);

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
@@ -199,6 +199,7 @@ public class TrainModule implements UIModule {
                 }
             }));
             r.add(new Route("/train/:sessionId/info", HttpMethod.GET, (path, rc) -> this.sessionInfoForSession(path.get(0), rc)));
+            r.add(new Route("/train/:sessionId/system/data", HttpMethod.GET, (path, rc) -> this.getSystemDataForSession(path.get(0), rc)));
         } else {
             r.add(new Route("/train", HttpMethod.GET, (path, rc) -> rc.reroute("/train/overview")));
             r.add(new Route("/train/sessions/current", HttpMethod.GET, (path, rc) -> rc.response().end(currentSessionID == null ? "" : currentSessionID)));

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/module/train/TrainModule.java
@@ -137,7 +137,7 @@ public class TrainModule implements UIModule {
             maxChartPoints = DEFAULT_MAX_CHART_POINTS;
         }
 
-        configuration = new Configuration(new Version(2, 3, 29));
+        configuration = new Configuration(new Version(2, 3, 23));
         configuration.setDefaultEncoding("UTF-8");
         configuration.setLocale(Locale.US);
         configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
@@ -67,28 +67,19 @@ import static org.junit.Assert.*;
 @Ignore
 public class TestVertxUI extends BaseDL4JTest {
 
-    @Override
-    public long getTimeoutMilliseconds() {
-        return 600_000L;
-    }
-
     @Before
     public void setUp() throws Exception {
         UIServer.stopInstance();
     }
 
     @Test
-    @Ignore
     public void testUI() throws Exception {
         VertxUIServer uiServer = (VertxUIServer) UIServer.getInstance();
         assertEquals(9000, uiServer.getPort());
-
-        Thread.sleep(30_000);
         uiServer.stop();
     }
 
     @Test
-    @Ignore
     public void testUI_VAE() throws Exception {
         //Variational autoencoder - for unsupervised layerwise pretraining
 
@@ -126,13 +117,9 @@ public class TestVertxUI extends BaseDL4JTest {
             Thread.sleep(100);
         }
 
-
-        Thread.sleep(100000);
     }
 
-
     @Test
-    @Ignore
     public void testUIMultipleSessions() throws Exception {
 
         for (int session = 0; session < 3; session++) {
@@ -160,59 +147,10 @@ public class TestVertxUI extends BaseDL4JTest {
                 Thread.sleep(100);
             }
         }
-
-
-        Thread.sleep(1000000);
-    }
-    
-    @Test
-    @Ignore
-    public void testUISequentialSessions() throws Exception {
-        UIServer uiServer = UIServer.getInstance();
-        StatsStorage ss = null;
-        for (int session = 0; session < 3; session++) {
-            
-            if (ss != null) {
-                uiServer.detach(ss);
-            }
-            ss = new InMemoryStatsStorage();
-            uiServer.attach(ss);
-
-            int numInputs = 4;
-            int outputNum = 3;
-            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-                .activation(Activation.TANH)
-                .weightInit(WeightInit.XAVIER)
-                .updater(new Sgd(0.03))
-                .l2(1e-4)
-                .list()
-                .layer(0, new DenseLayer.Builder().nIn(numInputs).nOut(3)
-                        .build())
-                .layer(1, new DenseLayer.Builder().nIn(3).nOut(3)
-                        .build())
-                .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
-                        .activation(Activation.SOFTMAX)
-                        .nIn(3).nOut(outputNum).build())
-                .build();
-
-            MultiLayerNetwork net = new MultiLayerNetwork(conf);
-            net.init();
-            net.setListeners(new StatsListener(ss), new ScoreIterationListener(1));
-
-            DataSetIterator iter = new IrisDataSetIterator(150, 150);
-
-            for (int i = 0; i < 1000; i++) {
-                net.fit(iter);
-            }
-            Thread.sleep(5000);
-        }
-
-        Thread.sleep(1000000);
     }
 
     @Test
-    @Ignore
-    public void testUICompGraph() throws Exception {
+    public void testUICompGraph() {
 
         StatsStorage ss = new InMemoryStatsStorage();
 
@@ -235,10 +173,7 @@ public class TestVertxUI extends BaseDL4JTest {
 
         for (int i = 0; i < 100; i++) {
             net.fit(iter);
-            Thread.sleep(100);
         }
-
-        Thread.sleep(1000000);
     }
 
     @Test
@@ -322,7 +257,7 @@ public class TestVertxUI extends BaseDL4JTest {
         assertTrue(uiServer.isMultiSession());
         assertFalse(uiServer.isStopped());
 
-        long sleepMilliseconds = 10_000;
+        long sleepMilliseconds = 1_000;
         log.info("Waiting {} ms before stopping.", sleepMilliseconds);
         Thread.sleep(sleepMilliseconds);
         uiServer.stop();
@@ -347,7 +282,7 @@ public class TestVertxUI extends BaseDL4JTest {
         assertTrue(uiServer.isMultiSession());
         assertFalse(uiServer.isStopped());
 
-        long sleepMilliseconds = 10_000;
+        long sleepMilliseconds = 1_000;
         log.info("Waiting {} ms before stopping.", sleepMilliseconds);
         Thread.sleep(sleepMilliseconds);
 

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.IOUtils;
 import org.deeplearning4j.BaseDL4JTest;
 import org.deeplearning4j.api.storage.StatsStorage;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.exception.DL4JException;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
@@ -78,9 +79,6 @@ public class TestVertxUI extends BaseDL4JTest {
     @Test
     @Ignore
     public void testUI() throws Exception {
-
-        StatsStorage ss = new InMemoryStatsStorage();
-
         VertxUIServer uiServer = (VertxUIServer) UIServer.getInstance();
         assertEquals(9000, uiServer.getPort());
 
@@ -208,7 +206,6 @@ public class TestVertxUI extends BaseDL4JTest {
             Thread.sleep(5000);
         }
 
-
         Thread.sleep(1000000);
     }
 
@@ -287,11 +284,11 @@ public class TestVertxUI extends BaseDL4JTest {
                 }
             });
 
-            String json1 = IOUtils.toString(new URL("http://localhost:9000/train/ss1/overview/data"), StandardCharsets.UTF_8);
-//            System.out.println(json1);
+            String json1 = IOUtils.toString(new URL("http://localhost:9000/train/ss1/overview/data"),
+                    StandardCharsets.UTF_8);
 
-            String json2 = IOUtils.toString(new URL("http://localhost:9000/train/ss2/overview/data"), StandardCharsets.UTF_8);
-//            System.out.println(json2);
+            String json2 = IOUtils.toString(new URL("http://localhost:9000/train/ss2/overview/data"),
+                    StandardCharsets.UTF_8);
 
             assertNotEquals(json1, json2);
 
@@ -338,7 +335,7 @@ public class TestVertxUI extends BaseDL4JTest {
         uiServer.stop();
     }
 
-    @Test (expected = RuntimeException.class)
+    @Test (expected = DL4JException.class)
     public void testUIStartFailure() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         int port = VertxUIServer.DEFAULT_UI_PORT;

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
@@ -56,6 +56,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
 
@@ -407,5 +408,15 @@ public class TestVertxUI extends BaseDL4JTest {
         } else {
             log.debug("UI server failed to deploy.", promise.future().cause());
         }
+    }
+
+    @Test
+    public void testUIAutoStopOnThreadExit() throws InterruptedException {
+        AtomicReference<UIServer> uiServer = new AtomicReference<>();
+        Thread thread = new Thread(() -> uiServer.set(UIServer.getInstance()));
+        thread.start();
+        thread.join();
+        Thread.sleep(1_000);
+        assertTrue(uiServer.get().isStopped());
     }
 }

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
@@ -58,6 +58,11 @@ import static org.junit.Assert.*;
  */
 @Ignore
 public class TestVertxUI extends BaseDL4JTest {
+    @Override
+    public long getTimeoutMilliseconds() {
+        return 600_000L;
+    }
+
     @Before
     public void setUp() throws Exception {
         UIServer.stopInstance();
@@ -72,7 +77,7 @@ public class TestVertxUI extends BaseDL4JTest {
         VertxUIServer uiServer = (VertxUIServer) UIServer.getInstance();
         assertEquals(9000, uiServer.getPort());
         uiServer.stop();
-        VertxUIServer vertxUIServer = new VertxUIServer();
+//        VertxUIServer vertxUIServer = new VertxUIServer();
 //        vertxUIServer.runMain(new String[] {"--uiPort", "9100", "-r", "true"});
 //
 //        assertEquals(9100, vertxUIServer.getPort());
@@ -340,6 +345,7 @@ public class TestVertxUI extends BaseDL4JTest {
         UIServer uiServer = UIServer.getInstance(true, null);
         assertTrue(uiServer.isMultiSession());
         uiServer.stop();
+
         uiServer = UIServer.getInstance(false, null);
         assertFalse(uiServer.isMultiSession());
     }

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIManual.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIManual.java
@@ -1,0 +1,272 @@
+package org.deeplearning4j.ui;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.api.storage.StatsStorage;
+import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
+import org.deeplearning4j.ui.api.UIServer;
+import org.deeplearning4j.ui.stats.StatsListener;
+import org.deeplearning4j.ui.storage.InMemoryStatsStorage;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.function.Function;
+import org.nd4j.linalg.learning.config.Sgd;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.*;
+
+@Slf4j
+@Ignore
+public class TestVertxUIManual extends BaseDL4JTest {
+
+    @Override
+        public long getTimeoutMilliseconds() {
+        return 3600_000L;
+    }
+
+    @Test
+    @Ignore
+    public void testUI() throws Exception {
+        VertxUIServer uiServer = (VertxUIServer) UIServer.getInstance();
+        assertEquals(9000, uiServer.getPort());
+
+        Thread.sleep(3000_000);
+        uiServer.stop();
+    }
+
+    @Test
+    @Ignore
+    public void testUISequentialSessions() throws Exception {
+        UIServer uiServer = UIServer.getInstance();
+        StatsStorage ss = null;
+        for (int session = 0; session < 3; session++) {
+
+            if (ss != null) {
+                uiServer.detach(ss);
+            }
+            ss = new InMemoryStatsStorage();
+            uiServer.attach(ss);
+
+            int numInputs = 4;
+            int outputNum = 3;
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .activation(Activation.TANH)
+                    .weightInit(WeightInit.XAVIER)
+                    .updater(new Sgd(0.03))
+                    .l2(1e-4)
+                    .list()
+                    .layer(0, new DenseLayer.Builder().nIn(numInputs).nOut(3)
+                            .build())
+                    .layer(1, new DenseLayer.Builder().nIn(3).nOut(3)
+                            .build())
+                    .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
+                            .activation(Activation.SOFTMAX)
+                            .nIn(3).nOut(outputNum).build())
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+            net.setListeners(new StatsListener(ss), new ScoreIterationListener(1));
+
+            DataSetIterator iter = new IrisDataSetIterator(150, 150);
+
+            for (int i = 0; i < 100; i++) {
+                net.fit(iter);
+            }
+            Thread.sleep(5_000);
+        }
+    }
+
+    @Test
+    @Ignore
+    public void testUIServerStop() throws Exception {
+        UIServer uiServer = UIServer.getInstance(true, null);
+        assertTrue(uiServer.isMultiSession());
+        assertFalse(uiServer.isStopped());
+
+        long sleepMilliseconds = 30_000;
+        log.info("Waiting {} ms before stopping.", sleepMilliseconds);
+        Thread.sleep(sleepMilliseconds);
+        uiServer.stop();
+        assertTrue(uiServer.isStopped());
+
+        log.info("UI server is stopped. Waiting {} ms before starting new UI server.", sleepMilliseconds);
+        Thread.sleep(sleepMilliseconds);
+        uiServer = UIServer.getInstance(false, null);
+        assertFalse(uiServer.isMultiSession());
+        assertFalse(uiServer.isStopped());
+
+        log.info("Waiting {} ms before stopping.", sleepMilliseconds);
+        Thread.sleep(sleepMilliseconds);
+        uiServer.stop();
+        assertTrue(uiServer.isStopped());
+    }
+
+
+    @Test
+    @Ignore
+    public void testUIServerStopAsync() throws Exception {
+        UIServer uiServer = UIServer.getInstance(true, null);
+        assertTrue(uiServer.isMultiSession());
+        assertFalse(uiServer.isStopped());
+
+        long sleepMilliseconds = 30_000;
+        log.info("Waiting {} ms before stopping.", sleepMilliseconds);
+        Thread.sleep(sleepMilliseconds);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Promise<Void> promise = Promise.promise();
+        promise.future().compose(
+                success -> Future.future(prom -> latch.countDown()),
+                failure -> Future.future(prom -> latch.countDown())
+        );
+
+        uiServer.stopAsync(promise);
+        latch.await();
+        assertTrue(uiServer.isStopped());
+
+        log.info("UI server is stopped. Waiting {} ms before starting new UI server.", sleepMilliseconds);
+        Thread.sleep(sleepMilliseconds);
+        uiServer = UIServer.getInstance(false, null);
+        assertFalse(uiServer.isMultiSession());
+
+        log.info("Waiting {} ms before stopping.", sleepMilliseconds);
+        Thread.sleep(sleepMilliseconds);
+        uiServer.stop();
+    }
+
+    @Test
+    @Ignore
+    public void testUIAutoAttachDetach() throws Exception {
+        long detachTimeoutMillis = 15_000;
+        AutoDetachingStatsStorageProvider statsProvider = new AutoDetachingStatsStorageProvider(detachTimeoutMillis);
+        UIServer uIServer = UIServer.getInstance(true, statsProvider);
+        statsProvider.setUIServer(uIServer);
+        InMemoryStatsStorage ss = null;
+        for (int session = 0; session < 3; session++) {
+            int layerSize = session + 4;
+
+            ss = new InMemoryStatsStorage();
+            String sessionId = Integer.toString(session);
+            statsProvider.put(sessionId, ss);
+            MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                    .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT).list()
+                    .layer(0, new DenseLayer.Builder().activation(Activation.TANH).nIn(4).nOut(layerSize).build())
+                    .layer(1, new OutputLayer.Builder().lossFunction(LossFunctions.LossFunction.MCXENT)
+                            .activation(Activation.SOFTMAX).nIn(layerSize).nOut(3).build())
+                    .build();
+
+            MultiLayerNetwork net = new MultiLayerNetwork(conf);
+            net.init();
+
+            StatsListener statsListener = new StatsListener(ss, 1);
+            statsListener.setSessionID(sessionId);
+            net.setListeners(statsListener, new ScoreIterationListener(1));
+            uIServer.attach(ss);
+
+            DataSetIterator iter = new IrisDataSetIterator(150, 150);
+
+            for (int i = 0; i < 20; i++) {
+                net.fit(iter);
+            }
+
+            assertTrue(uIServer.isAttached(ss));
+            uIServer.detach(ss);
+            assertFalse(uIServer.isAttached(ss));
+
+            /*
+             * Visiting /train/:sessionId to auto-attach StatsStorage
+             */
+            String sessionUrl = trainingSessionUrl(uIServer.getAddress(), sessionId);
+            HttpURLConnection conn = (HttpURLConnection) new URL(sessionUrl).openConnection();
+            conn.connect();
+
+            assertEquals(HttpResponseStatus.OK.code(), conn.getResponseCode());
+            assertTrue(uIServer.isAttached(ss));
+        }
+
+        Thread.sleep(detachTimeoutMillis + 60_000);
+        assertFalse(uIServer.isAttached(ss));
+    }
+
+
+    /**
+     * Get URL-encoded URL for training session on given server address
+     * @param serverAddress server address
+     * @param sessionId session ID
+     * @return URL
+     * @throws UnsupportedEncodingException if the used encoding is not supported
+     */
+    private static String trainingSessionUrl(String serverAddress, String sessionId)
+            throws UnsupportedEncodingException {
+        return String.format("%s/train/%s", serverAddress, URLEncoder.encode(sessionId, "UTF-8"));
+    }
+
+    /**
+     * StatsStorage provider with automatic detaching of StatsStorage after a timeout
+     * @author Tamas Fenyvesi
+     */
+    private static class AutoDetachingStatsStorageProvider implements Function<String, StatsStorage> {
+        HashMap<String, InMemoryStatsStorage> storageForSession = new HashMap<>();
+        UIServer uIServer;
+        long autoDetachTimeoutMillis;
+
+        public AutoDetachingStatsStorageProvider(long autoDetachTimeoutMillis) {
+            this.autoDetachTimeoutMillis = autoDetachTimeoutMillis;
+        }
+
+        public void put(String sessionId, InMemoryStatsStorage statsStorage) {
+            storageForSession.put(sessionId, statsStorage);
+        }
+
+        public void setUIServer(UIServer uIServer) {
+            this.uIServer = uIServer;
+        }
+
+        @Override
+        public StatsStorage apply(String sessionId) {
+            StatsStorage statsStorage = storageForSession.get(sessionId);
+
+            if (statsStorage != null) {
+                new Thread(() -> {
+                    try {
+                        log.info("Waiting to detach StatsStorage (session ID: {})" +
+                                " after {} ms ", sessionId, autoDetachTimeoutMillis);
+                        Thread.sleep(autoDetachTimeoutMillis);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    } finally {
+                        log.info("Auto-detaching StatsStorage (session ID: {}) after {} ms.",
+                                sessionId, autoDetachTimeoutMillis);
+                        uIServer.detach(statsStorage);
+                        log.info(" To re-attach StatsStorage of training session, visit {}}/train/{}",
+                                uIServer.getAddress(), sessionId);
+                    }
+                }).start();
+            }
+
+            return statsStorage;
+        }
+    }
+
+}

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
@@ -190,7 +190,7 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
     @Test
     public void testUIAutoAttachDetach() throws Exception {
 
-        long detachTimeoutMillis = 10_000;
+        long detachTimeoutMillis = 30_000;
         AutoDetachingStatsStorageProvider statsProvider = new AutoDetachingStatsStorageProvider(detachTimeoutMillis);
         UIServer uIServer = UIServer.getInstance(true, statsProvider);
         statsProvider.setUIServer(uIServer);

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
@@ -18,6 +18,7 @@
 package org.deeplearning4j.ui;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.BaseDL4JTest;
 import org.deeplearning4j.api.storage.StatsStorage;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
@@ -40,8 +41,6 @@ import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.function.Function;
 import org.nd4j.linalg.learning.config.Adam;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -55,9 +54,9 @@ import static org.junit.Assert.*;
 /**
  * @author Tamas Fenyvesi
  */
+@Slf4j
 @Ignore
 public class TestVertxUIMultiSession extends BaseDL4JTest {
-    private static final Logger log = LoggerFactory.getLogger(TestVertxUIMultiSession.class);
     @Override
     public long getTimeoutMilliseconds() {
         return 600_000L;

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import org.deeplearning4j.BaseDL4JTest;
 import org.deeplearning4j.api.storage.StatsStorage;
 import org.deeplearning4j.datasets.iterator.impl.IrisDataSetIterator;
+import org.deeplearning4j.exception.DL4JException;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -189,8 +190,8 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
     @Test
     public void testUIAutoAttachDetach() throws Exception {
 
-        long autoDetachTimeoutMillis = 10_000;
-        AutoDetachingStatsStorageProvider statsProvider = new AutoDetachingStatsStorageProvider(autoDetachTimeoutMillis);
+        long detachTimeoutMillis = 10_000;
+        AutoDetachingStatsStorageProvider statsProvider = new AutoDetachingStatsStorageProvider(detachTimeoutMillis);
         UIServer uIServer = UIServer.getInstance(true, statsProvider);
         statsProvider.setUIServer(uIServer);
         InMemoryStatsStorage ss = null;
@@ -236,12 +237,12 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
             assertTrue(uIServer.isAttached(ss));
         }
 
-        Thread.sleep(autoDetachTimeoutMillis + 1_000);
+        Thread.sleep(detachTimeoutMillis + 1_000);
         assertFalse(uIServer.isAttached(ss));
 
     }
 
-    @Test (expected = RuntimeException.class)
+    @Test (expected = DL4JException.class)
     public void testUIServerGetInstanceMultipleCalls1() throws InterruptedException {
         UIServer uiServer = UIServer.getInstance();
         assertFalse(uiServer.isMultiSession());
@@ -249,7 +250,7 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
 
     }
 
-    @Test (expected = RuntimeException.class)
+    @Test (expected = DL4JException.class)
     public void testUIServerGetInstanceMultipleCalls2() throws InterruptedException {
         UIServer uiServer = UIServer.getInstance(true, null);
         assertTrue(uiServer.isMultiSession());
@@ -263,7 +264,8 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
      * @return URL
      * @throws UnsupportedEncodingException if the used encoding is not supported
      */
-    private static String trainingSessionUrl(String serverAddress, String sessionId) throws UnsupportedEncodingException {
+    private static String trainingSessionUrl(String serverAddress, String sessionId)
+            throws UnsupportedEncodingException {
         return String.format("%s/train/%s", serverAddress, URLEncoder.encode(sessionId, "UTF-8"));
     }
 

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
@@ -64,6 +64,7 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
         UIServer.stopInstance();
     }
 
+    @Ignore
     @Test
     public void testUIMultiSession() throws Exception {
 
@@ -189,15 +190,15 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
     @Test
     public void testUIAutoAttachDetach() throws Exception {
 
-        long autoDetachTimeoutMillis = 30_000;
+        long autoDetachTimeoutMillis = 20_000;
         AutoDetachingStatsStorageProvider statsProvider = new AutoDetachingStatsStorageProvider(autoDetachTimeoutMillis);
         UIServer uIServer = UIServer.getInstance(true, statsProvider);
         statsProvider.setUIServer(uIServer);
-
+        InMemoryStatsStorage ss = null;
         for (int session = 0; session < 3; session++) {
             int layerSize = session + 4;
 
-            InMemoryStatsStorage ss = new InMemoryStatsStorage();
+            ss = new InMemoryStatsStorage();
             String sessionId = Integer.toString(session);
             statsProvider.put(sessionId, ss);
             MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
@@ -236,7 +237,9 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
             assertTrue(uIServer.isAttached(ss));
         }
 
-        Thread.sleep(1_000_000);
+        Thread.sleep(autoDetachTimeoutMillis);
+        assertFalse(uIServer.isAttached(ss));
+
     }
 
     @Test (expected = RuntimeException.class)

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
@@ -54,6 +54,11 @@ import static org.junit.Assert.*;
  */
 @Ignore
 public class TestVertxUIMultiSession extends BaseDL4JTest {
+    @Override
+    public long getTimeoutMilliseconds() {
+        return 600_000L;
+    }
+
     @Before
     public void setUp() throws Exception {
         UIServer.stopInstance();
@@ -182,7 +187,6 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
     }
 
     @Test
-    @Ignore
     public void testUIAutoAttachDetach() throws Exception {
 
         long autoDetachTimeoutMillis = 30_000;

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUIMultiSession.java
@@ -127,7 +127,7 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
 
                 assertEquals(HttpResponseStatus.OK.code(), conn.getResponseCode());
                 assertTrue(uIServer.isAttached(ss));
-            } catch (InterruptedException | IOException e) {
+            } catch (IOException e) {
                 e.printStackTrace();
                 fail(e.getMessage());
             } finally {
@@ -243,7 +243,7 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
     }
 
     @Test (expected = DL4JException.class)
-    public void testUIServerGetInstanceMultipleCalls1() throws InterruptedException {
+    public void testUIServerGetInstanceMultipleCalls1() {
         UIServer uiServer = UIServer.getInstance();
         assertFalse(uiServer.isMultiSession());
         UIServer.getInstance(true, null);
@@ -251,7 +251,7 @@ public class TestVertxUIMultiSession extends BaseDL4JTest {
     }
 
     @Test (expected = DL4JException.class)
-    public void testUIServerGetInstanceMultipleCalls2() throws InterruptedException {
+    public void testUIServerGetInstanceMultipleCalls2() {
         UIServer uiServer = UIServer.getInstance(true, null);
         assertTrue(uiServer.isMultiSession());
         UIServer.getInstance(false, null);


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix Freemarker version mismatch: change version requested in `TrainModule` to 2.3.23 (freemarker.version in pom.xml) (fixes #8725)
fix checking multi-session mode in `VertxUIServer.getInstance`. Tested multiple calls in `TestVertxUIMultiSession`.
fix `UIServer.getInstance()` to return existing instance
extend timeout for manual UI tests from 30 to 600 seconds
fix for auto-attaching `StatsStorage` given in `VertxUIServer.getInstance(Integer, boolean, Function<String,StatsStorage>)`, test improvements
start and stop UI server synchronously (wait until complete), tests (should fix issue #8779)
exception handling, test improvements
add asynchronous method to start UI server
fix UI server language setting in multi-session mode
fix UI server system tab not loading data in multi-session mode (fixes #8794)
fix async stopping of UIServer.stopAsync(Promise<Void>), added test
restore the daemon thread style behaviour of UIServer: don't keep the process alive just because the UI is running 
speed up and don't Ignore tests in TestVertxUI and TestVertxUIMultiSession, put longer tests to separate class TestVertxUIManual

## How was this patch tested?

Tests in `TestVertxUI` and `TestVertxUIMultiSession`, manual tests in `TestVertxUIManual`

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
