### PR TITLE
Upgrade arrow dep, add dep on arrow-unsafe rather than netty

### DIFF
--- a/datavec/datavec-arrow/pom.xml
+++ b/datavec/datavec-arrow/pom.xml
@@ -46,11 +46,13 @@
             <artifactId>arrow-vector</artifactId>
             <version>${arrow.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.arrow</groupId>
-            <artifactId>arrow-memory</artifactId>
+            <artifactId>arrow-memory-unsafe</artifactId>
             <version>${arrow.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-format</artifactId>

--- a/datavec/datavec-arrow/src/main/java/org/datavec/arrow/ArrowConverter.java
+++ b/datavec/datavec-arrow/src/main/java/org/datavec/arrow/ArrowConverter.java
@@ -169,7 +169,7 @@ public class ArrowConverter {
     public static INDArray convertArrowVector(FieldVector fieldVector,ColumnType type) {
         DataBuffer buffer = null;
         int cols = fieldVector.getValueCount();
-        ByteBuffer direct = ByteBuffer.allocateDirect(fieldVector.getDataBuffer().capacity());
+        ByteBuffer direct = ByteBuffer.allocateDirect((int) fieldVector.getDataBuffer().capacity());
         direct.order(ByteOrder.nativeOrder());
         fieldVector.getDataBuffer().getBytes(0,direct);
         Buffer buffer1 = (Buffer) direct;

--- a/nd4j/nd4j-serde/nd4j-arrow/pom.xml
+++ b/nd4j/nd4j-serde/nd4j-arrow/pom.xml
@@ -36,14 +36,16 @@
     <name>nd4j-arrow</name>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-unsafe</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
-            <version>${arrow.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.arrow</groupId>
-            <artifactId>arrow-memory</artifactId>
             <version>${arrow.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <jackson-asl.version>1.9.13</jackson-asl.version>
         <asm.version>5.1</asm.version>
-        <arrow.version>0.11.0</arrow.version>
+        <arrow.version>4.0.0</arrow.version>
         <avro.version>1.7.7</avro.version>
         <curator.version>2.8.0</curator.version>
         <guice.version>4.0</guice.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updates arrow to 4.0.0 and removes the netty dependency.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Ran all existing tests on cpu backend. They passed.
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
