### PR TITLE
fix segfault (threading: tryAcquire)

### DIFF
--- a/libnd4j/include/execution/impl/ThreadPool.cpp
+++ b/libnd4j/include/execution/impl/ThreadPool.cpp
@@ -151,7 +151,7 @@ namespace samediff {
 
     Ticket* ThreadPool::tryAcquire(int numThreads) {
         //std::vector<BlockingQueue<CallableWithArguments*>*> queues;
-
+        if(numThreads<=0) return nullptr;
         Ticket *t = nullptr;
         // we check for threads availability first
         bool threaded = false;


### PR DESCRIPTION
parallel_do tries to acquire numThreads-1 threads. And there are cases it wanted to get 0 threads. And it was falsely returning back valid ticket because of missing conditions. Here how it was happening in real run: There are functions where nested threading can happen. So in segfault case (example:gather op) outer threading acquired all threads. and as inner functions tried to acquire threads themselves. And as the inner function was using faulty parallel_do it seg faulted.
 

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

unit tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
