### PR TITLE
Allow pre preprocessing hooks to substitute for ops, adds onnx  global pooling averaging and max

### DIFF
--- a/nd4j/samediff-import/pom.xml
+++ b/nd4j/samediff-import/pom.xml
@@ -254,7 +254,7 @@
         </dependency>
         <dependency>
           <groupId>org.nd4j</groupId>
-          <artifactId>nd4j-native-platform</artifactId>
+          <artifactId>nd4j-native</artifactId>
           <version>${nd4j.version}</version>
           <scope>test</scope>
         </dependency>

--- a/nd4j/samediff-import/pom.xml
+++ b/nd4j/samediff-import/pom.xml
@@ -254,7 +254,7 @@
         </dependency>
         <dependency>
           <groupId>org.nd4j</groupId>
-          <artifactId>nd4j-native</artifactId>
+          <artifactId>nd4j-native-platform</artifactId>
           <version>${nd4j.version}</version>
           <scope>test</scope>
         </dependency>

--- a/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/context/AbstractMappingContext.kt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/context/AbstractMappingContext.kt
@@ -63,12 +63,12 @@ abstract class AbstractMappingContext<GRAPH_TYPE: GeneratedMessageV3,
             relevantPreProcessingHooks.addAll(hooks)
         }
 
-        ImportReflectionCache.preProcessRuleImplementationsByOp.filterKeys { input -> input == nd4jOpName() }.values.forEach { hooks ->
+        ImportReflectionCache.preProcessRuleImplementationsByOp.filterKeys { input -> input == opName() }.values.forEach { hooks ->
             relevantPreProcessingHooks.addAll(hooks)
         }
 
 
-        ImportReflectionCache.postProcessRuleImplementationsByOp.filterKeys { input -> input == nd4jOpName() }.values.forEach { hooks ->
+        ImportReflectionCache.postProcessRuleImplementationsByOp.filterKeys { input -> input == opName() }.values.forEach { hooks ->
             relevantPostProcessingHooks.addAll(hooks)
         }
 

--- a/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/reflect/ImportReflectionCache.kt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/reflect/ImportReflectionCache.kt
@@ -53,7 +53,7 @@ object ImportReflectionCache {
             val opNames = rule.parameterValues["opNames"].value as Array<String>
             opNames.forEach { opName ->
                 if(!preProcessRuleImplementationsByOp.containsKey(opName)) {
-                    preProcessRuleImplementationsByNode[opName] = ArrayList()
+                    preProcessRuleImplementationsByOp[opName] = ArrayList()
                 }
 
                 preProcessRuleImplementationsByOp[opName]!!.add(instance)

--- a/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/registry/OpMappingRegistry.kt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/registry/OpMappingRegistry.kt
@@ -32,6 +32,7 @@ import org.nd4j.samediff.frameworkimport.findOp
 import org.nd4j.samediff.frameworkimport.opdefs.OpDescriptorLoaderHolder
 import org.nd4j.samediff.frameworkimport.process.MappingProcess
 import org.nd4j.samediff.frameworkimport.process.MappingProcessLoader
+import org.nd4j.samediff.frameworkimport.reflect.ImportReflectionCache
 import org.nd4j.shade.protobuf.TextFormat
 import java.io.File
 import java.lang.IllegalArgumentException
@@ -47,20 +48,13 @@ class OpMappingRegistry<GRAPH_TYPE: GeneratedMessageV3,
         ATTRIBUTE_VALUE_TYPE: GeneratedMessageV3>(inputFrameworkName: String,nd4jOpDescriptors: OpNamespace.OpDescriptorList) {
 
     val registeredOps: MultiValuedMap<String, MappingProcess<GRAPH_TYPE, OP_DEF_TYPE, NODE_TYPE,
-            TENSOR_TYPE, ATTRIBUTE_TYPE, ATTRIBUTE_VALUE_TYPE, DATA_TYPE>> = HashSetValuedHashMap<
-            String,MappingProcess<GRAPH_TYPE,
-            OP_DEF_TYPE,
-            NODE_TYPE,
-            TENSOR_TYPE,
-            ATTRIBUTE_TYPE,
-            ATTRIBUTE_VALUE_TYPE,
-            DATA_TYPE>>()
+            TENSOR_TYPE, ATTRIBUTE_TYPE, ATTRIBUTE_VALUE_TYPE, DATA_TYPE>> = HashSetValuedHashMap()
 
     val opDefList = HashMap<String,OP_DEF_TYPE>()
     val nd4jOpDefs = HashMap<String,OpNamespace.OpDescriptor>()
     val inputFrameworkName = inputFrameworkName
     val nd4jOpDescriptors = nd4jOpDescriptors
-
+    val cache = ImportReflectionCache
 
     fun mappedNd4jOpNames(): Set<String> {
         return registeredOps.values().map { input -> input.opName() }.toSortedSet()!!
@@ -126,7 +120,13 @@ class OpMappingRegistry<GRAPH_TYPE: GeneratedMessageV3,
 
 
         if(!registeredOps.containsKey(inputFrameworkOpName)) {
-            throw IllegalArgumentException("No import process defined for $inputFrameworkOpName")
+            val allRules = cache.preProcessRuleImplementationsByOp
+            val noRules = allRules.filterKeys { input -> input == inputFrameworkOpName }.values.isEmpty()
+            if(noRules)
+                throw IllegalArgumentException("No import process defined for $inputFrameworkOpName")
+            else {
+                println()
+            }
         }
         return registeredOps[inputFrameworkOpName]!!.first()
     }
@@ -135,6 +135,13 @@ class OpMappingRegistry<GRAPH_TYPE: GeneratedMessageV3,
         val descriptor = nd4jOpDescriptors.findOp(nd4jOpName)
         return descriptor.opDeclarationType
     }
+
+    fun opHasRuleNoProcess(inputFrameworkOpName: String): Boolean {
+        val allRules = cache.preProcessRuleImplementationsByOp
+        val noRules = allRules.filterKeys { input -> input == inputFrameworkOpName }.values.isEmpty()
+        return noRules && !registeredOps.containsKey(inputFrameworkOpName)
+    }
+
 
     /**
      * TODO: Make loading op mapping rules (both tensor and attribute), input framework op definitions casted as

--- a/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/rule/attribute/ValueMapping.kt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/rule/attribute/ValueMapping.kt
@@ -110,7 +110,7 @@ abstract class ValueMapping<
                 }
 
                 else -> {
-                    throw IllegalArgumentException("Unable to map value $k. Please use different rule for list values and tensors.")
+                    throw IllegalArgumentException("Unable to map value $k for op name ${mappingCtx.opName() }. Please use different rule for list values and tensors.")
                 }
             }
 

--- a/nd4j/samediff-import/samediff-import-api/src/main/resources/nd4j-op-def.pbtxt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/resources/nd4j-op-def.pbtxt
@@ -21,21 +21,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "thresholdRelative"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "thresholdAbsolute"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "y"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "thresholdRelative"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "thresholdAbsolute"
+    argType: DOUBLE
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -51,14 +51,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -67,6 +59,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -74,6 +74,10 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
@@ -87,10 +91,6 @@ opList {
     name: "clipValueMax"
     argType: DOUBLE
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
 }
 opList {
@@ -172,10 +172,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -198,6 +194,10 @@ opList {
     name: "dLdy"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -227,10 +227,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -238,6 +234,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -306,16 +306,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
+    name: "condition"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "isConstant"
     argType: BOOL
   }
   argDescriptor {
-    name: "condition"
-    argType: INPUT_TENSOR
+    name: "frameName"
+    argType: STRING
   }
   opDeclarationType: LOGIC_OP_IMPL
 }
@@ -330,12 +330,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -350,10 +350,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -361,6 +357,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -371,16 +371,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "pow"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -395,6 +395,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -402,10 +406,6 @@ opList {
     name: "precise"
     argType: BOOL
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -420,10 +420,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -431,6 +427,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -445,10 +445,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -456,6 +452,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -470,12 +470,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -490,21 +490,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "absolute_difference_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -527,13 +523,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "absolute_difference_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "absolute_difference_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -566,6 +562,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "acos"
@@ -578,12 +578,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -598,12 +598,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -622,15 +622,6 @@ opList {
     name: "stateMsdx"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dRho"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "gradient"
@@ -661,6 +652,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 5
   }
+  argDescriptor {
+    name: "dRho"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -672,15 +672,6 @@ opList {
   argDescriptor {
     name: "stateH"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -702,14 +693,19 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "ada_max_updater"
-  argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
   argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
@@ -723,25 +719,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -776,16 +753,35 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adabelief_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -798,25 +794,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -851,16 +828,35 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adam_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -873,25 +869,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -926,6 +903,29 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -940,10 +940,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -951,6 +947,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -970,10 +970,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -987,6 +983,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "add_scalar"
@@ -995,12 +995,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1028,10 +1028,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -1040,14 +1036,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "factor"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adjust_hue"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -1061,21 +1057,21 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "adjust_saturation"
   argDescriptor {
     name: "dimC"
     argType: INT64
   }
   argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "adjust_saturation"
+  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "factor"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -1085,22 +1081,18 @@ opList {
     name: "factor"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "all"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1110,6 +1102,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1120,7 +1120,11 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "a"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "p"
     argType: DOUBLE
   }
   argDescriptor {
@@ -1138,21 +1142,31 @@ opList {
     argType: DOUBLE
     argIndex: 3
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "alpha_dropout_bp"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradOut"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "reduceShape"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
   }
   argDescriptor {
     name: "probValue"
@@ -1173,44 +1187,30 @@ opList {
     argType: DOUBLE
     argIndex: 3
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradOut"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "reduceShape"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "amax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
     name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1238,16 +1238,8 @@ opList {
 opList {
   name: "amean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1257,22 +1249,22 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "amin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1282,6 +1274,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1309,10 +1309,6 @@ opList {
 opList {
   name: "ams_grad_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -1329,25 +1325,6 @@ opList {
   argDescriptor {
     name: "stateH"
     argType: OUTPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
     argIndex: 3
   }
   argDescriptor {
@@ -1389,6 +1366,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -1402,10 +1402,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -1413,6 +1409,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1423,28 +1423,20 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "any"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1455,6 +1447,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -1462,10 +1462,6 @@ opList {
   argDescriptor {
     name: "Z"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "lr"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "parameters"
@@ -1481,6 +1477,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "lr"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -1493,20 +1493,12 @@ opList {
 opList {
   name: "argamax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1516,25 +1508,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argamin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1544,25 +1536,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argmax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1572,25 +1564,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argmin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1600,6 +1592,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -1613,12 +1613,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1633,12 +1633,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1692,16 +1692,8 @@ opList {
 opList {
   name: "asum"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1711,6 +1703,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1725,12 +1725,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1745,18 +1745,30 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "avgpool2d"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "kH"
     argType: INT64
   }
@@ -1809,23 +1821,28 @@ opList {
     name: "isNCHW"
     argType: INT64
     argIndex: 10
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
 }
 opList {
   name: "avgpool2d_bp"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "gradI"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
     name: "kH"
     argType: INT64
   }
@@ -1879,100 +1896,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "avgpool3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 11
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 12
-  }
-  argDescriptor {
-    name: "extraParam0"
-    argType: INT64
-    argIndex: 13
-  }
-  argDescriptor {
-    name: "isNCDHW"
-    argType: INT64
-    argIndex: 14
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -1985,9 +1911,6 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "avgpool3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -2062,6 +1985,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "avgpool3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2079,13 +2005,83 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "extraParam0"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "axpy"
-  argDescriptor {
-    name: "n"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -2093,10 +2089,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "a"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -2112,14 +2104,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "n"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "a"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "barnes_edge_forces"
-  argDescriptor {
-    name: "N"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2147,6 +2143,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "N"
+    argType: INT64
+  }
 }
 opList {
   name: "barnes_gains"
@@ -2172,10 +2172,6 @@ opList {
 }
 opList {
   name: "barnes_symmetrized"
-  argDescriptor {
-    name: "N"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2213,23 +2209,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "N"
+    argType: INT64
+  }
 }
 opList {
   name: "batch_to_space"
-  argDescriptor {
-    name: "blockSize"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "croppingTop"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "croppingBottom"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2247,13 +2233,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blockSize"
+    argType: INT64
+  }
 }
 opList {
   name: "batch_to_space_nd"
-  argDescriptor {
-    name: "blocks"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2261,10 +2251,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -2280,9 +2266,53 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blocks"
+    argType: INT64
+  }
 }
 opList {
   name: "batched_gemm"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "vC"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "beta"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "vA"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "vB"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "transposeA"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "transposeB"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "transA"
     argType: INT64
@@ -2327,54 +2357,9 @@ opList {
     argType: INT64
     argIndex: 8
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "vC"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "transposeA"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "transposeB"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "beta"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "vA"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "vB"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "batchnorm"
-  argDescriptor {
-    name: "applyScale"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "applyOffset"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2382,24 +2367,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "applyGamma"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "applyBeta"
-    argType: BOOL
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -2420,9 +2387,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "batchnorm_bp"
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "applyGamma"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "applyBeta"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "applyScale"
     argType: INT64
@@ -2432,6 +2414,9 @@ opList {
     argType: INT64
     argIndex: 1
   }
+}
+opList {
+  name: "batchnorm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2456,24 +2441,6 @@ opList {
     argIndex: 3
   }
   argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "applyGamma"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "applyBeta"
-    argType: BOOL
-    argIndex: 2
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2491,6 +2458,33 @@ opList {
     name: "gamma"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "applyGamma"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "applyBeta"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "applyScale"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "applyOffset"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -2526,10 +2520,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2537,6 +2527,10 @@ opList {
     name: "bias"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
   }
 }
 opList {
@@ -2555,10 +2549,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2572,23 +2562,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
 }
 opList {
   name: "bincount"
-  argDescriptor {
-    name: "minLength"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "maxLength"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outputType"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "outputType"
     argType: DATA_TYPE
@@ -2616,13 +2596,23 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "minLength"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "maxLength"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "outputType"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "bitcast"
-  argDescriptor {
-    name: "newType"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2639,6 +2629,10 @@ opList {
     name: "dataType"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "newType"
+    argType: INT64
   }
 }
 opList {
@@ -2672,10 +2666,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2683,6 +2673,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2697,10 +2691,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2708,6 +2698,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2722,10 +2716,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2733,6 +2723,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2823,6 +2817,18 @@ opList {
 opList {
   name: "broadcast_amax"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2830,24 +2836,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_amin"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2855,18 +2861,6 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -2893,16 +2887,8 @@ opList {
 opList {
   name: "broadcast_equalto"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -2913,10 +2899,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_greaterthan"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   argDescriptor {
     name: "shape"
     argType: INT64
@@ -2925,24 +2931,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_greaterthanorequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2950,24 +2956,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_lessthan"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2975,24 +2981,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_lessthanorequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3000,24 +3006,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_max"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3025,24 +3031,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_min"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3050,24 +3056,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_notequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3075,18 +3081,6 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -3113,10 +3107,6 @@ opList {
 opList {
   name: "broadcastadd"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -3128,12 +3118,32 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastcopy"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3141,24 +3151,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastdiv"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3166,28 +3176,12 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastgradientargs"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -3199,12 +3193,32 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: OP_IMPL
 }
 opList {
   name: "broadcastmul"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3212,24 +3226,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastrdiv"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3237,24 +3251,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastrsub"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3262,24 +3276,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastsub"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3288,26 +3302,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "car"
-  argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -3315,20 +3313,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "compare"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "set"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -3339,21 +3323,9 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "cas"
   argDescriptor {
     name: "mode"
     argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "compare"
@@ -3369,18 +3341,44 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "cas"
+  argDescriptor {
+    name: "dataType"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "compare"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "set"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
+    argIndex: 2
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cast"
-  argDescriptor {
-    name: "dst"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3390,37 +3388,23 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dst"
+    argType: INT64
   }
 }
 opList {
   name: "cbow"
   argDescriptor {
-    name: "numWorkers"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "nsRounds"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "trainWords"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "isInference"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "target"
@@ -3496,6 +3480,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 14
   }
+  argDescriptor {
+    name: "trainWords"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isInference"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numWorkers"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "nsRounds"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -3509,21 +3511,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cell_contains"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3531,10 +3529,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "contains"
-    argType: BOOL
   }
   argDescriptor {
     name: "corner"
@@ -3549,6 +3543,14 @@ opList {
     name: "point"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "contains"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
 }
 opList {
@@ -3603,10 +3605,6 @@ opList {
 opList {
   name: "choose"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -3620,10 +3618,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "scalar"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "arg"
     argType: INPUT_TENSOR
   }
@@ -3631,6 +3625,14 @@ opList {
     name: "comp"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "scalar"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3644,31 +3646,31 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
   }
 }
 opList {
   name: "clipbyavgnorm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -3683,10 +3685,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3695,33 +3693,33 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "clipbynorm"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipValue"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "clipbynorm_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3731,10 +3729,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3742,6 +3736,14 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipValue"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3751,6 +3753,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "left"
     argType: DOUBLE
   }
@@ -3758,10 +3764,6 @@ opList {
     name: "right"
     argType: DOUBLE
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -3779,6 +3781,23 @@ opList {
 }
 opList {
   name: "col2im"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inputArrays"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
   argDescriptor {
     name: "strideY"
     argType: INT64
@@ -3818,23 +3837,6 @@ opList {
     argType: INT64
     argIndex: 7
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inputArrays"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "compare_and_bitpack"
@@ -3847,10 +3849,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3858,6 +3856,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3928,20 +3930,12 @@ opList {
 opList {
   name: "concat"
   argDescriptor {
-    name: "concatDimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isDynamicAxis"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -3952,13 +3946,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "concat_bp"
+  argDescriptor {
+    name: "isDynamicAxis"
+    argType: BOOL
+  }
   argDescriptor {
     name: "concatDimension"
     argType: INT64
   }
+}
+opList {
+  name: "concat_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3966,10 +3964,6 @@ opList {
   argDescriptor {
     name: "epsilonChunk"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dynamicAxis"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -3980,18 +3974,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dynamicAxis"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "concatDimension"
+    argType: INT64
+  }
 }
 opList {
   name: "confusion_matrix"
-  argDescriptor {
-    name: "numClasses"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4014,9 +4007,35 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numClasses"
+    argType: INT64
+  }
 }
 opList {
   name: "conv1d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "weights"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "bias"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
   argDescriptor {
     name: "kW"
     argType: INT64
@@ -4050,33 +4069,48 @@ opList {
     name: "wFormat"
     argType: INT64
     argIndex: 6
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "bias"
-    argType: INPUT_TENSOR
-    argIndex: 2
   }
 }
 opList {
   name: "conv1d_bp"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "gradI"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradW"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gradB"
+    argType: OUTPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "weights"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "bias"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
     name: "kW"
     argType: INT64
   }
@@ -4110,100 +4144,9 @@ opList {
     argType: INT64
     argIndex: 6
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradW"
-    argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gradB"
-    argType: OUTPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "bias"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "conv2d"
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4226,9 +4169,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -4283,6 +4223,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "conv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4320,9 +4263,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "conv2d_input_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -4377,6 +4317,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "conv2d_input_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4399,83 +4342,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
-    name: "paddingMode"
+    name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
     name: "wFormat"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "conv3dnew"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4498,9 +4421,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -4575,6 +4495,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "conv3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4612,6 +4535,80 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "paddingMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "copy"
@@ -4624,10 +4621,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -4635,6 +4628,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -4649,12 +4646,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -4669,26 +4666,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cosine_distance_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4711,9 +4699,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "cosine_distance_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
@@ -4723,6 +4708,9 @@ opList {
     argType: INT64
     argIndex: 1
   }
+}
+opList {
+  name: "cosine_distance_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4755,16 +4743,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "cosinedistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -4776,25 +4778,25 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cosinesimilarity"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -4806,29 +4808,16 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "countNonZero"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -4838,22 +4827,22 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "countZero"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -4864,19 +4853,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "create"
-  argDescriptor {
-    name: "order"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputType"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "outputType"
     argType: DATA_TYPE
@@ -4886,16 +4874,33 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "init"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "order"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "outputType"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "create_list"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "create_list"
   argDescriptor {
     name: "height"
     argType: INT64
@@ -4904,14 +4909,6 @@ opList {
     name: "expandable"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LIST_OP_IMPL
 }
@@ -4953,20 +4950,12 @@ opList {
 opList {
   name: "crop_and_resize"
   argDescriptor {
-    name: "method"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "extrapolationVal"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "image"
@@ -4987,6 +4976,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "method"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "extrapolationVal"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "cross"
@@ -5006,11 +5003,55 @@ opList {
   opDeclarationType: OP_IMPL
 }
 opList {
-  name: "ctc_loss"
+  name: "ctc_beam"
   argDescriptor {
-    name: "blankIndex"
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "result_sequences"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "result_probs"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "result_sequences_length"
+    argType: OUTPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "logit"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "sequence_length"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "normalize_logits"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blank_index"
     argType: INT64
   }
+  argDescriptor {
+    name: "beam_width"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "nbest_len"
+    argType: INT64
+    argIndex: 2
+  }
+}
+opList {
+  name: "ctc_loss"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5038,13 +5079,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "ctc_loss_grad"
   argDescriptor {
     name: "blankIndex"
     argType: INT64
   }
+}
+opList {
+  name: "ctc_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5072,6 +5113,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "blankIndex"
+    argType: INT64
+  }
 }
 opList {
   name: "cube"
@@ -5084,12 +5129,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -5121,18 +5166,40 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cumprod"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
     name: "exclusive"
     argType: INT64
   }
@@ -5145,63 +5212,18 @@ opList {
     name: "dimensions"
     argType: INT64
     argIndex: 2
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "cumprod_bp"
   argDescriptor {
-    name: "exclusive"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5215,37 +5237,37 @@ opList {
   argDescriptor {
     name: "gradOut"
     argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 2
   }
 }
 opList {
   name: "cumsum"
   argDescriptor {
-    name: "exclusive"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5256,10 +5278,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "cumsum_bp"
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "exclusive"
     argType: INT64
@@ -5274,6 +5301,10 @@ opList {
     argType: INT64
     argIndex: 2
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "cumsum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5281,15 +5312,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5303,6 +5325,29 @@ opList {
   argDescriptor {
     name: "gradOut"
     argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 2
   }
 }
@@ -5317,10 +5362,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -5328,6 +5369,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -5342,10 +5387,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -5353,6 +5394,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -5399,60 +5444,6 @@ opList {
 opList {
   name: "deconv2d"
   argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -5474,9 +5465,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -5531,6 +5519,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "deconv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5568,9 +5559,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "deconv2d_tf"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -5625,6 +5613,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "deconv2d_tf"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5647,83 +5638,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv3d"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
     name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
     name: "wFormat"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "deconv3d"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5746,9 +5717,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv3d_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -5823,6 +5791,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "deconv3d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5859,6 +5830,80 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 14
   }
 }
 opList {
@@ -5885,15 +5930,6 @@ opList {
 opList {
   name: "depth_to_space"
   argDescriptor {
-    name: "block_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isNHWC"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -5905,63 +5941,18 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "depthwise_conv2d"
   argDescriptor {
-    name: "kH"
+    name: "block_size"
     argType: INT64
   }
   argDescriptor {
-    name: "kW"
+    name: "isNHWC"
     argType: INT64
     argIndex: 1
   }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
+}
+opList {
+  name: "depthwise_conv2d"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5984,9 +5975,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "depthwise_conv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -6041,6 +6029,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "depthwise_conv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6078,6 +6069,60 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 10
+  }
 }
 opList {
   name: "diag"
@@ -6090,12 +6135,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6109,12 +6154,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6132,35 +6177,12 @@ opList {
 opList {
   name: "dilation2d"
   argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "rates"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "strides"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -6181,9 +6203,40 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "isSameMode"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "rates"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "strides"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "distribution_bernoulli"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "prob"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6193,18 +6246,18 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_binomial"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "prob"
+    name: "probability"
     argType: DOUBLE
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_binomial"
   argDescriptor {
     name: "trials"
     argType: INT64
@@ -6219,25 +6272,17 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "probability"
-    argType: DOUBLE
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "distribution_binomial_ex"
   argDescriptor {
-    name: "trials"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "trials"
+    argType: INT64
   }
   argDescriptor {
     name: "probability"
@@ -6248,15 +6293,6 @@ opList {
 opList {
   name: "distribution_gaussian"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -6267,6 +6303,15 @@ opList {
   argDescriptor {
     name: "stddev"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "shape"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -6274,20 +6319,11 @@ opList {
 opList {
   name: "distribution_lognormal"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "mean"
+    name: "stddev"
     argType: DOUBLE
   }
   argDescriptor {
@@ -6295,10 +6331,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_truncated"
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6308,6 +6340,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_truncated"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -6321,10 +6357,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_uniform"
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6334,6 +6366,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_uniform"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -6345,6 +6381,15 @@ opList {
   argDescriptor {
     name: "to"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "shape"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -6377,10 +6422,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6388,6 +6429,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -6407,10 +6452,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6423,6 +6464,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6445,12 +6490,17 @@ opList {
 opList {
   name: "dot"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "newFormat"
@@ -6462,27 +6512,13 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "dot_product_attention"
-  argDescriptor {
-    name: "normalization"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputWeights"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6494,15 +6530,6 @@ opList {
   argDescriptor {
     name: "weights"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "withWeights"
-    argType: BOOL
     argIndex: 1
   }
   argDescriptor {
@@ -6524,13 +6551,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "dot_product_attention_bp"
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "withWeights"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "normalization"
     argType: INT64
   }
+  argDescriptor {
+    name: "outputWeights"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "dot_product_attention_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6548,10 +6589,6 @@ opList {
     name: "dLdv"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
   }
   argDescriptor {
     name: "queries"
@@ -6576,6 +6613,14 @@ opList {
     name: "mask"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "normalization"
+    argType: INT64
   }
 }
 opList {
@@ -6603,16 +6648,8 @@ opList {
 opList {
   name: "dropout"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "probValue"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -6623,21 +6660,21 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "dropout_bp"
   argDescriptor {
     name: "seed"
     argType: INT64
   }
   argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
     name: "probValue"
     argType: DOUBLE
+  }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "dropout_bp"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -6653,6 +6690,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "probValue"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -6662,21 +6707,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "p"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "p"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "dynamic_bidirectional_rnn"
-  argDescriptor {
-    name: "timeMajor"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6744,13 +6785,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
+  argDescriptor {
+    name: "timeMajor"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_partition"
-  argDescriptor {
-    name: "numPartitions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6768,13 +6809,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "numPartitions"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_partition_bp"
-  argDescriptor {
-    name: "numPartition"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6797,13 +6838,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numPartition"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_rnn"
-  argDescriptor {
-    name: "timeMajor"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6841,13 +6882,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "timeMajor"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_stitch"
-  argDescriptor {
-    name: "numPartitions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6865,6 +6906,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "numPartitions"
+    argType: INT64
+  }
+}
+opList {
+  name: "eig"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "eig_vals"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "eig_vectors"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
 }
 opList {
   name: "elu"
@@ -6873,12 +6938,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -6889,10 +6954,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6901,14 +6962,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "embedding_lookup"
-  argDescriptor {
-    name: "partition_mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6925,6 +6986,10 @@ opList {
     name: "indices"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "partition_mode"
+    argType: INT64
   }
 }
 opList {
@@ -6943,10 +7008,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6960,13 +7021,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "encode_threshold"
-  argDescriptor {
-    name: "boundary"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6981,10 +7042,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6992,6 +7049,14 @@ opList {
     name: "encoded"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "boundary"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
   }
 }
 opList {
@@ -7001,31 +7066,23 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "isConstant"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
   name: "entropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -7035,6 +7092,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7057,6 +7122,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -7066,12 +7135,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7086,10 +7155,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7097,6 +7162,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -7107,32 +7176,20 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "equals_with_eps"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -7142,6 +7199,18 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7156,12 +7225,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7176,24 +7245,29 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "euclidean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -7205,13 +7279,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7226,21 +7295,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "oldFormat"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "inputShape"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "dimensions"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "oldFormat"
+    argType: BOOL
     argIndex: 1
   }
 }
@@ -7251,12 +7320,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -7270,21 +7339,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "expand_dims"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7294,12 +7359,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7313,12 +7378,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7339,6 +7404,22 @@ opList {
 }
 opList {
   name: "extract_image_patches"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "sameMode"
+    argType: BOOL
+  }
   argDescriptor {
     name: "ksizeRows"
     argType: INT64
@@ -7373,6 +7454,9 @@ opList {
     argType: INT64
     argIndex: 6
   }
+}
+opList {
+  name: "eye"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7382,16 +7466,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "sameMode"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
+    name: "numRows"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "eye"
+  argDescriptor {
+    name: "numCols"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "numRows"
     argType: INT64
@@ -7411,41 +7497,24 @@ opList {
     argType: INT64
     argIndex: 3
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "numRows"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "numCols"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "fake_quant_with_min_max_args"
   argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "narrowRange"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "numBits"
+    argType: INT64
   }
   argDescriptor {
     name: "min"
@@ -7456,24 +7525,34 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "fake_quant_with_min_max_vars"
-  argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "min"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "max"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
     name: "narrowed"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "numBits"
+    argType: INT64
   }
   argDescriptor {
     name: "m"
@@ -7484,6 +7563,14 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "fake_quant_with_min_max_vars_per_channel"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
@@ -7497,45 +7584,19 @@ opList {
     name: "max"
     argType: INPUT_TENSOR
     argIndex: 2
-  }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "fake_quant_with_min_max_vars_per_channel"
-  argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "narrowed"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "min"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "max"
-    argType: INPUT_TENSOR
-    argIndex: 2
+    name: "numBits"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "fill"
-  argDescriptor {
-    name: "dtype"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7545,10 +7606,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "value"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "shape"
     argType: INPUT_TENSOR
   }
@@ -7556,6 +7613,14 @@ opList {
     name: "outputs"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dtype"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "value"
+    argType: DOUBLE
   }
 }
 opList {
@@ -7588,16 +7653,20 @@ opList {
 opList {
   name: "first_index"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -7608,19 +7677,11 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "flatten"
   argDescriptor {
-    name: "order"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7631,15 +7692,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "order"
+    argType: INT64
   }
 }
 opList {
   name: "flatten_2d"
   argDescriptor {
-    name: "flattenDimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7650,6 +7711,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7663,12 +7728,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7683,10 +7748,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7694,6 +7755,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -7713,10 +7778,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7730,6 +7791,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "floormod"
@@ -7742,10 +7807,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7753,6 +7814,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -7772,10 +7837,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7789,6 +7850,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "fmod"
@@ -7801,10 +7866,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7812,6 +7873,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7835,15 +7900,6 @@ opList {
 opList {
   name: "fused_batch_norm"
   argDescriptor {
-    name: "dataFormat"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isTraining"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7860,10 +7916,6 @@ opList {
     name: "batchVar"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -7894,13 +7946,22 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 5
   }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "isTraining"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "gather"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7908,10 +7969,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -7926,6 +7983,14 @@ opList {
     name: "intArgs"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7960,10 +8025,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7971,6 +8032,10 @@ opList {
     name: "indices"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
   }
 }
 opList {
@@ -7984,6 +8049,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -7991,10 +8060,6 @@ opList {
     name: "precise"
     argType: BOOL
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8036,10 +8101,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -8047,6 +8108,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -8061,10 +8126,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -8072,6 +8133,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -8082,12 +8147,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8098,12 +8163,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8362,12 +8427,17 @@ opList {
 opList {
   name: "hammingdistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -8379,13 +8449,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8400,12 +8465,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8420,12 +8485,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8469,12 +8534,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -8506,12 +8571,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8533,49 +8598,45 @@ opList {
 opList {
   name: "hasinf"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "hasnan"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "hinge_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8598,13 +8659,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "hinge_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "hinge_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8637,13 +8698,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "histogram"
-  argDescriptor {
-    name: "numBins"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8656,13 +8717,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "numBins"
+    argType: INT64
+  }
 }
 opList {
   name: "histogram_fixed_width"
-  argDescriptor {
-    name: "nbins"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8685,13 +8746,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "nbins"
+    argType: INT64
+  }
 }
 opList {
   name: "hsv_to_rgb"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -8700,14 +8761,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "huber_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8715,10 +8776,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "delta"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "predictions"
@@ -8734,13 +8791,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "huber_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "huber_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8760,10 +8821,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "delta"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -8777,6 +8834,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "identity"
@@ -8789,12 +8854,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -8867,6 +8932,27 @@ opList {
 opList {
   name: "im2col"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inputArrays"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "zeroPadVal"
+    argType: DOUBLE
+  }
+  argDescriptor {
     name: "kernelHeight"
     argType: INT64
   }
@@ -8905,6 +8991,9 @@ opList {
     argType: INT64
     argIndex: 7
   }
+}
+opList {
+  name: "im2col_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8914,21 +9003,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "zeroPadVal"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "inputArrays"
+    name: "gradAtOutput"
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "im2col_bp"
+  argDescriptor {
+    name: "zeroPadVal"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "kernelHeight"
     argType: INT64
@@ -8968,41 +9054,25 @@ opList {
     argType: INT64
     argIndex: 7
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "zeroPadVal"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradAtOutput"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "image_resize"
   argDescriptor {
-    name: "method"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "image"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "size"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "preserveAspectRatio"
@@ -9014,21 +9084,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "image"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "size"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "method"
+    argType: INT64
   }
 }
 opList {
   name: "in_top_k"
-  argDescriptor {
-    name: "k"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9038,10 +9099,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "sorted"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -9049,6 +9106,14 @@ opList {
     name: "target"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "sorted"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "k"
+    argType: INT64
   }
 }
 opList {
@@ -9062,12 +9127,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9078,12 +9143,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9094,12 +9159,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9110,12 +9175,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9130,12 +9195,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9150,21 +9215,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "ismax"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -9172,6 +9233,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9186,24 +9251,29 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "jaccarddistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -9215,13 +9285,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9273,16 +9338,20 @@ opList {
 opList {
   name: "last_index"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -9293,25 +9362,13 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "layer_norm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "noBias"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9327,14 +9384,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "layer_norm_bp"
+  argDescriptor {
+    name: "channelsFirst"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "layer_norm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9352,10 +9413,6 @@ opList {
     name: "dLdb"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "noBias"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9391,6 +9448,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 6
   }
+  argDescriptor {
+    name: "channelsFirst"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "leakyrelu"
@@ -9399,12 +9464,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9415,12 +9484,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9435,10 +9508,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9446,6 +9515,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -9460,10 +9533,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9471,6 +9540,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -9481,12 +9554,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9497,12 +9570,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9522,24 +9595,11 @@ opList {
   name: "lin_space"
   argDescriptor {
     name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "start"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "stop"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "start"
@@ -9555,24 +9615,42 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "start"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "stop"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "linspace_random"
-  argDescriptor {
-    name: "length"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "from"
+    name: "step"
     argType: DOUBLE
   }
   argDescriptor {
     name: "to"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "length"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -9613,12 +9691,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9633,21 +9711,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "log_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9655,10 +9729,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "predictions"
@@ -9674,13 +9744,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "log_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "log_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9700,10 +9774,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -9716,6 +9786,14 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
   }
 }
 opList {
@@ -9729,20 +9807,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
   name: "log_poisson_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9750,10 +9824,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "full"
-    argType: BOOL
   }
   argDescriptor {
     name: "log_predictions"
@@ -9769,13 +9839,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "log_poisson_loss_grad"
+  argDescriptor {
+    name: "full"
+    argType: BOOL
+  }
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "log_poisson_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9795,10 +9869,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "full"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "log_predictions"
     argType: INPUT_TENSOR
   }
@@ -9812,13 +9882,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "full"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "log_softmax"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -9827,14 +9901,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "log_softmax_bp"
   argDescriptor {
     name: "dimension"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "log_softmax_bp"
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
@@ -9848,6 +9922,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -9857,12 +9935,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "base"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "base"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9884,16 +9962,8 @@ opList {
 opList {
   name: "logentropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9903,6 +9973,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9917,12 +9995,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9933,12 +10011,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -9948,12 +10026,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9964,10 +10042,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9976,21 +10050,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lrn"
   argDescriptor {
-    name: "depth"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
   }
   argDescriptor {
     name: "bias"
@@ -10005,40 +10087,14 @@ opList {
     name: "beta"
     argType: DOUBLE
     argIndex: 2
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lrn_bp"
   argDescriptor {
-    name: "depth"
-    argType: INT64
-  }
-  argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "bias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "beta"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -10049,19 +10105,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "bias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "beta"
+    argType: DOUBLE
+    argIndex: 2
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lstm"
-  argDescriptor {
-    name: "peephole"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "projection"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10074,20 +10143,6 @@ opList {
     name: "c"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingProjValue"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -10128,18 +10183,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmBlock"
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "dataFormat"
+    name: "projection"
     argType: INT64
     argIndex: 1
   }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingProjValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
+    argIndex: 2
+  }
+}
+opList {
+  name: "lstmBlock"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10177,15 +10246,6 @@ opList {
     name: "y"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "maxTSLength"
@@ -10231,13 +10291,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
-}
-opList {
-  name: "lstmBlockCell"
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "lstmBlockCell"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10275,15 +10349,6 @@ opList {
     name: "y"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "xt"
@@ -10324,18 +10389,22 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmCell"
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "projection"
-    argType: INT64
+    name: "forgetBias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
     argIndex: 1
   }
+}
+opList {
+  name: "lstmCell"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10348,20 +10417,6 @@ opList {
     name: "ct"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingProjValue"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "xt"
@@ -10402,33 +10457,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmLayer"
   argDescriptor {
-    name: "dataFormat"
+    name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "directionMode"
+    name: "projection"
     argType: INT64
     argIndex: 1
   }
   argDescriptor {
-    name: "gateAct"
-    argType: INT64
+    name: "clippingCellValue"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingProjValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 4
-  }
+}
+opList {
+  name: "lstmLayer"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10446,6 +10500,45 @@ opList {
     name: "cL"
     argType: OUTPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "Wx"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "Wr"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "b"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "seqLen"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "hI"
+    argType: INPUT_TENSOR
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "cI"
+    argType: INPUT_TENSOR
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "Wp"
+    argType: INPUT_TENSOR
+    argIndex: 7
   }
   argDescriptor {
     name: "hasBiases"
@@ -10487,6 +10580,30 @@ opList {
     argIndex: 7
   }
   argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "directionMode"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
     name: "cellClip"
     argType: DOUBLE
   }
@@ -10520,62 +10637,9 @@ opList {
     argType: DOUBLE
     argIndex: 6
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "Wx"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "Wr"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "b"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "seqLen"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "hI"
-    argType: INPUT_TENSOR
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "cI"
-    argType: INPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "Wp"
-    argType: INPUT_TENSOR
-    argIndex: 7
-  }
 }
 opList {
   name: "lstmLayerCell"
-  argDescriptor {
-    name: "gateAct"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10590,6 +10654,40 @@ opList {
     argIndex: 1
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "Wx"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "Wr"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "b"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "hI"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "cI"
+    argType: INPUT_TENSOR
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "Wp"
+    argType: INPUT_TENSOR
+    argIndex: 6
+  }
+  argDescriptor {
     name: "hasBiases"
     argType: BOOL
   }
@@ -10597,6 +10695,20 @@ opList {
     name: "hasPH"
     argType: BOOL
     argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 2
   }
   argDescriptor {
     name: "cellClip"
@@ -10632,57 +10744,9 @@ opList {
     argType: DOUBLE
     argIndex: 6
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "Wx"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "Wr"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "b"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "hI"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "cI"
-    argType: INPUT_TENSOR
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "Wp"
-    argType: INPUT_TENSOR
-    argIndex: 6
-  }
 }
 opList {
   name: "lstmLayerCellBp"
-  argDescriptor {
-    name: "gateAct"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10719,49 +10783,6 @@ opList {
   argDescriptor {
     name: "dLdWp"
     argType: OUTPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "hasBiases"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "hasPH"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "cellClip"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "gateAlpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gateBeta"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "cellAlpha"
-    argType: DOUBLE
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "cellBeta"
-    argType: DOUBLE
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "outAlpha"
-    argType: DOUBLE
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "outBeta"
-    argType: DOUBLE
     argIndex: 6
   }
   argDescriptor {
@@ -10803,33 +10824,66 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmLayer_bp"
   argDescriptor {
-    name: "dataFormat"
-    argType: INT64
+    name: "hasBiases"
+    argType: BOOL
   }
   argDescriptor {
-    name: "directionMode"
-    argType: INT64
+    name: "hasPH"
+    argType: BOOL
     argIndex: 1
   }
   argDescriptor {
     name: "gateAct"
     argType: INT64
-    argIndex: 2
   }
   argDescriptor {
     name: "cellAct"
     argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "outAct"
     argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellClip"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "gateAlpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateBeta"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAlpha"
+    argType: DOUBLE
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "cellBeta"
+    argType: DOUBLE
     argIndex: 4
   }
+  argDescriptor {
+    name: "outAlpha"
+    argType: DOUBLE
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "outBeta"
+    argType: DOUBLE
+    argIndex: 6
+  }
+}
+opList {
+  name: "lstmLayer_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10866,79 +10920,6 @@ opList {
   argDescriptor {
     name: "dLdWp"
     argType: OUTPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "hasBiases"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "hasSeqLen"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "hasInitH"
-    argType: BOOL
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "hasInitC"
-    argType: BOOL
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "hasPH"
-    argType: BOOL
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "retFullSeq"
-    argType: BOOL
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "retLastH"
-    argType: BOOL
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "retLastC"
-    argType: BOOL
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "cellClip"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "gateAlpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gateBeta"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "cellAlpha"
-    argType: DOUBLE
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "cellBeta"
-    argType: DOUBLE
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "outAlpha"
-    argType: DOUBLE
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "outBeta"
-    argType: DOUBLE
     argIndex: 6
   }
   argDescriptor {
@@ -11000,6 +10981,103 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 11
   }
+  argDescriptor {
+    name: "hasBiases"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "hasSeqLen"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "hasInitH"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "hasInitC"
+    argType: BOOL
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "hasPH"
+    argType: BOOL
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "retFullSeq"
+    argType: BOOL
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "retLastH"
+    argType: BOOL
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "retLastC"
+    argType: BOOL
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "directionMode"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "cellClip"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "gateAlpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateBeta"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAlpha"
+    argType: DOUBLE
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "cellBeta"
+    argType: DOUBLE
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "outAlpha"
+    argType: DOUBLE
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "outBeta"
+    argType: DOUBLE
+    argIndex: 6
+  }
 }
 opList {
   name: "lstsq"
@@ -11012,14 +11090,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "fastFlag"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "l2_factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -11027,6 +11097,14 @@ opList {
     name: "b"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "fastFlag"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "l2_factor"
+    argType: DOUBLE
   }
 }
 opList {
@@ -11052,12 +11130,17 @@ opList {
 opList {
   name: "manhattan"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -11069,29 +11152,28 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "match_condition"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -11102,18 +11184,10 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "match_condition_transform"
-  argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -11123,6 +11197,19 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
     name: "compare"
     argType: DOUBLE
   }
@@ -11130,6 +11217,18 @@ opList {
     name: "eps"
     argType: DOUBLE
     argIndex: 1
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "matmul"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -11139,32 +11238,6 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "matmul"
-  argDescriptor {
-    name: "transX"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "transY"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "transZ"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "transposeX"
@@ -11190,18 +11263,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-}
-opList {
-  name: "matmul_bp"
-  argDescriptor {
     name: "transX"
     argType: INT64
   }
@@ -11215,6 +11276,9 @@ opList {
     argType: INT64
     argIndex: 2
   }
+}
+opList {
+  name: "matmul_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11226,15 +11290,6 @@ opList {
   argDescriptor {
     name: "dldy"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "beta"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -11261,18 +11316,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "matrix_band_part"
   argDescriptor {
-    name: "minLower"
+    name: "alpha"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "beta"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "transX"
     argType: INT64
   }
   argDescriptor {
-    name: "maxUpper"
+    name: "transY"
     argType: INT64
     argIndex: 1
   }
+  argDescriptor {
+    name: "transZ"
+    argType: INT64
+    argIndex: 2
+  }
+}
+opList {
+  name: "matrix_band_part"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -11291,6 +11360,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "minLower"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "maxUpper"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -11304,12 +11382,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11323,12 +11401,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "diagonal"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11342,12 +11420,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11357,12 +11435,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -11373,10 +11451,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -11384,6 +11458,10 @@ opList {
     name: "diagonal"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -11410,6 +11488,28 @@ opList {
 }
 opList {
   name: "max_pool_with_argmax"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "indices"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "outArgMax"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -11464,28 +11564,6 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "indices"
-    argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "outArgMax"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "max_scalar"
@@ -11515,10 +11593,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -11526,6 +11600,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -11573,64 +11651,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "maxpool2d"
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "extraParam0"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 10
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11643,9 +11671,6 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "maxpool2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -11700,6 +11725,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "maxpool2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11717,83 +11745,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "maxpool3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
     name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
     name: "extraParam0"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "maxpool3dnew"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11811,9 +11819,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "maxpool3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -11888,6 +11893,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "maxpool3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11905,13 +11913,83 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "extraParam0"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "mean_pairwssqerr_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11933,15 +12011,15 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
   }
 }
 opList {
   name: "mean_pairwssqerr_loss_grad"
   argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -11973,13 +12051,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "mean_sqerr_loss"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "mean_sqerr_loss"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12002,13 +12080,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "mean_sqerr_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "mean_sqerr_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12040,6 +12118,10 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
   }
 }
 opList {
@@ -12064,12 +12146,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "inArrs"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -12160,10 +12242,6 @@ opList {
 opList {
   name: "mergemaxindex"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -12174,6 +12252,10 @@ opList {
   argDescriptor {
     name: "inArrs"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -12190,10 +12272,6 @@ opList {
 opList {
   name: "meshgrid"
   argDescriptor {
-    name: "swapFirst2Dims"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -12202,16 +12280,28 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "inArrs"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "cartesian"
     argType: BOOL
   }
   argDescriptor {
-    name: "inArrs"
-    argType: INPUT_TENSOR
+    name: "swapFirst2Dims"
+    argType: INT64
   }
 }
 opList {
   name: "meta_postulate"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "meta_predicate"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -12228,14 +12318,6 @@ opList {
   opDeclarationType: LEGACY_XYZ
 }
 opList {
-  name: "meta_predicate"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
   name: "meta_predicate_inverted"
   argDescriptor {
     name: "outputs"
@@ -12246,12 +12328,12 @@ opList {
 opList {
   name: "meta_reduce"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12287,10 +12369,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12298,6 +12376,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12334,20 +12416,12 @@ opList {
 opList {
   name: "mirror_pad"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isSymmetric"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -12357,6 +12431,14 @@ opList {
     name: "paddings"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "isSymmetric"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
 }
 opList {
@@ -12370,12 +12452,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12390,10 +12472,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12401,6 +12479,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12420,10 +12502,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12437,13 +12515,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "moments"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12456,10 +12534,6 @@ opList {
     name: "variances"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -12475,6 +12549,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "mul_scalar"
@@ -12483,26 +12565,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "multi_head_dot_product_attention"
-  argDescriptor {
-    name: "normalization"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12510,15 +12584,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "withWeights"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "queries"
@@ -12559,13 +12624,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "multi_head_dot_product_attention_bp"
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "withWeights"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "normalization"
     argType: INT64
   }
+  argDescriptor {
+    name: "weights"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "multi_head_dot_product_attention_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12603,10 +12682,6 @@ opList {
     name: "dLdWo"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
   }
   argDescriptor {
     name: "queries"
@@ -12652,6 +12727,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "normalization"
+    argType: INT64
+  }
 }
 opList {
   name: "multiply"
@@ -12664,10 +12747,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12675,6 +12754,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12694,10 +12777,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12711,13 +12790,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "nadam_updater"
-  argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
   argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
@@ -12731,25 +12810,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -12785,6 +12845,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 6
   }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -12798,12 +12881,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12816,15 +12899,6 @@ opList {
   argDescriptor {
     name: "stateV"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dMomentum"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -12846,6 +12920,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dMomentum"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -12855,20 +12938,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
   name: "non_max_suppression"
-  argDescriptor {
-    name: "maxOutputSize"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12901,13 +12980,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "non_max_suppression_overlaps"
   argDescriptor {
     name: "maxOutputSize"
     argType: INT64
   }
+}
+opList {
+  name: "non_max_suppression_overlaps"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12915,6 +12994,34 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "boxes"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "scales"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "maxOutSize"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "iouThreshold"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "scoreThreshold"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "maxOutputSize"
+    argType: INT64
   }
   argDescriptor {
     name: "overlapThreshold"
@@ -12925,37 +13032,9 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "boxes"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "scales"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "maxOutSize"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "iouThreshold"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "scoreThreshold"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
 }
 opList {
   name: "non_max_suppression_v3"
-  argDescriptor {
-    name: "maxOutputSize"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12987,6 +13066,10 @@ opList {
     name: "scoreThreshold"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "maxOutputSize"
+    argType: INT64
   }
 }
 opList {
@@ -13008,10 +13091,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "mode"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13019,6 +13098,10 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: DOUBLE
   }
   opDeclarationType: REDUCTION_OP_IMPL
 }
@@ -13038,10 +13121,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "shift"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "counts"
     argType: INPUT_TENSOR
   }
@@ -13056,14 +13135,8 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "outMean"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "outVar"
-    argType: INPUT_TENSOR
-    argIndex: 4
+    name: "shift"
+    argType: DOUBLE
   }
 }
 opList {
@@ -13077,10 +13150,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13088,6 +13157,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13102,10 +13175,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13113,6 +13182,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -13123,12 +13196,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13139,21 +13212,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "nth_element"
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13163,10 +13232,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "reverse"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13174,6 +13239,14 @@ opList {
     name: "n"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
   }
 }
 opList {
@@ -13187,31 +13260,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "onehot"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "depth"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13219,15 +13278,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "on"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "off"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -13248,6 +13298,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "on"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "off"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "oneminus"
@@ -13260,21 +13333,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "ones_as"
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13286,6 +13355,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -13299,16 +13372,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "comparable"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13319,12 +13393,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13346,20 +13420,12 @@ opList {
 opList {
   name: "pad"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "padValue"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -13369,6 +13435,14 @@ opList {
     name: "paddings"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "padValue"
+    argType: DOUBLE
   }
 }
 opList {
@@ -13394,16 +13468,20 @@ opList {
 opList {
   name: "percentile"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   argDescriptor {
     name: "q"
@@ -13419,17 +13497,9 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "permute"
-  argDescriptor {
-    name: "reverseDims"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13443,9 +13513,13 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "permutationVector"
+    name: "permuteDims"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "reverseDims"
+    argType: INT64
   }
 }
 opList {
@@ -13467,6 +13541,18 @@ opList {
 }
 opList {
   name: "pnormpool2d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
   argDescriptor {
     name: "kY"
     argType: INT64
@@ -13521,21 +13607,30 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "pnormpool2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
-    name: "outputs"
+    name: "gradI"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "pnormpool2d_bp"
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -13590,39 +13685,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "pointwise_conv2d"
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13644,6 +13709,15 @@ opList {
     name: "bias"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -13670,10 +13744,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13681,6 +13751,10 @@ opList {
     name: "inputArrays"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -13690,14 +13764,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "pow"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13705,6 +13771,14 @@ opList {
     name: "pow"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "pow"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13719,10 +13793,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13730,6 +13800,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13744,6 +13818,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -13752,18 +13830,10 @@ opList {
     argType: BOOL
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "prelu"
-  argDescriptor {
-    name: "sharedAxes"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -13777,14 +13847,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "prelu_bp"
   argDescriptor {
     name: "sharedAxes"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "prelu_bp"
   argDescriptor {
     name: "dLdI"
     argType: OUTPUT_TENSOR
@@ -13818,6 +13888,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "sharedAxes"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -13846,10 +13920,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "printSpecial"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13857,6 +13927,10 @@ opList {
     name: "message"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "printSpecial"
+    argType: BOOL
   }
 }
 opList {
@@ -13866,10 +13940,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "probability"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13877,6 +13947,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "probability"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13896,12 +13970,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "fullMatricies"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "fullMatricies"
+    argType: BOOL
   }
 }
 opList {
@@ -13915,20 +13989,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "f"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "f"
+    argType: DOUBLE
   }
 }
 opList {
   name: "random_crop"
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13946,13 +14016,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_exponential"
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13962,16 +14032,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "shape"
+    argType: INT64
+  }
+  argDescriptor {
     name: "lambda"
     argType: DOUBLE
   }
 }
 opList {
   name: "random_gamma"
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13994,13 +14064,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_multinomial"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14017,6 +14087,10 @@ opList {
     name: "inputSamples"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
 }
 opList {
@@ -14037,10 +14111,6 @@ opList {
 opList {
   name: "random_poisson"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14057,13 +14127,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_shuffle"
-  argDescriptor {
-    name: "seeds"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -14071,6 +14141,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "seeds"
+    argType: INT64
   }
   opDeclarationType: OP_IMPL
 }
@@ -14081,6 +14155,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "shape"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "mean"
     argType: DOUBLE
   }
@@ -14089,22 +14167,9 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "shape"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "randomuniform"
-  argDescriptor {
-    name: "dtype"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -14114,15 +14179,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "min"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "max"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "shape"
     argType: INPUT_TENSOR
   }
@@ -14136,23 +14192,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "range"
   argDescriptor {
-    name: "from"
-    argType: INT64
+    name: "min"
+    argType: DOUBLE
   }
   argDescriptor {
-    name: "to"
-    argType: INT64
+    name: "max"
+    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
-    name: "step"
+    name: "dtype"
     argType: INT64
-    argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "range"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14163,30 +14223,44 @@ opList {
   }
   argDescriptor {
     name: "from"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "to"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
     argIndex: 1
   }
   argDescriptor {
     name: "step"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
     argIndex: 2
   }
   argDescriptor {
     name: "from"
-    argType: INPUT_TENSOR
+    argType: INT64
   }
   argDescriptor {
     name: "to"
-    argType: INPUT_TENSOR
+    argType: INT64
     argIndex: 1
   }
   argDescriptor {
     name: "step"
-    argType: INPUT_TENSOR
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "from"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "to"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "step"
+    argType: DOUBLE
     argIndex: 2
   }
 }
@@ -14201,12 +14275,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -14220,12 +14294,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14240,12 +14314,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14298,10 +14372,6 @@ opList {
 opList {
   name: "read_list"
   argDescriptor {
-    name: "index"
-    argType: INT64
-  }
-  argDescriptor {
     name: "importDataType"
     argType: DATA_TYPE
   }
@@ -14318,6 +14388,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "index"
+    argType: INT64
+  }
   opDeclarationType: LIST_OP_IMPL
 }
 opList {
@@ -14331,10 +14405,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14342,6 +14412,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -14386,12 +14460,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14406,12 +14480,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14447,10 +14521,6 @@ opList {
 opList {
   name: "reduce_dot_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14462,10 +14532,6 @@ opList {
     name: "gradY"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14491,13 +14557,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "reduce_logsumexp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_logsumexp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14505,31 +14575,31 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDim"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   argDescriptor {
     name: "keepDims"
     argType: DOUBLE
   }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "reduce_max"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14539,10 +14609,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14550,25 +14616,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_max_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14583,25 +14649,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_mean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14611,25 +14677,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_mean_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14644,25 +14710,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_min"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14672,25 +14738,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_min_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14705,25 +14771,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_norm1"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14733,25 +14799,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_norm1_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14767,13 +14833,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_norm2"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_norm2"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14783,10 +14853,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14795,13 +14861,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_norm2_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_norm2_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14809,10 +14879,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14827,6 +14893,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -14840,10 +14914,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14852,13 +14922,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
 }
 opList {
   name: "reduce_norm_max_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14866,10 +14936,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14885,20 +14951,20 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_normmax"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_normmax"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14908,16 +14974,20 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "reduce_prod"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14926,10 +14996,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14937,25 +15003,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_prod_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14970,25 +15036,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_sqnorm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14999,13 +15065,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_sqnorm_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_sqnorm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15013,10 +15083,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -15031,6 +15097,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -15044,15 +15118,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15061,13 +15126,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "reduce_stdev_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15075,24 +15145,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -15108,13 +15160,31 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_sum"
+  argDescriptor {
+    name: "biasCorrected"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
+}
+opList {
+  name: "reduce_sum"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15124,10 +15194,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15136,13 +15202,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_sum_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_sum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15150,10 +15220,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -15168,6 +15234,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -15181,15 +15255,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15198,13 +15263,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "reduce_variance_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15212,24 +15282,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -15245,6 +15297,28 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "relu"
@@ -15253,16 +15327,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15277,16 +15351,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15297,10 +15371,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "cutoff"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15308,6 +15378,10 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "cutoff"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15318,10 +15392,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "scalar"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15329,6 +15399,10 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "scalar"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15368,8 +15442,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "remainder_scalar"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -15383,27 +15474,7 @@ opList {
   opDeclarationType: LEGACY_XYZ
 }
 opList {
-  name: "remainder_scalar"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
   name: "repeat"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15416,6 +15487,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "replace_nans"
@@ -15424,21 +15499,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "set"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "set"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "reshape"
-  argDescriptor {
-    name: "shapeArr"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15455,6 +15526,10 @@ opList {
     name: "shape"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "shapeArr"
+    argType: INT64
   }
 }
 opList {
@@ -15480,15 +15555,6 @@ opList {
 opList {
   name: "resize_area"
   argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -15497,16 +15563,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "size"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "height"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15521,15 +15596,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "alignPixelCenters"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
@@ -15538,18 +15604,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alignPixelCenters"
+    argType: BOOL
+    argIndex: 1
+  }
 }
 opList {
   name: "resize_bilinear"
-  argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15559,21 +15625,30 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "halfPixelCenter"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "newImageSize"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "halfPixelCenters"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "height"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15586,15 +15661,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "preserveAspectRatio"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "image"
@@ -15610,18 +15676,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "preserveAspectRatio"
+    argType: BOOL
+    argIndex: 1
+  }
 }
 opList {
   name: "resize_nearest_neighbor"
-  argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15629,6 +15695,15 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "image"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "newImageSize"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "alignCorners"
@@ -15640,12 +15715,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "image"
-    argType: INPUT_TENSOR
+    name: "height"
+    argType: INT64
   }
   argDescriptor {
-    name: "newImageSize"
-    argType: INPUT_TENSOR
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15659,10 +15734,6 @@ opList {
 opList {
   name: "reverse"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -15675,14 +15746,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "reverse_bp"
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "reverse_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15705,18 +15776,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "reverse_sequence"
-  argDescriptor {
-    name: "seqDim"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "batchDim"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15732,6 +15798,15 @@ opList {
   argDescriptor {
     name: "seqLengths"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "seqDim"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "batchDim"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15757,10 +15832,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15768,6 +15839,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -15787,10 +15862,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15803,6 +15874,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -15863,10 +15938,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15874,6 +15945,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -15893,10 +15968,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15910,13 +15981,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "rgb_to_grs"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15929,13 +16000,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "rgb_to_hsv"
   argDescriptor {
     name: "dimC"
     argType: INT64
   }
+}
+opList {
+  name: "rgb_to_hsv"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -15943,38 +16014,42 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "rgb_to_yiq"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "rgb_to_yuv"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15989,12 +16064,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -16008,20 +16083,6 @@ opList {
     name: "stateG"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dRmsDecay"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "gradient"
@@ -16047,14 +16108,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dRmsDecay"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 2
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "roll"
-  argDescriptor {
-    name: "shift"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -16073,6 +16144,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "shift"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -16086,12 +16161,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16106,10 +16181,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16117,6 +16188,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -16131,12 +16206,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16147,12 +16222,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16187,15 +16262,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16208,6 +16274,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16218,15 +16293,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16239,6 +16305,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16275,15 +16350,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16296,6 +16362,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16306,15 +16381,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16327,6 +16393,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16337,15 +16412,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16358,6 +16424,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16370,15 +16445,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "indices"
@@ -16394,13 +16460,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "scatter_nd_add"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
   argDescriptor {
     name: "lock"
     argType: BOOL
@@ -16409,6 +16468,13 @@ opList {
     name: "checkIndices"
     argType: BOOL
     argIndex: 1
+  }
+}
+opList {
+  name: "scatter_nd_add"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -16423,6 +16489,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16433,15 +16508,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16454,6 +16520,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16464,15 +16539,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16485,6 +16551,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16495,15 +16570,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16516,6 +16582,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16526,15 +16601,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16547,6 +16613,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16575,60 +16650,6 @@ opList {
 opList {
   name: "sconv2d"
   argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -16650,9 +16671,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "sconv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -16707,6 +16725,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "sconv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -16745,9 +16766,63 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "bias"
+    name: "weightsPoint"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 10
   }
 }
 opList {
@@ -17031,12 +17106,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17068,21 +17143,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "sequence_mask"
-  argDescriptor {
-    name: "maxInd"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17092,16 +17163,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "is_static_maxlen"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "maxlen"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "is_static_maxlen"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "maxInd"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -17146,10 +17226,6 @@ opList {
 opList {
   name: "set_seed"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -17161,6 +17237,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "setrange"
@@ -17171,6 +17251,10 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
@@ -17185,10 +17269,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -17198,12 +17278,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17214,10 +17294,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lr"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -17225,22 +17301,18 @@ opList {
     name: "lr"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "lr"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "shannonentropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -17250,6 +17322,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17264,12 +17344,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -17283,12 +17363,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -17302,10 +17382,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -17314,14 +17390,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
 opList {
   name: "sigm_cross_entropy_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17329,10 +17405,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "logits"
@@ -17348,13 +17420,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "sigm_cross_entropy_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "sigm_cross_entropy_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17374,10 +17450,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "labelSmoothing"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "logits"
     argType: INPUT_TENSOR
   }
@@ -17391,6 +17463,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "labelSmoothing"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "sigmoid"
@@ -17403,12 +17483,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17440,12 +17520,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17460,12 +17540,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17480,12 +17560,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17507,10 +17587,6 @@ opList {
 opList {
   name: "size_at"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -17521,6 +17597,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -17538,26 +17618,8 @@ opList {
 opList {
   name: "skipgram"
   argDescriptor {
-    name: "numWorkers"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "nsRounds"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isInference"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "isPreciseMode"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "target"
@@ -17618,14 +17680,28 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 11
   }
+  argDescriptor {
+    name: "isInference"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isPreciseMode"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numWorkers"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "nsRounds"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "slice"
-  argDescriptor {
-    name: "size"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17648,13 +17724,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "slice_bp"
   argDescriptor {
     name: "size"
     argType: INT64
   }
+}
+opList {
+  name: "slice_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17682,13 +17758,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "size"
+    argType: INT64
+  }
 }
 opList {
   name: "softmax"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -17698,21 +17774,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "softmax_bp"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
@@ -17726,14 +17802,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "softmax_cross_entropy_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17741,10 +17817,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "logits"
@@ -17760,13 +17832,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "softmax_cross_entropy_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "softmax_cross_entropy_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17786,10 +17862,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "logits"
     argType: INPUT_TENSOR
   }
@@ -17803,13 +17875,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "softmax_cross_entropy_loss_with_logits"
-  argDescriptor {
-    name: "classesDim"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17827,13 +17903,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "softmax_cross_entropy_loss_with_logits_grad"
   argDescriptor {
     name: "classesDim"
     argType: INT64
   }
+}
+opList {
+  name: "softmax_cross_entropy_loss_with_logits_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17856,6 +17932,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "classesDim"
+    argType: INT64
+  }
 }
 opList {
   name: "softplus"
@@ -17868,12 +17948,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17905,12 +17985,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17942,12 +18022,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17960,10 +18040,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "useAdjoint"
-    argType: BOOL
   }
   argDescriptor {
     name: "a"
@@ -17979,6 +18055,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "useAdjoint"
+    argType: BOOL
+  }
 }
 opList {
   name: "solve_ls"
@@ -17991,14 +18071,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "fastFlag"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "l2_factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -18006,6 +18078,14 @@ opList {
     name: "b"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "fastFlag"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "l2_factor"
+    argType: DOUBLE
   }
 }
 opList {
@@ -18038,20 +18118,6 @@ opList {
 opList {
   name: "space_to_batch"
   argDescriptor {
-    name: "blockSize"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "paddingTop"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "paddingBottom"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18068,13 +18134,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blockSize"
+    argType: INT64
+  }
 }
 opList {
   name: "space_to_batch_nd"
-  argDescriptor {
-    name: "blocks"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18082,10 +18152,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -18101,18 +18167,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blocks"
+    argType: INT64
+  }
 }
 opList {
   name: "space_to_depth"
-  argDescriptor {
-    name: "block_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isNHWC"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18124,6 +18189,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "block_size"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "isNHWC"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -18169,15 +18243,6 @@ opList {
 opList {
   name: "split"
   argDescriptor {
-    name: "numSplit"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18192,6 +18257,15 @@ opList {
   argDescriptor {
     name: "b"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numSplit"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -18244,15 +18318,6 @@ opList {
 opList {
   name: "split_v"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "numSplit"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18274,6 +18339,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "numSplit"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "sqrt"
@@ -18286,12 +18360,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18318,12 +18392,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -18338,10 +18412,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -18349,6 +18419,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -18385,10 +18459,6 @@ opList {
 opList {
   name: "squeeze"
   argDescriptor {
-    name: "_a"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18404,6 +18474,10 @@ opList {
     name: "a"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "_a"
+    argType: INT64
   }
 }
 opList {
@@ -18662,6 +18736,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -18679,18 +18757,10 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "stack"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18707,6 +18777,10 @@ opList {
     name: "inArrs"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -18728,10 +18802,6 @@ opList {
 opList {
   name: "standardize"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -18744,14 +18814,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "standardize_bp"
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "standardize_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18773,6 +18843,10 @@ opList {
     name: "eps"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -18883,15 +18957,15 @@ opList {
 opList {
   name: "std"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "biasCorrected"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "newFormat"
     argType: BOOL
   }
   argDescriptor {
@@ -18900,8 +18974,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18912,16 +18986,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18936,41 +19010,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
 opList {
   name: "strided_slice"
-  argDescriptor {
-    name: "begin_mask"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "ellipsis_mask"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "end_mask"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "new_axis_mask"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "shrink_axis_mask"
-    argType: INT64
-    argIndex: 4
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18998,9 +19048,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "strided_slice_bp"
   argDescriptor {
     name: "begin_mask"
     argType: INT64
@@ -19025,6 +19072,9 @@ opList {
     argType: INT64
     argIndex: 4
   }
+}
+opList {
+  name: "strided_slice_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19057,6 +19107,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "begin_mask"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "ellipsis_mask"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "end_mask"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "new_axis_mask"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "shrink_axis_mask"
+    argType: INT64
+    argIndex: 4
+  }
 }
 opList {
   name: "sub_scalar"
@@ -19069,9 +19143,8 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19086,10 +19159,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19097,6 +19166,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -19116,10 +19189,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19132,6 +19201,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -19177,6 +19250,27 @@ opList {
 opList {
   name: "svd"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "fullUV"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "computeUv"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
     name: "fullUV"
     argType: INT64
   }
@@ -19190,42 +19284,6 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "full_matrices"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "computeUv"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "s"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "u"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "v"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "swish"
@@ -19238,12 +19296,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19254,10 +19312,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19265,6 +19319,10 @@ opList {
     name: "predicate"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -19278,12 +19336,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19314,12 +19372,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -19358,12 +19416,12 @@ opList {
 opList {
   name: "tensorarrayv3"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -19380,15 +19438,20 @@ opList {
 opList {
   name: "tensordot"
   argDescriptor {
-    name: "dimensionsY"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "addedEdges"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "transposeX"
     argType: BOOL
   }
   argDescriptor {
@@ -19402,26 +19465,12 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensionsY"
+    argType: INT64
   }
 }
 opList {
   name: "tensormmul"
-  argDescriptor {
-    name: "axe0_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "axe1_size"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19439,13 +19488,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "axe0_size"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "axe1_size"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "tensormmul_bp"
-  argDescriptor {
-    name: "axe0Size"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19472,6 +19526,20 @@ opList {
     name: "dLdC"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "dldx"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "dldy"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "axe0Size"
+    argType: INT64
   }
 }
 opList {
@@ -19553,10 +19621,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "y"
     argType: INPUT_TENSOR
   }
@@ -19564,6 +19628,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -19574,16 +19642,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -19594,10 +19662,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "cutoff"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19606,14 +19670,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "cutoff"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "tile"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19621,10 +19685,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "is_static_reps"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -19635,13 +19695,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "is_static_reps"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "tile_bp"
-  argDescriptor {
-    name: "repeat"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19658,6 +19722,10 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "repeat"
+    argType: INT64
   }
 }
 opList {
@@ -19706,12 +19774,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19835,10 +19903,6 @@ opList {
 opList {
   name: "top_k"
   argDescriptor {
-    name: "k"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -19852,12 +19916,16 @@ opList {
     argIndex: 1
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "needSort"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "k"
+    argType: INT64
   }
 }
 opList {
@@ -19890,13 +19958,25 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "permuteDims"
+    name: "permutationVector"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "permuteDims"
+    argType: INT64
   }
 }
 opList {
   name: "tri"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "row"
     argType: INT64
@@ -19911,14 +19991,6 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
 }
 opList {
   name: "triangular_solve"
@@ -19931,15 +20003,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "isLower"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "useAdjoint"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -19949,22 +20012,17 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "lower"
-    argType: INPUT_TENSOR
-    argIndex: 2
+    name: "isLower"
+    argType: BOOL
   }
   argDescriptor {
-    name: "adjoint"
-    argType: INPUT_TENSOR
-    argIndex: 3
+    name: "useAdjoint"
+    argType: BOOL
+    argIndex: 1
   }
 }
 opList {
   name: "triu"
-  argDescriptor {
-    name: "diag"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19977,13 +20035,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "triu_bp"
   argDescriptor {
     name: "diag"
     argType: INT64
   }
+}
+opList {
+  name: "triu_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20001,6 +20059,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "diag"
+    argType: INT64
+  }
 }
 opList {
   name: "truncatediv"
@@ -20013,10 +20075,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20024,6 +20082,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -20075,10 +20137,6 @@ opList {
 opList {
   name: "unsorted_segment_max"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20099,15 +20157,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_max_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20128,15 +20186,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_mean"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20157,15 +20215,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_mean_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20186,15 +20244,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_min"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20215,15 +20273,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_min_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20244,15 +20302,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_prod"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20273,15 +20331,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_prod_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20302,15 +20360,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_sqrt_n"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20331,15 +20389,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_sqrt_n_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20361,13 +20419,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "unsorted_segment_sum"
   argDescriptor {
     name: "numSegments"
     argType: INT64
   }
+}
+opList {
+  name: "unsorted_segment_sum"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20390,13 +20448,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "unsorted_segment_sum_bp"
   argDescriptor {
     name: "numSegments"
     argType: INT64
   }
+}
+opList {
+  name: "unsorted_segment_sum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20419,18 +20477,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
+  }
 }
 opList {
   name: "unstack"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "num"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20442,6 +20495,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "num"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -20459,6 +20521,22 @@ opList {
 opList {
   name: "upsampling2d"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "factorH"
     argType: INT64
   }
@@ -20472,29 +20550,9 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "upsampling2d_bp"
-  argDescriptor {
-    name: "scaleW"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20502,10 +20560,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "nchw"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -20516,9 +20570,33 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "scaleW"
+    argType: INT64
+  }
 }
 opList {
   name: "upsampling3d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "ncdhw"
+    argType: BOOL
+  }
   argDescriptor {
     name: "factorD"
     argType: INT64
@@ -20538,29 +20616,9 @@ opList {
     argType: INT64
     argIndex: 3
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "ncdhw"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "upsampling3d_bp"
-  argDescriptor {
-    name: "isNCDHW"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20568,10 +20626,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "ncdhw"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -20582,16 +20636,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "ncdhw"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+  }
 }
 opList {
   name: "var"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "biasCorrected"
@@ -20603,8 +20665,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -20658,10 +20720,6 @@ opList {
 opList {
   name: "write_list"
   argDescriptor {
-    name: "idx"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -20673,6 +20731,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "idx"
+    argType: INT64
   }
   opDeclarationType: LIST_OP_IMPL
 }
@@ -20687,10 +20749,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20698,6 +20756,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -20708,21 +20770,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "xw_plus_b"
-  argDescriptor {
-    name: "bTranspose"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20745,13 +20803,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "xw_plus_b_bp"
   argDescriptor {
     name: "bTranspose"
     argType: INT64
   }
+}
+opList {
+  name: "xw_plus_b_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20789,13 +20847,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "bTranspose"
+    argType: INT64
+  }
 }
 opList {
   name: "yiq_to_rgb"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -20803,22 +20861,26 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "yuv_to_rgb"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -20862,20 +20924,20 @@ opList {
 opList {
   name: "zeroslike"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -20889,10 +20951,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20900,6 +20958,10 @@ opList {
     name: "q"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }

--- a/nd4j/samediff-import/samediff-import-onnx/ops-added-new.txt
+++ b/nd4j/samediff-import/samediff-import-onnx/ops-added-new.txt
@@ -1,3 +1,2 @@
 Constant,x
-Constant,y
-Or,output
+GlobalAveragePool,y

--- a/nd4j/samediff-import/samediff-import-onnx/ops-imported-new.txt
+++ b/nd4j/samediff-import/samediff-import-onnx/ops-imported-new.txt
@@ -1,1 +1,0 @@
-Or,output

--- a/nd4j/samediff-import/samediff-import-onnx/ops-removed-new.txt
+++ b/nd4j/samediff-import/samediff-import-onnx/ops-removed-new.txt
@@ -1,3 +1,2 @@
 x
 y
-output

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
@@ -360,8 +360,18 @@ val gemm = OnnxMappingProcess(
                 invertBooleanNumber(mutableMapOf("transX" to "transA","transY" to "transB")))
 )
 //TODO: GlobalAveragePool
+val globalAveragePooling = OnnxMappingProcess(
+        opName = "noop",
+        inputFrameworkOpName = "GlobalAveragePool",
+        opMappingRegistry = onnxOpRegistry
+)
 //TODO: GlobalLpPool
 //TODO: GlobalMaxPool
+val globalMaxPooling = OnnxMappingProcess(
+        opName = "noop",
+        inputFrameworkOpName = "GlobalMaxPool",
+        opMappingRegistry = onnxOpRegistry
+)
 //TODO: Gradient
 //TODO: GraphCall
 val hardSigmoid = OnnxMappingProcess(
@@ -390,9 +400,8 @@ val or = OnnxMappingProcess(
         inputFrameworkOpName = "Or",
         opMappingRegistry = onnxOpRegistry,
         attributeMappingRules = listOf(
-                booleanConstant(inputName = "inPlace", constantValue = false,argumentIndex = 0)[0],
                 doubleConstant(inputName = "comparable", constantValue = 0.0,argumentIndex = 0)[0]),
-        tensorMappingRules = listOf(mappingNDArrayInputs((mutableMapOf("input" to "A"))))
+        tensorMappingRules = listOf(mappingNDArrayInputs((mutableMapOf("input" to "A","y" to "B"))))
 )
 
 val xor = OnnxMappingProcess(
@@ -476,7 +485,8 @@ val leakyRelu = OnnxMappingProcess(
         inputFrameworkOpName = "LeakyRelu",
         opName = "leakyrelu",
         tensorMappingRules = listOf(mappingNDArrayInputs(mutableMapOf("input" to "X"))),
-        attributeMappingRules = listOf(valueMappings(mapOf("alpha" to "alpha"))),
+        attributeMappingRules = listOf(valueMappings(mapOf("alpha" to "alpha")),
+                booleanConstant("inPlace",false,argumentIndex = 0)[0]),
         opMappingRegistry = onnxOpRegistry
 )
 //TODO: LinearClassifier
@@ -489,6 +499,9 @@ val matMul = OnnxMappingProcess(
         inputFrameworkOpName = "MatMul",
         opName = "matmul",
         attributeMappingRules = listOf(
+                booleanConstant(inputName = "transX",constantValue = false,argumentIndex = 0)[0],
+                booleanConstant(inputName = "transY",constantValue = false,argumentIndex = 1)[0],
+                booleanConstant(inputName = "transZ",constantValue = false,argumentIndex = 2)[0],
                 booleanConstant(inputName = "transposeX",constantValue = false,argumentIndex = 0)[0],
                 booleanConstant(inputName = "transposeY",constantValue = false,argumentIndex = 1)[0],
                 booleanConstant(inputName = "transposeZ",constantValue = false,argumentIndex = 2)[0],
@@ -631,8 +644,11 @@ val randomUniform = OnnxMappingProcess(
         inputFrameworkOpName = "RandomUniform",
         opName = "randomuniform",
         opMappingRegistry = onnxOpRegistry,
-        attributeMappingRules = listOf(valueMappings(mapOf("min" to "low","max" to "high")),
-                listNumberToNDarray(outputAttributeValue = "shape",inputAttributeValue = "shape"))
+        attributeMappingRules = listOf(
+                valueMappings(mapOf("min" to "low","max" to "high")),
+                intConstant(inputName = "seed",constantValue = 0,argumentIndex = 0)[0],
+                listNumberToNDarray(outputAttributeValue = "shape",
+                        inputAttributeValue = "shape"))
 )
 
 //TODO: RandomUniformLike
@@ -683,7 +699,7 @@ val reduceLogSumExp = OnnxMappingProcess(
         tensorMappingRules = listOf(mappingNDArrayInputs(mutableMapOf("input" to "data"))),
         attributeMappingRules = listOf(
                 invertBooleanNumber(mutableMapOf("keepDims" to "keepdims")),
-                valueMappings(mutableMapOf("keepDims" to "keepdims")),
+                valueMappings(mutableMapOf("keepDim" to "keepdims")),
                 listNumberToListNumber(outputAttributeValue =  "dimensions",inputAttributeValue = "axes")),
         opMappingRegistry = onnxOpRegistry
 )
@@ -737,7 +753,7 @@ val flatten = OnnxMappingProcess(
         inputFrameworkOpName = "Flatten",
         opName = "flatten_2d",
         tensorMappingRules = listOf(mappingNDArrayInputs(mutableMapOf("input" to "input"))),
-        attributeMappingRules = listOf(valueMappings(mutableMapOf("flattenDimension" to "axis"))),
+        attributeMappingRules = listOf(valueMappings(mutableMapOf("dimensions" to "axis"))),
         opMappingRegistry = onnxOpRegistry
 )
 
@@ -906,7 +922,7 @@ val transpose = OnnxMappingProcess(
         opName = "transpose",
         inputFrameworkOpName = "Transpose",
         tensorMappingRules = listOf(mappingNDArrayInputs(mutableMapOf("input" to "data"))),
-        attributeMappingRules = listOf(listNumberToNDarray(outputAttributeValue = "permuteDims", inputAttributeValue = "perm")),
+        attributeMappingRules = listOf(listNumberToListNumber(outputAttributeValue = "permuteDims",inputAttributeValue = "perm")),
         opMappingRegistry = onnxOpRegistry
 )
 

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
@@ -359,14 +359,14 @@ val gemm = OnnxMappingProcess(
                 booleanConstant(inputName = "transposeZ",constantValue = false,argumentIndex = 2)[0],
                 invertBooleanNumber(mutableMapOf("transX" to "transA","transY" to "transB")))
 )
-//TODO: GlobalAveragePool
+//Note, this is implemented via a pre processing hook.
 val globalAveragePooling = OnnxMappingProcess(
         opName = "noop",
         inputFrameworkOpName = "GlobalAveragePool",
         opMappingRegistry = onnxOpRegistry
 )
 //TODO: GlobalLpPool
-//TODO: GlobalMaxPool
+//Note, this is implemented via a pre processing hook.
 val globalMaxPooling = OnnxMappingProcess(
         opName = "noop",
         inputFrameworkOpName = "GlobalMaxPool",

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalAveragePooling.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalAveragePooling.kt
@@ -1,0 +1,57 @@
+package org.nd4j.samediff.frameworkimport.onnx.definitions.implementations
+
+import org.nd4j.autodiff.samediff.SameDiff
+import org.nd4j.autodiff.samediff.internal.SameDiffOp
+import org.nd4j.common.util.ArrayUtil
+import org.nd4j.ir.OpNamespace
+import org.nd4j.linalg.api.buffer.DataType
+import org.nd4j.linalg.factory.Nd4j
+import org.nd4j.samediff.frameworkimport.hooks.PreImportHook
+import org.nd4j.samediff.frameworkimport.hooks.annotations.HookResult
+import org.nd4j.samediff.frameworkimport.hooks.annotations.PreHookRule
+
+@PreHookRule(nodeNames = [],opNames = ["GlobalAveragePool"],frameworkName = "onnx")
+class GlobalAveragePooling: PreImportHook {
+    override fun preProcess(
+        op: SameDiffOp,
+        sd: SameDiff,
+        attributes: Map<String, Any>,
+        descriptor: OpNamespace.OpDescriptor
+    ): HookResult {
+        val inputVariable = sd.getVariable(op.inputsToOp[0])
+        val rankOf = sd.rank(inputVariable)
+        val range = sd.range(sd.constant(2),rankOf,sd.constant(1),inputVariable.dataType())
+        val output = sd.math.mean(op.name,inputVariable,range,true)
+        sd.ops.remove(op.name)
+        return HookResult(outputVariables = mapOf(output.name() to listOf(output)),
+            proceedWithInit = false)
+    }
+
+    fun trueBodyFor(rank: Int): SameDiff {
+        val ret = SameDiff.create()
+        if(rank == 2)
+            ret.constant(Nd4j.create(Nd4j.createBuffer(intArrayOf(2))))
+        else if(rank == 3) {
+            ret.constant(Nd4j.create(Nd4j.createBuffer(intArrayOf(2,3))))
+        } else if(rank == 4) {
+            ret.constant(Nd4j.create(Nd4j.createBuffer(intArrayOf(2,3,4))))
+
+        }
+        return ret
+    }
+
+    fun rankTest(rank: Int): SameDiff {
+        val ret = SameDiff.create()
+        val input = ret.placeHolder("x", DataType.INT64)
+        val const = ret.constant(rank)
+        ret.eq(input,const)
+        return ret
+    }
+
+    fun minNum (rank: Int): Int {
+        if(rank < 4)
+            return 2
+        return 3
+    }
+
+}

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalMaxPooling.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalMaxPooling.kt
@@ -1,0 +1,35 @@
+package org.nd4j.samediff.frameworkimport.onnx.definitions.implementations
+
+import org.nd4j.autodiff.samediff.SameDiff
+import org.nd4j.autodiff.samediff.internal.SameDiffOp
+import org.nd4j.common.util.ArrayUtil
+import org.nd4j.ir.OpNamespace
+import org.nd4j.samediff.frameworkimport.hooks.PreImportHook
+import org.nd4j.samediff.frameworkimport.hooks.annotations.HookResult
+import org.nd4j.samediff.frameworkimport.hooks.annotations.PreHookRule
+
+@PreHookRule(nodeNames = [],opNames = ["GlobalAMaxPool"],frameworkName = "onnx")
+class GlobalMaxPooling: PreImportHook {
+    override fun preProcess(
+        op: SameDiffOp,
+        sd: SameDiff,
+        attributes: Map<String, Any>,
+        descriptor: OpNamespace.OpDescriptor
+    ): HookResult {
+        val inputVariable = sd.getVariable(op.inputsToOp[0])
+        val rankOf = sd.rank(inputVariable)
+        val range = sd.range(sd.constant(2),rankOf,sd.constant(1),inputVariable.dataType())
+        val output = sd.math.reduceMax(op.name,inputVariable,range,true)
+        sd.ops.remove(op.name)
+        return HookResult(outputVariables = mapOf(output.name() to listOf(output)),
+            proceedWithInit = false)
+
+    }
+
+    fun minNum (rank: Int): Int {
+        if(rank < 4)
+            return 2
+        return 3
+    }
+
+}

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/resources/nd4j-op-def.pbtxt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/resources/nd4j-op-def.pbtxt
@@ -21,21 +21,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "thresholdRelative"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "thresholdAbsolute"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "y"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "thresholdRelative"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "thresholdAbsolute"
+    argType: DOUBLE
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -51,14 +51,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -67,6 +59,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -74,6 +74,10 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
@@ -87,10 +91,6 @@ opList {
     name: "clipValueMax"
     argType: DOUBLE
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
 }
 opList {
@@ -172,10 +172,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -198,6 +194,10 @@ opList {
     name: "dLdy"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -227,10 +227,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -238,6 +234,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -306,16 +306,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
+    name: "condition"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "isConstant"
     argType: BOOL
   }
   argDescriptor {
-    name: "condition"
-    argType: INPUT_TENSOR
+    name: "frameName"
+    argType: STRING
   }
   opDeclarationType: LOGIC_OP_IMPL
 }
@@ -330,12 +330,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -350,10 +350,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -361,6 +357,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -371,16 +371,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "pow"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -395,6 +395,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -402,10 +406,6 @@ opList {
     name: "precise"
     argType: BOOL
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -420,10 +420,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -431,6 +427,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -445,10 +445,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -456,6 +452,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -470,12 +470,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -490,21 +490,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "absolute_difference_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -527,13 +523,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "absolute_difference_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "absolute_difference_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -566,6 +562,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "acos"
@@ -578,12 +578,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -598,12 +598,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -622,15 +622,6 @@ opList {
     name: "stateMsdx"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dRho"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "gradient"
@@ -661,6 +652,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 5
   }
+  argDescriptor {
+    name: "dRho"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -672,15 +672,6 @@ opList {
   argDescriptor {
     name: "stateH"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -702,14 +693,19 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "ada_max_updater"
-  argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
   argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
@@ -723,25 +719,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -776,16 +753,35 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adabelief_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -798,25 +794,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -851,16 +828,35 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adam_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -873,25 +869,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -926,6 +903,29 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -940,10 +940,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -951,6 +947,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -970,10 +970,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -987,6 +983,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "add_scalar"
@@ -995,12 +995,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1028,10 +1028,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -1040,14 +1036,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "factor"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adjust_hue"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -1061,21 +1057,21 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "adjust_saturation"
   argDescriptor {
     name: "dimC"
     argType: INT64
   }
   argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "adjust_saturation"
+  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "factor"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -1085,22 +1081,18 @@ opList {
     name: "factor"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "all"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1110,6 +1102,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1120,7 +1120,11 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "a"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "p"
     argType: DOUBLE
   }
   argDescriptor {
@@ -1138,21 +1142,31 @@ opList {
     argType: DOUBLE
     argIndex: 3
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "alpha_dropout_bp"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradOut"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "reduceShape"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
   }
   argDescriptor {
     name: "probValue"
@@ -1173,44 +1187,30 @@ opList {
     argType: DOUBLE
     argIndex: 3
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradOut"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "reduceShape"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "amax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
     name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1238,16 +1238,8 @@ opList {
 opList {
   name: "amean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1257,22 +1249,22 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "amin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1282,6 +1274,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1309,10 +1309,6 @@ opList {
 opList {
   name: "ams_grad_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -1329,25 +1325,6 @@ opList {
   argDescriptor {
     name: "stateH"
     argType: OUTPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
     argIndex: 3
   }
   argDescriptor {
@@ -1389,6 +1366,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -1402,10 +1402,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -1413,6 +1409,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1423,28 +1423,20 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "any"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1455,6 +1447,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -1462,10 +1462,6 @@ opList {
   argDescriptor {
     name: "Z"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "lr"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "parameters"
@@ -1481,6 +1477,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "lr"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -1493,20 +1493,12 @@ opList {
 opList {
   name: "argamax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1516,25 +1508,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argamin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1544,25 +1536,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argmax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1572,25 +1564,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argmin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1600,6 +1592,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -1613,12 +1613,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1633,12 +1633,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1692,16 +1692,8 @@ opList {
 opList {
   name: "asum"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1711,6 +1703,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1725,12 +1725,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1745,18 +1745,30 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "avgpool2d"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "kH"
     argType: INT64
   }
@@ -1809,23 +1821,28 @@ opList {
     name: "isNCHW"
     argType: INT64
     argIndex: 10
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
 }
 opList {
   name: "avgpool2d_bp"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "gradI"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
     name: "kH"
     argType: INT64
   }
@@ -1879,100 +1896,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "avgpool3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 11
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 12
-  }
-  argDescriptor {
-    name: "extraParam0"
-    argType: INT64
-    argIndex: 13
-  }
-  argDescriptor {
-    name: "isNCDHW"
-    argType: INT64
-    argIndex: 14
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -1985,9 +1911,6 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "avgpool3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -2062,6 +1985,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "avgpool3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2079,13 +2005,83 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "extraParam0"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "axpy"
-  argDescriptor {
-    name: "n"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -2093,10 +2089,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "a"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -2112,14 +2104,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "n"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "a"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "barnes_edge_forces"
-  argDescriptor {
-    name: "N"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2147,6 +2143,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "N"
+    argType: INT64
+  }
 }
 opList {
   name: "barnes_gains"
@@ -2172,10 +2172,6 @@ opList {
 }
 opList {
   name: "barnes_symmetrized"
-  argDescriptor {
-    name: "N"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2213,23 +2209,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "N"
+    argType: INT64
+  }
 }
 opList {
   name: "batch_to_space"
-  argDescriptor {
-    name: "blockSize"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "croppingTop"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "croppingBottom"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2247,13 +2233,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blockSize"
+    argType: INT64
+  }
 }
 opList {
   name: "batch_to_space_nd"
-  argDescriptor {
-    name: "blocks"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2261,10 +2251,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -2280,9 +2266,53 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blocks"
+    argType: INT64
+  }
 }
 opList {
   name: "batched_gemm"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "vC"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "beta"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "vA"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "vB"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "transposeA"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "transposeB"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "transA"
     argType: INT64
@@ -2327,54 +2357,9 @@ opList {
     argType: INT64
     argIndex: 8
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "vC"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "transposeA"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "transposeB"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "beta"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "vA"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "vB"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "batchnorm"
-  argDescriptor {
-    name: "applyScale"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "applyOffset"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2382,24 +2367,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "applyGamma"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "applyBeta"
-    argType: BOOL
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -2420,9 +2387,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "batchnorm_bp"
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "applyGamma"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "applyBeta"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "applyScale"
     argType: INT64
@@ -2432,6 +2414,9 @@ opList {
     argType: INT64
     argIndex: 1
   }
+}
+opList {
+  name: "batchnorm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2456,24 +2441,6 @@ opList {
     argIndex: 3
   }
   argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "applyGamma"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "applyBeta"
-    argType: BOOL
-    argIndex: 2
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2491,6 +2458,33 @@ opList {
     name: "gamma"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "applyGamma"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "applyBeta"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "applyScale"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "applyOffset"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -2526,10 +2520,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2537,6 +2527,10 @@ opList {
     name: "bias"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
   }
 }
 opList {
@@ -2555,10 +2549,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2572,23 +2562,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
 }
 opList {
   name: "bincount"
-  argDescriptor {
-    name: "minLength"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "maxLength"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outputType"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "outputType"
     argType: DATA_TYPE
@@ -2616,13 +2596,23 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "minLength"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "maxLength"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "outputType"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "bitcast"
-  argDescriptor {
-    name: "newType"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2639,6 +2629,10 @@ opList {
     name: "dataType"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "newType"
+    argType: INT64
   }
 }
 opList {
@@ -2672,10 +2666,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2683,6 +2673,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2697,10 +2691,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2708,6 +2698,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2722,10 +2716,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2733,6 +2723,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2823,6 +2817,18 @@ opList {
 opList {
   name: "broadcast_amax"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2830,24 +2836,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_amin"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2855,18 +2861,6 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -2893,16 +2887,8 @@ opList {
 opList {
   name: "broadcast_equalto"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -2913,10 +2899,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_greaterthan"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   argDescriptor {
     name: "shape"
     argType: INT64
@@ -2925,24 +2931,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_greaterthanorequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2950,24 +2956,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_lessthan"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2975,24 +2981,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_lessthanorequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3000,24 +3006,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_max"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3025,24 +3031,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_min"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3050,24 +3056,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_notequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3075,18 +3081,6 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -3113,10 +3107,6 @@ opList {
 opList {
   name: "broadcastadd"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -3128,12 +3118,32 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastcopy"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3141,24 +3151,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastdiv"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3166,28 +3176,12 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastgradientargs"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -3199,12 +3193,32 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: OP_IMPL
 }
 opList {
   name: "broadcastmul"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3212,24 +3226,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastrdiv"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3237,24 +3251,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastrsub"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3262,24 +3276,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastsub"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3288,26 +3302,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "car"
-  argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -3315,20 +3313,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "compare"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "set"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -3339,21 +3323,9 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "cas"
   argDescriptor {
     name: "mode"
     argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "compare"
@@ -3369,18 +3341,44 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "cas"
+  argDescriptor {
+    name: "dataType"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "compare"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "set"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
+    argIndex: 2
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cast"
-  argDescriptor {
-    name: "dst"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3390,37 +3388,23 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dst"
+    argType: INT64
   }
 }
 opList {
   name: "cbow"
   argDescriptor {
-    name: "numWorkers"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "nsRounds"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "trainWords"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "isInference"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "target"
@@ -3496,6 +3480,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 14
   }
+  argDescriptor {
+    name: "trainWords"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isInference"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numWorkers"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "nsRounds"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -3509,21 +3511,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cell_contains"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3531,10 +3529,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "contains"
-    argType: BOOL
   }
   argDescriptor {
     name: "corner"
@@ -3549,6 +3543,14 @@ opList {
     name: "point"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "contains"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
 }
 opList {
@@ -3603,10 +3605,6 @@ opList {
 opList {
   name: "choose"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -3620,10 +3618,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "scalar"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "arg"
     argType: INPUT_TENSOR
   }
@@ -3631,6 +3625,14 @@ opList {
     name: "comp"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "scalar"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3644,31 +3646,31 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
   }
 }
 opList {
   name: "clipbyavgnorm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -3683,10 +3685,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3695,33 +3693,33 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "clipbynorm"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipValue"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "clipbynorm_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3731,10 +3729,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3742,6 +3736,14 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipValue"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3751,6 +3753,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "left"
     argType: DOUBLE
   }
@@ -3758,10 +3764,6 @@ opList {
     name: "right"
     argType: DOUBLE
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -3779,6 +3781,23 @@ opList {
 }
 opList {
   name: "col2im"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inputArrays"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
   argDescriptor {
     name: "strideY"
     argType: INT64
@@ -3818,23 +3837,6 @@ opList {
     argType: INT64
     argIndex: 7
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inputArrays"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "compare_and_bitpack"
@@ -3847,10 +3849,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3858,6 +3856,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3928,20 +3930,12 @@ opList {
 opList {
   name: "concat"
   argDescriptor {
-    name: "concatDimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isDynamicAxis"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -3952,13 +3946,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "concat_bp"
+  argDescriptor {
+    name: "isDynamicAxis"
+    argType: BOOL
+  }
   argDescriptor {
     name: "concatDimension"
     argType: INT64
   }
+}
+opList {
+  name: "concat_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3966,10 +3964,6 @@ opList {
   argDescriptor {
     name: "epsilonChunk"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dynamicAxis"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -3980,18 +3974,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dynamicAxis"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "concatDimension"
+    argType: INT64
+  }
 }
 opList {
   name: "confusion_matrix"
-  argDescriptor {
-    name: "numClasses"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4014,9 +4007,35 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numClasses"
+    argType: INT64
+  }
 }
 opList {
   name: "conv1d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "weights"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "bias"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
   argDescriptor {
     name: "kW"
     argType: INT64
@@ -4050,33 +4069,48 @@ opList {
     name: "wFormat"
     argType: INT64
     argIndex: 6
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "bias"
-    argType: INPUT_TENSOR
-    argIndex: 2
   }
 }
 opList {
   name: "conv1d_bp"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "gradI"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradW"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gradB"
+    argType: OUTPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "weights"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "bias"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
     name: "kW"
     argType: INT64
   }
@@ -4110,100 +4144,9 @@ opList {
     argType: INT64
     argIndex: 6
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradW"
-    argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gradB"
-    argType: OUTPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "bias"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "conv2d"
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4226,9 +4169,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -4283,6 +4223,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "conv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4320,9 +4263,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "conv2d_input_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -4377,6 +4317,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "conv2d_input_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4399,83 +4342,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
-    name: "paddingMode"
+    name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
     name: "wFormat"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "conv3dnew"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4498,9 +4421,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -4575,6 +4495,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "conv3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4612,6 +4535,80 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "paddingMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "copy"
@@ -4624,10 +4621,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -4635,6 +4628,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -4649,12 +4646,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -4669,26 +4666,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cosine_distance_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4711,9 +4699,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "cosine_distance_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
@@ -4723,6 +4708,9 @@ opList {
     argType: INT64
     argIndex: 1
   }
+}
+opList {
+  name: "cosine_distance_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4755,16 +4743,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "cosinedistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -4776,25 +4778,25 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cosinesimilarity"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -4806,29 +4808,16 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "countNonZero"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -4838,22 +4827,22 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "countZero"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -4864,19 +4853,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "create"
-  argDescriptor {
-    name: "order"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputType"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "outputType"
     argType: DATA_TYPE
@@ -4886,16 +4874,33 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "init"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "order"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "outputType"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "create_list"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "create_list"
   argDescriptor {
     name: "height"
     argType: INT64
@@ -4904,14 +4909,6 @@ opList {
     name: "expandable"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LIST_OP_IMPL
 }
@@ -4953,20 +4950,12 @@ opList {
 opList {
   name: "crop_and_resize"
   argDescriptor {
-    name: "method"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "extrapolationVal"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "image"
@@ -4987,6 +4976,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "method"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "extrapolationVal"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "cross"
@@ -5006,11 +5003,55 @@ opList {
   opDeclarationType: OP_IMPL
 }
 opList {
-  name: "ctc_loss"
+  name: "ctc_beam"
   argDescriptor {
-    name: "blankIndex"
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "result_sequences"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "result_probs"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "result_sequences_length"
+    argType: OUTPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "logit"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "sequence_length"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "normalize_logits"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blank_index"
     argType: INT64
   }
+  argDescriptor {
+    name: "beam_width"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "nbest_len"
+    argType: INT64
+    argIndex: 2
+  }
+}
+opList {
+  name: "ctc_loss"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5038,13 +5079,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "ctc_loss_grad"
   argDescriptor {
     name: "blankIndex"
     argType: INT64
   }
+}
+opList {
+  name: "ctc_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5072,6 +5113,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "blankIndex"
+    argType: INT64
+  }
 }
 opList {
   name: "cube"
@@ -5084,12 +5129,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -5121,18 +5166,40 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cumprod"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
     name: "exclusive"
     argType: INT64
   }
@@ -5145,63 +5212,18 @@ opList {
     name: "dimensions"
     argType: INT64
     argIndex: 2
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "cumprod_bp"
   argDescriptor {
-    name: "exclusive"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5215,37 +5237,37 @@ opList {
   argDescriptor {
     name: "gradOut"
     argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 2
   }
 }
 opList {
   name: "cumsum"
   argDescriptor {
-    name: "exclusive"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5256,10 +5278,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "cumsum_bp"
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "exclusive"
     argType: INT64
@@ -5274,6 +5301,10 @@ opList {
     argType: INT64
     argIndex: 2
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "cumsum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5281,15 +5312,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5303,6 +5325,29 @@ opList {
   argDescriptor {
     name: "gradOut"
     argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 2
   }
 }
@@ -5317,10 +5362,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -5328,6 +5369,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -5342,10 +5387,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -5353,6 +5394,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -5399,60 +5444,6 @@ opList {
 opList {
   name: "deconv2d"
   argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -5474,9 +5465,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -5531,6 +5519,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "deconv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5568,9 +5559,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "deconv2d_tf"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -5625,6 +5613,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "deconv2d_tf"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5647,83 +5638,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv3d"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
     name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
     name: "wFormat"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "deconv3d"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5746,9 +5717,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv3d_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -5823,6 +5791,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "deconv3d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5859,6 +5830,80 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 14
   }
 }
 opList {
@@ -5885,15 +5930,6 @@ opList {
 opList {
   name: "depth_to_space"
   argDescriptor {
-    name: "block_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isNHWC"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -5905,63 +5941,18 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "depthwise_conv2d"
   argDescriptor {
-    name: "kH"
+    name: "block_size"
     argType: INT64
   }
   argDescriptor {
-    name: "kW"
+    name: "isNHWC"
     argType: INT64
     argIndex: 1
   }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
+}
+opList {
+  name: "depthwise_conv2d"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5984,9 +5975,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "depthwise_conv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -6041,6 +6029,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "depthwise_conv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6078,6 +6069,60 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 10
+  }
 }
 opList {
   name: "diag"
@@ -6090,12 +6135,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6109,12 +6154,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6132,35 +6177,12 @@ opList {
 opList {
   name: "dilation2d"
   argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "rates"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "strides"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -6181,9 +6203,40 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "isSameMode"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "rates"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "strides"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "distribution_bernoulli"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "prob"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6193,18 +6246,18 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_binomial"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "prob"
+    name: "probability"
     argType: DOUBLE
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_binomial"
   argDescriptor {
     name: "trials"
     argType: INT64
@@ -6219,25 +6272,17 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "probability"
-    argType: DOUBLE
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "distribution_binomial_ex"
   argDescriptor {
-    name: "trials"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "trials"
+    argType: INT64
   }
   argDescriptor {
     name: "probability"
@@ -6248,15 +6293,6 @@ opList {
 opList {
   name: "distribution_gaussian"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -6267,6 +6303,15 @@ opList {
   argDescriptor {
     name: "stddev"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "shape"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -6274,20 +6319,11 @@ opList {
 opList {
   name: "distribution_lognormal"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "mean"
+    name: "stddev"
     argType: DOUBLE
   }
   argDescriptor {
@@ -6295,10 +6331,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_truncated"
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6308,6 +6340,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_truncated"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -6321,10 +6357,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_uniform"
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6334,6 +6366,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_uniform"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -6345,6 +6381,15 @@ opList {
   argDescriptor {
     name: "to"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "shape"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -6377,10 +6422,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6388,6 +6429,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -6407,10 +6452,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6423,6 +6464,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6445,12 +6490,17 @@ opList {
 opList {
   name: "dot"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "newFormat"
@@ -6462,27 +6512,13 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "dot_product_attention"
-  argDescriptor {
-    name: "normalization"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputWeights"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6494,15 +6530,6 @@ opList {
   argDescriptor {
     name: "weights"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "withWeights"
-    argType: BOOL
     argIndex: 1
   }
   argDescriptor {
@@ -6524,13 +6551,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "dot_product_attention_bp"
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "withWeights"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "normalization"
     argType: INT64
   }
+  argDescriptor {
+    name: "outputWeights"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "dot_product_attention_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6548,10 +6589,6 @@ opList {
     name: "dLdv"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
   }
   argDescriptor {
     name: "queries"
@@ -6576,6 +6613,14 @@ opList {
     name: "mask"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "normalization"
+    argType: INT64
   }
 }
 opList {
@@ -6603,16 +6648,8 @@ opList {
 opList {
   name: "dropout"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "probValue"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -6623,21 +6660,21 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "dropout_bp"
   argDescriptor {
     name: "seed"
     argType: INT64
   }
   argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
     name: "probValue"
     argType: DOUBLE
+  }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "dropout_bp"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -6653,6 +6690,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "probValue"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -6662,21 +6707,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "p"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "p"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "dynamic_bidirectional_rnn"
-  argDescriptor {
-    name: "timeMajor"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6744,13 +6785,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
+  argDescriptor {
+    name: "timeMajor"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_partition"
-  argDescriptor {
-    name: "numPartitions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6768,13 +6809,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "numPartitions"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_partition_bp"
-  argDescriptor {
-    name: "numPartition"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6797,13 +6838,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numPartition"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_rnn"
-  argDescriptor {
-    name: "timeMajor"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6841,13 +6882,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "timeMajor"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_stitch"
-  argDescriptor {
-    name: "numPartitions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6865,6 +6906,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "numPartitions"
+    argType: INT64
+  }
+}
+opList {
+  name: "eig"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "eig_vals"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "eig_vectors"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
 }
 opList {
   name: "elu"
@@ -6873,12 +6938,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -6889,10 +6954,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6901,14 +6962,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "embedding_lookup"
-  argDescriptor {
-    name: "partition_mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6925,6 +6986,10 @@ opList {
     name: "indices"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "partition_mode"
+    argType: INT64
   }
 }
 opList {
@@ -6943,10 +7008,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6960,13 +7021,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "encode_threshold"
-  argDescriptor {
-    name: "boundary"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6981,10 +7042,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6992,6 +7049,14 @@ opList {
     name: "encoded"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "boundary"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
   }
 }
 opList {
@@ -7001,31 +7066,23 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "isConstant"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
   name: "entropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -7035,6 +7092,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7057,6 +7122,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -7066,12 +7135,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7086,10 +7155,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7097,6 +7162,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -7107,32 +7176,20 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "equals_with_eps"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -7142,6 +7199,18 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7156,12 +7225,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7176,24 +7245,29 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "euclidean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -7205,13 +7279,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7226,21 +7295,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "oldFormat"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "inputShape"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "dimensions"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "oldFormat"
+    argType: BOOL
     argIndex: 1
   }
 }
@@ -7251,12 +7320,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -7270,21 +7339,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "expand_dims"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7294,12 +7359,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7313,12 +7378,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7339,6 +7404,22 @@ opList {
 }
 opList {
   name: "extract_image_patches"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "sameMode"
+    argType: BOOL
+  }
   argDescriptor {
     name: "ksizeRows"
     argType: INT64
@@ -7373,6 +7454,9 @@ opList {
     argType: INT64
     argIndex: 6
   }
+}
+opList {
+  name: "eye"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7382,16 +7466,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "sameMode"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
+    name: "numRows"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "eye"
+  argDescriptor {
+    name: "numCols"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "numRows"
     argType: INT64
@@ -7411,41 +7497,24 @@ opList {
     argType: INT64
     argIndex: 3
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "numRows"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "numCols"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "fake_quant_with_min_max_args"
   argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "narrowRange"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "numBits"
+    argType: INT64
   }
   argDescriptor {
     name: "min"
@@ -7456,24 +7525,34 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "fake_quant_with_min_max_vars"
-  argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "min"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "max"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
     name: "narrowed"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "numBits"
+    argType: INT64
   }
   argDescriptor {
     name: "m"
@@ -7484,6 +7563,14 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "fake_quant_with_min_max_vars_per_channel"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
@@ -7497,45 +7584,19 @@ opList {
     name: "max"
     argType: INPUT_TENSOR
     argIndex: 2
-  }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "fake_quant_with_min_max_vars_per_channel"
-  argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "narrowed"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "min"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "max"
-    argType: INPUT_TENSOR
-    argIndex: 2
+    name: "numBits"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "fill"
-  argDescriptor {
-    name: "dtype"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7545,10 +7606,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "value"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "shape"
     argType: INPUT_TENSOR
   }
@@ -7556,6 +7613,14 @@ opList {
     name: "outputs"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dtype"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "value"
+    argType: DOUBLE
   }
 }
 opList {
@@ -7588,16 +7653,20 @@ opList {
 opList {
   name: "first_index"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -7608,19 +7677,11 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "flatten"
   argDescriptor {
-    name: "order"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7631,15 +7692,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "order"
+    argType: INT64
   }
 }
 opList {
   name: "flatten_2d"
   argDescriptor {
-    name: "flattenDimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7650,6 +7711,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7663,12 +7728,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7683,10 +7748,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7694,6 +7755,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -7713,10 +7778,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7730,6 +7791,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "floormod"
@@ -7742,10 +7807,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7753,6 +7814,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -7772,10 +7837,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7789,6 +7850,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "fmod"
@@ -7801,10 +7866,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7812,6 +7873,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7835,15 +7900,6 @@ opList {
 opList {
   name: "fused_batch_norm"
   argDescriptor {
-    name: "dataFormat"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isTraining"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7860,10 +7916,6 @@ opList {
     name: "batchVar"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -7894,13 +7946,22 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 5
   }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "isTraining"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "gather"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7908,10 +7969,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -7926,6 +7983,14 @@ opList {
     name: "intArgs"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7960,10 +8025,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7971,6 +8032,10 @@ opList {
     name: "indices"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
   }
 }
 opList {
@@ -7984,6 +8049,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -7991,10 +8060,6 @@ opList {
     name: "precise"
     argType: BOOL
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8036,10 +8101,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -8047,6 +8108,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -8061,10 +8126,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -8072,6 +8133,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -8082,12 +8147,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8098,12 +8163,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8362,12 +8427,17 @@ opList {
 opList {
   name: "hammingdistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -8379,13 +8449,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8400,12 +8465,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8420,12 +8485,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8469,12 +8534,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -8506,12 +8571,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8533,49 +8598,45 @@ opList {
 opList {
   name: "hasinf"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "hasnan"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "hinge_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8598,13 +8659,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "hinge_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "hinge_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8637,13 +8698,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "histogram"
-  argDescriptor {
-    name: "numBins"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8656,13 +8717,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "numBins"
+    argType: INT64
+  }
 }
 opList {
   name: "histogram_fixed_width"
-  argDescriptor {
-    name: "nbins"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8685,13 +8746,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "nbins"
+    argType: INT64
+  }
 }
 opList {
   name: "hsv_to_rgb"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -8700,14 +8761,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "huber_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8715,10 +8776,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "delta"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "predictions"
@@ -8734,13 +8791,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "huber_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "huber_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8760,10 +8821,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "delta"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -8777,6 +8834,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "identity"
@@ -8789,12 +8854,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -8867,6 +8932,27 @@ opList {
 opList {
   name: "im2col"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inputArrays"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "zeroPadVal"
+    argType: DOUBLE
+  }
+  argDescriptor {
     name: "kernelHeight"
     argType: INT64
   }
@@ -8905,6 +8991,9 @@ opList {
     argType: INT64
     argIndex: 7
   }
+}
+opList {
+  name: "im2col_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8914,21 +9003,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "zeroPadVal"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "inputArrays"
+    name: "gradAtOutput"
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "im2col_bp"
+  argDescriptor {
+    name: "zeroPadVal"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "kernelHeight"
     argType: INT64
@@ -8968,41 +9054,25 @@ opList {
     argType: INT64
     argIndex: 7
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "zeroPadVal"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradAtOutput"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "image_resize"
   argDescriptor {
-    name: "method"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "image"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "size"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "preserveAspectRatio"
@@ -9014,21 +9084,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "image"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "size"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "method"
+    argType: INT64
   }
 }
 opList {
   name: "in_top_k"
-  argDescriptor {
-    name: "k"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9038,10 +9099,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "sorted"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -9049,6 +9106,14 @@ opList {
     name: "target"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "sorted"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "k"
+    argType: INT64
   }
 }
 opList {
@@ -9062,12 +9127,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9078,12 +9143,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9094,12 +9159,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9110,12 +9175,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9130,12 +9195,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9150,21 +9215,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "ismax"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -9172,6 +9233,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9186,24 +9251,29 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "jaccarddistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -9215,13 +9285,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9273,16 +9338,20 @@ opList {
 opList {
   name: "last_index"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -9293,25 +9362,13 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "layer_norm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "noBias"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9327,14 +9384,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "layer_norm_bp"
+  argDescriptor {
+    name: "channelsFirst"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "layer_norm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9352,10 +9413,6 @@ opList {
     name: "dLdb"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "noBias"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9391,6 +9448,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 6
   }
+  argDescriptor {
+    name: "channelsFirst"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "leakyrelu"
@@ -9399,12 +9464,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9415,12 +9484,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9435,10 +9508,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9446,6 +9515,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -9460,10 +9533,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9471,6 +9540,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -9481,12 +9554,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9497,12 +9570,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9522,24 +9595,11 @@ opList {
   name: "lin_space"
   argDescriptor {
     name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "start"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "stop"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "start"
@@ -9555,24 +9615,42 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "start"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "stop"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "linspace_random"
-  argDescriptor {
-    name: "length"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "from"
+    name: "step"
     argType: DOUBLE
   }
   argDescriptor {
     name: "to"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "length"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -9613,12 +9691,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9633,21 +9711,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "log_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9655,10 +9729,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "predictions"
@@ -9674,13 +9744,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "log_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "log_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9700,10 +9774,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -9716,6 +9786,14 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
   }
 }
 opList {
@@ -9729,20 +9807,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
   name: "log_poisson_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9750,10 +9824,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "full"
-    argType: BOOL
   }
   argDescriptor {
     name: "log_predictions"
@@ -9769,13 +9839,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "log_poisson_loss_grad"
+  argDescriptor {
+    name: "full"
+    argType: BOOL
+  }
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "log_poisson_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9795,10 +9869,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "full"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "log_predictions"
     argType: INPUT_TENSOR
   }
@@ -9812,13 +9882,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "full"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "log_softmax"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -9827,14 +9901,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "log_softmax_bp"
   argDescriptor {
     name: "dimension"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "log_softmax_bp"
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
@@ -9848,6 +9922,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -9857,12 +9935,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "base"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "base"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9884,16 +9962,8 @@ opList {
 opList {
   name: "logentropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9903,6 +9973,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9917,12 +9995,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9933,12 +10011,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -9948,12 +10026,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9964,10 +10042,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9976,21 +10050,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lrn"
   argDescriptor {
-    name: "depth"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
   }
   argDescriptor {
     name: "bias"
@@ -10005,40 +10087,14 @@ opList {
     name: "beta"
     argType: DOUBLE
     argIndex: 2
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lrn_bp"
   argDescriptor {
-    name: "depth"
-    argType: INT64
-  }
-  argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "bias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "beta"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -10049,19 +10105,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "bias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "beta"
+    argType: DOUBLE
+    argIndex: 2
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lstm"
-  argDescriptor {
-    name: "peephole"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "projection"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10074,20 +10143,6 @@ opList {
     name: "c"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingProjValue"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -10128,18 +10183,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmBlock"
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "dataFormat"
+    name: "projection"
     argType: INT64
     argIndex: 1
   }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingProjValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
+    argIndex: 2
+  }
+}
+opList {
+  name: "lstmBlock"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10177,15 +10246,6 @@ opList {
     name: "y"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "maxTSLength"
@@ -10231,13 +10291,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
-}
-opList {
-  name: "lstmBlockCell"
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "lstmBlockCell"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10275,15 +10349,6 @@ opList {
     name: "y"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "xt"
@@ -10324,18 +10389,22 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmCell"
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "projection"
-    argType: INT64
+    name: "forgetBias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
     argIndex: 1
   }
+}
+opList {
+  name: "lstmCell"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10348,20 +10417,6 @@ opList {
     name: "ct"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingProjValue"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "xt"
@@ -10402,33 +10457,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmLayer"
   argDescriptor {
-    name: "dataFormat"
+    name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "directionMode"
+    name: "projection"
     argType: INT64
     argIndex: 1
   }
   argDescriptor {
-    name: "gateAct"
-    argType: INT64
+    name: "clippingCellValue"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingProjValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 4
-  }
+}
+opList {
+  name: "lstmLayer"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10446,6 +10500,45 @@ opList {
     name: "cL"
     argType: OUTPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "Wx"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "Wr"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "b"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "seqLen"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "hI"
+    argType: INPUT_TENSOR
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "cI"
+    argType: INPUT_TENSOR
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "Wp"
+    argType: INPUT_TENSOR
+    argIndex: 7
   }
   argDescriptor {
     name: "hasBiases"
@@ -10487,6 +10580,30 @@ opList {
     argIndex: 7
   }
   argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "directionMode"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
     name: "cellClip"
     argType: DOUBLE
   }
@@ -10520,62 +10637,9 @@ opList {
     argType: DOUBLE
     argIndex: 6
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "Wx"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "Wr"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "b"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "seqLen"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "hI"
-    argType: INPUT_TENSOR
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "cI"
-    argType: INPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "Wp"
-    argType: INPUT_TENSOR
-    argIndex: 7
-  }
 }
 opList {
   name: "lstmLayerCell"
-  argDescriptor {
-    name: "gateAct"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10590,6 +10654,40 @@ opList {
     argIndex: 1
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "Wx"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "Wr"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "b"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "hI"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "cI"
+    argType: INPUT_TENSOR
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "Wp"
+    argType: INPUT_TENSOR
+    argIndex: 6
+  }
+  argDescriptor {
     name: "hasBiases"
     argType: BOOL
   }
@@ -10597,6 +10695,20 @@ opList {
     name: "hasPH"
     argType: BOOL
     argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 2
   }
   argDescriptor {
     name: "cellClip"
@@ -10632,57 +10744,9 @@ opList {
     argType: DOUBLE
     argIndex: 6
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "Wx"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "Wr"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "b"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "hI"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "cI"
-    argType: INPUT_TENSOR
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "Wp"
-    argType: INPUT_TENSOR
-    argIndex: 6
-  }
 }
 opList {
   name: "lstmLayerCellBp"
-  argDescriptor {
-    name: "gateAct"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10719,49 +10783,6 @@ opList {
   argDescriptor {
     name: "dLdWp"
     argType: OUTPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "hasBiases"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "hasPH"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "cellClip"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "gateAlpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gateBeta"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "cellAlpha"
-    argType: DOUBLE
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "cellBeta"
-    argType: DOUBLE
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "outAlpha"
-    argType: DOUBLE
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "outBeta"
-    argType: DOUBLE
     argIndex: 6
   }
   argDescriptor {
@@ -10803,33 +10824,66 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmLayer_bp"
   argDescriptor {
-    name: "dataFormat"
-    argType: INT64
+    name: "hasBiases"
+    argType: BOOL
   }
   argDescriptor {
-    name: "directionMode"
-    argType: INT64
+    name: "hasPH"
+    argType: BOOL
     argIndex: 1
   }
   argDescriptor {
     name: "gateAct"
     argType: INT64
-    argIndex: 2
   }
   argDescriptor {
     name: "cellAct"
     argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "outAct"
     argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellClip"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "gateAlpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateBeta"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAlpha"
+    argType: DOUBLE
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "cellBeta"
+    argType: DOUBLE
     argIndex: 4
   }
+  argDescriptor {
+    name: "outAlpha"
+    argType: DOUBLE
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "outBeta"
+    argType: DOUBLE
+    argIndex: 6
+  }
+}
+opList {
+  name: "lstmLayer_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10866,79 +10920,6 @@ opList {
   argDescriptor {
     name: "dLdWp"
     argType: OUTPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "hasBiases"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "hasSeqLen"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "hasInitH"
-    argType: BOOL
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "hasInitC"
-    argType: BOOL
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "hasPH"
-    argType: BOOL
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "retFullSeq"
-    argType: BOOL
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "retLastH"
-    argType: BOOL
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "retLastC"
-    argType: BOOL
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "cellClip"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "gateAlpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gateBeta"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "cellAlpha"
-    argType: DOUBLE
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "cellBeta"
-    argType: DOUBLE
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "outAlpha"
-    argType: DOUBLE
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "outBeta"
-    argType: DOUBLE
     argIndex: 6
   }
   argDescriptor {
@@ -11000,6 +10981,103 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 11
   }
+  argDescriptor {
+    name: "hasBiases"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "hasSeqLen"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "hasInitH"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "hasInitC"
+    argType: BOOL
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "hasPH"
+    argType: BOOL
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "retFullSeq"
+    argType: BOOL
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "retLastH"
+    argType: BOOL
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "retLastC"
+    argType: BOOL
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "directionMode"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "cellClip"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "gateAlpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateBeta"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAlpha"
+    argType: DOUBLE
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "cellBeta"
+    argType: DOUBLE
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "outAlpha"
+    argType: DOUBLE
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "outBeta"
+    argType: DOUBLE
+    argIndex: 6
+  }
 }
 opList {
   name: "lstsq"
@@ -11012,14 +11090,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "fastFlag"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "l2_factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -11027,6 +11097,14 @@ opList {
     name: "b"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "fastFlag"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "l2_factor"
+    argType: DOUBLE
   }
 }
 opList {
@@ -11052,12 +11130,17 @@ opList {
 opList {
   name: "manhattan"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -11069,29 +11152,28 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "match_condition"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -11102,18 +11184,10 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "match_condition_transform"
-  argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -11123,6 +11197,19 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
     name: "compare"
     argType: DOUBLE
   }
@@ -11130,6 +11217,18 @@ opList {
     name: "eps"
     argType: DOUBLE
     argIndex: 1
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "matmul"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -11139,32 +11238,6 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "matmul"
-  argDescriptor {
-    name: "transX"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "transY"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "transZ"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "transposeX"
@@ -11190,18 +11263,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-}
-opList {
-  name: "matmul_bp"
-  argDescriptor {
     name: "transX"
     argType: INT64
   }
@@ -11215,6 +11276,9 @@ opList {
     argType: INT64
     argIndex: 2
   }
+}
+opList {
+  name: "matmul_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11226,15 +11290,6 @@ opList {
   argDescriptor {
     name: "dldy"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "beta"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -11261,18 +11316,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "matrix_band_part"
   argDescriptor {
-    name: "minLower"
+    name: "alpha"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "beta"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "transX"
     argType: INT64
   }
   argDescriptor {
-    name: "maxUpper"
+    name: "transY"
     argType: INT64
     argIndex: 1
   }
+  argDescriptor {
+    name: "transZ"
+    argType: INT64
+    argIndex: 2
+  }
+}
+opList {
+  name: "matrix_band_part"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -11291,6 +11360,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "minLower"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "maxUpper"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -11304,12 +11382,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11323,12 +11401,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "diagonal"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11342,12 +11420,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11357,12 +11435,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -11373,10 +11451,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -11384,6 +11458,10 @@ opList {
     name: "diagonal"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -11410,6 +11488,28 @@ opList {
 }
 opList {
   name: "max_pool_with_argmax"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "indices"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "outArgMax"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -11464,28 +11564,6 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "indices"
-    argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "outArgMax"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "max_scalar"
@@ -11515,10 +11593,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -11526,6 +11600,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -11573,64 +11651,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "maxpool2d"
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "extraParam0"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 10
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11643,9 +11671,6 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "maxpool2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -11700,6 +11725,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "maxpool2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11717,83 +11745,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "maxpool3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
     name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
     name: "extraParam0"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "maxpool3dnew"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11811,9 +11819,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "maxpool3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -11888,6 +11893,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "maxpool3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11905,13 +11913,83 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "extraParam0"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "mean_pairwssqerr_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11933,15 +12011,15 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
   }
 }
 opList {
   name: "mean_pairwssqerr_loss_grad"
   argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -11973,13 +12051,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "mean_sqerr_loss"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "mean_sqerr_loss"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12002,13 +12080,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "mean_sqerr_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "mean_sqerr_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12040,6 +12118,10 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
   }
 }
 opList {
@@ -12064,12 +12146,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "inArrs"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -12160,10 +12242,6 @@ opList {
 opList {
   name: "mergemaxindex"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -12174,6 +12252,10 @@ opList {
   argDescriptor {
     name: "inArrs"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -12190,10 +12272,6 @@ opList {
 opList {
   name: "meshgrid"
   argDescriptor {
-    name: "swapFirst2Dims"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -12202,16 +12280,28 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "inArrs"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "cartesian"
     argType: BOOL
   }
   argDescriptor {
-    name: "inArrs"
-    argType: INPUT_TENSOR
+    name: "swapFirst2Dims"
+    argType: INT64
   }
 }
 opList {
   name: "meta_postulate"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "meta_predicate"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -12228,14 +12318,6 @@ opList {
   opDeclarationType: LEGACY_XYZ
 }
 opList {
-  name: "meta_predicate"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
   name: "meta_predicate_inverted"
   argDescriptor {
     name: "outputs"
@@ -12246,12 +12328,12 @@ opList {
 opList {
   name: "meta_reduce"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12287,10 +12369,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12298,6 +12376,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12334,20 +12416,12 @@ opList {
 opList {
   name: "mirror_pad"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isSymmetric"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -12357,6 +12431,14 @@ opList {
     name: "paddings"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "isSymmetric"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
 }
 opList {
@@ -12370,12 +12452,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12390,10 +12472,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12401,6 +12479,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12420,10 +12502,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12437,13 +12515,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "moments"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12456,10 +12534,6 @@ opList {
     name: "variances"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -12475,6 +12549,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "mul_scalar"
@@ -12483,26 +12565,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "multi_head_dot_product_attention"
-  argDescriptor {
-    name: "normalization"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12510,15 +12584,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "withWeights"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "queries"
@@ -12559,13 +12624,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "multi_head_dot_product_attention_bp"
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "withWeights"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "normalization"
     argType: INT64
   }
+  argDescriptor {
+    name: "weights"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "multi_head_dot_product_attention_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12603,10 +12682,6 @@ opList {
     name: "dLdWo"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
   }
   argDescriptor {
     name: "queries"
@@ -12652,6 +12727,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "normalization"
+    argType: INT64
+  }
 }
 opList {
   name: "multiply"
@@ -12664,10 +12747,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12675,6 +12754,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12694,10 +12777,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12711,13 +12790,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "nadam_updater"
-  argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
   argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
@@ -12731,25 +12810,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -12785,6 +12845,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 6
   }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -12798,12 +12881,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12816,15 +12899,6 @@ opList {
   argDescriptor {
     name: "stateV"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dMomentum"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -12846,6 +12920,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dMomentum"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -12855,20 +12938,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
   name: "non_max_suppression"
-  argDescriptor {
-    name: "maxOutputSize"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12901,13 +12980,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "non_max_suppression_overlaps"
   argDescriptor {
     name: "maxOutputSize"
     argType: INT64
   }
+}
+opList {
+  name: "non_max_suppression_overlaps"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12915,6 +12994,34 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "boxes"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "scales"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "maxOutSize"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "iouThreshold"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "scoreThreshold"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "maxOutputSize"
+    argType: INT64
   }
   argDescriptor {
     name: "overlapThreshold"
@@ -12925,37 +13032,9 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "boxes"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "scales"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "maxOutSize"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "iouThreshold"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "scoreThreshold"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
 }
 opList {
   name: "non_max_suppression_v3"
-  argDescriptor {
-    name: "maxOutputSize"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12987,6 +13066,10 @@ opList {
     name: "scoreThreshold"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "maxOutputSize"
+    argType: INT64
   }
 }
 opList {
@@ -13008,10 +13091,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "mode"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13019,6 +13098,10 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: DOUBLE
   }
   opDeclarationType: REDUCTION_OP_IMPL
 }
@@ -13038,10 +13121,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "shift"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "counts"
     argType: INPUT_TENSOR
   }
@@ -13056,14 +13135,8 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "outMean"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "outVar"
-    argType: INPUT_TENSOR
-    argIndex: 4
+    name: "shift"
+    argType: DOUBLE
   }
 }
 opList {
@@ -13077,10 +13150,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13088,6 +13157,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13102,10 +13175,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13113,6 +13182,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -13123,12 +13196,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13139,21 +13212,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "nth_element"
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13163,10 +13232,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "reverse"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13174,6 +13239,14 @@ opList {
     name: "n"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
   }
 }
 opList {
@@ -13187,31 +13260,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "onehot"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "depth"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13219,15 +13278,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "on"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "off"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -13248,6 +13298,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "on"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "off"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "oneminus"
@@ -13260,21 +13333,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "ones_as"
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13286,6 +13355,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -13299,16 +13372,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "comparable"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13319,12 +13393,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13346,20 +13420,12 @@ opList {
 opList {
   name: "pad"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "padValue"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -13369,6 +13435,14 @@ opList {
     name: "paddings"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "padValue"
+    argType: DOUBLE
   }
 }
 opList {
@@ -13394,16 +13468,20 @@ opList {
 opList {
   name: "percentile"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   argDescriptor {
     name: "q"
@@ -13419,17 +13497,9 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "permute"
-  argDescriptor {
-    name: "reverseDims"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13443,9 +13513,13 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "permutationVector"
+    name: "permuteDims"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "reverseDims"
+    argType: INT64
   }
 }
 opList {
@@ -13467,6 +13541,18 @@ opList {
 }
 opList {
   name: "pnormpool2d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
   argDescriptor {
     name: "kY"
     argType: INT64
@@ -13521,21 +13607,30 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "pnormpool2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
-    name: "outputs"
+    name: "gradI"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "pnormpool2d_bp"
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -13590,39 +13685,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "pointwise_conv2d"
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13644,6 +13709,15 @@ opList {
     name: "bias"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -13670,10 +13744,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13681,6 +13751,10 @@ opList {
     name: "inputArrays"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -13690,14 +13764,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "pow"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13705,6 +13771,14 @@ opList {
     name: "pow"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "pow"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13719,10 +13793,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13730,6 +13800,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13744,6 +13818,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -13752,18 +13830,10 @@ opList {
     argType: BOOL
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "prelu"
-  argDescriptor {
-    name: "sharedAxes"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -13777,14 +13847,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "prelu_bp"
   argDescriptor {
     name: "sharedAxes"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "prelu_bp"
   argDescriptor {
     name: "dLdI"
     argType: OUTPUT_TENSOR
@@ -13818,6 +13888,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "sharedAxes"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -13846,10 +13920,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "printSpecial"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13857,6 +13927,10 @@ opList {
     name: "message"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "printSpecial"
+    argType: BOOL
   }
 }
 opList {
@@ -13866,10 +13940,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "probability"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13877,6 +13947,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "probability"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13896,12 +13970,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "fullMatricies"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "fullMatricies"
+    argType: BOOL
   }
 }
 opList {
@@ -13915,20 +13989,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "f"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "f"
+    argType: DOUBLE
   }
 }
 opList {
   name: "random_crop"
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13946,13 +14016,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_exponential"
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13962,16 +14032,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "shape"
+    argType: INT64
+  }
+  argDescriptor {
     name: "lambda"
     argType: DOUBLE
   }
 }
 opList {
   name: "random_gamma"
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13994,13 +14064,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_multinomial"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14017,6 +14087,10 @@ opList {
     name: "inputSamples"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
 }
 opList {
@@ -14037,10 +14111,6 @@ opList {
 opList {
   name: "random_poisson"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14057,13 +14127,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_shuffle"
-  argDescriptor {
-    name: "seeds"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -14071,6 +14141,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "seeds"
+    argType: INT64
   }
   opDeclarationType: OP_IMPL
 }
@@ -14081,6 +14155,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "shape"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "mean"
     argType: DOUBLE
   }
@@ -14089,22 +14167,9 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "shape"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "randomuniform"
-  argDescriptor {
-    name: "dtype"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -14114,15 +14179,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "min"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "max"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "shape"
     argType: INPUT_TENSOR
   }
@@ -14136,23 +14192,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "range"
   argDescriptor {
-    name: "from"
-    argType: INT64
+    name: "min"
+    argType: DOUBLE
   }
   argDescriptor {
-    name: "to"
-    argType: INT64
+    name: "max"
+    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
-    name: "step"
+    name: "dtype"
     argType: INT64
-    argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "range"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14163,30 +14223,44 @@ opList {
   }
   argDescriptor {
     name: "from"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "to"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
     argIndex: 1
   }
   argDescriptor {
     name: "step"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
     argIndex: 2
   }
   argDescriptor {
     name: "from"
-    argType: INPUT_TENSOR
+    argType: INT64
   }
   argDescriptor {
     name: "to"
-    argType: INPUT_TENSOR
+    argType: INT64
     argIndex: 1
   }
   argDescriptor {
     name: "step"
-    argType: INPUT_TENSOR
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "from"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "to"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "step"
+    argType: DOUBLE
     argIndex: 2
   }
 }
@@ -14201,12 +14275,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -14220,12 +14294,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14240,12 +14314,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14298,10 +14372,6 @@ opList {
 opList {
   name: "read_list"
   argDescriptor {
-    name: "index"
-    argType: INT64
-  }
-  argDescriptor {
     name: "importDataType"
     argType: DATA_TYPE
   }
@@ -14318,6 +14388,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "index"
+    argType: INT64
+  }
   opDeclarationType: LIST_OP_IMPL
 }
 opList {
@@ -14331,10 +14405,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14342,6 +14412,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -14386,12 +14460,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14406,12 +14480,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14447,10 +14521,6 @@ opList {
 opList {
   name: "reduce_dot_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14462,10 +14532,6 @@ opList {
     name: "gradY"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14491,13 +14557,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "reduce_logsumexp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_logsumexp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14505,31 +14575,31 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDim"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   argDescriptor {
     name: "keepDims"
     argType: DOUBLE
   }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "reduce_max"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14539,10 +14609,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14550,25 +14616,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_max_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14583,25 +14649,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_mean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14611,25 +14677,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_mean_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14644,25 +14710,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_min"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14672,25 +14738,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_min_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14705,25 +14771,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_norm1"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14733,25 +14799,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_norm1_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14767,13 +14833,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_norm2"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_norm2"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14783,10 +14853,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14795,13 +14861,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_norm2_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_norm2_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14809,10 +14879,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14827,6 +14893,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -14840,10 +14914,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14852,13 +14922,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
 }
 opList {
   name: "reduce_norm_max_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14866,10 +14936,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14885,20 +14951,20 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_normmax"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_normmax"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14908,16 +14974,20 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "reduce_prod"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14926,10 +14996,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14937,25 +15003,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_prod_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14970,25 +15036,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_sqnorm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14999,13 +15065,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_sqnorm_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_sqnorm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15013,10 +15083,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -15031,6 +15097,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -15044,15 +15118,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15061,13 +15126,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "reduce_stdev_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15075,24 +15145,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -15108,13 +15160,31 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_sum"
+  argDescriptor {
+    name: "biasCorrected"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
+}
+opList {
+  name: "reduce_sum"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15124,10 +15194,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15136,13 +15202,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_sum_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_sum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15150,10 +15220,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -15168,6 +15234,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -15181,15 +15255,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15198,13 +15263,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "reduce_variance_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15212,24 +15282,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -15245,6 +15297,28 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "relu"
@@ -15253,16 +15327,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15277,16 +15351,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15297,10 +15371,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "cutoff"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15308,6 +15378,10 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "cutoff"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15318,10 +15392,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "scalar"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15329,6 +15399,10 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "scalar"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15368,8 +15442,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "remainder_scalar"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -15383,27 +15474,7 @@ opList {
   opDeclarationType: LEGACY_XYZ
 }
 opList {
-  name: "remainder_scalar"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
   name: "repeat"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15416,6 +15487,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "replace_nans"
@@ -15424,21 +15499,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "set"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "set"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "reshape"
-  argDescriptor {
-    name: "shapeArr"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15455,6 +15526,10 @@ opList {
     name: "shape"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "shapeArr"
+    argType: INT64
   }
 }
 opList {
@@ -15480,15 +15555,6 @@ opList {
 opList {
   name: "resize_area"
   argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -15497,16 +15563,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "size"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "height"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15521,15 +15596,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "alignPixelCenters"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
@@ -15538,18 +15604,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alignPixelCenters"
+    argType: BOOL
+    argIndex: 1
+  }
 }
 opList {
   name: "resize_bilinear"
-  argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15559,21 +15625,30 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "halfPixelCenter"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "newImageSize"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "halfPixelCenters"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "height"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15586,15 +15661,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "preserveAspectRatio"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "image"
@@ -15610,18 +15676,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "preserveAspectRatio"
+    argType: BOOL
+    argIndex: 1
+  }
 }
 opList {
   name: "resize_nearest_neighbor"
-  argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15629,6 +15695,15 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "image"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "newImageSize"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "alignCorners"
@@ -15640,12 +15715,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "image"
-    argType: INPUT_TENSOR
+    name: "height"
+    argType: INT64
   }
   argDescriptor {
-    name: "newImageSize"
-    argType: INPUT_TENSOR
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15659,10 +15734,6 @@ opList {
 opList {
   name: "reverse"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -15675,14 +15746,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "reverse_bp"
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "reverse_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15705,18 +15776,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "reverse_sequence"
-  argDescriptor {
-    name: "seqDim"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "batchDim"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15732,6 +15798,15 @@ opList {
   argDescriptor {
     name: "seqLengths"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "seqDim"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "batchDim"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15757,10 +15832,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15768,6 +15839,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -15787,10 +15862,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15803,6 +15874,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -15863,10 +15938,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15874,6 +15945,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -15893,10 +15968,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15910,13 +15981,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "rgb_to_grs"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15929,13 +16000,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "rgb_to_hsv"
   argDescriptor {
     name: "dimC"
     argType: INT64
   }
+}
+opList {
+  name: "rgb_to_hsv"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -15943,38 +16014,42 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "rgb_to_yiq"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "rgb_to_yuv"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15989,12 +16064,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -16008,20 +16083,6 @@ opList {
     name: "stateG"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dRmsDecay"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "gradient"
@@ -16047,14 +16108,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dRmsDecay"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 2
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "roll"
-  argDescriptor {
-    name: "shift"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -16073,6 +16144,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "shift"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -16086,12 +16161,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16106,10 +16181,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16117,6 +16188,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -16131,12 +16206,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16147,12 +16222,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16187,15 +16262,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16208,6 +16274,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16218,15 +16293,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16239,6 +16305,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16275,15 +16350,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16296,6 +16362,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16306,15 +16381,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16327,6 +16393,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16337,15 +16412,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16358,6 +16424,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16370,15 +16445,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "indices"
@@ -16394,13 +16460,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "scatter_nd_add"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
   argDescriptor {
     name: "lock"
     argType: BOOL
@@ -16409,6 +16468,13 @@ opList {
     name: "checkIndices"
     argType: BOOL
     argIndex: 1
+  }
+}
+opList {
+  name: "scatter_nd_add"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -16423,6 +16489,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16433,15 +16508,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16454,6 +16520,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16464,15 +16539,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16485,6 +16551,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16495,15 +16570,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16516,6 +16582,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16526,15 +16601,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16547,6 +16613,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16575,60 +16650,6 @@ opList {
 opList {
   name: "sconv2d"
   argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -16650,9 +16671,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "sconv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -16707,6 +16725,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "sconv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -16745,9 +16766,63 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "bias"
+    name: "weightsPoint"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 10
   }
 }
 opList {
@@ -17031,12 +17106,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17068,21 +17143,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "sequence_mask"
-  argDescriptor {
-    name: "maxInd"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17092,16 +17163,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "is_static_maxlen"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "maxlen"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "is_static_maxlen"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "maxInd"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -17146,10 +17226,6 @@ opList {
 opList {
   name: "set_seed"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -17161,6 +17237,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "setrange"
@@ -17171,6 +17251,10 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
@@ -17185,10 +17269,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -17198,12 +17278,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17214,10 +17294,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lr"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -17225,22 +17301,18 @@ opList {
     name: "lr"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "lr"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "shannonentropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -17250,6 +17322,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17264,12 +17344,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -17283,12 +17363,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -17302,10 +17382,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -17314,14 +17390,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
 opList {
   name: "sigm_cross_entropy_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17329,10 +17405,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "logits"
@@ -17348,13 +17420,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "sigm_cross_entropy_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "sigm_cross_entropy_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17374,10 +17450,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "labelSmoothing"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "logits"
     argType: INPUT_TENSOR
   }
@@ -17391,6 +17463,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "labelSmoothing"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "sigmoid"
@@ -17403,12 +17483,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17440,12 +17520,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17460,12 +17540,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17480,12 +17560,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17507,10 +17587,6 @@ opList {
 opList {
   name: "size_at"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -17521,6 +17597,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -17538,26 +17618,8 @@ opList {
 opList {
   name: "skipgram"
   argDescriptor {
-    name: "numWorkers"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "nsRounds"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isInference"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "isPreciseMode"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "target"
@@ -17618,14 +17680,28 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 11
   }
+  argDescriptor {
+    name: "isInference"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isPreciseMode"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numWorkers"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "nsRounds"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "slice"
-  argDescriptor {
-    name: "size"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17648,13 +17724,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "slice_bp"
   argDescriptor {
     name: "size"
     argType: INT64
   }
+}
+opList {
+  name: "slice_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17682,13 +17758,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "size"
+    argType: INT64
+  }
 }
 opList {
   name: "softmax"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -17698,21 +17774,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "softmax_bp"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
@@ -17726,14 +17802,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "softmax_cross_entropy_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17741,10 +17817,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "logits"
@@ -17760,13 +17832,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "softmax_cross_entropy_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "softmax_cross_entropy_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17786,10 +17862,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "logits"
     argType: INPUT_TENSOR
   }
@@ -17803,13 +17875,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "softmax_cross_entropy_loss_with_logits"
-  argDescriptor {
-    name: "classesDim"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17827,13 +17903,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "softmax_cross_entropy_loss_with_logits_grad"
   argDescriptor {
     name: "classesDim"
     argType: INT64
   }
+}
+opList {
+  name: "softmax_cross_entropy_loss_with_logits_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17856,6 +17932,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "classesDim"
+    argType: INT64
+  }
 }
 opList {
   name: "softplus"
@@ -17868,12 +17948,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17905,12 +17985,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17942,12 +18022,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17960,10 +18040,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "useAdjoint"
-    argType: BOOL
   }
   argDescriptor {
     name: "a"
@@ -17979,6 +18055,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "useAdjoint"
+    argType: BOOL
+  }
 }
 opList {
   name: "solve_ls"
@@ -17991,14 +18071,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "fastFlag"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "l2_factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -18006,6 +18078,14 @@ opList {
     name: "b"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "fastFlag"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "l2_factor"
+    argType: DOUBLE
   }
 }
 opList {
@@ -18038,20 +18118,6 @@ opList {
 opList {
   name: "space_to_batch"
   argDescriptor {
-    name: "blockSize"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "paddingTop"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "paddingBottom"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18068,13 +18134,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blockSize"
+    argType: INT64
+  }
 }
 opList {
   name: "space_to_batch_nd"
-  argDescriptor {
-    name: "blocks"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18082,10 +18152,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -18101,18 +18167,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blocks"
+    argType: INT64
+  }
 }
 opList {
   name: "space_to_depth"
-  argDescriptor {
-    name: "block_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isNHWC"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18124,6 +18189,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "block_size"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "isNHWC"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -18169,15 +18243,6 @@ opList {
 opList {
   name: "split"
   argDescriptor {
-    name: "numSplit"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18192,6 +18257,15 @@ opList {
   argDescriptor {
     name: "b"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numSplit"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -18244,15 +18318,6 @@ opList {
 opList {
   name: "split_v"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "numSplit"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18274,6 +18339,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "numSplit"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "sqrt"
@@ -18286,12 +18360,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18318,12 +18392,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -18338,10 +18412,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -18349,6 +18419,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -18385,10 +18459,6 @@ opList {
 opList {
   name: "squeeze"
   argDescriptor {
-    name: "_a"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18404,6 +18474,10 @@ opList {
     name: "a"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "_a"
+    argType: INT64
   }
 }
 opList {
@@ -18662,6 +18736,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -18679,18 +18757,10 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "stack"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18707,6 +18777,10 @@ opList {
     name: "inArrs"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -18728,10 +18802,6 @@ opList {
 opList {
   name: "standardize"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -18744,14 +18814,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "standardize_bp"
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "standardize_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18773,6 +18843,10 @@ opList {
     name: "eps"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -18883,15 +18957,15 @@ opList {
 opList {
   name: "std"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "biasCorrected"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "newFormat"
     argType: BOOL
   }
   argDescriptor {
@@ -18900,8 +18974,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18912,16 +18986,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18936,41 +19010,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
 opList {
   name: "strided_slice"
-  argDescriptor {
-    name: "begin_mask"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "ellipsis_mask"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "end_mask"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "new_axis_mask"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "shrink_axis_mask"
-    argType: INT64
-    argIndex: 4
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18998,9 +19048,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "strided_slice_bp"
   argDescriptor {
     name: "begin_mask"
     argType: INT64
@@ -19025,6 +19072,9 @@ opList {
     argType: INT64
     argIndex: 4
   }
+}
+opList {
+  name: "strided_slice_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19057,6 +19107,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "begin_mask"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "ellipsis_mask"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "end_mask"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "new_axis_mask"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "shrink_axis_mask"
+    argType: INT64
+    argIndex: 4
+  }
 }
 opList {
   name: "sub_scalar"
@@ -19069,9 +19143,8 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19086,10 +19159,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19097,6 +19166,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -19116,10 +19189,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19132,6 +19201,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -19177,6 +19250,27 @@ opList {
 opList {
   name: "svd"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "fullUV"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "computeUv"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
     name: "fullUV"
     argType: INT64
   }
@@ -19190,42 +19284,6 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "full_matrices"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "computeUv"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "s"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "u"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "v"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "swish"
@@ -19238,12 +19296,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19254,10 +19312,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19265,6 +19319,10 @@ opList {
     name: "predicate"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -19278,12 +19336,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19314,12 +19372,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -19358,12 +19416,12 @@ opList {
 opList {
   name: "tensorarrayv3"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -19380,15 +19438,20 @@ opList {
 opList {
   name: "tensordot"
   argDescriptor {
-    name: "dimensionsY"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "addedEdges"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "transposeX"
     argType: BOOL
   }
   argDescriptor {
@@ -19402,26 +19465,12 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensionsY"
+    argType: INT64
   }
 }
 opList {
   name: "tensormmul"
-  argDescriptor {
-    name: "axe0_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "axe1_size"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19439,13 +19488,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "axe0_size"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "axe1_size"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "tensormmul_bp"
-  argDescriptor {
-    name: "axe0Size"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19472,6 +19526,20 @@ opList {
     name: "dLdC"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "dldx"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "dldy"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "axe0Size"
+    argType: INT64
   }
 }
 opList {
@@ -19553,10 +19621,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "y"
     argType: INPUT_TENSOR
   }
@@ -19564,6 +19628,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -19574,16 +19642,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -19594,10 +19662,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "cutoff"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19606,14 +19670,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "cutoff"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "tile"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19621,10 +19685,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "is_static_reps"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -19635,13 +19695,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "is_static_reps"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "tile_bp"
-  argDescriptor {
-    name: "repeat"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19658,6 +19722,10 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "repeat"
+    argType: INT64
   }
 }
 opList {
@@ -19706,12 +19774,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19835,10 +19903,6 @@ opList {
 opList {
   name: "top_k"
   argDescriptor {
-    name: "k"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -19852,12 +19916,16 @@ opList {
     argIndex: 1
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "needSort"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "k"
+    argType: INT64
   }
 }
 opList {
@@ -19890,13 +19958,25 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "permuteDims"
+    name: "permutationVector"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "permuteDims"
+    argType: INT64
   }
 }
 opList {
   name: "tri"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "row"
     argType: INT64
@@ -19911,14 +19991,6 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
 }
 opList {
   name: "triangular_solve"
@@ -19931,15 +20003,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "isLower"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "useAdjoint"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -19949,22 +20012,17 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "lower"
-    argType: INPUT_TENSOR
-    argIndex: 2
+    name: "isLower"
+    argType: BOOL
   }
   argDescriptor {
-    name: "adjoint"
-    argType: INPUT_TENSOR
-    argIndex: 3
+    name: "useAdjoint"
+    argType: BOOL
+    argIndex: 1
   }
 }
 opList {
   name: "triu"
-  argDescriptor {
-    name: "diag"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19977,13 +20035,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "triu_bp"
   argDescriptor {
     name: "diag"
     argType: INT64
   }
+}
+opList {
+  name: "triu_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20001,6 +20059,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "diag"
+    argType: INT64
+  }
 }
 opList {
   name: "truncatediv"
@@ -20013,10 +20075,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20024,6 +20082,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -20075,10 +20137,6 @@ opList {
 opList {
   name: "unsorted_segment_max"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20099,15 +20157,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_max_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20128,15 +20186,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_mean"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20157,15 +20215,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_mean_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20186,15 +20244,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_min"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20215,15 +20273,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_min_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20244,15 +20302,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_prod"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20273,15 +20331,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_prod_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20302,15 +20360,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_sqrt_n"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20331,15 +20389,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_sqrt_n_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20361,13 +20419,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "unsorted_segment_sum"
   argDescriptor {
     name: "numSegments"
     argType: INT64
   }
+}
+opList {
+  name: "unsorted_segment_sum"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20390,13 +20448,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "unsorted_segment_sum_bp"
   argDescriptor {
     name: "numSegments"
     argType: INT64
   }
+}
+opList {
+  name: "unsorted_segment_sum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20419,18 +20477,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
+  }
 }
 opList {
   name: "unstack"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "num"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20442,6 +20495,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "num"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -20459,6 +20521,22 @@ opList {
 opList {
   name: "upsampling2d"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "factorH"
     argType: INT64
   }
@@ -20472,29 +20550,9 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "upsampling2d_bp"
-  argDescriptor {
-    name: "scaleW"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20502,10 +20560,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "nchw"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -20516,9 +20570,33 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "scaleW"
+    argType: INT64
+  }
 }
 opList {
   name: "upsampling3d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "ncdhw"
+    argType: BOOL
+  }
   argDescriptor {
     name: "factorD"
     argType: INT64
@@ -20538,29 +20616,9 @@ opList {
     argType: INT64
     argIndex: 3
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "ncdhw"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "upsampling3d_bp"
-  argDescriptor {
-    name: "isNCDHW"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20568,10 +20626,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "ncdhw"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -20582,16 +20636,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "ncdhw"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+  }
 }
 opList {
   name: "var"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "biasCorrected"
@@ -20603,8 +20665,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -20658,10 +20720,6 @@ opList {
 opList {
   name: "write_list"
   argDescriptor {
-    name: "idx"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -20673,6 +20731,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "idx"
+    argType: INT64
   }
   opDeclarationType: LIST_OP_IMPL
 }
@@ -20687,10 +20749,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20698,6 +20756,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -20708,21 +20770,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "xw_plus_b"
-  argDescriptor {
-    name: "bTranspose"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20745,13 +20803,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "xw_plus_b_bp"
   argDescriptor {
     name: "bTranspose"
     argType: INT64
   }
+}
+opList {
+  name: "xw_plus_b_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20789,13 +20847,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "bTranspose"
+    argType: INT64
+  }
 }
 opList {
   name: "yiq_to_rgb"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -20803,22 +20861,26 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "yuv_to_rgb"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -20862,20 +20924,20 @@ opList {
 opList {
   name: "zeroslike"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -20889,10 +20951,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20900,6 +20958,10 @@ opList {
     name: "q"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }

--- a/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/processing/GroupConvPreProcessingRule.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/processing/GroupConvPreProcessingRule.kt
@@ -33,7 +33,7 @@ import org.nd4j.samediff.frameworkimport.hooks.annotations.HookResult
 import org.nd4j.samediff.frameworkimport.hooks.annotations.PreHookRule
 import java.lang.IllegalArgumentException
 
-@PreHookRule(nodeNames = ["conv2_1"],opNames = [],"onnx")
+@PreHookRule(nodeNames = ["conv2_1"],opNames = [],frameworkName = "onnx")
 class GroupConvPreProcessingRule: PreImportHook {
     override fun preProcess(
         op: SameDiffOp,

--- a/nd4j/samediff-import/samediff-import-onnx/variables-added-new.txt
+++ b/nd4j/samediff-import/samediff-import-onnx/variables-added-new.txt
@@ -1,1 +1,0 @@
-output,output

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/resources/nd4j-op-def.pbtxt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/resources/nd4j-op-def.pbtxt
@@ -21,21 +21,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "thresholdRelative"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "thresholdAbsolute"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "y"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "thresholdRelative"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "thresholdAbsolute"
+    argType: DOUBLE
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -51,14 +51,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -67,6 +59,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -74,6 +74,10 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
@@ -87,10 +91,6 @@ opList {
     name: "clipValueMax"
     argType: DOUBLE
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
 }
 opList {
@@ -172,10 +172,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -198,6 +194,10 @@ opList {
     name: "dLdy"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -227,10 +227,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -238,6 +234,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -306,16 +306,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
+    name: "condition"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "isConstant"
     argType: BOOL
   }
   argDescriptor {
-    name: "condition"
-    argType: INPUT_TENSOR
+    name: "frameName"
+    argType: STRING
   }
   opDeclarationType: LOGIC_OP_IMPL
 }
@@ -330,12 +330,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -350,10 +350,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -361,6 +357,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -371,16 +371,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "pow"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -395,6 +395,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -402,10 +406,6 @@ opList {
     name: "precise"
     argType: BOOL
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -420,10 +420,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -431,6 +427,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -445,10 +445,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -456,6 +452,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -470,12 +470,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -490,21 +490,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "absolute_difference_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -527,13 +523,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "absolute_difference_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "absolute_difference_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -566,6 +562,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "acos"
@@ -578,12 +578,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -598,12 +598,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -622,15 +622,6 @@ opList {
     name: "stateMsdx"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dRho"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "gradient"
@@ -661,6 +652,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 5
   }
+  argDescriptor {
+    name: "dRho"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -672,15 +672,6 @@ opList {
   argDescriptor {
     name: "stateH"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -702,14 +693,19 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "ada_max_updater"
-  argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
   argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
@@ -723,25 +719,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -776,16 +753,35 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adabelief_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -798,25 +794,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -851,16 +828,35 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adam_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -873,25 +869,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -926,6 +903,29 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 6
+  }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -940,10 +940,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -951,6 +947,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -970,10 +970,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -987,6 +983,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "add_scalar"
@@ -995,12 +995,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1028,10 +1028,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -1040,14 +1036,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "factor"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "adjust_hue"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -1061,21 +1057,21 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "adjust_saturation"
   argDescriptor {
     name: "dimC"
     argType: INT64
   }
   argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "adjust_saturation"
+  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "factor"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -1085,22 +1081,18 @@ opList {
     name: "factor"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "all"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1110,6 +1102,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1120,7 +1120,11 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "a"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "p"
     argType: DOUBLE
   }
   argDescriptor {
@@ -1138,21 +1142,31 @@ opList {
     argType: DOUBLE
     argIndex: 3
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "alpha_dropout_bp"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradOut"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "reduceShape"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
   }
   argDescriptor {
     name: "probValue"
@@ -1173,44 +1187,30 @@ opList {
     argType: DOUBLE
     argIndex: 3
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradOut"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "reduceShape"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "amax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
     name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1238,16 +1238,8 @@ opList {
 opList {
   name: "amean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1257,22 +1249,22 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "amin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1282,6 +1274,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1309,10 +1309,6 @@ opList {
 opList {
   name: "ams_grad_updater"
   argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
-  argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
   }
@@ -1329,25 +1325,6 @@ opList {
   argDescriptor {
     name: "stateH"
     argType: OUTPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
     argIndex: 3
   }
   argDescriptor {
@@ -1389,6 +1366,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -1402,10 +1402,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -1413,6 +1409,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1423,28 +1423,20 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "any"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1455,6 +1447,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -1462,10 +1462,6 @@ opList {
   argDescriptor {
     name: "Z"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "lr"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "parameters"
@@ -1481,6 +1477,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "lr"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -1493,20 +1493,12 @@ opList {
 opList {
   name: "argamax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1516,25 +1508,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argamin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1544,25 +1536,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argmax"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1572,25 +1564,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "argmin"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1600,6 +1592,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -1613,12 +1613,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1633,12 +1633,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1692,16 +1692,8 @@ opList {
 opList {
   name: "asum"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -1711,6 +1703,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1725,12 +1725,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -1745,18 +1745,30 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "avgpool2d"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "kH"
     argType: INT64
   }
@@ -1809,23 +1821,28 @@ opList {
     name: "isNCHW"
     argType: INT64
     argIndex: 10
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
 }
 opList {
   name: "avgpool2d_bp"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "gradI"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
     name: "kH"
     argType: INT64
   }
@@ -1879,100 +1896,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "avgpool3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 11
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 12
-  }
-  argDescriptor {
-    name: "extraParam0"
-    argType: INT64
-    argIndex: 13
-  }
-  argDescriptor {
-    name: "isNCDHW"
-    argType: INT64
-    argIndex: 14
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -1985,9 +1911,6 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "avgpool3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -2062,6 +1985,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "avgpool3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2079,13 +2005,83 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "extraParam0"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "axpy"
-  argDescriptor {
-    name: "n"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -2093,10 +2089,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "a"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -2112,14 +2104,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "n"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "a"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "barnes_edge_forces"
-  argDescriptor {
-    name: "N"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2147,6 +2143,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "N"
+    argType: INT64
+  }
 }
 opList {
   name: "barnes_gains"
@@ -2172,10 +2172,6 @@ opList {
 }
 opList {
   name: "barnes_symmetrized"
-  argDescriptor {
-    name: "N"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2213,23 +2209,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "N"
+    argType: INT64
+  }
 }
 opList {
   name: "batch_to_space"
-  argDescriptor {
-    name: "blockSize"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "croppingTop"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "croppingBottom"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2247,13 +2233,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blockSize"
+    argType: INT64
+  }
 }
 opList {
   name: "batch_to_space_nd"
-  argDescriptor {
-    name: "blocks"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2261,10 +2251,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -2280,9 +2266,53 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blocks"
+    argType: INT64
+  }
 }
 opList {
   name: "batched_gemm"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "vC"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "beta"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "vA"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "vB"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "transposeA"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "transposeB"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "transA"
     argType: INT64
@@ -2327,54 +2357,9 @@ opList {
     argType: INT64
     argIndex: 8
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "vC"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "transposeA"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "transposeB"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "beta"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "vA"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "vB"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "batchnorm"
-  argDescriptor {
-    name: "applyScale"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "applyOffset"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2382,24 +2367,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "applyGamma"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "applyBeta"
-    argType: BOOL
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -2420,9 +2387,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "batchnorm_bp"
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "applyGamma"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "applyBeta"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "applyScale"
     argType: INT64
@@ -2432,6 +2414,9 @@ opList {
     argType: INT64
     argIndex: 1
   }
+}
+opList {
+  name: "batchnorm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2456,24 +2441,6 @@ opList {
     argIndex: 3
   }
   argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "applyGamma"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "applyBeta"
-    argType: BOOL
-    argIndex: 2
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2491,6 +2458,33 @@ opList {
     name: "gamma"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "applyGamma"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "applyBeta"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "applyScale"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "applyOffset"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -2526,10 +2520,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2537,6 +2527,10 @@ opList {
     name: "bias"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
   }
 }
 opList {
@@ -2555,10 +2549,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2572,23 +2562,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
 }
 opList {
   name: "bincount"
-  argDescriptor {
-    name: "minLength"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "maxLength"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outputType"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "outputType"
     argType: DATA_TYPE
@@ -2616,13 +2596,23 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "minLength"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "maxLength"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "outputType"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "bitcast"
-  argDescriptor {
-    name: "newType"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -2639,6 +2629,10 @@ opList {
     name: "dataType"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "newType"
+    argType: INT64
   }
 }
 opList {
@@ -2672,10 +2666,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2683,6 +2673,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2697,10 +2691,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2708,6 +2698,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2722,10 +2716,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -2733,6 +2723,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -2823,6 +2817,18 @@ opList {
 opList {
   name: "broadcast_amax"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2830,24 +2836,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_amin"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2855,18 +2861,6 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -2893,16 +2887,8 @@ opList {
 opList {
   name: "broadcast_equalto"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -2913,10 +2899,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_greaterthan"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   argDescriptor {
     name: "shape"
     argType: INT64
@@ -2925,24 +2931,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_greaterthanorequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2950,24 +2956,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_lessthan"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -2975,24 +2981,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_lessthanorequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3000,24 +3006,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_max"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3025,24 +3031,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_min"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3050,24 +3056,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcast_notequal"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3075,18 +3081,6 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -3113,10 +3107,6 @@ opList {
 opList {
   name: "broadcastadd"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -3128,12 +3118,32 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastcopy"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3141,24 +3151,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastdiv"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3166,28 +3176,12 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastgradientargs"
   argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -3199,12 +3193,32 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: OP_IMPL
 }
 opList {
   name: "broadcastmul"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3212,24 +3226,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastrdiv"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3237,24 +3251,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastrsub"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3262,24 +3276,24 @@ opList {
     name: "dimension"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "broadcastsub"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "shape"
     argType: INT64
   }
@@ -3288,26 +3302,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "car"
-  argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -3315,20 +3313,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "compare"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "set"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -3339,21 +3323,9 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "cas"
   argDescriptor {
     name: "mode"
     argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "compare"
@@ -3369,18 +3341,44 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "cas"
+  argDescriptor {
+    name: "dataType"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "compare"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "set"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
+    argIndex: 2
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cast"
-  argDescriptor {
-    name: "dst"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3390,37 +3388,23 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dst"
+    argType: INT64
   }
 }
 opList {
   name: "cbow"
   argDescriptor {
-    name: "numWorkers"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "nsRounds"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "trainWords"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "isInference"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "target"
@@ -3496,6 +3480,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 14
   }
+  argDescriptor {
+    name: "trainWords"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isInference"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numWorkers"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "nsRounds"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -3509,21 +3511,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cell_contains"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3531,10 +3529,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "contains"
-    argType: BOOL
   }
   argDescriptor {
     name: "corner"
@@ -3549,6 +3543,14 @@ opList {
     name: "point"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "contains"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
   }
 }
 opList {
@@ -3603,10 +3605,6 @@ opList {
 opList {
   name: "choose"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -3620,10 +3618,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "scalar"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "arg"
     argType: INPUT_TENSOR
   }
@@ -3631,6 +3625,14 @@ opList {
     name: "comp"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "scalar"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3644,31 +3646,31 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
   }
 }
 opList {
   name: "clipbyavgnorm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -3683,10 +3685,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipNorm"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3695,33 +3693,33 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "clipNorm"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "clipbynorm"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipValue"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "clipbynorm_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3731,10 +3729,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "clipValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3742,6 +3736,14 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "clipValue"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3751,6 +3753,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "left"
     argType: DOUBLE
   }
@@ -3758,10 +3764,6 @@ opList {
     name: "right"
     argType: DOUBLE
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -3779,6 +3781,23 @@ opList {
 }
 opList {
   name: "col2im"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inputArrays"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
   argDescriptor {
     name: "strideY"
     argType: INT64
@@ -3818,23 +3837,6 @@ opList {
     argType: INT64
     argIndex: 7
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inputArrays"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "compare_and_bitpack"
@@ -3847,10 +3849,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -3858,6 +3856,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
   }
 }
 opList {
@@ -3928,20 +3930,12 @@ opList {
 opList {
   name: "concat"
   argDescriptor {
-    name: "concatDimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isDynamicAxis"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -3952,13 +3946,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "concat_bp"
+  argDescriptor {
+    name: "isDynamicAxis"
+    argType: BOOL
+  }
   argDescriptor {
     name: "concatDimension"
     argType: INT64
   }
+}
+opList {
+  name: "concat_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -3966,10 +3964,6 @@ opList {
   argDescriptor {
     name: "epsilonChunk"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dynamicAxis"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -3980,18 +3974,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dynamicAxis"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "concatDimension"
+    argType: INT64
+  }
 }
 opList {
   name: "confusion_matrix"
-  argDescriptor {
-    name: "numClasses"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4014,9 +4007,35 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numClasses"
+    argType: INT64
+  }
 }
 opList {
   name: "conv1d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "weights"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "bias"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
   argDescriptor {
     name: "kW"
     argType: INT64
@@ -4050,33 +4069,48 @@ opList {
     name: "wFormat"
     argType: INT64
     argIndex: 6
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "bias"
-    argType: INPUT_TENSOR
-    argIndex: 2
   }
 }
 opList {
   name: "conv1d_bp"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "gradI"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "gradW"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gradB"
+    argType: OUTPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "weights"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "bias"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
     name: "kW"
     argType: INT64
   }
@@ -4110,100 +4144,9 @@ opList {
     argType: INT64
     argIndex: 6
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradW"
-    argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gradB"
-    argType: OUTPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "bias"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "conv2d"
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4226,9 +4169,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -4283,6 +4223,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "conv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4320,9 +4263,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "conv2d_input_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -4377,6 +4317,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "conv2d_input_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4399,83 +4342,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
-    name: "paddingMode"
+    name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
     name: "wFormat"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "conv3dnew"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4498,9 +4421,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "conv3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -4575,6 +4495,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "conv3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4612,6 +4535,80 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "paddingMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "copy"
@@ -4624,10 +4621,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -4635,6 +4628,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -4649,12 +4646,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -4669,26 +4666,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cosine_distance_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4711,9 +4699,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "cosine_distance_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
@@ -4723,6 +4708,9 @@ opList {
     argType: INT64
     argIndex: 1
   }
+}
+opList {
+  name: "cosine_distance_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -4755,16 +4743,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "cosinedistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -4776,25 +4778,25 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cosinesimilarity"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -4806,29 +4808,16 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "countNonZero"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -4838,22 +4827,22 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "countZero"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -4864,19 +4853,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "create"
-  argDescriptor {
-    name: "order"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputType"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "outputType"
     argType: DATA_TYPE
@@ -4886,16 +4874,33 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "init"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "order"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "outputType"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "create_list"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "create_list"
   argDescriptor {
     name: "height"
     argType: INT64
@@ -4904,14 +4909,6 @@ opList {
     name: "expandable"
     argType: INT64
     argIndex: 1
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LIST_OP_IMPL
 }
@@ -4953,20 +4950,12 @@ opList {
 opList {
   name: "crop_and_resize"
   argDescriptor {
-    name: "method"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "extrapolationVal"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "image"
@@ -4987,6 +4976,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "method"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "extrapolationVal"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "cross"
@@ -5006,11 +5003,55 @@ opList {
   opDeclarationType: OP_IMPL
 }
 opList {
-  name: "ctc_loss"
+  name: "ctc_beam"
   argDescriptor {
-    name: "blankIndex"
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "result_sequences"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "result_probs"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "result_sequences_length"
+    argType: OUTPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "logit"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "sequence_length"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "normalize_logits"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blank_index"
     argType: INT64
   }
+  argDescriptor {
+    name: "beam_width"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "nbest_len"
+    argType: INT64
+    argIndex: 2
+  }
+}
+opList {
+  name: "ctc_loss"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5038,13 +5079,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "ctc_loss_grad"
   argDescriptor {
     name: "blankIndex"
     argType: INT64
   }
+}
+opList {
+  name: "ctc_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5072,6 +5113,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "blankIndex"
+    argType: INT64
+  }
 }
 opList {
   name: "cube"
@@ -5084,12 +5129,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -5121,18 +5166,40 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "cumprod"
   argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
     name: "exclusive"
     argType: INT64
   }
@@ -5145,63 +5212,18 @@ opList {
     name: "dimensions"
     argType: INT64
     argIndex: 2
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "cumprod_bp"
   argDescriptor {
-    name: "exclusive"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5215,37 +5237,37 @@ opList {
   argDescriptor {
     name: "gradOut"
     argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 2
   }
 }
 opList {
   name: "cumsum"
   argDescriptor {
-    name: "exclusive"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5256,10 +5278,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "cumsum_bp"
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "exclusive"
     argType: INT64
@@ -5274,6 +5301,10 @@ opList {
     argType: INT64
     argIndex: 2
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "cumsum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5281,15 +5312,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "exclusive"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "reverse"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -5303,6 +5325,29 @@ opList {
   argDescriptor {
     name: "gradOut"
     argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "exclusive"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 2
   }
 }
@@ -5317,10 +5362,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -5328,6 +5369,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -5342,10 +5387,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -5353,6 +5394,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -5399,60 +5444,6 @@ opList {
 opList {
   name: "deconv2d"
   argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -5474,9 +5465,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -5531,6 +5519,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "deconv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5568,9 +5559,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "deconv2d_tf"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -5625,6 +5613,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "deconv2d_tf"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5647,83 +5638,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv3d"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
     name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
     name: "wFormat"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "deconv3d"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5746,9 +5717,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "deconv3d_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -5823,6 +5791,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "deconv3d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5859,6 +5830,80 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 14
   }
 }
 opList {
@@ -5885,15 +5930,6 @@ opList {
 opList {
   name: "depth_to_space"
   argDescriptor {
-    name: "block_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isNHWC"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -5905,63 +5941,18 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "depthwise_conv2d"
   argDescriptor {
-    name: "kH"
+    name: "block_size"
     argType: INT64
   }
   argDescriptor {
-    name: "kW"
+    name: "isNHWC"
     argType: INT64
     argIndex: 1
   }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
+}
+opList {
+  name: "depthwise_conv2d"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -5984,9 +5975,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "depthwise_conv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -6041,6 +6029,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "depthwise_conv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6078,6 +6069,60 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 10
+  }
 }
 opList {
   name: "diag"
@@ -6090,12 +6135,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6109,12 +6154,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6132,35 +6177,12 @@ opList {
 opList {
   name: "dilation2d"
   argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "rates"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "strides"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -6181,9 +6203,40 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "isSameMode"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "rates"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "strides"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "distribution_bernoulli"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "prob"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6193,18 +6246,18 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_binomial"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "prob"
+    name: "probability"
     argType: DOUBLE
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_binomial"
   argDescriptor {
     name: "trials"
     argType: INT64
@@ -6219,25 +6272,17 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "probability"
-    argType: DOUBLE
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "distribution_binomial_ex"
   argDescriptor {
-    name: "trials"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "trials"
+    argType: INT64
   }
   argDescriptor {
     name: "probability"
@@ -6248,15 +6293,6 @@ opList {
 opList {
   name: "distribution_gaussian"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -6267,6 +6303,15 @@ opList {
   argDescriptor {
     name: "stddev"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "shape"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -6274,20 +6319,11 @@ opList {
 opList {
   name: "distribution_lognormal"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "mean"
+    name: "stddev"
     argType: DOUBLE
   }
   argDescriptor {
@@ -6295,10 +6331,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_truncated"
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6308,6 +6340,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_truncated"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -6321,10 +6357,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "distribution_uniform"
   argDescriptor {
     name: "dataType"
     argType: INT64
@@ -6334,6 +6366,10 @@ opList {
     argType: INT64
     argIndex: 1
   }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "distribution_uniform"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -6345,6 +6381,15 @@ opList {
   argDescriptor {
     name: "to"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "shape"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -6377,10 +6422,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6388,6 +6429,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -6407,10 +6452,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6423,6 +6464,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -6445,12 +6490,17 @@ opList {
 opList {
   name: "dot"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "newFormat"
@@ -6462,27 +6512,13 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "dot_product_attention"
-  argDescriptor {
-    name: "normalization"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputWeights"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6494,15 +6530,6 @@ opList {
   argDescriptor {
     name: "weights"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "withWeights"
-    argType: BOOL
     argIndex: 1
   }
   argDescriptor {
@@ -6524,13 +6551,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "dot_product_attention_bp"
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "withWeights"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "normalization"
     argType: INT64
   }
+  argDescriptor {
+    name: "outputWeights"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "dot_product_attention_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6548,10 +6589,6 @@ opList {
     name: "dLdv"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
   }
   argDescriptor {
     name: "queries"
@@ -6576,6 +6613,14 @@ opList {
     name: "mask"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "normalization"
+    argType: INT64
   }
 }
 opList {
@@ -6603,16 +6648,8 @@ opList {
 opList {
   name: "dropout"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "probValue"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -6623,21 +6660,21 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "dropout_bp"
   argDescriptor {
     name: "seed"
     argType: INT64
   }
   argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
     name: "probValue"
     argType: DOUBLE
+  }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "dropout_bp"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -6653,6 +6690,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "probValue"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -6662,21 +6707,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "p"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "p"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "dynamic_bidirectional_rnn"
-  argDescriptor {
-    name: "timeMajor"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6744,13 +6785,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
+  argDescriptor {
+    name: "timeMajor"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_partition"
-  argDescriptor {
-    name: "numPartitions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6768,13 +6809,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "numPartitions"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_partition_bp"
-  argDescriptor {
-    name: "numPartition"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6797,13 +6838,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numPartition"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_rnn"
-  argDescriptor {
-    name: "timeMajor"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6841,13 +6882,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "timeMajor"
+    argType: INT64
+  }
 }
 opList {
   name: "dynamic_stitch"
-  argDescriptor {
-    name: "numPartitions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6865,6 +6906,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "numPartitions"
+    argType: INT64
+  }
+}
+opList {
+  name: "eig"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "eig_vals"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "eig_vectors"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
 }
 opList {
   name: "elu"
@@ -6873,12 +6938,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -6889,10 +6954,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6901,14 +6962,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "embedding_lookup"
-  argDescriptor {
-    name: "partition_mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6925,6 +6986,10 @@ opList {
     name: "indices"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "partition_mode"
+    argType: INT64
   }
 }
 opList {
@@ -6943,10 +7008,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6960,13 +7021,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "encode_threshold"
-  argDescriptor {
-    name: "boundary"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -6981,10 +7042,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "threshold"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -6992,6 +7049,14 @@ opList {
     name: "encoded"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "boundary"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "threshold"
+    argType: DOUBLE
   }
 }
 opList {
@@ -7001,31 +7066,23 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "isConstant"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
   name: "entropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -7035,6 +7092,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7057,6 +7122,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -7066,12 +7135,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7086,10 +7155,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7097,6 +7162,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -7107,32 +7176,20 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "equals_with_eps"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -7142,6 +7199,18 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7156,12 +7225,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7176,24 +7245,29 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "euclidean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -7205,13 +7279,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7226,21 +7295,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "oldFormat"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "inputShape"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "dimensions"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "oldFormat"
+    argType: BOOL
     argIndex: 1
   }
 }
@@ -7251,12 +7320,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -7270,21 +7339,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "expand_dims"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7294,12 +7359,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7313,12 +7378,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7339,6 +7404,22 @@ opList {
 }
 opList {
   name: "extract_image_patches"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "sameMode"
+    argType: BOOL
+  }
   argDescriptor {
     name: "ksizeRows"
     argType: INT64
@@ -7373,6 +7454,9 @@ opList {
     argType: INT64
     argIndex: 6
   }
+}
+opList {
+  name: "eye"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7382,16 +7466,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "sameMode"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
+    name: "numRows"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "eye"
+  argDescriptor {
+    name: "numCols"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "numRows"
     argType: INT64
@@ -7411,41 +7497,24 @@ opList {
     argType: INT64
     argIndex: 3
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "numRows"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "numCols"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "fake_quant_with_min_max_args"
   argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "narrowRange"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "numBits"
+    argType: INT64
   }
   argDescriptor {
     name: "min"
@@ -7456,24 +7525,34 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "fake_quant_with_min_max_vars"
-  argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "min"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "max"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
     name: "narrowed"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "numBits"
+    argType: INT64
   }
   argDescriptor {
     name: "m"
@@ -7484,6 +7563,14 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "fake_quant_with_min_max_vars_per_channel"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
@@ -7497,45 +7584,19 @@ opList {
     name: "max"
     argType: INPUT_TENSOR
     argIndex: 2
-  }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "fake_quant_with_min_max_vars_per_channel"
-  argDescriptor {
-    name: "numBits"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "narrowed"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "min"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "max"
-    argType: INPUT_TENSOR
-    argIndex: 2
+    name: "numBits"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "fill"
-  argDescriptor {
-    name: "dtype"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7545,10 +7606,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "value"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "shape"
     argType: INPUT_TENSOR
   }
@@ -7556,6 +7613,14 @@ opList {
     name: "outputs"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dtype"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "value"
+    argType: DOUBLE
   }
 }
 opList {
@@ -7588,16 +7653,20 @@ opList {
 opList {
   name: "first_index"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -7608,19 +7677,11 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "flatten"
   argDescriptor {
-    name: "order"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7631,15 +7692,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "order"
+    argType: INT64
   }
 }
 opList {
   name: "flatten_2d"
   argDescriptor {
-    name: "flattenDimension"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7650,6 +7711,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7663,12 +7728,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7683,10 +7748,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7694,6 +7755,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -7713,10 +7778,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7730,6 +7791,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "floormod"
@@ -7742,10 +7807,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7753,6 +7814,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -7772,10 +7837,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7789,6 +7850,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "fmod"
@@ -7801,10 +7866,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7812,6 +7873,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -7835,15 +7900,6 @@ opList {
 opList {
   name: "fused_batch_norm"
   argDescriptor {
-    name: "dataFormat"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isTraining"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -7860,10 +7916,6 @@ opList {
     name: "batchVar"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -7894,13 +7946,22 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 5
   }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "isTraining"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "gather"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -7908,10 +7969,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -7926,6 +7983,14 @@ opList {
     name: "intArgs"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -7960,10 +8025,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -7971,6 +8032,10 @@ opList {
     name: "indices"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
   }
 }
 opList {
@@ -7984,6 +8049,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -7991,10 +8060,6 @@ opList {
     name: "precise"
     argType: BOOL
     argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8036,10 +8101,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -8047,6 +8108,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -8061,10 +8126,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -8072,6 +8133,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -8082,12 +8147,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8098,12 +8163,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8362,12 +8427,17 @@ opList {
 opList {
   name: "hammingdistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -8379,13 +8449,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8400,12 +8465,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8420,12 +8485,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8469,12 +8534,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -8506,12 +8571,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -8533,49 +8598,45 @@ opList {
 opList {
   name: "hasinf"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "hasnan"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "keepDims"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "hinge_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8598,13 +8659,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "hinge_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "hinge_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8637,13 +8698,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "histogram"
-  argDescriptor {
-    name: "numBins"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8656,13 +8717,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "numBins"
+    argType: INT64
+  }
 }
 opList {
   name: "histogram_fixed_width"
-  argDescriptor {
-    name: "nbins"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8685,13 +8746,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "nbins"
+    argType: INT64
+  }
 }
 opList {
   name: "hsv_to_rgb"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -8700,14 +8761,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "huber_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8715,10 +8776,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "delta"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "predictions"
@@ -8734,13 +8791,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "huber_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "huber_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8760,10 +8821,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "delta"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -8777,6 +8834,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "delta"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "identity"
@@ -8789,12 +8854,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -8867,6 +8932,27 @@ opList {
 opList {
   name: "im2col"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inputArrays"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "zeroPadVal"
+    argType: DOUBLE
+  }
+  argDescriptor {
     name: "kernelHeight"
     argType: INT64
   }
@@ -8905,6 +8991,9 @@ opList {
     argType: INT64
     argIndex: 7
   }
+}
+opList {
+  name: "im2col_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -8914,21 +9003,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "zeroPadVal"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "inputArrays"
+    name: "gradAtOutput"
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "im2col_bp"
+  argDescriptor {
+    name: "zeroPadVal"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "kernelHeight"
     argType: INT64
@@ -8968,41 +9054,25 @@ opList {
     argType: INT64
     argIndex: 7
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "zeroPadVal"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradAtOutput"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "image_resize"
   argDescriptor {
-    name: "method"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "image"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "size"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "preserveAspectRatio"
@@ -9014,21 +9084,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "image"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "size"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "method"
+    argType: INT64
   }
 }
 opList {
   name: "in_top_k"
-  argDescriptor {
-    name: "k"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9038,10 +9099,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "sorted"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -9049,6 +9106,14 @@ opList {
     name: "target"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "sorted"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "k"
+    argType: INT64
   }
 }
 opList {
@@ -9062,12 +9127,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9078,12 +9143,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9094,12 +9159,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9110,12 +9175,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BOOLEAN_OP_IMPL
 }
@@ -9130,12 +9195,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9150,21 +9215,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "ismax"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -9172,6 +9233,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9186,24 +9251,29 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "jaccarddistance"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -9215,13 +9285,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9273,16 +9338,20 @@ opList {
 opList {
   name: "last_index"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -9293,25 +9362,13 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "layer_norm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "noBias"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9327,14 +9384,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "layer_norm_bp"
+  argDescriptor {
+    name: "channelsFirst"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "layer_norm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9352,10 +9413,6 @@ opList {
     name: "dLdb"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "noBias"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9391,6 +9448,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 6
   }
+  argDescriptor {
+    name: "channelsFirst"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "leakyrelu"
@@ -9399,12 +9464,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9415,12 +9484,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9435,10 +9508,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9446,6 +9515,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -9460,10 +9533,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9471,6 +9540,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -9481,12 +9554,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9497,12 +9570,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9522,24 +9595,11 @@ opList {
   name: "lin_space"
   argDescriptor {
     name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dataType"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "start"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "stop"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "start"
@@ -9555,24 +9615,42 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "start"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "stop"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "linspace_random"
-  argDescriptor {
-    name: "length"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "from"
+    name: "step"
     argType: DOUBLE
   }
   argDescriptor {
     name: "to"
     argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "length"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
     argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
@@ -9613,12 +9691,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9633,21 +9711,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "log_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9655,10 +9729,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "predictions"
@@ -9674,13 +9744,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "log_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "log_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9700,10 +9774,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "epsilon"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "predictions"
     argType: INPUT_TENSOR
   }
@@ -9716,6 +9786,14 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "epsilon"
+    argType: DOUBLE
   }
 }
 opList {
@@ -9729,20 +9807,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
   name: "log_poisson_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9750,10 +9824,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "full"
-    argType: BOOL
   }
   argDescriptor {
     name: "log_predictions"
@@ -9769,13 +9839,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "log_poisson_loss_grad"
+  argDescriptor {
+    name: "full"
+    argType: BOOL
+  }
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "log_poisson_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -9795,10 +9869,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "full"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "log_predictions"
     argType: INPUT_TENSOR
   }
@@ -9812,13 +9882,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "full"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
 }
 opList {
   name: "log_softmax"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -9827,14 +9901,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "log_softmax_bp"
   argDescriptor {
     name: "dimension"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "log_softmax_bp"
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
@@ -9848,6 +9922,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -9857,12 +9935,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "base"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "base"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9884,16 +9962,8 @@ opList {
 opList {
   name: "logentropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -9903,6 +9973,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9917,12 +9995,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -9933,12 +10011,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -9948,12 +10026,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -9964,10 +10042,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -9976,21 +10050,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lrn"
   argDescriptor {
-    name: "depth"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
   }
   argDescriptor {
     name: "bias"
@@ -10005,40 +10087,14 @@ opList {
     name: "beta"
     argType: DOUBLE
     argIndex: 2
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lrn_bp"
   argDescriptor {
-    name: "depth"
-    argType: INT64
-  }
-  argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "bias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "beta"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -10049,19 +10105,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "bias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "alpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "beta"
+    argType: DOUBLE
+    argIndex: 2
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "lstm"
-  argDescriptor {
-    name: "peephole"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "projection"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10074,20 +10143,6 @@ opList {
     name: "c"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingProjValue"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "input"
@@ -10128,18 +10183,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmBlock"
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "dataFormat"
+    name: "projection"
     argType: INT64
     argIndex: 1
   }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingProjValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
+    argIndex: 2
+  }
+}
+opList {
+  name: "lstmBlock"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10177,15 +10246,6 @@ opList {
     name: "y"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "maxTSLength"
@@ -10231,13 +10291,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
-}
-opList {
-  name: "lstmBlockCell"
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "lstmBlockCell"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10275,15 +10349,6 @@ opList {
     name: "y"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "xt"
@@ -10324,18 +10389,22 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmCell"
   argDescriptor {
     name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "projection"
-    argType: INT64
+    name: "forgetBias"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingCellValue"
+    argType: DOUBLE
     argIndex: 1
   }
+}
+opList {
+  name: "lstmCell"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10348,20 +10417,6 @@ opList {
     name: "ct"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "clippingCellValue"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "clippingProjValue"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "forgetBias"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "xt"
@@ -10402,33 +10457,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmLayer"
   argDescriptor {
-    name: "dataFormat"
+    name: "peephole"
     argType: INT64
   }
   argDescriptor {
-    name: "directionMode"
+    name: "projection"
     argType: INT64
     argIndex: 1
   }
   argDescriptor {
-    name: "gateAct"
-    argType: INT64
+    name: "clippingCellValue"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "clippingProjValue"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "forgetBias"
+    argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 4
-  }
+}
+opList {
+  name: "lstmLayer"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10446,6 +10500,45 @@ opList {
     name: "cL"
     argType: OUTPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "Wx"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "Wr"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "b"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "seqLen"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "hI"
+    argType: INPUT_TENSOR
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "cI"
+    argType: INPUT_TENSOR
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "Wp"
+    argType: INPUT_TENSOR
+    argIndex: 7
   }
   argDescriptor {
     name: "hasBiases"
@@ -10487,6 +10580,30 @@ opList {
     argIndex: 7
   }
   argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "directionMode"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
     name: "cellClip"
     argType: DOUBLE
   }
@@ -10520,62 +10637,9 @@ opList {
     argType: DOUBLE
     argIndex: 6
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "Wx"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "Wr"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "b"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "seqLen"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "hI"
-    argType: INPUT_TENSOR
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "cI"
-    argType: INPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "Wp"
-    argType: INPUT_TENSOR
-    argIndex: 7
-  }
 }
 opList {
   name: "lstmLayerCell"
-  argDescriptor {
-    name: "gateAct"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10590,6 +10654,40 @@ opList {
     argIndex: 1
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "Wx"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "Wr"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "b"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "hI"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "cI"
+    argType: INPUT_TENSOR
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "Wp"
+    argType: INPUT_TENSOR
+    argIndex: 6
+  }
+  argDescriptor {
     name: "hasBiases"
     argType: BOOL
   }
@@ -10597,6 +10695,20 @@ opList {
     name: "hasPH"
     argType: BOOL
     argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 2
   }
   argDescriptor {
     name: "cellClip"
@@ -10632,57 +10744,9 @@ opList {
     argType: DOUBLE
     argIndex: 6
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "Wx"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "Wr"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "b"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "hI"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "cI"
-    argType: INPUT_TENSOR
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "Wp"
-    argType: INPUT_TENSOR
-    argIndex: 6
-  }
 }
 opList {
   name: "lstmLayerCellBp"
-  argDescriptor {
-    name: "gateAct"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "cellAct"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "outAct"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10719,49 +10783,6 @@ opList {
   argDescriptor {
     name: "dLdWp"
     argType: OUTPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "hasBiases"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "hasPH"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "cellClip"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "gateAlpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gateBeta"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "cellAlpha"
-    argType: DOUBLE
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "cellBeta"
-    argType: DOUBLE
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "outAlpha"
-    argType: DOUBLE
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "outBeta"
-    argType: DOUBLE
     argIndex: 6
   }
   argDescriptor {
@@ -10803,33 +10824,66 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "lstmLayer_bp"
   argDescriptor {
-    name: "dataFormat"
-    argType: INT64
+    name: "hasBiases"
+    argType: BOOL
   }
   argDescriptor {
-    name: "directionMode"
-    argType: INT64
+    name: "hasPH"
+    argType: BOOL
     argIndex: 1
   }
   argDescriptor {
     name: "gateAct"
     argType: INT64
-    argIndex: 2
   }
   argDescriptor {
     name: "cellAct"
     argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "outAct"
     argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellClip"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "gateAlpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateBeta"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAlpha"
+    argType: DOUBLE
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "cellBeta"
+    argType: DOUBLE
     argIndex: 4
   }
+  argDescriptor {
+    name: "outAlpha"
+    argType: DOUBLE
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "outBeta"
+    argType: DOUBLE
+    argIndex: 6
+  }
+}
+opList {
+  name: "lstmLayer_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -10866,79 +10920,6 @@ opList {
   argDescriptor {
     name: "dLdWp"
     argType: OUTPUT_TENSOR
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "hasBiases"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "hasSeqLen"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "hasInitH"
-    argType: BOOL
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "hasInitC"
-    argType: BOOL
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "hasPH"
-    argType: BOOL
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "retFullSeq"
-    argType: BOOL
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "retLastH"
-    argType: BOOL
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "retLastC"
-    argType: BOOL
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "cellClip"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "gateAlpha"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "gateBeta"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "cellAlpha"
-    argType: DOUBLE
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "cellBeta"
-    argType: DOUBLE
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "outAlpha"
-    argType: DOUBLE
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "outBeta"
-    argType: DOUBLE
     argIndex: 6
   }
   argDescriptor {
@@ -11000,6 +10981,103 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 11
   }
+  argDescriptor {
+    name: "hasBiases"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "hasSeqLen"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "hasInitH"
+    argType: BOOL
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "hasInitC"
+    argType: BOOL
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "hasPH"
+    argType: BOOL
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "retFullSeq"
+    argType: BOOL
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "retLastH"
+    argType: BOOL
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "retLastC"
+    argType: BOOL
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "dataFormat"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "directionMode"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateAct"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAct"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "outAct"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "cellClip"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "gateAlpha"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "gateBeta"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "cellAlpha"
+    argType: DOUBLE
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "cellBeta"
+    argType: DOUBLE
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "outAlpha"
+    argType: DOUBLE
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "outBeta"
+    argType: DOUBLE
+    argIndex: 6
+  }
 }
 opList {
   name: "lstsq"
@@ -11012,14 +11090,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "fastFlag"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "l2_factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -11027,6 +11097,14 @@ opList {
     name: "b"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "fastFlag"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "l2_factor"
+    argType: DOUBLE
   }
 }
 opList {
@@ -11052,12 +11130,17 @@ opList {
 opList {
   name: "manhattan"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "keepDims"
@@ -11069,29 +11152,28 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "match_condition"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "keepDims"
     argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
   argDescriptor {
     name: "compare"
@@ -11102,18 +11184,10 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "match_condition_transform"
-  argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -11123,6 +11197,19 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
     name: "compare"
     argType: DOUBLE
   }
@@ -11130,6 +11217,18 @@ opList {
     name: "eps"
     argType: DOUBLE
     argIndex: 1
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "matmul"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -11139,32 +11238,6 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
-  name: "matmul"
-  argDescriptor {
-    name: "transX"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "transY"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "transZ"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "transposeX"
@@ -11190,18 +11263,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-}
-opList {
-  name: "matmul_bp"
-  argDescriptor {
     name: "transX"
     argType: INT64
   }
@@ -11215,6 +11276,9 @@ opList {
     argType: INT64
     argIndex: 2
   }
+}
+opList {
+  name: "matmul_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11226,15 +11290,6 @@ opList {
   argDescriptor {
     name: "dldy"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "alpha"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "beta"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -11261,18 +11316,32 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "matrix_band_part"
   argDescriptor {
-    name: "minLower"
+    name: "alpha"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "beta"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "transX"
     argType: INT64
   }
   argDescriptor {
-    name: "maxUpper"
+    name: "transY"
     argType: INT64
     argIndex: 1
   }
+  argDescriptor {
+    name: "transZ"
+    argType: INT64
+    argIndex: 2
+  }
+}
+opList {
+  name: "matrix_band_part"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -11291,6 +11360,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "minLower"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "maxUpper"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -11304,12 +11382,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11323,12 +11401,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "diagonal"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11342,12 +11420,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -11357,12 +11435,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -11373,10 +11451,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -11384,6 +11458,10 @@ opList {
     name: "diagonal"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -11410,6 +11488,28 @@ opList {
 }
 opList {
   name: "max_pool_with_argmax"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "indices"
+    argType: OUTPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "outArgMax"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -11464,28 +11564,6 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "indices"
-    argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "outArgMax"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "max_scalar"
@@ -11515,10 +11593,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -11526,6 +11600,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -11573,64 +11651,14 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "maxpool2d"
-  argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "extraParam0"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 10
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11643,9 +11671,6 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "maxpool2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -11700,6 +11725,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "maxpool2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11717,83 +11745,63 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "maxpool3dnew"
-  argDescriptor {
-    name: "kD"
-    argType: INT64
-  }
   argDescriptor {
     name: "kH"
     argType: INT64
-    argIndex: 1
   }
   argDescriptor {
     name: "kW"
     argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sD"
-    argType: INT64
-    argIndex: 3
+    argIndex: 1
   }
   argDescriptor {
     name: "sH"
     argType: INT64
-    argIndex: 4
+    argIndex: 2
   }
   argDescriptor {
     name: "sW"
     argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "pD"
-    argType: INT64
-    argIndex: 6
+    argIndex: 3
   }
   argDescriptor {
     name: "pH"
     argType: INT64
-    argIndex: 7
+    argIndex: 4
   }
   argDescriptor {
     name: "pW"
     argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "dD"
-    argType: INT64
-    argIndex: 9
+    argIndex: 5
   }
   argDescriptor {
     name: "dH"
     argType: INT64
-    argIndex: 10
+    argIndex: 6
   }
   argDescriptor {
     name: "dW"
     argType: INT64
-    argIndex: 11
+    argIndex: 7
   }
   argDescriptor {
     name: "isSameMode"
     argType: INT64
-    argIndex: 12
+    argIndex: 8
   }
   argDescriptor {
     name: "extraParam0"
     argType: INT64
-    argIndex: 13
+    argIndex: 9
   }
   argDescriptor {
-    name: "isNCDHW"
+    name: "isNCHW"
     argType: INT64
-    argIndex: 14
+    argIndex: 10
   }
+}
+opList {
+  name: "maxpool3dnew"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11811,9 +11819,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "maxpool3dnew_bp"
   argDescriptor {
     name: "kD"
     argType: INT64
@@ -11888,6 +11893,9 @@ opList {
     argType: INT64
     argIndex: 14
   }
+}
+opList {
+  name: "maxpool3dnew_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11905,13 +11913,83 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "kD"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sD"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "pD"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "dD"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 10
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 11
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 12
+  }
+  argDescriptor {
+    name: "extraParam0"
+    argType: INT64
+    argIndex: 13
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+    argIndex: 14
+  }
 }
 opList {
   name: "mean_pairwssqerr_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -11933,15 +12011,15 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
   }
 }
 opList {
   name: "mean_pairwssqerr_loss_grad"
   argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -11973,13 +12051,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "mean_sqerr_loss"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "mean_sqerr_loss"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12002,13 +12080,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "mean_sqerr_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+}
+opList {
+  name: "mean_sqerr_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12040,6 +12118,10 @@ opList {
     name: "labels"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
   }
 }
 opList {
@@ -12064,12 +12146,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "inArrs"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -12160,10 +12242,6 @@ opList {
 opList {
   name: "mergemaxindex"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -12174,6 +12252,10 @@ opList {
   argDescriptor {
     name: "inArrs"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -12190,10 +12272,6 @@ opList {
 opList {
   name: "meshgrid"
   argDescriptor {
-    name: "swapFirst2Dims"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -12202,16 +12280,28 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "inArrs"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "cartesian"
     argType: BOOL
   }
   argDescriptor {
-    name: "inArrs"
-    argType: INPUT_TENSOR
+    name: "swapFirst2Dims"
+    argType: INT64
   }
 }
 opList {
   name: "meta_postulate"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "meta_predicate"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -12228,14 +12318,6 @@ opList {
   opDeclarationType: LEGACY_XYZ
 }
 opList {
-  name: "meta_predicate"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
   name: "meta_predicate_inverted"
   argDescriptor {
     name: "outputs"
@@ -12246,12 +12328,12 @@ opList {
 opList {
   name: "meta_reduce"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12287,10 +12369,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12298,6 +12376,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12334,20 +12416,12 @@ opList {
 opList {
   name: "mirror_pad"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isSymmetric"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -12357,6 +12431,14 @@ opList {
     name: "paddings"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "isSymmetric"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
   }
 }
 opList {
@@ -12370,12 +12452,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12390,10 +12472,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12401,6 +12479,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12420,10 +12502,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12437,13 +12515,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "moments"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12456,10 +12534,6 @@ opList {
     name: "variances"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -12475,6 +12549,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "mul_scalar"
@@ -12483,26 +12565,18 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "multi_head_dot_product_attention"
-  argDescriptor {
-    name: "normalization"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "weights"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12510,15 +12584,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "withWeights"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "queries"
@@ -12559,13 +12624,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 7
   }
-}
-opList {
-  name: "multi_head_dot_product_attention_bp"
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "withWeights"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "normalization"
     argType: INT64
   }
+  argDescriptor {
+    name: "weights"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "multi_head_dot_product_attention_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12603,10 +12682,6 @@ opList {
     name: "dLdWo"
     argType: OUTPUT_TENSOR
     argIndex: 6
-  }
-  argDescriptor {
-    name: "scaled"
-    argType: BOOL
   }
   argDescriptor {
     name: "queries"
@@ -12652,6 +12727,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 8
   }
+  argDescriptor {
+    name: "scaled"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "normalization"
+    argType: INT64
+  }
 }
 opList {
   name: "multiply"
@@ -12664,10 +12747,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12675,6 +12754,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -12694,10 +12777,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -12711,13 +12790,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "nadam_updater"
-  argDescriptor {
-    name: "iteration"
-    argType: INT64
-  }
   argDescriptor {
     name: "update"
     argType: OUTPUT_TENSOR
@@ -12731,25 +12810,6 @@ opList {
     name: "stateM"
     argType: OUTPUT_TENSOR
     argIndex: 2
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dBeta1"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dBeta2"
-    argType: DOUBLE
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 3
   }
   argDescriptor {
     name: "gradient"
@@ -12785,6 +12845,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 6
   }
+  argDescriptor {
+    name: "iteration"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dBeta1"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dBeta2"
+    argType: DOUBLE
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 3
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -12798,12 +12881,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -12816,15 +12899,6 @@ opList {
   argDescriptor {
     name: "stateV"
     argType: OUTPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dMomentum"
-    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
@@ -12846,6 +12920,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dMomentum"
+    argType: DOUBLE
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -12855,20 +12938,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
   name: "non_max_suppression"
-  argDescriptor {
-    name: "maxOutputSize"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12901,13 +12980,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "non_max_suppression_overlaps"
   argDescriptor {
     name: "maxOutputSize"
     argType: INT64
   }
+}
+opList {
+  name: "non_max_suppression_overlaps"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12915,6 +12994,34 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "boxes"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "scales"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "maxOutSize"
+    argType: INPUT_TENSOR
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "iouThreshold"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "scoreThreshold"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "maxOutputSize"
+    argType: INT64
   }
   argDescriptor {
     name: "overlapThreshold"
@@ -12925,37 +13032,9 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "boxes"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "scales"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "maxOutSize"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "iouThreshold"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "scoreThreshold"
-    argType: INPUT_TENSOR
-    argIndex: 4
-  }
 }
 opList {
   name: "non_max_suppression_v3"
-  argDescriptor {
-    name: "maxOutputSize"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -12987,6 +13066,10 @@ opList {
     name: "scoreThreshold"
     argType: INPUT_TENSOR
     argIndex: 4
+  }
+  argDescriptor {
+    name: "maxOutputSize"
+    argType: INT64
   }
 }
 opList {
@@ -13008,10 +13091,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "mode"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13019,6 +13098,10 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: DOUBLE
   }
   opDeclarationType: REDUCTION_OP_IMPL
 }
@@ -13038,10 +13121,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "shift"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "counts"
     argType: INPUT_TENSOR
   }
@@ -13056,14 +13135,8 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "outMean"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "outVar"
-    argType: INPUT_TENSOR
-    argIndex: 4
+    name: "shift"
+    argType: DOUBLE
   }
 }
 opList {
@@ -13077,10 +13150,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13088,6 +13157,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13102,10 +13175,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13113,6 +13182,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_BOOL_OP_IMPL
 }
@@ -13123,12 +13196,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13139,21 +13212,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "nth_element"
-  argDescriptor {
-    name: "reverse"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13163,10 +13232,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "reverse"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13174,6 +13239,14 @@ opList {
     name: "n"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "reverse"
+    argType: INT64
   }
 }
 opList {
@@ -13187,31 +13260,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "onehot"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "depth"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-    argIndex: 2
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13219,15 +13278,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "on"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "off"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -13248,6 +13298,29 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "on"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "off"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "depth"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
+    argIndex: 2
+  }
 }
 opList {
   name: "oneminus"
@@ -13260,21 +13333,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "ones_as"
-  argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13286,6 +13355,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -13299,16 +13372,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "comparable"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13319,12 +13393,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13346,20 +13420,12 @@ opList {
 opList {
   name: "pad"
   argDescriptor {
-    name: "mode"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "padValue"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "input"
@@ -13369,6 +13435,14 @@ opList {
     name: "paddings"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "mode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "padValue"
+    argType: DOUBLE
   }
 }
 opList {
@@ -13394,16 +13468,20 @@ opList {
 opList {
   name: "percentile"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   argDescriptor {
     name: "q"
@@ -13419,17 +13497,9 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "permute"
-  argDescriptor {
-    name: "reverseDims"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13443,9 +13513,13 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "permutationVector"
+    name: "permuteDims"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "reverseDims"
+    argType: INT64
   }
 }
 opList {
@@ -13467,6 +13541,18 @@ opList {
 }
 opList {
   name: "pnormpool2d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
   argDescriptor {
     name: "kY"
     argType: INT64
@@ -13521,21 +13607,30 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "pnormpool2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
-    name: "outputs"
+    name: "gradI"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "pnormpool2d_bp"
+  argDescriptor {
+    name: "gradO"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "eps"
+    argType: DOUBLE
+  }
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -13590,39 +13685,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "gradI"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "eps"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "gradO"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "pointwise_conv2d"
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13644,6 +13709,15 @@ opList {
     name: "bias"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -13670,10 +13744,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13681,6 +13751,10 @@ opList {
     name: "inputArrays"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -13690,14 +13764,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "pow"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13705,6 +13771,14 @@ opList {
     name: "pow"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "pow"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13719,10 +13793,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13730,6 +13800,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13744,6 +13818,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -13752,18 +13830,10 @@ opList {
     argType: BOOL
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "prelu"
-  argDescriptor {
-    name: "sharedAxes"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -13777,14 +13847,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "prelu_bp"
   argDescriptor {
     name: "sharedAxes"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "prelu_bp"
   argDescriptor {
     name: "dLdI"
     argType: OUTPUT_TENSOR
@@ -13818,6 +13888,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "sharedAxes"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -13846,10 +13920,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "printSpecial"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13857,6 +13927,10 @@ opList {
     name: "message"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "printSpecial"
+    argType: BOOL
   }
 }
 opList {
@@ -13866,10 +13940,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "probability"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -13877,6 +13947,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "probability"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -13896,12 +13970,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "fullMatricies"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "fullMatricies"
+    argType: BOOL
   }
 }
 opList {
@@ -13915,20 +13989,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "f"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "f"
+    argType: DOUBLE
   }
 }
 opList {
   name: "random_crop"
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13946,13 +14016,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_exponential"
-  argDescriptor {
-    name: "shape"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13962,16 +14032,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "shape"
+    argType: INT64
+  }
+  argDescriptor {
     name: "lambda"
     argType: DOUBLE
   }
 }
 opList {
   name: "random_gamma"
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -13994,13 +14064,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_multinomial"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14017,6 +14087,10 @@ opList {
     name: "inputSamples"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
 }
 opList {
@@ -14037,10 +14111,6 @@ opList {
 opList {
   name: "random_poisson"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14057,13 +14127,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "random_shuffle"
-  argDescriptor {
-    name: "seeds"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -14071,6 +14141,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "seeds"
+    argType: INT64
   }
   opDeclarationType: OP_IMPL
 }
@@ -14081,6 +14155,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "shape"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "mean"
     argType: DOUBLE
   }
@@ -14089,22 +14167,9 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "shape"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "randomuniform"
-  argDescriptor {
-    name: "dtype"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "seed"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -14114,15 +14179,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "min"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "max"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "shape"
     argType: INPUT_TENSOR
   }
@@ -14136,23 +14192,27 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "range"
   argDescriptor {
-    name: "from"
-    argType: INT64
+    name: "min"
+    argType: DOUBLE
   }
   argDescriptor {
-    name: "to"
-    argType: INT64
+    name: "max"
+    argType: DOUBLE
     argIndex: 1
   }
   argDescriptor {
-    name: "step"
+    name: "dtype"
     argType: INT64
-    argIndex: 2
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+    argIndex: 1
+  }
+}
+opList {
+  name: "range"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14163,30 +14223,44 @@ opList {
   }
   argDescriptor {
     name: "from"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "to"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
     argIndex: 1
   }
   argDescriptor {
     name: "step"
-    argType: DOUBLE
+    argType: INPUT_TENSOR
     argIndex: 2
   }
   argDescriptor {
     name: "from"
-    argType: INPUT_TENSOR
+    argType: INT64
   }
   argDescriptor {
     name: "to"
-    argType: INPUT_TENSOR
+    argType: INT64
     argIndex: 1
   }
   argDescriptor {
     name: "step"
-    argType: INPUT_TENSOR
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "from"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "to"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "step"
+    argType: DOUBLE
     argIndex: 2
   }
 }
@@ -14201,12 +14275,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -14220,12 +14294,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14240,12 +14314,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14298,10 +14372,6 @@ opList {
 opList {
   name: "read_list"
   argDescriptor {
-    name: "index"
-    argType: INT64
-  }
-  argDescriptor {
     name: "importDataType"
     argType: DATA_TYPE
   }
@@ -14318,6 +14388,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "index"
+    argType: INT64
+  }
   opDeclarationType: LIST_OP_IMPL
 }
 opList {
@@ -14331,10 +14405,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14342,6 +14412,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -14386,12 +14460,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14406,12 +14480,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -14447,10 +14521,6 @@ opList {
 opList {
   name: "reduce_dot_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14462,10 +14532,6 @@ opList {
     name: "gradY"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14491,13 +14557,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
-}
-opList {
-  name: "reduce_logsumexp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_logsumexp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14505,31 +14575,31 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDim"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   argDescriptor {
     name: "keepDims"
     argType: DOUBLE
   }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
 }
 opList {
   name: "reduce_max"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14539,10 +14609,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14550,25 +14616,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_max_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14583,25 +14649,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_mean"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14611,25 +14677,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_mean_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14644,25 +14710,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_min"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14672,25 +14738,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_min_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14705,25 +14771,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_norm1"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14733,25 +14799,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_norm1_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14767,13 +14833,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_norm2"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_norm2"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14783,10 +14853,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14795,13 +14861,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_norm2_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_norm2_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14809,10 +14879,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14827,6 +14893,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -14840,10 +14914,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14852,13 +14922,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
 }
 opList {
   name: "reduce_norm_max_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -14866,10 +14936,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14885,20 +14951,20 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_normmax"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_normmax"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14908,16 +14974,20 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "reduce_prod"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -14926,10 +14996,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -14937,25 +15003,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_prod_bp"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14970,25 +15036,25 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
   name: "reduce_sqnorm"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -14999,13 +15065,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_sqnorm_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_sqnorm_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15013,10 +15083,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -15031,6 +15097,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -15044,15 +15118,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15061,13 +15126,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "reduce_stdev_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15075,24 +15145,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -15108,13 +15160,31 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "reduce_sum"
+  argDescriptor {
+    name: "biasCorrected"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+    argIndex: 1
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
+}
+opList {
+  name: "reduce_sum"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15124,10 +15194,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15136,13 +15202,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "reduce_sum_bp"
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+}
+opList {
+  name: "reduce_sum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15150,10 +15220,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -15168,6 +15234,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -15181,15 +15255,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15198,13 +15263,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "reduce_variance_bp"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15212,24 +15282,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "biasCorrected"
-    argType: DOUBLE
-    argIndex: 1
   }
   argDescriptor {
     name: "input"
@@ -15245,6 +15297,28 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "biasCorrected"
+    argType: DOUBLE
+    argIndex: 1
+  }
 }
 opList {
   name: "relu"
@@ -15253,16 +15327,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15277,16 +15351,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15297,10 +15371,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "cutoff"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15308,6 +15378,10 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "cutoff"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15318,10 +15392,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "scalar"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15329,6 +15399,10 @@ opList {
     name: "epsilon"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "scalar"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15368,8 +15442,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
+  }
+  opDeclarationType: LEGACY_XYZ
+}
+opList {
+  name: "remainder_scalar"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -15383,27 +15474,7 @@ opList {
   opDeclarationType: LEGACY_XYZ
 }
 opList {
-  name: "remainder_scalar"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  opDeclarationType: LEGACY_XYZ
-}
-opList {
   name: "repeat"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15416,6 +15487,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "replace_nans"
@@ -15424,21 +15499,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "set"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "set"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "reshape"
-  argDescriptor {
-    name: "shapeArr"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15455,6 +15526,10 @@ opList {
     name: "shape"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "shapeArr"
+    argType: INT64
   }
 }
 opList {
@@ -15480,15 +15555,6 @@ opList {
 opList {
   name: "resize_area"
   argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -15497,16 +15563,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "size"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "height"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15521,15 +15596,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "alignPixelCenters"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
@@ -15538,18 +15604,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "alignPixelCenters"
+    argType: BOOL
+    argIndex: 1
+  }
 }
 opList {
   name: "resize_bilinear"
-  argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15559,21 +15625,30 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "halfPixelCenter"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "image"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "newImageSize"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "halfPixelCenters"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "height"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15586,15 +15661,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "alignCorners"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "preserveAspectRatio"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "image"
@@ -15610,18 +15676,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "alignCorners"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "preserveAspectRatio"
+    argType: BOOL
+    argIndex: 1
+  }
 }
 opList {
   name: "resize_nearest_neighbor"
-  argDescriptor {
-    name: "height"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "width"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15629,6 +15695,15 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "image"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "newImageSize"
+    argType: INPUT_TENSOR
+    argIndex: 1
   }
   argDescriptor {
     name: "alignCorners"
@@ -15640,12 +15715,12 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "image"
-    argType: INPUT_TENSOR
+    name: "height"
+    argType: INT64
   }
   argDescriptor {
-    name: "newImageSize"
-    argType: INPUT_TENSOR
+    name: "width"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15659,10 +15734,6 @@ opList {
 opList {
   name: "reverse"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -15675,14 +15746,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "reverse_bp"
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "reverse_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15705,18 +15776,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "reverse_sequence"
-  argDescriptor {
-    name: "seqDim"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "batchDim"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15732,6 +15798,15 @@ opList {
   argDescriptor {
     name: "seqLengths"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "seqDim"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "batchDim"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -15757,10 +15832,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15768,6 +15839,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -15787,10 +15862,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15803,6 +15874,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -15863,10 +15938,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15874,6 +15945,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -15893,10 +15968,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -15910,13 +15981,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
 }
 opList {
   name: "rgb_to_grs"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -15929,13 +16000,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "rgb_to_hsv"
   argDescriptor {
     name: "dimC"
     argType: INT64
   }
+}
+opList {
+  name: "rgb_to_hsv"
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -15943,38 +16014,42 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "rgb_to_yiq"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "rgb_to_yuv"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -15989,12 +16064,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -16008,20 +16083,6 @@ opList {
     name: "stateG"
     argType: OUTPUT_TENSOR
     argIndex: 1
-  }
-  argDescriptor {
-    name: "dLr"
-    argType: DOUBLE
-  }
-  argDescriptor {
-    name: "dRmsDecay"
-    argType: DOUBLE
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "dEpsilon"
-    argType: DOUBLE
-    argIndex: 2
   }
   argDescriptor {
     name: "gradient"
@@ -16047,14 +16108,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "dLr"
+    argType: DOUBLE
+  }
+  argDescriptor {
+    name: "dRmsDecay"
+    argType: DOUBLE
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "dEpsilon"
+    argType: DOUBLE
+    argIndex: 2
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "roll"
-  argDescriptor {
-    name: "shift"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -16073,6 +16144,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "shift"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
@@ -16086,12 +16161,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16106,10 +16181,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16117,6 +16188,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -16131,12 +16206,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16147,12 +16222,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -16187,15 +16262,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16208,6 +16274,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16218,15 +16293,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16239,6 +16305,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16275,15 +16350,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16296,6 +16362,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16306,15 +16381,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16327,6 +16393,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16337,15 +16412,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16358,6 +16424,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16370,15 +16445,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "indices"
@@ -16394,13 +16460,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "scatter_nd_add"
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
   argDescriptor {
     name: "lock"
     argType: BOOL
@@ -16409,6 +16468,13 @@ opList {
     name: "checkIndices"
     argType: BOOL
     argIndex: 1
+  }
+}
+opList {
+  name: "scatter_nd_add"
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
@@ -16423,6 +16489,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16433,15 +16508,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16454,6 +16520,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16464,15 +16539,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16485,6 +16551,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16495,15 +16570,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16516,6 +16582,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16526,15 +16601,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lock"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "checkIndices"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -16547,6 +16613,15 @@ opList {
     name: "updates"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "lock"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "checkIndices"
+    argType: BOOL
+    argIndex: 1
   }
   opDeclarationType: OP_IMPL
 }
@@ -16575,60 +16650,6 @@ opList {
 opList {
   name: "sconv2d"
   argDescriptor {
-    name: "kH"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "kW"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "sH"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "sW"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "pH"
-    argType: INT64
-    argIndex: 4
-  }
-  argDescriptor {
-    name: "pW"
-    argType: INT64
-    argIndex: 5
-  }
-  argDescriptor {
-    name: "dH"
-    argType: INT64
-    argIndex: 6
-  }
-  argDescriptor {
-    name: "dW"
-    argType: INT64
-    argIndex: 7
-  }
-  argDescriptor {
-    name: "isSameMode"
-    argType: INT64
-    argIndex: 8
-  }
-  argDescriptor {
-    name: "isNCHW"
-    argType: INT64
-    argIndex: 9
-  }
-  argDescriptor {
-    name: "wFormat"
-    argType: INT64
-    argIndex: 10
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -16650,9 +16671,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "sconv2d_bp"
   argDescriptor {
     name: "kH"
     argType: INT64
@@ -16707,6 +16725,9 @@ opList {
     argType: INT64
     argIndex: 10
   }
+}
+opList {
+  name: "sconv2d_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -16745,9 +16766,63 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "bias"
+    name: "weightsPoint"
     argType: INPUT_TENSOR
     argIndex: 3
+  }
+  argDescriptor {
+    name: "kH"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "kW"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "sH"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "sW"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "pH"
+    argType: INT64
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "pW"
+    argType: INT64
+    argIndex: 5
+  }
+  argDescriptor {
+    name: "dH"
+    argType: INT64
+    argIndex: 6
+  }
+  argDescriptor {
+    name: "dW"
+    argType: INT64
+    argIndex: 7
+  }
+  argDescriptor {
+    name: "isSameMode"
+    argType: INT64
+    argIndex: 8
+  }
+  argDescriptor {
+    name: "isNCHW"
+    argType: INT64
+    argIndex: 9
+  }
+  argDescriptor {
+    name: "wFormat"
+    argType: INT64
+    argIndex: 10
   }
 }
 opList {
@@ -17031,12 +17106,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17068,21 +17143,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "sequence_mask"
-  argDescriptor {
-    name: "maxInd"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17092,16 +17163,25 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "is_static_maxlen"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "maxlen"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "is_static_maxlen"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "maxInd"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -17146,10 +17226,6 @@ opList {
 opList {
   name: "set_seed"
   argDescriptor {
-    name: "seed"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -17161,6 +17237,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+    name: "seed"
+    argType: INT64
+  }
 }
 opList {
   name: "setrange"
@@ -17171,6 +17251,10 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
@@ -17185,10 +17269,6 @@ opList {
     argType: DOUBLE
     argIndex: 1
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
@@ -17198,12 +17278,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17214,10 +17294,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "lr"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -17225,22 +17301,18 @@ opList {
     name: "lr"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "lr"
+    argType: DOUBLE
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "shannonentropy"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "keepDims"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -17250,6 +17322,14 @@ opList {
     name: "dimensions"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "keepDims"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17264,12 +17344,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -17283,12 +17363,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -17302,10 +17382,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -17314,14 +17390,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
 opList {
   name: "sigm_cross_entropy_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17329,10 +17405,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "logits"
@@ -17348,13 +17420,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "sigm_cross_entropy_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "sigm_cross_entropy_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17374,10 +17450,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "labelSmoothing"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "logits"
     argType: INPUT_TENSOR
   }
@@ -17391,6 +17463,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "labelSmoothing"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "sigmoid"
@@ -17403,12 +17483,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17440,12 +17520,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17460,12 +17540,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17480,12 +17560,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17507,10 +17587,6 @@ opList {
 opList {
   name: "size_at"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -17521,6 +17597,10 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -17538,26 +17618,8 @@ opList {
 opList {
   name: "skipgram"
   argDescriptor {
-    name: "numWorkers"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "nsRounds"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "isInference"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "isPreciseMode"
-    argType: BOOL
-    argIndex: 1
   }
   argDescriptor {
     name: "target"
@@ -17618,14 +17680,28 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 11
   }
+  argDescriptor {
+    name: "isInference"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isPreciseMode"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numWorkers"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "nsRounds"
+    argType: INT64
+    argIndex: 1
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "slice"
-  argDescriptor {
-    name: "size"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17648,13 +17724,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "slice_bp"
   argDescriptor {
     name: "size"
     argType: INT64
   }
+}
+opList {
+  name: "slice_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17682,13 +17758,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "size"
+    argType: INT64
+  }
 }
 opList {
   name: "softmax"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "dataType"
     argType: DATA_TYPE
@@ -17698,21 +17774,21 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimension"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "softmax_bp"
-  argDescriptor {
-    name: "dimension"
-    argType: INT64
-  }
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
@@ -17726,14 +17802,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "dimension"
+    argType: INT64
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "softmax_cross_entropy_loss"
-  argDescriptor {
-    name: "reductionMode"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17741,10 +17817,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
   }
   argDescriptor {
     name: "logits"
@@ -17760,13 +17832,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "softmax_cross_entropy_loss_grad"
   argDescriptor {
     name: "reductionMode"
     argType: INT64
   }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
+}
+opList {
+  name: "softmax_cross_entropy_loss_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17786,10 +17862,6 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "labelsSmoothing"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "logits"
     argType: INPUT_TENSOR
   }
@@ -17803,13 +17875,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "reductionMode"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "labelsSmoothing"
+    argType: DOUBLE
+  }
 }
 opList {
   name: "softmax_cross_entropy_loss_with_logits"
-  argDescriptor {
-    name: "classesDim"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17827,13 +17903,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-}
-opList {
-  name: "softmax_cross_entropy_loss_with_logits_grad"
   argDescriptor {
     name: "classesDim"
     argType: INT64
   }
+}
+opList {
+  name: "softmax_cross_entropy_loss_with_logits_grad"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -17856,6 +17932,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "classesDim"
+    argType: INT64
+  }
 }
 opList {
   name: "softplus"
@@ -17868,12 +17948,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17905,12 +17985,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -17942,12 +18022,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -17960,10 +18040,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "useAdjoint"
-    argType: BOOL
   }
   argDescriptor {
     name: "a"
@@ -17979,6 +18055,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "useAdjoint"
+    argType: BOOL
+  }
 }
 opList {
   name: "solve_ls"
@@ -17991,14 +18071,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "fastFlag"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "l2_factor"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -18006,6 +18078,14 @@ opList {
     name: "b"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "fastFlag"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "l2_factor"
+    argType: DOUBLE
   }
 }
 opList {
@@ -18038,20 +18118,6 @@ opList {
 opList {
   name: "space_to_batch"
   argDescriptor {
-    name: "blockSize"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "paddingTop"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "paddingBottom"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18068,13 +18134,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blockSize"
+    argType: INT64
+  }
 }
 opList {
   name: "space_to_batch_nd"
-  argDescriptor {
-    name: "blocks"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18082,10 +18152,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "inPlace"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -18101,18 +18167,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "blocks"
+    argType: INT64
+  }
 }
 opList {
   name: "space_to_depth"
-  argDescriptor {
-    name: "block_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "isNHWC"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18124,6 +18189,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "block_size"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "isNHWC"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -18169,15 +18243,6 @@ opList {
 opList {
   name: "split"
   argDescriptor {
-    name: "numSplit"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18192,6 +18257,15 @@ opList {
   argDescriptor {
     name: "b"
     argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "numSplit"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
     argIndex: 1
   }
 }
@@ -18244,15 +18318,6 @@ opList {
 opList {
   name: "split_v"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "numSplit"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18274,6 +18339,15 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "numSplit"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "sqrt"
@@ -18286,12 +18360,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18318,12 +18392,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
@@ -18338,10 +18412,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -18349,6 +18419,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -18385,10 +18459,6 @@ opList {
 opList {
   name: "squeeze"
   argDescriptor {
-    name: "_a"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -18404,6 +18474,10 @@ opList {
     name: "a"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "_a"
+    argType: INT64
   }
 }
 opList {
@@ -18662,6 +18736,10 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
@@ -18679,18 +18757,10 @@ opList {
     argType: DOUBLE
     argIndex: 2
   }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "stack"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18707,6 +18777,10 @@ opList {
     name: "inArrs"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -18728,10 +18802,6 @@ opList {
 opList {
   name: "standardize"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -18744,14 +18814,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
-  opDeclarationType: CONFIGURABLE_OP_IMPL
-}
-opList {
-  name: "standardize_bp"
   argDescriptor {
     name: "dimensions"
     argType: INT64
   }
+  opDeclarationType: CONFIGURABLE_OP_IMPL
+}
+opList {
+  name: "standardize_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18773,6 +18843,10 @@ opList {
     name: "eps"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
   }
 }
 opList {
@@ -18883,15 +18957,15 @@ opList {
 opList {
   name: "std"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "biasCorrected"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "newFormat"
     argType: BOOL
   }
   argDescriptor {
@@ -18900,8 +18974,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18912,16 +18986,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -18936,41 +19010,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: OP_IMPL
 }
 opList {
   name: "strided_slice"
-  argDescriptor {
-    name: "begin_mask"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "ellipsis_mask"
-    argType: INT64
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "end_mask"
-    argType: INT64
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "new_axis_mask"
-    argType: INT64
-    argIndex: 3
-  }
-  argDescriptor {
-    name: "shrink_axis_mask"
-    argType: INT64
-    argIndex: 4
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -18998,9 +19048,6 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
-}
-opList {
-  name: "strided_slice_bp"
   argDescriptor {
     name: "begin_mask"
     argType: INT64
@@ -19025,6 +19072,9 @@ opList {
     argType: INT64
     argIndex: 4
   }
+}
+opList {
+  name: "strided_slice_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19057,6 +19107,30 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 4
   }
+  argDescriptor {
+    name: "begin_mask"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "ellipsis_mask"
+    argType: INT64
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "end_mask"
+    argType: INT64
+    argIndex: 2
+  }
+  argDescriptor {
+    name: "new_axis_mask"
+    argType: INT64
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "shrink_axis_mask"
+    argType: INT64
+    argIndex: 4
+  }
 }
 opList {
   name: "sub_scalar"
@@ -19069,9 +19143,8 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19086,10 +19159,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19097,6 +19166,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -19116,10 +19189,6 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19132,6 +19201,10 @@ opList {
     name: "epsNext"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
 }
 opList {
@@ -19177,6 +19250,27 @@ opList {
 opList {
   name: "svd"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "fullUV"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "computeUv"
+    argType: BOOL
+    argIndex: 1
+  }
+  argDescriptor {
     name: "fullUV"
     argType: INT64
   }
@@ -19190,42 +19284,6 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "full_matrices"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "computeUv"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "s"
-    argType: INPUT_TENSOR
-    argIndex: 1
-  }
-  argDescriptor {
-    name: "u"
-    argType: INPUT_TENSOR
-    argIndex: 2
-  }
-  argDescriptor {
-    name: "v"
-    argType: INPUT_TENSOR
-    argIndex: 3
-  }
 }
 opList {
   name: "swish"
@@ -19238,12 +19296,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19254,10 +19312,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "frameName"
-    argType: STRING
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19265,6 +19319,10 @@ opList {
     name: "predicate"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "frameName"
+    argType: STRING
   }
 }
 opList {
@@ -19278,12 +19336,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19314,12 +19372,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -19358,12 +19416,12 @@ opList {
 opList {
   name: "tensorarrayv3"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -19380,15 +19438,20 @@ opList {
 opList {
   name: "tensordot"
   argDescriptor {
-    name: "dimensionsY"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "addedEdges"
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "y"
+    argType: INPUT_TENSOR
+    argIndex: 1
+  }
+  argDescriptor {
+    name: "transposeX"
     argType: BOOL
   }
   argDescriptor {
@@ -19402,26 +19465,12 @@ opList {
     argIndex: 2
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
-  argDescriptor {
-    name: "y"
-    argType: INPUT_TENSOR
-    argIndex: 1
+    name: "dimensionsY"
+    argType: INT64
   }
 }
 opList {
   name: "tensormmul"
-  argDescriptor {
-    name: "axe0_size"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "axe1_size"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19439,13 +19488,18 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "axe0_size"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "axe1_size"
+    argType: INT64
+    argIndex: 1
+  }
 }
 opList {
   name: "tensormmul_bp"
-  argDescriptor {
-    name: "axe0Size"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19472,6 +19526,20 @@ opList {
     name: "dLdC"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "dldx"
+    argType: INPUT_TENSOR
+    argIndex: 3
+  }
+  argDescriptor {
+    name: "dldy"
+    argType: INPUT_TENSOR
+    argIndex: 4
+  }
+  argDescriptor {
+    name: "axe0Size"
+    argType: INT64
   }
 }
 opList {
@@ -19553,10 +19621,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "y"
     argType: INPUT_TENSOR
   }
@@ -19564,6 +19628,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -19574,16 +19642,16 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
     name: "cutoff"
     argType: DOUBLE
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -19594,10 +19662,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "cutoff"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -19606,14 +19670,14 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "cutoff"
+    argType: DOUBLE
+  }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "tile"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19621,10 +19685,6 @@ opList {
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "is_static_reps"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -19635,13 +19695,17 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "is_static_reps"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
 }
 opList {
   name: "tile_bp"
-  argDescriptor {
-    name: "repeat"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19658,6 +19722,10 @@ opList {
     name: "gradO"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "repeat"
+    argType: INT64
   }
 }
 opList {
@@ -19706,12 +19774,12 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -19835,10 +19903,6 @@ opList {
 opList {
   name: "top_k"
   argDescriptor {
-    name: "k"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -19852,12 +19916,16 @@ opList {
     argIndex: 1
   }
   argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
     name: "needSort"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "k"
+    argType: INT64
   }
 }
 opList {
@@ -19890,13 +19958,25 @@ opList {
     argType: INPUT_TENSOR
   }
   argDescriptor {
-    name: "permuteDims"
+    name: "permutationVector"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "permuteDims"
+    argType: INT64
   }
 }
 opList {
   name: "tri"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
   argDescriptor {
     name: "row"
     argType: INT64
@@ -19911,14 +19991,6 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
 }
 opList {
   name: "triangular_solve"
@@ -19931,15 +20003,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "isLower"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "useAdjoint"
-    argType: BOOL
-    argIndex: 1
-  }
-  argDescriptor {
     name: "a"
     argType: INPUT_TENSOR
   }
@@ -19949,22 +20012,17 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "lower"
-    argType: INPUT_TENSOR
-    argIndex: 2
+    name: "isLower"
+    argType: BOOL
   }
   argDescriptor {
-    name: "adjoint"
-    argType: INPUT_TENSOR
-    argIndex: 3
+    name: "useAdjoint"
+    argType: BOOL
+    argIndex: 1
   }
 }
 opList {
   name: "triu"
-  argDescriptor {
-    name: "diag"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -19977,13 +20035,13 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
   }
-}
-opList {
-  name: "triu_bp"
   argDescriptor {
     name: "diag"
     argType: INT64
   }
+}
+opList {
+  name: "triu_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20001,6 +20059,10 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "diag"
+    argType: INT64
+  }
 }
 opList {
   name: "truncatediv"
@@ -20013,10 +20075,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20024,6 +20082,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: BROADCASTABLE_OP_IMPL
 }
@@ -20075,10 +20137,6 @@ opList {
 opList {
   name: "unsorted_segment_max"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20099,15 +20157,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_max_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20128,15 +20186,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_mean"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20157,15 +20215,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_mean_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20186,15 +20244,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_min"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20215,15 +20273,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_min_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20244,15 +20302,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_prod"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20273,15 +20331,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_prod_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20302,15 +20360,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_sqrt_n"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20331,15 +20389,15 @@ opList {
     name: "numSegments"
     argType: INPUT_TENSOR
     argIndex: 2
+  }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
   }
 }
 opList {
   name: "unsorted_segment_sqrt_n_bp"
   argDescriptor {
-    name: "numSegments"
-    argType: INT64
-  }
-  argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
   }
@@ -20361,13 +20419,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "unsorted_segment_sum"
   argDescriptor {
     name: "numSegments"
     argType: INT64
   }
+}
+opList {
+  name: "unsorted_segment_sum"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20390,13 +20448,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "unsorted_segment_sum_bp"
   argDescriptor {
     name: "numSegments"
     argType: INT64
   }
+}
+opList {
+  name: "unsorted_segment_sum_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20419,18 +20477,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
+  argDescriptor {
+    name: "numSegments"
+    argType: INT64
+  }
 }
 opList {
   name: "unstack"
-  argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
-    name: "num"
-    argType: INT64
-    argIndex: 1
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20442,6 +20495,15 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimensions"
+    argType: INT64
+  }
+  argDescriptor {
+    name: "num"
+    argType: INT64
+    argIndex: 1
   }
 }
 opList {
@@ -20459,6 +20521,22 @@ opList {
 opList {
   name: "upsampling2d"
   argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
+  argDescriptor {
     name: "factorH"
     argType: INT64
   }
@@ -20472,29 +20550,9 @@ opList {
     argType: INT64
     argIndex: 2
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "nchw"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "upsampling2d_bp"
-  argDescriptor {
-    name: "scaleW"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20502,10 +20560,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "nchw"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -20516,9 +20570,33 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "nchw"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "scaleW"
+    argType: INT64
+  }
 }
 opList {
   name: "upsampling3d"
+  argDescriptor {
+    name: "dtype"
+    argType: DATA_TYPE
+  }
+  argDescriptor {
+    name: "outputs"
+    argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "ncdhw"
+    argType: BOOL
+  }
   argDescriptor {
     name: "factorD"
     argType: INT64
@@ -20538,29 +20616,9 @@ opList {
     argType: INT64
     argIndex: 3
   }
-  argDescriptor {
-    name: "dtype"
-    argType: DATA_TYPE
-  }
-  argDescriptor {
-    name: "outputs"
-    argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "ncdhw"
-    argType: BOOL
-  }
-  argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
-  }
 }
 opList {
   name: "upsampling3d_bp"
-  argDescriptor {
-    name: "isNCDHW"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20568,10 +20626,6 @@ opList {
   argDescriptor {
     name: "gradI"
     argType: OUTPUT_TENSOR
-  }
-  argDescriptor {
-    name: "ncdhw"
-    argType: BOOL
   }
   argDescriptor {
     name: "input"
@@ -20582,16 +20636,24 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 1
   }
+  argDescriptor {
+    name: "ncdhw"
+    argType: BOOL
+  }
+  argDescriptor {
+    name: "isNCDHW"
+    argType: INT64
+  }
 }
 opList {
   name: "var"
   argDescriptor {
-    name: "dimensions"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "biasCorrected"
@@ -20603,8 +20665,8 @@ opList {
     argIndex: 1
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dimensions"
+    argType: INT64
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -20658,10 +20720,6 @@ opList {
 opList {
   name: "write_list"
   argDescriptor {
-    name: "idx"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
@@ -20673,6 +20731,10 @@ opList {
     name: "input"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "idx"
+    argType: INT64
   }
   opDeclarationType: LIST_OP_IMPL
 }
@@ -20687,10 +20749,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "comparable"
-    argType: DOUBLE
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20698,6 +20756,10 @@ opList {
     name: "y"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "comparable"
+    argType: DOUBLE
   }
   opDeclarationType: LEGACY_XYZ
 }
@@ -20708,21 +20770,17 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: LEGACY_XYZ
 }
 opList {
   name: "xw_plus_b"
-  argDescriptor {
-    name: "bTranspose"
-    argType: INT64
-  }
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20745,13 +20803,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 2
   }
-}
-opList {
-  name: "xw_plus_b_bp"
   argDescriptor {
     name: "bTranspose"
     argType: INT64
   }
+}
+opList {
+  name: "xw_plus_b_bp"
   argDescriptor {
     name: "dtype"
     argType: DATA_TYPE
@@ -20789,13 +20847,13 @@ opList {
     argType: INPUT_TENSOR
     argIndex: 3
   }
+  argDescriptor {
+    name: "bTranspose"
+    argType: INT64
+  }
 }
 opList {
   name: "yiq_to_rgb"
-  argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
@@ -20803,22 +20861,26 @@ opList {
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
 opList {
   name: "yuv_to_rgb"
   argDescriptor {
-    name: "dimC"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
+  }
+  argDescriptor {
+    name: "dimC"
+    argType: INT64
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }
@@ -20862,20 +20924,20 @@ opList {
 opList {
   name: "zeroslike"
   argDescriptor {
-    name: "dataType"
-    argType: INT64
-  }
-  argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR
+  }
+  argDescriptor {
+    name: "input"
+    argType: INPUT_TENSOR
   }
   argDescriptor {
     name: "inPlace"
     argType: BOOL
   }
   argDescriptor {
-    name: "input"
-    argType: INPUT_TENSOR
+    name: "dataType"
+    argType: INT64
   }
 }
 opList {
@@ -20889,10 +20951,6 @@ opList {
     argType: OUTPUT_TENSOR
   }
   argDescriptor {
-    name: "inPlace"
-    argType: BOOL
-  }
-  argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
@@ -20900,6 +20958,10 @@ opList {
     name: "q"
     argType: INPUT_TENSOR
     argIndex: 1
+  }
+  argDescriptor {
+    name: "inPlace"
+    argType: BOOL
   }
   opDeclarationType: CONFIGURABLE_OP_IMPL
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Allow pre preprocessing hooks to substitute for ops, adds global pooling averaging and max
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
