### PR TITLE
Add support for keras 1d pooling nwhc

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/HelperUtilsTest.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/HelperUtilsTest.java
@@ -57,6 +57,7 @@ import org.nd4j.linalg.lossfunctions.LossFunctions;
 
 import java.util.List;
 
+import static org.deeplearning4j.common.config.DL4JSystemProperties.DISABLE_HELPER_PROPERTY;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -75,7 +76,7 @@ public class HelperUtilsTest extends BaseDL4JTest {
     @Test
     @DisplayName("Test instance creation of various helpers")
     public void testOneDnnHelperCreation() {
-        System.setProperty(HelperUtils.DISABLE_HELPER_PROPERTY,"false");
+        System.setProperty(DISABLE_HELPER_PROPERTY,"false");
         assertNotNull(HelperUtils.createHelper("",
                 MKLDNNLSTMHelper.class.getName(), LSTMHelper.class,"layername",getDataType()));
         assertNotNull(HelperUtils.createHelper("", MKLDNNBatchNormHelper.class.getName(),

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasPooling1D.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasPooling1D.java
@@ -66,6 +66,7 @@ public class KerasPooling1D extends KerasLayer {
         Subsampling1DLayer.Builder builder = new Subsampling1DLayer.Builder(
                 KerasPoolingUtils.mapPoolingType(this.className, conf)).name(this.layerName)
                 .dropOut(this.dropout)
+                .dataFormat(dimOrder == DimOrder.TENSORFLOW ? CNN2DFormat.NHWC : CNN2DFormat.NCHW)
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 1, conf, kerasMajorVersion)[0])
                 .stride(getStrideFromConfig(layerConfig, 1, conf)[0]);

--- a/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasPooling1DTest.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasPooling1DTest.java
@@ -19,21 +19,31 @@
  */
 package org.deeplearning4j.nn.modelimport.keras.layers.pooling;
 
+import org.deeplearning4j.nn.api.Layer;
+import org.deeplearning4j.nn.conf.CNN2DFormat;
 import org.deeplearning4j.nn.conf.ConvolutionMode;
 import org.deeplearning4j.nn.conf.layers.PoolingType;
 import org.deeplearning4j.nn.conf.layers.Subsampling1DLayer;
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.graph.vertex.GraphVertex;
+import org.deeplearning4j.nn.modelimport.keras.KerasModelImport;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras1LayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras2LayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.config.KerasLayerConfiguration;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.nd4j.common.resources.Resources;
 import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
 
@@ -111,4 +121,18 @@ class KerasPooling1DTest extends BaseDL4JTest {
         assertEquals(ConvolutionMode.Truncate, layer.getConvolutionMode());
         assertEquals(VALID_PADDING[0], layer.getPadding()[0]);
     }
+
+
+    @Test
+    public void testPooling1dNWHC() throws  Exception {
+        File file = Resources.asFile("modelimport/keras/tfkeras/issue_9349.hdf5");
+        ComputationGraph computationGraph = KerasModelImport.importKerasModelAndWeights(file.getAbsolutePath());
+        GraphVertex maxpooling1d = computationGraph.getVertex("max_pooling1d");
+        assertNotNull(maxpooling1d);
+        Layer layer = maxpooling1d.getLayer();
+        org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer subsampling1DLayer = (org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer) layer;
+        assertEquals(CNN2DFormat.NHWC,subsampling1DLayer.layerConf().getCnn2dDataFormat());
+    }
+
+
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -102,7 +102,9 @@ public class SubsamplingLayer extends NoParamLayer {
         this.convolutionMode = builder.convolutionMode;
         if (builder instanceof Builder) {
             this.dilation = ((Builder) builder).dilation;
-            this.cnn2dDataFormat = ((Builder) builder).dataFormat;
+            this.cnn2dDataFormat = builder.cnn2DFormat;
+        } else {
+            this.cnn2dDataFormat = builder.cnn2DFormat;
         }
         this.pnorm = builder.pnorm;
         this.eps = builder.eps;
@@ -239,7 +241,6 @@ public class SubsamplingLayer extends NoParamLayer {
          * Dilation for kernel
          */
         private int[] dilation = new int[] {1, 1};
-        protected CNN2DFormat dataFormat = CNN2DFormat.NCHW;
 
         public Builder(PoolingType poolingType, int[] kernelSize, int[] stride) {
             super(poolingType, kernelSize, stride);
@@ -318,16 +319,7 @@ public class SubsamplingLayer extends NoParamLayer {
             return this;
         }
 
-        /**
-         * Set the data format for the CNN activations - NCHW (channels first) or NHWC (channels last).
-         * See {@link CNN2DFormat} for more details.<br>
-         * Default: NCHW
-         * @param format Format for activations (in and out)
-         */
-        public Builder dataFormat(CNN2DFormat format){
-            this.dataFormat = format;
-            return this;
-        }
+
 
         /**
          * Kernel dilation. Default: {1, 1}, which is standard convolutions. Used for implementing dilated convolutions,
@@ -382,7 +374,7 @@ public class SubsamplingLayer extends NoParamLayer {
         }
 
         public void setDataFormat(CNN2DFormat format){
-            this.dataFormat = format;
+            this.cnn2DFormat = format;
         }
     }
 
@@ -417,6 +409,11 @@ public class SubsamplingLayer extends NoParamLayer {
          */
         protected boolean cudnnAllowFallback = true;
         protected boolean avgPoolIncludePadInDivisor = false;
+
+        /**
+         * Configure the 2d data format
+         */
+        protected CNN2DFormat cnn2DFormat = CNN2DFormat.NCHW;
 
         protected BaseSubsamplingBuilder(PoolingType poolingType, int[] kernelSize, int[] stride) {
             this.setPoolingType(poolingType.toPoolingType());
@@ -477,7 +474,7 @@ public class SubsamplingLayer extends NoParamLayer {
             this.pnorm = pnorm;
         }
 
-        public void setEps(double eps){
+        public void setEps(double eps) {
             ValidationUtils.validateNonNegative(eps, "eps");
             this.eps = eps;
         }
@@ -488,6 +485,17 @@ public class SubsamplingLayer extends NoParamLayer {
             Preconditions.checkState(allowCausal() || convolutionMode != ConvolutionMode.Causal, "Causal convolution mode can only be used with 1D" +
                     " convolutional neural network layers");
             this.convolutionMode = convolutionMode;
+        }
+
+        /**
+         * Set the data format for the CNN activations - NCHW (channels first) or NHWC (channels last).
+         * See {@link CNN2DFormat} for more details.<br>
+         * Default: NCHW
+         * @param cnn2DFormat Format for activations (in and out)
+         */
+        public T dataFormat(CNN2DFormat cnn2DFormat) {
+            this.cnn2DFormat = cnn2DFormat;
+            return (T) this;
         }
 
         /**

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/SubsamplingLayer.java
@@ -100,12 +100,12 @@ public class SubsamplingLayer extends NoParamLayer {
         this.stride = builder.stride;
         this.padding = builder.padding;
         this.convolutionMode = builder.convolutionMode;
+        this.cnn2dDataFormat = builder.cnn2DFormat;
+
         if (builder instanceof Builder) {
             this.dilation = ((Builder) builder).dilation;
-            this.cnn2dDataFormat = builder.cnn2DFormat;
-        } else {
-            this.cnn2dDataFormat = builder.cnn2DFormat;
         }
+        
         this.pnorm = builder.pnorm;
         this.eps = builder.eps;
         this.cudnnAllowFallback = builder.cudnnAllowFallback;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -87,7 +87,7 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
         CNN2DFormat dataFormat = layerConf().getCnn2dDataFormat();
         int hIdx = 2;
         int wIdx = 3;
-        if(dataFormat == CNN2DFormat.NHWC){
+        if(dataFormat == CNN2DFormat.NHWC) {
             hIdx = 1;
             wIdx = 2;
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add support for keras 1d pooling nwhc
Fixes #9349 
(Please fill in changes proposed in this fix)

## How was this patch tested?
Adds test model from end user and asserts that NWHC is propagated.
NWHC was supported by the 2d version but not configured for 1D.


## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
