### PR TITLE
Add onnx changes for global pooling to be more generalized

### DIFF
--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
@@ -378,8 +378,7 @@ val gemm = OnnxMappingProcess(
         attributeMappingRules = listOf(valueMappings(mapOf("alpha" to "alpha","beta" to "beta",
                 "transposeX" to "transA", "transposeY" to "transB")),
                 booleanConstant(inputName = "transZ",constantValue = false,argumentIndex = 2)[0],
-                booleanConstant(inputName = "transposeZ",constantValue = false,argumentIndex = 2)[0],
-                invertBooleanNumber(mutableMapOf("transX" to "transA","transY" to "transB")))
+                booleanConstant(inputName = "transposeZ",constantValue = false,argumentIndex = 2)[0])
 )
 //note: no ops are mostly just stubs for ops implemented as pre processors
 //These are implemented using the PreImportHook found: https://github.com/eclipse/deeplearning4j/tree/master/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalAveragePooling.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalAveragePooling.kt
@@ -42,8 +42,10 @@ class GlobalAveragePooling: PreImportHook {
     ): Map<String, List<SDVariable>> {
         val inputVariable = sd.getVariable(op.inputsToOp[0])
         val rankOf = sd.rank(inputVariable)
-        val range = sd.range(sd.constant(2),rankOf,sd.constant(1),DataType.INT64)
-        val output = sd.math.mean(outputNames[0],inputVariable,range,true)
+        val range = sd.range(sd.constant(0),rankOf,sd.constant(1),DataType.INT64)
+        val sizes = sd.concat(0,sd.constant(2).castTo(DataType.INT64),sd.prod(range.shape()).sub(2.0).castTo(DataType.INT64))
+        val split = sd.splitV(range,sizes,2,0)
+        val output = sd.math.mean(outputNames[0],inputVariable,split[1],true)
         return mapOf(output.name() to listOf(output))
     }
 

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalMaxPooling.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/GlobalMaxPooling.kt
@@ -43,8 +43,10 @@ class GlobalMaxPooling: PreImportHook {
     ): Map<String, List<SDVariable>> {
         val inputVariable = sd.getVariable(op.inputsToOp[0])
         val rankOf = sd.rank(inputVariable)
-        val range = sd.range(sd.constant(2),rankOf,sd.constant(1), DataType.INT64)
-        val output = sd.math.reduceMax(op.name,inputVariable,range,true)
+        val range = sd.range(sd.constant(0),rankOf,sd.constant(1),DataType.INT64)
+        val sizes = sd.concat(0,sd.constant(2).castTo(DataType.INT64),sd.prod(range.shape()).sub(2.0).castTo(DataType.INT64))
+        val split = sd.splitV(range,sizes,2,0)
+        val output = sd.math.reduceMax(outputNames[0],inputVariable,split[1],true)
         return mapOf(output.name() to listOf(output))
     }
 

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/resources/onnx-mapping-ruleset.pbtxt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/resources/onnx-mapping-ruleset.pbtxt
@@ -1271,24 +1271,6 @@ mappings {
     }
     inputFrameworkOpName: "Gemm"
   }
-  rule {
-    ruleName: "invertbooleannumber"
-    functionName: "invertbooleannumber"
-    inputIntName: "transA"
-    inputIntName: "transB"
-    outputIntName: "transX"
-    outputIntName: "transY"
-    inputToOutput {
-      key: "transX"
-      value: "transA"
-    }
-    inputToOutput {
-      key: "transY"
-      value: "transB"
-    }
-    ruleType: "attribute"
-    inputFrameworkOpName: "Gemm"
-  }
 }
 mappings {
   frameworkName: "onnx"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Depends on https://github.com/eclipse/deeplearning4j/pull/9501

Changes global and average pooling to be more general and handle multiple sizes. Also updates op definitions for onnx.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
