### PR TITLE
Manually sync cuda buffer inside shuffle. 

### DIFF
--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -891,6 +891,13 @@ public class JCublasNDArrayFactory extends BaseNativeNDArrayFactory {
         for (int i = 0; i < arrays.size(); i++) {
             val array = arrays.get(i);
 
+            //we have to sync manually here as we are calling the method with raw cuda pointers
+            AllocationPoint point = allocator.getAllocationPoint(array); 
+            if(point.isActualOnHostSide()){
+                AtomicAllocator.getInstance().getFlowController().synchronizeToDevice(point);
+                point.tickDeviceWrite();
+            }
+
             val x = AtomicAllocator.getInstance().getPointer(array, context);
             val xShapeInfo = AtomicAllocator.getInstance().getPointer(array.shapeInfoDataBuffer(), context);
 


### PR DESCRIPTION
Manually sync cuda buffer inside shuffle. as JCublasNDArrayFactory::shuffle method was calling libnd4j shuffle with raw cuda pointers there was sync problems when the host buffer was new. For example: when putScalar is used
 
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
