### PR TITLE
cudnn lstm forward inference and other fixes

### DIFF
--- a/libnd4j/include/ops/declarable/helpers/impl/ctcBeam.cpp
+++ b/libnd4j/include/ops/declarable/helpers/impl/ctcBeam.cpp
@@ -624,7 +624,6 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
     const auto strides = logit.stridesOf();
     const auto rank = logit.rankOf();
 
-    const IndexType* len_t_ptr = nullptr;
     uint64_t element_stride_t = 1;
 
     //checks before
@@ -636,19 +635,11 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
     if (len_c < 1 || max_len_t < 1) return;
     //defaulting blankIndex to the last class if its incorrect or -1
     if (blank_index > len_c || blank_index < 0) blank_index = static_cast<int>(len_c) - 1;
-    if (sequence_length.rankOf() == 1 && sequence_length.shapeOf()[0] == batch_len)
-    {
-        sequence_length.syncToHost();
-        len_t_ptr = sequence_length.bufferAsT<IndexType>();
-        element_stride_t = sequence_length.stridesOf()[0];
-    }
 
     //strides
     auto batch_stride = rank > 2 ? strides[0] : 0;
     auto inc_p = strides[rank - 2];
     auto element_stride = logit.stridesOf()[rank - 1];
-    logit.syncToHost();
-    auto logits_ptr = logit.bufferAsT<Type>();
 
 #if defined(ASSERT_INNER)
     //result_probs should be [batch_len, nbest_len]
@@ -657,12 +648,19 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
     assert(result_sequences.ews() == 1 && result_sequences.rankOf() == 3 && result_sequences.shapeOf()[0] == batch_len && result_sequences.shapeOf()[1] == nbest_len
             && result_sequences.shapeOf()[2] == max_len_t);
 #endif
+    //as ctcBeam search runs on Cpu we should make NdArray buffers available on the host side as well
+    NDArray::preparePrimaryUse({&result_sequences, &result_probs, &result_sequences_length}, {&sequence_length, &logit});
 
-    NDArray::preparePrimaryUse({&result_sequences, &result_probs, &result_sequences_length}, {});
+    auto logits_ptr = logit.bufferAsT<Type>();
     auto result_seq_ptr = result_sequences.bufferAsT<IndexType>();
     auto result_probs_ptr = result_probs.bufferAsT<Type>();
     auto result_seq_length_ptr = result_sequences_length.bufferAsT<IndexType>();
-
+    const IndexType* len_t_ptr = nullptr;
+    if (sequence_length.rankOf() == 1 && sequence_length.shapeOf()[0] == batch_len)
+    {
+        len_t_ptr = sequence_length.bufferAsT<IndexType>();
+        element_stride_t = sequence_length.stridesOf()[0];
+    }
     const auto  batch_stride_res = result_sequences.stridesOf()[0];
     const auto  inc_res = result_sequences.stridesOf()[1];
     const auto  batch_stride_res_prob = result_probs.stridesOf()[0];
@@ -708,7 +706,7 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
     };
     samediff::Threads::parallel_for(func, 0, batch_len, 1);
 
-    NDArray::registerPrimaryUse({&result_sequences, &result_probs, &result_sequences_length}, {});
+    NDArray::registerPrimaryUse({&result_sequences, &result_probs, &result_sequences_length}, {&sequence_length, &logit});
     return;
 }
 

--- a/libnd4j/include/ops/declarable/helpers/impl/ctcBeam.cpp
+++ b/libnd4j/include/ops/declarable/helpers/impl/ctcBeam.cpp
@@ -638,6 +638,7 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
     if (blank_index > len_c || blank_index < 0) blank_index = static_cast<int>(len_c) - 1;
     if (sequence_length.rankOf() == 1 && sequence_length.shapeOf()[0] == batch_len)
     {
+        sequence_length.syncToHost();
         len_t_ptr = sequence_length.bufferAsT<IndexType>();
         element_stride_t = sequence_length.stridesOf()[0];
     }
@@ -646,7 +647,7 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
     auto batch_stride = rank > 2 ? strides[0] : 0;
     auto inc_p = strides[rank - 2];
     auto element_stride = logit.stridesOf()[rank - 1];
-
+    logit.syncToHost();
     auto logits_ptr = logit.bufferAsT<Type>();
 
 #if defined(ASSERT_INNER)
@@ -656,6 +657,8 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
     assert(result_sequences.ews() == 1 && result_sequences.rankOf() == 3 && result_sequences.shapeOf()[0] == batch_len && result_sequences.shapeOf()[1] == nbest_len
             && result_sequences.shapeOf()[2] == max_len_t);
 #endif
+
+    NDArray::preparePrimaryUse({&result_sequences, &result_probs, &result_sequences_length}, {});
     auto result_seq_ptr = result_sequences.bufferAsT<IndexType>();
     auto result_probs_ptr = result_probs.bufferAsT<Type>();
     auto result_seq_length_ptr = result_sequences_length.bufferAsT<IndexType>();
@@ -704,6 +707,8 @@ beamSearch_(const NDArray& logit, const NDArray& sequence_length, NDArray& resul
         }
     };
     samediff::Threads::parallel_for(func, 0, batch_len, 1);
+
+    NDArray::registerPrimaryUse({&result_sequences, &result_probs, &result_sequences_length}, {});
     return;
 }
 

--- a/libnd4j/include/ops/declarable/platform/cudnn/ctcloss.cu
+++ b/libnd4j/include/ops/declarable/platform/cudnn/ctcloss.cu
@@ -29,22 +29,6 @@ namespace platforms {
 
 
 
-    template<typename Op, typename ...Args>
-    void callCudnnIfNoErr(cudnnStatus_t &err, Op op, Args&&... args){
-        if(err==CUDNN_STATUS_SUCCESS){
-            err = op(std::forward<Args>(args)...);
-            if(err){
-                nd4j_printf("Cudnn error code %s\n",cudnnGetErrorString(err));
-            }
-        }
-    }
-
-    template <typename T>
-    const T* bufferInHost( const NDArray &array)  {
-        array.syncToHost();
-        return reinterpret_cast<const T*>(array.buffer());
-    }
-
     std::vector<int> getConcatTargets(const NDArray &targetLabels, const NDArray &targetLabelLengths){
                 //concatenate target labels
                 const int32_t *tlabels = bufferInHost<int32_t>(targetLabels);
@@ -85,17 +69,16 @@ namespace platforms {
         cudnnStatus_t err = CUDNN_STATUS_SUCCESS;
         callCudnnIfNoErr(err, cudnnSetStream, *handle, *context.getCudaStream());
 
-        cudnnCTCLossDescriptor_t  ctcLossDesc;
-        cudnnTensorDescriptor_t probsDesc = nullptr;
-        cudnnTensorDescriptor_t gradsDesc = nullptr;
-        callCudnnIfNoErr(err, cudnnCreateCTCLossDescriptor, &ctcLossDesc);
-        callCudnnIfNoErr(err, cudnnSetCTCLossDescriptorEx, ctcLossDesc, CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_PROPAGATE_NAN);
-        callCudnnIfNoErr(err, cudnnCreateTensorDescriptor, &probsDesc);
-        callCudnnIfNoErr(err, cudnnSetTensorNdDescriptor, probsDesc, cudnnDataType(probs.dataType()), probs.rankOf() , dims, strides);
-        if(!grads.isEmpty()){
+        CTCLossDesc  ctcLossDesc;
+        CudnnTensor probsDesc, gradsDesc(false);
+        bool calcGrads = !grads.isEmpty();
+        ctcLossDesc.set( err, CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_PROPAGATE_NAN);
+        probsDesc.set( err, cudnnDataType(probs.dataType()), probs.rankOf() , dims, strides);
+
+        if(calcGrads){
+            gradsDesc.create();
             const int gradStrides[] = {(int)grads.strideAt(0), (int)grads.strideAt(1), (int)grads.strideAt(2)};
-            callCudnnIfNoErr(err, cudnnCreateTensorDescriptor, &gradsDesc);
-            callCudnnIfNoErr(err, cudnnSetTensorNdDescriptor, gradsDesc, cudnnDataType(grads.dataType()), grads.rankOf() , dims, gradStrides);
+            gradsDesc.set( err, cudnnDataType(grads.dataType()), grads.rankOf() , dims, gradStrides);
         }
 
         size_t tempWorkSpaceSize=0;
@@ -119,7 +102,7 @@ namespace platforms {
             bufferInHost<int32_t>(probInputLengthes),
             ctcLosses.specialBuffer(),
             gradsDesc,
-            grads.specialBuffer(),
+            calcGrads ? grads.specialBuffer() :nullptr,
             CUDNN_CTC_LOSS_ALGO_DETERMINISTIC,
             ctcLossDesc,
             tempWorkSpace,
@@ -128,9 +111,6 @@ namespace platforms {
         NDArray::registerSpecialUse({&ctcLosses, &grads}, {&probs});
 
         cudaFree(tempWorkSpace);
-        callCudnnIfNoErr(err, cudnnDestroyTensorDescriptor,probsDesc);
-        if(gradsDesc) callCudnnIfNoErr(err, cudnnDestroyTensorDescriptor,gradsDesc);
-        callCudnnIfNoErr(err, cudnnDestroyCTCLossDescriptor,ctcLossDesc);
         return err;
      }
 
@@ -188,6 +168,7 @@ namespace platforms {
         auto logitInputLengths = INPUT_VARIABLE(3);
         auto outputGradients = OUTPUT_VARIABLE(0);
         auto context = block.launchContext();
+        REQUIRE_TRUE(outputGradients->isSameShape(logitInput), 0, "CtcLoss Gradient: wrong shape of output array, expected is %s but got %s instead !", ShapeUtils::shapeAsString(logitInput).c_str(), ShapeUtils::shapeAsString(outputGradients).c_str());
         //in Cudnn Batch is in the middle dimension
         logitInput->permutei({1,0,2});
         outputGradients->permutei({1,0,2});

--- a/libnd4j/include/ops/declarable/platform/cudnn/ctcloss.cu
+++ b/libnd4j/include/ops/declarable/platform/cudnn/ctcloss.cu
@@ -72,8 +72,9 @@ namespace platforms {
         CTCLossDesc  ctcLossDesc;
         CudnnTensor probsDesc, gradsDesc(false);
         bool calcGrads = !grads.isEmpty();
-        ctcLossDesc.set( err, CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_PROPAGATE_NAN);
-        probsDesc.set( err, cudnnDataType(probs.dataType()), probs.rankOf() , dims, strides);
+        auto cudnnType = cudnnDataType(probs.dataType());
+        ctcLossDesc.set( err, cudnnType, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_PROPAGATE_NAN);
+        probsDesc.set( err, cudnnType, probs.rankOf() , dims, strides);
 
         if(calcGrads){
             gradsDesc.create();
@@ -180,7 +181,7 @@ namespace platforms {
         if(err!=CUDNN_STATUS_SUCCESS) throw sd::cuda_exception::build("ctc_loss CUDNN call failure ", err);
         //restore grads shape from {T, BATCH, C} -> {BATCHS, T, C}
         outputGradients->permutei({1,0,2});
-        //tempLosses.printIndexedBuffer("tempLosses");
+
         return Status::OK();
     }
 

--- a/libnd4j/include/ops/declarable/platform/cudnn/lstmLayer.cu
+++ b/libnd4j/include/ops/declarable/platform/cudnn/lstmLayer.cu
@@ -192,7 +192,7 @@ cudnnStatus_t cudnn_rnn_old(LaunchContext *contextPtr, int dataFormat, NDArray *
     // dimension 4*nOut implies order it, ft, c't, ot
     // input gate, forget gate, new gate, output gate, input gate, forget gate, new gate, output gate
     // Note: our weights should be transposed and duplicated with C order to match cudnn ones
-    // As returned memory addresses using cudnnGetRNNLinLayerMatrixParams linLayerID was contingiuous we will map directly
+
     NDArray inputWeightsT, recurrentWeightsT;
     uint8_t *inputWeightsData = nullptr;
     uint8_t *recurrentWeightsData = nullptr;
@@ -388,7 +388,7 @@ cudnnStatus_t cudnn_rnn_v8(LaunchContext  *contextPtr, int dataFormat,  NDArray 
     // dimension 4*nOut implies order it, ft, c't, ot
     // input gate, forget gate, new gate, output gate, input gate, forget gate, new gate, output gate
     // Note: our weights should be transposed and duplicated with C order to match cudnn ones
-    // As returned memory addresses using cudnnGetRNNLinLayerMatrixParams linLayerID was contingiuous we will map directly
+
     NDArray inputWeightsT, recurrentWeightsT;
     uint8_t *inputWeightsData = nullptr;
     uint8_t *recurrentWeightsData = nullptr;
@@ -526,7 +526,7 @@ cudnnStatus_t cudnn_rnn_v8(LaunchContext  *contextPtr, int dataFormat,  NDArray 
 //  - Clipping is allowed for cudnn version >= 7.2.1
 //  - SeqLen array is allowed for cudnn version >= 8.0.1
 //  - gateActivation: sigmoid, cellActivation and outputActivation: tanh
-//  - NDArrays (exluding weight ones, as we have to transpose or permute it) should follow 'c' order and ews()==1
+//  - NDArrays (excluding the weight arrays, as we have to transpose or permute it) should follow 'c' order and ews()==1
  PLATFORM_CHECK(lstmLayer, ENGINE_CUDA) {
  
     const auto dataFormat    = INT_ARG(0);    // for unidirectional: 0 = [sL, bS, nIn], 1 = [bS, sL ,nIn], 2 = [bS, nIn, sL], for bidirectional: 3 = [sL, 2, bS, nOut] (for ONNX)

--- a/libnd4j/include/ops/declarable/platform/cudnn/lstmLayer.cu
+++ b/libnd4j/include/ops/declarable/platform/cudnn/lstmLayer.cu
@@ -1,0 +1,609 @@
+/* ******************************************************************************
+ *
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  See the NOTICE file distributed with this work for additional
+ *  information regarding copyright ownership.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+ //
+ // @author AbdelRauf
+ //
+
+ #include <ops/declarable/OpRegistrator.h>
+ #include "cudnnUtils.h"
+ #include <array/NDArrayFactory.h>
+
+ namespace sd     {
+ namespace ops      {
+ namespace platforms {
+
+//our implementation designed for 1 physical layer
+constexpr int numLayers = 1;
+
+//we will copy without using cudnnGetRNNLinLayerMatrixParams : 1 pseudo layer , isBidirectional : 2 pseudo layer
+void copyWeights(const cudaStream_t &stream , bool isBidirectional, uint8_t *weightsSpace, size_t weightsSize, uint8_t *inputWeightsData, uint8_t *recurrentWeightsData, uint8_t *biasesData, int inputSize, int hiddenSize, int dataTypeSize){
+    int pseudo_layer_count = isBidirectional ? 2 :1 ;
+    uint8_t * wptr = weightsSpace;
+    auto wEnd = wptr + weightsSize;
+
+    //copy size for 1 full pseudo layer
+    //in bidirectional 1 layer consist of 2 pseduo layers
+    auto input_pseudo_size = 4 * inputSize * hiddenSize * dataTypeSize;
+    auto hidden_pseudo_size = 4 * hiddenSize * hiddenSize * dataTypeSize;
+    for(int i=0; i< pseudo_layer_count ; i++){
+        if(wptr + input_pseudo_size + hidden_pseudo_size > wEnd) return;
+        //copy input weights
+        if(inputWeightsData){
+            cudaMemcpyAsync(wptr, inputWeightsData, input_pseudo_size, cudaMemcpyDeviceToDevice, stream);
+            inputWeightsData +=  input_pseudo_size;
+        }
+        wptr += input_pseudo_size;
+        //copy recurrent weights
+        if(recurrentWeightsData){
+            cudaMemcpyAsync(wptr, recurrentWeightsData, hidden_pseudo_size, cudaMemcpyDeviceToDevice, stream);
+            recurrentWeightsData += hidden_pseudo_size;
+        }
+        wptr += hidden_pseudo_size;
+    }
+
+    //copy bias first 4
+    auto bias_size =  4 * hiddenSize * dataTypeSize;
+    for(int i=0; i< pseudo_layer_count ; i++){
+        //refill first 4 biases
+        if(biasesData && wptr + bias_size < wEnd){
+            cudaMemcpyAsync(wptr, biasesData, bias_size, cudaMemcpyDeviceToDevice, stream);
+            biasesData += bias_size;
+        }
+        wptr += bias_size; 
+        //refill next 4 with zeros
+        if(wptr + bias_size < wEnd){
+            cudaMemsetAsync(wptr, 0, bias_size, stream);
+            wptr += bias_size; 
+        } 
+   }
+       //metset the rest
+    if( wEnd-wptr ) cudaMemsetAsync(wptr, 0 , wEnd-wptr, stream);
+}
+
+cudnnStatus_t cudnn_rnn_old(LaunchContext *contextPtr, int dataFormat, NDArray *input, NDArray *inputWeights,  NDArray *recurrentWeights,
+    NDArray *biases, NDArray *prevAct, NDArray *prevMemCell, NDArray *outputActivations, NDArray *finalTimeStepActivations, NDArray *finalMemCellState,
+    int maxSeqLength, int batchSize, int inputSize, int hiddenSize, double cellClip, bool isBidirectional){
+
+    nd4j_debug("cudnn rnn api %s \n", "v6");
+
+    bool training = false;
+    cudnnHandle_t handle = *(reinterpret_cast<cudnnHandle_t *>(contextPtr->getCuDnnHandle()));
+    cudnnStatus_t err = CUDNN_STATUS_SUCCESS;
+    auto stream = *(contextPtr->getCudaStream());
+    callCudnnIfNoErr(err, cudnnSetStream, handle, stream); 
+
+    CudnnTensorList xDescList (maxSeqLength);
+    CudnnTensorList yDescList (maxSeqLength);
+
+    auto cudnnType = cudnnDataType(input->dataType());
+    auto dataTypeSize = input->sizeOfT(); 
+
+    CudnnTensor hxDesc, cxDesc, hyDesc, cyDesc;  
+
+    constexpr int rankOf = 3;
+    const int numDirections     = isBidirectional ? 2 : 1;
+
+    const int dimsX[rankOf]    = {batchSize,  inputSize, 1};
+    const int stridesX[rankOf] = {inputSize, 1, 1};
+
+    const int dimsY[rankOf]    = {batchSize, hiddenSize * numDirections , 1};
+    const int stridesY[rankOf] = {hiddenSize * numDirections, 1, 1};
+
+    const int dimC[rankOf]    = {numLayers * numDirections,  batchSize,  hiddenSize};
+    const int strideC[rankOf]  = {batchSize * hiddenSize, hiddenSize, 1}; 
+
+    for(int i=0; i<maxSeqLength; i++){
+        xDescList.set(err, i, cudnnType, rankOf, dimsX, stridesX);
+        // dxDescList.set(err, i, cudnnType, rankOf, dimsX, stridesX);
+        yDescList.set(err, i, cudnnType, rankOf, dimsY, stridesY);
+        // dyDescList.set(err, i, cudnnType, rankOf, dimsY, stridesY);
+        if(err!=CUDNN_STATUS_SUCCESS)  break;
+    }
+
+    auto xDesc0 = xDescList.get(0);
+
+    hxDesc.set(err, cudnnType, rankOf, dimC, strideC);
+    cxDesc.set(err, cudnnType, rankOf, dimC, strideC);
+    hyDesc.set(err, cudnnType, rankOf, dimC, strideC);
+    cyDesc.set(err, cudnnType, rankOf, dimC, strideC);
+
+    //dropout section
+    DropoutDesc dropoutDesc; 
+    //dropout
+    float dropout = 0;
+    size_t sizeInBytes=0;
+    void *droupoutMem = nullptr;
+    uint64_t seed =1; //seed
+    if(dropout!=0){
+       // dropoutDesc.create();
+        callCudnnIfNoErr(err, cudnnDropoutGetStatesSize, handle, &sizeInBytes);
+        //allocate and set
+        cudaMalloc(&droupoutMem, sizeInBytes);
+        dropoutDesc.set(err, handle, dropout, droupoutMem, sizeInBytes, seed );
+    }
+
+    //RNN
+    RnnDesc rnnDesc;
+    cudnnRNNMode_t rnnCellMode = CUDNN_LSTM;
+    cudnnRNNAlgo_t algo = CUDNN_RNN_ALGO_STANDARD;
+
+    auto direction = isBidirectional ? CUDNN_BIDIRECTIONAL : CUDNN_UNIDIRECTIONAL;
+    auto mathPrec = cudnnType;
+
+    //Note: We will set some parameters manually
+    constexpr auto inputMode = CUDNN_LINEAR_INPUT;
+    rnnDesc.setUsingOldAPI(err, handle, inputMode, direction, rnnCellMode, algo, mathPrec, hiddenSize, numLayers, dropoutDesc);
+#if CUDNN_VERSION >= CUDNN_CLIPPING_API_VER
+    if(cellClip>0 && cudnnGetVersion()>=CUDNN_CLIPPING_API_VER){
+        callCudnnIfNoErr(err, cudnnRNNSetClip, handle, rnnDesc, CUDNN_RNN_CLIP_MINMAX, CUDNN_PROPAGATE_NAN, -cellClip, cellClip);
+    }
+#endif
+    //set up parameters
+    size_t weightsSize=0;
+    callCudnnIfNoErr(err, cudnnGetRNNParamsSize, handle, rnnDesc, xDesc0, &weightsSize, cudnnType);
+
+    FilterDesc wDesc; 
+    int dimW[] = {(int) weightsSize / dataTypeSize, 1, 1};
+
+    wDesc.set(err, cudnnType, CUDNN_TENSOR_NCHW, 3, dimW); 
+    //allocation
+    uint8_t *weightsSpace =nullptr;
+    cudaMalloc(&weightsSpace,  weightsSize); 
+
+    // Set up work space and reserved memory
+    void *workSpace = nullptr;
+    void *reserveSpace = nullptr;
+
+    size_t workSpaceSizeInBytes = 0 ;
+    size_t reserveSpaceSizeInBytes = 0;
+
+    callCudnnIfNoErr(err, cudnnGetRNNWorkspaceSize, handle, rnnDesc, maxSeqLength, xDescList.getDescriptors(), &workSpaceSizeInBytes);
+    cudaMalloc(&workSpace, workSpaceSizeInBytes);
+
+    // training
+    if(training) {
+        callCudnnIfNoErr(err, cudnnGetRNNTrainingReserveSize, handle, rnnDesc, maxSeqLength, xDescList.getDescriptors(), &reserveSpaceSizeInBytes);
+        cudaMalloc(&reserveSpace, reserveSpaceSizeInBytes);
+    }
+
+    NDArray::prepareSpecialUse({outputActivations, finalTimeStepActivations, finalMemCellState}, {input, inputWeights, recurrentWeights, biases, prevAct, prevMemCell});
+
+    uint8_t *biasesData = biases ? (uint8_t*)biases->specialBuffer() : nullptr;
+    auto prevActData = prevAct ? prevAct->specialBuffer() : nullptr;
+    auto prevMemCellData = prevMemCell ? prevMemCell->specialBuffer() : nullptr;
+    auto finalTimeStepActivationsData = finalTimeStepActivations ? finalTimeStepActivations->specialBuffer() : nullptr;
+    auto finalMemCellStateData = finalMemCellState ? finalMemCellState->specialBuffer() : nullptr;
+
+    // dimension 4*nOut implies order it, ft, c't, ot
+    // input gate, forget gate, new gate, output gate, input gate, forget gate, new gate, output gate
+    // Note: our weights should be transposed and duplicated with C order to match cudnn ones
+    // As returned memory addresses using cudnnGetRNNLinLayerMatrixParams linLayerID was contingiuous we will map directly
+    NDArray inputWeightsT, recurrentWeightsT;
+    uint8_t *inputWeightsData = nullptr;
+    uint8_t *recurrentWeightsData = nullptr;
+    if(inputWeights){
+      inputWeightsT= inputWeights->rankOf()==3?inputWeights->permute({0, 2, 1}).dup('c'):inputWeights->transpose().dup('c');
+      inputWeightsData = (uint8_t*)inputWeightsT.specialBuffer();
+    }
+    if(recurrentWeights){
+      recurrentWeightsT = recurrentWeights->rankOf()==3?recurrentWeights->permute({0, 2, 1}).dup('c'):recurrentWeights->transpose().dup('c');
+      recurrentWeightsData =  (uint8_t*)recurrentWeightsT.specialBuffer();
+    }
+
+    //copy without cudnnGetRNNLinLayerMatrixParams
+    copyWeights(stream,isBidirectional, weightsSpace, weightsSize, inputWeightsData, recurrentWeightsData, biasesData, inputSize, hiddenSize, dataTypeSize);
+
+    //permute based on dataformat
+    NDArray *argX = input;
+    NDArray *argOutput= outputActivations;
+    NDArray permutedX, outputH;
+
+    if(outputActivations!=nullptr && (dataFormat != 0 ||  outputActivations->ordering()!='c')){
+        outputH = NDArray('c',  std::vector<Nd4jLong>{maxSeqLength, batchSize, (numDirections * hiddenSize)}, outputActivations->dataType(), contextPtr);
+        argOutput = &outputH;
+    }
+
+    if(dataFormat == 1){
+        permutedX = input->permute({1, 0, 2}).dup('c');
+        argX = &permutedX; 
+    }
+
+    auto xData = argX->specialBuffer();
+    auto yData = argOutput ? argOutput->specialBuffer() : nullptr;
+
+    if (training) {
+          callCudnnIfNoErr(err, cudnnRNNForwardTraining, handle,  rnnDesc, (int) maxSeqLength, xDescList.getDescriptors(), xData,
+                        hxDesc, prevActData, cxDesc, prevMemCellData, wDesc,
+                       weightsSpace, yDescList.getDescriptors(), yData, hyDesc,
+                       finalTimeStepActivationsData,  cyDesc, finalMemCellStateData, workSpace,
+                       workSpaceSizeInBytes, reserveSpace, reserveSpaceSizeInBytes);
+    } else {
+          callCudnnIfNoErr(err, cudnnRNNForwardInference, handle,  rnnDesc, (int) maxSeqLength, xDescList.getDescriptors(), xData,
+                        hxDesc, prevActData, cxDesc, prevMemCellData,  wDesc,
+                       weightsSpace, yDescList.getDescriptors(), yData,  hyDesc,
+                       finalTimeStepActivationsData, cyDesc, finalMemCellStateData, workSpace,
+                       workSpaceSizeInBytes);
+    }
+
+    //remap output
+    if(outputActivations!=nullptr && argOutput!=outputActivations){
+        //refill output
+        if(dataFormat == 1){
+            outputActivations->assign( argOutput->permute({1, 0, 2}));
+        }
+    }
+    NDArray::registerSpecialUse({outputActivations, finalTimeStepActivations, finalMemCellState}, {input, inputWeights, recurrentWeights, biases, prevAct, prevMemCell});
+
+    cudaFree(droupoutMem);
+    cudaFree(weightsSpace);
+    cudaFree(workSpace);
+    cudaFree(reserveSpace);
+
+    return err;
+
+}
+
+#if CUDNN_VERSION >= CUDNN_NEW_RNN_API_VER
+
+cudnnStatus_t cudnn_rnn_v8(LaunchContext  *contextPtr, int dataFormat,  NDArray *input, NDArray *seqLengthArray, NDArray *inputWeights,  NDArray *recurrentWeights,
+    NDArray *biases, NDArray *prevAct, NDArray *prevMemCell, NDArray *outputActivations, NDArray *finalTimeStepActivations, NDArray *finalMemCellState,
+    int maxSeqLength, int batchSize, int inputSize, int hiddenSize, double cellClip, bool isBidirectional){
+    nd4j_debug("cudnn rnn api %s \n", "v8");
+    //seqLengthArray should be int
+    NDArray *argSeqNdArray = nullptr;
+    NDArray seqArrIntData;
+    if(seqLengthArray){
+        if(seqLengthArray->ews()==1 && seqLengthArray->dataType()==DataType::INT32){
+            argSeqNdArray = seqLengthArray;
+        }else{
+            if(seqLengthArray->dataType()!=DataType::INT32){
+                seqArrIntData = seqLengthArray->cast(DataType::INT32);
+                if(seqArrIntData.ews()!=1) seqArrIntData=seqArrIntData.dup('c');
+            }else{
+                seqArrIntData = seqLengthArray->dup('c');
+            }
+            argSeqNdArray = &seqArrIntData;
+        }
+    }else{
+        seqArrIntData = NDArray('c', std::vector<Nd4jLong>{batchSize}, DataType::INT32, contextPtr);
+        seqArrIntData.assign(maxSeqLength);
+        argSeqNdArray = &seqArrIntData;
+    }
+
+    bool training = false;
+    cudnnHandle_t handle = *(reinterpret_cast<cudnnHandle_t *>(contextPtr->getCuDnnHandle()));
+    cudnnStatus_t err = CUDNN_STATUS_SUCCESS;
+    auto stream = *(contextPtr->getCudaStream());
+    callCudnnIfNoErr(err, cudnnSetStream, handle, stream); 
+
+    auto cudnnType = cudnnDataType(input->dataType());
+    auto dataTypeSize = input->sizeOfT(); 
+
+    CudnnTensor hDesc, cDesc;  
+
+    constexpr int rankOf = 3;
+    const int numDirections     = isBidirectional ? 2 : 1;
+
+    const int dimC[rankOf]    = {numLayers * numDirections,  batchSize,  hiddenSize};
+    const int strideC[rankOf]  = {batchSize * hiddenSize, hiddenSize, 1}; 
+
+    hDesc.set(err, cudnnType, rankOf, dimC, strideC);
+    cDesc.set(err, cudnnType, rankOf, dimC, strideC);
+
+    //dropout section
+    DropoutDesc dropoutDesc; 
+    //dropout
+    float dropout = 0;
+    size_t sizeInBytes=0;
+    void *droupoutMem = nullptr;
+    uint64_t seed = 1; //seed
+    if(dropout!=0){
+       // dropoutDesc.create();
+        callCudnnIfNoErr(err, cudnnDropoutGetStatesSize, handle, &sizeInBytes);
+        //allocate and set
+        cudaMalloc(&droupoutMem, sizeInBytes);
+        dropoutDesc.set(err, handle, dropout, droupoutMem, sizeInBytes, seed );
+    }
+
+    //RNN
+    RnnDesc rnnDesc;
+    cudnnRNNMode_t rnnCellMode = CUDNN_LSTM;
+    cudnnRNNAlgo_t algo = CUDNN_RNN_ALGO_STANDARD;
+    auto direction = isBidirectional ? CUDNN_BIDIRECTIONAL : CUDNN_UNIDIRECTIONAL;
+    auto mathPrec = cudnnType;
+
+    //Note: We will set some parameters manually. Some of them could be parameter in future
+    constexpr auto inputMode = CUDNN_LINEAR_INPUT;
+    bool use_tensor_ops = false ; // could be parameter in future
+#if CUDNN_VERSION >= CUDNN_NEW_RNN_API_VER
+    cudnnMathType_t mathType = use_tensor_ops ? CUDNN_TENSOR_OP_MATH : CUDNN_FMA_MATH;
+#else
+    cudnnMathType_t mathType = use_tensor_ops ? CUDNN_TENSOR_OP_MATH : CUDNN_DEFAULT_MATH;
+#endif
+    //disable projection
+    int projSize = hiddenSize;
+    cudnnRNNBiasMode_t bias_mode = CUDNN_RNN_DOUBLE_BIAS;
+    uint32_t aux_flags = CUDNN_RNN_PADDED_IO_ENABLED;
+
+    rnnDesc.set(err, algo, rnnCellMode, bias_mode, direction, inputMode, cudnnType, mathPrec, mathType, inputSize, hiddenSize, projSize, numLayers, dropoutDesc, aux_flags);
+    if(cellClip>0){
+        callCudnnIfNoErr(err, cudnnRNNSetClip, handle, rnnDesc, CUDNN_RNN_CLIP_MINMAX, CUDNN_PROPAGATE_NAN, -cellClip, cellClip);
+    }
+    //set Data desc
+    RnnDataDesc xDataDesc, yDataDesc;
+    bool time_major = false;
+    float padding_fill = 0.0f;
+    auto hostSeqArr = bufferInHost<int>(*argSeqNdArray);
+    cudnnRNNDataLayout_t layout = dataFormat==0 ? CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_UNPACKED : CUDNN_RNN_DATA_LAYOUT_BATCH_MAJOR_UNPACKED;
+    xDataDesc.set(err, cudnnType, layout, maxSeqLength, batchSize, inputSize, hostSeqArr, (void*)&padding_fill);
+    yDataDesc.set(err, cudnnType, layout, maxSeqLength, batchSize, hiddenSize * numDirections, hostSeqArr, (void*)&padding_fill);
+    //set up parameters
+    size_t weightsSize=0;
+    callCudnnIfNoErr(err, cudnnGetRNNWeightSpaceSize, handle, rnnDesc, &weightsSize);
+
+    //allocation
+    uint8_t *weightsSpace =nullptr;
+    cudaMalloc(&weightsSpace,  weightsSize); 
+
+    // Set up work space and reserved memory
+    void *workSpace = nullptr;
+    void *reserveSpace = nullptr;
+
+    size_t workSpaceSizeInBytes = 0 ;
+    size_t reserveSpaceSizeInBytes = 0;
+
+    cudnnForwardMode_t fwdMode = training ? CUDNN_FWD_MODE_TRAINING : CUDNN_FWD_MODE_INFERENCE; 
+    callCudnnIfNoErr(err, cudnnGetRNNTempSpaceSizes, handle, rnnDesc, fwdMode, xDataDesc, &workSpaceSizeInBytes, &reserveSpaceSizeInBytes);
+    cudaMalloc(&workSpace, workSpaceSizeInBytes);
+    // training
+    if(training) {
+        cudaMalloc(&reserveSpace, reserveSpaceSizeInBytes);
+    }
+
+    NDArray::prepareSpecialUse({outputActivations, finalTimeStepActivations, finalMemCellState}, {input, inputWeights, recurrentWeights, biases, prevAct, prevMemCell, argSeqNdArray});
+
+    auto xData = input->specialBuffer();
+    uint8_t *biasesData = biases ? (uint8_t*)biases->specialBuffer() : nullptr;
+    auto prevActData = prevAct ? prevAct->specialBuffer() : nullptr;
+    auto prevMemCellData = prevMemCell ? prevMemCell->specialBuffer() : nullptr;
+    auto yData = outputActivations ? outputActivations->specialBuffer() : nullptr;
+    auto finalTimeStepActivationsData = finalTimeStepActivations ? finalTimeStepActivations->specialBuffer() : nullptr;
+    auto finalMemCellStateData = finalMemCellState ? finalMemCellState->specialBuffer() : nullptr;
+
+    // dimension 4*nOut implies order it, ft, c't, ot
+    // input gate, forget gate, new gate, output gate, input gate, forget gate, new gate, output gate
+    // Note: our weights should be transposed and duplicated with C order to match cudnn ones
+    // As returned memory addresses using cudnnGetRNNLinLayerMatrixParams linLayerID was contingiuous we will map directly
+    NDArray inputWeightsT, recurrentWeightsT;
+    uint8_t *inputWeightsData = nullptr;
+    uint8_t *recurrentWeightsData = nullptr;
+    if(inputWeights){
+      inputWeightsT= inputWeights->rankOf()==3?inputWeights->permute({0, 2, 1}).dup('c'):inputWeights->transpose().dup('c');
+      inputWeightsData = (uint8_t*)inputWeightsT.specialBuffer();
+    }
+    if(recurrentWeights){
+      recurrentWeightsT = recurrentWeights->rankOf()==3?recurrentWeights->permute({0, 2, 1}).dup('c'):recurrentWeights->transpose().dup('c');
+      recurrentWeightsData =  (uint8_t*)recurrentWeightsT.specialBuffer();
+    }
+
+    //copy without cudnnGetRNNLinLayerMatrixParams
+    copyWeights(stream, isBidirectional, weightsSpace, weightsSize, inputWeightsData, recurrentWeightsData, biasesData, inputSize, hiddenSize, dataTypeSize);
+
+    callCudnnIfNoErr(err, cudnnRNNForward, handle, rnnDesc, fwdMode, (const int32_t *)argSeqNdArray->specialBuffer(),  xDataDesc, xData,
+        yDataDesc, yData, hDesc, prevActData,finalTimeStepActivationsData,  cDesc, prevMemCellData, finalMemCellStateData,
+        weightsSize, weightsSpace, workSpaceSizeInBytes, workSpace, reserveSpaceSizeInBytes, reserveSpace);
+
+    NDArray::registerSpecialUse({outputActivations, finalTimeStepActivations, finalMemCellState}, {input, inputWeights, recurrentWeights, biases, prevAct, prevMemCell});
+
+    cudaFree(droupoutMem);
+    cudaFree(weightsSpace);
+    cudaFree(workSpace);
+    cudaFree(reserveSpace);
+
+    return err;
+
+}
+
+#endif
+
+ //////////////////////////////////////////////////////////////////////////
+ PLATFORM_IMPL(lstmLayer, ENGINE_CUDA) {
+ 
+    const auto dataFormat    = INT_ARG(0);    // for unidirectional: 0 = [sL, bS, nIn], 1 = [bS, sL ,nIn], 2 = [bS, nIn, sL], for bidirectional: 3 = [sL, 2, bS, nOut] (for ONNX)
+    const auto directionMode = INT_ARG(1);    // direction: 0 = fwd, 1 = bwd, 2 = bidirectional sum, 3 = bidirectional concat, 4 = bidirectional extra output dim (in conjunction with format dataFormat = 3)
+ 
+    const auto hasBiases  = B_ARG(0);   // indicates whether biases array is provided
+    const auto hasSeqLenArray  = B_ARG(1);   // indicates whether seqLen array is provided
+    const auto hasInitH   = B_ARG(2);   // indicates whether initial output is provided
+    const auto hasInitC   = B_ARG(3);   // indicates whether initial cell state is provided
+    const auto hasPH     = B_ARG(4);   // indicates whether peephole connections are present
+    const auto retFullSeq = B_ARG(5);   // indicates whether to return whole time sequence h {h_0, h_1, ... , h_sL-1}
+    const auto retLastH   = B_ARG(6);   // indicates whether to return output at last time step only, in this case shape would be [bS, nOut] (exact shape depends on dataFormat argument)
+    const auto retLastC   = B_ARG(7);   // indicates whether to return cells state at last time step only, in this case shape would be [bS, nOut] (exact shape depends on dataFormat argument)
+ 
+    const auto cellClip = T_ARG(0);    // cell clipping value, if it = 0 then do not apply clipping
+ 
+    const auto x  = INPUT_VARIABLE(0);        // input
+    const auto Wx = INPUT_VARIABLE(1);        // input weights
+    const auto Wr = INPUT_VARIABLE(2);        // recurrent weights
+ 
+    int count = 3;
+    const auto b     = hasBiases ? INPUT_VARIABLE(count++) : nullptr;  // biases
+    const auto seqLengthArray = hasSeqLenArray ? INPUT_VARIABLE(count++) : nullptr;  // seqLen vector
+    const auto hI    = hasInitH  ? INPUT_VARIABLE(count++) : nullptr;  // initial output
+    const auto cI    = hasInitC  ? INPUT_VARIABLE(count++) : nullptr;  // initial cell state
+    const auto Wp    = hasPH    ? INPUT_VARIABLE(count++) : nullptr;  // peephole weights
+
+    count = 0;
+    auto h  = retFullSeq ? OUTPUT_VARIABLE(count++) : nullptr;         // output
+    auto hL = retLastH   ? OUTPUT_VARIABLE(count++) : nullptr;         // output at last step
+    auto cL = retLastC   ? OUTPUT_VARIABLE(count++) : nullptr;         // cell state at last step
+
+    REQUIRE_TRUE(cellClip >= 0 , 0, "LSTM_LAYER operation: cell clipping value should be nonnegative (>=0) !");
+    REQUIRE_TRUE(retFullSeq || retLastH || retLastC, 0, "LSTM_LAYER operation: please specify what output arrays to produce !");
+    // evaluate dimensions
+    const Nd4jLong seqLength = dataFormat == 3 ?  x->sizeAt(0) : x->sizeAt(dataFormat);
+    const Nd4jLong bS   = dataFormat == 1 || dataFormat == 2 ? x->sizeAt(0) : x->sizeAt(1);
+    const Nd4jLong nIn  = dataFormat == 2 ? x->sizeAt(1) : x->sizeAt(2);
+    const Nd4jLong nOut = Wx->sizeAt(-1) / 4;
+    const Nd4jLong hiddenSize = nOut;
+
+    auto contextPtr = block.launchContext();
+    bool isBidirectional =  directionMode >= 2;
+
+    if(!isBidirectional) {     // no bidirectional
+        // Wx validation
+        if(Wx->rankOf() != 2 || Wx->sizeAt(0) != nIn)
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of input weights, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({nIn, 4*nOut}).c_str(), ShapeUtils::shapeAsString(Wx).c_str());
+        // Wr validation
+        if(Wr->rankOf() != 2 || Wr->sizeAt(0) != nOut || Wr->sizeAt(1) != 4*nOut)
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of recurrent weights, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({nOut, 4*nOut}).c_str(), ShapeUtils::shapeAsString(Wr).c_str());
+        // biases validation
+        if(b != nullptr && (b->rankOf() != 1 || b->sizeAt(0) != 4*nOut))
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of biases, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({4*nOut}).c_str(), ShapeUtils::shapeAsString(b).c_str());
+        // initial output validation
+        if(hI != nullptr && (hI->rankOf() != 2 || hI->sizeAt(0) != bS || hI->sizeAt(1) != nOut))
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of initial output, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({bS, nOut}).c_str(), ShapeUtils::shapeAsString(hI).c_str());
+        // initial cell  validation
+        if(cI != nullptr && (cI->rankOf() != 2 || cI->sizeAt(0) != bS || cI->sizeAt(1) != nOut))
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of initial cell state, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({bS, nOut}).c_str(), ShapeUtils::shapeAsString(cI).c_str());
+    }
+    else {                  // bidirectional
+         // Wx validation
+        if(Wx->rankOf() != 3 || Wx->sizeAt(0) != 2 || Wx->sizeAt(1) != nIn)
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of input weights, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({2, nIn, 4*nOut}).c_str(), ShapeUtils::shapeAsString(Wx).c_str());
+        // Wr validation
+        if(Wr->rankOf() != 3 || Wr->sizeAt(0) != 2 || Wr->sizeAt(1) != nOut || Wr->sizeAt(2) != 4*nOut)
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of recurrent weights, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({2, nOut, 4*nOut}).c_str(), ShapeUtils::shapeAsString(Wr).c_str());
+        // biases validation
+        if(b != nullptr && (b->rankOf() != 2 || b->sizeAt(0) != 2 || b->sizeAt(1) != 4*nOut))
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of biases, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({2, 4*nOut}).c_str(), ShapeUtils::shapeAsString(b).c_str());
+        // initial output validation
+        if(hI != nullptr && (hI->rankOf() != 3 || hI->sizeAt(0) != 2 || hI->sizeAt(1) != bS || hI->sizeAt(2) != nOut))
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of initial output, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({2, bS, nOut}).c_str(), ShapeUtils::shapeAsString(hI).c_str());
+        // initial cell  validation
+        if(cI != nullptr && (cI->rankOf() != 3 || cI->sizeAt(0) != 2 || cI->sizeAt(1) != bS || cI->sizeAt(2) != nOut))
+            REQUIRE_TRUE(false, 0, "LSTM_LAYER operation: wrong shape of initial cell state, expected is %s, but got %s instead !", ShapeUtils::shapeAsString({2, bS, nOut}).c_str(), ShapeUtils::shapeAsString(cI).c_str());
+    }
+
+    cudnnStatus_t err;
+#if CUDNN_VERSION < CUDNN_NEW_RNN_API_VER
+    err = cudnn_rnn_old( contextPtr, dataFormat, x, Wx, Wr, b, hI, cI, h, hL, cL,  seqLength, bS, nIn, hiddenSize, (double)cellClip, isBidirectional);
+#else
+    if(cudnnGetVersion() >= CUDNN_NEW_RNN_API_VER){
+        err = cudnn_rnn_v8( contextPtr, dataFormat, x, seqLengthArray, Wx, Wr, b, hI, cI, h, hL, cL,  seqLength, bS, nIn, hiddenSize, (double)cellClip, isBidirectional);
+    }else{
+        err = cudnn_rnn_old( contextPtr, dataFormat, x, Wx, Wr, b, hI, cI, h, hL, cL,  seqLength, bS, nIn, hiddenSize, (double)cellClip, isBidirectional);
+    }
+#endif
+    if(err!=CUDNN_STATUS_SUCCESS) throw sd::cuda_exception::build("lstmLayer CUDNN call failure ", err);
+    return Status::OK();
+ }
+
+// Cudnn Lstm:
+// Forward inference implemented using v6, and v8 (when version > 8.0.1) api calls.
+// As our Cuda Lstm implementation has 1 layer. Cudnn implementation was implemented for 1 physical layer
+// Cudnn helper restrictions:
+//  - all NDArrays should be the same type
+//  - dataFormat should be 0 or 1
+//  - only unidirectional (directionMode == 0) and bidirectional concat (directionMode == 3)
+//  - no peephole connection
+//  - Clipping is allowed for cudnn version >= 7.2.1
+//  - SeqLen array is allowed for cudnn version >= 8.0.1
+//  - gateActivation: sigmoid, cellActivation and outputActivation: tanh
+//  - NDArrays (exluding weight ones, as we have to transpose or permute it) should follow 'c' order and ews()==1
+ PLATFORM_CHECK(lstmLayer, ENGINE_CUDA) {
+ 
+    const auto dataFormat    = INT_ARG(0);    // for unidirectional: 0 = [sL, bS, nIn], 1 = [bS, sL ,nIn], 2 = [bS, nIn, sL], for bidirectional: 3 = [sL, 2, bS, nOut] (for ONNX)
+    const auto directionMode = INT_ARG(1);    // direction: 0 = fwd, 1 = bwd, 2 = bidirectional sum, 3 = bidirectional concat, 4 = bidirectional extra output dim (in conjunction with format dataFormat = 3)
+    // integer numbers corresponding to activations: 0=tanh, 1=relu, 2=sigmoid, 3=affine, 4=leaky relu, 5= thresholded relu, 6=scaled tanh, 7=hard sigmoid, 8=ELU, 9=softsign, 10=softplus
+    const auto gateAct      = INT_ARG(2);    // activation for input (i), forget (f) and output (o) gates
+    const auto cellAct      = INT_ARG(3);    // activation for cell state (c)
+    const auto outAct       = INT_ARG(4);    // activation for output (h)
+
+    const auto hasBiases  = B_ARG(0);   // indicates whether biases array is provided
+    const auto hasSeqLenArray  = B_ARG(1);   // indicates whether seqLen array is provided
+    const auto hasInitH   = B_ARG(2);   // indicates whether initial output is provided
+    const auto hasInitC   = B_ARG(3);   // indicates whether initial cell state is provided
+    const auto hasPH     = B_ARG(4);   // indicates whether peephole connections are present
+    const auto retFullSeq = B_ARG(5);   // indicates whether to return whole time sequence h {h_0, h_1, ... , h_sL-1}
+    const auto retLastH   = B_ARG(6);   // indicates whether to return output at last time step only, in this case shape would be [bS, nOut] (exact shape depends on dataFormat argument)
+    const auto retLastC   = B_ARG(7);   // indicates whether to return cells state at last time step only, in this case shape would be [bS, nOut] (exact shape depends on dataFormat argument)
+ 
+    const auto cellClip = T_ARG(0);  // cell clipping value, if it = 0 then do not apply clipping
+ 
+    const auto x  = INPUT_VARIABLE(0);        // input
+    const auto Wx = INPUT_VARIABLE(1);        // input weights
+    const auto Wr = INPUT_VARIABLE(2);        // recurrent weights
+ 
+    int count = 3;
+    const auto b     = hasBiases ? INPUT_VARIABLE(count++) : nullptr;  // biases
+    const auto hI    = hasInitH  ? INPUT_VARIABLE(count++) : nullptr;  // initial output
+    const auto cI    = hasInitC  ? INPUT_VARIABLE(count++) : nullptr;  // initial cell state
+ 
+    count = 0;
+    auto h  = retFullSeq ? OUTPUT_VARIABLE(count++) : nullptr;         // output
+    auto hL = retLastH   ? OUTPUT_VARIABLE(count++) : nullptr;         // output at last step
+    auto cL = retLastC   ? OUTPUT_VARIABLE(count++) : nullptr;         // cell state at last step
+ 
+    DataType xType  = x->dataType();
+    DataType WxType = Wx->dataType();
+    DataType WrType = Wr->dataType();
+    DataType bType  = b  != nullptr ? b->dataType() : xType;
+    DataType hIType = hI != nullptr ? hI->dataType() : xType;
+    DataType cIType = cI != nullptr ? cI->dataType() : xType;
+    DataType hType  = h  != nullptr ? h->dataType()  : xType;
+    DataType hLType = hL != nullptr ? hL->dataType() : xType;
+    DataType cLType = cL != nullptr ? cL->dataType() : xType;
+
+    //cudnn related restrictions    //gateAct: sigmoid, cellAct: tanh adn et cetera
+    bool implRestrictions = gateAct ==2 && cellAct == 0 && outAct == 0 && 
+                       !hasPH && (directionMode==0 || directionMode==3);
+
+    //cudnn api version related restrictions in our helpers
+    size_t cudnn_version = cudnnGetVersion();
+    //though seqlengthArray was added in earlier versions we do not handle it below 8.0.0.1
+#if CUDNN_VERSION < CUDNN_NEW_RNN_API_VER
+    implRestrictions = implRestrictions && !hasSeqLenArray;
+#else
+    implRestrictions = implRestrictions && (cudnn_version >= CUDNN_NEW_RNN_API_VER || !hasSeqLenArray);
+#endif
+    implRestrictions = implRestrictions && (cudnn_version >= CUDNN_CLIPPING_API_VER || cellClip==0);
+
+    //restriction that comes either from not setting Descriptor or not handling manipulation:
+    //restrict0: the same types
+    bool inputRestrictions = WxType == xType && xType == WrType && bType == xType && 
+                    xType == hIType && cIType == xType && xType == hType &&
+                    hLType == xType && xType == cLType; 
+    //restrict1: format and some input output shapes
+    inputRestrictions = inputRestrictions && (dataFormat ==0 || dataFormat ==1) &&
+                (!x  || (x && x->ordering() == 'c'   && x->ews() == 1))  &&
+                (!h  || (h && h->ordering() == 'c'   && h->ews() == 1))  &&
+                (!hI || (hI && hI->ordering() == 'c' && hI->ews() == 1)) &&
+                (!cI || (cI && cI->ordering() == 'c' && cI->ews() == 1)) &&
+                (!hL || (hL && hL->ordering() == 'c' && hL->ews() == 1)) &&
+                (!cL || (cL && cL->ordering() == 'c' && cL->ews() == 1));
+
+    return implRestrictions && inputRestrictions;
+ }
+ 
+ 
+ 
+ }
+ }
+ }

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests13.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests13.cpp
@@ -1367,7 +1367,8 @@ TEST_F(DeclarableOpsTests13, lstmLayer_4) {
     hI({1,2, 0,0, 0,0}) = -1;
     cI({0,1, 0,0, 0,0}) = 2;
     cI({1,2, 0,0, 0,0}) = -2;
-
+    hI.printIndexedBuffer("hI");
+    cI.printIndexedBuffer("cI");
     std::vector<double>   tArgs = {cellClip};
     std::vector<Nd4jLong> iArgs = {dataFormat, directionMode, gateAct, cellAct, outAct};
     std::vector<bool>     bArgs = {hasBiases, hasSeqLen, hasInitH, hasInitC, hasPH, retFullSeq, retLastH, retLastC};
@@ -2067,6 +2068,94 @@ TEST_F(DeclarableOpsTests13, lstmLayer_12) {
     ASSERT_TRUE(expCL.equalsTo(cL));
 
     #endif
+}
+
+////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests13, lstmLayer_13) {
+
+    sd::Environment::getInstance().setDebug(true);
+    sd::Environment::getInstance().setVerbose(true);
+
+    const int sL   = 5;
+    const int bS   = 3;
+    const int nIn  = 4;
+    const int nOut = 5;
+
+    // input arguments
+    const int dataFormat = 0;       // [sL,bS,nIn]
+    const int directionMode = 0;    // forward
+    const int gateAct = 2;          // sigmoid activation for input (i), forget (f) and output (o) gates
+    const int cellAct = 0;          // tanh activation for cell state
+    const int outAct = 0;           // tanh activation for output
+
+    const bool hasBiases  = true;   // biases array is provided
+    const bool hasSeqLen  = false;  // seqLen array is not provided
+    const auto hasInitH   = true;   // initial output is provided
+    const auto hasInitC   = true;   // initial cell state is provided
+    const auto hasPH      = false;  // peephole connections are absent
+    const auto retFullSeq = true;   // return whole h {h_0, h_1, ... , h_sL-1}, [sL,bS,nOut]
+    const auto retLastH   = true;  //  return output at last time step
+    const auto retLastC   = true;   // return cells state at last time step
+
+    const double cellClip = 0;       // do not apply clipping
+
+    NDArray x('c', {sL, bS, nIn}, sd::DataType::FLOAT32);
+    NDArray Wx('c', {nIn, 4*nOut},  sd::DataType::FLOAT32);
+    NDArray Wr('c', {nOut, 4*nOut}, sd::DataType::FLOAT32);
+    NDArray b('c', {4*nOut}, sd::DataType::FLOAT32);
+    NDArray hI('c', {bS, nOut}, sd::DataType::FLOAT32);
+    NDArray cI('c', {bS, nOut}, sd::DataType::FLOAT32);
+    auto expH = NDArrayFactory::create<float>('c', {sL, bS, nOut}, {
+                0.585381f, 0.618957f, 0.650373f, 0.679638f, 0.706795f,
+                0.821222f, 0.839291f, 0.855572f, 0.870221f, 0.883389f,
+                0.913720f, 0.922729f, 0.930756f, 0.937913f, 0.944299f,
+
+                0.938296f, 0.945774f, 0.952322f, 0.958059f, 0.963085f,
+                0.976104f, 0.978968f, 0.981458f, 0.983628f, 0.985523f,
+                0.988348f, 0.989659f, 0.990806f, 0.991811f, 0.992695f,
+
+                0.991718f, 0.992766f, 0.993673f, 0.994459f, 0.995141f,
+                0.996805f, 0.997194f, 0.997531f, 0.997823f, 0.998077f,
+                0.998440f, 0.998616f, 0.998770f, 0.998905f, 0.999023f,
+
+                0.998884f, 0.999026f, 0.999148f, 0.999254f, 0.999346f,
+                0.999571f, 0.999623f, 0.999668f, 0.999707f, 0.999741f,
+                0.999790f, 0.999814f, 0.999835f, 0.999853f, 0.999869f,
+
+                0.999849f, 0.999869f, 0.999885f, 0.999899f, 0.999912f,
+                0.999942f, 0.999949f, 0.999955f, 0.999960f, 0.999965f,
+                0.999972f, 0.999975f, 0.999978f, 0.999980f, 0.999982f });
+
+    auto expClast = NDArrayFactory::create<float>('c', {bS, nOut}, {
+                4.749328f, 4.816851f, 4.883604f, 4.949651f, 5.015049f,
+                5.227203f, 5.291582f, 5.354893f, 5.417225f, 5.478654f,
+                5.584539f, 5.643831f, 5.702098f, 5.759458f, 5.816012f });
+
+    x.linspace(0.15f, 0.25f);
+    Wx.linspace(0.003f, 0.005f);
+    Wr.linspace(0.006f, 0.007f);
+    b.linspace(0.11f, 0.05f);
+    hI.linspace(0.13f, 0.05f);
+    cI.linspace(0.17f, 0.05f);
+
+    std::vector<double>   tArgs = {cellClip};
+    std::vector<Nd4jLong> iArgs = {dataFormat, directionMode, gateAct, cellAct, outAct};
+    std::vector<bool>     bArgs = {hasBiases, hasSeqLen, hasInitH, hasInitC, hasPH, retFullSeq, retLastH, retLastC};
+
+    sd::ops::lstmLayer op;
+    auto results = op.evaluate({&x, &Wx, &Wr, &b, &hI, &cI}, tArgs, iArgs, bArgs);
+
+    sd::Environment::getInstance().setDebug(false);
+    sd::Environment::getInstance().setVerbose(false);
+
+    ASSERT_EQ(ND4J_STATUS_OK, results.status()); 
+    auto h  = results.at(0);
+    auto cL = results.at(2); 
+    ASSERT_TRUE(expH.isSameShape(h));
+    ASSERT_TRUE(expH.equalsTo(h));
+
+    ASSERT_TRUE(expClast.isSameShape(cL));
+    ASSERT_TRUE(expClast.equalsTo(cL));
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests13.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests13.cpp
@@ -1367,8 +1367,7 @@ TEST_F(DeclarableOpsTests13, lstmLayer_4) {
     hI({1,2, 0,0, 0,0}) = -1;
     cI({0,1, 0,0, 0,0}) = 2;
     cI({1,2, 0,0, 0,0}) = -2;
-    hI.printIndexedBuffer("hI");
-    cI.printIndexedBuffer("cI");
+
     std::vector<double>   tArgs = {cellClip};
     std::vector<Nd4jLong> iArgs = {dataFormat, directionMode, gateAct, cellAct, outAct};
     std::vector<bool>     bArgs = {hasBiases, hasSeqLen, hasInitH, hasInitC, hasPH, retFullSeq, retLastH, retLastC};


### PR DESCRIPTION
## What changes were proposed in this pull request?

ctcLoss: refactored to use new scoped Descriptors in cudnn call

Cudnn Lstm:
Forward inference implemented using v6, and v8 (when version > 8.0.1) api calls.
As our Cuda Lstm implementation has 1 layer. Cudnn implementation was implemented for 1 physical layer
Cudnn helper restrictions:
 - all NDArrays should be the same type
 - dataFormat should be 0 or 1
 - only unidirectional (directionMode == 0) and bidirectional concat (directionMode == 3)
 - no peephole connection
 - Clipping is allowed for cudnn version >= 7.2.1
 - SeqLen array is allowed for cudnn version >= 8.0.1
 - gateActivation: sigmoid, cellActivation and outputActivation: tanh
 - NDArrays (excluding weight ones, as we have to transpose or permute it) should follow 'c' order and ews()==1

 
ctcBeam fix: run when NdArray allocated on the device 

## How was this patch tested?

unit tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
