### PR TITLE
Fix up test to use right overload (object arrays)

### DIFF
--- a/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/DL4JClassLoadingTest.java
+++ b/deeplearning4j/deeplearning4j-common/src/test/java/org/deeplearning4j/common/config/DL4JClassLoadingTest.java
@@ -62,8 +62,8 @@ class DL4JClassLoadingTest {
         String colorClassName = PACKAGE_PREFIX + "TestColor";
         String rectangleClassName = PACKAGE_PREFIX + "TestRectangle";
         /* When */
-        TestAbstract color = DL4JClassLoading.createNewInstance(colorClassName, Object.class, new Class<?>[] { int.class, int.class, int.class }, 45, 175, 200);
-        TestAbstract rectangle = DL4JClassLoading.createNewInstance(rectangleClassName, Object.class, new Class<?>[] { int.class, int.class, TestAbstract.class }, 10, 15, color);
+        TestAbstract color = DL4JClassLoading.createNewInstance(colorClassName, Object.class, new Class<?>[] { int.class, int.class, int.class }, new Object[]{45, 175, 200});
+        TestAbstract rectangle = DL4JClassLoading.createNewInstance(rectangleClassName, Object.class, new Class<?>[] { int.class, int.class, TestAbstract.class }, new Object[]{10, 15, color});
         /* Then */
         assertNotNull(color);
         assertEquals(colorClassName, color.getClass().getName());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Follow up to: https://github.com/eclipse/deeplearning4j/pull/9333

This fixes an issue identified in this pull request and makes the test call the method with the right signature.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
