### PR TITLE
Add options for changing the default CNN2D format

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/inputs/InputType.java
@@ -57,6 +57,15 @@ public abstract class InputType implements Serializable {
         FF, RNN, CNN, CNNFlat, CNN3D
     }
 
+    public static CNN2DFormat getDefaultCNN2DFormat() {
+        return defaultCNN2DFormat;
+    }
+
+    public static void setDefaultCNN2DFormat(CNN2DFormat defaultCNN2DFormat) {
+        InputType.defaultCNN2DFormat = defaultCNN2DFormat;
+    }
+
+    private static CNN2DFormat defaultCNN2DFormat = CNN2DFormat.NCHW;
 
     @JsonIgnore
     public abstract Type getType();
@@ -137,7 +146,7 @@ public abstract class InputType implements Serializable {
      * @return InputTypeConvolutional
      */
     public static InputType convolutional(long height, long width, long depth) {
-        return convolutional(height, width, depth, CNN2DFormat.NCHW);
+        return convolutional(height, width, depth, getDefaultCNN2DFormat());
     }
 
     public static InputType convolutional(long height, long width, long depth, CNN2DFormat format){


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added static method to be able to change the default CNN2DFormat. This means that when a model is being loaded (e.g., from a Keras H5 file), the default CNN2DFormat used for the model's layers can be configured. Currently, it always defaults to 'Channels First' which can cause problems for some models.

Please note that this change is completely backward-compatible; the default format is still NCHW so any models that previously loaded correctly will still work with this - it just adds an extra option for users that need it (like myself :))

## How was this patch tested?

Built `.jar` and used in my project - was able to load an EfficientNet model which previously wasn't able to be loaded due to the default CNN2DFormat.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
