### PR TITLE
Empty array casting fix

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -5521,7 +5521,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     public INDArray castTo(DataType dataType) {
         if(dataType == dataType())  //No-op if correct datatype
             return this;
-        if(isEmpty()){
+        if(isEmpty() && rank() == 0){
             return Nd4j.empty(dataType);
         }
         val result = Nd4j.createUninitialized(dataType, this.shape(), this.ordering());


### PR DESCRIPTION
In some cases we go from (for example) shape [0, 1] -> [] when we cast