### PR TITLE
Fix compilation error after removal of running benchmark suite

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
@@ -970,15 +970,6 @@ public abstract class DefaultOpExecutioner implements OpExecutioner {
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public String runLightBenchmarkSuit(boolean printOut) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String runFullBenchmarkSuit(boolean printOut) {
-        throw new UnsupportedOperationException();
-    }
 
 
     public void setX(INDArray x, Op op, OpContext oc){

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutioner.java
@@ -471,6 +471,4 @@ public interface OpExecutioner {
     DataBuffer createConstantBuffer(double[] values, DataType desiredType);
 
 
-    String runLightBenchmarkSuit(boolean printOut);
-    String runFullBenchmarkSuit(boolean printOut);
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
@@ -2229,15 +2229,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         return buffer;
     }
 
-    @Override
-    public String runLightBenchmarkSuit(boolean printOut) {
-        return nativeOps.runLightBenchmarkSuit(printOut);
-    }
 
-    @Override
-    public String runFullBenchmarkSuit(boolean printOut) {
-        return nativeOps.runFullBenchmarkSuit(printOut);
-    }
 }
 
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -2064,21 +2064,5 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
     }
 
 
-    @Override
-    public String runLightBenchmarkSuit(boolean printOut) {
-        val s = loop.runLightBenchmarkSuit(printOut);
-        if (loop.lastErrorCode() != 0)
-            throw new RuntimeException(loop.lastErrorMessage());
 
-        return s;
-    }
-
-    @Override
-    public String runFullBenchmarkSuit(boolean printOut) {
-        val s = loop.runFullBenchmarkSuit(printOut);
-        if (loop.lastErrorCode() != 0)
-            throw new RuntimeException(loop.lastErrorMessage());
-
-        return s;
-    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removes benchmark suite related method invocations.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
