### PR TITLE
Fix compilation error with system properties in cuda

### DIFF
--- a/deeplearning4j/deeplearning4j-cuda/src/test/java/org/deeplearning4j/cuda/HelperUtilsTests.java
+++ b/deeplearning4j/deeplearning4j-cuda/src/test/java/org/deeplearning4j/cuda/HelperUtilsTests.java
@@ -15,6 +15,7 @@ import org.deeplearning4j.nn.layers.normalization.LocalResponseNormalizationHelp
 import org.deeplearning4j.nn.layers.recurrent.LSTMHelper;
 import org.junit.jupiter.api.Test;
 import org.nd4j.common.tests.tags.NativeTag;
+import org.deeplearning4j.common.config.DL4JSystemProperties;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -25,9 +26,8 @@ public class HelperUtilsTests extends BaseDL4JTest  {
 
     @Test
     public void testHelperCreation() {
-        System.setProperty(HelperUtils.DISABLE_HELPER_PROPERTY,"false");
+        System.setProperty(DL4JSystemProperties.DISABLE_HELPER_PROPERTY,"false");
 
-        assertNotNull(HelperUtils.createHelper(CudnnLSTMHelper.class.getName(),"", LSTMHelper.class,"layer-name",getDataType()));
         assertNotNull(HelperUtils.createHelper(CudnnDropoutHelper.class.getName(),"", DropoutHelper.class,"layer-name",getDataType()));
         assertNotNull(HelperUtils.createHelper(CudnnConvolutionHelper.class.getName(),"", ConvolutionHelper.class,"layer-name",getDataType()));
         assertNotNull(HelperUtils.createHelper(CudnnLocalResponseNormalizationHelper.class.getName(),"", LocalResponseNormalizationHelper.class,"layer-name",getDataType()));


### PR DESCRIPTION
## What changes were proposed in this pull request?
See build here: https://github.com/eclipse/deeplearning4j/runs/3109317172?check_suite_focus=true  - just need to migrate constant to system properties.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
