### PR TITLE
Switch to older gcc version for cuda for backwards compat

### DIFF
--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: konduitai/cuda-install/.github/actions/install-cuda-ubuntu@master
         env:
           cuda: 11.0.167
-          GCC: 9
+          GCC:  7.5.0
 
       - name: Setup libnd4j home if a download url is specified
         shell: bash

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: konduitai/cuda-install/.github/actions/install-cuda-ubuntu@master
         env:
           cuda: 11.0.167
-          GCC:  7.5.0
+          GCC:  7
 
       - name: Setup libnd4j home if a download url is specified
         shell: bash

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: konduitai/cuda-install/.github/actions/install-cuda-ubuntu@master
         env:
           cuda: 11.2.0_460
-          GCC:  7.5.0
+          GCC:  7
 
       - name: Setup libnd4j home if a download url is specified
         shell: bash

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: konduitai/cuda-install/.github/actions/install-cuda-ubuntu@master
         env:
           cuda: 11.2.0_460
-          GCC: 9
+          GCC:  7.5.0
 
       - name: Setup libnd4j home if a download url is specified
         shell: bash

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -86,11 +86,6 @@ jobs:
       - name: Setup windows path
         shell: powershell
         run: echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v1
-        env:
-          GPG_PRIVATE_KEY:  ${{ secrets.SONATYPE_GPG_KEY }}
-          PASSPHRASE:  ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       - name: Setup libnd4j home if a download url is specified
         shell: powershell
         run: |

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -86,6 +86,11 @@ jobs:
       - name: Setup windows path
         shell: powershell
         run: echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@v1
+        env:
+          GPG_PRIVATE_KEY:  ${{ secrets.SONATYPE_GPG_KEY }}
+          PASSPHRASE:  ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       - name: Setup libnd4j home if a download url is specified
         shell: powershell
         run: |

--- a/libnd4j/pi_build.sh
+++ b/libnd4j/pi_build.sh
@@ -36,7 +36,7 @@ if [ -z "${NDK_VERSION}" ]; then export NDK_VERSION="r21d"; fi
 if [ -z "${PERFORM_RELEASE}" ]; then export PERFORM_RELEASE=0; fi
 if [ -z "${RELEASE_VERSION}" ]; then export RELEASE_VERSION="1.0.0-M1"; fi
 if [ -z "${SNAPSHOT_VERSION}" ]; then export SNAPSHOT_VERSION="1.0.0-SNAPSHOT"; fi
-if [ -z "${MODULES}" ]; then export MODULES="-pl \"nd4j-native\" --also-make"; fi
+if [ -z "${MODULES}" ]; then export MODULES=; fi
 if [ -z "${RELEASE_REPO_ID}" ]; then export RELEASE_REPO_ID="deeplearning4j-release-${RELEASE_VERSION}"; fi
 
 
@@ -381,7 +381,7 @@ fi #if armcompute
 
 if [ "${TARGET_OS}" = "android" ];then
 	export ANDROID_NDK="${CROSS_COMPILER_DIR}"
-	XTRA_MVN_ARGS="${XTRA_MVN_ARGS} -pl \":libnd4j,:nd4j-native\" "
+	XTRA_MVN_ARGS="${XTRA_MVN_ARGS}"
 else
 	 if [ "${CURRENT_TARGET}" == "jetson-arm64" ];then
 	 	message  "jetson cuda build "
@@ -389,10 +389,10 @@ else
 		XTRA_ARGS="${XTRA_ARGS} -c cuda  -h cudnn  "
 		XTRA_MVN_ARGS="${XTRA_MVN_ARGS} -Djavacpp.version=1.5.3 -Dcuda.version=${CUDA_VER} -Dlibnd4j.cuda=${CUDA_VER} -Dlibnd4j.chip=cuda -Dlibnd4j.compute=5.3 "
 		bash "${BASE_DIR}/../change-cuda-versions.sh" "${CUDA_VER}"
-		XTRA_MVN_ARGS="${XTRA_MVN_ARGS}  -Dlibnd4j.helper=cudnn -pl \":libnd4j,:nd4j-cuda-${CUDA_VER}\" "
+		XTRA_MVN_ARGS="${XTRA_MVN_ARGS}  -Dlibnd4j.helper=cudnn"
 		export SYSROOT="${CROSS_COMPILER_DIR}/${PREFIX}/libc"
 	else
-		XTRA_MVN_ARGS="${XTRA_MVN_ARGS} -pl \":libnd4j,:nd4j-native\" "
+		XTRA_MVN_ARGS="${XTRA_MVN_ARGS}"
 	fi
 	export RPI_BIN="${CROSS_COMPILER_DIR}/bin/${PREFIX}"
 	export JAVA_LIBRARY_PATH="${CROSS_COMPILER_DIR}/${PREFIX}/lib"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Switch the gcc version used in cuda for backwards compatibility.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
