### PR TITLE
Add new way of specifying OS/Version and enabling centos 6 builds

### DIFF
--- a/.github/actions/set-linux-distro-version/action.yml
+++ b/.github/actions/set-linux-distro-version/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
           if [ -f /etc/os-release ]; then
-              source /etc/os-release
+              . /etc/os-release
               OS="$NAME"
               VER="$VERSION_ID"
           elif [ type lsb_release >/dev/null 2>&1 ]; then
@@ -34,5 +34,5 @@ runs:
               VER="$(uname -r)"
           fi
 
-          echo "$OS" >> "$GITHUB_ENV"
-          echo  "$VER" >> "$GITHUB_ENV"
+          echo "OS=$OS" >> "$GITHUB_ENV"
+          echo  "VER=$VER" >> "$GITHUB_ENV"

--- a/.github/actions/set-linux-distro-version/action.yml
+++ b/.github/actions/set-linux-distro-version/action.yml
@@ -1,4 +1,4 @@
-name: Remove un needed packages for linux
+name: Set OS install version
 description:
 runs:
   using: composite

--- a/.github/actions/set-linux-distro-version/action.yml
+++ b/.github/actions/set-linux-distro-version/action.yml
@@ -9,32 +9,32 @@ runs:
           if [ -f /etc/os-release ]; then
               # freedesktop.org and systemd
               . /etc/os-release
-              OS=$NAME
-              VER=$VERSION_ID
-          elif type lsb_release >/dev/null 2>&1; then
+              OS="$NAME"
+              VER="$VERSION_ID"
+          elif [ type lsb_release >/dev/null 2>&1 ]; then
               # linuxbase.org
-              OS=$(lsb_release -si)
-              VER=$(lsb_release -sr)
+              OS="$(lsb_release -si)"
+              VER="$(lsb_release -sr)"
           elif [ -f /etc/lsb-release ]; then
               # For some versions of Debian/Ubuntu without lsb_release command
-              . /etc/lsb-release
-              OS=$DISTRIB_ID
-              VER=$DISTRIB_RELEASE
+              /etc/lsb-release
+              OS="$DISTRIB_ID"
+              VER="$DISTRIB_RELEASE"
           elif [ -f /etc/debian_version ]; then
               # Older Debian/Ubuntu/etc.
-              OS=Debian
-              VER=$(cat /etc/debian_version)
+              OS="Debian"
+              VER="$(cat /etc/debian_version)"
           elif [ -f /etc/SuSe-release ]; then
-              OS=SUSE
-              VER=13.1
+              OS="SUSE"
+              VER="13.1"
           elif [ -f /etc/redhat-release ]; then
               # Older Red Hat, CentOS, etc.
-               OS=Centos
-               VER=6
+               OS="Centos"
+               VER="6"
           else
               # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
               OS="$(uname -s)"
               VER="$(uname -r)"
           fi
           echo "$OS" >> "$GITHUB_ENV"
-          echo  "$VER" >> $GITHUB_ENV"
+          echo  "$VER" >> "$GITHUB_ENV"

--- a/.github/actions/set-linux-distro-version/action.yml
+++ b/.github/actions/set-linux-distro-version/action.yml
@@ -7,8 +7,7 @@ runs:
       shell: bash
       run: |
           if [ -f /etc/os-release ]; then
-              # freedesktop.org and systemd
-              . /etc/os-release
+              source /etc/os-release
               OS="$NAME"
               VER="$VERSION_ID"
           elif [ type lsb_release >/dev/null 2>&1 ]; then
@@ -16,12 +15,10 @@ runs:
               OS="$(lsb_release -si)"
               VER="$(lsb_release -sr)"
           elif [ -f /etc/lsb-release ]; then
-              # For some versions of Debian/Ubuntu without lsb_release command
               /etc/lsb-release
               OS="$DISTRIB_ID"
               VER="$DISTRIB_RELEASE"
           elif [ -f /etc/debian_version ]; then
-              # Older Debian/Ubuntu/etc.
               OS="Debian"
               VER="$(cat /etc/debian_version)"
           elif [ -f /etc/SuSe-release ]; then
@@ -36,5 +33,6 @@ runs:
               OS="$(uname -s)"
               VER="$(uname -r)"
           fi
+
           echo "$OS" >> "$GITHUB_ENV"
           echo  "$VER" >> "$GITHUB_ENV"

--- a/.github/actions/set-linux-distro-version/action.yml
+++ b/.github/actions/set-linux-distro-version/action.yml
@@ -25,15 +25,16 @@ runs:
               OS=Debian
               VER=$(cat /etc/debian_version)
           elif [ -f /etc/SuSe-release ]; then
-              # Older SuSE/etc.
-              ...
+              OS=SUSE
+              VER=13.1
           elif [ -f /etc/redhat-release ]; then
               # Older Red Hat, CentOS, etc.
-              ...
+               OS=Centos
+               VER=6
           else
               # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
-              OS=$(uname -s)
-              VER=$(uname -r)
+              OS="$(uname -s)"
+              VER="$(uname -r)"
           fi
           echo "$OS" >> "$GITHUB_ENV"
-          ech  "$VER" >> $GITHUB_ENV"
+          echo  "$VER" >> $GITHUB_ENV"

--- a/.github/actions/set-linux-distro-version/action.yml
+++ b/.github/actions/set-linux-distro-version/action.yml
@@ -1,0 +1,39 @@
+name: Remove un needed packages for linux
+description:
+runs:
+  using: composite
+  steps:
+    - name: Initial install
+      shell: bash
+      run: |
+          if [ -f /etc/os-release ]; then
+              # freedesktop.org and systemd
+              . /etc/os-release
+              OS=$NAME
+              VER=$VERSION_ID
+          elif type lsb_release >/dev/null 2>&1; then
+              # linuxbase.org
+              OS=$(lsb_release -si)
+              VER=$(lsb_release -sr)
+          elif [ -f /etc/lsb-release ]; then
+              # For some versions of Debian/Ubuntu without lsb_release command
+              . /etc/lsb-release
+              OS=$DISTRIB_ID
+              VER=$DISTRIB_RELEASE
+          elif [ -f /etc/debian_version ]; then
+              # Older Debian/Ubuntu/etc.
+              OS=Debian
+              VER=$(cat /etc/debian_version)
+          elif [ -f /etc/SuSe-release ]; then
+              # Older SuSE/etc.
+              ...
+          elif [ -f /etc/redhat-release ]; then
+              # Older Red Hat, CentOS, etc.
+              ...
+          else
+              # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
+              OS=$(uname -s)
+              VER=$(uname -r)
+          fi
+          echo "$OS" >> "$GITHUB_ENV"
+          ech  "$VER" >> $GITHUB_ENV"

--- a/.github/actions/update-deps-linux/action.yml
+++ b/.github/actions/update-deps-linux/action.yml
@@ -5,7 +5,32 @@ runs:
     - name: Install protobuf linux
       shell: bash
       run: |
-        sudo apt-get install build-essential make zlib1g-dev wget
+        if [[ "$OS" == *"Ubuntu"* ] || [ "$OS" == *"Debian"* ]]
+        then
+             sudo apt-get install build-essential make zlib1g-dev wget
+             sudo apt-get install pinentry-curses
+             sudo apt-get install ca-certificates libgomp1
+        fi
+        if [[ "$OS" == *"Centos"* ] || [ "$OS" == *"Fedora"* ]]
+               then
+                   SCL_ENABLE="devtoolset-7"
+                   CENTOS_VERSION=$(rpm --eval '%{centos_ver}')
+                   if [[ "$CENTOS_VERSION" == "6" ]]; then
+                     find /etc/yum.repos.d/ -name *.repo | xargs -i sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/$releasever/6.10/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g' {}
+                     SCL_ENABLE="devtoolset-7 rh-python36 python27"
+                   fi
+                   yum -y update
+                   yum -y install centos-release-scl-rh epel-release
+                   if [[ "$CENTOS_VERSION" == "6" ]]; then
+                     sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/6\/sclo/6.10\/sclo/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+                   fi
+                   yum -y install $SCL_ENABLE rh-java-common-ant boost-devel ccache clang gcc-c++ gcc-gfortran java-1.8.0-openjdk-devel ant python python36-devel python36-pip swig file which wget unzip tar bzip2 gzip xz patch autoconf-archive automake make libtool bison flex perl nasm alsa-lib-devel freeglut-devel gtk2-devel libusb-devel libusb1-devel curl-devel expat-devel gettext-devel openssl-devel bzip2-devel zlib-devel SDL-devel libva-devel libxkbcommon-devel libxkbcommon-x11-devel xcb-util* fontconfig-devel libffi-devel ragel ocl-icd-devel GeoIP-devel pcre-devel ssdeep-devel yajl-devel libgomp pinentry zlib-devel ca-certificates
+                   # https://gcc.gnu.org/legacy-ml/gcc-patches/2018-01/msg01962.html
+                   sed -i 's/_mm512_abs_pd (__m512 __A)/_mm512_abs_pd (__m512d __A)/g' /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include/avx512fintrin.h
+                   source scl_source enable $SCL_ENABLE || true
+                   echo "SCL_ENABLE=$SCL_ENABLE" >> $GITHUB_ENV
+        fi
+
         wget https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
         tar jxf libgpg-error-1.36.tar.bz2
         cd libgpg-error-1.36
@@ -57,7 +82,5 @@ runs:
         make
         sudo make install
         cd ..
-        sudo apt-get install pinentry-curses
         #echo 'pinentry-program /usr/bin/pinentry-curses' | tee -a ~/.gnupg/gpg-agent.conf
         #gpg-connect-agent reloadagent /bye
-        sudo apt-get install ca-certificates libgomp1

--- a/.github/actions/update-deps-linux/action.yml
+++ b/.github/actions/update-deps-linux/action.yml
@@ -5,13 +5,13 @@ runs:
     - name: Install protobuf linux
       shell: bash
       run: |
-          if [[ "$OS" == *"Ubuntu"* ] || [ "$OS" == *"Debian"* ]];
+          if [ "$OS" == *"Ubuntu"* ] || [ "$OS" == *"Debian"* ];
           then
                sudo apt-get install build-essential make zlib1g-dev wget
                sudo apt-get install pinentry-curses
                sudo apt-get install ca-certificates libgomp1
           fi
-          if [[ "$OS" == *"Centos"* ] || [ "$OS" == *"Fedora"* ]];
+          if [ "$OS" == *"Centos"* ] || [ "$OS" == *"Fedora"* ];
                  then
                      SCL_ENABLE="devtoolset-7"
                      CENTOS_VERSION=$(rpm --eval '%{centos_ver}')

--- a/.github/actions/update-deps-linux/action.yml
+++ b/.github/actions/update-deps-linux/action.yml
@@ -5,82 +5,82 @@ runs:
     - name: Install protobuf linux
       shell: bash
       run: |
-        if [[ "$OS" == *"Ubuntu"* ] || [ "$OS" == *"Debian"* ]]
-        then
-             sudo apt-get install build-essential make zlib1g-dev wget
-             sudo apt-get install pinentry-curses
-             sudo apt-get install ca-certificates libgomp1
-        fi
-        if [[ "$OS" == *"Centos"* ] || [ "$OS" == *"Fedora"* ]]
-               then
-                   SCL_ENABLE="devtoolset-7"
-                   CENTOS_VERSION=$(rpm --eval '%{centos_ver}')
-                   if [[ "$CENTOS_VERSION" == "6" ]]; then
-                     find /etc/yum.repos.d/ -name *.repo | xargs -i sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/$releasever/6.10/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g' {}
-                     SCL_ENABLE="devtoolset-7 rh-python36 python27"
-                   fi
-                   yum -y update
-                   yum -y install centos-release-scl-rh epel-release
-                   if [[ "$CENTOS_VERSION" == "6" ]]; then
-                     sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/6\/sclo/6.10\/sclo/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-                   fi
-                   yum -y install $SCL_ENABLE rh-java-common-ant boost-devel ccache clang gcc-c++ gcc-gfortran java-1.8.0-openjdk-devel ant python python36-devel python36-pip swig file which wget unzip tar bzip2 gzip xz patch autoconf-archive automake make libtool bison flex perl nasm alsa-lib-devel freeglut-devel gtk2-devel libusb-devel libusb1-devel curl-devel expat-devel gettext-devel openssl-devel bzip2-devel zlib-devel SDL-devel libva-devel libxkbcommon-devel libxkbcommon-x11-devel xcb-util* fontconfig-devel libffi-devel ragel ocl-icd-devel GeoIP-devel pcre-devel ssdeep-devel yajl-devel libgomp pinentry zlib-devel ca-certificates
-                   # https://gcc.gnu.org/legacy-ml/gcc-patches/2018-01/msg01962.html
-                   sed -i 's/_mm512_abs_pd (__m512 __A)/_mm512_abs_pd (__m512d __A)/g' /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include/avx512fintrin.h
-                   source scl_source enable $SCL_ENABLE || true
-                   echo "SCL_ENABLE=$SCL_ENABLE" >> $GITHUB_ENV
-        fi
+          if [[ "$OS" == *"Ubuntu"* ] || [ "$OS" == *"Debian"* ]];
+          then
+               sudo apt-get install build-essential make zlib1g-dev wget
+               sudo apt-get install pinentry-curses
+               sudo apt-get install ca-certificates libgomp1
+          fi
+          if [[ "$OS" == *"Centos"* ] || [ "$OS" == *"Fedora"* ]];
+                 then
+                     SCL_ENABLE="devtoolset-7"
+                     CENTOS_VERSION=$(rpm --eval '%{centos_ver}')
+                     if [[ "$CENTOS_VERSION" == "6" ]]; then
+                       find /etc/yum.repos.d/ -name *.repo | xargs -i sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/$releasever/6.10/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g' {}
+                       SCL_ENABLE="devtoolset-7 rh-python36 python27"
+                     fi
+                     yum -y update
+                     yum -y install centos-release-scl-rh epel-release
+                     if [[ "$CENTOS_VERSION" == "6" ]]; then
+                       sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/6\/sclo/6.10\/sclo/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+                     fi
+                     yum -y install $SCL_ENABLE rh-java-common-ant boost-devel ccache clang gcc-c++ gcc-gfortran java-1.8.0-openjdk-devel ant python python36-devel python36-pip swig file which wget unzip tar bzip2 gzip xz patch autoconf-archive automake make libtool bison flex perl nasm alsa-lib-devel freeglut-devel gtk2-devel libusb-devel libusb1-devel curl-devel expat-devel gettext-devel openssl-devel bzip2-devel zlib-devel SDL-devel libva-devel libxkbcommon-devel libxkbcommon-x11-devel xcb-util* fontconfig-devel libffi-devel ragel ocl-icd-devel GeoIP-devel pcre-devel ssdeep-devel yajl-devel libgomp pinentry zlib-devel ca-certificates
+                     # https://gcc.gnu.org/legacy-ml/gcc-patches/2018-01/msg01962.html
+                     sed -i 's/_mm512_abs_pd (__m512 __A)/_mm512_abs_pd (__m512d __A)/g' /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/include/avx512fintrin.h
+                     source scl_source enable $SCL_ENABLE || true
+                     echo "SCL_ENABLE=$SCL_ENABLE" >> $GITHUB_ENV
+          fi
 
-        wget https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
-        tar jxf libgpg-error-1.36.tar.bz2
-        cd libgpg-error-1.36
-        ./configure
-        make
-        sudo make install
-        cd ..
-        wget https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.4.tar.bz2
-        tar jxf libgcrypt-1.8.4.tar.bz2
-        cd libgcrypt-1.8.4
-        ./configure
-        make
-        sudo make install
-        cd ..
-        wget https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.3.5.tar.bz2
-        tar jxf libksba-1.3.5.tar.bz2
-        cd libksba-1.3.5
-        ./configure
-        make
-        sudo make install
-        cd ..
-        wget https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.5.3.tar.bz2
-        tar jxf libassuan-2.5.3.tar.bz2
-        cd libassuan-2.5.3
-        ./configure
-        make
-        sudo make install
-        cd ..
-        wget https://www.gnupg.org/ftp/gcrypt/ntbtls/ntbtls-0.1.2.tar.bz2
-        tar jxf ntbtls-0.1.2.tar.bz2
-        cd ntbtls-0.1.2
-        ./configure
-        make
-        sudo make install
-        cd ..
-        wget https://www.gnupg.org/ftp/gcrypt/npth/npth-1.6.tar.bz2
-        tar jxf npth-1.6.tar.bz2
-        cd npth-1.6
-        ./configure
-        make
-        sudo make install
-        cd ..
-        echo 'include /usr/local/lib/' | sudo tee -a /etc/ld.so.conf
-        sudo ldconfig -v
-        wget https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.17.tar.bz2
-        tar jxf gnupg-2.2.17.tar.bz2
-        cd gnupg-2.2.17/
-        ./configure
-        make
-        sudo make install
-        cd ..
-        #echo 'pinentry-program /usr/bin/pinentry-curses' | tee -a ~/.gnupg/gpg-agent.conf
-        #gpg-connect-agent reloadagent /bye
+          wget https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
+          tar jxf libgpg-error-1.36.tar.bz2
+          cd libgpg-error-1.36
+          ./configure
+          make
+          sudo make install
+          cd ..
+          wget https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.4.tar.bz2
+          tar jxf libgcrypt-1.8.4.tar.bz2
+          cd libgcrypt-1.8.4
+          ./configure
+          make
+          sudo make install
+          cd ..
+          wget https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.3.5.tar.bz2
+          tar jxf libksba-1.3.5.tar.bz2
+          cd libksba-1.3.5
+          ./configure
+          make
+          sudo make install
+          cd ..
+          wget https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.5.3.tar.bz2
+          tar jxf libassuan-2.5.3.tar.bz2
+          cd libassuan-2.5.3
+          ./configure
+          make
+          sudo make install
+          cd ..
+          wget https://www.gnupg.org/ftp/gcrypt/ntbtls/ntbtls-0.1.2.tar.bz2
+          tar jxf ntbtls-0.1.2.tar.bz2
+          cd ntbtls-0.1.2
+          ./configure
+          make
+          sudo make install
+          cd ..
+          wget https://www.gnupg.org/ftp/gcrypt/npth/npth-1.6.tar.bz2
+          tar jxf npth-1.6.tar.bz2
+          cd npth-1.6
+          ./configure
+          make
+          sudo make install
+          cd ..
+          echo 'include /usr/local/lib/' | sudo tee -a /etc/ld.so.conf
+          sudo ldconfig -v
+          wget https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.17.tar.bz2
+          tar jxf gnupg-2.2.17.tar.bz2
+          cd gnupg-2.2.17/
+          ./configure
+          make
+          sudo make install
+          cd ..
+          #echo 'pinentry-program /usr/bin/pinentry-curses' | tee -a ~/.gnupg/gpg-agent.conf
+          #gpg-connect-agent reloadagent /bye

--- a/.github/workflows/build-deploy-android-arm32.yml
+++ b/.github/workflows/build-deploy-android-arm32.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-android-arm32.yml
+++ b/.github/workflows/build-deploy-android-arm32.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-android-arm64.yml
+++ b/.github/workflows/build-deploy-android-arm64.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-android-arm64.yml
+++ b/.github/workflows/build-deploy-android-arm64.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-android-x86.yml
+++ b/.github/workflows/build-deploy-android-x86.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-android-x86.yml
+++ b/.github/workflows/build-deploy-android-x86.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-android-x86_64.yml
+++ b/.github/workflows/build-deploy-android-x86_64.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-android-x86_64.yml
+++ b/.github/workflows/build-deploy-android-x86_64.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-cross-platform.yml
+++ b/.github/workflows/build-deploy-cross-platform.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-cross-platform.yml
+++ b/.github/workflows/build-deploy-cross-platform.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-linux-arm32.yml
+++ b/.github/workflows/build-deploy-linux-arm32.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-linux-arm32.yml
+++ b/.github/workflows/build-deploy-linux-arm32.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-linux-arm64.yml
+++ b/.github/workflows/build-deploy-linux-arm64.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-linux-arm64.yml
+++ b/.github/workflows/build-deploy-linux-arm64.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install
         uses: actions/cache@v2

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - name: Set mvn build command based on matrix
         shell: bash
         run: |

--- a/.github/workflows/build-deploy-linux-cuda-11.0.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.0.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+      - uses: ./github/actions/set-linux-distro-version
       - name: Set mvn build command based on matrix
         shell: bash
         run: |

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -136,7 +136,7 @@ jobs:
             fi
             echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
             echo "COMMAND=${command}" >> $GITHUB_ENV
-
+      - uses: ./github/actions/set-linux-distro-version
       - uses: ./.github/actions/remove-unneeded-tools-linux
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install

--- a/.github/workflows/build-deploy-linux-cuda-11.2.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.2.yml
@@ -136,7 +136,7 @@ jobs:
             fi
             echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
             echo "COMMAND=${command}" >> $GITHUB_ENV
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/remove-unneeded-tools-linux
       - uses: ./.github/actions/update-deps-linux
       - name: Cache cmake install

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -57,8 +57,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        helper: [onednn,""]
-        extension: [avx2,avx512,""]
+        helper: []
+        extension: [compat]
         include:
           - mvn_ext: ${{ github.event.inputs.mvnFlags }}
             experimental: true
@@ -105,6 +105,7 @@ jobs:
 
 
     runs-on: ${{ matrix.runs_on }}
+    container: centos:6
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -222,17 +223,6 @@ jobs:
           protoc --version
           export PATH=/opt/protobuf/bin:/opt/cmake/bin:$PATH
           export LIBGOMP_PATH=/usr/lib/gcc/x86_64-linux-gnu/5.5.0/libgomp.so
-          if [ -z "${EXTENSION}" ] || [ -n "${EXTENSION}" ]; then
-              export LIBGOMP_PATH=/usr/lib/gcc/x86_64-linux-gnu/7.5.0/libgomp.so
-              echo "Extensions specified. This needs a newer version of gcc."
-              sudo apt-get install gcc-7 g++-7
-              echo "Using newer version of libgomp."
-              ls /usr/bin | grep gcc
-              ls /usr/bin | grep g++
-              sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
-              sudo update-alternatives --install  /usr/bin/g++ g++ /usr/bin/g++-7  90
-              gcc --version
-          fi
           # NOTE: Complete hack. Find better way later. This moves libgomp.so to a directory where javacpp can find it.
           # For linux, this can be found here: https://github.com/eclipse/deeplearning4j/blob/master/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/src/main/java/org/nd4j/nativeblas/Nd4jCpuPresets.java#L150
           # Note also, that the g++ --version as of this writing (May 3,2021) currently returns 5.5.0. This will need to be changed in other versions if there is an update.

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - name: Set mvn build command based on matrix
         shell: bash
         run: |

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - uses: ./github/actions/set-linux-distro-version
+      - uses: ./.github/actions/set-linux-distro-version
       - name: Set mvn build command based on matrix
         shell: bash
         run: |


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enables centos 6 builds , fixes https://github.com/eclipse/deeplearning4j/issues/9352
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
