### PR TITLE
Update op exclusion to add missing prefixes for proper pre processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/nativebla
 
 *.dll
 *.tmp
+libnd4j/include/generated/include_ops.h

--- a/libnd4j/include/ops/declarable/generic/images/extract_image_patches.cpp
+++ b/libnd4j/include/ops/declarable/generic/images/extract_image_patches.cpp
@@ -22,7 +22,7 @@
 
 #include <ops/declarable/CustomOperations.h>
 #include <ops/declarable/helpers/extract_patches.h>
-#if NOT_EXCLUDED(extract_image_patches)
+#if NOT_EXCLUDED(OP_extract_image_patches)
 namespace sd {
     namespace ops {
         CUSTOM_OP_IMPL(extract_image_patches, 1, 1, false, 0, 7) {

--- a/libnd4j/include/ops/declarable/generic/images/rgbToYiq.cpp
+++ b/libnd4j/include/ops/declarable/generic/images/rgbToYiq.cpp
@@ -25,7 +25,7 @@
 #include <helpers/ConstantTadHelper.h>
 #include <execution/Threads.h>
 
-#if NOT_EXCLUDED(rgb_to_yiq)
+#if NOT_EXCLUDED(OP_rgb_to_yiq)
 namespace sd {
     namespace ops {
 

--- a/libnd4j/include/ops/declarable/generic/nn/recurrent/staticBidirectionalRNN.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/recurrent/staticBidirectionalRNN.cpp
@@ -25,7 +25,7 @@
 #include<ops/declarable/helpers/reverse.h>
 #include<ops/declarable/helpers/transforms.h>
 
-#if NOT_EXCLUDED(static_bi_directional_rnn)
+#if NOT_EXCLUDED(OP_static_bi_directional_rnn)
 namespace sd {
 namespace ops  {
 

--- a/libnd4j/include/ops/declarable/generic/tests/test_output_reshape.cpp
+++ b/libnd4j/include/ops/declarable/generic/tests/test_output_reshape.cpp
@@ -22,7 +22,7 @@
 
 #include <system/op_boilerplate.h>
 
-#if NOT_EXCLUDED(test_output_reshape)
+#if NOT_EXCLUDED(OP_test_output_reshape)
 #include <ops/declarable/headers/tests.h>
 
 namespace sd {

--- a/libnd4j/include/ops/declarable/generic/updaters/adaGradUpdater.cpp
+++ b/libnd4j/include/ops/declarable/generic/updaters/adaGradUpdater.cpp
@@ -27,7 +27,7 @@
 #include <helpers/ConstantTadHelper.h>
 #include <execution/Threads.h>
 #include <array/NDArray.h>
-#if NOT_EXCLUDED(ada_grad_updater)
+#if NOT_EXCLUDED(OP_ada_grad_updater)
 namespace sd {
     namespace ops {
 

--- a/libnd4j/include/ops/declarable/generic/updaters/adamUpdater.cpp
+++ b/libnd4j/include/ops/declarable/generic/updaters/adamUpdater.cpp
@@ -27,7 +27,7 @@
 #include <helpers/ConstantTadHelper.h>
 #include <execution/Threads.h>
 #include <array/NDArray.h>
-#if NOT_EXCLUDED(adam_updater)
+#if NOT_EXCLUDED(OP_adam_updater)
 namespace sd {
     namespace ops {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Every NOT_EXCLUDED check expects an OP_ prefix.
This adds some missing prefixes for various ops that prevent them from being properly included when
not all ops are incldued.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
