### PR TITLE
BertWordPieceTokenizer supports more punctuation marks

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizer.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizer.java
@@ -29,7 +29,8 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class BertWordPieceTokenizer implements Tokenizer {
-    public static final Pattern splitPattern = Pattern.compile("\\p{javaWhitespace}+|((?<=\\p{Punct})+|(?=\\p{Punct}+))");
+    public static final Pattern splitPattern = Pattern.compile("\\p{javaWhitespace}+|((?<=\\p{Punct})+|(?=\\p{Punct}+))",
+            Pattern.UNICODE_CHARACTER_CLASS);
 
     private final List<String> tokens;
     private final TokenPreProcess preTokenizePreProcessor;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizer.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizer.java
@@ -29,7 +29,17 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class BertWordPieceTokenizer implements Tokenizer {
-    public static final Pattern splitPattern = Pattern.compile("\\p{javaWhitespace}+|((?<=\\p{Punct})+|(?=\\p{Punct}+))",
+    // We treat all non-letter/number ASCII as punctuation.
+    // Characters such as "^", "$", and "`" are not in the Unicode
+    // Punctuation class but we treat them as punctuation anyways, for
+    // consistency.
+    public static final Pattern splitPattern = Pattern.compile(
+            "\\p{javaWhitespace}+" +
+                    "|((?<=\\p{Punct})+|(?=\\p{Punct}+))" +
+                    "|((?<=[\\x21-\\x2F])+|(?=[\\x21-\\x2F]+))" +
+                    "|((?<=[\\x3A-\\x40])+|(?=[\\x3A-\\x40]+))" +
+                    "|((?<=[\\x5B-\\x60])+|(?=[\\x5B-\\x60]+))" +
+                    "|((?<=[\\x7B-\\x7E])+|(?=[\\x7B-\\x7E]+))",
             Pattern.UNICODE_CHARACTER_CLASS);
 
     private final List<String> tokens;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizerTests.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizerTests.java
@@ -264,4 +264,22 @@ public class BertWordPieceTokenizerTests extends BaseDL4JTest {
         final List<String> expected = Arrays.asList("i", "saw", "a", "girl", "with", "a", "tele", "##scope", arabicQuestionMark);
         assertEquals(expected, tokenizer.getTokens());
     }
+
+    @Test
+    public void testBertWordPieceTokenizerHandlesMorePunctuations() throws Exception {
+        String toTokenizePrefix = "I saw a girl with a telescope";
+        BertWordPieceTokenizerFactory t = new BertWordPieceTokenizerFactory(pathToVocab, true, true, c);
+
+        char[] punctuations = {'!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';',
+                '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '{', '|', '}', '~'
+        };
+
+        for (char p: punctuations) {
+            String toTokenize = toTokenizePrefix + p;
+            Tokenizer tokenizer = t.create(toTokenize);
+
+            final List<String> expected = Arrays.asList("i", "saw", "a", "girl", "with", "a", "tele", "##scope", String.valueOf(p));
+            assertEquals(expected, tokenizer.getTokens());
+        }
+    }
 }

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizerTests.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizerTests.java
@@ -46,7 +46,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
-@Disabled
+//@Disabled
 @Tag(TagNames.FILE_IO)
 @NativeTag
 public class BertWordPieceTokenizerTests extends BaseDL4JTest {
@@ -250,5 +250,18 @@ public class BertWordPieceTokenizerTests extends BaseDL4JTest {
         System.out.println(list);
 
         assertEquals(8, list.size());
+    }
+
+    @Test
+    public void testBertWordPieceTokenizerHandlesUnicodePunctuation() throws Exception {
+        //Insert some unicode punctuations
+        String arabicQuestionMark = "\u061F"; //؟
+        String toTokenize = "I saw a girl with a telescope" + arabicQuestionMark;
+        BertWordPieceTokenizerFactory t = new BertWordPieceTokenizerFactory(pathToVocab, true, true, c);
+
+        Tokenizer tokenizer = t.create(toTokenize);
+
+        final List<String> expected = Arrays.asList("i", "saw", "a", "girl", "with", "a", "tele", "##scope", arabicQuestionMark);
+        assertEquals(expected, tokenizer.getTokens());
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to make `BertWordPieceTokenizer` to support more punctuation marks.

## How was this patch tested?

unit tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
