### PR TITLE
Allow disabling of python  thread management

### DIFF
--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonConstants.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonConstants.java
@@ -1,0 +1,137 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.python4j;
+
+/**
+ *
+ * This class helps control the runtime's {@link PythonExecutioner} -
+ * the {@link PythonExecutioner} is heavily system properties based.
+ * Various aspects of the python executioner can be controlled with
+ * the properties in this class. Python's core behavior of initialization,
+ * python path setting, and working with javacpp's embedded cpython
+ * are keys to integrating the python executioner successfully with various applications.
+ *
+ * @author Adam Gibson
+ */
+public class PythonConstants {
+    public final static String DEFAULT_PYTHON_PATH_PROPERTY = "org.eclipse.python4j.path";
+    public final static String JAVACPP_PYTHON_APPEND_TYPE = "org.eclipse.python4j.path.append";
+    //for embedded execution, this is to ensure we allow customization of the gil state releasing when running in another embedded python situation
+    public final static String RELEASE_GIL_AUTOMATICALLY = "org.eclipse.python4j.release_gil_automatically";
+    public final static String DEFAULT_RELEASE_GIL_AUTOMATICALLY = "true";
+    public final static String DEFAULT_APPEND_TYPE = "before";
+    public final static String INITIALIZE_PYTHON = "org.eclipse.python4j.python.initialize";
+    public final static String DEFAULT_INITIALIZE_PYTHON = "true";
+    public final static String PYTHON_EXEC_RESOURCE = "org/nd4j/python4j/pythonexec/pythonexec.py";
+    final static String PYTHON_EXCEPTION_KEY = "__python_exception__";
+
+
+    /**
+     * Sets the default python path.
+     * See {@link #defaultPythonPath()}
+     * for more information.
+     * @param newPythonPath the new python path to use
+     */
+    public static void setDefaultPythonPath(String newPythonPath) {
+        System.setProperty(DEFAULT_PYTHON_PATH_PROPERTY,newPythonPath);
+    }
+
+    /**
+     * Returns the default python path.
+     * This python path should be initialized before the {@link PythonExecutioner}
+     * is called.
+     * @return
+     */
+    public static String defaultPythonPath() {
+        return System.getProperty(PythonConstants.DEFAULT_PYTHON_PATH_PROPERTY);
+    }
+
+    /**
+     * Returns whether to initialize python or not.
+     * This property is used when python should be initialized manually.
+     * Normally, the {@link PythonExecutioner} will handle initialization
+     * in its {@link PythonExecutioner#init()} method
+     *
+     * @return
+     */
+    public static boolean initializePythonOrNot() {
+        return Boolean.parseBoolean(System.getProperty(INITIALIZE_PYTHON,DEFAULT_INITIALIZE_PYTHON));
+    }
+
+    /**
+     * See {@link #initializePythonOrNot()}
+     *  for more information on this property.
+     *  This is the setter method for the associated value.
+     * @param initializePython whether to initialize python or not
+     */
+    public static void setInitializePython(boolean initializePython) {
+        System.setProperty(INITIALIZE_PYTHON,String.valueOf(initializePython));
+    }
+
+
+    /**
+     * Returns the default javacpp python append type.
+     * In javacpp's cython module, it comes with built in support
+     * for determining the python path of most modules.
+     *
+     * This can clash when invoking python using another distribution of python
+     * such as anaconda. This property allows the user to control how javacpp
+     * interacts with a different python present on the classpath.
+     *
+     * The default value is {@link #DEFAULT_APPEND_TYPE}
+     * @return
+     */
+    public static PythonExecutioner.JavaCppPathType javaCppPythonAppendType() {
+        return PythonExecutioner.JavaCppPathType.valueOf(System.getProperty(JAVACPP_PYTHON_APPEND_TYPE,DEFAULT_APPEND_TYPE).toUpperCase());
+    }
+
+    /**
+     * Setter for the javacpp append type.
+     * See {@link #javaCppPythonAppendType()}
+     * for more information on value set by this setter.
+     * @param appendType the append type to use
+     */
+    public static void setJavacppPythonAppendType(PythonExecutioner.JavaCppPathType appendType) {
+        System.setProperty(JAVACPP_PYTHON_APPEND_TYPE,appendType.name());
+    }
+
+
+    /**
+     * See {@link #gilIsReleaseAutomatically()}
+     * for more information on this setter.
+     * @param releaseGilAutomatically whether to release the gil automatically or not.
+     */
+    public static void setReleaseGilAutomatically(boolean releaseGilAutomatically) {
+        System.setProperty(RELEASE_GIL_AUTOMATICALLY,String.valueOf(releaseGilAutomatically));
+    }
+
+    /**
+     * Returns true if the GIL is released automatically or not.
+     * For linking against applications where python is already present
+     * this is a knob allowing people to turn automatic python thread management off.
+     * This is enabled by default. See {@link #RELEASE_GIL_AUTOMATICALLY}
+     * and its default value {@link #DEFAULT_RELEASE_GIL_AUTOMATICALLY}
+     * @return
+     */
+    public final static boolean gilIsReleaseAutomatically() {
+        return Boolean.parseBoolean(System.getProperty(RELEASE_GIL_AUTOMATICALLY,DEFAULT_RELEASE_GIL_AUTOMATICALLY));
+    }
+
+}

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonConstants.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonConstants.java
@@ -71,12 +71,12 @@ public class PythonConstants {
      *
      * @return
      */
-    public static boolean initializePythonOrNot() {
+    public static boolean initializePython() {
         return Boolean.parseBoolean(System.getProperty(INITIALIZE_PYTHON,DEFAULT_INITIALIZE_PYTHON));
     }
 
     /**
-     * See {@link #initializePythonOrNot()}
+     * See {@link #initializePython()}
      *  for more information on this property.
      *  This is the setter method for the associated value.
      * @param initializePython whether to initialize python or not
@@ -114,7 +114,7 @@ public class PythonConstants {
 
 
     /**
-     * See {@link #gilIsReleaseAutomatically()}
+     * See {@link #releaseGilAutomatically()}
      * for more information on this setter.
      * @param releaseGilAutomatically whether to release the gil automatically or not.
      */
@@ -130,7 +130,7 @@ public class PythonConstants {
      * and its default value {@link #DEFAULT_RELEASE_GIL_AUTOMATICALLY}
      * @return
      */
-    public final static boolean gilIsReleaseAutomatically() {
+    public final static boolean releaseGilAutomatically() {
         return Boolean.parseBoolean(System.getProperty(RELEASE_GIL_AUTOMATICALLY,DEFAULT_RELEASE_GIL_AUTOMATICALLY));
     }
 

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
@@ -77,7 +77,7 @@ public class PythonExecutioner {
 
         init.set(true);
         initPythonPath();
-        if(PythonConstants.initializePythonOrNot())
+        if(PythonConstants.initializePython())
             Py_InitializeEx(0);
         //initialize separately to ensure that numpy import array is not imported twice
         for (PythonType type: PythonTypes.get()) {
@@ -86,7 +86,7 @@ public class PythonExecutioner {
 
         //set the main thread state for the gil
         PythonGIL.setMainThreadState();
-        if(_Py_IsFinalizing() != 1 && PythonConstants.gilIsReleaseAutomatically())
+        if(_Py_IsFinalizing() != 1 && PythonConstants.releaseGilAutomatically())
             PyEval_SaveThread();
 
     }

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
@@ -69,6 +69,9 @@ public class PythonExecutioner {
     private static AtomicBoolean init = new AtomicBoolean(false);
     public final static String DEFAULT_PYTHON_PATH_PROPERTY = "org.eclipse.python4j.path";
     public final static String JAVACPP_PYTHON_APPEND_TYPE = "org.eclipse.python4j.path.append";
+    //for embedded execution, this is to ensure we allow customization of the gil state releasing when running in another embedded python situation
+    public final static String RELEASE_GIL_AUTOMATICALLY = "org.eclipse.python4j.release_gil_automatically";
+    public final static String DEFAULT_RELEASE_GIL_AUTOMATICALLY = "true";
     public final static String DEFAULT_APPEND_TYPE = "before";
     public final static String INITIALIZE_PYTHON = "org.eclipse.python4j.python.initialize";
     public final static String DEFAULT_INITIALIZE_PYTHON = "true";
@@ -92,7 +95,8 @@ public class PythonExecutioner {
 
         //set the main thread state for the gil
         PythonGIL.setMainThreadState();
-        PyEval_SaveThread();
+        if(_Py_IsFinalizing() != 1 && Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+            PyEval_SaveThread();
 
     }
 

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonExecutioner.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.io.IOUtils;
-import org.bytedeco.cpython.PyThreadState;
 import org.bytedeco.cpython.global.python;
 import org.nd4j.common.io.ClassPathResource;
 
@@ -45,7 +44,7 @@ import static org.bytedeco.cpython.helper.python.Py_SetPath;
  * or via a python script.
  *
  * PythonExecutioner has a few java system properties to be aware of when executing python:
- * @link {{@link #DEFAULT_PYTHON_PATH_PROPERTY}} : The default python path to be used by the executioner.
+ * @link {{@link PythonConstants#DEFAULT_PYTHON_PATH_PROPERTY}} : The default python path to be used by the executioner.
  * This can be passed with -Dorg.eclipse.python4j.path=your/python/path
  *
  * Python4j has a default python path that imports the javacpp python path depending on what is present.
@@ -53,7 +52,7 @@ import static org.bytedeco.cpython.helper.python.Py_SetPath;
  * that leverages loading python artifacts from the python path.
  *
  * This python path can be merged with a custom one or just used as is.
- * A user specifies this behavior with the system property {@link #JAVACPP_PYTHON_APPEND_TYPE}
+ * A user specifies this behavior with the system property {@link PythonConstants#JAVACPP_PYTHON_APPEND_TYPE}
  * This property can have 3 possible values:
  * 1. before
  * 2. after
@@ -65,16 +64,8 @@ import static org.bytedeco.cpython.helper.python.Py_SetPath;
  * @author Adam Gibson, Fariz Rahman
  */
 public class PythonExecutioner {
-    private final static String PYTHON_EXCEPTION_KEY = "__python_exception__";
     private static AtomicBoolean init = new AtomicBoolean(false);
-    public final static String DEFAULT_PYTHON_PATH_PROPERTY = "org.eclipse.python4j.path";
-    public final static String JAVACPP_PYTHON_APPEND_TYPE = "org.eclipse.python4j.path.append";
-    //for embedded execution, this is to ensure we allow customization of the gil state releasing when running in another embedded python situation
-    public final static String RELEASE_GIL_AUTOMATICALLY = "org.eclipse.python4j.release_gil_automatically";
-    public final static String DEFAULT_RELEASE_GIL_AUTOMATICALLY = "true";
-    public final static String DEFAULT_APPEND_TYPE = "before";
-    public final static String INITIALIZE_PYTHON = "org.eclipse.python4j.python.initialize";
-    public final static String DEFAULT_INITIALIZE_PYTHON = "true";
+
     static {
         init();
     }
@@ -86,7 +77,7 @@ public class PythonExecutioner {
 
         init.set(true);
         initPythonPath();
-        if(Boolean.parseBoolean(System.getProperty(INITIALIZE_PYTHON,DEFAULT_INITIALIZE_PYTHON)))
+        if(PythonConstants.initializePythonOrNot())
             Py_InitializeEx(0);
         //initialize separately to ensure that numpy import array is not imported twice
         for (PythonType type: PythonTypes.get()) {
@@ -95,7 +86,7 @@ public class PythonExecutioner {
 
         //set the main thread state for the gil
         PythonGIL.setMainThreadState();
-        if(_Py_IsFinalizing() != 1 && Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+        if(_Py_IsFinalizing() != 1 && PythonConstants.gilIsReleaseAutomatically())
             PyEval_SaveThread();
 
     }
@@ -204,16 +195,19 @@ public class PythonExecutioner {
     }
 
     private static void throwIfExecutionFailed() {
-        PythonObject ex = getVariable(PYTHON_EXCEPTION_KEY);
+        PythonObject ex = getVariable(PythonConstants.PYTHON_EXCEPTION_KEY);
         if (ex != null && !ex.isNone() && !ex.toString().isEmpty()) {
-            setVariable(PYTHON_EXCEPTION_KEY, PythonTypes.STR.toPython(""));
+            setVariable(PythonConstants.PYTHON_EXCEPTION_KEY, PythonTypes.STR.toPython(""));
             throw new PythonException(ex);
         }
     }
 
 
     private static String getWrappedCode(String code) {
-        ClassPathResource resource = new ClassPathResource("org/nd4j/python4j/pythonexec/pythonexec.py");
+        ClassPathResource resource = new ClassPathResource(PythonConstants.PYTHON_EXEC_RESOURCE);
+        if(!resource.exists()) {
+            throw new IllegalStateException("Unable to find class path resource for python script execution: " + PythonConstants.PYTHON_EXEC_RESOURCE + " if using via graalvm, please ensure this resource is included in your resources-config.json");
+        }
         try (InputStream is = resource.getInputStream()) {
             String base = IOUtils.toString(is, StandardCharsets.UTF_8);
             String indentedCode = "    " + code.replace("\n", "\n    ");
@@ -323,7 +317,7 @@ public class PythonExecutioner {
 
     private static synchronized void initPythonPath() {
         try {
-            String path = System.getProperty(DEFAULT_PYTHON_PATH_PROPERTY);
+            String path = PythonConstants.defaultPythonPath();
 
             List<File> packagesList = new ArrayList<>();
             packagesList.addAll(Arrays.asList(cachePackages()));
@@ -340,7 +334,7 @@ public class PythonExecutioner {
             } else {
                 StringBuffer sb = new StringBuffer();
 
-                JavaCppPathType pathAppendValue = JavaCppPathType.valueOf(System.getProperty(JAVACPP_PYTHON_APPEND_TYPE, DEFAULT_APPEND_TYPE).toUpperCase());
+                JavaCppPathType pathAppendValue = PythonConstants.javaCppPythonAppendType();
                 switch (pathAppendValue) {
                     case BEFORE:
                         for (File cacheDir : packages) {
@@ -370,7 +364,7 @@ public class PythonExecutioner {
         }
     }
 
-    private enum JavaCppPathType {
+    public enum JavaCppPathType {
         BEFORE, AFTER, NONE
     }
 

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonGIL.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonGIL.java
@@ -132,7 +132,7 @@ public class PythonGIL implements AutoCloseable {
             //From this thread: // PyEval_RestoreThread() should not be called if runtime is finalizing
             // See https://docs.python.org/3/c-api/init.html#c.PyEval_RestoreThread
 
-            if(_Py_IsFinalizing() != 1 && Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+            if(_Py_IsFinalizing() != 1 && PythonConstants.gilIsReleaseAutomatically())
                 PyEval_RestoreThread(mainThreadState);
         }
     }
@@ -140,7 +140,7 @@ public class PythonGIL implements AutoCloseable {
     private  void release() { // do not synchronize!
         if(Thread.currentThread().getId() != mainThreadId) {
             log.debug("Pre gil state release for thread " + Thread.currentThread().getId());
-            if(Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+            if(PythonConstants.gilIsReleaseAutomatically())
                 PyGILState_Release(gilState);
         }
         else {
@@ -148,7 +148,7 @@ public class PythonGIL implements AutoCloseable {
             //From this thread: // PyEval_RestoreThread() should not be called if runtime is finalizing
             // See https://docs.python.org/3/c-api/init.html#c.PyEval_RestoreThread
 
-            if(_Py_IsFinalizing() != 1 && Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+            if(_Py_IsFinalizing() != 1 && PythonConstants.gilIsReleaseAutomatically())
                 PyEval_RestoreThread(mainThreadState);
         }
     }

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonGIL.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonGIL.java
@@ -128,17 +128,28 @@ public class PythonGIL implements AutoCloseable {
             gilState = PyGILState_Ensure();
             log.info("Thread " + Thread.currentThread().getId() + " acquired GIL");
         } else {
-            PyEval_RestoreThread(mainThreadState);
+            //See: https://github.com/pytorch/pytorch/issues/47776#issuecomment-726455206
+            //From this thread: // PyEval_RestoreThread() should not be called if runtime is finalizing
+            // See https://docs.python.org/3/c-api/init.html#c.PyEval_RestoreThread
+
+            if(_Py_IsFinalizing() != 1 && Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+                PyEval_RestoreThread(mainThreadState);
         }
     }
 
     private  void release() { // do not synchronize!
         if(Thread.currentThread().getId() != mainThreadId) {
             log.debug("Pre gil state release for thread " + Thread.currentThread().getId());
-            PyGILState_Release(gilState);
+            if(Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+                PyGILState_Release(gilState);
         }
         else {
-            PyEval_RestoreThread(mainThreadState);
+            //See: https://github.com/pytorch/pytorch/issues/47776#issuecomment-726455206
+            //From this thread: // PyEval_RestoreThread() should not be called if runtime is finalizing
+            // See https://docs.python.org/3/c-api/init.html#c.PyEval_RestoreThread
+
+            if(_Py_IsFinalizing() != 1 && Boolean.parseBoolean(System.getProperty(PythonExecutioner.RELEASE_GIL_AUTOMATICALLY,PythonExecutioner.DEFAULT_RELEASE_GIL_AUTOMATICALLY)))
+                PyEval_RestoreThread(mainThreadState);
         }
     }
 

--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonGIL.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonGIL.java
@@ -132,7 +132,7 @@ public class PythonGIL implements AutoCloseable {
             //From this thread: // PyEval_RestoreThread() should not be called if runtime is finalizing
             // See https://docs.python.org/3/c-api/init.html#c.PyEval_RestoreThread
 
-            if(_Py_IsFinalizing() != 1 && PythonConstants.gilIsReleaseAutomatically())
+            if(_Py_IsFinalizing() != 1 && PythonConstants.releaseGilAutomatically())
                 PyEval_RestoreThread(mainThreadState);
         }
     }
@@ -140,7 +140,7 @@ public class PythonGIL implements AutoCloseable {
     private  void release() { // do not synchronize!
         if(Thread.currentThread().getId() != mainThreadId) {
             log.debug("Pre gil state release for thread " + Thread.currentThread().getId());
-            if(PythonConstants.gilIsReleaseAutomatically())
+            if(PythonConstants.releaseGilAutomatically())
                 PyGILState_Release(gilState);
         }
         else {
@@ -148,7 +148,7 @@ public class PythonGIL implements AutoCloseable {
             //From this thread: // PyEval_RestoreThread() should not be called if runtime is finalizing
             // See https://docs.python.org/3/c-api/init.html#c.PyEval_RestoreThread
 
-            if(_Py_IsFinalizing() != 1 && PythonConstants.gilIsReleaseAutomatically())
+            if(_Py_IsFinalizing() != 1 && PythonConstants.releaseGilAutomatically())
                 PyEval_RestoreThread(mainThreadState);
         }
     }

--- a/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
+++ b/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
@@ -86,7 +86,7 @@ public class NumpyArray extends PythonType<INDArray> {
             }
 
             //ensure python doesn't get initialized twice, this call is needed before numpy import array
-            System.setProperty(PythonExecutioner.INITIALIZE_PYTHON,"false");
+            PythonConstants.setInitializePython(false);
             Py_Initialize();
 
             int err = numpy._import_array();


### PR DESCRIPTION
## What changes were proposed in this pull request?
When embedding python4j in another application running python, it's necessary to disable the in built thread management.
This is due to clashes in the gil state management.
This pull request introduces a property which will allow disabling of the gil management, but be left on by default preserving old behavior.


(Please fill in changes proposed in this fix)

## How was this patch tested?
Tested manually using a cython embedded graalvm library.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
