### PR TITLE
Fixed index bound and incorrect array length equality checks

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
@@ -252,11 +252,13 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
         private void removeObject(INDArray array){
             long length = array.data().length();
             int idx = Arrays.binarySearch(lengths, 0, size, length);
-            Preconditions.checkState(idx > 0, "Cannot remove array from ArrayStore: no array with this length exists in the cache");
+            Preconditions.checkState(idx >= 0,
+                    "Cannot remove array from ArrayStore: no array with this length exists in the cache");
             boolean found = false;
             int i = 0;
-            while(!found && i <= size && lengths[i] == length){
-                found = sorted[i++] == array; //Object equality
+            while (!found && i < size) {
+                found = sorted[i] == array && lengths[i] == length; //Object and length equality
+                ++i;
             }
             Preconditions.checkState(found, "Cannot remove array: not found in ArrayCache");
             removeIdx(i - 1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed an issue described in https://community.konduit.ai/t/arraystore-removal-error-during-samediff-training/1099. 
Two logic errors of array's removal from cache have been fixed:

1. False positive precondition check failing when the array has the shortest length
2. Search loop for the target array index which checked the length of an array equality as the "while" loop's condition (the loop thus was interrupted in case any shorter than the target array was encountered)

## How was this patch tested?

Manual tests on local environment

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
