### PR TITLE
Add more flexible handling of creating numpy arrays

### DIFF
--- a/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonConstants.java
+++ b/python4j/python4j-core/src/main/java/org/nd4j/python4j/PythonConstants.java
@@ -41,6 +41,35 @@ public class PythonConstants {
     public final static String DEFAULT_INITIALIZE_PYTHON = "true";
     public final static String PYTHON_EXEC_RESOURCE = "org/nd4j/python4j/pythonexec/pythonexec.py";
     final static String PYTHON_EXCEPTION_KEY = "__python_exception__";
+    public final static String CREATE_NPY_VIA_PYTHON = "org.eclipse.python4j.create_npy_python";
+    public final static String DEFAULT_CREATE_NPY_VIA_PYTHON = "false";
+
+    /**
+     * Controls how to create the numpy array objects associated
+     * with the NumpyArray.java module.
+     *
+     * Depending on how threading is handled, Py_Type() causes a JVM crash
+     * when used. Py_Type() is used to obtain the type of a numpy array.
+     * Defaults to false, as most of the time this is less performant and not needed.
+     *
+     * The python based method uses raw pointer address + ctypes inline to create the proper numpy array
+     * on the python side.
+     * Otherwise, a more direct c based approach is used.
+     * @return
+     */
+   public static boolean createNpyViaPython() {
+       return Boolean.parseBoolean(System.getProperty(CREATE_NPY_VIA_PYTHON,DEFAULT_CREATE_NPY_VIA_PYTHON));
+   }
+
+    /**
+     * Setter for the associated property
+     * from {@link #createNpyViaPython()}
+     * please see this function for more information.
+     * @param createNpyViaPython
+     */
+   public static void setCreateNpyViaPython(boolean createNpyViaPython) {
+       System.setProperty(CREATE_NPY_VIA_PYTHON,String.valueOf(createNpyViaPython));
+   }
 
 
     /**

--- a/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
+++ b/python4j/python4j-numpy/src/main/java/org/nd4j/python4j/NumpyArray.java
@@ -110,7 +110,7 @@ public class NumpyArray extends PythonType<INDArray> {
 
     @Override
     public INDArray toJava(PythonObject pythonObject) {
-        log.info("Converting PythonObject to INDArray...");
+        log.debug("Converting PythonObject to INDArray...");
         PyObject np = PyImport_ImportModule("numpy");
         PyObject ndarray = PyObject_GetAttrString(np, "ndarray");
         if (PyObject_IsInstance(pythonObject.getNativePythonObject(), ndarray) != 1) {
@@ -199,7 +199,7 @@ public class NumpyArray extends PythonType<INDArray> {
         }
         ret = Nd4j.create(buff, shape, nd4jStrides, 0, Shape.getOrder(shape, nd4jStrides, 1), dtype);
         Nd4j.getAffinityManager().tagLocation(ret, AffinityManager.Location.HOST);
-        log.info("Done.");
+        log.debug("Done creating numpy arrray.");
         return ret;
 
 
@@ -207,7 +207,7 @@ public class NumpyArray extends PythonType<INDArray> {
 
     @Override
     public PythonObject toPython(INDArray indArray) {
-        log.info("Converting INDArray to PythonObject...");
+        log.debug("Converting INDArray to PythonObject...");
         DataType dataType = indArray.dataType();
         DataBuffer buff = indArray.data();
         String key = buff.pointer().address() + "_" + buff.length() + "_" + dataType;
@@ -285,14 +285,14 @@ public class NumpyArray extends PythonType<INDArray> {
         //likely embedded in python, always use this method instead
         if(!PythonConstants.releaseGilAutomatically() || PythonConstants.createNpyViaPython()) {
             try(PythonContextManager.Context context = new PythonContextManager.Context("__np_array_converter")){
-                log.info("Stringing exec...");
+                log.debug("Stringing exec...");
                 String code = "import ctypes\nimport numpy as np\n" +
                         "cArr = (ctypes." + ctype + "*" + indArray.length() + ")"+
                         ".from_address(" + indArray.data().pointer().address() + ")\n"+
                         "npArr = np.frombuffer(cArr, dtype=" + ((numpyType == NPY_HALF) ? "'half'" : "ctypes." + ctype)+
                         ").reshape(" + Arrays.toString(indArray.shape()) + ")";
                 PythonExecutioner.exec(code);
-                log.info("exec done.");
+                log.debug("exec done.");
                 PythonObject ret = PythonExecutioner.getVariable("npArr");
                 Py_IncRef(ret.getNativePythonObject());
                 return ret;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds a property allowing configuration of creating numpy arrays.
JVM crashes can happen when creating numpy arrays off the main thread.

This pull request re introduces the previous method for creating numpy arrays based on ctypes while allowing
either behavior to be used. We also detect the embedded python scenario introduced in https://github.com/eclipse/deeplearning4j/pull/9394
 if the associated gil management control is disabled, it's assumed that creating numpy arrays via ctypes should be the preferred method to avoid crashes. 
 This allows a more consistent experience when creating numpy arrays in an embedded environment.

(Please fill in changes proposed in this fix)

## How was this patch tested?
Manually
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
