### PR TITLE
FEATURE#8712: add possibility to specify classloader for DL4J

### DIFF
--- a/deeplearning4j/deeplearning4j-common/pom.xml
+++ b/deeplearning4j/deeplearning4j-common/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>nd4j-common</artifactId>
             <version>${nd4j.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -43,5 +49,4 @@
             <id>test-nd4j-cuda-11.0</id>
         </profile>
     </profiles>
-
 </project>

--- a/deeplearning4j/deeplearning4j-common/src/main/java/org/deeplearning4j/common/config/DL4JClassLoading.java
+++ b/deeplearning4j/deeplearning4j-common/src/main/java/org/deeplearning4j/common/config/DL4JClassLoading.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) Eclipse Deeplearning4j Contributors 2020
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.deeplearning4j.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.nd4j.common.config.ND4JClassLoading;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+/**
+ * Global context for class-loading in DL4J.
+ * <p>Use {@code DL4JClassLoading} to define classloader for Deeplearning4j only! To define classloader used by
+ * {@code ND4J} use class {@link org.nd4j.common.config.ND4JClassLoading}.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * public class Application {
+ *     static {
+ *         DL4JClassLoading.setDl4jClassloaderFromClass(Application.class);
+ *     }
+ *
+ *     public static void main(String[] args) {
+ *     }
+ * }
+ * }</code>
+ *
+ * @see org.nd4j.common.config.ND4JClassLoading
+ *
+ * @author Alexei KLENIN
+ */
+@Slf4j
+public class DL4JClassLoading {
+    private static ClassLoader dl4jClassloader = ND4JClassLoading.getNd4jClassloader();
+
+    private DL4JClassLoading() {
+    }
+
+    public static ClassLoader getDl4jClassloader() {
+        return DL4JClassLoading.dl4jClassloader;
+    }
+
+    public static void setDl4jClassloaderFromClass(Class<?> clazz) {
+        setDl4jClassloader(clazz.getClassLoader());
+    }
+
+    public static void setDl4jClassloader(ClassLoader dl4jClassloader) {
+        DL4JClassLoading.dl4jClassloader = dl4jClassloader;
+        log.debug("Global class-loader for DL4J was changed.");
+    }
+
+    public static boolean classPresentOnClasspath(String className) {
+        return classPresentOnClasspath(className, dl4jClassloader);
+    }
+
+    public static boolean classPresentOnClasspath(String className, ClassLoader classLoader) {
+        return loadClassByName(className, false, classLoader) != null;
+    }
+
+    public static <T> Class<T> loadClassByName(String className) {
+        return loadClassByName(className, true, dl4jClassloader);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Class<T> loadClassByName(String className, boolean initialize, ClassLoader classLoader) {
+        try {
+            return (Class<T>) Class.forName(className, initialize, classLoader);
+        } catch (ClassNotFoundException classNotFoundException) {
+            log.error(String.format("Cannot find class [%s] of provided class-loader.", className));
+            return null;
+        }
+    }
+
+    public static <T> T createNewInstance(String className, Object... args) {
+        return createNewInstance(className, Object.class, args);
+    }
+
+    public static <T> T createNewInstance(String className, Class<? super T> superclass) {
+        return createNewInstance(className, superclass, new Class<?>[]{}, new Object[]{});
+    }
+
+    public static <T> T createNewInstance(String className, Class<? super T> superclass, Object... args) {
+        Class<?>[] parameterTypes = new Class<?>[args.length];
+        for (int i = 0; i < args.length; i++) {
+            Object arg = args[i];
+            Objects.requireNonNull(arg);
+            parameterTypes[i] = arg.getClass();
+        }
+
+        return createNewInstance(className, superclass, parameterTypes, args);
+    }
+
+    public static <T> T createNewInstance(
+            String className,
+            Class<? super T> superclass,
+            Class<?>[] parameterTypes,
+            Object... args) {
+        try {
+            return (T) DL4JClassLoading
+                    .loadClassByName(className)
+                    .asSubclass(superclass)
+                    .getDeclaredConstructor(parameterTypes)
+                    .newInstance(args);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException
+                | NoSuchMethodException instantiationException) {
+            log.error(String.format("Cannot create instance of class '%s'.", className), instantiationException);
+            throw new RuntimeException(instantiationException);
+        }
+    }
+
+    public static <S> ServiceLoader<S> loadService(Class<S> serviceClass) {
+        return loadService(serviceClass, dl4jClassloader);
+    }
+
+    public static <S> ServiceLoader<S> loadService(Class<S> serviceClass, ClassLoader classLoader) {
+        return ServiceLoader.load(serviceClass, classLoader);
+    }
+}

--- a/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/DL4JClassLoadingTest.java
+++ b/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/DL4JClassLoadingTest.java
@@ -1,0 +1,67 @@
+package org.deeplearning4j.common.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.deeplearning4j.common.config.dummies.TestAbstract;
+import org.junit.Test;
+
+public class DL4JClassLoadingTest {
+    private static final String PACKAGE_PREFIX = "org.deeplearning4j.common.config.dummies.";
+
+    @Test
+    public void testCreateNewInstance_constructorWithoutArguments() {
+
+        /* Given */
+        String className = PACKAGE_PREFIX + "TestDummy";
+
+        /* When */
+        Object instance = DL4JClassLoading.createNewInstance(className);
+
+        /* Then */
+        assertNotNull(instance);
+        assertEquals(className, instance.getClass().getName());
+    }
+
+    @Test
+    public void testCreateNewInstance_constructorWithArgument_implicitArgumentTypes() {
+
+        /* Given */
+        String className = PACKAGE_PREFIX + "TestColor";
+
+        /* When */
+        TestAbstract instance = DL4JClassLoading.createNewInstance(className, TestAbstract.class, "white");
+
+        /* Then */
+        assertNotNull(instance);
+        assertEquals(className, instance.getClass().getName());
+    }
+
+    @Test
+    public void testCreateNewInstance_constructorWithArgument_explicitArgumentTypes() {
+
+        /* Given */
+        String colorClassName = PACKAGE_PREFIX + "TestColor";
+        String rectangleClassName = PACKAGE_PREFIX + "TestRectangle";
+
+        /* When */
+        TestAbstract color = DL4JClassLoading.createNewInstance(
+                colorClassName,
+                Object.class,
+                new Class<?>[]{ int.class, int.class, int.class },
+                45, 175, 200);
+
+        TestAbstract rectangle = DL4JClassLoading.createNewInstance(
+                rectangleClassName,
+                Object.class,
+                new Class<?>[]{ int.class, int.class, TestAbstract.class },
+                10, 15, color);
+
+        /* Then */
+        assertNotNull(color);
+        assertEquals(colorClassName, color.getClass().getName());
+
+        assertNotNull(rectangle);
+        assertEquals(rectangleClassName, rectangle.getClass().getName());
+    }
+}

--- a/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestAbstract.java
+++ b/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestAbstract.java
@@ -1,0 +1,4 @@
+package org.deeplearning4j.common.config.dummies;
+
+public abstract class TestAbstract {
+}

--- a/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestColor.java
+++ b/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestColor.java
@@ -1,0 +1,9 @@
+package org.deeplearning4j.common.config.dummies;
+
+public class TestColor extends TestAbstract {
+    public TestColor(String color) {
+    }
+
+    public TestColor(int r, int g, int b) {
+    }
+}

--- a/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestDummy.java
+++ b/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestDummy.java
@@ -1,0 +1,6 @@
+package org.deeplearning4j.common.config.dummies;
+
+public class TestDummy {
+    public TestDummy() {
+    }
+}

--- a/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestRectangle.java
+++ b/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/dummies/TestRectangle.java
@@ -1,0 +1,6 @@
+package org.deeplearning4j.common.config.dummies;
+
+public class TestRectangle extends TestAbstract {
+    public TestRectangle(int width, int height, TestAbstract color) {
+    }
+}

--- a/deeplearning4j/deeplearning4j-core/src/main/java/org/deeplearning4j/core/parallelism/AsyncIterator.java
+++ b/deeplearning4j/deeplearning4j-core/src/main/java/org/deeplearning4j/core/parallelism/AsyncIterator.java
@@ -102,7 +102,6 @@ public class AsyncIterator<T extends Object> implements Iterator<T> {
         }
     }
 
-
     private class ReaderThread<T> extends Thread implements Runnable {
         private BlockingQueue<T> buffer;
         private Iterator<T> iterator;

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/LayerHelperValidationUtil.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/LayerHelperValidationUtil.java
@@ -19,6 +19,7 @@ package org.deeplearning4j;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
 import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
@@ -66,23 +67,23 @@ public class LayerHelperValidationUtil {
 
     public static void disableCppHelpers(){
         try {
-            Class<?> c = Class.forName("org.nd4j.nativeblas.Nd4jCpu$Environment");
-            Method m = c.getMethod("getInstance");
-            Object instance = m.invoke(null);
-            Method m2 = c.getMethod("allowHelpers", boolean.class);
-            m2.invoke(instance, false);
+            Class<?> clazz = DL4JClassLoading.loadClassByName("org.nd4j.nativeblas.Nd4jCpu$Environment");
+            Method getInstance = clazz.getMethod("getInstance");
+            Object instance = getInstance.invoke(null);
+            Method allowHelpers = clazz.getMethod("allowHelpers", boolean.class);
+            allowHelpers.invoke(instance, false);
         } catch (Throwable t){
             throw new RuntimeException(t);
         }
     }
 
     public static void enableCppHelpers(){
-        try{
-            Class<?> c = Class.forName("org.nd4j.nativeblas.Nd4jCpu$Environment");
-            Method m = c.getMethod("getInstance");
-            Object instance = m.invoke(null);
-            Method m2 = c.getMethod("allowHelpers", boolean.class);
-            m2.invoke(instance, true);
+        try {
+            Class<?> clazz = DL4JClassLoading.loadClassByName("org.nd4j.nativeblas.Nd4jCpu$Environment");
+            Method getInstance = clazz.getMethod("getInstance");
+            Object instance = getInstance.invoke(null);
+            Method allowHelpers = clazz.getMethod("allowHelpers", boolean.class);
+            allowHelpers.invoke(instance, true);
         } catch (Throwable t){
             throw new RuntimeException(t);
         }

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTMTest.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/recurrent/GravesLSTMTest.java
@@ -18,6 +18,7 @@ package org.deeplearning4j.nn.layers.recurrent;
 
 import lombok.val;
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -167,7 +168,7 @@ public class GravesLSTMTest extends BaseDL4JTest {
         actHelper.setAccessible(true);
 
         //Call activateHelper with both forBackprop == true, and forBackprop == false and compare
-        Class<?> innerClass = Class.forName("org.deeplearning4j.nn.layers.recurrent.FwdPassReturn");
+        Class<?> innerClass = DL4JClassLoading.loadClassByName("org.deeplearning4j.nn.layers.recurrent.FwdPassReturn");
 
         Object oFalse = actHelper.invoke(lstm, false, null, null, false, LayerWorkspaceMgr.noWorkspacesImmutable()); //GravesLSTM.FwdPassReturn object; want fwdPassOutput INDArray
         Object oTrue = actHelper.invoke(lstm, false, null, null, true, LayerWorkspaceMgr.noWorkspacesImmutable()); //want fwdPassOutputAsArrays object

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/TFOpLayerImpl.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/TFOpLayerImpl.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.nn.modelimport.keras.layers;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.AbstractLayer;
@@ -110,7 +111,7 @@ public class TFOpLayerImpl extends AbstractLayer<TFOpLayer> {
             org.nd4j.shade.protobuf.ByteString serialized = graphDef.toByteString();
             byte[] graphBytes = serialized.toByteArray();
 
-            ServiceLoader<TFGraphRunnerService> sl = ServiceLoader.load(TFGraphRunnerService.class);
+            ServiceLoader<TFGraphRunnerService> sl = DL4JClassLoading.loadService(TFGraphRunnerService.class);
             Iterator<TFGraphRunnerService> iter = sl.iterator();
             if (!iter.hasNext()){
                 throw new RuntimeException("The model contains a Tensorflow Op, which requires the nd4j-tensorflow dependency to execute.");

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-chinese/src/main/java/org/ansj/app/crf/Model.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-chinese/src/main/java/org/ansj/app/crf/Model.java
@@ -60,15 +60,13 @@ public abstract class Model {
 
     /**
      * 模型读取
-     * 
-     * @param path
-     * @return
-     * @return
-     * @throws Exception
+     *
      */
-    public static Model load(Class<? extends Model> c, InputStream is) throws Exception {
-        Model model = c.newInstance();
-        return model.loadModel(is);
+    public static Model load(Class<? extends Model> modelClass, InputStream inputStream) throws Exception {
+        return modelClass
+                .getDeclaredConstructor()
+                .newInstance()
+                .loadModel(inputStream);
     }
 
     /**

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-chinese/src/main/java/org/ansj/dic/impl/Jar2Stream.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-chinese/src/main/java/org/ansj/dic/impl/Jar2Stream.java
@@ -3,6 +3,7 @@ package org.ansj.dic.impl;
 import org.ansj.dic.DicReader;
 import org.ansj.dic.PathToStream;
 import org.ansj.exception.LibraryException;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 
 import java.io.InputStream;
 
@@ -17,12 +18,16 @@ public class Jar2Stream extends PathToStream {
     @Override
     public InputStream toStream(String path) {
         if (path.contains("|")) {
-            String[] split = path.split("\\|");
-            try {
-                return Class.forName(split[0].substring(6)).getResourceAsStream(split[1].trim());
-            } catch (ClassNotFoundException e) {
-                throw new LibraryException(e);
+            String[] tokens = path.split("\\|");
+            String className = tokens[0].substring(6);
+            String resourceName = tokens[1].trim();
+
+            Class<Object> resourceClass = DL4JClassLoading.loadClassByName(className);
+            if (resourceClass == null) {
+                throw new LibraryException(String.format("Class '%s' was not found.", className));
             }
+
+            return resourceClass.getResourceAsStream(resourceName);
         } else {
             return DicReader.getInputStream(path.substring(6));
         }

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-chinese/src/main/java/org/ansj/dic/impl/Jdbc2Stream.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp-chinese/src/main/java/org/ansj/dic/impl/Jdbc2Stream.java
@@ -2,6 +2,7 @@ package org.ansj.dic.impl;
 
 import org.ansj.dic.PathToStream;
 import org.ansj.exception.LibraryException;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -22,20 +23,26 @@ public class Jdbc2Stream extends PathToStream {
 
     private static final byte[] LINE = "\n".getBytes();
 
+    private static final String[] JDBC_DRIVERS = {
+            "org.h2.Driver",
+            "com.ibm.db2.jcc.DB2Driver",
+            "org.hsqldb.jdbcDriver",
+            "org.gjt.mm.mysql.Driver",
+            "oracle.jdbc.OracleDriver",
+            "org.postgresql.Driver",
+            "net.sourceforge.jtds.jdbc.Driver",
+            "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+            "org.sqlite.JDBC",
+            "com.mysql.jdbc.Driver"
+    };
+
     static {
-        String[] drivers = {"org.h2.Driver", "com.ibm.db2.jcc.DB2Driver", "org.hsqldb.jdbcDriver",
-                        "org.gjt.mm.mysql.Driver", "oracle.jdbc.OracleDriver", "org.postgresql.Driver",
-                        "net.sourceforge.jtds.jdbc.Driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-                        "org.sqlite.JDBC", "com.mysql.jdbc.Driver"};
-        for (String driverClassName : drivers) {
-            try {
-                try {
-                    Thread.currentThread().getContextClassLoader().loadClass(driverClassName);
-                } catch (ClassNotFoundException e) {
-                    Class.forName(driverClassName);
-                }
-            } catch (Throwable e) {
-            }
+        loadJdbcDrivers();
+    }
+
+    static void loadJdbcDrivers() {
+        for (String driverClassName : JDBC_DRIVERS) {
+            DL4JClassLoading.loadClassByName(driverClassName);
         }
     }
 

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
@@ -16,6 +16,8 @@
 
 package org.deeplearning4j.models.sequencevectors;
 
+import org.apache.commons.lang3.StringUtils;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.nd4j.shade.guava.primitives.Ints;
 import org.nd4j.shade.guava.util.concurrent.AtomicDouble;
 import lombok.Getter;
@@ -494,15 +496,17 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
             this.useHierarchicSoftmax = configuration.isUseHierarchicSoftmax();
             this.preciseMode = configuration.isPreciseMode();
 
-            if (configuration.getModelUtils() != null && !configuration.getModelUtils().isEmpty()) {
-
+            String modelUtilsClassName = configuration.getModelUtils();
+            if (StringUtils.isNotEmpty(modelUtilsClassName)) {
                 try {
-                    this.modelUtils = (ModelUtils<T>) Class.forName(configuration.getModelUtils()).newInstance();
-                } catch (Exception e) {
-                    log.error("Got {} trying to instantiate ModelUtils, falling back to BasicModelUtils instead");
+                    this.modelUtils = DL4JClassLoading.createNewInstance(modelUtilsClassName);
+                } catch (Exception instantiationException) {
+                    log.error(
+                            "Got '{}' trying to instantiate ModelUtils, falling back to BasicModelUtils instead",
+                            instantiationException.getMessage(),
+                            instantiationException);
                     this.modelUtils = new BasicModelUtils<>();
                 }
-
             }
 
             if (configuration.getElementsLearningAlgorithm() != null
@@ -551,12 +555,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
          * @return
          */
         public Builder<T> sequenceLearningAlgorithm(@NonNull String algoName) {
-            try {
-                Class clazz = Class.forName(algoName);
-                sequenceLearningAlgorithm = (SequenceLearningAlgorithm<T>) clazz.newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            this.sequenceLearningAlgorithm = DL4JClassLoading.createNewInstance(algoName);
             return this;
         }
 
@@ -578,13 +577,9 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
          * @return
          */
         public Builder<T> elementsLearningAlgorithm(@NonNull String algoName) {
-            try {
-                Class clazz = Class.forName(algoName);
-                elementsLearningAlgorithm = (ElementsLearningAlgorithm<T>) clazz.newInstance();
-                this.configuration.setElementsLearningAlgorithm(elementsLearningAlgorithm.getClass().getCanonicalName());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            this.elementsLearningAlgorithm = DL4JClassLoading.createNewInstance(algoName);
+            this.configuration.setElementsLearningAlgorithm(elementsLearningAlgorithm.getClass().getCanonicalName());
+
             return this;
         }
 
@@ -943,31 +938,23 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                                 .lr(learningRate).seed(seed).build();
             }
 
-            if (this.configuration.getElementsLearningAlgorithm() != null) {
-                try {
-                    elementsLearningAlgorithm = (ElementsLearningAlgorithm<T>) Class
-                                    .forName(this.configuration.getElementsLearningAlgorithm()).newInstance();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+            String elementsLearningAlgorithm = this.configuration.getElementsLearningAlgorithm();
+            if (StringUtils.isNotEmpty(elementsLearningAlgorithm)) {
+                this.elementsLearningAlgorithm = DL4JClassLoading.createNewInstance(elementsLearningAlgorithm);
             }
 
-            if (this.configuration.getSequenceLearningAlgorithm() != null) {
-                try {
-                    sequenceLearningAlgorithm = (SequenceLearningAlgorithm<T>) Class
-                                    .forName(this.configuration.getSequenceLearningAlgorithm()).newInstance();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+            String sequenceLearningAlgorithm = this.configuration.getSequenceLearningAlgorithm();
+            if (StringUtils.isNotEmpty(sequenceLearningAlgorithm)) {
+                this.sequenceLearningAlgorithm = DL4JClassLoading.createNewInstance(sequenceLearningAlgorithm);
             }
 
-            if (trainElementsVectors && elementsLearningAlgorithm == null) {
+            if (trainElementsVectors && this.elementsLearningAlgorithm == null) {
                 // create default implementation of ElementsLearningAlgorithm
-                elementsLearningAlgorithm = new SkipGram<>();
+                this.elementsLearningAlgorithm = new SkipGram<>();
             }
 
-            if (trainSequenceVectors && sequenceLearningAlgorithm == null) {
-                sequenceLearningAlgorithm = new DBOW<>();
+            if (trainSequenceVectors && this.sequenceLearningAlgorithm == null) {
+                this.sequenceLearningAlgorithm = new DBOW<>();
             }
 
             this.modelUtils.init(lookupTable);

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/BaseMKLDNNHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/BaseMKLDNNHelper.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.nn.layers.mkldnn;
 
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.lang.reflect.Method;
@@ -47,12 +48,11 @@ public class BaseMKLDNNHelper {
         }
 
         try{
-            Class<?> c = Class.forName("org.nd4j.nativeblas.Nd4jCpu$Environment");
-            Method m = c.getMethod("getInstance");
-            Object instance = m.invoke(null);
-            Method m2 = c.getMethod("isUseMKLDNN");
-            boolean b = (Boolean)m2.invoke(instance);
-            return b;
+            Class<?> clazz = DL4JClassLoading.loadClassByName("org.nd4j.nativeblas.Nd4jCpu$Environment");
+            Method getInstance = clazz.getMethod("getInstance");
+            Object instance = getInstance.invoke(null);
+            Method isUseMKLDNNMethod = clazz.getMethod("isUseMKLDNN");
+            return (boolean) isUseMKLDNNMethod.invoke(instance);
         } catch (Throwable t ){
             FAILED_CHECK = new AtomicBoolean(true);
             return false;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/LocalResponseNormalization.java
@@ -16,7 +16,9 @@
 
 package org.deeplearning4j.nn.layers.normalization;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.nn.api.Layer;
 import org.deeplearning4j.nn.conf.CNN2DFormat;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
@@ -36,9 +38,6 @@ import org.nd4j.common.primitives.Pair;
 import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.nn.workspace.ArrayType;
 import org.nd4j.common.primitives.Triple;
-import org.nd4j.common.util.OneTimeLogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
 
@@ -65,10 +64,9 @@ import static org.nd4j.linalg.indexing.NDArrayIndex.interval;
  * <p>
  * Created by nyghtowl on 10/29/15.
  */
+@Slf4j
 public class LocalResponseNormalization
-                extends AbstractLayer<org.deeplearning4j.nn.conf.layers.LocalResponseNormalization> {
-    protected static final Logger log =
-                    LoggerFactory.getLogger(org.deeplearning4j.nn.conf.layers.LocalResponseNormalization.class);
+        extends AbstractLayer<org.deeplearning4j.nn.conf.layers.LocalResponseNormalization> {
 
     protected LocalResponseNormalizationHelper helper = null;
     protected int helperCountFail = 0;
@@ -86,19 +84,11 @@ public class LocalResponseNormalization
     void initializeHelper() {
         String backend = Nd4j.getExecutioner().getEnvironmentInformation().getProperty("backend");
         if("CUDA".equalsIgnoreCase(backend)) {
-            try {
-                helper = Class.forName("org.deeplearning4j.cuda.normalization.CudnnLocalResponseNormalizationHelper")
-                        .asSubclass(LocalResponseNormalizationHelper.class).getConstructor(DataType.class).newInstance(dataType);
-                log.debug("CudnnLocalResponseNormalizationHelper successfully initialized");
-            } catch (Throwable t) {
-                if (!(t instanceof ClassNotFoundException)) {
-                    log.warn("Could not initialize CudnnLocalResponseNormalizationHelper", t);
-                } else {
-                    OneTimeLogger.info(log, "cuDNN not found: "
-                            + "use cuDNN for better GPU performance by including the deeplearning4j-cuda module. "
-                            + "For more information, please refer to: https://deeplearning4j.konduit.ai/config/backends/config-cudnn", t);
-                }
-            }
+            helper = DL4JClassLoading.createNewInstance(
+                    "org.deeplearning4j.cuda.normalization.CudnnLocalResponseNormalizationHelper",
+                    LocalResponseNormalizationHelper.class,
+                    dataType);
+            log.debug("CudnnLocalResponseNormalizationHelper successfully initialized");
         }
         //2019-03-09 AB - MKL-DNN helper disabled: https://github.com/deeplearning4j/deeplearning4j/issues/7272
 //        else if("CPU".equalsIgnoreCase(backend)){

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/SparkSequenceVectors.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/SparkSequenceVectors.java
@@ -25,6 +25,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.storage.StorageLevel;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.exception.DL4JInvalidConfigException;
 import org.deeplearning4j.models.embeddings.loader.VectorsConfiguration;
 import org.deeplearning4j.models.sequencevectors.SequenceVectors;
@@ -161,14 +162,9 @@ public class SparkSequenceVectors<T extends SequenceElement> extends SequenceVec
         validateConfiguration();
 
         if (ela == null) {
-            try {
-                ela = (SparkElementsLearningAlgorithm) Class.forName(configuration.getElementsLearningAlgorithm())
-                                .newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            String className = configuration.getElementsLearningAlgorithm();
+            ela = DL4JClassLoading.createNewInstance(className);
         }
-
 
         if (workers > 1) {
             log.info("Repartitioning corpus to {} parts...", workers);

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/BaseTokenizerFunction.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/BaseTokenizerFunction.java
@@ -18,6 +18,7 @@ package org.deeplearning4j.spark.models.sequencevectors.functions;
 
 import lombok.NonNull;
 import org.apache.spark.broadcast.Broadcast;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.models.embeddings.loader.VectorsConfiguration;
 import org.deeplearning4j.text.tokenization.tokenizer.TokenPreProcess;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
@@ -42,24 +43,17 @@ public abstract class BaseTokenizerFunction implements Serializable {
         String tpClassName = this.configurationBroadcast.getValue().getTokenPreProcessor();
 
         if (tfClassName != null && !tfClassName.isEmpty()) {
-            try {
-                tokenizerFactory = (TokenizerFactory) Class.forName(tfClassName).newInstance();
+            tokenizerFactory = DL4JClassLoading.createNewInstance(tfClassName);
 
-                if (tpClassName != null && !tpClassName.isEmpty()) {
-                    try {
-                        tokenPreprocessor = (TokenPreProcess) Class.forName(tpClassName).newInstance();
-                    } catch (Exception e) {
-                        throw new RuntimeException("Unable to instantiate TokenPreProcessor.", e);
-                    }
-                }
-
-                if (tokenPreprocessor != null) {
-                    tokenizerFactory.setTokenPreProcessor(tokenPreprocessor);
-                }
-            } catch (Exception e) {
-                throw new RuntimeException("Unable to instantiate TokenizerFactory.", e);
+            if (tpClassName != null && !tpClassName.isEmpty()) {
+                tokenPreprocessor = DL4JClassLoading.createNewInstance(tpClassName);
             }
-        } else
+
+            if (tokenPreprocessor != null) {
+                tokenizerFactory.setTokenPreProcessor(tokenPreprocessor);
+            }
+        } else {
             throw new RuntimeException("TokenizerFactory wasn't defined.");
+        }
     }
 }

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/CountFunction.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/CountFunction.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.Accumulator;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.broadcast.Broadcast;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.models.embeddings.loader.VectorsConfiguration;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.sequence.SequenceElement;
@@ -65,13 +66,8 @@ public class CountFunction<T extends SequenceElement> implements Function<Sequen
         long seqLen = 0;
 
         if (ela == null) {
-            try {
-                ela = (SparkElementsLearningAlgorithm) Class
-                                .forName(vectorsConfigurationBroadcast.getValue().getElementsLearningAlgorithm())
-                                .newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            String elementsLearningAlgorithm = vectorsConfigurationBroadcast.getValue().getElementsLearningAlgorithm();
+            ela = DL4JClassLoading.createNewInstance(elementsLearningAlgorithm);
         }
         driver = ela.getTrainingDriver();
 

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/PartitionTrainingFunction.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/PartitionTrainingFunction.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.spark.models.sequencevectors.functions;
 import lombok.NonNull;
 import org.apache.spark.api.java.function.VoidFunction;
 import org.apache.spark.broadcast.Broadcast;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.models.embeddings.loader.VectorsConfiguration;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.sequence.SequenceElement;
@@ -74,19 +75,15 @@ public class PartitionTrainingFunction<T extends SequenceElement> implements Voi
         if (vectorsConfiguration == null)
             vectorsConfiguration = configurationBroadcast.getValue();
 
+        String elementsLearningAlgorithm = vectorsConfiguration.getElementsLearningAlgorithm();
         if (paramServer == null) {
             paramServer = VoidParameterServer.getInstance();
 
-            if (elementsLearningAlgorithm == null) {
-                try {
-                    elementsLearningAlgorithm = (SparkElementsLearningAlgorithm) Class
-                                    .forName(vectorsConfiguration.getElementsLearningAlgorithm()).newInstance();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+            if (this.elementsLearningAlgorithm == null) {
+                this.elementsLearningAlgorithm = DL4JClassLoading.createNewInstance(elementsLearningAlgorithm);
             }
 
-            driver = elementsLearningAlgorithm.getTrainingDriver();
+            driver = this.elementsLearningAlgorithm.getTrainingDriver();
 
             // FIXME: init line should probably be removed, basically init happens in VocabRddFunction
             paramServer.init(paramServerConfigurationBroadcast.getValue(), new RoutedTransport(), driver);
@@ -95,33 +92,24 @@ public class PartitionTrainingFunction<T extends SequenceElement> implements Voi
         if (shallowVocabCache == null)
             shallowVocabCache = vocabCacheBroadcast.getValue();
 
-        if (elementsLearningAlgorithm == null && vectorsConfiguration.getElementsLearningAlgorithm() != null) {
+        if (this.elementsLearningAlgorithm == null && elementsLearningAlgorithm != null) {
             // TODO: do ELA initialization
-            try {
-                elementsLearningAlgorithm = (SparkElementsLearningAlgorithm) Class
-                                .forName(vectorsConfiguration.getElementsLearningAlgorithm()).newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            this.elementsLearningAlgorithm = DL4JClassLoading.createNewInstance(elementsLearningAlgorithm);
         }
 
-        if (elementsLearningAlgorithm != null)
-            elementsLearningAlgorithm.configure(shallowVocabCache, null, vectorsConfiguration);
+        if (this.elementsLearningAlgorithm != null)
+            this.elementsLearningAlgorithm.configure(shallowVocabCache, null, vectorsConfiguration);
 
-        if (sequenceLearningAlgorithm == null && vectorsConfiguration.getSequenceLearningAlgorithm() != null) {
+        String sequenceLearningAlgorithm = vectorsConfiguration.getSequenceLearningAlgorithm();
+        if (this.sequenceLearningAlgorithm == null && sequenceLearningAlgorithm != null) {
             // TODO: do SLA initialization
-            try {
-                sequenceLearningAlgorithm = (SparkSequenceLearningAlgorithm) Class
-                                .forName(vectorsConfiguration.getSequenceLearningAlgorithm()).newInstance();
-                sequenceLearningAlgorithm.configure(shallowVocabCache, null, vectorsConfiguration);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            this.sequenceLearningAlgorithm = DL4JClassLoading.createNewInstance(sequenceLearningAlgorithm);
+            this.sequenceLearningAlgorithm.configure(shallowVocabCache, null, vectorsConfiguration);
         }
-        if (sequenceLearningAlgorithm != null)
-            sequenceLearningAlgorithm.configure(shallowVocabCache, null, vectorsConfiguration);
+        if (this.sequenceLearningAlgorithm != null)
+            this.sequenceLearningAlgorithm.configure(shallowVocabCache, null, vectorsConfiguration);
 
-        if (elementsLearningAlgorithm == null && sequenceLearningAlgorithm == null) {
+        if (this.elementsLearningAlgorithm == null && this.sequenceLearningAlgorithm == null) {
             throw new ND4JIllegalStateException("No LearningAlgorithms specified!");
         }
 
@@ -142,7 +130,7 @@ public class PartitionTrainingFunction<T extends SequenceElement> implements Voi
             }
 
             // do the same with labels, transfer them, if any
-            if (sequenceLearningAlgorithm != null && vectorsConfiguration.isTrainSequenceVectors()) {
+            if (this.sequenceLearningAlgorithm != null && vectorsConfiguration.isTrainSequenceVectors()) {
                 for (T label : sequence.getSequenceLabels()) {
                     ShallowSequenceElement reduced = shallowVocabCache.tokenFor(label.getStorageId());
 

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/VocabRddFunctionFlat.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp-java8/src/main/java/org/deeplearning4j/spark/models/sequencevectors/functions/VocabRddFunctionFlat.java
@@ -19,6 +19,7 @@ package org.deeplearning4j.spark.models.sequencevectors.functions;
 import lombok.NonNull;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.models.embeddings.loader.VectorsConfiguration;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.sequence.SequenceElement;
@@ -56,12 +57,8 @@ public class VocabRddFunctionFlat<T extends SequenceElement> implements FlatMapF
             configuration = vectorsConfigurationBroadcast.getValue();
 
         if (ela == null) {
-            try {
-                ela = (SparkElementsLearningAlgorithm) Class.forName(configuration.getElementsLearningAlgorithm())
-                        .newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            String className = configuration.getElementsLearningAlgorithm();
+            ela = DL4JClassLoading.createNewInstance(className);
         }
         driver = ela.getTrainingDriver();
 

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/time/TimeSourceProvider.java
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/src/main/java/org/deeplearning4j/spark/time/TimeSourceProvider.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.spark.time;
 
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.common.config.DL4JSystemProperties;
 
 import java.lang.reflect.Method;
@@ -62,9 +63,9 @@ public class TimeSourceProvider {
      */
     public static TimeSource getInstance(String className) {
         try {
-            Class<?> c = Class.forName(className);
-            Method m = c.getMethod("getInstance");
-            return (TimeSource) m.invoke(null);
+            Class<?> clazz = DL4JClassLoading.loadClassByName(className);
+            Method getInstance = clazz.getMethod("getInstance");
+            return (TimeSource) getInstance.invoke(null);
         } catch (Exception e) {
             throw new RuntimeException("Error getting TimeSource instance for class \"" + className + "\"", e);
         }

--- a/deeplearning4j/dl4j-integration-tests/src/test/java/org/deeplearning4j/integration/IntegrationTestRunner.java
+++ b/deeplearning4j/dl4j-integration-tests/src/test/java/org/deeplearning4j/integration/IntegrationTestRunner.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.common.config.DL4JClassLoading;
 import org.deeplearning4j.datasets.iterator.MultiDataSetWrapperIterator;
 import org.deeplearning4j.integration.util.CountingMultiDataSetIterator;
 import org.deeplearning4j.nn.api.Model;
@@ -127,7 +128,7 @@ public class IntegrationTestRunner {
         }
 
         for (ClassPath.ClassInfo c : info) {
-            Class<?> clazz = Class.forName(c.getName());
+            Class<?> clazz = DL4JClassLoading.loadClassByName(c.getName());
             if (Modifier.isAbstract(clazz.getModifiers()) || clazz.isInterface())
                 continue;
 

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/common/config/ND4JClassLoading.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/common/config/ND4JClassLoading.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) Eclipse Deeplearning4j Contributors 2020
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
 package org.nd4j.common.config;
 
 import lombok.extern.slf4j.Slf4j;
@@ -6,6 +22,22 @@ import java.util.ServiceLoader;
 
 /**
  * Global context for class-loading in ND4J.
+ * <p>Use {@code ND4JClassLoading} to define classloader for ND4J only! To define classloader used by
+ * {@code Deeplearning4j} use class {@link org.deeplearning4j.common.config.DL4JClassLoading}.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * public class Application {
+ *     static {
+ *         ND4JClassLoading.setNd4jClassloaderFromClass(Application.class);
+ *     }
+ *
+ *     public static void main(String[] args) {
+ *     }
+ * }
+ * }</code>
+ *
+ * @see org.deeplearning4j.common.config.DL4JClassLoading
  *
  * @author Alexei KLENIN
  */


### PR DESCRIPTION
Signed-off-by: hosuaby <alexei.klenin@gmail.com>

## What changes were proposed in this pull request?

Adds possibility to define classloader used by DL4J modules.
How it works. You need to set classloader in the entry point of your application (generally, class containing `public static void main`). Important! No other ND4J/DL4J classes, except `ND4JClassLoading` and `DL4JClassLoading` must be used in the same entry-point. Any other import risk to trigger uncontrolled class-loading.

```java
 public class Application {
     static {
         ND4JClassLoading.setNd4jClassloaderFromClass(Application.class);
         DL4JClassLoading.setDl4jClassloaderFromClass(Application.class);
     }

      public static void main(String[] args) {
     }
 }
```

## How was this patch tested?

Old tests + new tests for `DL4JClassLoading`.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
