### PR TITLE
Fix compilation errors from logback dep removal

### DIFF
--- a/deeplearning4j/deeplearning4j-common-tests/src/main/java/org/deeplearning4j/BaseDL4JTest.java
+++ b/deeplearning4j/deeplearning4j-common-tests/src/main/java/org/deeplearning4j/BaseDL4JTest.java
@@ -19,7 +19,7 @@
  */
 package org.deeplearning4j;
 
-import ch.qos.logback.classic.LoggerContext;
+import lombok.SneakyThrows;
 import org.bytedeco.javacpp.Pointer;
 import org.junit.jupiter.api.*;
 
@@ -34,6 +34,7 @@ import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -129,6 +130,7 @@ public abstract class BaseDL4JTest {
         threadCountBefore = ManagementFactory.getThreadMXBean().getThreadCount();
     }
 
+    @SneakyThrows
     @AfterEach
     void afterTest(TestInfo testInfo) {
         // Attempt to keep workspaces isolated between tests
@@ -147,8 +149,11 @@ public abstract class BaseDL4JTest {
             } catch (InterruptedException e) {
             }
             ILoggerFactory lf = LoggerFactory.getILoggerFactory();
-            if (lf instanceof LoggerContext) {
-                ((LoggerContext) lf).stop();
+            //work around to remove explicit dependency on logback
+            if( lf.getClass().getName().equals("ch.qos.logback.classic.LoggerContext")) {
+                Method method = lf.getClass().getMethod("stop");
+                method.setAccessible(true);
+                method.invoke(lf);
             }
             try {
                 Thread.sleep(1000);

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/factory/Nd4jTest.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/factory/Nd4jTest.java
@@ -295,7 +295,7 @@ public class Nd4jTest extends BaseNd4jTestWithBackends {
 
         INDArray source = Nd4j.createFromArray(new double[] { 1.0, 0.0 });
         INDArray probs = Nd4j.valueArrayOf(new long[] { 2 }, 0.5, DataType.DOUBLE);
-        INDArray actual = Nd4j.choice(s, p, 10);
+        INDArray actual = Nd4j.choice(source, probs, 10);
     
 
         assertEquals(dataTypeIsDouble.dataType(), actual.dataType());

--- a/nd4j/nd4j-common-tests/pom.xml
+++ b/nd4j/nd4j-common-tests/pom.xml
@@ -89,6 +89,8 @@
             <artifactId>spring-core</artifactId>
             <version>5.0.2.RELEASE</version>
         </dependency>
+
+
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removes an explicit use of logback by changing the direct use to reflection in the relevant test modules
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
