### PR TITLE
Fix buffer rewind compilation error compat with jdk 9+

### DIFF
--- a/datavec/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
+++ b/datavec/datavec-api/src/test/java/org/datavec/api/writable/WritableTest.java
@@ -20,6 +20,7 @@
 package org.datavec.api.writable;
 
 import org.datavec.api.writable.batch.NDArrayRecordBatch;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.nd4j.common.tests.BaseND4JTest;
@@ -28,13 +29,13 @@ import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import org.junit.jupiter.api.DisplayName;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/datavec/datavec-arrow/src/main/java/org/datavec/arrow/ArrowConverter.java
+++ b/datavec/datavec-arrow/src/main/java/org/datavec/arrow/ArrowConverter.java
@@ -46,18 +46,19 @@ import org.datavec.api.util.ndarray.RecordConverter;
 import org.datavec.api.writable.*;
 import org.datavec.arrow.recordreader.ArrowWritableRecordBatch;
 import org.datavec.arrow.recordreader.ArrowWritableRecordTimeSeriesBatch;
+import org.nd4j.common.primitives.Pair;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.exception.ND4JIllegalArgumentException;
 import org.nd4j.linalg.factory.Nd4j;
-import org.nd4j.common.primitives.Pair;
 import org.nd4j.serde.binary.BinarySerde;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.*;
@@ -171,7 +172,8 @@ public class ArrowConverter {
         ByteBuffer direct = ByteBuffer.allocateDirect(fieldVector.getDataBuffer().capacity());
         direct.order(ByteOrder.nativeOrder());
         fieldVector.getDataBuffer().getBytes(0,direct);
-        direct.rewind();
+        Buffer buffer1 = (Buffer) direct;
+        buffer1.rewind();
         switch(type) {
             case Integer:
                 buffer = Nd4j.createBuffer(direct, DataType.INT,cols,0);

--- a/nd4j/nd4j-serde/nd4j-aeron/src/main/java/org/nd4j/aeron/util/BufferUtil.java
+++ b/nd4j/nd4j-serde/nd4j-aeron/src/main/java/org/nd4j/aeron/util/BufferUtil.java
@@ -44,8 +44,8 @@ public class BufferUtil {
             ByteBuffer curr = buffers[i].slice();
             all.put(curr);
         }
-
-        all.rewind();
+        Buffer buffer = (Buffer) all;
+        buffer.rewind();
         return all;
     }
 

--- a/nd4j/nd4j-serde/nd4j-aeron/src/test/java/org/nd4j/aeron/ipc/NDArrayMessageTest.java
+++ b/nd4j/nd4j-serde/nd4j-aeron/src/test/java/org/nd4j/aeron/ipc/NDArrayMessageTest.java
@@ -31,6 +31,7 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.nio.Buffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -45,7 +46,8 @@ public class NDArrayMessageTest extends BaseND4JTest {
     public void testNDArrayMessageToAndFrom() {
         NDArrayMessage message = NDArrayMessage.wholeArrayUpdate(Nd4j.scalar(1.0));
         DirectBuffer bufferConvert = NDArrayMessage.toBuffer(message);
-        bufferConvert.byteBuffer().rewind();
+        Buffer buffer = (Buffer) bufferConvert.byteBuffer();
+        buffer.rewind();
         NDArrayMessage newMessage = NDArrayMessage.fromBuffer(bufferConvert, 0);
         assertEquals(message, newMessage);
 

--- a/nd4j/nd4j-serde/nd4j-aeron/src/test/java/org/nd4j/aeron/ipc/chunk/NDArrayMessageChunkTests.java
+++ b/nd4j/nd4j-serde/nd4j-aeron/src/test/java/org/nd4j/aeron/ipc/chunk/NDArrayMessageChunkTests.java
@@ -24,14 +24,15 @@ import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.nd4j.common.tests.BaseND4JTest;
 import org.nd4j.aeron.ipc.NDArrayMessage;
 import org.nd4j.aeron.util.BufferUtil;
+import org.nd4j.common.tests.BaseND4JTest;
 import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.linalg.factory.Nd4j;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -67,11 +68,13 @@ public class NDArrayMessageChunkTests extends BaseND4JTest {
         //test equality of direct byte buffer contents vs chunked
         ByteBuffer byteBuffer = buffer.byteBuffer();
         ByteBuffer concatAll = BufferUtil.concat(concat, buffer.capacity());
+        Buffer concatAllBuffer = (Buffer) concatAll;
+        Buffer byteBuffer1 = (Buffer)  byteBuffer;
         byte[] arrays = new byte[byteBuffer.capacity()];
-        byteBuffer.rewind();
+        byteBuffer1.rewind();
         byteBuffer.get(arrays);
         byte[] arrays2 = new byte[concatAll.capacity()];
-        concatAll.rewind();
+        concatAllBuffer.rewind();
         concatAll.get(arrays2);
         assertArrayEquals(arrays, arrays2);
         NDArrayMessage message1 = NDArrayMessage.fromChunks(chunks);


### PR DESCRIPTION
See similar issue: https://github.com/apache/felix/pull/114

## What changes were proposed in this pull request?
Fixes java 9 compilation error related to bytebuffer types like mentioned above
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
