### PR TITLE
Add nano build updates

### DIFF
--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
       - uses: konduitai/cuda-install/.github/actions/install-cuda-ubuntu@master
-          env:
+        env:
             cuda: 10.2
             GCC: 7
       - name: Cache cmake install

--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -65,6 +65,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/set-linux-distro-version
       - uses: ./.github/actions/update-deps-linux
+      - uses: konduitai/cuda-install/.github/actions/install-cuda-ubuntu@master
+          env:
+            cuda: 10.2
+            GCC: 7
       - name: Cache cmake install
         uses: actions/cache@v2
         id: cache-cmake

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativebla
 *.swp
 
 *.dll
+*.tmp

--- a/change-cuda-versions.sh
+++ b/change-cuda-versions.sh
@@ -70,8 +70,8 @@ case $VERSION in
     VERSION3="1.5.4"
     ;;
   10.2)
-    VERSION2="7.6"
-    VERSION3="1.5.3"
+    VERSION2="8.2"
+    VERSION3="1.5.6"
     ;;
   10.1)
     VERSION2="7.6"
@@ -88,7 +88,9 @@ case $VERSION in
 esac
 
 sed_i() {
-  sed -i "" -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
+  if test -f "$2" && test -f "$1"; then
+     sed -i "" -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
+  fi
 }
 
 export -f sed_i
@@ -106,6 +108,11 @@ BASEDIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 #Artifact ids, ending with "-8.0", "-9.0", etc. nd4j-cuda, etc.
 find "$BASEDIR" -name 'pom.xml' -not -path '*target*' \
   -exec bash -c "sed_i 's/\(artifactId>nd4j-cuda-\)[0-9.]*<\/artifactId>/\1'$VERSION'<\/artifactId>/g' '{}'" \;
+
+#Artifact ids, ending with "-8.0", "-9.0", etc. nd4j-cuda, etc.
+find "$BASEDIR" -name 'pom.xml' -not -path '*target*' \
+  -exec bash -c "sed_i 's/\(artifactId>nd4j-cuda-preset\)[0-9.]*<\/artifactId>/\1'$VERSION'<\/artifactId>/g' '{}'" \;
+
 
 #Artifact ids, ending with "-8.0-platform", "-9.0-platform", etc. nd4j-cuda-platform, etc.
 find "$BASEDIR" -name 'pom.xml' -not -path '*target*' \

--- a/libnd4j/CMakeLists.txt
+++ b/libnd4j/CMakeLists.txt
@@ -309,6 +309,18 @@ if (${HELPERS_cudnn})
     #set(CUDNN_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA cuDNN")
 
     SET(CUDNN_LIBNAME "cudnn")
+    if(${SD_ARCH} MATCHES "armv8-a")
+        message("Adding jetson nano specific settings")
+        # Need to manually specify stubbed links in order
+        # for cublas and cusolver to be resolved
+        if(NOT DEFINED CUDA_cublas_LIBRARY)
+            set(CUDA_cublas_LIBRARY $ENV{loc_DIR}/cuda/targets/aarch64-linux/lib/stubs/libcublas.so)
+        endif()
+
+        if(NOT DEFINED CUDA_cusolver_LIBRARY)
+            set(CUDA_cusolver_LIBRARY $ENV{loc_DIR}/cuda/targets/aarch64-linux/lib/stubs/libcusolver.so)
+        endif()
+    endif()
     if(DEFINED ENV{CUDNN_ROOT_DIR})
        message("Using cudnn root directory from environment")
        set(CUDNN_ROOT_DIR $ENV{CUDNN_ROOT_DIR})

--- a/libnd4j/blas/CMakeLists.txt
+++ b/libnd4j/blas/CMakeLists.txt
@@ -157,11 +157,14 @@ endif()
 
 if(SD_CUDA)
     message("Build cublas")
-    find_package(CUDA)
+
+    find_package(CUDA REQUIRED)
     add_definitions(-D__CUDABLAS__=true)
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         set (CMAKE_CXX_FLAGS "")
     endif()
+
+
 
     if (CUDA_FOUND)
         message("CUDA include directory: ${CUDA_INCLUDE_DIRS}")
@@ -187,14 +190,14 @@ if(SD_CUDA)
         endif()
 
         if(WIN32)
-         message("In windows, setting cublas library and cusolver library")
-         if(NOT DEFINED CUDA_cublas_LIBRARY)
-                  set(CUDA_cublas_LIBRARY ${CUDA_HOME}/lib/x64/cublas.lib)
-          endif()
+            message("In windows, setting cublas library and cusolver library")
+            if(NOT DEFINED CUDA_cublas_LIBRARY)
+                set(CUDA_cublas_LIBRARY ${CUDA_HOME}/lib/x64/cublas.lib)
+            endif()
 
-          if(NOT DEFINED CUDA_cusolver_LIBRARY)
+            if(NOT DEFINED CUDA_cusolver_LIBRARY)
                 set(CUDA_cusolver_LIBRARY ${CUDA_HOME}/lib/x64/cusolver.lib)
-          endif()
+            endif()
         endif()
 
 
@@ -369,13 +372,13 @@ elseif(SD_CPU)
         if(NOT SD_STATIC_LIB OR SD_SHARED_LIB)
             add_library(${SD_LIBRARY_NAME} SHARED $<TARGET_OBJECTS:samediff_obj>)
             if(ANDROID)
-              # See: https://www.scivision.dev/cmake-ninja-job-pool-limited-memory/
-              # See: https://cmake.org/cmake/help/v3.0/command/cmake_host_system_information.html
-              # See: https://cmake.org/cmake/help/latest/prop_gbl/JOB_POOLS.html
-              cmake_host_system_information(RESULT _logical_cores QUERY NUMBER_OF_LOGICAL_CORES)
-             if(_logical_cores LESS 4)
-               set_target_properties(${SD_LIBRARY_NAME} PROPERTIES JOB_POOL_COMPILE one_jobs)
-             endif()
+                # See: https://www.scivision.dev/cmake-ninja-job-pool-limited-memory/
+                # See: https://cmake.org/cmake/help/v3.0/command/cmake_host_system_information.html
+                # See: https://cmake.org/cmake/help/latest/prop_gbl/JOB_POOLS.html
+                cmake_host_system_information(RESULT _logical_cores QUERY NUMBER_OF_LOGICAL_CORES)
+                if(_logical_cores LESS 4)
+                    set_target_properties(${SD_LIBRARY_NAME} PROPERTIES JOB_POOL_COMPILE one_jobs)
+                endif()
             endif()
         endif()
 

--- a/libnd4j/pi_build.sh
+++ b/libnd4j/pi_build.sh
@@ -396,7 +396,7 @@ else
 	 	message  "jetson cuda build "
 		cuda_cross_setup ${CUDA_VER}
 		XTRA_ARGS="${XTRA_ARGS} -c cuda  -h cudnn  "
-		XTRA_MVN_ARGS="${XTRA_MVN_ARGS} -Djavacpp.version=1.5.6 -Dcuda.version=${CUDA_VER} -Dlibnd4j.cuda=${CUDA_VER} -Dlibnd4j.chip=cuda -Dlibnd4j.compute=5.3 "
+		XTRA_MVN_ARGS="${XTRA_MVN_ARGS} -Pcuda -Djavacpp.version=1.5.6 -Dcuda.version=${CUDA_VER} -Dlibnd4j.cuda=${CUDA_VER} -Dlibnd4j.chip=cuda -Dlibnd4j.compute=5.3 "
 		bash "${BASE_DIR}/../change-cuda-versions.sh" "${CUDA_VER}"
 		XTRA_MVN_ARGS="${XTRA_MVN_ARGS}  -Dlibnd4j.helper=cudnn"
 		export SYSROOT="${CROSS_COMPILER_DIR}/${PREFIX}/libc"

--- a/libnd4j/pi_build.sh
+++ b/libnd4j/pi_build.sh
@@ -170,7 +170,7 @@ function download_extract_base {
 	down_file="${down_dir}_file"
 	if [ ! -f "${down_file}" ]; then
 		message "download ${down_url}"
-		wget --quiet --show-progress -O "${down_file}" "${down_url}"
+		wget  --show-progress -O "${down_file}" "${down_url}"
 	fi
  
 	message "extract $@"
@@ -187,7 +187,7 @@ function download_extract_base {
 }
 
 function download_extract {
-	download_extract_base -xzf "$@"
+	download_extract_base -xvf "$@"
 }
 
 function download_extract_xz {
@@ -225,19 +225,18 @@ function fix_pi_linker {
 function cuda_cross_setup {
 		# $1 is local  cuda toolkit version
 		# $2 the folder where cross cuda toolkit will be
-		loc_VER="${LOCAL_CUDA_INSTALLED_VER}"
-		loc_DIR="${2-/tmp}"
-		CUDA_DIR="${CUDA_DIR-/usr/local/cuda-${loc_VER}}"
-		CUDA_TARGET_STUBS="${loc_DIR}/target_stub${loc_VER}"
-		CUDA_TARGET_STUB_URL=https://github.com/KonduitAI/jetson-release/releases/download/0.1.0/aarch64_linux_cuda_10.2_cudnn8.2.tar.gz
+		export loc_VER="${LOCAL_CUDA_INSTALLED_VER}"
+		export loc_DIR="${2-/tmp}"
+		export CUDA_DIR="${CUDA_DIR-/usr/local/cuda-${loc_VER}}"
+		export CUDA_TARGET_STUBS="${loc_DIR}/target_stub${loc_VER}"
+		export CUDA_TARGET_STUB_URL=https://github.com/KonduitAI/jetson-release/releases/download/0.1.0/aarch64_linux_cuda_10.2_cudnn8.2.tar.gz
 		download_extract "${CUDA_TARGET_STUB_URL}" "${CUDA_TARGET_STUBS}"
 		mv "${CUDA_TARGET_STUBS}/aarch64_linux_cuda_10.2_cudnn8.2" "${CUDA_TARGET_STUBS}/aarch64-linux/"
 		message "Moving  ${CUDA_TARGET_STUBS}/aarch64_linux_cuda_10.2_cudnn8.2 to ${CUDA_TARGET_STUBS}/aarch64-linux/"
 		message "Files in ${CUDA_TARGET_STUBS}/aarch64-linux/"
+		message "Files in ${CUDA_TARGET_STUBS}/aarch64-linux/"
 		ls "${CUDA_TARGET_STUBS}/aarch64-linux/"
-		message "Files in ${CUDA_TARGET_STUBS}/aarch64-linux/aarch64-linux"
-		ls "${CUDA_TARGET_STUBS}/aarch64-linux/aarch64-linux"
-		cp -r ${CUDA_TARGET_STUBS}/aarch64-linux/aarch64-linux/* "${CUDA_TARGET_STUBS}/aarch64-linux/"
+		cp -r ${CUDA_TARGET_STUBS}/aarch64-linux/* "${CUDA_TARGET_STUBS}/aarch64-linux/"
 		message "lets setup cuda toolkit by combining local cuda-${loc_VER} and target ${CUDA_TARGET_STUBS}"
 		message "cuda cross folder: ${loc_DIR}"
 		check_requirements "${CUDA_DIR}" "${CUDA_TARGET_STUBS}/aarch64-linux/"


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
Adds nano build updates to handle linking out of the box including:
1. nano version updates for 10.2
2. Additional linkage support based on the download of the binary distribution from the build repo

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
