### PR TITLE
Fixes #9476 , ensure weights aren't double counted

### DIFF
--- a/deeplearning4j/deeplearning4j-modelimport/pom.xml
+++ b/deeplearning4j/deeplearning4j-modelimport/pom.xml
@@ -121,6 +121,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.8.0-M1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution3D.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/convolutional/KerasConvolution3D.java
@@ -101,6 +101,7 @@ public class KerasConvolution3D extends KerasConvolution {
                 .convolutionMode(getConvolutionModeFromConfig(layerConfig, conf))
                 .kernelSize(getKernelSizeFromConfig(layerConfig, 3, conf, kerasMajorVersion))
                 .hasBias(hasBias)
+                .dataFormat(getCNN3DDataFormatFromConfig(layerConfig,conf))
                 .stride(getStrideFromConfig(layerConfig, 3, conf));
         int[] padding = getPaddingFromBorderModeConfig(layerConfig, 3, conf, kerasMajorVersion);
         if (hasBias)

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/normalization/KerasBatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/layers/normalization/KerasBatchNormalization.java
@@ -121,7 +121,7 @@ public class KerasBatchNormalization extends KerasLayer {
         List<Object> inboundNodes = (List<Object>) layerConfig.get(conf.getLAYER_FIELD_INBOUND_NODES());
         CNN2DFormat cnn2DFormat = CNN2DFormat.NCHW;
 
-        if(!inboundNodes.isEmpty()) {
+        if(inboundNodes != null && !inboundNodes.isEmpty()) {
             List<Object> list = (List<Object>) inboundNodes.get(0);
             List<Object> list1 = (List<Object>) list.get(0);
             String inputName = list1.get(0).toString();

--- a/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/convolution/KerasConvolution3DTest.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/convolution/KerasConvolution3DTest.java
@@ -168,7 +168,7 @@ class KerasConvolution3DTest extends BaseDL4JTest {
         assertNotNull(multiLayerConfiguration);
         //null pre processor should still work and default to channels last
         ReshapePreprocessor reshapePreprocessor = (ReshapePreprocessor) multiLayerConfiguration.getInputPreProcess(4);
-        assertNull(reshapePreprocessor.getFormat());
+        assertNotNull(reshapePreprocessor.getFormat());
         System.out.println(multiLayerConfiguration);
     }
 

--- a/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasPooling1DTest.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/test/java/org/deeplearning4j/nn/modelimport/keras/layers/pooling/KerasPooling1DTest.java
@@ -31,6 +31,7 @@ import org.deeplearning4j.nn.modelimport.keras.KerasModelImport;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras1LayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.config.Keras2LayerConfiguration;
 import org.deeplearning4j.nn.modelimport.keras.config.KerasLayerConfiguration;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -38,14 +39,17 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.nd4j.common.io.ClassPathResource;
 import org.nd4j.common.resources.Resources;
 import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Max Pumperla
@@ -132,6 +136,14 @@ class KerasPooling1DTest extends BaseDL4JTest {
         Layer layer = maxpooling1d.getLayer();
         org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer subsampling1DLayer = (org.deeplearning4j.nn.layers.convolution.subsampling.Subsampling1DLayer) layer;
         assertEquals(CNN2DFormat.NHWC,subsampling1DLayer.layerConf().getCnn2dDataFormat());
+    }
+
+    @Test
+    public void test1dWeightInit() throws Exception {
+        File file = Resources.asFile("modelimport/keras/tfkeras/cnn_1d_doublecount.h5.h5");
+        MultiLayerNetwork multiLayerNetwork = KerasModelImport.importKerasSequentialModelAndWeights(file.getAbsolutePath(), false);
+        INDArray output = multiLayerNetwork.output(Nd4j.ones(1, 6, 1));
+        assertArrayEquals(new long[]{1,2,6},output.shape());
     }
 
 

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Convolution1DLayer.java
@@ -110,7 +110,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
             if(this.rnnDataFormat == null || override)
                 this.rnnDataFormat = r.getFormat();
 
-             if(this.cnn2dDataFormat == null || override)
+            if(this.cnn2dDataFormat == null || override)
                 this.cnn2dDataFormat = rnnDataFormat == RNNFormat.NCW ? CNN2DFormat.NCHW : CNN2DFormat.NHWC;
         } else if(inputType.getType() == InputType.Type.FF) {
             InputType.InputTypeFeedForward r = (InputType.InputTypeFeedForward) inputType;
@@ -236,11 +236,7 @@ public class Convolution1DLayer extends ConvolutionLayer {
                 return;
             }
 
-            if(this.kernelSize == null){
-                this.kernelSize = new int[] {1, 1};
-            }
-
-            this.kernelSize[0] = ValidationUtils.validate1NonNegative(kernelSize, "kernelSize")[0];
+            this.kernelSize = ConvolutionUtils.getIntConfig(kernelSize,1);
         }
 
         @Override
@@ -251,11 +247,8 @@ public class Convolution1DLayer extends ConvolutionLayer {
                 return;
             }
 
-            if(this.stride == null){
-                this.stride = new int[] {1, 1};
-            }
+            this.stride = ConvolutionUtils.getIntConfig(stride,1);
 
-            this.stride[0] = ValidationUtils.validate1NonNegative(stride, "stride")[0];
         }
 
         @Override
@@ -266,26 +259,20 @@ public class Convolution1DLayer extends ConvolutionLayer {
                 return;
             }
 
-            if(this.padding == null){
-                this.padding = new int[] {0, 0};
-            }
+            this.padding = ConvolutionUtils.getIntConfig(padding,0);
 
-            this.padding[0] = ValidationUtils.validate1NonNegative(padding, "padding")[0];
         }
 
         @Override
         public void setDilation(int... dilation) {
 
-            if(dilation == null){
+            if(dilation == null) {
                 this.dilation = null;
                 return;
             }
 
-            if(this.dilation == null){
-                this.dilation = new int[] {1, 1};
-            }
+            this.dilation = ConvolutionUtils.getIntConfig(dilation,1);
 
-            this.dilation[0] = ValidationUtils.validate1NonNegative(dilation, "dilation")[0];
         }
 
         @Override

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/Subsampling1DLayer.java
@@ -258,7 +258,7 @@ public class Subsampling1DLayer extends SubsamplingLayer {
          */
         @Override
         public void setStride(int... stride) {
-            this.stride[0] = ValidationUtils.validate1NonNegative(stride, "stride")[0];
+            this.stride = ConvolutionUtils.getIntConfig(stride,1);
         }
 
         /**
@@ -268,7 +268,7 @@ public class Subsampling1DLayer extends SubsamplingLayer {
          */
         @Override
         public void setPadding(int... padding) {
-            this.padding[0] = ValidationUtils.validate1NonNegative(padding, "padding")[0];
+            this.padding = ConvolutionUtils.getIntConfig(padding,1);
         }
     }
 }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -2368,7 +2368,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                 }
 
 
-                try (MemoryWorkspace wsFFWorking = workspaceMgr.notifyScopeEntered(ArrayType.FF_WORKING_MEM)) {
+                 try (MemoryWorkspace wsFFWorking = workspaceMgr.notifyScopeEntered(ArrayType.FF_WORKING_MEM)) {
                     VertexIndices[] inputsTo = current.getOutputVertices();
 
                     INDArray out = null;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/normalization/BatchNormalization.java
@@ -517,7 +517,8 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
             } else {
                 var = getParam(BatchNormalizationParamInitializer.GLOBAL_VAR);
             }
-            std = Transforms.sqrt(workspaceMgr.dup(ArrayType.INPUT, var).addi(layerConf().getEps()), false);
+
+            std = Transforms.sqrt(var.add(layerConf().getEps()));
         }
 
         // BN(xk) = gamma*xˆ + β (applying gamma and beta for each activation)
@@ -544,9 +545,9 @@ public class BatchNormalization extends BaseLayer<org.deeplearning4j.nn.conf.lay
         } else if (x.rank() == 4) {
             if (!Shape.strideDescendingCAscendingF(x))
                 x = x.dup(); //TODO: temp Workaround for broadcast bug. To be removed when fixed
-            xMu = workspaceMgr.createUninitialized(ArrayType.INPUT, x.dataType(), x.shape(), x.ordering());
+            xMu = Nd4j.createUninitialized(x.dataType(), x.shape(), x.ordering());
             xMu = Nd4j.getExecutioner().exec(new BroadcastSubOp(x, mean,xMu, chIdx));
-            xHat =  workspaceMgr.createUninitialized(ArrayType.INPUT, x.dataType(), x.shape(), x.ordering());
+            xHat =  Nd4j.createUninitialized(x.dataType(), x.shape(), x.ordering());
             xHat = Nd4j.getExecutioner().exec(new BroadcastDivOp(xMu, std,xHat, chIdx));
 
             if (layerConf.isLockGammaBeta()) {

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/ConvolutionUtils.java
@@ -62,6 +62,27 @@ public class ConvolutionUtils {
     private ConvolutionUtils() {
     }
 
+
+    /**
+     * Return the configuration for a given value
+     * for values like stride, dilation, kernel size
+     * that require 2 values
+     * If the input is already length 2, return that
+     * if the length is only 1, return the value specified twice
+     * otherwise return the default value duplicated twice
+     *
+     * @param inputValue the input value to return
+     * @param defaultValue the default value if none is present
+     * @return the int value as specified above.
+     */
+    public static int[] getIntConfig(int[] inputValue,int defaultValue) {
+        if(inputValue != null && inputValue.length < 2)
+            return new int[]{ inputValue[0] ,inputValue[0]};
+        else if(inputValue.length == 2)
+            return inputValue;
+        return new int[]{ defaultValue ,defaultValue};
+    }
+
     /**
      * Use {@link #getOutputSize(INDArray, int[], int[], int[], ConvolutionMode, int[], CNN2DFormat)}
      */
@@ -120,7 +141,7 @@ public class ConvolutionUtils {
      * @return Output size: int[2] with output height/width
      */
     public static long[] getDeconvolution3DOutputSize(INDArray inputData, int[] kernel, int[] strides, int[] padding, int[] dilation,
-                                                   ConvolutionMode convolutionMode, Convolution3D.DataFormat dataFormat) {
+                                                      ConvolutionMode convolutionMode, Convolution3D.DataFormat dataFormat) {
 
         long hIn, wIn, dIn;
         if(dataFormat == Convolution3D.DataFormat.NCDHW){
@@ -200,10 +221,10 @@ public class ConvolutionUtils {
      * layer
      */
     public static CNN2DFormat getFormatForLayer(Layer layer) {
-       if(layer instanceof Convolution1DLayer) {
-           Convolution1DLayer convolution1DLayer = (Convolution1DLayer) layer;
-           return convolution1DLayer.getCnn2dDataFormat();
-       } else if(layer instanceof ConvolutionLayer) {
+        if(layer instanceof Convolution1DLayer) {
+            Convolution1DLayer convolution1DLayer = (Convolution1DLayer) layer;
+            return convolution1DLayer.getCnn2dDataFormat();
+        } else if(layer instanceof ConvolutionLayer) {
             ConvolutionLayer convolutionLayer = (ConvolutionLayer) layer;
             return convolutionLayer.getCnn2dDataFormat();
         } else if(layer instanceof SubsamplingLayer) {
@@ -222,18 +243,18 @@ public class ConvolutionUtils {
             ZeroPaddingLayer zeroPaddingLayer = (ZeroPaddingLayer) layer;
             return zeroPaddingLayer.getDataFormat();
         } else if(layer instanceof SeparableConvolution2D) {
-           SeparableConvolution2D separableConvolution2D = (SeparableConvolution2D) layer;
-           return separableConvolution2D.getCnn2dDataFormat();
-       } else if(layer instanceof Deconvolution2D) {
-           Deconvolution2D deconvolution2D = (Deconvolution2D) layer;
-           return deconvolution2D.getCnn2dDataFormat();
-       } else if(layer instanceof DepthwiseConvolution2D) {
-           DepthwiseConvolution2D depthwiseConvolution2D = (DepthwiseConvolution2D) layer;
-           return depthwiseConvolution2D.getCnn2dDataFormat();
-       } else if(layer instanceof Cropping2D) {
-           Cropping2D cropping2D = (Cropping2D) layer;
-           return cropping2D.getDataFormat();
-       }
+            SeparableConvolution2D separableConvolution2D = (SeparableConvolution2D) layer;
+            return separableConvolution2D.getCnn2dDataFormat();
+        } else if(layer instanceof Deconvolution2D) {
+            Deconvolution2D deconvolution2D = (Deconvolution2D) layer;
+            return deconvolution2D.getCnn2dDataFormat();
+        } else if(layer instanceof DepthwiseConvolution2D) {
+            DepthwiseConvolution2D depthwiseConvolution2D = (DepthwiseConvolution2D) layer;
+            return depthwiseConvolution2D.getCnn2dDataFormat();
+        } else if(layer instanceof Cropping2D) {
+            Cropping2D cropping2D = (Cropping2D) layer;
+            return cropping2D.getDataFormat();
+        }
         else throw new IllegalArgumentException("Illegal type given " + layer.getClass().getName());
     }
 
@@ -252,7 +273,7 @@ public class ConvolutionUtils {
             case Same:
                 return PaddingMode.SAME;
             case Causal:
-               return PaddingMode.CAUSAL;
+                return PaddingMode.CAUSAL;
             case Strict:
             case Truncate:
                 return PaddingMode.VALID;
@@ -792,7 +813,7 @@ public class ConvolutionUtils {
         if (inputType instanceof InputType.InputTypeConvolutional) {
             InputType.InputTypeConvolutional conv = (InputType.InputTypeConvolutional) inputType;
             if (conv.getHeight() > Integer.MAX_VALUE || conv.getWidth() > Integer.MAX_VALUE ||
-                conv.getChannels() > Integer.MAX_VALUE){
+                    conv.getChannels() > Integer.MAX_VALUE){
                 throw new ND4JArraySizeException();
             }
             inH = (int) conv.getHeight();
@@ -801,7 +822,7 @@ public class ConvolutionUtils {
         } else if (inputType instanceof InputType.InputTypeConvolutionalFlat) {
             InputType.InputTypeConvolutionalFlat conv = (InputType.InputTypeConvolutionalFlat) inputType;
             if (conv.getHeight() > Integer.MAX_VALUE || conv.getWidth() > Integer.MAX_VALUE ||
-                conv.getDepth() > Integer.MAX_VALUE) {
+                    conv.getDepth() > Integer.MAX_VALUE) {
                 throw new ND4JArraySizeException();
             }
             inH = (int) conv.getHeight();

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/util/TimeSeriesUtils.java
@@ -252,12 +252,12 @@ public class TimeSeriesUtils {
      * @param in Input activations to reverse, with shape [minibatch, size, timeSeriesLength]
      * @return Reversed activations
      */
-    public static INDArray reverseTimeSeries(INDArray in, LayerWorkspaceMgr workspaceMgr, ArrayType arrayType){
+    public static INDArray reverseTimeSeries(INDArray in, LayerWorkspaceMgr workspaceMgr, ArrayType arrayType) {
         if(in == null){
             return null;
         }
 
-        if(in.ordering() != 'f' || in.isView() || !Shape.strideDescendingCAscendingF(in)){
+        if(in.ordering() != 'f' || in.isView() || !Shape.strideDescendingCAscendingF(in)) {
             in = workspaceMgr.dup(arrayType, in, 'f');
         }
 
@@ -265,7 +265,7 @@ public class TimeSeriesUtils {
             throw new ND4JArraySizeException();
         int[] idxs = new int[(int) in.size(2)];
         int j=0;
-        for( int i=idxs.length-1; i>=0; i--){
+        for( int i = idxs.length-1; i >= 0; i--) {
             idxs[j++] = i;
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes  https://github.com/eclipse/deeplearning4j/issues/9476

Also fixes minor unit test issues related to keras import:
1. Batch normalization errors upon activation when activating within an INPUT workspace type
2. KerasConvolution3D asserting null for default type - this has been changed to not null


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
