### PR TITLE
Update reduction signatures to allow optional shapes

### DIFF
--- a/libnd4j/include/ops/declarable/generic/reduce/reduceMean.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduceMean.cpp
@@ -25,139 +25,140 @@
 #include <ops/declarable/helpers/axis.h>
 #if NOT_EXCLUDED(OP_reduce_mean)
 namespace sd    {
-namespace ops     {
+    namespace ops     {
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_mean, 1, 1, false, 0, 0) {
-    auto input   = INPUT_VARIABLE(0);
-    auto output  = OUTPUT_VARIABLE(0);
+        CUSTOM_OP_IMPL(reduce_mean, -1, 1, false, 0, 0) {
+            auto input   = INPUT_VARIABLE(0);
+            auto output  = OUTPUT_VARIABLE(0);
 
-    auto dimensions = *block.getIArguments();
-    if (block.width() > 1) {
-        auto axesVector = INPUT_VARIABLE(1);
-        helpers::adjustAxis(input->rankOf(), axesVector, dimensions);
-    }
+            auto dimensions = *block.getIArguments();
+            if (block.width() > 1) {
+                auto axesVector = INPUT_VARIABLE(1);
+                helpers::adjustAxis(input->rankOf(), axesVector, dimensions);
+            }
 
-    bool keepDims = false;
-    if (block.getBArguments()->size())
-        keepDims = B_ARG(0);
-    else if (block.getTArguments()->size())
-        keepDims = (bool)T_ARG(0);
+            bool keepDims = false;
+            if (block.getBArguments()->size())
+                keepDims = B_ARG(0);
+            else if (block.getTArguments()->size())
+                keepDims = (bool)T_ARG(0);
 
-    REQUIRE_TRUE(dimensions.size() <= input->rankOf(), 0, "REDUCE_MEAN OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
+            REQUIRE_TRUE(dimensions.size() <= input->rankOf(), 0, "REDUCE_MEAN OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
 
-    for(const auto& item : dimensions)
-        REQUIRE_TRUE(item >= -input->rankOf() && item < input->rankOf(), 0, "REDUCE_MEAN OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !" , input->rankOf(), input->rankOf(), item);
+            for(const auto& item : dimensions) {
+                REQUIRE_TRUE(item >= -input->rankOf() && item < input->rankOf(), 0,
+                             "REDUCE_MEAN OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !",
+                             input->rankOf(), input->rankOf(), item);
+            }
 
-    input->reduceAlongDimension(reduce::Mean, *output, dimensions, keepDims);
-
-    return Status::OK();
-}
-
-DECLARE_SHAPE_FN(reduce_mean) {
-
-    auto dimensions = *block.getIArguments();
-    auto in = inputShape->at(0);
-    if (block.width() > 1) {
-        auto axesVector = INPUT_VARIABLE(1);
-        helpers::adjustAxis(shape::rank(in), axesVector, dimensions);
-    }
-
-    bool keepDims = false;
-    if (block.getBArguments()->size())
-        keepDims = B_ARG(0);
-    else if (block.getTArguments()->size())
-        keepDims = (bool)T_ARG(0);
-
-    REQUIRE_TRUE(dimensions.size() <= in[0], 0, "REDUCE_MEAN OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
-
-    for(const auto& item : dimensions)
-        REQUIRE_TRUE(item >= -inputShape->at(0)[0] && item < inputShape->at(0)[0], 0, "REDUCE_MEAN OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !" , inputShape->at(0)[0], inputShape->at(0)[0], item);
-
-    auto outShapeInfo = ShapeUtils::evalReduceShapeInfo(shape::order(in), dimensions, in, keepDims, false, block.getWorkspace());
-
-    return SHAPELIST(outShapeInfo);
-}
-
-DECLARE_TYPES(reduce_mean) {
-    getOpDescriptor()
-        ->setAllowedInputTypes(sd::DataType::ANY)
-        ->setAllowedOutputTypes({ALL_FLOATS});
-}
-
-
-//////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_mean_bp, 2, 1, false, 0, 0) {
-    auto input  = INPUT_VARIABLE(0);
-    auto gradO  = INPUT_VARIABLE(1);
-
-    auto gradI  = OUTPUT_VARIABLE(0);
-
-    auto dimensions = *block.getIArguments();
-    if (block.width() > 2) {
-        auto axesVector = INPUT_VARIABLE(2);
-        helpers::adjustAxis(input->rankOf(), axesVector, dimensions);
-    }
-
-    bool keepDims = false;
-    if (block.getBArguments()->size())
-        keepDims = B_ARG(0);
-    else if (block.getTArguments()->size())
-        keepDims = (bool)T_ARG(0);
-
-    REQUIRE_TRUE(dimensions.size() <= input->rankOf(), 0, "REDUCE_MEAN_BP OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
-
-    for(const auto& item : dimensions)
-        REQUIRE_TRUE(item >= -input->rankOf() && item < input->rankOf(), 0, "REDUCE_MEAN_BP OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !" , input->rankOf(), input->rankOf(), item);
-
-    if(gradO->lengthOf() == 1) {
-        gradI->assign(gradO->e(0) / input->lengthOf());
-    }
-    else {
-
-        gradI->assign((gradO->lengthOf() + 0.) / input->lengthOf());
-
-        if(!keepDims) {
-            auto gradOShapeKeepDims = ShapeUtils::evalReduceShapeInfo(gradO->ordering(), dimensions, *input, true, false, block.getWorkspace());
-            *gradI *= gradO->reshape(gradO->ordering(), ShapeUtils::pullShapeFromShapeInfo(gradOShapeKeepDims));  // for example could be something like [a,b] -> [1,a,1,b]
+            input->reduceAlongDimension(reduce::Mean, *output, dimensions, keepDims);
+            output->printShapeInfo("Shape info for output mean is \n");
+            return Status::OK();
         }
-        else
-            *gradI *= *gradO;
+
+        DECLARE_SHAPE_FN(reduce_mean) {
+
+            auto dimensions = *block.getIArguments();
+            auto in = inputShape->at(0);
+            if (block.width() > 1) {
+                auto axesVector = INPUT_VARIABLE(1);
+                helpers::adjustAxis(shape::rank(in), axesVector, dimensions);
+            }
+
+            bool keepDims = false;
+            if (block.getBArguments()->size())
+                keepDims = B_ARG(0);
+            else if (block.getTArguments()->size())
+                keepDims = (bool)T_ARG(0);
+
+            REQUIRE_TRUE(dimensions.size() <= in[0], 0, "REDUCE_MEAN OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
+
+            for(const auto& item : dimensions)
+            REQUIRE_TRUE(item >= -inputShape->at(0)[0] && item < inputShape->at(0)[0], 0, "REDUCE_MEAN OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !" , inputShape->at(0)[0], inputShape->at(0)[0], item);
+
+            auto outShapeInfo = ShapeUtils::evalReduceShapeInfo(shape::order(in), dimensions, in, keepDims, false, block.getWorkspace());
+
+            return SHAPELIST(outShapeInfo);
+        }
+
+        DECLARE_TYPES(reduce_mean) {
+            getOpDescriptor()
+                    ->setAllowedInputTypes(sd::DataType::ANY)
+                    ->setAllowedOutputTypes({ALL_FLOATS});
+        }
+
+
+//////////////////////////////////////////////////////////////////////////
+        CUSTOM_OP_IMPL(reduce_mean_bp, -2, 1, false, 0, 0) {
+            auto input  = INPUT_VARIABLE(0);
+            auto gradO  = INPUT_VARIABLE(1);
+
+            auto gradI  = OUTPUT_VARIABLE(0);
+
+            auto dimensions = *block.getIArguments();
+            if (block.width() > 2) {
+                auto axesVector = INPUT_VARIABLE(2);
+                helpers::adjustAxis(input->rankOf(), axesVector, dimensions);
+            }
+
+            bool keepDims = false;
+            if (block.getBArguments()->size())
+                keepDims = B_ARG(0);
+            else if (block.getTArguments()->size())
+                keepDims = (bool)T_ARG(0);
+
+            REQUIRE_TRUE(dimensions.size() <= input->rankOf(), 0, "REDUCE_MEAN_BP OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
+
+            for(const auto& item : dimensions)
+            REQUIRE_TRUE(item >= -input->rankOf() && item < input->rankOf(), 0, "REDUCE_MEAN_BP OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !" , input->rankOf(), input->rankOf(), item);
+
+            if(gradO->lengthOf() == 1) {
+                gradI->assign(gradO->e(0) / input->lengthOf());
+            }
+            else {
+                gradI->assign((gradO->lengthOf() + 0.) / input->lengthOf());
+                if(!keepDims) {
+                    auto gradOShapeKeepDims = ShapeUtils::evalReduceShapeInfo(gradO->ordering(), dimensions, *input, true, false, block.getWorkspace());
+                    *gradI *= gradO->reshape(gradO->ordering(), ShapeUtils::pullShapeFromShapeInfo(gradOShapeKeepDims));  // for example could be something like [a,b] -> [1,a,1,b]
+                }
+                else {
+                    gradI->applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(),*gradO,*gradI);
+                }
+            }
+
+            return Status::OK();
+        }
+
+        DECLARE_SHAPE_FN(reduce_mean_bp) {
+            auto in = inputShape->at(0);
+            auto dimensions = *block.getIArguments();
+            auto rank = shape::rank(in);
+
+            if (block.width() > 2) {
+                auto axesVector = INPUT_VARIABLE(2);
+                helpers::adjustAxis(rank, axesVector, dimensions);
+            }
+            REQUIRE_TRUE(dimensions.size() <= rank, 0, "REDUCE_MEAN_BP OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
+
+            for(const auto& item : dimensions)
+            REQUIRE_TRUE(item >= -rank || item < rank, 0, "REDUCE_MEAN_BP OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !" , rank, rank, item);
+
+            Nd4jLong* gradIshapeInfo(nullptr);
+            COPY_SHAPE(inputShape->at(0), gradIshapeInfo);
+
+            return SHAPELIST(CONSTANT(gradIshapeInfo));
+        }
+
+
+        DECLARE_TYPES(reduce_mean_bp) {
+            getOpDescriptor()
+                    ->setAllowedInputTypes(sd::DataType::ANY)
+                    ->setAllowedOutputTypes({ALL_FLOATS});
+        }
+
+
 
     }
-
-    return Status::OK();
-}
-
-DECLARE_SHAPE_FN(reduce_mean_bp) {
-    auto in = inputShape->at(0);
-    auto dimensions = *block.getIArguments();
-    auto rank = shape::rank(in);
-
-    if (block.width() > 2) {
-        auto axesVector = INPUT_VARIABLE(2);
-        helpers::adjustAxis(rank, axesVector, dimensions);
-    }
-    REQUIRE_TRUE(dimensions.size() <= rank, 0, "REDUCE_MEAN_BP OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead" , dimensions.size());
-
-    for(const auto& item : dimensions)
-        REQUIRE_TRUE(item >= -rank || item < rank, 0, "REDUCE_MEAN_BP OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !" , rank, rank, item);
-
-    Nd4jLong* gradIshapeInfo(nullptr);
-    COPY_SHAPE(inputShape->at(0), gradIshapeInfo);
-
-    return SHAPELIST(CONSTANT(gradIshapeInfo));
-}
-
-
-DECLARE_TYPES(reduce_mean_bp) {
-    getOpDescriptor()
-        ->setAllowedInputTypes(sd::DataType::ANY)
-        ->setAllowedOutputTypes({ALL_FLOATS});
-}
-
-
-
-}
 }
 #endif

--- a/libnd4j/include/ops/declarable/generic/reduce/reduceStDev.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduceStDev.cpp
@@ -29,7 +29,7 @@ namespace sd    {
 namespace ops     {
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_stdev, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_stdev, -1, 1, false, 0, 0) {
     auto input   = INPUT_VARIABLE(0);
     auto output  = OUTPUT_VARIABLE(0);
 
@@ -99,7 +99,7 @@ DECLARE_TYPES(reduce_stdev) {
 
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_stdev_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_stdev_bp, -1, 1, false, 0, 0) {
     auto input  = INPUT_VARIABLE(0);
     auto gradO  = INPUT_VARIABLE(1);
 

--- a/libnd4j/include/ops/declarable/generic/reduce/reduceVariance.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduceVariance.cpp
@@ -29,7 +29,7 @@ namespace sd    {
 namespace ops     {
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_variance, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_variance, -1, 1, false, 0, 0) {
     auto input   = INPUT_VARIABLE(0);
     auto output  = OUTPUT_VARIABLE(0);
 
@@ -96,7 +96,7 @@ DECLARE_TYPES(reduce_variance) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_variance_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_variance_bp, -1, 1, false, 0, 0) {
     auto input  = INPUT_VARIABLE(0);
     auto gradO  = INPUT_VARIABLE(1);
 

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_dot.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_dot.cpp
@@ -29,7 +29,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_dot_bp)
 
 ////////////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_dot_bp, 3, 2, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_dot_bp, -1, 2, false, 0, 0) {
 
     auto x     = INPUT_VARIABLE(0);
     auto y     = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_logsumexp.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_logsumexp.cpp
@@ -26,7 +26,7 @@ namespace sd {
 namespace ops {
 #if NOT_EXCLUDED(OP_reduce_logsumexp)
 
-    CUSTOM_OP_IMPL(reduce_logsumexp, 1, 1, false, 0, 0) {
+    CUSTOM_OP_IMPL(reduce_logsumexp, -1, 1, false, 0, -1) {
         auto input = INPUT_VARIABLE(0);
         auto output = OUTPUT_VARIABLE(0);
         std::vector<int> axes;// = *block.getIArguments();

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_max.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_max.cpp
@@ -31,7 +31,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_max)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_max, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_max, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto output = OUTPUT_VARIABLE(0);
@@ -94,7 +94,7 @@ DECLARE_TYPES(reduce_max) {
 #if NOT_EXCLUDED(OP_reduce_max_bp)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_max_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_max_bp, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto gradO = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_min.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_min.cpp
@@ -31,7 +31,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_min)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_min, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_min, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto output = OUTPUT_VARIABLE(0);
@@ -97,7 +97,7 @@ DECLARE_TYPES(reduce_min) {
 #if NOT_EXCLUDED(OP_reduce_min_bp)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_min_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_min_bp, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto gradO = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_norm1.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_norm1.cpp
@@ -29,7 +29,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_norm1)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_norm1, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_norm1, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto output = OUTPUT_VARIABLE(0);
@@ -91,7 +91,7 @@ DECLARE_TYPES(reduce_norm1) {
 #if NOT_EXCLUDED(OP_reduce_norm1_bp)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_norm1_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_norm1_bp, -1, 1, false, 0, 0) {
     // L = Sum abs(x_i) for all i = 1 to N
     // dL/dx_i = 1 if x_i >= 0 and -1 when x_i < 0
     // out_i = epsilon_i if x_i > 0 and -epsilon_i when x_i < 0

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_norm2.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_norm2.cpp
@@ -29,7 +29,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_norm2)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_norm2, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_norm2, -1, 1, false, 0, 0) {
     auto input = INPUT_VARIABLE(0);
     auto output = OUTPUT_VARIABLE(0);
 
@@ -92,7 +92,7 @@ DECLARE_TYPES(reduce_norm2) {
 #if NOT_EXCLUDED(OP_reduce_norm2_bp)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_norm2_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_norm2_bp, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto gradO = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_norm_max.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_norm_max.cpp
@@ -30,7 +30,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_norm_max)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_norm_max, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_norm_max, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto output = OUTPUT_VARIABLE(0);
@@ -94,7 +94,7 @@ DECLARE_TYPES(reduce_norm_max) {
 #if NOT_EXCLUDED(OP_reduce_norm_max_bp)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_norm_max_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_norm_max_bp, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto gradO = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_prod.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_prod.cpp
@@ -29,7 +29,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_prod)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_prod, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_prod, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto output = OUTPUT_VARIABLE(0);
@@ -92,7 +92,7 @@ DECLARE_TYPES(reduce_prod) {
 #if NOT_EXCLUDED(OP_reduce_prod_bp)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_prod_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_prod_bp, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto gradO = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_sqnorm.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_sqnorm.cpp
@@ -28,7 +28,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_sqnorm)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_sqnorm, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_sqnorm, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto gradI = OUTPUT_VARIABLE(0);
@@ -93,7 +93,7 @@ DECLARE_TYPES(reduce_sqnorm) {
 #if NOT_EXCLUDED(OP_reduce_sqnorm_bp)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_sqnorm_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_sqnorm_bp, -1, 1, false, 0, 0) {
 
     auto input  = INPUT_VARIABLE(0);
     auto gradO  = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_sum.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_sum.cpp
@@ -29,7 +29,7 @@ namespace ops {
 #if NOT_EXCLUDED(OP_reduce_sum)
 
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_sum, 1, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_sum, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto output = OUTPUT_VARIABLE(0);
@@ -91,7 +91,7 @@ DECLARE_TYPES(reduce_sum) {
 
 #if NOT_EXCLUDED(OP_reduce_sum_bp)
 //////////////////////////////////////////////////////////////////////////
-CUSTOM_OP_IMPL(reduce_sum_bp, 2, 1, false, 0, 0) {
+CUSTOM_OP_IMPL(reduce_sum_bp, -1, 1, false, 0, 0) {
 
     auto input = INPUT_VARIABLE(0);
     auto gradO = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/headers/parity_ops.h
+++ b/libnd4j/include/ops/declarable/headers/parity_ops.h
@@ -1500,11 +1500,11 @@ namespace sd {
          *    0 - NDArray with reduces shape accordingly to axes (the scalar in default case).
          */
         #if NOT_EXCLUDED(OP_reduce_sum)
-        DECLARE_CUSTOM_OP(reduce_sum, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_sum, -1, 1, false, 0, 0);
         #endif
 
         #if NOT_EXCLUDED(OP_reduce_sum_bp)
-        DECLARE_CUSTOM_OP(reduce_sum_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_sum_bp, -1, 1, false, 0, 0);
         #endif
 
         /**
@@ -1528,11 +1528,11 @@ namespace sd {
          *    0 - NDArray with reduces shape accordingly to axes (the scalar in default case).
          */
         #if NOT_EXCLUDED(OP_reduce_prod)
-        DECLARE_CUSTOM_OP(reduce_prod, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_prod, -1, 1, false, 0, 0);
         #endif
 
         #if NOT_EXCLUDED(OP_reduce_prod_bp)
-        DECLARE_CUSTOM_OP(reduce_prod_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_prod_bp, -1, 1, false, 0, 0);
         #endif
 
        /**
@@ -1551,10 +1551,10 @@ namespace sd {
         *    reduced tensor with calculated mins
         */
         #if NOT_EXCLUDED(OP_reduce_min)
-        DECLARE_CUSTOM_OP(reduce_min, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_min, -1, 1, false, 0, 0);
         #endif
         #if NOT_EXCLUDED(OP_reduce_min_bp)
-        DECLARE_CUSTOM_OP(reduce_min_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_min_bp, -1, 1, false, 0, 0);
         #endif
 
        /**
@@ -1573,10 +1573,10 @@ namespace sd {
         *    reduced tensor with calculated maxes
         */
         #if NOT_EXCLUDED(OP_reduce_max)
-        DECLARE_CUSTOM_OP(reduce_max, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_max, -1, 1, false, 0, 0);
         #endif
         #if NOT_EXCLUDED(OP_reduce_max_bp)
-        DECLARE_CUSTOM_OP(reduce_max_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_max_bp, -1, 1, false, 0, 0);
         #endif
 
        /**
@@ -1595,10 +1595,10 @@ namespace sd {
         *    reduced tensor with calculated norm1
         */
         #if NOT_EXCLUDED(OP_reduce_norm1)
-        DECLARE_CUSTOM_OP(reduce_norm1, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_norm1, -1, 1, false, 0, 0);
         #endif
         #if NOT_EXCLUDED(OP_reduce_norm1_bp)
-        DECLARE_CUSTOM_OP(reduce_norm1_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_norm1_bp, -1, 1, false, 0, 0);
         #endif
 
        /**
@@ -1617,10 +1617,10 @@ namespace sd {
         *    reduced tensor with calculated norm2
         */
         #if NOT_EXCLUDED(OP_reduce_norm2)
-        DECLARE_CUSTOM_OP(reduce_norm2, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_norm2, -1, 1, false, 0, 0);
         #endif
         #if NOT_EXCLUDED(OP_reduce_norm2_bp)
-        DECLARE_CUSTOM_OP(reduce_norm2_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_norm2_bp, -1, 1, false, 0, 0);
         #endif
 
 
@@ -1640,10 +1640,10 @@ namespace sd {
         *    reduced tensor with calculated norm
         */
         #if NOT_EXCLUDED(OP_reduce_sqnorm)
-        DECLARE_CUSTOM_OP(reduce_sqnorm, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_sqnorm, -1, 1, false, 0, 0);
         #endif
         #if NOT_EXCLUDED(OP_reduce_sqnorm_bp)
-        DECLARE_CUSTOM_OP(reduce_sqnorm_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_sqnorm_bp, -1, 1, false, 0, 0);
         #endif
 
        /**
@@ -1662,10 +1662,10 @@ namespace sd {
         *    reduced tensor with calculated norm
         */
         #if NOT_EXCLUDED(OP_reduce_norm_max)
-        DECLARE_CUSTOM_OP(reduce_norm_max, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_norm_max, -1, 1, false, 0, 0);
         #endif
         #if NOT_EXCLUDED(OP_reduce_norm_max_bp)
-        DECLARE_CUSTOM_OP(reduce_norm_max_bp, 2, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_norm_max_bp, -1, 1, false, 0, 0);
         #endif
 
         /**
@@ -1684,11 +1684,11 @@ namespace sd {
         *    reduced tensor with calculated means
         */
         #if NOT_EXCLUDED(OP_reduce_mean)
-        DECLARE_CUSTOM_OP(reduce_mean, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_mean, -1, 1, false, 0, 0);
         #endif
 
         #if NOT_EXCLUDED(OP_reduce_mean_bp)
-        DECLARE_CUSTOM_OP(reduce_mean_bp, 2, 1, false, 0, 0)
+        DECLARE_CUSTOM_OP(reduce_mean_bp, -1, 1, false, 0, 0)
         #endif
         /**
         * This op calculates sample variance of elements along given dimensions
@@ -1707,8 +1707,8 @@ namespace sd {
         *    reduced tensor with calculated means
         */
         #if NOT_EXCLUDED(OP_reduce_variance)
-        DECLARE_CUSTOM_OP(reduce_variance, 1, 1, false, 0, 0);
-        DECLARE_CUSTOM_OP(reduce_variance_bp, 2, 1, false, 0, 0)
+        DECLARE_CUSTOM_OP(reduce_variance, -1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_variance_bp, -1, 1, false, 0, 0)
         #endif
         /**
         * This op calculates sample standard deviation of elements along given dimensions
@@ -1727,8 +1727,8 @@ namespace sd {
         *    reduced tensor with calculated means
         */
 #if NOT_EXCLUDED(OP_reduce_stdev)
-        DECLARE_CUSTOM_OP(reduce_stdev, 1, 1, false, 0, 0);
-        DECLARE_CUSTOM_OP(reduce_stdev_bp, 2, 1, false, 0, 0)
+        DECLARE_CUSTOM_OP(reduce_stdev, -1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_stdev_bp, -1, 1, false, 0, 0)
 #endif
         /**
         * This op calculates backprop dot for two tensors along given dimensions
@@ -1749,7 +1749,7 @@ namespace sd {
         */
 
         #if NOT_EXCLUDED(OP_reduce_dot_bp)
-        DECLARE_CUSTOM_OP(reduce_dot_bp, 3, 2, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_dot_bp, -1, 2, false, 0, 0);
         #endif
         /**
          * reduce_logsumexp - tf.reduce_logsumexe operation
@@ -1774,14 +1774,14 @@ namespace sd {
          *    0 - NDArray with reduces shape accordingly to axes (the scalar in default case).
          */
         #if NOT_EXCLUDED(OP_reduce_logsumexp)
-        DECLARE_CUSTOM_OP(reduce_logsumexp, 1, 1, false, 0, 0);
+        DECLARE_CUSTOM_OP(reduce_logsumexp, -1, 1, false, 0, -1);
         #endif
 
        /**
         * Copy a tensor setting everything outside a central band in each innermost matrix
         *
         * input array:
-        *    x: given tensor with shape {..., M, N} - as vector (matrix) of matricies MxN
+        *    x: given tensor with shape {..., M, N} - as vector (matrix) of matrices MxN
         *
         * int arguments:
         *   lower band


### PR DESCRIPTION
Add updated signatures for reduce operations reflecting the ability t…o allow input shapes as optional extra inputs.

We already allowed it in the implementation, but this was not reflected in the signature.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
