### PR TITLE
shutdown hook for UI server

### DIFF
--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
@@ -195,7 +195,7 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
                 try {
                     instance.stop();
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    log.error("Interrupted stopping of Deeplearning4j UI server in shutdown hook.", e);
                 }
             }
         });

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/api/UIServer.java
@@ -168,4 +168,14 @@ public interface UIServer {
      * @param stopCallback callback {@link Promise} to notify on completion
      */
     void stopAsync(Promise<Void> stopCallback);
+
+    /**
+     * Get shutdown hook of UI server, that will stop the server when the Runtime is stopped.
+     * You may de-register this shutdown hook with {@link Runtime#removeShutdownHook(Thread)},
+     * and add your own hook with {@link Runtime#addShutdownHook(Thread)}
+     * @return shutdown hook
+     */
+    static Thread getShutdownHook() {
+        return VertxUIServer.getShutdownHook();
+    };
 }

--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/test/java/org/deeplearning4j/ui/TestVertxUI.java
@@ -346,12 +346,16 @@ public class TestVertxUI extends BaseDL4JTest {
     }
 
     @Test
-    public void testUIAutoStopOnThreadExit() throws InterruptedException {
-        AtomicReference<UIServer> uiServer = new AtomicReference<>();
-        Thread thread = new Thread(() -> uiServer.set(UIServer.getInstance()));
-        thread.start();
-        thread.join();
-        Thread.sleep(1_000);
-        assertTrue(uiServer.get().isStopped());
+    public void testUIShutdownHook() throws InterruptedException {
+        UIServer uIServer = UIServer.getInstance();
+        Thread shutdownHook = UIServer.getShutdownHook();
+        shutdownHook.start();
+        shutdownHook.join();
+        /*
+         * running the shutdown hook thread before the Runtime is terminated
+         * enables us to check if the UI server has been shut down or not
+         */
+        assertTrue(uIServer.isStopped());
+        log.info("Deeplearning4j UI server stopped in shutdown hook.");
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add shutdown hook for Deeplearning4j UI server, replacing plain `Thread.join()`. This will stop the UI when the `Runtime` is about to exit, not when the calling thread died.
This should fix #9001

## How was this patch tested?

Unit test: `org.deeplearning4j.ui.TestVertxUI#testUIShutdownHook`

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
