### PR TITLE
Add pbtxt prefix to ensure included in nd4j resources

### DIFF
--- a/nd4j/pom.xml
+++ b/nd4j/pom.xml
@@ -124,6 +124,7 @@
                 <configuration>
                     <includes>
                         <include>**/*.so</include>
+                        <include>**/*.pbtxt</include>
                         <include>**/*.so.*</include>
                         <include>META-INF/*</include>
                         <include>META-INF/services/**</include>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Before, pbtxt resources were not explicitly included in nd4j's maven-jar-plugin. configuration
This prevented the new model import feature as well as the newer op resolution
from working properly by default.
This PR fixes that.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
