### PR TITLE
Improved Exception Message in ReshapePreprocessor.preProcess() and dead code removal

### DIFF
--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/ReshapePreprocessor.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/ReshapePreprocessor.java
@@ -106,7 +106,6 @@ public class ReshapePreprocessor extends BaseInputPreProcessor {
     public INDArray preProcess(INDArray input, int miniBatchSize, LayerWorkspaceMgr workspaceMgr) {
         // the target shape read from a keras config does not have mini-batch size included. We prepend it here dynamically.
         long[] targetShape = getShape(this.targetShape, miniBatchSize);
-        long[] inputShape = getShape(this.inputShape, miniBatchSize);
 
         if (prodLong(input.shape()) == prodLong((targetShape))) {
             if (input.ordering() != 'c' || !Shape.hasDefaultStridesForShape(input)) {
@@ -115,7 +114,7 @@ public class ReshapePreprocessor extends BaseInputPreProcessor {
             return workspaceMgr.leverageTo(ArrayType.ACTIVATIONS, input.reshape(targetShape));
         } else {
             throw new IllegalStateException("Input shape " + Arrays.toString(input.shape())
-                    + " and output shape" + Arrays.toString(inputShape) + " do not match");
+                    + " and target shape" + Arrays.toString(targetShape) + " do not match");
         }
     }
 


### PR DESCRIPTION
The preProcess() method throws an exception with a misleading message. Instead of including the targetShape, which when it does not match the input.shape() throws the exception, it was using this.inputShape which is incorrect and irrelevant in this method. Additionally removed the unused and unneeded local var: "inputShape" and getShape() call.

## What changes were proposed in this pull request?
Improved Exception message and dead code removal
(Please fill in changes proposed in this fix)

## How was this patch tested
code compiles, unit tests pass, minor changes made to exception message and removal of unused local var
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
