### PR TITLE
Add default value for cnn3d keras import channel layout, fix mkldnn class missing interfaces

### DIFF
--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/ReshapePreprocessor.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/preprocessors/ReshapePreprocessor.java
@@ -172,8 +172,8 @@ public class ReshapePreprocessor extends BaseInputPreProcessor {
                     Convolution3D.DataFormat dataFormat = (Convolution3D.DataFormat) this.format;
                     if(dataFormat == Convolution3D.DataFormat.NCDHW) {
                         ret =  InputType.convolutional3D(dataFormat,shape[2],shape[3],shape[4],shape[0]);
-
-                    } else if(dataFormat == Convolution3D.DataFormat.NDHWC) {
+                        //default value
+                    } else if(dataFormat == Convolution3D.DataFormat.NDHWC || dataFormat == null) {
                         ret =  InputType.convolutional3D(dataFormat,shape[1],shape[2],shape[3],shape[0]);
                     } else {
                         throw new IllegalArgumentException("Illegal format found " + dataFormat);

--- a/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasYolo9000PredictTest.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/e2e/KerasYolo9000PredictTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Tag(TagNames.FILE_IO)
 @Tag(TagNames.KERAS)
 @NativeTag
+
 class KerasYolo9000PredictTest extends BaseDL4JTest {
 
     private static final String DL4J_MODEL_FILE_NAME = ".";

--- a/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/convolution/KerasConvolution3DTest.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/convolution/KerasConvolution3DTest.java
@@ -19,29 +19,39 @@
  */
 package org.deeplearning4j.nn.modelimport.keras.layers.convolution;
 
+import org.apache.commons.io.FileUtils;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.dropout.Dropout;
 import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.nn.modelimport.keras.KerasModelImport;
 import org.deeplearning4j.nn.modelimport.keras.KerasTestUtils;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras1LayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras2LayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.config.KerasLayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.layers.convolutional.KerasConvolution3D;
+import org.deeplearning4j.nn.modelimport.keras.preprocessors.ReshapePreprocessor;
 import org.deeplearning4j.nn.weights.IWeightInit;
 import org.deeplearning4j.nn.weights.WeightInitXavier;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Max Pumperla
@@ -148,4 +158,18 @@ class KerasConvolution3DTest extends BaseDL4JTest {
         assertEquals(ConvolutionMode.Truncate, layer.getConvolutionMode());
         assertArrayEquals(VALID_PADDING, layer.getPadding());
     }
+
+    @Test
+    public void testDefaultLayout(@TempDir Path testDir) throws Exception {
+        String config = "{\"class_name\": \"Sequential\", \"config\": {\"name\": \"sequential_1\", \"layers\": [{\"class_name\": \"InputLayer\", \"config\": {\"batch_input_shape\": [null, 32], \"dtype\": \"float32\", \"sparse\": false, \"ragged\": false, \"name\": \"input_2\"}}, {\"class_name\": \"Dense\", \"config\": {\"name\": \"dense_4\", \"trainable\": true, \"dtype\": \"float32\", \"units\": 720, \"activation\": \"linear\", \"use_bias\": true, \"kernel_initializer\": {\"class_name\": \"GlorotUniform\", \"config\": {\"seed\": null}}, \"bias_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"kernel_regularizer\": null, \"bias_regularizer\": null, \"activity_regularizer\": null, \"kernel_constraint\": null, \"bias_constraint\": null}}, {\"class_name\": \"LeakyReLU\", \"config\": {\"name\": \"leaky_re_lu\", \"trainable\": true, \"dtype\": \"float32\", \"alpha\": 0.10000000149011612}}, {\"class_name\": \"BatchNormalization\", \"config\": {\"name\": \"batch_normalization_3\", \"trainable\": true, \"dtype\": \"float32\", \"axis\": [1], \"momentum\": 0.99, \"epsilon\": 0.001, \"center\": true, \"scale\": true, \"beta_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"gamma_initializer\": {\"class_name\": \"Ones\", \"config\": {}}, \"moving_mean_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"moving_variance_initializer\": {\"class_name\": \"Ones\", \"config\": {}}, \"beta_regularizer\": null, \"gamma_regularizer\": null, \"beta_constraint\": null, \"gamma_constraint\": null}}, {\"class_name\": \"Dropout\", \"config\": {\"name\": \"dropout_1\", \"trainable\": true, \"dtype\": \"float32\", \"rate\": 0.2, \"noise_shape\": null, \"seed\": null}}, {\"class_name\": \"Reshape\", \"config\": {\"name\": \"reshape\", \"trainable\": true, \"dtype\": \"float32\", \"target_shape\": [60, 1, 3, 4]}}, {\"class_name\": \"Conv3D\", \"config\": {\"name\": \"conv3d_4\", \"trainable\": true, \"dtype\": \"float32\", \"filters\": 256, \"kernel_size\": [3, 3, 3], \"strides\": [1, 1, 1], \"padding\": \"same\", \"data_format\": \"channels_last\", \"dilation_rate\": [1, 1, 1], \"groups\": 1, \"activation\": \"linear\", \"use_bias\": true, \"kernel_initializer\": {\"class_name\": \"GlorotUniform\", \"config\": {\"seed\": null}}, \"bias_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"kernel_regularizer\": null, \"bias_regularizer\": null, \"activity_regularizer\": null, \"kernel_constraint\": null, \"bias_constraint\": null}}, {\"class_name\": \"LeakyReLU\", \"config\": {\"name\": \"leaky_re_lu_1\", \"trainable\": true, \"dtype\": \"float32\", \"alpha\": 0.10000000149011612}}, {\"class_name\": \"UpSampling3D\", \"config\": {\"name\": \"up_sampling3d\", \"trainable\": true, \"dtype\": \"float32\", \"size\": [2, 2, 2], \"data_format\": \"channels_last\"}}, {\"class_name\": \"Conv3D\", \"config\": {\"name\": \"conv3d_5\", \"trainable\": true, \"dtype\": \"float32\", \"filters\": 128, \"kernel_size\": [3, 3, 3], \"strides\": [1, 1, 1], \"padding\": \"same\", \"data_format\": \"channels_last\", \"dilation_rate\": [1, 1, 1], \"groups\": 1, \"activation\": \"linear\", \"use_bias\": true, \"kernel_initializer\": {\"class_name\": \"GlorotUniform\", \"config\": {\"seed\": null}}, \"bias_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"kernel_regularizer\": null, \"bias_regularizer\": null, \"activity_regularizer\": null, \"kernel_constraint\": null, \"bias_constraint\": null}}, {\"class_name\": \"LeakyReLU\", \"config\": {\"name\": \"leaky_re_lu_2\", \"trainable\": true, \"dtype\": \"float32\", \"alpha\": 0.10000000149011612}}, {\"class_name\": \"UpSampling3D\", \"config\": {\"name\": \"up_sampling3d_1\", \"trainable\": true, \"dtype\": \"float32\", \"size\": [2, 2, 2], \"data_format\": \"channels_last\"}}, {\"class_name\": \"Conv3D\", \"config\": {\"name\": \"conv3d_6\", \"trainable\": true, \"dtype\": \"float32\", \"filters\": 16, \"kernel_size\": [3, 3, 3], \"strides\": [1, 1, 1], \"padding\": \"same\", \"data_format\": \"channels_last\", \"dilation_rate\": [1, 1, 1], \"groups\": 1, \"activation\": \"linear\", \"use_bias\": true, \"kernel_initializer\": {\"class_name\": \"GlorotUniform\", \"config\": {\"seed\": null}}, \"bias_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"kernel_regularizer\": null, \"bias_regularizer\": null, \"activity_regularizer\": null, \"kernel_constraint\": null, \"bias_constraint\": null}}, {\"class_name\": \"LeakyReLU\", \"config\": {\"name\": \"leaky_re_lu_3\", \"trainable\": true, \"dtype\": \"float32\", \"alpha\": 0.10000000149011612}}, {\"class_name\": \"UpSampling3D\", \"config\": {\"name\": \"up_sampling3d_2\", \"trainable\": true, \"dtype\": \"float32\", \"size\": [2, 2, 2], \"data_format\": \"channels_last\"}}, {\"class_name\": \"Conv3D\", \"config\": {\"name\": \"conv3d_7\", \"trainable\": true, \"dtype\": \"float32\", \"filters\": 8, \"kernel_size\": [3, 3, 3], \"strides\": [1, 1, 1], \"padding\": \"same\", \"data_format\": \"channels_last\", \"dilation_rate\": [1, 1, 1], \"groups\": 1, \"activation\": \"linear\", \"use_bias\": true, \"kernel_initializer\": {\"class_name\": \"GlorotUniform\", \"config\": {\"seed\": null}}, \"bias_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"kernel_regularizer\": null, \"bias_regularizer\": null, \"activity_regularizer\": null, \"kernel_constraint\": null, \"bias_constraint\": null}}, {\"class_name\": \"LeakyReLU\", \"config\": {\"name\": \"leaky_re_lu_4\", \"trainable\": true, \"dtype\": \"float32\", \"alpha\": 0.10000000149011612}}, {\"class_name\": \"Conv3D\", \"config\": {\"name\": \"conv3d_8\", \"trainable\": true, \"dtype\": \"float32\", \"filters\": 1, \"kernel_size\": [3, 3, 3], \"strides\": [1, 1, 1], \"padding\": \"same\", \"data_format\": \"channels_last\", \"dilation_rate\": [1, 1, 1], \"groups\": 1, \"activation\": \"linear\", \"use_bias\": true, \"kernel_initializer\": {\"class_name\": \"GlorotUniform\", \"config\": {\"seed\": null}}, \"bias_initializer\": {\"class_name\": \"Zeros\", \"config\": {}}, \"kernel_regularizer\": null, \"bias_regularizer\": null, \"activity_regularizer\": null, \"kernel_constraint\": null, \"bias_constraint\": null}}]}, \"keras_version\": \"2.4.0\", \"backend\": \"tensorflow\"}\n";
+        File tempFile = testDir.resolve("temp.json").toFile();
+        FileUtils.writeStringToFile(tempFile,config, Charset.defaultCharset());
+        MultiLayerConfiguration multiLayerConfiguration = KerasModelImport.importKerasSequentialConfiguration(tempFile.getAbsolutePath());
+        assertNotNull(multiLayerConfiguration);
+        //null pre processor should still work and default to channels last
+        ReshapePreprocessor reshapePreprocessor = (ReshapePreprocessor) multiLayerConfiguration.getInputPreProcess(4);
+        assertNull(reshapePreprocessor.getFormat());
+        System.out.println(multiLayerConfiguration);
+    }
+
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNBatchNormHelper.java
@@ -197,4 +197,9 @@ public class MKLDNNBatchNormHelper implements BatchNormalizationHelper {
     public Map<String, Long> helperMemoryUse() {
         return Collections.emptyMap();
     }
+
+    @Override
+    public boolean checkSupported() {
+        return BaseMKLDNNHelper.mklDnnEnabled();
+    }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLSTMHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLSTMHelper.java
@@ -159,6 +159,11 @@ public class MKLDNNLSTMHelper implements LSTMHelper {
         return Collections.emptyMap();
     }
 
+    @Override
+    public boolean checkSupported() {
+        return BaseMKLDNNHelper.mklDnnEnabled();
+    }
+
     private int activationToArg(IActivation a){
         //0=tanh, 1=relu, 2=sigmoid, 3=affine, 4=leaky relu, 5= thresholded relu, 6=scaled tanh, 7=hard sigmoid, 8=ELU, 9=softsign, 10=softplus
         if(a instanceof ActivationTanH)

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLocalResponseNormalizationHelper.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/mkldnn/MKLDNNLocalResponseNormalizationHelper.java
@@ -94,4 +94,9 @@ public class MKLDNNLocalResponseNormalizationHelper extends BaseMKLDNNHelper imp
     public Map<String, Long> helperMemoryUse() {
         return Collections.emptyMap();
     }
+
+    @Override
+    public boolean checkSupported() {
+        return BaseMKLDNNHelper.mklDnnEnabled();
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes issue reported here: https://community.konduit.ai/t/cannot-infer-input-type-for-reshape-array/1358/6
CNN3D default values were not being handled in the import. 

Also fixes mkldnn compilation issue

(Please fill in changes proposed in this fix)

## How was this patch tested?
Manually
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
