### PR TITLE
Update Dl4jClassLoading to throw a better error when class not found

### DIFF
--- a/deeplearning4j/deeplearning4j-common/src/main/java/org/deeplearning4j/common/config/DL4JClassLoading.java
+++ b/deeplearning4j/deeplearning4j-common/src/main/java/org/deeplearning4j/common/config/DL4JClassLoading.java
@@ -21,6 +21,7 @@
 package org.deeplearning4j.common.config;
 
 import lombok.extern.slf4j.Slf4j;
+import org.nd4j.common.base.Preconditions;
 import org.nd4j.common.config.ND4JClassLoading;
 
 import java.lang.reflect.InvocationTargetException;
@@ -94,8 +95,10 @@ public class DL4JClassLoading {
             Class<?>[] parameterTypes,
             Object... args) {
         try {
-            return (T) DL4JClassLoading
-                    .loadClassByName(className)
+            Class<Object> loadedClass =  DL4JClassLoading
+                    .loadClassByName(className);
+            Preconditions.checkNotNull(loadedClass,"Attempted to load class " + className + " but failed. No class found with this name.");
+            return (T) loadedClass
                     .asSubclass(superclass)
                     .getDeclaredConstructor(parameterTypes)
                     .newInstance(args);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update Dl4jClassLoading to throw a better error when class not found
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
