### PR TITLE
change NativeRandom generator to use next methods to achieve prng

### DIFF
--- a/libnd4j/include/legacy/NativeOps.h
+++ b/libnd4j/include/legacy/NativeOps.h
@@ -1641,6 +1641,10 @@ ND4J_EXPORT float getRandomGeneratorRelativeFloat(OpaqueRandomGenerator* ptr, Nd
 ND4J_EXPORT double getRandomGeneratorRelativeDouble(OpaqueRandomGenerator* ptr, Nd4jLong index);
 ND4J_EXPORT int getRandomGeneratorRelativeInt(OpaqueRandomGenerator* ptr, Nd4jLong index);
 ND4J_EXPORT Nd4jLong getRandomGeneratorRelativeLong(OpaqueRandomGenerator* ptr, Nd4jLong index);
+ND4J_EXPORT float getRandomGeneratorNextFloat(OpaqueRandomGenerator* ptr);
+ND4J_EXPORT double getRandomGeneratorNextDouble(OpaqueRandomGenerator* ptr);
+ND4J_EXPORT int getRandomGeneratorNextInt(OpaqueRandomGenerator* ptr);
+ND4J_EXPORT Nd4jLong getRandomGeneratorNextLong(OpaqueRandomGenerator* ptr);
 ND4J_EXPORT void deleteRandomGenerator(OpaqueRandomGenerator* ptr);
 
 

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -2867,6 +2867,33 @@ Nd4jLong getRandomGeneratorRelativeLong(sd::graph::RandomGenerator* ptr, Nd4jLon
     return ptr->relativeLong(index);
 }
 
+int getRandomGeneratorNextInt(sd::graph::RandomGenerator* ptr) {
+    //to nullify  _nodeState._long ^= (steps ^ 0xdeadbeef);
+    //we will use step = 0xdeadbeef
+    auto result= ptr->relativeInt(1);
+    ptr->rewindH(0xdeadbeef);
+    return result;
+}
+
+Nd4jLong getRandomGeneratorNextLong(sd::graph::RandomGenerator* ptr) {
+    auto result= ptr->relativeLong(1);
+    ptr->rewindH(0xdeadbeef);
+    return result;
+}
+
+float getRandomGeneratorNextFloat(sd::graph::RandomGenerator* ptr) {
+  auto result= ptr->relativeT<float>(1);
+  ptr->rewindH(0xdeadbeef);
+  return result;
+}
+
+double getRandomGeneratorNextDouble(sd::graph::RandomGenerator* ptr) {
+  auto result= ptr->relativeT<double>(1);
+  ptr->rewindH(0xdeadbeef);
+  return result;
+}
+
+
 void deleteRandomGenerator(sd::graph::RandomGenerator* ptr) {
     delete ptr;
 }

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -3587,6 +3587,32 @@ Nd4jLong getRandomGeneratorRelativeLong(sd::graph::RandomGenerator* ptr, Nd4jLon
     return ptr->relativeLong(index);
 }
 
+int getRandomGeneratorNextInt(sd::graph::RandomGenerator* ptr) {
+    //to nullify  _nodeState._long ^= (steps ^ 0xdeadbeef);
+    //we will use step = 0xdeadbeef
+    auto result= ptr->relativeInt(1);
+    ptr->rewindH(0xdeadbeef);
+    return result;
+}
+
+Nd4jLong getRandomGeneratorNextLong(sd::graph::RandomGenerator* ptr) {
+    auto result= ptr->relativeLong(1);
+    ptr->rewindH(0xdeadbeef);
+    return result;
+}
+
+float getRandomGeneratorNextFloat(sd::graph::RandomGenerator* ptr) {
+  auto result= ptr->relativeT<float>(1);
+  ptr->rewindH(0xdeadbeef);
+  return result;
+}
+
+double getRandomGeneratorNextDouble(sd::graph::RandomGenerator* ptr) {
+  auto result= ptr->relativeT<double>(1);
+  ptr->rewindH(0xdeadbeef);
+  return result;
+}
+
 void deleteRandomGenerator(sd::graph::RandomGenerator* ptr) {
     delete ptr;
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -1190,6 +1190,10 @@ public interface NativeOps {
     double getRandomGeneratorRelativeDouble(OpaqueRandomGenerator ptr, @Cast("Nd4jLong") long index);
     int getRandomGeneratorRelativeInt(OpaqueRandomGenerator ptr, @Cast("Nd4jLong") long index);
     long getRandomGeneratorRelativeLong(OpaqueRandomGenerator ptr, @Cast("Nd4jLong") long index);
+    float getRandomGeneratorNextFloat(OpaqueRandomGenerator ptr);
+    double getRandomGeneratorNextDouble(OpaqueRandomGenerator ptr);
+    int getRandomGeneratorNextInt(OpaqueRandomGenerator ptr);
+    long getRandomGeneratorNextLong(OpaqueRandomGenerator ptr);
     void deleteRandomGenerator(OpaqueRandomGenerator ptr);
 
   

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/rng/CudaNativeRandom.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/rng/CudaNativeRandom.java
@@ -87,22 +87,22 @@ public class CudaNativeRandom extends NativeRandom {
 
     @Override
     public float nextFloat() {
-        return nativeOps.getRandomGeneratorRelativeFloat((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextFloat((OpaqueRandomGenerator)statePointer);
     }
 
     @Override
     public double nextDouble() {
-        return nativeOps.getRandomGeneratorRelativeDouble((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextDouble((OpaqueRandomGenerator)statePointer);
     }
 
     @Override
     public int nextInt() {
-        return nativeOps.getRandomGeneratorRelativeInt((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextInt((OpaqueRandomGenerator)statePointer);
     }
 
     @Override
     public long nextLong() {
-        return nativeOps.getRandomGeneratorRelativeLong((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextLong((OpaqueRandomGenerator)statePointer);
     }
 
     public long rootState() {

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/rng/CpuNativeRandom.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/rng/CpuNativeRandom.java
@@ -71,22 +71,22 @@ public class CpuNativeRandom extends NativeRandom {
 
     @Override
     public int nextInt() {
-        return nativeOps.getRandomGeneratorRelativeInt((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextInt((OpaqueRandomGenerator)statePointer);
     }
 
     @Override
     public float nextFloat() {
-        return nativeOps.getRandomGeneratorRelativeFloat((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextFloat((OpaqueRandomGenerator)statePointer);
     }
 
     @Override
     public double nextDouble() {
-        return nativeOps.getRandomGeneratorRelativeDouble((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextDouble((OpaqueRandomGenerator)statePointer);
     }
 
     @Override
     public long nextLong() {
-        return nativeOps.getRandomGeneratorRelativeLong((OpaqueRandomGenerator)statePointer, currentPosition.getAndIncrement());
+        return nativeOps.getRandomGeneratorNextLong((OpaqueRandomGenerator)statePointer);
     }
 
     public long rootState() {


### PR DESCRIPTION
change NativeRandom generator to use next methods to achieve prng

Signed-off-by: AbdelRauf <rauf@konduit.ai>

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

manual tests
[chi_square test for uniformity  p 0.05 level of significance](https://gist.github.com/quickwritereader/94f6c261ad285817fa85e9fe3f41e687#file-chi_sq_test-java)
[chi_square results](https://gist.github.com/quickwritereader/94f6c261ad285817fa85e9fe3f41e687#file-chi_test_result)
total 187 chi fails 5

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
