### PR TITLE
Add javacpp platform extension to output path

### DIFF
--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -249,7 +249,7 @@
                             <classOrPackageName>org.nd4j.nativeblas.Nd4jCuda</classOrPackageName>
                             <copyLibs>true</copyLibs>
                             <configDirectory>${project.build.directory}/classes/META-INF/native-image/${javacpp.platform}${javacpp.platform.extension}/</configDirectory>
-                            <outputDirectory>${project.build.directory}/classes/org/nd4j/nativeblas/${javacpp.platform}${javacpp.platform.extension}</outputDirectory>
+                            <outputDirectory>${javacpp.build.output.path}</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -40,6 +40,9 @@
         <cuda.version>11.0</cuda.version>
         <cudnn.version>8.0</cudnn.version>
         <javacpp-presets.cuda.version>1.5.4</javacpp-presets.cuda.version>
+        <!-- Try to avoid setting this. This is mainly for being able to override for where we put binaries in javacpp jars for android. -->
+        <javacpp.build.output.path>${project.build.directory}/classes/org/nd4j/nativeblas/${javacpp.platform}${javacpp.platform.extension}</javacpp.build.output.path>
+
     </properties>
 
     <dependencies>
@@ -246,7 +249,7 @@
                             <classOrPackageName>org.nd4j.nativeblas.Nd4jCuda</classOrPackageName>
                             <copyLibs>true</copyLibs>
                             <configDirectory>${project.build.directory}/classes/META-INF/native-image/${javacpp.platform}${javacpp.platform.extension}/</configDirectory>
-                            <outputDirectory>${project.build.directory}/classes/org/nd4j/nativeblas/${javacpp.platform}</outputDirectory>
+                            <outputDirectory>${project.build.directory}/classes/org/nd4j/nativeblas/${javacpp.platform}${javacpp.platform.extension}</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <!-- Try to avoid setting this. This is mainly for being able to override for where we put binaries in javacpp jars for android. -->
-        <javacpp.build.output.path>${project.build.directory}/classes/org/nd4j/nativeblas/${javacpp.platform}</javacpp.build.output.path>
+        <javacpp.build.output.path>${project.build.directory}/classes/org/nd4j/nativeblas/${javacpp.platform}${javacpp.platform.extension}</javacpp.build.output.path>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds javacpp platform extension to output path so we can properly detect platform + extension when manually specifying path. Related to:
https://github.com/eclipse/deeplearning4j/pull/9298
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
