### PR TITLE
Close arrow vectors when closing ArrowWritableRecordBatch

### DIFF
--- a/datavec/datavec-arrow/src/main/java/org/datavec/arrow/ArrowConverter.java
+++ b/datavec/datavec-arrow/src/main/java/org/datavec/arrow/ArrowConverter.java
@@ -273,42 +273,16 @@ public class ArrowConverter {
      * @param outputStream the output stream to write to
      */
     public static void writeRecordBatchTo(BufferAllocator bufferAllocator ,List<List<Writable>> recordBatch, Schema inputSchema,OutputStream outputStream) {
-        if(!(recordBatch instanceof ArrowWritableRecordBatch)) {
-            val convertedSchema = toArrowSchema(inputSchema);
-            List<FieldVector> columns  = toArrowColumns(bufferAllocator,inputSchema,recordBatch);
-            try {
-                VectorSchemaRoot root = new VectorSchemaRoot(convertedSchema,columns,recordBatch.size());
-
-                ArrowFileWriter writer = new ArrowFileWriter(root, providerForVectors(columns,convertedSchema.getFields()),
-                        newChannel(outputStream));
-                writer.start();
-                writer.writeBatch();
-                writer.end();
-
-
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-
+        val convertedSchema = toArrowSchema(inputSchema);
+        List<FieldVector> columns  = toArrowColumns(bufferAllocator,inputSchema,recordBatch);
+        try (VectorSchemaRoot root = new VectorSchemaRoot(convertedSchema,columns,recordBatch.size());
+            ArrowFileWriter writer = new ArrowFileWriter(root, providerForVectors(columns,convertedSchema.getFields()), newChannel(outputStream))) {
+            writer.start();
+            writer.writeBatch();
+            writer.end();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
         }
-        else {
-            val convertedSchema = toArrowSchema(inputSchema);
-            val pair = toArrowColumns(bufferAllocator,inputSchema,recordBatch);
-            try {
-                VectorSchemaRoot root = new VectorSchemaRoot(convertedSchema,pair,recordBatch.size());
-
-                ArrowFileWriter writer = new ArrowFileWriter(root, providerForVectors(pair,convertedSchema.getFields()),
-                        newChannel(outputStream));
-                writer.start();
-                writer.writeBatch();
-                writer.end();
-
-
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-
     }
 
 

--- a/datavec/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordBatch.java
+++ b/datavec/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordBatch.java
@@ -23,6 +23,7 @@ package org.datavec.arrow.recordreader;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
@@ -240,7 +241,7 @@ public class ArrowWritableRecordBatch extends AbstractWritableRecordBatch implem
         if(vectorLoader != null)
             vectorLoader.close();
 
-
+        list.forEach(ValueVector::close);
     }
 
 

--- a/datavec/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordTimeSeriesBatch.java
+++ b/datavec/datavec-arrow/src/main/java/org/datavec/arrow/recordreader/ArrowWritableRecordTimeSeriesBatch.java
@@ -23,6 +23,7 @@ package org.datavec.arrow.recordreader;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
@@ -232,7 +233,7 @@ public class ArrowWritableRecordTimeSeriesBatch extends AbstractTimeSeriesWritab
         if(vectorLoader != null)
             vectorLoader.close();
 
-
+        list.forEach(ValueVector::close);
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
I got out of direct memory issue when was processing a large amount of data using `LocalTransformExecutor`. It turned out, that after arrow vectors were used, they aren't closed to release the direct memory they were using.

This PR adds changes to close vectors provided to `ArrowWritableRecordBatch`, so end users can just call `ArrowWritableRecordBatch.close()`, and it also close value vectors it holds, since in most of the cases, there is no access to the passed list of value vectors.

## How was this patch tested?
Checked manually.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
