### PR TITLE
Fixes https://github.com/eclipse/deeplearning4j/issues/9347

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,6 @@
         <kotlin.version>1.4.31</kotlin.version>
         <test.heap.size>512m</test.heap.size>
         <test.offheap.size>512m</test.offheap.size>
-        <cpu.core.count>1</cpu.core.count>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,7 @@
         <kotlin.version>1.4.31</kotlin.version>
         <test.heap.size>512m</test.heap.size>
         <test.offheap.size>512m</test.offheap.size>
+        <cpu.core.count>1</cpu.core.count>
     </properties>
 
 
@@ -529,7 +530,7 @@
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
-                        <forkCount>${cpu.core.count}</forkCount>
+                        <forkCount>1</forkCount>
                         <reuseForks>false</reuseForks>
                         <environmentVariables>
                             <OMP_NUM_THREADS>1</OMP_NUM_THREADS>
@@ -546,7 +547,7 @@
                         <forkedProcessExitTimeoutInSeconds>240</forkedProcessExitTimeoutInSeconds>
                         <parallelTestsTimeoutInSeconds>240</parallelTestsTimeoutInSeconds>
                         <parallelTestsTimeoutForcedInSeconds>240</parallelTestsTimeoutForcedInSeconds>
-                        <forkCount>0</forkCount>
+                        <forkCount>1</forkCount>
                         <threadCount>1</threadCount>
                         <perCoreThreadCount>false</perCoreThreadCount>
                     </configuration>
@@ -1292,7 +1293,7 @@
                         <inherited>true</inherited>
                         <configuration>
                             <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
-                            <forkCount>${cpu.core.count}</forkCount>
+                            <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
                             <trimStackTrace>false</trimStackTrace>
                             <environmentVariables>
@@ -1300,13 +1301,13 @@
                                 <DL4J_INTEGRATION_TESTS>true</DL4J_INTEGRATION_TESTS>
                             </environmentVariables>
                             <argLine>-Xmx${test.heap.size} -Dorg.bytedeco.javacpp.maxphysicalbytes=${test.offheap.size} -Dorg.bytedeco.javacpp.maxbytes=${test.offheap.size}</argLine>
-                            <forkCount>${cpu.core.count}</forkCount>
+                            <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
                             <forkedProcessTimeoutInSeconds>240</forkedProcessTimeoutInSeconds>
                             <forkedProcessExitTimeoutInSeconds>240</forkedProcessExitTimeoutInSeconds>
                             <parallelTestsTimeoutInSeconds>240</parallelTestsTimeoutInSeconds>
                             <parallelTestsTimeoutForcedInSeconds>240</parallelTestsTimeoutForcedInSeconds>
-                            <forkCount>0</forkCount>
+                            <forkCount>1</forkCount>
                             <threadCount>1</threadCount>
                             <perCoreThreadCount>false</perCoreThreadCount>
                         </configuration>

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
@@ -39,7 +39,30 @@ import org.nd4j.common.io.ClassPathResource;
 import static org.bytedeco.cpython.global.python.*;
 import static org.bytedeco.cpython.helper.python.Py_SetPath;
 
-
+/**
+ * PythonExecutioner handles executing python code either from passed in python code
+ * or via a python script.
+ *
+ * PythonExecutioner has a few java system properties to be aware of when executing python:
+ * @link {{@link #DEFAULT_PYTHON_PATH_PROPERTY}} : The default python path to be used by the executioner.
+ * This can be passed with -Dorg.eclipse.python4j.path=your/python/path
+ *
+ * Python4j has a default python path that imports the javacpp python path depending on what is present.
+ * The javacpp python presets such as {@link org.bytedeco.cpython.global.python} have a cachePackages() method
+ * that leverages loading python artifacts from the python path.
+ *
+ * This python path can be merged with a custom one or just used as is.
+ * A user specifies this behavior with the system property {@link #JAVACPP_PYTHON_APPEND_TYPE}
+ * This property can have 3 possible values:
+ * 1. before
+ * 2. after
+ * 3. none
+ *
+ * Order can matter when resolving versions of libraries very similar to the system path. Ensure when adding a custom python path
+ * that these properties are well tested and well understood before use.
+ *
+ * @author Adam Gibson, Fariz Rahman
+ */
 public class PythonExecutioner {
     private final static String PYTHON_EXCEPTION_KEY = "__python_exception__";
     private static AtomicBoolean init = new AtomicBoolean(false);
@@ -60,8 +83,10 @@ public class PythonExecutioner {
         initPythonPath();
         PyEval_InitThreads();
         Py_InitializeEx(0);
+        //initialize separately to ensure that numpy import array is not imported twice
         for (PythonType type: PythonTypes.get()) {
-            type.init();
+            if(!type.getClass().getName().equals("org.nd4j.python4j.NumpyArray"))
+                type.init();
         }
 
         //set the main thread state for the gil

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.io.IOUtils;
+import org.bytedeco.cpython.PyThreadState;
 import org.bytedeco.cpython.global.python;
 import org.nd4j.common.io.ClassPathResource;
 
@@ -81,12 +82,10 @@ public class PythonExecutioner {
 
         init.set(true);
         initPythonPath();
-        PyEval_InitThreads();
         Py_InitializeEx(0);
         //initialize separately to ensure that numpy import array is not imported twice
         for (PythonType type: PythonTypes.get()) {
-            if(!type.getClass().getName().equals("org.nd4j.python4j.NumpyArray"))
-                type.init();
+            type.init();
         }
 
         //set the main thread state for the gil

--- a/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
+++ b/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
@@ -50,11 +50,15 @@ public class NumpyArray extends PythonType<INDArray> {
     public static final NumpyArray INSTANCE;
     private static final AtomicBoolean init = new AtomicBoolean(false);
     private static final Map<String, DataBuffer> cache = new HashMap<>();
+    public final static String IMPORT_NUMPY_ARRAY = "org.eclipse.python4j.numpyimport";
+    public final static String DEFAULT_IMPORT_NUMPY_ARRAY = "true";
+
 
     static {
         new PythonExecutioner();
         INSTANCE = new NumpyArray();
         INSTANCE.init();
+
     }
 
     @Override
@@ -70,14 +74,24 @@ public class NumpyArray extends PythonType<INDArray> {
     public synchronized void init() {
         if (init.get()) return;
         init.set(true);
+
+        if(Boolean.parseBoolean(System.getProperty(IMPORT_NUMPY_ARRAY,DEFAULT_IMPORT_NUMPY_ARRAY))) {
+            //See: https://numpy.org/doc/1.17/reference/c-api.array.html#importing-the-api
+            //DO NOT REMOVE
+            System.out.println("Called import numpy");
+            int err = numpy._import_array();
+            if (err < 0){
+                System.out.println("Numpy import failed!");
+                throw new PythonException("Numpy import failed!");
+            }
+        }
+
         if (PythonGIL.locked()) {
             throw new PythonException("Can not initialize numpy - GIL already acquired.");
         }
-        int err = numpy._import_array();
-        if (err < 0){
-            System.out.println("Numpy import failed!");
-            throw new PythonException("Numpy import failed!");
-        }
+
+
+
     }
 
     public NumpyArray() {

--- a/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
+++ b/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
@@ -54,6 +54,7 @@ public class NumpyArray extends PythonType<INDArray> {
     static {
         new PythonExecutioner();
         INSTANCE = new NumpyArray();
+        INSTANCE.init();
     }
 
     @Override
@@ -81,7 +82,6 @@ public class NumpyArray extends PythonType<INDArray> {
 
     public NumpyArray() {
         super("numpy.ndarray", INDArray.class);
-
     }
 
     @Override

--- a/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyBasicTest.java
+++ b/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyBasicTest.java
@@ -23,6 +23,7 @@
 
 package org.nd4j.python4j;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -48,6 +49,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @NativeTag
 @Tag(TagNames.PYTHON)
 public class PythonNumpyBasicTest {
+
+
+    @BeforeAll
+    public static void init() {
+        new NumpyArray().init();
+    }
 
     public static Stream<Arguments> params() {
         DataType[] types = new DataType[] {

--- a/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyCollectionsTest.java
+++ b/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyCollectionsTest.java
@@ -42,6 +42,7 @@ package org.nd4j.python4j;/*
  */
 
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -70,6 +71,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @NativeTag
 @Tag(TagNames.PYTHON)
 public class PythonNumpyCollectionsTest {
+
+    @BeforeAll
+    public static void init() {
+        new NumpyArray().init();
+    }
 
 
     public static Stream<Arguments> params() {

--- a/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyGCTest.java
+++ b/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyGCTest.java
@@ -41,6 +41,7 @@ package org.nd4j.python4j;/*
  *  *****************************************************************************
  */
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.nd4j.common.tests.tags.NativeTag;
@@ -57,6 +58,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @NativeTag
 @Tag(TagNames.PYTHON)
 public class PythonNumpyGCTest {
+
+    @BeforeAll
+    public static void init() {
+        new NumpyArray().init();
+    }
 
     @Test
     public void testGC() {

--- a/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyImportTest.java
+++ b/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyImportTest.java
@@ -41,6 +41,7 @@ package org.nd4j.python4j;/*
  *  *****************************************************************************
  */
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.nd4j.common.tests.tags.NativeTag;
@@ -54,6 +55,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @NativeTag
 @Tag(TagNames.PYTHON)
 public class PythonNumpyImportTest {
+
+    @BeforeAll
+    public static void init() {
+        new NumpyArray().init();
+    }
 
     @Test
     public void testNumpyImport(){

--- a/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyMultiThreadTest.java
+++ b/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyMultiThreadTest.java
@@ -41,6 +41,7 @@ package org.nd4j.python4j;/*
  *  *****************************************************************************
  */
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -70,6 +71,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @NativeTag
 @Tag(TagNames.PYTHON)
 public class PythonNumpyMultiThreadTest {
+
+    @BeforeAll
+    public static void init() {
+        new NumpyArray().init();
+    }
 
     public static Stream<Arguments> params() {
         return Arrays.asList(new DataType[]{

--- a/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyServiceLoaderTest.java
+++ b/python4j/python4j-numpy/src/test/java/org/nd4j/python4j/PythonNumpyServiceLoaderTest.java
@@ -43,6 +43,7 @@ package org.nd4j.python4j;/*
 
 
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.nd4j.common.tests.tags.NativeTag;
@@ -61,6 +62,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @NativeTag
 @Tag(TagNames.PYTHON)
 public class PythonNumpyServiceLoaderTest {
+
+    @BeforeAll
+    public static void init() {
+        new NumpyArray().init();
+    }
 
     @Test
     public void testServiceLoader(){


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updates the test configuration and python4j tests to prevent a numpy.import_array()
JVM crash
Fixes https://github.com/eclipse/deeplearning4j/issues/9347
(Please fill in changes proposed in this fix)

## How was this patch tested?
Fixes and runs existing unit tests
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
