### PR TITLE
Global Pooling Collapse Dimension change

### DIFF
--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/HelperUtilsTest.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/layers/HelperUtilsTest.java
@@ -83,8 +83,6 @@ public class HelperUtilsTest extends BaseDL4JTest {
                 LocalResponseNormalizationHelper.class,"layername",getDataType()));
         assertNotNull(HelperUtils.createHelper("", MKLDNNSubsamplingHelper.class.getName(),
                 SubsamplingHelper.class,"layername",getDataType()));
-        assertNotNull(HelperUtils.createHelper("", "",
-                DropoutHelper.class,"layername",getDataType()));
 
     }
 

--- a/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
+++ b/deeplearning4j/deeplearning4j-core/src/test/java/org/deeplearning4j/nn/multilayer/MultiLayerTest.java
@@ -867,7 +867,7 @@ public class MultiLayerTest extends BaseDL4JTest {
         MultiLayerConfiguration conf = builder.build();
         List<InputType> outBuilder = builder.getLayerActivationTypes();
         List<InputType> outConf = conf.getLayerActivationTypes(InputType.recurrent(10));
-        List<InputType> exp = Arrays.asList(InputType.recurrent(6), InputType.recurrent(7), InputType.feedForward(7), InputType.feedForward(8));
+        List<InputType> exp = Arrays.asList(InputType.recurrent(6), InputType.recurrent(7), InputType.recurrent(7), InputType.feedForward(8,RNNFormat.NCW));
         assertEquals(exp, outBuilder);
         assertEquals(exp, outConf);
     }

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasGlobalPooling.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasGlobalPooling.java
@@ -75,7 +75,7 @@ public class KerasGlobalPooling extends KerasLayer {
         GlobalPoolingLayer.Builder builder =
                 new GlobalPoolingLayer.Builder(mapPoolingType(this.className, conf))
                         .poolingDimensions(dimensions)
-                        .collapseDimensions(e) // keras 2 collapses dimensions
+                        .collapseDimensions(true) // keras 2 collapses dimensions
                         .name(this.layerName)
                         .dropOut(this.dropout);
         this.layer = builder.build();

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasGlobalPooling.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasGlobalPooling.java
@@ -75,7 +75,7 @@ public class KerasGlobalPooling extends KerasLayer {
         GlobalPoolingLayer.Builder builder =
                 new GlobalPoolingLayer.Builder(mapPoolingType(this.className, conf))
                         .poolingDimensions(dimensions)
-                        .collapseDimensions(false) // keras 2 collapses dimensions
+                        .collapseDimensions(e) // keras 2 collapses dimensions
                         .name(this.layerName)
                         .dropOut(this.dropout);
         this.layer = builder.build();

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasGlobalPooling.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasGlobalPooling.java
@@ -75,7 +75,7 @@ public class KerasGlobalPooling extends KerasLayer {
         GlobalPoolingLayer.Builder builder =
                 new GlobalPoolingLayer.Builder(mapPoolingType(this.className, conf))
                         .poolingDimensions(dimensions)
-                        .collapseDimensions(true) // keras 2 collapses dimensions
+                        .collapseDimensions(false) // keras 2 collapses dimensions
                         .name(this.layerName)
                         .dropOut(this.dropout);
         this.layer = builder.build();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/BatchNormalization.java
@@ -167,9 +167,6 @@ public class BatchNormalization extends FeedForwardLayer {
         if (inputType.getType() == InputType.Type.CNNFlat) {
             InputType.InputTypeConvolutionalFlat i = (InputType.InputTypeConvolutionalFlat) inputType;
             return new FeedForwardToCnnPreProcessor(i.getHeight(), i.getWidth(), i.getDepth());
-        } else if (inputType.getType() == InputType.Type.RNN) {
-            InputType.InputTypeRecurrent inputTypeRecurrent = (InputType.InputTypeRecurrent) inputType;
-            return new RnnToFeedForwardPreProcessor(inputTypeRecurrent.getFormat());
         }
 
         return null;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -23,6 +23,7 @@ package org.deeplearning4j.nn.conf.layers;
 import lombok.*;
 import org.deeplearning4j.nn.conf.DataFormat;
 import org.deeplearning4j.nn.conf.InputPreProcessor;
+import org.deeplearning4j.nn.conf.RNNFormat;
 import org.deeplearning4j.nn.conf.inputs.InputType;
 import org.deeplearning4j.nn.conf.preprocessor.Cnn3DToFeedForwardPreProcessor;
 import org.deeplearning4j.nn.conf.preprocessor.CnnToFeedForwardPreProcessor;
@@ -74,8 +75,10 @@ public abstract class FeedForwardLayer extends BaseLayer {
                 //default value when initializing input type recurrent
                 if(recurrent.getTimeSeriesLength() < 0) {
                     this.nIn = recurrent.getSize();
-                }else
-                    this.nIn = recurrent.getSize() * recurrent.getTimeSeriesLength();
+                } else {
+                    this.nIn = recurrent.getSize();
+
+                }
             } else {
                 InputType.InputTypeConvolutionalFlat f = (InputType.InputTypeConvolutionalFlat) inputType;
                 this.nIn = f.getFlattenedSize();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/FeedForwardLayer.java
@@ -49,9 +49,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public InputType getOutputType(int layerIndex, InputType inputType) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                        && inputType.getType() != InputType.Type.CNNFlat)) {
+                && inputType.getType() != InputType.Type.CNNFlat)) {
             throw new IllegalStateException("Invalid input type (layer index = " + layerIndex + ", layer name=\""
-                            + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
+                    + getLayerName() + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         return InputType.feedForward(nOut, timeDistributedFormat);
@@ -60,9 +60,9 @@ public abstract class FeedForwardLayer extends BaseLayer {
     @Override
     public void setNIn(InputType inputType, boolean override) {
         if (inputType == null || (inputType.getType() != InputType.Type.FF
-                        && inputType.getType() != InputType.Type.CNNFlat && inputType.getType() != InputType.Type.RNN)) {
+                && inputType.getType() != InputType.Type.CNNFlat && inputType.getType() != InputType.Type.RNN)) {
             throw new IllegalStateException("Invalid input type (layer name=\"" + getLayerName()
-                            + "\"): expected FeedForward input type. Got: " + inputType);
+                    + "\"): expected FeedForward input type. Got: " + inputType);
         }
 
         if (nIn <= 0 || override) {
@@ -71,7 +71,11 @@ public abstract class FeedForwardLayer extends BaseLayer {
                 this.nIn = f.getSize();
             } else if(inputType.getType() == InputType.Type.RNN) {
                 InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
-                this.nIn = recurrent.getSize() * recurrent.getTimeSeriesLength();
+                //default value when initializing input type recurrent
+                if(recurrent.getTimeSeriesLength() < 0) {
+                    this.nIn = recurrent.getSize();
+                }else
+                    this.nIn = recurrent.getSize() * recurrent.getTimeSeriesLength();
             } else {
                 InputType.InputTypeConvolutionalFlat f = (InputType.InputTypeConvolutionalFlat) inputType;
                 this.nIn = f.getFlattenedSize();
@@ -88,7 +92,7 @@ public abstract class FeedForwardLayer extends BaseLayer {
     public InputPreProcessor getPreProcessorForInputType(InputType inputType) {
         if (inputType == null) {
             throw new IllegalStateException(
-                            "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
+                    "Invalid input for layer (layer name = \"" + getLayerName() + "\"): input type is null");
         }
 
         switch (inputType.getType()) {
@@ -107,7 +111,7 @@ public abstract class FeedForwardLayer extends BaseLayer {
                 //CNN3D -> FF
                 InputType.InputTypeConvolutional3D c3d = (InputType.InputTypeConvolutional3D) inputType;
                 return new Cnn3DToFeedForwardPreProcessor(c3d.getDepth(), c3d.getHeight(), c3d.getWidth(),
-                                c3d.getChannels(), c3d.getDataFormat() == Convolution3D.DataFormat.NCDHW);
+                        c3d.getChannels(), c3d.getDataFormat() == Convolution3D.DataFormat.NCDHW);
             default:
                 throw new RuntimeException("Unknown input type: " + inputType);
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -97,13 +97,8 @@ public class GlobalPoolingLayer extends NoParamLayer {
                                 + inputType);
             case RNN:
                 InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
-                if (collapseDimensions) {
-                    //Return 2d (feed-forward) activations
-                    return InputType.feedForward(recurrent.getSize());
-                } else {
-                    //Return 3d activations, with shape [minibatch, timeStepSize, 1]
-                    return recurrent;
-                }
+                //Return 3d activations, with shape [minibatch, timeStepSize, 1]
+                return recurrent;
             case CNN:
                 InputType.InputTypeConvolutional conv = (InputType.InputTypeConvolutional) inputType;
                 if (collapseDimensions) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
@@ -52,14 +52,19 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
     @Override
     public INDArray preProcess(INDArray input, int miniBatchSize, LayerWorkspaceMgr workspaceMgr) {
         //Need to reshape RNN activations (3d) activations to 2d (for input into feed forward layer)
-        if (input.rank() != 3)
-            throw new IllegalArgumentException(
-                            "Invalid input: expect NDArray with rank 3 (i.e., activations for RNN layer)");
-
+        if (input.rank() != 3) {
+            if(input.rank() == 2) {
+                log.trace("Input rank was already 2. RNNToFeedForwardPreProcessor maybe un needed ");
+                return input;
+            }
+            else
+                throw new IllegalArgumentException(
+                        "Invalid input: expect NDArray with rank 3 (i.e., activations for RNN layer)");
+        }
         if (input.ordering() != 'f' || !Shape.hasDefaultStridesForShape(input))
             input = workspaceMgr.dup(ArrayType.ACTIVATIONS, input, 'f');
 
-        if (rnnDataFormat == RNNFormat.NWC){
+        if (rnnDataFormat == RNNFormat.NWC) {
             input = input.permute(0, 2, 1);
         }
         val shape = input.shape();
@@ -82,7 +87,7 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
         //Need to reshape FeedForward layer epsilons (2d) to 3d (for use in RNN layer backprop calculations)
         if (output.rank() != 2)
             throw new IllegalArgumentException(
-                            "Invalid input: expect NDArray with rank 2 (i.e., epsilons from feed forward layer)");
+                    "Invalid input: expect NDArray with rank 2 (i.e., epsilons from feed forward layer)");
         if (output.ordering() != 'f' || !Shape.hasDefaultStridesForShape(output))
             output = workspaceMgr.dup(ArrayType.ACTIVATION_GRAD, output, 'f');
 
@@ -111,7 +116,7 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
 
     @Override
     public Pair<INDArray, MaskState> feedForwardMaskArray(INDArray maskArray, MaskState currentMaskState,
-                    int minibatchSize) {
+                                                          int minibatchSize) {
         //Assume mask array is 2d for time series (1 value per time step)
         if (maskArray == null) {
             return new Pair<>(maskArray, currentMaskState);
@@ -121,7 +126,7 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
                     currentMaskState);
         } else {
             throw new IllegalArgumentException("Received mask array of rank " + maskArray.rank()
-                            + "; expected rank 2 mask array. Mask array shape: " + Arrays.toString(maskArray.shape()));
+                    + "; expected rank 2 mask array. Mask array shape: " + Arrays.toString(maskArray.shape()));
         }
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/preprocessor/RnnToFeedForwardPreProcessor.java
@@ -54,7 +54,7 @@ public class RnnToFeedForwardPreProcessor implements InputPreProcessor {
         //Need to reshape RNN activations (3d) activations to 2d (for input into feed forward layer)
         if (input.rank() != 3) {
             if(input.rank() == 2) {
-                log.trace("Input rank was already 2. RNNToFeedForwardPreProcessor maybe un needed ");
+                log.trace("Input rank was already 2. This can happen when an RNN like layer (such as GlobalPooling) is hooked up to an OutputLayer.");
                 return input;
             }
             else

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/pooling/GlobalPoolingLayer.java
@@ -311,6 +311,10 @@ public class GlobalPoolingLayer extends AbstractLayer<org.deeplearning4j.nn.conf
                 }
 
                 INDArray denom = Transforms.pow(pNorm, pnorm - 1, false);
+                //2 and 3d case
+                if(denom.rank() != epsilon.rank() && denom.length() == epsilon.length()) {
+                    denom = denom.reshape(epsilon.shape());
+                }
                 denom.rdivi(epsilon);
                 Nd4j.getExecutioner().execAndReturn(new BroadcastMulOp(numerator, denom, numerator, broadcastDims));
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -960,9 +960,11 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
 
 
     protected void validateArrayWorkspaces(LayerWorkspaceMgr mgr, INDArray array, ArrayType arrayType, int layerIdx,
-                                           boolean isPreprocessor, String op){
+                                           boolean isPreprocessor, String op) {
         try{
-            mgr.validateArrayLocation(arrayType, array, false, layerIdx > 0);
+            //if the layer is a pre processor be a bit more flexible with migration, for strict layers
+            //throw exception (mainly for performance reasons)
+            mgr.validateArrayLocation(arrayType, array, isPreprocessor, layerIdx > 0);
         } catch (ND4JWorkspaceException e){
             String layerName = layers[layerIdx].conf().getLayer().getLayerName();
             String clazz;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
@@ -204,7 +204,8 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
             //Array is supposed to be detached (no workspace)
             boolean ok = !array.isAttached();
             if(!ok){
-                if(migrateIfInvalid){
+                if(migrateIfInvalid) {
+                    log.trace("Migrating array of type " + arrayType + " to workspace " + getWorkspaceName(arrayType));
                     return leverageTo(arrayType, array);
                 } else {
                     throw new ND4JWorkspaceException("Array workspace validation failed: Array of type " + arrayType


### PR DESCRIPTION
## What changes were proposed in this pull request?
Global pooling collapse dimensions returned input type feed forward.
This sometimes made interacting with it inconsistent.
Since GlobalPooling is mainly used in the RNN context, it's preferrable to add a pre processor
where necessary and just keep the rnn type for most interactions rather than collapsing to feed forward.

(Please fill in changes proposed in this fix)
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
