### PR TITLE
Fix doc

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/conf/Configuration.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/conf/Configuration.java
@@ -50,11 +50,11 @@ import java.util.regex.PatternSyntaxException;
  * <h4 id="Resources">Resources</h4>
  *
  * <p>Configurations are specified by resources. A resource contains a set of
- * name/value pairs as XML data. Each resource is named by either a 
- * <code>String</code>. If named by a <code>String</code>,
- * then the classpath is examined for a file with that name.  If named by a 
- * <code>Path</code>, then the local filesystem is examined directly, without 
- * referring to the classpath.
+ * name/value pairs as XML data. Each resource is named by either a
+ * <code>String</code> or a <code>Path</code>. If named by a
+ * <code>String</code>, then the classpath is examined for a file with that
+ * name. If named by a <code>Path</code>, then the local filesystem is
+ * examined directly, without referring to the classpath.
  *
  * <p>Unless explicitly turned off, Hadoop by default specifies two 
  * resources, loaded in-order from the classpath: <ol>


### PR DESCRIPTION
Fix docstring: "By either a String *or a Path*"

## What changes were proposed in this pull request?

Fix the documentation.

## How was this patch tested?

It was not.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [N/A] Created tests for any significant new code additions.
- [N/A] Relevant tests for your changes are passing.
