### PR TITLE
Remove unused dependencies

### DIFF
--- a/python4j/python4j-core/pom.xml
+++ b/python4j/python4j-core/pom.xml
@@ -43,6 +43,12 @@
             <groupId>org.bytedeco</groupId>
             <artifactId>cpython-platform</artifactId>
             <version>${cpython-platform.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>javacpp-platform</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
@agibsonccc Hi, I am a user of project **_org.nd4j:python4j-core:1.0.0-SNAPSHOT_**. I found that its pom file introduced **_36_** dependencies. However, among them, **_15_** libraries (**_41%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_org.nd4j:python4j-core:1.0.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.bytedeco:javacpp:jar:android-x86:1.5.4:compile
org.bytedeco:javacpp:jar:ios-x86_64:1.5.4:compile
org.bytedeco:javacpp:jar:linux-x86_64:1.5.4:compile
org.bytedeco:javacpp:jar:linux-armhf:1.5.4:compile
org.bytedeco:javacpp:jar:linux-arm64:1.5.4:compile
org.bytedeco:javacpp:jar:linux-ppc64le:1.5.4:compile
org.bytedeco:javacpp:jar:windows-x86:1.5.4:compile
org.bytedeco:javacpp:jar:android-arm64:1.5.4:compile
org.bytedeco:javacpp:jar:android-arm:1.5.4:compile
org.bytedeco:javacpp:jar:windows-x86_64:1.5.4:compile
org.bytedeco:javacpp:jar:ios-arm64:1.5.4:compile
org.bytedeco:javacpp:jar:linux-x86:1.5.4:compile
org.bytedeco:javacpp:jar:macosx-x86_64:1.5.4:compile
org.bytedeco:javacpp-platform:jar:1.5.4:compile
org.bytedeco:javacpp:jar:android-x86_64:1.5.4:compile
</code></pre>