### PR TITLE
Using embedded copying of an array instead of manual

### DIFF
--- a/datavec/datavec-python/src/main/java/org/datavec/python/PythonExecutioner.java
+++ b/datavec/datavec-python/src/main/java/org/datavec/python/PythonExecutioner.java
@@ -345,10 +345,7 @@ public class PythonExecutioner {
                     //// TODO: fix in javacpp
                     File sitePackagesWindows = new File(python.cachePackage(), "site-packages");
                     File[] packages2 = new File[packages.length + 1];
-                    for (int i = 0;i < packages.length; i++){
-                        //System.out.println(packages[i].getAbsolutePath());
-                        packages2[i] = packages[i];
-                    }
+                    System.arraycopy(packages, 0, packages2, 0, packages.length);
                     packages2[packages.length] = sitePackagesWindows;
                     //System.out.println(sitePackagesWindows.getAbsolutePath());
                     packages = packages2;

--- a/datavec/datavec-python/src/main/java/org/datavec/python/PythonProcess.java
+++ b/datavec/datavec-python/src/main/java/org/datavec/python/PythonProcess.java
@@ -30,9 +30,7 @@ public class PythonProcess {
     private static String pythonExecutable = Loader.load(org.bytedeco.cpython.python.class);
     public static String runAndReturn(String... arguments)throws IOException, InterruptedException{
         String[] allArgs = new String[arguments.length + 1];
-        for (int i = 0; i < arguments.length; i++){
-            allArgs[i + 1] = arguments[i];
-        }
+        System.arraycopy(arguments, 0, allArgs, 1, arguments.length);
         allArgs[0] = pythonExecutable;
         log.info("Executing command: " + Arrays.toString(allArgs));
         ProcessBuilder pb = new ProcessBuilder(allArgs);
@@ -45,9 +43,7 @@ public class PythonProcess {
 
     public static void run(String... arguments)throws IOException, InterruptedException{
         String[] allArgs = new String[arguments.length + 1];
-        for (int i = 0; i < arguments.length; i++){
-            allArgs[i + 1] = arguments[i];
-        }
+        System.arraycopy(arguments, 0, allArgs, 1, arguments.length);
         allArgs[0] = pythonExecutable;
         log.info("Executing command: " + Arrays.toString(allArgs));
         ProcessBuilder pb = new ProcessBuilder(allArgs);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using the System.arraycopy for copying array instead of manual copying elements one by one is faster because System.arraycopy uses a memmove operation.


## How was this patch tested?

Run existing tests and build package.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
