### PR TITLE
Add missing data types declaration to maven pom

### DIFF
--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -20,8 +20,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -56,6 +56,7 @@
         <libnd4j.helper></libnd4j.helper>
         <libnd4j.buildprogram>bash</libnd4j.buildprogram>
         <libnd4j.operations></libnd4j.operations>
+        <libnd4j.datatypes></libnd4j.datatypes>
     </properties>
 
     <build>
@@ -153,7 +154,8 @@
                                 <argument>${libnd4j.helper}</argument>
                                 <argument>--operations</argument>
                                 <argument>${libnd4j.operations}</argument>
-
+                                <argument>--datatypes</argument>
+                                <argument>${libnd4j.datatypes}</argument>
                             </buildCommand>
                             <workingDirectory>${project.basedir}</workingDirectory>
                         </configuration>
@@ -340,6 +342,8 @@
                                         <argument>${libnd4j.helper}</argument>
                                         <argument>--operations</argument>
                                         <argument>"${libnd4j.operations}"</argument>
+                                        <argument>--datatypes</argument>
+                                        <argument>${libnd4j.datatypes}</argument>
                                     </buildCommand>
                                     <workingDirectory>${project.basedir}</workingDirectory>
                                 </configuration>

--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -155,7 +155,7 @@
                                 <argument>--operations</argument>
                                 <argument>${libnd4j.operations}</argument>
                                 <argument>--datatypes</argument>
-                                <argument>${libnd4j.datatypes}</argument>
+                                <argument>"${libnd4j.datatypes}"</argument>
                             </buildCommand>
                             <workingDirectory>${project.basedir}</workingDirectory>
                         </configuration>
@@ -343,7 +343,7 @@
                                         <argument>--operations</argument>
                                         <argument>"${libnd4j.operations}"</argument>
                                         <argument>--datatypes</argument>
-                                        <argument>${libnd4j.datatypes}</argument>
+                                        <argument>"${libnd4j.datatypes}"</argument>
                                     </buildCommand>
                                     <workingDirectory>${project.basedir}</workingDirectory>
                                 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds missing pom declaration for the newly added data types pruning support in the libnd4j build.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
