### PR TITLE
Allow empty class names and return null as proper case

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/HelperUtilsTest.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/HelperUtilsTest.java
@@ -25,6 +25,7 @@ import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.dropout.DropoutHelper;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.layers.ActivationLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
@@ -82,7 +83,8 @@ public class HelperUtilsTest extends BaseDL4JTest {
                 LocalResponseNormalizationHelper.class,"layername",getDataType()));
         assertNotNull(HelperUtils.createHelper("", MKLDNNSubsamplingHelper.class.getName(),
                 SubsamplingHelper.class,"layername",getDataType()));
-
+        assertNotNull(HelperUtils.createHelper("", "",
+                DropoutHelper.class,"layername",getDataType()));
 
     }
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/HelperUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/HelperUtils.java
@@ -51,7 +51,7 @@ public class HelperUtils {
                                                          Object... arguments) {
         String backend = Nd4j.getExecutioner().getEnvironmentInformation().getProperty("backend");
         LayerHelper helperRet = null;
-        if("CUDA".equalsIgnoreCase(backend)) {
+        if("CUDA".equalsIgnoreCase(backend) && cudnnHelperClassName != null && !cudnnHelperClassName.isEmpty()) {
             if(DL4JClassLoading.loadClassByName(cudnnHelperClassName) != null) {
                 log.debug("Attempting to initialize cudnn helper {}",cudnnHelperClassName);
                 helperRet =  DL4JClassLoading.createNewInstance(
@@ -88,7 +88,7 @@ public class HelperUtils {
                 log.debug("{} successfully initialized",cudnnHelperClassName);
             }
 
-        } else if("CPU".equalsIgnoreCase(backend)) {
+        } else if("CPU".equalsIgnoreCase(backend) && oneDnnClassName != null && !oneDnnClassName.isEmpty()) {
             helperRet =  DL4JClassLoading.createNewInstance(
                     oneDnnClassName,
                     arguments);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes drop out helper issue (empty one dnn class name) by returning null when a class name is empty or null.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Manually, also adds test
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
