### PR TITLE
Close iterator properly to avoid resource not closed issue on training

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/LineRecordReader.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/LineRecordReader.java
@@ -165,6 +165,7 @@ public class LineRecordReader extends BaseRecordReader {
             throw new UnsupportedOperationException("Cannot reset without first initializing");
         try {
             inputSplit.reset();
+            close();
             initialize(inputSplit);
             splitIndex = 0;
         } catch (Exception e) {


### PR DESCRIPTION
Signed-off-by: CH Kang <ch1010.developer@gmail.com>

## What changes were proposed in this pull request?

When training model by EarlyStoppingTrainer, which data is read by CSVRecordReader, there are continuous warnings "A resource failed to call close".
To fix this issue, the change closes used iterator before a new iterator is initialized.
Please refer to [#8204](https://github.com/eclipse/deeplearning4j/issues/8204) for more detail.

## How was this patch tested?

Complete training in my project by applying the fix in original LineRecordReader/CSVRecordReader.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
