### PR TITLE
Add ability to define training config data type for initial loss

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -4536,7 +4536,7 @@ public class SameDiff extends SDBaseOps {
                 }
 
 
-                return new SDVariable[]{sameDiff.var(GRAD_FN_KEY, org.nd4j.linalg.api.buffer.DataType.FLOAT, 1)};
+                return new SDVariable[]{sameDiff.var(GRAD_FN_KEY, trainingConfig.getInitialLossDataType(), 1)};
             }
         });
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/bp/BaseReductionBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/bp/BaseReductionBp.java
@@ -119,7 +119,12 @@ public abstract class BaseReductionBp extends DynamicCustomOp {
 
 
     @Override
-    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes){
+    public int getNumOutputs() {
+        return 1;
+    }
+
+    @Override
+    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes) {
         //Reduction backprop ops: expect 2 inputs... the original input, and the gradient at the outputs
         //For example, for y=mean(x), inputs to ReduceMeanBp are x and dL/dy; output is dL/dx
         //Now, we expect gradient dL/dx datatype to be same as x - which resticts us to real-valued x input

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/BaseDynamicTransformOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/BaseDynamicTransformOp.java
@@ -46,6 +46,11 @@ public abstract class BaseDynamicTransformOp extends DynamicCustomOp {
     }
 
     @Override
+    public int getNumOutputs() {
+        return 1;
+    }
+
+    @Override
     public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes){
         Preconditions.checkState(dataTypes != null && dataTypes.size() == 2, "Expected exactly 2 input datatypes for %s, got input %s", getClass(), dataTypes);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In order for data type subsets to work (eg: only compile with certain supported dataypes) one thing we need to do is have the ability to define what data type the initial loss should be. This PR adds that ability by allowing samediff to pull the data type from the training configuration.

We still default to float, but allow overriding where necessary.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Manually

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
