### PR TITLE
Implements the ADR: #9290 Supplants https://github.com/eclipse/deeplearning4j/pull/9292, adds extensions to presets for discovery by javacpp

### DIFF
--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
-              command="mvn -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda  -Pcuda clean --batch-mode package deploy -DskipTests"
+              command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda  -Pcuda clean --batch-mode package deploy -DskipTests"
               if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                   mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               elif [ "${{ matrix.helper }}" != '' ]; then

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -134,9 +134,9 @@ jobs:
               if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                   mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               elif [ "${HELPER}" != '' ]; then
-                  mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+                  mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }}"
               else
-                  mvn_ext="-Djavacpp.platform.extension=${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+                  mvn_ext=""
               fi
 
               command="${command} ${mvn_ext}"

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -132,9 +132,9 @@ jobs:
         run: |
               command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda  -Pcuda clean --batch-mode package deploy -DskipTests"
               if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
-                  mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+                  mvn_ext= "-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               elif [ "${{ matrix.helper }}" != '' ]; then
-                  mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }}"
+                  mvn_ext=" -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }}"
               else
                   mvn_ext=""
               fi

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
+              command="mvn -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda  -Pcuda clean --batch-mode package deploy -DskipTests"
               if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                   mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               elif [ "${HELPER}" != '' ]; then
@@ -138,7 +139,7 @@ jobs:
                   mvn_ext="-Djavacpp.platform.extension=${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               fi
 
-              command="mvn -Possrh ${mvn_ext} -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
+              command="${command} ${mvn_ext}"
               echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
               echo "COMMAND=${command}" >> $GITHUB_ENV
 

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -130,15 +130,15 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
-              HELPER=${{ matrix.helper }}
-              EXTENSION=${{ matrix.extension }}
-              if [ "${HELPER}" != '' ] && [ "${EXTENSION}" != '' ]; then
-              command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+              if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
+                  mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               elif [ "${HELPER}" != '' ]; then
-                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+                  mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               else
-                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+                  mvn_ext="-Djavacpp.platform.extension=${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
               fi
+
+              command="mvn -Possrh ${mvn_ext} -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
               echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
               echo "COMMAND=${command}" >> $GITHUB_ENV
 

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -64,8 +64,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linux-x86_64-cuda_11-0:
+    strategy:
+      fail-fast: false
+      matrix:
+        helper: [ cudnn, "" ]
+        extension: [ "" ]
+    runs-on: ${{ github.event.inputs.runsOn }}
     needs: pre-ci
-    runs-on: ubuntu-16.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -122,6 +127,21 @@ jobs:
         run: |
             echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" >> "$GITHUB_ENV"
         if: ${{ github.event.inputs.libnd4jUrl != '' }}
+      - name: Set mvn build command based on matrix
+        shell: bash
+        run: |
+              HELPER=${{ matrix.helper }}
+              EXTENSION=${{ matrix.extension }}
+              if [ "${HELPER}" != '' ] && [ "${EXTENSION}" != '' ]; then
+              command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+              elif [ "${HELPER}" != '' ]; then
+                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+              else
+                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+              fi
+              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
+              echo "COMMAND=${command}" >> $GITHUB_ENV
+
       - name: Build cuda
         shell: bash
         env:
@@ -138,33 +158,50 @@ jobs:
           RELEASE_REPO_ID: ${{ github.event.inputs.releaseRepoId }}
           MODULES: ${{ github.event.inputs.modules  }}
           LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
+          CUDA_PATH: /usr/local/cuda-11.0
+          CUDNN_ROOT_DIR: /usr/local/cuda-11.0/
           LIBND4J_HOME_SUFFIX: cuda
-
-
+          HELPER: ${{ matrix.helper }}
+          EXTENSION: ${{ matrix.extension }}
         run: |
           sudo apt list --installed
           export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
+          export CUDA_PATH=/usr/local/cuda-11.0
           export PATH="/usr/local/cuda-11.0/bin:$PATH"
+          # Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
+          # See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
+          echo "Helper is ${HELPER}"
+          if [ "${HELPER}" == "cudnn" ]; then
+              echo "Linking against cudnn"
+              echo "CUDA PATH is ${CUDA_PATH} CUDA_ROOT_DIR ${CUDNN_ROOT_DIR}"
+              ls -R "${CUDA_PATH}"
+            else
+               echo "Cudnn will not be linked against"
+          fi
+
+
           mvn --version
           cmake --version
           protoc --version
           nvcc --version
           sudo apt-get autoremove
           sudo apt-get clean
+<<<<<<< Updated upstream
           command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\" -Dlibnd4j.chip=cuda   --also-make  -Pcuda  clean --batch-mode package deploy  -DskipTests"
+=======
+>>>>>>> Stashed changes
           # download libnd4j from a url and set it up if LIBND4J_URL is defined
           bash ./bootstrap-libnd4j-from-url.sh
           if [ "$PERFORM_RELEASE" == 1 ]; then
                echo "Performing release"
-               bash ${GITHUB_WORKSPACE}/release-specified-component.sh  "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${command}"
+               bash ${GITHUB_WORKSPACE}/release-specified-component.sh  "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${COMMAND}"
               else
+<<<<<<< Updated upstream
                   "Running build and deploying to snapshots"
                   eval "$command"
+=======
+                  echo "Running build and deploying to snapshots with command ${COMMAND}"
+                  eval "${COMMAND}"
+>>>>>>> Stashed changes
           fi
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
-
-
 

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -186,22 +186,13 @@ jobs:
           nvcc --version
           sudo apt-get autoremove
           sudo apt-get clean
-<<<<<<< Updated upstream
-          command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\" -Dlibnd4j.chip=cuda   --also-make  -Pcuda  clean --batch-mode package deploy  -DskipTests"
-=======
->>>>>>> Stashed changes
           # download libnd4j from a url and set it up if LIBND4J_URL is defined
           bash ./bootstrap-libnd4j-from-url.sh
           if [ "$PERFORM_RELEASE" == 1 ]; then
                echo "Performing release"
                bash ${GITHUB_WORKSPACE}/release-specified-component.sh  "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${COMMAND}"
               else
-<<<<<<< Updated upstream
-                  "Running build and deploying to snapshots"
-                  eval "$command"
-=======
                   echo "Running build and deploying to snapshots with command ${COMMAND}"
                   eval "${COMMAND}"
->>>>>>> Stashed changes
           fi
 

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -133,7 +133,7 @@ jobs:
               command="mvn -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda  -Pcuda clean --batch-mode package deploy -DskipTests"
               if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                   mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
-              elif [ "${HELPER}" != '' ]; then
+              elif [ "${{ matrix.helper }}" != '' ]; then
                   mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }}"
               else
                   mvn_ext=""

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -130,15 +130,16 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
-              if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
-              command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
-              elif [ ${{ matrix.helper }} != '' ]; then
-                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
-              else
-                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
-              fi
-              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
-              echo "COMMAND=${command}" >> $GITHUB_ENV
+            if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
+               mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+            elif [ "${HELPER}" != '' ]; then
+               mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+           else
+               mvn_ext="-Djavacpp.platform.extension=${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+           fi
+           command="mvn -Possrh ${mvn_ext} -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
+           echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
+           echo "COMMAND=${command}" >> $GITHUB_ENV
 
       - name: Run cuda compilation on linux-x86_64
         shell: bash

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
-            command="mvn -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
+            command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
             if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
             elif [ "${{ matrix.helper }}" != '' ]; then

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -173,10 +173,6 @@ jobs:
           sudo apt-get autoremove
           sudo apt-get clean
           bash ./change-cuda-versions.sh 11.2
-<<<<<<< Updated upstream
-          command="mvn  -Possrh  -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\"   -Dlibnd4j.chip=cuda clean --batch-mode deploy -DskipTests"
-=======
->>>>>>> Stashed changes
           # download libnd4j from a url and set it up if LIBND4J_URL is defined
           bash ./bootstrap-libnd4j-from-url.sh
           # Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
@@ -186,11 +182,6 @@ jobs:
                     echo "Performing release"
                     bash ${GITHUB_WORKSPACE}/release-specified-component.sh  "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${COMMAND}"
                    else
-<<<<<<< Updated upstream
-                       "Running build and deploying to snapshots"
-                       eval "$command"
-=======
                        echo "Running build and deploying to snapshots"
                        eval "${COMMAND}"
->>>>>>> Stashed changes
           fi

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -65,8 +65,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linux-x86_64-cuda-11-2:
+    strategy:
+      fail-fast: false
+      matrix:
+        helper: [ cudnn, "" ]
+        extension: [ ""  ]
+    runs-on: ${{ github.event.inputs.runsOn }}
     needs: pre-ci
-    runs-on: ubuntu-16.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -121,6 +126,20 @@ jobs:
         run: |
             echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" >> "$GITHUB_ENV"
         if: ${{ github.event.inputs.libnd4jUrl != '' }}
+
+      - name: Set mvn build command based on matrix
+        shell: bash
+        run: |
+              if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
+              command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+              elif [ ${{ matrix.helper }} != '' ]; then
+                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+              else
+                  command="mvn  -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform.extension=${{ matrix.extension }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda   --also-make  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Pcuda  clean --batch-mode package deploy  -DskipTests"
+              fi
+              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
+              echo "COMMAND=${command}" >> $GITHUB_ENV
+
       - name: Run cuda compilation on linux-x86_64
         shell: bash
         env:
@@ -139,8 +158,12 @@ jobs:
           LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
           LIBND4J_HOME_SUFFIX: cuda
           MAVEN_OPTS: -Xmx2g
-
+          CUDA_PATH: /usr/local/cuda-11.2
+          CUDNN_ROOT_DIR: /usr/local/cuda-11.2/cuda
+          HELPER: ${{ matrix.helper }}
+          EXTENSION: ${{ matrix.extension }}
         run: |
+          export CUDA_PATH=/usr/local/cuda-11.2
           export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
           export PATH="/usr/local/cuda-11.2/bin:$PATH"
           nvcc --version
@@ -150,17 +173,24 @@ jobs:
           sudo apt-get autoremove
           sudo apt-get clean
           bash ./change-cuda-versions.sh 11.2
+<<<<<<< Updated upstream
           command="mvn  -Possrh  -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=linux-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\"   -Dlibnd4j.chip=cuda clean --batch-mode deploy -DskipTests"
+=======
+>>>>>>> Stashed changes
           # download libnd4j from a url and set it up if LIBND4J_URL is defined
           bash ./bootstrap-libnd4j-from-url.sh
+          # Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
+          # See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
+          export CUDNN_ROOT_DIR="${CUDA_PATH}/cuda"
           if [ "$PERFORM_RELEASE" == 1 ]; then
                     echo "Performing release"
-                    bash ${GITHUB_WORKSPACE}/release-specified-component.sh  "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${command}"
+                    bash ${GITHUB_WORKSPACE}/release-specified-component.sh  "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${COMMAND}"
                    else
+<<<<<<< Updated upstream
                        "Running build and deploying to snapshots"
                        eval "$command"
+=======
+                       echo "Running build and deploying to snapshots"
+                       eval "${COMMAND}"
+>>>>>>> Stashed changes
           fi
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -134,12 +134,12 @@ jobs:
                mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
             elif [ "${HELPER}" != '' ]; then
                mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
-           else
+            else
                mvn_ext="-Djavacpp.platform.extension=${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
-           fi
-           command="mvn -Possrh ${mvn_ext} -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
-           echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
-           echo "COMMAND=${command}" >> $GITHUB_ENV
+            fi
+            command="mvn -Possrh ${mvn_ext} -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
+            echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
+            echo "COMMAND=${command}" >> $GITHUB_ENV
 
       - name: Run cuda compilation on linux-x86_64
         shell: bash

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
+            command="mvn -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
             if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
             elif [ "${HELPER}" != '' ]; then
@@ -137,7 +138,7 @@ jobs:
             else
                mvn_ext="-Djavacpp.platform.extension=${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
             fi
-            command="mvn -Possrh ${mvn_ext} -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
+            command="${command} ${mvn_ext}"
             echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
             echo "COMMAND=${command}" >> $GITHUB_ENV
 

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -133,10 +133,10 @@ jobs:
             command="mvn -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
             if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
-            elif [ "${HELPER}" != '' ]; then
-               mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+            elif [ "${{ matrix.helper }}" != '' ]; then
+               mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }}"
             else
-               mvn_ext="-Djavacpp.platform.extension=${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+               mvn_ext=""
             fi
             command="${command} ${mvn_ext}"
             echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -132,9 +132,9 @@ jobs:
         run: |
             command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh -Dlibnd4j.buildThreads=${{ github.event.inputs.buildThreads }}  -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cuda --also-make -Pcuda clean --batch-mode package deploy -DskipTests"
             if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
-               mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
+               mvn_ext=" -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }}"
             elif [ "${{ matrix.helper }}" != '' ]; then
-               mvn_ext="-Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }}"
+               mvn_ext=" -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.helper=${{ matrix.helper }}"
             else
                mvn_ext=""
             fi

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -54,102 +54,107 @@ on:
 jobs:
   #Note: no -pl here because we publish everything from this branch and use this as the basis for all uploads.
   linux-x86_64:
-    runs-on: ${{ github.event.inputs.runsOn }}
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/update-deps-linux
-      - name: Cache cmake install
-        uses: actions/cache@v2
-        id: cache-cmake
-        with:
-          path: /opt/cmake
-          key: ${{ runner.os }}-cmake
-          restore-keys: ${{ runner.os }}-cmake
-      - name: Cache protobuf install
-        uses: actions/cache@v2
-        id: cache-protobuf
-        with:
-          path: /opt/protobuf
-          key: ${{ runner.os }}-protobuf
-          restore-keys: ${{ runner.os }}-protobuf
-      - uses: ./.github/actions/install-protobuf-linux
-        if: steps.cache-protobuf.outputs.cache-hit != 'true'
-      - uses: ./.github/actions/install-cmake-linux
-        if: steps.cache-cmake.outputs.cache-hit != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        helper: [mkldnn,]
+        extension: [avx2,avx512]
+      runs-on: ${{ github.event.inputs.runsOn }}
+      steps:
+        - name: Cancel Previous Runs
+          uses: styfle/cancel-workflow-action@0.8.0
+          with:
+            access_token: ${{ github.token }}
+        - uses: actions/checkout@v2
+        - uses: ./.github/actions/update-deps-linux
+        - name: Cache cmake install
+          uses: actions/cache@v2
+          id: cache-cmake
+          with:
+            path: /opt/cmake
+            key: ${{ runner.os }}-cmake
+            restore-keys: ${{ runner.os }}-cmake
+        - name: Cache protobuf install
+          uses: actions/cache@v2
+          id: cache-protobuf
+          with:
+            path: /opt/protobuf
+            key: ${{ runner.os }}-protobuf
+            restore-keys: ${{ runner.os }}-protobuf
+        - uses: ./.github/actions/install-protobuf-linux
+          if: steps.cache-protobuf.outputs.cache-hit != 'true'
+        - uses: ./.github/actions/install-cmake-linux
+          if: steps.cache-cmake.outputs.cache-hit != 'true'
 
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+        - name: Cache Maven packages
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2
+            key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+            restore-keys: ${{ runner.os }}-m2
 
-      - name: Set up Java for publishing to GitHub Packages
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: 'zulu'
-          server-id:  ${{ github.event.inputs.serverId }}
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+        - name: Set up Java for publishing to GitHub Packages
+          uses: actions/setup-java@v2
+          with:
+            java-version: 8
+            distribution: 'zulu'
+            server-id:  ${{ github.event.inputs.serverId }}
+            server-username: MAVEN_USERNAME
+            server-password: MAVEN_PASSWORD
+            gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
+            gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Setup libnd4j home if a download url is specified
-        shell: bash
-        run: |
-              echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" >> "$GITHUB_ENV"
-              mkdir "${GITHUB_WORKSPACE}/openblas_home"
-              cd "${GITHUB_WORKSPACE}/openblas_home"
-              wget https://repo1.maven.org/maven2/org/bytedeco/openblas/0.3.13-1.5.5/openblas-0.3.13-1.5.5-linux-x86_64.jar
-              unzip openblas-0.3.13-1.5.5-linux-x86_64.jar
-              cd ..
-              echo "OPENBLAS_PATH=${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64" >> "$GITHUB_ENV"
-              cp ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so.0  ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so
-        if: ${{ github.event.inputs.libnd4jUrl != '' }}
+        - name: Setup libnd4j home if a download url is specified
+          shell: bash
+          run: |
+                echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" >> "$GITHUB_ENV"
+                mkdir "${GITHUB_WORKSPACE}/openblas_home"
+                cd "${GITHUB_WORKSPACE}/openblas_home"
+                wget https://repo1.maven.org/maven2/org/bytedeco/openblas/0.3.13-1.5.5/openblas-0.3.13-1.5.5-linux-x86_64.jar
+                unzip openblas-0.3.13-1.5.5-linux-x86_64.jar
+                cd ..
+                echo "OPENBLAS_PATH=${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64" >> "$GITHUB_ENV"
+                cp ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so.0  ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so
+          if: ${{ github.event.inputs.libnd4jUrl != '' }}
 
-      - name: Build on  linux-x86_64
-        shell: bash
-        env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-          DEBIAN_FRONTEND: noninteractive
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLISH_TO: ossrh
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
-          PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
-          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
-          SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}
-          RELEASE_REPO_ID: ${{ github.event.inputs.releaseRepoId }}
-          MODULES: ${{ github.event.inputs.modules  }}
-          LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
+        - name: Build on  linux-x86_64
+          shell: bash
+          env:
+            MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+            DEBIAN_FRONTEND: noninteractive
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            PUBLISH_TO: ossrh
+            MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
+            MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
+            MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+            PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
+            RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+            SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}
+            RELEASE_REPO_ID: ${{ github.event.inputs.releaseRepoId }}
+            MODULES: ${{ github.event.inputs.modules  }}
+            LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
 
-        run: |
-          export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
-          mvn --version
-          cmake --version
-          protoc --version
-          sudo sysctl vm.overcommit_memory=2
-          export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
-          sudo apt-get -y autoremove
-          sudo apt-get -y clean
-          command="mvn  -X  -Possrh  -Dlibnd4j.helper=mkldnn -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
-          # download libnd4j from a url and set it up if LIBND4J_URL is defined
-          bash ./bootstrap-libnd4j-from-url.sh
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENBLAS_PATH"
-          if [ "$PERFORM_RELEASE" == 1 ]; then
-                    bash ${GITHUB_WORKSPACE}/release-specified-component.sh "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${command}"
-                   else
-                       "Running build and deploying to snapshots"
-                       eval "$command"
-          fi
+          run: |
+            export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
+            mvn --version
+            cmake --version
+            protoc --version
+            sudo sysctl vm.overcommit_memory=2
+            export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
+            sudo apt-get -y autoremove
+            sudo apt-get -y clean
+            command="mvn  -X  -Possrh  -Dlibnd4j.helper=${matrix.helper} -Dlibnd4j.extension=${matrix.extension} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+            # download libnd4j from a url and set it up if LIBND4J_URL is defined
+            bash ./bootstrap-libnd4j-from-url.sh
+            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENBLAS_PATH"
+            if [ "$PERFORM_RELEASE" == 1 ]; then
+                      bash ${GITHUB_WORKSPACE}/release-specified-component.sh "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${command}"
+                     else
+                         "Running build and deploying to snapshots"
+                         eval "$command"
+            fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
+        - name: Setup tmate session
+          uses: mxschmitt/action-tmate@v3
+          if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
 

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -122,11 +122,11 @@ jobs:
         run: |
              command="mvn   -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
              if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
-                    mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
+                    mvn_ext=" -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
              elif [ "${{ matrix.helper }}" != '' ]; then
-                    mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
+                    mvn_ext=" -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
              elif [ "${{ matrix.extension }}" != '' ]; then
-                    mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }}"
+                    mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }}"
               else
                   mvn_ext=""
              fi

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -57,6 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+<<<<<<< Updated upstream
         helper: [mkldnn,]
         extension: [avx2,avx512]
       runs-on: ${{ github.event.inputs.runsOn }}
@@ -157,4 +158,132 @@ jobs:
         - name: Setup tmate session
           uses: mxschmitt/action-tmate@v3
           if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
+=======
+        helper: [mkldnn,""]
+        extension: [avx2,avx512,""]
+    runs-on: ${{ github.event.inputs.runsOn }}
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/update-deps-linux
+      - name: Cache cmake install
+        uses: actions/cache@v2
+        id: cache-cmake
+        with:
+          path: /opt/cmake
+          key: ${{ runner.os }}-cmake
+          restore-keys: ${{ runner.os }}-cmake
+      - name: Cache protobuf install
+        uses: actions/cache@v2
+        id: cache-protobuf
+        with:
+          path: /opt/protobuf
+          key: ${{ runner.os }}-protobuf
+          restore-keys: ${{ runner.os }}-protobuf
+      - uses: ./.github/actions/install-protobuf-linux
+        if: steps.cache-protobuf.outputs.cache-hit != 'true'
+      - uses: ./.github/actions/install-cmake-linux
+        if: steps.cache-cmake.outputs.cache-hit != 'true'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Set up Java for publishing to GitHub Packages
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'zulu'
+          server-id:  ${{ github.event.inputs.serverId }}
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Setup libnd4j home if a download url is specified
+        shell: bash
+        run: |
+              echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" >> "$GITHUB_ENV"
+              mkdir "${GITHUB_WORKSPACE}/openblas_home"
+              cd "${GITHUB_WORKSPACE}/openblas_home"
+              wget https://repo1.maven.org/maven2/org/bytedeco/openblas/0.3.13-1.5.5/openblas-0.3.13-1.5.5-linux-x86_64.jar
+              unzip openblas-0.3.13-1.5.5-linux-x86_64.jar
+              cd ..
+              echo "OPENBLAS_PATH=${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64" >> "$GITHUB_ENV"
+              cp ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so.0  ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so
+        if: ${{ github.event.inputs.libnd4jUrl != '' }}
+
+      - name: Set mvn build command based on matrix
+        shell: bash
+        run: |
+             if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
+                command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                elif [ ${{ matrix.helper }} != '' ]; then
+                    command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }}  -Djavacpp.platform.extension=-${{ matrix.helper }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                else
+                    command="mvn  -X  -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+             fi
+             echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
+             echo "COMMAND=${command}" >> $GITHUB_ENV
+      - name: Build on  linux-x86_64
+        shell: bash
+        env:
+          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          DEBIAN_FRONTEND: noninteractive
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH_TO: ossrh
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+          SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}
+          RELEASE_REPO_ID: ${{ github.event.inputs.releaseRepoId }}
+          MODULES: ${{ github.event.inputs.modules  }}
+          LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
+          HELPER: ${{ matrix.helper }}
+          EXTENSION: ${{ matrix.extension }}
+
+        run: |
+          export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
+          mvn --version
+          cmake --version
+          protoc --version
+          sudo sysctl vm.overcommit_memory=2
+          export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
+          export LIBGOMP_PATH=/usr/lib/gcc/x86_64-linux-gnu/5.5.0/libgomp.so
+          if [ -z "${EXTENSION}" ] || [ -n "${EXTENSION}" ]; then
+              export LIBGOMP_PATH=/usr/lib/gcc/x86_64-linux-gnu/7.5.0/libgomp.so
+              echo "Extensions specified. This needs a newer version of gcc."
+              sudo apt-get install gcc-7 g++-7
+              echo "Using newer version of libgomp."
+              ls /usr/bin | grep gcc
+              ls /usr/bin | grep g++
+              sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
+              sudo update-alternatives --install  /usr/bin/g++ g++ /usr/bin/g++-7  90
+              gcc --version
+          fi
+          # NOTE: Complete hack. Find better way later. This moves libgomp.so to a directory where javacpp can find it.
+          # For linux, this can be found here: https://github.com/eclipse/deeplearning4j/blob/master/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java#L150
+          # Note also, that the g++ --version as of this writing (May 3,2021) currently returns 5.5.0. This will need to be changed in other versions if there is an update.
+          sudo cp "${LIBGOMP_PATH}" /usr/lib
+          sudo apt-get -y autoremove
+          sudo apt-get -y clean
+          # download libnd4j from a url and set it up if LIBND4J_URL is defined
+          bash ./bootstrap-libnd4j-from-url.sh
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENBLAS_PATH"
+          if [ "$PERFORM_RELEASE" == 1 ]; then
+                    bash ${GITHUB_WORKSPACE}/release-specified-component.sh "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${command}"
+                   else
+                       echo "Running build and deploying to snapshots"
+                       eval "${COMMAND}"
+          fi
+
+>>>>>>> Stashed changes
 

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -120,13 +120,15 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
+             command="mvn  -X  -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
              if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
-                command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                    mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
                 elif [ ${{ matrix.helper }} != '' ]; then
-                    command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }}  -Djavacpp.platform.extension=-${{ matrix.helper }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                    mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
                 else
-                    command="mvn  -X  -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                    mvn_ext=""
              fi
+             command="${command} ${mvn_ext}"
              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
              echo "COMMAND=${command}" >> $GITHUB_ENV
       - name: Build on  linux-x86_64

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
-             command="mvn  -X  -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+             command="mvn   -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
              if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                     mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
              elif [ "${{ matrix.helper }}" != '' ]; then

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -57,108 +57,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< Updated upstream
-        helper: [mkldnn,]
-        extension: [avx2,avx512]
-      runs-on: ${{ github.event.inputs.runsOn }}
-      steps:
-        - name: Cancel Previous Runs
-          uses: styfle/cancel-workflow-action@0.8.0
-          with:
-            access_token: ${{ github.token }}
-        - uses: actions/checkout@v2
-        - uses: ./.github/actions/update-deps-linux
-        - name: Cache cmake install
-          uses: actions/cache@v2
-          id: cache-cmake
-          with:
-            path: /opt/cmake
-            key: ${{ runner.os }}-cmake
-            restore-keys: ${{ runner.os }}-cmake
-        - name: Cache protobuf install
-          uses: actions/cache@v2
-          id: cache-protobuf
-          with:
-            path: /opt/protobuf
-            key: ${{ runner.os }}-protobuf
-            restore-keys: ${{ runner.os }}-protobuf
-        - uses: ./.github/actions/install-protobuf-linux
-          if: steps.cache-protobuf.outputs.cache-hit != 'true'
-        - uses: ./.github/actions/install-cmake-linux
-          if: steps.cache-cmake.outputs.cache-hit != 'true'
-
-        - name: Cache Maven packages
-          uses: actions/cache@v2
-          with:
-            path: ~/.m2
-            key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-            restore-keys: ${{ runner.os }}-m2
-
-        - name: Set up Java for publishing to GitHub Packages
-          uses: actions/setup-java@v2
-          with:
-            java-version: 8
-            distribution: 'zulu'
-            server-id:  ${{ github.event.inputs.serverId }}
-            server-username: MAVEN_USERNAME
-            server-password: MAVEN_PASSWORD
-            gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
-            gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-        - name: Setup libnd4j home if a download url is specified
-          shell: bash
-          run: |
-                echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" >> "$GITHUB_ENV"
-                mkdir "${GITHUB_WORKSPACE}/openblas_home"
-                cd "${GITHUB_WORKSPACE}/openblas_home"
-                wget https://repo1.maven.org/maven2/org/bytedeco/openblas/0.3.13-1.5.5/openblas-0.3.13-1.5.5-linux-x86_64.jar
-                unzip openblas-0.3.13-1.5.5-linux-x86_64.jar
-                cd ..
-                echo "OPENBLAS_PATH=${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64" >> "$GITHUB_ENV"
-                cp ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so.0  ${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/linux-x86_64/libopenblas.so
-          if: ${{ github.event.inputs.libnd4jUrl != '' }}
-
-        - name: Build on  linux-x86_64
-          shell: bash
-          env:
-            MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-            DEBIAN_FRONTEND: noninteractive
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            PUBLISH_TO: ossrh
-            MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-            MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-            MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
-            PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
-            RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
-            SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}
-            RELEASE_REPO_ID: ${{ github.event.inputs.releaseRepoId }}
-            MODULES: ${{ github.event.inputs.modules  }}
-            LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
-
-          run: |
-            export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
-            mvn --version
-            cmake --version
-            protoc --version
-            sudo sysctl vm.overcommit_memory=2
-            export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
-            sudo apt-get -y autoremove
-            sudo apt-get -y clean
-            command="mvn  -X  -Possrh  -Dlibnd4j.helper=${matrix.helper} -Dlibnd4j.extension=${matrix.extension} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
-            # download libnd4j from a url and set it up if LIBND4J_URL is defined
-            bash ./bootstrap-libnd4j-from-url.sh
-            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENBLAS_PATH"
-            if [ "$PERFORM_RELEASE" == 1 ]; then
-                      bash ${GITHUB_WORKSPACE}/release-specified-component.sh "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${command}"
-                     else
-                         "Running build and deploying to snapshots"
-                         eval "$command"
-            fi
-
-        - name: Setup tmate session
-          uses: mxschmitt/action-tmate@v3
-          if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
-=======
         helper: [mkldnn,""]
         extension: [avx2,avx512,""]
     runs-on: ${{ github.event.inputs.runsOn }}
@@ -285,5 +183,4 @@ jobs:
                        eval "${COMMAND}"
           fi
 
->>>>>>> Stashed changes
 

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        helper: [mkldnn,""]
+        helper: [onednn,""]
         extension: [avx2,avx512,""]
     runs-on: ${{ github.event.inputs.runsOn }}
     steps:

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -121,12 +121,14 @@ jobs:
         shell: bash
         run: |
              command="mvn  -X  -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=linux-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
-             if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
+             if [ "${{ matrix.helper }}" != '' ] && [ "${{ matrix.extension }}" != '' ]; then
                     mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
-                elif [ ${{ matrix.helper }} != '' ]; then
+             elif [ "${{ matrix.helper }}" != '' ]; then
                     mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
-                else
-                    mvn_ext=""
+             elif [ "${{ matrix.extension }}" != '' ]; then
+                    mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }}"
+              else
+                  mvn_ext=""
              fi
              command="${command} ${mvn_ext}"
              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -127,13 +127,15 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
+          command="mvn  -X  -Possrh   -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
           if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
-             command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                 mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
              elif [ ${{ matrix.helper }} != '' ]; then
-                 command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }}  -Djavacpp.platform.extension=-${{ matrix.helper }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                 mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
              else
-                 command="mvn  -X  -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+                 mvn_ext=""
           fi
+          command="${command} ${mvn_ext}"
           echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
           echo "COMMAND=${command}" >> $GITHUB_ENV
 

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -132,6 +132,8 @@ jobs:
                  mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
              elif [ ${{ matrix.helper }} != '' ]; then
                  mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
+             elif [ ${{ matrix.extension }} != '' ]; then
+                mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }}"
              else
                  mvn_ext=""
           fi

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        helper: [ mkldnn,"" ]
+        helper: [ onednn,"" ]
         extension: [ avx2,avx512,"" ]
     runs-on: ${{ github.event.inputs.runsOn }}
     steps:

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: bash
         run: |
-          command="mvn  -X  -Possrh   -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+          command="mvn   -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh   -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
           if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
                  mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
              elif [ ${{ matrix.helper }} != '' ]; then

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -68,6 +68,11 @@ jobs:
 #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   mac-x86_64:
     #needs: pre-ci
+    strategy:
+      fail-fast: false
+      matrix:
+        helper: [ mkldnn,"" ]
+        extension: [ avx2,avx512,"" ]
     runs-on: ${{ github.event.inputs.runsOn }}
     steps:
       - name: Cancel Previous Runs
@@ -119,6 +124,19 @@ jobs:
             echo "OPENBLAS_PATH=${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/macosx-x86_64/" >> "$GITHUB_ENV"
 
         if: ${{ github.event.inputs.libnd4jUrl != '' }}
+      - name: Set mvn build command based on matrix
+        shell: bash
+        run: |
+          if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
+             command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+             elif [ ${{ matrix.helper }} != '' ]; then
+                 command="mvn  -X  -Possrh  -Dlibnd4j.helper=${{ matrix.helper }}  -Djavacpp.platform.extension=-${{ matrix.helper }} -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+             else
+                 command="mvn  -X  -Possrh  -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
+          fi
+          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
+          echo "COMMAND=${command}" >> $GITHUB_ENV
+
       - name: Build and install
         shell: bash
         env:
@@ -133,9 +151,11 @@ jobs:
           SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}
           RELEASE_REPO_ID: ${{ github.event.inputs.releaseRepoId }}
           MODULES: ${{ github.event.inputs.modules  }}
-          COMMAND: "mvn -Possrh   -Dlibnd4j.helper=mkldnn -Djavacpp.platform=macosx-x86_64 -Djavacpp.platform=macosx-x86_64    --also-make -Dlibnd4j.platform=macosx-x86_64 -Dlibnd4j.chip=cpu  deploy -DskipTests"
           LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
           MAVEN_OPTS: "-Xmx2g"
+          HELPER: ${{ matrix.helper }}
+          EXTENSION: ${{ matrix.extension }}
+
 
         run: |
           gpg --version
@@ -152,8 +172,3 @@ jobs:
                   echo "Running build and deploying to snapshots"
                   eval "${COMMAND}"
           fi
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
-

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -129,11 +129,11 @@ jobs:
         run: |
           command="mvn   -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh   -DskipTestResourceEnforcement=true  -Dmaven.javadoc.failOnError=false -Djavacpp.platform=macosx-x86_64 -Dlibnd4j.chip=cpu -Pcpu  --also-make  --batch-mode deploy -DskipTests"
           if [ ${{ matrix.helper }} != '' ] && [ ${{ matrix.extension }} != '' ]; then
-                 mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
+                 mvn_ext=" -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}"
              elif [ ${{ matrix.helper }} != '' ]; then
-                 mvn_ext="-Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
+                 mvn_ext=" -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }}"
              elif [ ${{ matrix.extension }} != '' ]; then
-                mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }}"
+                mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }}"
              else
                  mvn_ext=""
           fi

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -130,8 +130,8 @@ jobs:
                   $mvn_ext=""
           }
 
-          $command2=-join($($command),$($mvn_ext));
-          $to_write = -join("COMMAND=",$($command));
+          $command2= -join("$($command)","$($mvn_ext)");
+          $to_write = -join("COMMAND=","$($command)");
           echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command2)"
           echo $command2  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
           echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -64,6 +64,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows-x86_64-cuda-11-0:
     needs: pre-ci
+    strategy:
+      fail-fast: false
+      matrix:
+        helper: [ cudnn,"" ]
+        extension: [ "" ]
     runs-on: ${{ github.event.inputs.runsOn }}
     steps:
       - name: Cancel Previous Runs
@@ -113,6 +118,22 @@ jobs:
              echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
         if: ${{ github.event.inputs.libnd4jUrl != '' }}
 
+      - name: Set mvn build command based on matrix
+        shell: powershell
+        run: |
+          if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
+              $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+           } elseif ( "${{ matrix.helper }}" -ne "" ) {
+                $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+           } else {
+                  $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+          }
+
+          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
+          $to_write = -join("COMMAND=",$($command));
+          echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+          echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
+
       - name: Run windows build
         shell: cmd
         env:
@@ -129,10 +150,12 @@ jobs:
           CUDA_PATH: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.0
           GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           GPG_SIGNING_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-          COMMAND: "mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\" -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda clean --batch-mode deploy -DskipTests"
           MODULES: ${{ github.event.inputs.modules  }}
           LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
           LIBND4J_HOME_SUFFIX: cuda
+          HELPER: ${{ matrix.helper }}
+          EXTENSION: ${{ matrix.extension }}
+
 
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
@@ -141,9 +164,12 @@ jobs:
           echo "Running cuda build"
           cd "%GITHUB_WORKSPACE%"
           bash ./change-cuda-versions.sh 11.0
+          # Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
+          # See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
+          set CUDNN_ROOT_DIR=%CUDA_PATH%
           if "%PERFORM_RELEASE%"=="1" (
                echo "Running release"
-                   bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
+               bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
                bash "./release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%"
           ) else (
              if "%PERFORM_RELEASE%"==1 (
@@ -153,7 +179,11 @@ jobs:
             ) else (
                       echo "Running snapshots"
                       bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
+<<<<<<< Updated upstream
                        mvn -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute="5.0 5.2 5.3 6.0 6.2 8.0" -Djavacpp.platform=windows-x86_64  "%MODULES%" --also-make -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda clean  --batch-mode deploy -DskipTests
+=======
+                      call "%GITHUB_WORKSPACE%\mvn-command.bat"
+>>>>>>> Stashed changes
             )
           )
 

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -179,11 +179,7 @@ jobs:
             ) else (
                       echo "Running snapshots"
                       bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-<<<<<<< Updated upstream
-                       mvn -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute="5.0 5.2 5.3 6.0 6.2 8.0" -Djavacpp.platform=windows-x86_64  "%MODULES%" --also-make -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda clean  --batch-mode deploy -DskipTests
-=======
                       call "%GITHUB_WORKSPACE%\mvn-command.bat"
->>>>>>> Stashed changes
             )
           )
 

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -133,7 +133,7 @@ jobs:
           $command=-join($($command),$($mvn_ext));
           $to_write = -join("COMMAND=",$($command));
           echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($to_write)"
-          echo $to_write  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+          echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
           echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 
       - name: Run windows build

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -166,8 +166,8 @@ jobs:
           echo "Running cuda build"
           cd "%GITHUB_WORKSPACE%"
           bash ./change-cuda-versions.sh 11.0
-          # Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
-          # See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
+          Rem  Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
+          Rem  See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
           set CUDNN_ROOT_DIR=%CUDA_PATH%
           if "%PERFORM_RELEASE%"=="1" (
                echo "Running release"

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -121,16 +121,17 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: powershell
         run: |
+          $command="mvn  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
           if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
-              $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+                $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
            } elseif ( "${{ matrix.helper }}" -ne "" ) {
-                $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+                $mvn_ext="-Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
            } else {
-                  $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+                  $mvn_ext=""
           }
 
           echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-          $to_write = -join("COMMAND=",$($command));
+          $to_write = -join("COMMAND=",$($command),$($mvn_ext));
           echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
           echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -130,10 +130,10 @@ jobs:
                   $mvn_ext=""
           }
 
-          $command=-join($($command),$($mvn_ext));
+          $command2=-join($($command),$($mvn_ext));
           $to_write = -join("COMMAND=",$($command));
-          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($to_write)"
-          echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command2)"
+          echo $command2  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
           echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 
       - name: Run windows build

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -123,9 +123,9 @@ jobs:
         run: |
           $command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
           if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
-                $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+                $mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
            } elseif ( "${{ matrix.helper }}" -ne "" ) {
-                $mvn_ext="-Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+                $mvn_ext=" -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
            } else {
                   $mvn_ext=""
           }

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: powershell
         run: |
-          $command="mvn  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+          $command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
           if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                 $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
            } elseif ( "${{ matrix.helper }}" -ne "" ) {

--- a/.github/workflows/build-deploy-windows-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.0.yml
@@ -130,9 +130,10 @@ jobs:
                   $mvn_ext=""
           }
 
-          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-          $to_write = -join("COMMAND=",$($command),$($mvn_ext));
-          echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+          $command=-join($($command),$($mvn_ext));
+          $to_write = -join("COMMAND=",$($command));
+          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($to_write)"
+          echo $to_write  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
           echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 
       - name: Run windows build

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: powershell
         run: |
-              $command="mvn  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn   -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                     $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
                } elseif ( "${{ matrix.helper }}" -ne "" ) {

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -130,8 +130,8 @@ jobs:
                       $mvn_ext=""
               }
 
-              $command2=-join($($command),$($mvn_ext));
-              $to_write = -join("COMMAND=",$($command2));
+              $command2= -join("$($command)","$($mvn_ext)");
+              $to_write = -join("COMMAND=","$($command2)");
               echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command2)"
               echo $command2  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
               echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -151,11 +151,7 @@ jobs:
           CUDA_PATH: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2
           GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           GPG_SIGNING_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-<<<<<<< Updated upstream
-          COMMAND: "mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\" -Djavacpp.platform=windows-x86_64 -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda clean  --batch-mode deploy -DskipTests"
-=======
           COMMAND: mvn  -Possrh   -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\" -Djavacpp.platform=windows-x86_64 -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda  -Dlibnd4j.helper=cudnn clean  --batch-mode deploy -DskipTests
->>>>>>> Stashed changes
           MODULES: ${{ github.event.inputs.modules  }}
           LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
           LIBND4J_HOME_SUFFIX: cuda
@@ -185,11 +181,7 @@ jobs:
                     ) else (
                         echo "Running snapshots"
                         bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-<<<<<<< Updated upstream
-                        mvn -T ${{ github.event.inputs.buildThreads }} -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute="5.0 5.2 5.3 6.0 6.2 8.0" -Djavacpp.platform=windows-x86_64  -pl ":nd4j-cuda-11.2,:deeplearning4j-cuda-11.2,:libnd4j" --also-make -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda clean  --batch-mode deploy -DskipTests
-=======
                         call "%GITHUB_WORKSPACE%\mvn-command.bat"
->>>>>>> Stashed changes
               )
           )
 

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -130,10 +130,10 @@ jobs:
                       $mvn_ext=""
               }
 
-              $command=-join($($command),$($mvn_ext));
-              $to_write = -join("COMMAND=",$($command));
-              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($to_write)"
-              echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+              $command2=-join($($command),$($mvn_ext));
+              $to_write = -join("COMMAND=",$($command2));
+              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command2)"
+              echo $command2  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
               echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 
 

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -123,9 +123,9 @@ jobs:
         run: |
               $command="mvn   -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
-                    $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+                    $mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
                } elseif ( "${{ matrix.helper }}" -ne "" ) {
-                    $mvn_ext="-Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+                    $mvn_ext=" -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
                } else {
                       $mvn_ext=""
               }

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -121,18 +121,19 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: powershell
         run: |
-          if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
-                 $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Pcuda -Dlibnd4j.chip=cuda -Dlibnd4j.platform=windows-x86_64    deploy -DskipTests"
-           } elseif ( "${{ matrix.helper }}" -ne "" ) {
-                $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Pcuda -Dlibnd4j.chip=cuda -Dlibnd4j.platform=windows-x86_64    deploy -DskipTests"
-           } else {
-                  $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
-          }
+              $command="mvn  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
+                    $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+               } elseif ( "${{ matrix.helper }}" -ne "" ) {
+                    $mvn_ext="-Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+               } else {
+                      $mvn_ext=""
+              }
 
-          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-          $to_write = -join("COMMAND=",$($command));
-          echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
-          echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
+              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
+              $to_write = -join("COMMAND=",$($command),$($mvn_ext));
+              echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+              echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 
 
       - name:  Run cuda build

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -64,6 +64,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows-x86_64-cuda-11-2:
     needs: pre-ci
+    strategy:
+      fail-fast: false
+      matrix:
+        helper: [ cudnn,"" ]
+        extension: [ "" ]
     runs-on: ${{ github.event.inputs.runsOn }}
     steps:
       - name: Cancel Previous Runs
@@ -113,6 +118,23 @@ jobs:
              echo "LIBND4J_HOME=${GITHUB_WORKSPACE}/libnd4j_home/libnd4j" | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
         if: ${{ github.event.inputs.libnd4jUrl != '' }}
 
+      - name: Set mvn build command based on matrix
+        shell: powershell
+        run: |
+          if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
+                 $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Pcuda -Dlibnd4j.chip=cuda -Dlibnd4j.platform=windows-x86_64    deploy -DskipTests"
+           } elseif ( "${{ matrix.helper }}" -ne "" ) {
+                $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Pcuda -Dlibnd4j.chip=cuda -Dlibnd4j.platform=windows-x86_64    deploy -DskipTests"
+           } else {
+                  $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+          }
+
+          echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
+          $to_write = -join("COMMAND=",$($command));
+          echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+          echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
+
+
       - name:  Run cuda build
         shell: cmd
         env:
@@ -129,10 +151,17 @@ jobs:
           CUDA_PATH: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2
           GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           GPG_SIGNING_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+<<<<<<< Updated upstream
           COMMAND: "mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\" -Djavacpp.platform=windows-x86_64 -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda clean  --batch-mode deploy -DskipTests"
+=======
+          COMMAND: mvn  -Possrh   -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute=\"5.0 5.2 5.3 6.0 6.2 8.0\" -Djavacpp.platform=windows-x86_64 -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda  -Dlibnd4j.helper=cudnn clean  --batch-mode deploy -DskipTests
+>>>>>>> Stashed changes
           MODULES: ${{ github.event.inputs.modules  }}
           LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
           LIBND4J_HOME_SUFFIX: cuda
+          HELPER: ${{ matrix.helper }}
+          EXTENSION: ${{ matrix.extension }}
+
 
 
         run: |
@@ -141,6 +170,9 @@ jobs:
           echo "Running cuda build"
           echo "Command is %COMMAND%"
           bash ./change-cuda-versions.sh 11.2
+          # Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
+          # See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
+          set CUDNN_ROOT_DIR=%CUDA_PATH%
           if "%PERFORM_RELEASE%"=="1" (
               echo "Running release"
               bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
@@ -153,7 +185,11 @@ jobs:
                     ) else (
                         echo "Running snapshots"
                         bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
+<<<<<<< Updated upstream
                         mvn -T ${{ github.event.inputs.buildThreads }} -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.compute="5.0 5.2 5.3 6.0 6.2 8.0" -Djavacpp.platform=windows-x86_64  -pl ":nd4j-cuda-11.2,:deeplearning4j-cuda-11.2,:libnd4j" --also-make -Dlibnd4j.platform=windows-x86_64 -Pcuda -Dlibnd4j.chip=cuda clean  --batch-mode deploy -DskipTests
+=======
+                        call "%GITHUB_WORKSPACE%\mvn-command.bat"
+>>>>>>> Stashed changes
               )
           )
 

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -130,8 +130,9 @@ jobs:
                       $mvn_ext=""
               }
 
-              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-              $to_write = -join("COMMAND=",$($command),$($mvn_ext));
+              $command=-join($($command),$($mvn_ext));
+              $to_write = -join("COMMAND=",$($command));
+              echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($to_write)"
               echo $command  | Out-File -FilePath  "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
               echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 

--- a/.github/workflows/build-deploy-windows-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.2.yml
@@ -168,8 +168,8 @@ jobs:
           echo "Running cuda build"
           echo "Command is %COMMAND%"
           bash ./change-cuda-versions.sh 11.2
-          # Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
-          # See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
+          Rem Note: we need this for the cudnn helpers, our cmake can't find it otherwise.
+          Rem See here: https://github.com/eclipse/deeplearning4j/blob/master/libnd4j/CMakeLists.txt#L298
           set CUDNN_ROOT_DIR=%CUDA_PATH%
           if "%PERFORM_RELEASE%"=="1" (
               echo "Running release"

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -120,7 +120,8 @@ jobs:
                 }
 
                 echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-                $to_write = -join("COMMAND=",$($command),$($mvn_ext));
+                $command = -join($($command),$($mvn_ext));
+                $to_write = -join("COMMAND=",$($command));
                 echo $command  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
                 echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -119,8 +119,8 @@ jobs:
                       $mvn_ext=""
                 }
 
-                $command2 = -join($($command),$($mvn_ext));
-                $to_write = -join("COMMAND=",$($command2));
+                $command2 = -join("$($command)","$($mvn_ext)");
+                $to_write = -join("COMMAND=","$($command2)");
                 echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command2)"
                 echo $command2  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
                 echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -126,22 +126,22 @@ jobs:
       - name: Run windows cpu build
         shell: cmd
         run: |
-            if "%PERFORM_RELEASE%"=="1" (
-                 echo "Running release"
-                 # download libnd4j from a url and set it up if LIBND4J_URL is defined
-                 bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-                 bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "%COMMAND%"
-            ) else (
-                if "%PERFORM_RELEASE%"==1 (
-                      echo "Running release"
-                       bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-                       bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "%COMMAND%"
-                 ) else (
-                    echo "Running snapshots"
-                    bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-                    call "%GITHUB_WORKSPACE%\mvn-command.bat"
-                 )
-            )
+              if "%PERFORM_RELEASE%"=="1" (
+                   echo "Running release"
+                   # download libnd4j from a url and set it up if LIBND4J_URL is defined
+                   bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
+                   bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "%COMMAND%"
+              ) else (
+                  if "%PERFORM_RELEASE%"==1 (
+                        echo "Running release"
+                         bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
+                         bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "%COMMAND%"
+                   ) else (
+                      echo "Running snapshots"
+                      bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
+                      call "%GITHUB_WORKSPACE%\mvn-command.bat"
+                   )
+              )
         env:
           MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -119,10 +119,10 @@ jobs:
                       $mvn_ext=""
                 }
 
-                $command = -join($($command),$($mvn_ext));
-                $to_write = -join("COMMAND=",$($command));
-                echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-                echo $command  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+                $command2 = -join($($command),$($mvn_ext));
+                $to_write = -join("COMMAND=",$($command2));
+                echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command2)"
+                echo $command2  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
                 echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 
       - name: Run windows cpu build

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -115,7 +115,9 @@ jobs:
                       $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                  } elseif ( "${{ matrix.helper }}" -ne "" ) {
                        $mvn_ext="-Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
-                 } else {
+                 }  elseif ( "${{ matrix.extension }}" -ne "" ) {
+                        $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                } else {
                       $mvn_ext=""
                 }
 

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -53,6 +53,11 @@ on:
         default: false
 jobs:
   windows-x86_64:
+    strategy:
+      fail-fast: false
+      matrix:
+        helper: [ mkldnn,"" ]
+        extension: [ avx2,avx512,"" ]
     runs-on: ${{ github.event.inputs.runsOn }}
     steps:
       - name: Cancel Previous Runs
@@ -102,6 +107,22 @@ jobs:
             cd ..
             echo "OPENBLAS_PATH=${GITHUB_WORKSPACE}/openblas_home/org/bytedeco/openblas/windows-x86_64/" | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
         if: ${{ github.event.inputs.libnd4jUrl != '' }}
+      - name: Set mvn build command based on matrix
+        shell: powershell
+        run: |
+                if ( "${{ matrix.helper }}" -ne ""  -And "${{ matrix.extension }}" -ne "" ) {
+                      $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                 } elseif ( "${{ matrix.helper }}" -ne "" ) {
+                      $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                 } else {
+                        $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                }
+
+                echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
+                $to_write = -join("COMMAND=",$($command));
+                echo $command  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
+                echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
+
       - name: Run windows cpu build
         shell: cmd
         run: |
@@ -109,16 +130,20 @@ jobs:
                  echo "Running release"
                  # download libnd4j from a url and set it up if LIBND4J_URL is defined
                  bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-                 bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=mkldnn -pl \":nd4j-native,:libnd4j\" --also-make -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                 bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "%COMMAND%"
             ) else (
                 if "%PERFORM_RELEASE%"==1 (
                       echo "Running release"
                        bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-                      bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64 -Dlibnd4j.helper=mkldnn -pl \":nd4j-native,:libnd4j\" --also-make -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                       bash "%GITHUB_WORKSPACE%/release-specified-component.sh"  "%RELEASE_VERSION%" "%SNAPSHOT_VERSION%" "%RELEASE_REPO_ID%" "%COMMAND%"
                  ) else (
                     echo "Running snapshots"
                     bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
+<<<<<<< Updated upstream
                     mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  "%MODULES%" --also-make -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  clean --batch-mode deploy -DskipTests
+=======
+                    call "%GITHUB_WORKSPACE%\mvn-command.bat"
+>>>>>>> Stashed changes
                  )
             )
         env:
@@ -136,6 +161,9 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
           MODULES: ${{ github.event.inputs.modules  }}
           LIBND4J_URL: ${{ github.event.inputs.libnd4jUrl }}
+          HELPER: ${{ matrix.helper }}
+          EXTENSION: ${{ matrix.extension }}
+
 
 
       - name: Setup tmate session

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -110,16 +110,17 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: powershell
         run: |
+                $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                 if ( "${{ matrix.helper }}" -ne ""  -And "${{ matrix.extension }}" -ne "" ) {
-                      $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                      $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                  } elseif ( "${{ matrix.helper }}" -ne "" ) {
-                      $command="mvn  -Possrh -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                       $mvn_ext="-Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                  } else {
-                        $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                      $mvn_ext=""
                 }
 
                 echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-                $to_write = -join("COMMAND=",$($command));
+                $to_write = -join("COMMAND=",$($command),$(mvn_ext));
                 echo $command  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
                 echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -112,11 +112,11 @@ jobs:
         run: |
                 $command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                 if ( "${{ matrix.helper }}" -ne ""  -And "${{ matrix.extension }}" -ne "" ) {
-                      $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                      $mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                  } elseif ( "${{ matrix.helper }}" -ne "" ) {
-                       $mvn_ext="-Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                       $mvn_ext=" -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                  }  elseif ( "${{ matrix.extension }}" -ne "" ) {
-                        $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                        $mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                 } else {
                       $mvn_ext=""
                 }

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -120,7 +120,7 @@ jobs:
                 }
 
                 echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
-                $to_write = -join("COMMAND=",$($command),$(mvn_ext));
+                $to_write = -join("COMMAND=",$($command),$($mvn_ext));
                 echo $command  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
                 echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -139,11 +139,7 @@ jobs:
                  ) else (
                     echo "Running snapshots"
                     bash "%GITHUB_WORKSPACE%/bootstrap-libnd4j-from-url.sh"
-<<<<<<< Updated upstream
-                    mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  "%MODULES%" --also-make -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  clean --batch-mode deploy -DskipTests
-=======
                     call "%GITHUB_WORKSPACE%\mvn-command.bat"
->>>>>>> Stashed changes
                  )
             )
         env:

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set mvn build command based on matrix
         shell: powershell
         run: |
-                $command="mvn  -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
+                $command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3   -Possrh -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                 if ( "${{ matrix.helper }}" -ne ""  -And "${{ matrix.extension }}" -ne "" ) {
                       $mvn_ext="-Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64  -Dlibnd4j.chip=cpu  deploy -DskipTests"
                  } elseif ( "${{ matrix.helper }}" -ne "" ) {

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -119,9 +119,9 @@ jobs:
                       $mvn_ext=""
                 }
 
-                echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
                 $command = -join($($command),$($mvn_ext));
                 $to_write = -join("COMMAND=",$($command));
+                echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to $($command)"
                 echo $command  | Out-File -FilePath   "$env:GITHUB_WORKSPACE/mvn-command.bat" -Encoding utf8 -Append
                 echo $to_write  | Out-File -FilePath  "$env:GITHUB_ENV" -Encoding utf8 -Append
 

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        helper: [ mkldnn,"" ]
+        helper: [ onednn,"" ]
         extension: [ avx2,avx512,"" ]
     runs-on: ${{ github.event.inputs.runsOn }}
     steps:

--- a/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/cuda/dropout/CudnnDropoutHelper.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/main/java/org/deeplearning4j/cuda/dropout/CudnnDropoutHelper.java
@@ -38,6 +38,9 @@ import org.nd4j.common.util.ArrayUtil;
 import org.bytedeco.cuda.cudart.*;
 import org.bytedeco.cuda.cudnn.*;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.bytedeco.cuda.global.cudnn.*;
 
 /**
@@ -117,6 +120,16 @@ public class CudnnDropoutHelper extends BaseCudnnHelper implements DropoutHelper
 
     public CudnnDropoutHelper(DataType dataType){
         super(dataType);
+    }
+
+    @Override
+    public Map<String, Long> helperMemoryUse() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean checkSupported() {
+        return true;
     }
 
     @Override

--- a/libnd4j/CMakeLists.txt
+++ b/libnd4j/CMakeLists.txt
@@ -321,7 +321,7 @@ if (${HELPERS_cudnn})
 
     if (CUDNN_LIBRARY AND CUDNN_INCLUDE_DIR)
         message("CUDNN include dir is ${CUDNN_INCLUDE_DIR}")
-
+        include_directories(${CUDNN_INCLUDE_DIR})
         set(HAVE_CUDNN true)
         set(CUDNN ${CUDNN_LIBRARY})
     else()

--- a/libnd4j/pi_build.sh
+++ b/libnd4j/pi_build.sh
@@ -418,7 +418,7 @@ cd "$BASE_DIR/.."
 message "lets build jars"
 if [ "${DEPLOY-}" != "" ]; then
   message "Deploying to maven"
-  command="mvn  $MODULES  -Dmaven.javadoc.failOnError=false -Dlibnd4j.buildthreads=\"${LIBND4J_BUILD_THREADS}\"  -P\"${PUBLISH_TO}\"  deploy  --batch-mode  -Dlibnd4j.platform=${LIBND4J_PLATFORM} -Djavacpp.platform=${LIBND4J_PLATFORM} ${XTRA_MVN_ARGS}  -DprotocCommand=\"${PROTO_EXEC}\"  -DprotocExecutable=\"${PROTO_EXEC}\" -Djavacpp.platform.compiler=\"${COMPILER}\" -Djava.library.path=\"${JAVA_LIBRARY_PATH}\"  -DskipTests -Dmaven.test.skip=true -Dmaven.javadoc.skip=true"
+  command="mvn  -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  $MODULES  -Dmaven.javadoc.failOnError=false -Dlibnd4j.buildthreads=\"${LIBND4J_BUILD_THREADS}\"  -P\"${PUBLISH_TO}\"  deploy  --batch-mode  -Dlibnd4j.platform=${LIBND4J_PLATFORM} -Djavacpp.platform=${LIBND4J_PLATFORM} ${XTRA_MVN_ARGS}  -DprotocCommand=\"${PROTO_EXEC}\"  -DprotocExecutable=\"${PROTO_EXEC}\" -Djavacpp.platform.compiler=\"${COMPILER}\" -Djava.library.path=\"${JAVA_LIBRARY_PATH}\"  -DskipTests -Dmaven.test.skip=true -Dmaven.javadoc.skip=true"
   message "$command"
   echo "Perform release or not ${PERFORM_RELEASE}"
   if [ "${PERFORM_RELEASE}" == "1" ] || [ "${PERFORM_RELEASE}" == 1 ]; then

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda-preset/src/main/java/org/nd4j/nativeblas/Nd4jCudaPresets.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda-preset/src/main/java/org/nd4j/nativeblas/Nd4jCudaPresets.java
@@ -35,100 +35,101 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  * @author saudet
  */
 @Properties(target = "org.nd4j.nativeblas.Nd4jCuda", helper = "org.nd4j.nativeblas.Nd4jCudaHelper",
-                value = {@Platform(define = "LIBND4J_ALL_OPS", include = {
-                        "array/DataType.h",
-                        "array/DataBuffer.h",
-                        "array/PointerDeallocator.h",
-                        "array/PointerWrapper.h",
-                        "array/ConstantDescriptor.h",
-                        "array/ConstantDataBuffer.h",
-                        "array/ConstantShapeBuffer.h",
-                        "array/ConstantOffsetsBuffer.h",
-                        "array/TadPack.h",
-                        "execution/ErrorReference.h",
-                        "execution/Engine.h",
-                        "execution/ExecutionMode.h",
-                        "memory/MemoryType.h",
-                        "system/Environment.h",
-                        "types/utf8string.h",
-                        "legacy/NativeOps.h",
-                        "memory/ExternalWorkspace.h",
-                        "memory/Workspace.h",
-                        "indexing/NDIndex.h",
-                        "indexing/IndicesList.h",
-                        "array/DataType.h",
-                        "graph/VariableType.h",
-                        "graph/ArgumentsList.h",
-                        "types/pair.h",
-                        "types/pair.h",
-                        "array/NDArray.h",
-                        "array/NDArrayList.h",
-                        "array/ResultSet.h",
-                        "graph/RandomGenerator.h",
-                        "graph/Variable.h",
-                        "graph/VariablesSet.h",
-                        "graph/FlowPath.h",
-                        "graph/Intervals.h",
-                        "graph/Stash.h",
-                        "graph/GraphState.h",
-                        "graph/VariableSpace.h",
-                        "helpers/helper_generator.h",
-                        "graph/profiling/GraphProfile.h",
-                        "graph/profiling/NodeProfile.h",
-                        "graph/Context.h",
-                        "graph/ContextPrototype.h",
-                        "graph/ResultWrapper.h",
-                        "helpers/shape.h",
-                        "array/ShapeList.h",
-                        //"system/op_boilerplate.h",
-                        "ops/InputType.h",
-                        "ops/declarable/OpDescriptor.h",
-                        "ops/declarable/PlatformHelper.h",
-                        "ops/declarable/BroadcastableOp.h",
-                        "ops/declarable/BroadcastableBoolOp.h",
-                        "helpers/OpArgsHolder.h",
-                        "ops/declarable/DeclarableOp.h",
-                        "ops/declarable/DeclarableListOp.h",
-                        "ops/declarable/DeclarableReductionOp.h",
-                        "ops/declarable/DeclarableCustomOp.h",
-                        "ops/declarable/BooleanOp.h",
-                        "ops/declarable/LogicOp.h",
-                        "ops/declarable/OpRegistrator.h",
-                        "execution/ContextBuffers.h",
-                        "execution/LaunchContext.h",
-                        "array/ShapeDescriptor.h",
-                        "array/TadDescriptor.h",
-                        "array/TadPack.h",
-                        "helpers/DebugInfo.h",
-                        "ops/declarable/CustomOperations.h",
-                        "build_info.h",
-                    },
-                        exclude = {"ops/declarable/headers/activations.h",
-                                "ops/declarable/headers/boolean.h",
-                                "ops/declarable/headers/broadcastable.h",
-                                "ops/declarable/headers/convo.h",
-                                "ops/declarable/headers/list.h",
-                                "ops/declarable/headers/recurrent.h",
-                                "ops/declarable/headers/transforms.h",
-                                "ops/declarable/headers/parity_ops.h",
-                                "ops/declarable/headers/shape.h",
-                                "ops/declarable/headers/random.h",
-                                "ops/declarable/headers/nn.h",
-                                "ops/declarable/headers/blas.h",
-                                "ops/declarable/headers/bitwise.h",
-                                "ops/declarable/headers/tests.h",
-                                "ops/declarable/headers/loss.h",
-                                "ops/declarable/headers/datatypes.h",
-                                "ops/declarable/headers/third_party.h",
-                                "cnpy/cnpy.h"
-                        },
-                                compiler = {"cpp11", "nowarnings"},
-                                library = "jnind4jcuda", link = "nd4jcuda", preload = "libnd4jcuda"),
+        value = {@Platform(define = "LIBND4J_ALL_OPS", include = {
+                "array/DataType.h",
+                "array/DataBuffer.h",
+                "array/PointerDeallocator.h",
+                "array/PointerWrapper.h",
+                "array/ConstantDescriptor.h",
+                "array/ConstantDataBuffer.h",
+                "array/ConstantShapeBuffer.h",
+                "array/ConstantOffsetsBuffer.h",
+                "array/TadPack.h",
+                "execution/ErrorReference.h",
+                "execution/Engine.h",
+                "execution/ExecutionMode.h",
+                "memory/MemoryType.h",
+                "system/Environment.h",
+                "types/utf8string.h",
+                "legacy/NativeOps.h",
+                "memory/ExternalWorkspace.h",
+                "memory/Workspace.h",
+                "indexing/NDIndex.h",
+                "indexing/IndicesList.h",
+                "array/DataType.h",
+                "graph/VariableType.h",
+                "graph/ArgumentsList.h",
+                "types/pair.h",
+                "types/pair.h",
+                "array/NDArray.h",
+                "array/NDArrayList.h",
+                "array/ResultSet.h",
+                "graph/RandomGenerator.h",
+                "graph/Variable.h",
+                "graph/VariablesSet.h",
+                "graph/FlowPath.h",
+                "graph/Intervals.h",
+                "graph/Stash.h",
+                "graph/GraphState.h",
+                "graph/VariableSpace.h",
+                "helpers/helper_generator.h",
+                "graph/profiling/GraphProfile.h",
+                "graph/profiling/NodeProfile.h",
+                "graph/Context.h",
+                "graph/ContextPrototype.h",
+                "graph/ResultWrapper.h",
+                "helpers/shape.h",
+                "array/ShapeList.h",
+                //"system/op_boilerplate.h",
+                "ops/InputType.h",
+                "ops/declarable/OpDescriptor.h",
+                "ops/declarable/PlatformHelper.h",
+                "ops/declarable/BroadcastableOp.h",
+                "ops/declarable/BroadcastableBoolOp.h",
+                "helpers/OpArgsHolder.h",
+                "ops/declarable/DeclarableOp.h",
+                "ops/declarable/DeclarableListOp.h",
+                "ops/declarable/DeclarableReductionOp.h",
+                "ops/declarable/DeclarableCustomOp.h",
+                "ops/declarable/BooleanOp.h",
+                "ops/declarable/LogicOp.h",
+                "ops/declarable/OpRegistrator.h",
+                "execution/ContextBuffers.h",
+                "execution/LaunchContext.h",
+                "array/ShapeDescriptor.h",
+                "array/TadDescriptor.h",
+                "array/TadPack.h",
+                "helpers/DebugInfo.h",
+                "ops/declarable/CustomOperations.h",
+                "build_info.h",
+        },
+                exclude = {"ops/declarable/headers/activations.h",
+                        "ops/declarable/headers/boolean.h",
+                        "ops/declarable/headers/broadcastable.h",
+                        "ops/declarable/headers/convo.h",
+                        "ops/declarable/headers/list.h",
+                        "ops/declarable/headers/recurrent.h",
+                        "ops/declarable/headers/transforms.h",
+                        "ops/declarable/headers/parity_ops.h",
+                        "ops/declarable/headers/shape.h",
+                        "ops/declarable/headers/random.h",
+                        "ops/declarable/headers/nn.h",
+                        "ops/declarable/headers/blas.h",
+                        "ops/declarable/headers/bitwise.h",
+                        "ops/declarable/headers/tests.h",
+                        "ops/declarable/headers/loss.h",
+                        "ops/declarable/headers/datatypes.h",
+                        "ops/declarable/headers/third_party.h",
+                        "cnpy/cnpy.h"
+                },
+                compiler = {"cpp11", "nowarnings"},
+                library = "jnind4jcuda", link = "nd4jcuda", preload = "libnd4jcuda"),
                 @Platform(value = "linux", preload = "gomp@.1", preloadpath = {"/lib64/", "/lib/", "/usr/lib64/", "/usr/lib/"}),
                 @Platform(value = "linux-armhf", preloadpath = {"/usr/arm-linux-gnueabihf/lib/", "/usr/lib/arm-linux-gnueabihf/"}),
                 @Platform(value = "linux-arm64", preloadpath = {"/usr/aarch64-linux-gnu/lib/", "/usr/lib/aarch64-linux-gnu/"}),
                 @Platform(value = "linux-ppc64", preloadpath = {"/usr/powerpc64-linux-gnu/lib/", "/usr/powerpc64le-linux-gnu/lib/", "/usr/lib/powerpc64-linux-gnu/", "/usr/lib/powerpc64le-linux-gnu/"}),
-                @Platform(value = "windows", preload = {"libwinpthread-1", "libgcc_s_seh-1", "libgomp-1", "libstdc++-6", "libnd4jcpu"}) })
+                @Platform(value = "windows", preload = {"libwinpthread-1", "libgcc_s_seh-1", "libgomp-1", "libstdc++-6", "libnd4jcpu"}),
+                @Platform(extension = {"-cudnn","-"})})
 public class Nd4jCudaPresets implements LoadEnabled, InfoMapper {
 
     @Override public void init(ClassProperties properties) {
@@ -142,8 +143,8 @@ public class Nd4jCudaPresets implements LoadEnabled, InfoMapper {
         }
         int i = 0;
         String[] libs = {"cudart", "cublasLt", "cublas", "curand", "cusolver", "cusparse", "cudnn",
-                         "cudnn_ops_infer", "cudnn_ops_train", "cudnn_adv_infer",
-                         "cudnn_adv_train", "cudnn_cnn_infer", "cudnn_cnn_train"};
+                "cudnn_ops_infer", "cudnn_ops_train", "cudnn_adv_infer",
+                "cudnn_adv_train", "cudnn_cnn_infer", "cudnn_cnn_train"};
         for (String lib : libs) {
             if (platform.startsWith("linux")) {
                 lib += lib.startsWith("cudnn") ? "@.8" : lib.equals("curand") ? "@.10" : lib.equals("cudart") ? "@.11.0" : "@.11";
@@ -164,7 +165,7 @@ public class Nd4jCudaPresets implements LoadEnabled, InfoMapper {
     @Override
     public void map(InfoMap infoMap) {
         infoMap.put(new Info("thread_local", "ND4J_EXPORT", "INLINEDEF", "CUBLASWINAPI", "FORCEINLINE",
-                             "_CUDA_H", "_CUDA_D", "_CUDA_G", "_CUDA_HD", "LIBND4J_ALL_OPS", "NOT_EXCLUDED").cppTypes().annotations())
+                "_CUDA_H", "_CUDA_D", "_CUDA_G", "_CUDA_HD", "LIBND4J_ALL_OPS", "NOT_EXCLUDED").cppTypes().annotations())
                 .put(new Info("NativeOps.h", "build_info.h").objectify())
                 .put(new Info("OpaqueTadPack").pointerTypes("OpaqueTadPack"))
                 .put(new Info("OpaqueResultWrapper").pointerTypes("OpaqueResultWrapper"))
@@ -193,11 +194,11 @@ public class Nd4jCudaPresets implements LoadEnabled, InfoMapper {
                         "short[]"));
 
         infoMap.put(new Info("__CUDACC__", "MAX_UINT", "HAVE_MKLDNN").define(false))
-               .put(new Info("__JAVACPP_HACK__", "LIBND4J_ALL_OPS","__CUDABLAS__").define(true))
-               .put(new Info("std::initializer_list", "cnpy::NpyArray", "sd::NDArray::applyLambda", "sd::NDArray::applyPairwiseLambda",
-                             "sd::graph::FlatResult", "sd::graph::FlatVariable", "sd::NDArray::subarray", "std::shared_ptr", "sd::PointerWrapper", "sd::PointerDeallocator").skip())
-               .put(new Info("std::string").annotations("@StdString").valueTypes("BytePointer", "String")
-                                           .pointerTypes("@Cast({\"char*\", \"std::string*\"}) BytePointer"))
+                .put(new Info("__JAVACPP_HACK__", "LIBND4J_ALL_OPS","__CUDABLAS__").define(true))
+                .put(new Info("std::initializer_list", "cnpy::NpyArray", "sd::NDArray::applyLambda", "sd::NDArray::applyPairwiseLambda",
+                        "sd::graph::FlatResult", "sd::graph::FlatVariable", "sd::NDArray::subarray", "std::shared_ptr", "sd::PointerWrapper", "sd::PointerDeallocator").skip())
+                .put(new Info("std::string").annotations("@StdString").valueTypes("BytePointer", "String")
+                        .pointerTypes("@Cast({\"char*\", \"std::string*\"}) BytePointer"))
                 .put(new Info("std::pair<int,int>").pointerTypes("IntIntPair").define())
                 .put(new Info("std::vector<std::vector<int> >").pointerTypes("IntVectorVector").define())
                 .put(new Info("std::vector<std::vector<Nd4jLong> >").pointerTypes("LongVectorVector").define())
@@ -205,7 +206,7 @@ public class Nd4jCudaPresets implements LoadEnabled, InfoMapper {
                 .put(new Info("std::vector<const sd::NDArray*>").pointerTypes("ConstNDArrayVector").define())
                 .put(new Info("bool").cast().valueTypes("boolean").pointerTypes("BooleanPointer", "boolean[]"))
                 .put(new Info("sd::graph::ResultWrapper").base("org.nd4j.nativeblas.ResultWrapperAbstraction").define())
-               .put(new Info("sd::IndicesList").purify());
+                .put(new Info("sd::IndicesList").purify());
 /*
         String classTemplates[] = {
                 "sd::NDArray",

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
@@ -152,7 +152,7 @@ import java.util.*;
                 @Platform(value = "linux-arm64", preloadpath = {"/usr/aarch64-linux-gnu/lib/", "/usr/lib/aarch64-linux-gnu/"}),
                 @Platform(value = "linux-ppc64", preloadpath = {"/usr/powerpc64-linux-gnu/lib/", "/usr/powerpc64le-linux-gnu/lib/", "/usr/lib/powerpc64-linux-gnu/", "/usr/lib/powerpc64le-linux-gnu/"}),
                 @Platform(value = "windows", preload = {"libwinpthread-1", "libgcc_s_seh-1", "libgomp-1", "libstdc++-6", "libnd4jcpu"}),
-                @Platform(extension = {"-avx512", "-avx2"}) })
+                @Platform(extension = {"-onednn", "-onednn-avx512","-onednn-avx2","-"}) })
 public class Nd4jCpuPresets implements InfoMapper, BuildEnabled {
 
     private Logger logger;

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java
@@ -152,7 +152,7 @@ import java.util.*;
                 @Platform(value = "linux-arm64", preloadpath = {"/usr/aarch64-linux-gnu/lib/", "/usr/lib/aarch64-linux-gnu/"}),
                 @Platform(value = "linux-ppc64", preloadpath = {"/usr/powerpc64-linux-gnu/lib/", "/usr/powerpc64le-linux-gnu/lib/", "/usr/lib/powerpc64-linux-gnu/", "/usr/lib/powerpc64le-linux-gnu/"}),
                 @Platform(value = "windows", preload = {"libwinpthread-1", "libgcc_s_seh-1", "libgomp-1", "libstdc++-6", "libnd4jcpu"}),
-                @Platform(extension = {"-onednn", "-onednn-avx512","-onednn-avx2","-"}) })
+                @Platform(extension = {"-onednn", "-onednn-avx512","-onednn-avx2","-","-avx2","-avx512"}) })
 public class Nd4jCpuPresets implements InfoMapper, BuildEnabled {
 
     private Logger logger;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Implements the ADR: #9290

Adds github workflows for a matrix based build structure for different classifiers.
Also adds proper extensions for presets to ensure javacpp can load the extensions.

## How was this patch tested?
Manually on GH actions

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
