### PR TITLE
PR#9434 additions. cmake typo fix. print typename instead of a positional number in RequirementsHelper debug output

### DIFF
--- a/libnd4j/blas/CMakeLists.txt
+++ b/libnd4j/blas/CMakeLists.txt
@@ -411,13 +411,13 @@ elseif(SD_CPU)
 
     #This breaks the build. Normally you want to run tests anyways.
     if(NOT "$ENV{CLION_IDE}")
-        target_link_libraries(${SD_LIBRARY_NAME} ${ONEDNN}  ${ONEDNN_LIBRARIES} ${ARMCOMPUTE_LIBRARIES} ${OPENBLAS_LIBRARIES} ${BLAS_LIBRARIES} ${CPU_FEATURES})
+        target_link_libraries(${SD_LIBRARY_NAME} ${ONEDNN} ${ONEDNN_LIBRARIES} ${ARMCOMPUTE_LIBRARIES} ${OPENBLAS_LIBRARIES} ${BLAS_LIBRARIES} ${CPU_FEATURES})
     endif()
 
     if ("${SD_ALL_OPS}" AND "${SD_BUILD_MINIFIER}")
         message(STATUS "Building minifier...")
         add_executable(minifier ../minifier/minifier.cpp ../minifier/graphopt.cpp)
-        target_link_libraries(minifier samediff_obj ${ONEDNN_LIBRARIES} ${ARMCOMPUTE_LIBRARIES} ${OPENBLAS_LIBRARIES} ${ONEDNN} ${ONEDNN_LIBRARIES} ${BLAS_LIBRARIES} ${CPU_FEATURES})
+        target_link_libraries(minifier samediff_obj ${ONEDNN} ${ONEDNN_LIBRARIES} ${ARMCOMPUTE_LIBRARIES} ${OPENBLAS_LIBRARIES} ${BLAS_LIBRARIES} ${CPU_FEATURES})
     endif()
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 4.9)

--- a/libnd4j/include/system/RequirementsHelper.h
+++ b/libnd4j/include/system/RequirementsHelper.h
@@ -33,6 +33,12 @@
 //#define ENABLE_LOG_TO_TEST 1
 namespace sd {
 
+inline std::ostream& operator<<(std::ostream& o, const sd::DataType &type)
+{ 
+    o << DataTypeUtils::asString(type);
+    return o;
+}
+
 template <class T, std::size_t N>
 std::ostream& operator<<(std::ostream& o, const std::array<T, N>& arr)
 {


### PR DESCRIPTION
## What changes were proposed in this pull request?

CMake typo fix. print type name instead of a positional number in RequirementsHelper debug output

## How was this patch tested?

tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
