### PR TITLE
Fix off by one error in ArrayCacheMemoryMgr

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
@@ -252,7 +252,7 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
         private void removeObject(INDArray array){
             long length = array.data().length();
             int idx = Arrays.binarySearch(lengths, 0, size, length);
-            Preconditions.checkState(idx > 0, "Cannot remove array from ArrayStore: no array with this length exists in the cache");
+            Preconditions.checkState(idx >= 0, "Cannot remove array from ArrayStore: no array with this length exists in the cache");
             boolean found = false;
             int i = 0;
             while(!found && i <= size && lengths[i] == length){


### PR DESCRIPTION
Signed-off-by: Dave <dave.d@canva.com>

## What changes were proposed in this pull request?
Fix an off by one error in ArrayCacheMemoryMgr which causes arrays not to be removed from cache.

## How was this patch tested?
Unable to test as I could not build from source on my local machine.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.

Arguably not a 'significant code addition'
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
