### PR TITLE
Fixing DL4J UI system property for getting port value

### DIFF
--- a/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
+++ b/deeplearning4j/deeplearning4j-ui-parent/deeplearning4j-vertx/src/main/java/org/deeplearning4j/ui/VertxUIServer.java
@@ -369,13 +369,17 @@ public class VertxUIServer extends AbstractVerticle implements UIServer {
 
         //Check port property
         int port = instancePort == null ? DEFAULT_UI_PORT : instancePort;
-        String portProp = System.getenv(DL4JSystemProperties.UI_SERVER_PORT_PROPERTY);
+        String portProp = System.getProperty(DL4JSystemProperties.UI_SERVER_PORT_PROPERTY);
         if(portProp != null && !portProp.isEmpty()){
             try{
                 port = Integer.parseInt(portProp);
             } catch (NumberFormatException e){
                 log.warn("Error parsing port property {}={}", DL4JSystemProperties.UI_SERVER_PORT_PROPERTY, portProp);
             }
+        }
+
+	if (port < 0 || port > 0xFFFF) {
+            throw new IllegalStateException("Valid port range is 0 <= port <= 65535. The given port was " + port);
         }
 
         uiEventRoutingThread = new Thread(new StatsEventRouterRunnable());


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/eclipse/deeplearning4j/issues/9150 Taking DL4J UI port from property instead of environment variable

## How was this patch tested?

Manual testing

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [X] Relevant tests for your changes are passing.
