### PR TITLE
Fixed #9125, make check agains the correct variable

### DIFF
--- a/libnd4j/include/legacy/impl/Environment.cpp
+++ b/libnd4j/include/legacy/impl/Environment.cpp
@@ -111,7 +111,7 @@ namespace sd {
          * If this env var is defined - we'll disallow use of platform-specific helpers (mkldnn, cudnn, etc)
          */
         const char* forbid_helpers = std::getenv("SD_FORBID_HELPERS");
-        if (max_master_threads != nullptr) {
+        if (forbid_helpers != nullptr) {
             _allowHelpers = false;
         }
 


### PR DESCRIPTION
Signed-off-by: Ulrik Holmen <ulrik.holmen@global.ntt>

## What changes were proposed in this pull request?

Updated checking against **forbid_helpers** instead of **max_master_threads** when  **SD_FORBID_HELPERS** environment variable is set. Effectively resolving issue #9125.