### PR TITLE
applyPairwiseLambda

### DIFF
--- a/libnd4j/include/array/NDArrayLambda.hXX
+++ b/libnd4j/include/array/NDArrayLambda.hXX
@@ -45,6 +45,9 @@ static SD_KERNEL void lambdaPairwiseKernel(const void *vx, const sd::LongType *x
                                            const sd::LongType *yShapeInfo, void *vz, const sd::LongType *zShapeInfo,
                                            Lambda lambda);
 template <typename T, typename Lambda>
+static SD_KERNEL void lambdaPairwiseKernel(const void *scalarPtr, const void *vx, const sd::LongType *xShapeInfo, void *vz, const sd::LongType *zShapeInfo,
+                                           Lambda lambda);
+template <typename T, typename Lambda>
 static SD_KERNEL void lambdaTriplewiseKernel(const void *vw, const sd::LongType *wShapeInfo, const void *vx,
                                              const sd::LongType *xShapeInfo, const void *vy,
                                              const sd::LongType *yShapeInfo, void *vz, const sd::LongType *zShapeInfo,
@@ -70,11 +73,15 @@ class LambdaHelper {
   }
 
   template <typename Lambda>
-  SD_INLINE static void lambdaPairwiseLauncher(cudaStream_t *stream, const void *vx, const sd::LongType *xShapeInfo,
+  SD_INLINE static void lambdaPairwiseLauncher(cudaStream_t *stream, const void *vx, const sd::LongType *xShapeInfo, bool otherIsScalar,
                                                const void *vy, const sd::LongType *yShapeInfo, void *vz,
                                                const sd::LongType *zShapeInfo, Lambda lambda) {
-    lambdaPairwiseKernel<T, Lambda>
-        <<<256, 512, 1024, *stream>>>(vx, xShapeInfo, vy, yShapeInfo, vz, zShapeInfo, lambda);
+    if (otherIsScalar) {
+      lambdaPairwiseKernel<T, Lambda><<<256, 512, 1024, *stream>>>(vy, vx, xShapeInfo, vz, zShapeInfo, lambda);
+    } else {
+      lambdaPairwiseKernel<T, Lambda>
+          <<<256, 512, 1024, *stream>>>(vx, xShapeInfo, vy, yShapeInfo, vz, zShapeInfo, lambda);
+    }
     auto err = cudaStreamSynchronize(*stream);
     if (err != 0) throw std::runtime_error("NDArray::applyPairwiseLambda execution failed");
   }
@@ -228,7 +235,37 @@ static SD_KERNEL void lambdaPairwiseKernel(const void *vx, const sd::LongType *x
     }
   }
 }
+///////////////////////////////////////////////////////////////////////
+template <typename T, typename Lambda>
+static SD_KERNEL void lambdaPairwiseKernel(const void *scalarPtr, const void *vx, const sd::LongType *xShapeInfo,
+                                           void *vz, const sd::LongType *zShapeInfo, Lambda lambda) {
+  auto x = reinterpret_cast<const T *>(vx);
+  auto y = reinterpret_cast<const T *>(scalarPtr);
+  auto z = reinterpret_cast<T *>(vz);
 
+  auto yVal = *y;
+
+  auto xEws = shape::elementWiseStride(xShapeInfo);
+  auto zEws = shape::elementWiseStride(zShapeInfo);
+
+  auto xOrder = shape::order(xShapeInfo);
+  auto zOrder = shape::order(zShapeInfo);
+
+  auto zLength = length(zShapeInfo);
+
+  auto tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (xEws >= 1 && zEws >= 1 && xOrder == zOrder) {
+    for (sd::Unsigned e = tid; e < zLength; e += blockDim.x * gridDim.x) z[e * zEws] = lambda(x[e * xEws], yVal);
+  } else {
+    for (sd::Unsigned e = tid; e < zLength; e += blockDim.x * gridDim.x) {
+      auto xOffset = getIndexOffset(e, xShapeInfo);
+      auto zOffset = getIndexOffset(e, zShapeInfo);
+
+      z[zOffset] = lambda(x[xOffset], yVal);
+    }
+  }
+}
 ////////////////////////////////////////////////////////////////////////
 template <typename T, typename Lambda>
 static SD_KERNEL void lambdaTriplewiseKernel(const void *vw, const sd::LongType *wShapeInfo, const void *vx,
@@ -295,11 +332,11 @@ void NDArray::applyPairwiseLambda(const NDArray &other, Lambda func, NDArray &ta
   if (dtype != target.dataType() || dtype != other.dataType())
     throw std::runtime_error("NDArray::applyPairwiseLambda X/Y/Z data types must be the same");
   // throw datatype_exception::build("NDArray::applyLambda X/Z data types must be the same", dtype, target.dataType());
-
+  bool otherIsScalar = other.isScalar();
   prepareSpecialUse({&target}, {this, &other});
   BUILD_SINGLE_SELECTOR(
       dtype, LambdaHelper,
-      ::lambdaPairwiseLauncher(this->_context->getCudaStream(), this->specialBuffer(), this->specialShapeInfo(),
+      ::lambdaPairwiseLauncher(this->_context->getCudaStream(), this->specialBuffer(), this->specialShapeInfo(), otherIsScalar,
                                other.specialBuffer(), other.specialShapeInfo(), target.specialBuffer(),
                                target.specialShapeInfo(), func),
       SD_COMMON_TYPES);

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests18.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests18.cpp
@@ -154,6 +154,23 @@ TEST_F(DeclarableOpsTests18, test_tanh_bp) {
   op.execute({&x, &dLdz}, {&dLdx});
   ASSERT_EQ(e, dLdx);
 }
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests18, test_tanh_bp_scalar) {
+  NDArray x('c', {2, 3, 4}, sd::DataType::FLOAT32);
+  NDArray dLdz = NDArrayFactory::create<float>(7.25f);
+  x.linspace(-1., 0.003);
+
+  NDArray exp('c', {2, 3, 4}, {3.0448139, 3.058747,  3.0727215, 3.086736,  3.1007907, 3.1148856, 3.1290195, 3.143194,
+                               3.157408,  3.1716602, 3.1859534, 3.2002847, 3.2146554, 3.229064,  3.243512,  3.2579987,
+                               3.2725236, 3.2870843, 3.3016858, 3.316324,  3.3309996, 3.345713,  3.3604617, 3.3752484},
+              sd::DataType::FLOAT32);
+
+  sd::ops::tanh_bp op;
+  auto result = op.evaluate({&x, &dLdz});
+  auto dLdxPtr = result.at(0);
+
+  ASSERT_TRUE(dLdxPtr->equalsTo(&exp));
+}
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests18, test_tanh_bp2) {
   NDArray x('f', {2, 3, 4}, sd::DataType::FLOAT32);


### PR DESCRIPTION
applyPairwiseLambda now can handle scalar case for its' second argume…nt. It's tested in the tanh_bp scalar case.

Note: if your first argument is scalar but the second argument and output argument have the same shape
you could just switch arguments and call applyPairwiseLambda. it was not handled for now

Signed-off-by: AbdelRauf <rauf@konduit.ai>

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
