### PR TITLE
Move explicit logback dep to testing scope only

### DIFF
--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -80,11 +80,13 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -116,10 +116,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/nd4j/pom.xml
+++ b/nd4j/pom.xml
@@ -57,6 +57,7 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/nd4j/samediff-import/samediff-import-api/pom.xml
+++ b/nd4j/samediff-import/samediff-import-api/pom.xml
@@ -86,6 +86,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/rl4j/rl4j-core/pom.xml
+++ b/rl4j/rl4j-core/pom.xml
@@ -89,6 +89,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bytedeco</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Moves the explicit logback dep from various modules to testing.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
