### PR TITLE
update sortCooIndicesGeneric to take any data type

### DIFF
--- a/libnd4j/include/legacy/NativeOpExecutioner.h
+++ b/libnd4j/include/legacy/NativeOpExecutioner.h
@@ -28,6 +28,7 @@
 #include <ops/specials_sparse.h>
 #include <execution/LaunchContext.h>
 #include <array/ArrayOptions.h>
+#include <helpers/shape.h>
 
 /**
  * Native op executioner:
@@ -652,8 +653,11 @@ static void execTransformBool(sd::LaunchContext  *lc,
         BUILD_SINGLE_SELECTOR(xType, sd::SpecialMethods, ::sortTadGeneric(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending), LIBND4J_TYPES);
     }
 
-    inline static void execSortCooIndices(Nd4jLong *indices, void *values, Nd4jLong length, int rank) {
-        sd::sparse::SparseUtils<Nd4jLong>::sortCooIndicesGeneric(indices, reinterpret_cast<Nd4jLong *>(values), length, rank);
+    inline static void execSortCooIndices(Nd4jLong *indices, void *x, Nd4jLong length, const Nd4jLong *xShapeInfo) {
+        auto xType = sd::ArrayOptions::dataType(xShapeInfo);
+        int rank = shape::rank(xShapeInfo);
+
+        BUILD_SINGLE_SELECTOR(xType, sd::sparse::SparseUtils, ::sortCooIndicesGeneric(indices, x, length, rank), LIBND4J_TYPES);
     }
 
 

--- a/libnd4j/include/legacy/NativeOps.h
+++ b/libnd4j/include/legacy/NativeOps.h
@@ -1476,7 +1476,11 @@ ND4J_EXPORT void sortTadByValue(Nd4jPointer *extraPointers,
 
 
 // special sort impl for sorting out COO indices and values
-ND4J_EXPORT void sortCooIndices(Nd4jPointer *extraPointers, Nd4jLong *indices, void *values, Nd4jLong length, int rank);
+ND4J_EXPORT void sortCooIndices(Nd4jPointer *extraPointers,
+                                Nd4jLong *indices,
+                                void *x,
+                                Nd4jLong length,
+                                const Nd4jLong *xShapeInfo);
 
 
 ND4J_EXPORT Nd4jLong* mmapFile(Nd4jPointer *extraPointers, const char *fileName, Nd4jLong length);

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -1832,11 +1832,11 @@ void sortTad(Nd4jPointer *extraPointers,
 
 void sortCooIndices(Nd4jPointer *extraPointers,
         Nd4jLong *indices,
-        void *values,
+        void *x,
         Nd4jLong length,
-        int rank) {
+        const Nd4jLong *xShapeInfo) {
     try {
-        NativeOpExecutioner::execSortCooIndices(indices, values, length, rank);
+        NativeOpExecutioner::execSortCooIndices(indices, x, length, xShapeInfo);
     } catch (std::exception &e) {
         sd::LaunchContext::defaultContext()->errorReference()->setErrorCode(1);
         sd::LaunchContext::defaultContext()->errorReference()->setErrorMessage(e.what());

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -2560,7 +2560,7 @@ void sortTad(Nd4jPointer *extraPointers,
     }
 }
 
-void sortCooIndices(Nd4jPointer *extraPointers, Nd4jLong *indices, void *values, Nd4jLong length, int rank) {
+void sortCooIndices(Nd4jPointer *extraPointers, Nd4jLong *indices, void *values, Nd4jLong length, const Nd4jLong *xShapeInfo) {
 	throw std::runtime_error("sortCooIndices:: Not implemented yet");
 }
 

--- a/libnd4j/include/ops/impl/specials_sparse.cpp
+++ b/libnd4j/include/ops/impl/specials_sparse.cpp
@@ -209,7 +209,8 @@ PRAGMA_OMP_SINGLE_ARGS(nowait)
         }
 
         template <typename T>
-        void SparseUtils<T>::sortCooIndicesGeneric(Nd4jLong *indices, T *values, Nd4jLong length, int rank) {
+        void SparseUtils<T>::sortCooIndicesGeneric(Nd4jLong *indices, void *vx, Nd4jLong length, int rank) {
+        auto values = reinterpret_cast<T *>(vx);
 #ifdef _OPENMP
             coo_quickSort_parallel(indices, values, length, omp_get_max_threads(), rank);
 #else

--- a/libnd4j/include/ops/specials_sparse.h
+++ b/libnd4j/include/ops/specials_sparse.h
@@ -60,7 +60,7 @@ namespace sd {
             static Nd4jLong coo_quickSort_findPivot(Nd4jLong *indices, T *array, Nd4jLong left, Nd4jLong right,
                                                     int rank);
 
-            static void sortCooIndicesGeneric(Nd4jLong *indices, T *values, Nd4jLong length, int rank);
+            static void sortCooIndicesGeneric(Nd4jLong *indices, void *vx, Nd4jLong length, int rank);
         };
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -1022,7 +1022,7 @@ public interface NativeOps {
                  boolean descending);
 
 
-    void sortCooIndices(PointerPointer extraPointers, @Cast("Nd4jLong *") LongPointer indices, Pointer values, long length, int rank);
+    void sortCooIndices(PointerPointer extraPointers, @Cast("Nd4jLong *") LongPointer indices, Pointer x, long length, @Cast("Nd4jLong *") LongPointer shapeInfo);
 
 
     LongPointer mmapFile(PointerPointer extraPointers, String fileName, long length);

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/nativeblas/Nd4jCpu.java
@@ -3135,9 +3135,21 @@ public native void sortTadByValue(@Cast("Nd4jPointer*") PointerPointer extraPoin
 
 
 // special sort impl for sorting out COO indices and values
-public native void sortCooIndices(@Cast("Nd4jPointer*") PointerPointer extraPointers, @Cast("Nd4jLong*") LongPointer indices, Pointer values, @Cast("Nd4jLong") long length, int rank);
-public native void sortCooIndices(@Cast("Nd4jPointer*") PointerPointer extraPointers, @Cast("Nd4jLong*") LongBuffer indices, Pointer values, @Cast("Nd4jLong") long length, int rank);
-public native void sortCooIndices(@Cast("Nd4jPointer*") PointerPointer extraPointers, @Cast("Nd4jLong*") long[] indices, Pointer values, @Cast("Nd4jLong") long length, int rank);
+public native void sortCooIndices(@Cast("Nd4jPointer*") PointerPointer extraPointers,
+                                @Cast("Nd4jLong*") LongPointer indices,
+                                Pointer x,
+                                @Cast("Nd4jLong") long length,
+                                @Cast("const Nd4jLong*") LongPointer xShapeInfo);
+public native void sortCooIndices(@Cast("Nd4jPointer*") PointerPointer extraPointers,
+                                @Cast("Nd4jLong*") LongBuffer indices,
+                                Pointer x,
+                                @Cast("Nd4jLong") long length,
+                                @Cast("const Nd4jLong*") LongBuffer xShapeInfo);
+public native void sortCooIndices(@Cast("Nd4jPointer*") PointerPointer extraPointers,
+                                @Cast("Nd4jLong*") long[] indices,
+                                Pointer x,
+                                @Cast("Nd4jLong") long length,
+                                @Cast("const Nd4jLong*") long[] xShapeInfo);
 
 
 public native @Cast("Nd4jLong*") LongPointer mmapFile(@Cast("Nd4jPointer*") PointerPointer extraPointers, @Cast("char*") String fileName, @Cast("Nd4jLong") long length);


### PR DESCRIPTION
Sorting indices for for COO sparse matrices was broken in by the migration to DataTypes in shapeinfo.

In current master, the data type for the values vector is hardcoded to `int64` which makes it work for only 64bit data types.

## What changes were proposed in this pull request?

use `BUILD_SINGLE_SELECTOR` for templating all possible data types and pass in data type as part of a `xShapeInfo`

## How was this patch tested?

`nd4j/linalg/specials/SortCooTests.java` modified to call sortCooIndicesGeneric with values databuffer of different data types.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
