### PR TITLE
Datavec bulk operation

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVVariableSlidingWindowRecordReader.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVVariableSlidingWindowRecordReader.java
@@ -128,9 +128,7 @@ public class CSVVariableSlidingWindowRecordReader extends CSVRecordReader implem
         }
 
         List<List<Writable>> sequence = new ArrayList<>();
-        for(List<Writable> line : queue) {
-            sequence.add(line);
-        }
+        sequence.addAll(queue);
 
         if(exhausted && queue.size()==1)
             queue.pollLast();

--- a/datavec/datavec-api/src/main/java/org/datavec/api/transform/sequence/window/OverlappingTimeWindowFunction.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/transform/sequence/window/OverlappingTimeWindowFunction.java
@@ -200,9 +200,8 @@ public class OverlappingTimeWindowFunction implements WindowFunction {
     public Schema transform(Schema inputSchema) {
         if (!addWindowStartTimeColumn && !addWindowEndTimeColumn)
             return inputSchema;
-        List<ColumnMetaData> newMeta = new ArrayList<>();
 
-        newMeta.addAll(inputSchema.getColumnMetaData());
+        List<ColumnMetaData> newMeta = new ArrayList<>(inputSchema.getColumnMetaData());
 
         if (addWindowStartTimeColumn) {
             newMeta.add(new TimeMetaData("windowStartTime"));

--- a/datavec/datavec-api/src/main/java/org/datavec/api/transform/sequence/window/TimeWindowFunction.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/transform/sequence/window/TimeWindowFunction.java
@@ -165,9 +165,8 @@ public class TimeWindowFunction implements WindowFunction {
     public Schema transform(Schema inputSchema) {
         if (!addWindowStartTimeColumn && !addWindowEndTimeColumn)
             return inputSchema;
-        List<ColumnMetaData> newMeta = new ArrayList<>();
 
-        newMeta.addAll(inputSchema.getColumnMetaData());
+        List<ColumnMetaData> newMeta = new ArrayList<>(inputSchema.getColumnMetaData());
 
         if (addWindowStartTimeColumn) {
             newMeta.add(new TimeMetaData("windowStartTime"));

--- a/datavec/datavec-api/src/main/java/org/datavec/api/transform/transform/column/AddConstantColumnTransform.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/transform/transform/column/AddConstantColumnTransform.java
@@ -53,8 +53,7 @@ public class AddConstantColumnTransform implements Transform {
 
     @Override
     public Schema transform(Schema inputSchema) {
-        List<ColumnMetaData> outMeta = new ArrayList<>();
-        outMeta.addAll(inputSchema.getColumnMetaData());
+        List<ColumnMetaData> outMeta = new ArrayList<>(inputSchema.getColumnMetaData());
 
         ColumnMetaData newColMeta = newColumnType.newColumnMetaData(newColumnName);
         outMeta.add(newColMeta);

--- a/datavec/datavec-api/src/main/java/org/datavec/api/transform/transform/string/ConcatenateStringColumns.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/transform/transform/string/ConcatenateStringColumns.java
@@ -75,8 +75,7 @@ public class ConcatenateStringColumns extends BaseTransform implements ColumnOp 
             }
         }
 
-        List<ColumnMetaData> outMeta = new ArrayList<>();
-        outMeta.addAll(inputSchema.getColumnMetaData());
+        List<ColumnMetaData> outMeta = new ArrayList<>(inputSchema.getColumnMetaData());
 
         ColumnMetaData newColMeta = ColumnType.String.newColumnMetaData(newColumnName);
         outMeta.add(newColMeta);

--- a/datavec/datavec-api/src/test/java/org/datavec/api/transform/transform/TestTransforms.java
+++ b/datavec/datavec-api/src/test/java/org/datavec/api/transform/transform/TestTransforms.java
@@ -279,8 +279,7 @@ public class TestTransforms extends BaseND4JTest {
         Assert.assertEquals(outputColumns, newSchema.getColumnNames());
 
         List<Writable> input = new ArrayList<>();
-        for (Writable value : COLUMN_VALUES)
-            input.add(value);
+        input.addAll(COLUMN_VALUES);
 
         transform.setInputSchema(schema);
         List<Writable> transformed = transform.map(input);

--- a/datavec/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordBatch.java
+++ b/datavec/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordBatch.java
@@ -243,8 +243,7 @@ public class ArrowWritableRecordBatch extends AbstractWritableRecordBatch implem
     public List<List<Writable>> toArrayList() {
         List<List<Writable>> ret = new ArrayList<>();
         for(int i = 0; i < size(); i++) {
-            List<Writable> add = new ArrayList<>();
-            add.addAll(get(i));
+            List<Writable> add = new ArrayList<>(get(i));
             ret.add(add);
         }
 

--- a/datavec/datavec-local/src/main/java/org/datavec/local/transforms/sequence/LocalGroupToSequenceFunction.java
+++ b/datavec/datavec-local/src/main/java/org/datavec/local/transforms/sequence/LocalGroupToSequenceFunction.java
@@ -40,8 +40,7 @@ public class LocalGroupToSequenceFunction implements Function<List<List<Writable
     public List<List<Writable>> apply(List<List<Writable>> lists) {
 
         List<List<Writable>> list = new ArrayList<>();
-        for (List<Writable> writables : lists)
-            list.add(writables);
+        list.addAll(lists);
 
         Collections.sort(list, comparator);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bulk operation can be used instead of iteration inspection (please look at the JMH benchmark below).
- Removed redundant 'Collection.addAll()' call inspection.

![image](https://user-images.githubusercontent.com/6116322/91408059-829cfa00-e843-11ea-8612-6f8d13a25e74.png)


## How was this patch tested?

Run existing tests and build package.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [X] Relevant tests for your changes are passing.
