### PR TITLE
Added Maximum merge layer to getKerasLayerFromConfig

### DIFF
--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLayerUtils.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLayerUtils.java
@@ -280,6 +280,9 @@ public class KerasLayerUtils {
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_MULTIPLY()) ||
                 layerClassName.equals(conf.getLAYER_CLASS_NAME_FUNCTIONAL_MULTIPLY())) {
             layer = new KerasMerge(layerConfig, ElementWiseVertex.Op.Product, enforceTrainingConfig);
+        } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_MAXIMUM()) ||
+                layerClassName.equals(conf.getLAYER_CLASS_NAME_FUNCTIONAL_MAXIMUM())) {
+            layer = new KerasMerge(layerConfig, ElementWiseVertex.Op.Max, enforceTrainingConfig);
         } else if (layerClassName.equals(conf.getLAYER_CLASS_NAME_CONCATENATE()) ||
                 layerClassName.equals(conf.getLAYER_CLASS_NAME_FUNCTIONAL_CONCATENATE())) {
             layer = new KerasMerge(layerConfig, null, enforceTrainingConfig);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pursuant to [this](https://github.com/eclipse/deeplearning4j/issues/9143) issue, this PR adds the ability to parse the keras maximum layer.

## How was this patch tested?

I don't have the time / resources e.t.c. to test this right now, so I haven't.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
