### PR TITLE
Adding kotlin extension for basic operators

### DIFF
--- a/nd4k/README.md
+++ b/nd4k/README.md
@@ -1,0 +1,29 @@
+# Gradle Kotlin Extension
+
+Kotlin Extension to simplify nd4j operation (numpy style)
+
+usage exemple:
+```
+val a:INDArray = ...
+val b:INDArray = ...
+
+// operations on array
+val multiplication = a * b   // => a.mul(b)
+val dotProduct = a.dot(b)    // => a.mmul(b) 
+val transpose = a.T()        // => a.transpose()
+...
+
+// operations on Number
+1 + a   // => a.add(1)
+a * 2   // => a.mul(2)
+...
+
+fun sigmoid(x: INDArray): INDArray { 
+    return 1.0 / (1.0 + exp(-x)) 
+}
+
+fun sigmoidDerivative(x: INDArray): INDArray { 
+    return ( 1 - sigmoid(x) ) * sigmoid(x) 
+}
+```
+

--- a/nd4k/pom.xml
+++ b/nd4k/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2015-2018 Skymind, Inc.
+  ~
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Apache License, Version 2.0 which is available at
+  ~ https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.deeplearning4j</groupId>
+        <artifactId>deeplearning4j</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.nd4j</groupId>
+    <artifactId>nd4k</artifactId>
+    <packaging>jar</packaging>
+
+    <name>nd4k</name>
+
+    <url>http://nd4j.org/</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <kotlin.version>1.3.72</kotlin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-api</artifactId>
+            <version>${nd4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-nd4j-native</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.deeplearning4j</groupId>
+                    <artifactId>dl4j-test-resources</artifactId>
+                    <version>${dl4j-test-resources.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/nd4k/src/main/kotlin/org/nd4k/INDArrayExt.kt
+++ b/nd4k/src/main/kotlin/org/nd4k/INDArrayExt.kt
@@ -1,0 +1,36 @@
+package org.nd4k
+
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.ops.transforms.Transforms.exp
+
+// a + b    &&    a += b
+operator fun INDArray.plus(other: INDArray): INDArray { return this.add(other) }
+operator fun INDArray.plus(other: Number): INDArray { return this.add(other) }
+operator fun Number.plus(other: INDArray): INDArray { return other.add(this) }
+
+// -a
+operator fun INDArray.unaryMinus(): INDArray { return this.mul(-1.0) }
+
+// a - b    &&    a -= b
+operator fun INDArray.minus(other: INDArray): INDArray { return this.sub(other) }
+operator fun INDArray.minus(other: Number): INDArray { return this.sub(other) }
+operator fun Number.minus(other: INDArray): INDArray { return this + -other }
+
+// a * b
+operator fun INDArray.times(other: INDArray): INDArray { return this.mul(other) }
+operator fun INDArray.times(other: Number): INDArray { return this.mul(other) }
+operator fun Number.times(other: INDArray): INDArray { return other * this }
+
+// a / b
+operator fun INDArray.div(other: INDArray): INDArray { return this.div(other) }
+// operator fun INDArray.div(other: Number): INDArray // already define in INDArray
+operator fun Number.div(other: INDArray): INDArray { return this * other.rdiv(1) }
+
+// a.T()
+fun INDArray.T(): INDArray { return this.transpose() }
+
+// a.dot(b) ~numpy style
+fun INDArray.dot(other: INDArray): INDArray { return this.mmul(other) }
+
+// exp(a)
+fun exp(a: INDArray): INDArray { return exp(a, false) }

--- a/nd4k/src/test/kotlin/org/nd4k/INDArrayExtTest.kt
+++ b/nd4k/src/test/kotlin/org/nd4k/INDArrayExtTest.kt
@@ -1,0 +1,116 @@
+package org.nd4k
+
+import org.junit.Assert.*
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.factory.Nd4j
+import org.nd4j.linalg.ops.transforms.Transforms
+import org.nd4j.linalg.ops.transforms.Transforms.exp
+import org.junit.Test as test
+
+class INDArrayExtTest {
+
+    @test fun plusBetweenINDArray() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val expected = Nd4j.create(floatArrayOf(2f, 4f, 6f, 8f, 10f), intArrayOf(1, 5))
+        assertEquals(expected, a + b)
+    }
+
+    @test fun plusBetweenNumberAndINDArray() {
+        val a = 1
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val expected = Nd4j.create(floatArrayOf(2f, 3f, 4f, 5f, 6f), intArrayOf(1, 5))
+        assertEquals(expected, a + b)
+    }
+
+    @test fun plusBetweenINDArrayAndNumber() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val b = 1
+        val expected = Nd4j.create(floatArrayOf(2f, 3f, 4f, 5f, 6f), intArrayOf(1, 5))
+        assertEquals(expected, a + b)
+    }
+
+    @test fun unaryMinusOnINDArray() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val expected = Nd4j.create(floatArrayOf(-1f, -2f, -3f, -4f, -5f), intArrayOf(1, 5))
+        assertEquals(expected, -a)
+    }
+
+    @test fun minusBetweenINDArray() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val expected = Nd4j.create(floatArrayOf(0f, 0f, 0f, 0f, 0f), intArrayOf(1, 5))
+        assertEquals(expected, a - b)
+    }
+
+    @test fun minusBetweenNumberAndINDArray() {
+        val a = 1
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val expected = Nd4j.create(floatArrayOf(0f, -1f, -2f, -3f, -4f), intArrayOf(1, 5))
+        assertEquals(expected, a - b)
+    }
+
+    @test fun minusBetweenINDArrayAndNumber() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val b = 1
+        val expected = Nd4j.create(floatArrayOf(0f, 1f, 2f, 3f, 4f), intArrayOf(1, 5))
+        assertEquals(expected, a - b)
+    }
+
+    @test fun timesBetweenINDArray() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f), intArrayOf(2, 2))
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f), intArrayOf(2, 2))
+        val expected = Nd4j.create(floatArrayOf(1f, 4f, 9f, 16f), intArrayOf(2, 2))
+        assertEquals(expected, a * b) // not dot() !!!
+    }
+
+    @test fun timesBetweenNumberAndINDArray() {
+        val a = 2
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val expected = Nd4j.create(floatArrayOf(2f, 4f, 6f, 8f, 10f), intArrayOf(1, 5))
+        assertEquals(expected, a * b)
+    }
+
+    @test fun timesBetweenINDArrayAndNumber() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f, 5f), intArrayOf(1, 5))
+        val b = -3
+        val expected = Nd4j.create(floatArrayOf(-3f, -6f, -9f, -12f, -15f), intArrayOf(1, 5))
+        assertEquals(expected, a * b)
+    }
+
+    @test fun divBetweenINDArray() {
+        val a = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f), intArrayOf(2, 2))
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 3f, 4f), intArrayOf(2, 2))
+        val expected = Nd4j.create(floatArrayOf(1f, 1f, 1f, 1f), intArrayOf(2, 2))
+        assertEquals(expected, a / b)
+    }
+
+    @test fun divBetweenNumberAndINDArray() {
+        val a = 10
+        val b = Nd4j.create(floatArrayOf(1f, 2f, 5f), intArrayOf(1, 3))
+        val expected = Nd4j.create(floatArrayOf(10f, 5f, 2f), intArrayOf(1, 3))
+        assertEquals(expected, a / b)
+    }
+
+    @test fun divBetweenINDArrayAndNumber() {
+        val a = Nd4j.create(floatArrayOf(15f, 10f, 5f), intArrayOf(1, 3))
+        val b = 5
+        val expected = Nd4j.create(floatArrayOf(3f, 2f, 1f), intArrayOf(1, 3))
+        assertEquals(expected, a / b)
+    }
+
+    @test fun sigmoidUsingOperator() {
+        fun sigmoidUsingOperator(x: INDArray): INDArray { return 1.0 / (1.0 + exp(-x)) }
+        val a = Nd4j.create(floatArrayOf(0.2f), intArrayOf(1, 1))
+        assertEquals(Transforms.sigmoid(a), sigmoidUsingOperator(a))
+    }
+
+    @test fun sigmoidDerivativeUsingOperator() {
+        fun s(x: INDArray): INDArray { return 1.0 / (1.0 + exp(-x)) }
+        fun sigmoidDerivativeUsingOperator(x: INDArray): INDArray { return ( 1 - s(x) ) * s(x) }
+        val a = Nd4j.create(floatArrayOf(0.2f), intArrayOf(1, 1))
+        assertEquals(Transforms.sigmoidDerivative(a), sigmoidDerivativeUsingOperator(a))
+    }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
         <module>deeplearning4j</module>
         <module>arbiter</module>
         <module>nd4s</module>
+        <module>nd4k</module>
         <module>rl4j</module>
         <module>scalnet</module>
         <module>jumpy</module>


### PR DESCRIPTION
Signed-off-by: fbrunacci <fbrunacci@gmail.com>

## What changes were proposed in this pull request?
Adding kotlin extension functions on basic operations to make symbolic representation (like + or *) available.

## How was this patch tested?
unit tests:
nd4k/src/test/kotlin/org/nd4k/INDArrayExtTest.kt