### PR TITLE
Global Pooling collapse dimensions  fixes

### DIFF
--- a/.github/actions/build-centos/build.sh
+++ b/.github/actions/build-centos/build.sh
@@ -38,5 +38,6 @@ cd "/github/workspace/"
 bash ./bootstrap-libnd4j-from-url.sh
 
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENBLAS_PATH"
+echo "Running INSTALL COMMAND ${INSTALL_COMMAND}"
 eval "${INSTALL_COMMAND}"
 

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -127,8 +127,8 @@ jobs:
               fi
               command="${command} ${mvn_ext}"
               echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
-              echo "DEPLOY_COMMAND=${command} deploy" >> $GITHUB_ENV
-              echo "INSTALL_COMMAND=${command} install  -Dlibnd4j.cpu.compile.skip=true -Djavacpp.compiler.skip=true -Djavacpp.parser.skip=true" >> "$GITHUB_ENV"
+              echo "DEPLOY_COMMAND=${command} deploy -Dlibnd4j.cpu.compile.skip=true -Djavacpp.compiler.skip=true -Djavacpp.parser.skip=true" >> $GITHUB_ENV
+              echo "INSTALL_COMMAND=${command} install" >> "$GITHUB_ENV"
               echo "COMMAND=${command}" >> "$GITHUB_ENV"
 
       - uses: ./.github/actions/update-deps-linux

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -127,9 +127,9 @@ jobs:
               fi
               command="${command} ${mvn_ext}"
               echo "Setting command for helper ${{ matrix.helper }} and extension ${{ matrix.extension }} to ${command}"
-              echo "DEPLOY_COMMAND=${command} deploy -Dlibnd4j.cpu.compile.skip=true -Djavacpp.compiler.skip=true -Djavacpp.parser.skip=true" >> $GITHUB_ENV
-              echo "INSTALL_COMMAND=${command} install" >> $GITHUB_ENV
-              echo "COMMAND=${command}" >> $GITHUB_ENV
+              echo "DEPLOY_COMMAND=${command} deploy" >> $GITHUB_ENV
+              echo "INSTALL_COMMAND=${command} install  -Dlibnd4j.cpu.compile.skip=true -Djavacpp.compiler.skip=true -Djavacpp.parser.skip=true" >> "$GITHUB_ENV"
+              echo "COMMAND=${command}" >> "$GITHUB_ENV"
 
       - uses: ./.github/actions/update-deps-linux
       - name: Build on  linux-x86_64

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -168,6 +168,7 @@ jobs:
               # Docker builds are root owned
               sudo chown -R $USER $GITHUB_WORKSPACE/*
               if [ "$PERFORM_RELEASE" == 1 ]; then
+                        export COMMAND="${DEPLOY_COMMAND}"
                         bash "$GITHUB_WORKSPACE/release-specified-component.sh" "${RELEASE_VERSION}" "${SNAPSHOT_VERSION}" "${RELEASE_REPO_ID}" "${DEPLOY_COMMAND}"
                        else
                            echo "Running build and deploying to snapshots"

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -49,9 +49,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                        && inputType.getType() != InputType.Type.CNNFlat)) {
+                && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer index = " + layerIndex + ", layer name=\""
-                            + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
+                    + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         return InputType.feedForward(nOut, timeDistributedFormat);
@@ -60,9 +60,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                        && inputType.getType() != InputType.Type.CNNFlat && inputType.getType() != InputType.Type.RNN)) {
+                && inputType.getType() != InputType.Type.CNNFlat && inputType.getType() != InputType.Type.RNN)) {
             throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName()
-                            + "\"): expected FeedForward input type. Got: " + inputType);
+                    + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -71,7 +71,11 @@ public abstract class FeedForwardLayer extends BaseLayer {
                 this.nIn = f.getSize();
             } else if(inputType.getType() == InputType.Type.RNN) {
                 InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
-                this.nIn = recurrent.getSize() * recurrent.getTimeSeriesLength();
+                //default value when initializing input type recurrent
+                if(recurrent.getTimeSeriesLength() < 0) {
+                    this.nIn = recurrent.getSize();
+                }else
+                    this.nIn = recurrent.getSize() * recurrent.getTimeSeriesLength();
             } else {
                 InputType.InputTypeConvolutionalFlat f = (InputType.InputTypeConvolutionalFlat) inputType;
                 this.nIn = f.getFlattenedSize();
@@ -88,7 +92,7 @@ public abstract class FeedForwardLayer extends BaseLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException(
-                            "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
+                    "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
         }
 
         switch (inputType.getType()) {
@@ -107,7 +111,7 @@ public abstract class FeedForwardLayer extends BaseLayer {
                 //CNN3D -> FF
                 InputType.InputTypeConvolutional3D c3d = (InputType.InputTypeConvolutional3D) inputType;
                 return new Cnn3DToFeedForwardPreProcessor(c3d.getDepth(), c3d.getHeight(), c3d.getWidth(),
-                                c3d.getChannels(), c3d.getDataFormat() == Convolution3D.DataFormat.NCDHW);
+                        c3d.getChannels(), c3d.getDataFormat() == Convolution3D.DataFormat.NCDHW);
             default:
                 throw new RuntimeException("Unknown input type: " + inputType);
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -97,13 +97,8 @@ public class GlobalPoolingLayer extends NoParamLayer {
                                 + inputType);
             case RNN:
                 InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
-                if (collapseDimensions) {
-                    //Return 2d (feed-forward) activations
-                    return InputType.feedForward(recurrent.getSize());
-                } else {
-                    //Return 3d activations, with shape [minibatch, timeStepSize, 1]
-                    return recurrent;
-                }
+                //Return 3d activations, with shape [minibatch, timeStepSize, 1]
+                return recurrent;
             case CNN:
                 InputType.InputTypeConvolutional conv = (InputType.InputTypeConvolutional) inputType;
                 if (collapseDimensions) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
@@ -52,14 +52,19 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
     @Override
     public INDArray preProcess(INDArray input, int miniBatchSize, LayerWorkspaceMgr workspaceMgr) {
         //Need to reshape RNN activations (3d) activations to 2d (for input into feed forward layer)
-        if (input.rank() != 3)
-            throw new IllegalArgumentException(
-                            "Invalid input: expect NDArray with rank 3 (i.e., activations for RNN layer)");
-
+        if (input.rank() != 3) {
+            if(input.rank() == 2) {
+                log.trace("Input rank was already 2. RNNToFeedForwardPreProcessor maybe un needed ");
+                return input;
+            }
+            else
+                throw new IllegalArgumentException(
+                        "Invalid input: expect NDArray with rank 3 (i.e., activations for RNN layer)");
+        }
         if (input.ordering() != 'f' || !Shape.hasDefaultStridesForShape(input))
             input = workspaceMgr.dup(ArrayType.ACTIVATIONS, input, 'f');
 
-        if (rnnDataFormat == RNNFormat.NWC){
+        if (rnnDataFormat == RNNFormat.NWC) {
             input = input.permute(0, 2, 1);
         }
         val shape = input.shape();
@@ -82,7 +87,7 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
         //Need to reshape FeedForward layer epsilons (2d) to 3d (for use in RNN layer backprop calculations)
         if (output.rank() != 2)
             throw new IllegalArgumentException(
-                            "Invalid input: expect NDArray with rank 2 (i.e., epsilons from feed forward layer)");
+                    "Invalid input: expect NDArray with rank 2 (i.e., epsilons from feed forward layer)");
         if (output.ordering() != 'f' || !Shape.hasDefaultStridesForShape(output))
             output = workspaceMgr.dup(ArrayType.ACTIVATION_GRAD, output, 'f');
 
@@ -111,7 +116,7 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
 
     @Override
     public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState,
-                    int minibatchSize) {
+                                                          int minibatchSize) {
         //Assume mask array is 2d for time series (1 value per time step)
         if (maskArray == null) {
             return new Pair<>(maskArray, currentMaskState);
@@ -121,7 +126,7 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
                     currentMaskState);
         } else {
             throw new IllegalArgumentException("Received mask array of rank " + maskArray.rank()
-                            + "; expected rank 2 mask array. Mask array shape: " + Arrays.toString(maskArray.shape()));
+                    + "; expected rank 2 mask array. Mask array shape: " + Arrays.toString(maskArray.shape()));
         }
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Global pooling collapse dimensions returned input type feed forward.
This sometimes made interacting with it inconsistent.
Since GlobalPooling is mainly used in the RNN context, it's preferrable to add a pre processor
where necessary and just keep the rnn type for most interactions rather than collapsing to feed forward.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
