### PR TITLE
Fix shape resolution when shapes are < 0 when suggesting input arrays

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/DynamicCustomOp.java
@@ -279,12 +279,15 @@ public class DynamicCustomOp extends DifferentialFunction implements CustomOp {
     public void computeArrays() {
         if(sameDiff.isEagerMode()) {
             SDVariable[] args = args();
-            if(inputArguments.isEmpty())
-                for(SDVariable arg : args) {
-                    if(arg.getArr() != null)
+            if(inputArguments.isEmpty()) {
+                for (SDVariable arg : args) {
+                    if (arg.getArr() != null)
                         addInputArgument(arg.getArr());
+                    else {
+                        throw new IllegalStateException("Variable name " + arg.name() + " from  op of type " + opName() + " with unique name of " + getOwnName() + " was not able to resolve an array for eager computation.");
+                    }
                 }
-
+            }
             INDArray[] exec = Nd4j.getExecutioner().exec(this);
             for (int i = 0; i < outputVariables.length; i++) {
                 outputVariables[i].setShape(exec[i].shape());

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Squeeze.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Squeeze.java
@@ -87,6 +87,10 @@ public class Squeeze extends DynamicCustomOp {
 
     @Override
     public void setPropertiesForFunction(Map<String, Object> properties) {
+        if(properties.containsKey("squeezeDims")) {
+            Long squeezeProp = getLongValueFromProperty("squeezeDims",properties);
+            this.squeezeDims = new int[] {squeezeProp.intValue()};
+        }
     }
 
     @Override
@@ -99,7 +103,7 @@ public class Squeeze extends DynamicCustomOp {
         for (int d : squeezeDims) {
             ret = sameDiff.expandDims(ret, d);
         }
-        ;
+
         return Arrays.asList(ret);
     }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -1525,7 +1525,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
             try {
                 val list = this.calculateOutputShape(op);
                 if (list.isEmpty())
-                    throw new ND4JIllegalStateException("Op name " + op.opName() + " failed to calculate output datatypes");
+                    throw new ND4JIllegalStateException("Op name " + op.opName() + " failed to calculate output shape and data types.");
 
                 for (LongShapeDescriptor shape : list)
                     op.addOutputArgument(Nd4j.create(shape, false));

--- a/nd4j/samediff-import/samediff-import-onnx/pom.xml
+++ b/nd4j/samediff-import/samediff-import-onnx/pom.xml
@@ -36,8 +36,8 @@
   <name>samediff-import-onnx</name>
   <properties>
     <jgit.version>5.10.0.202012080955-r</jgit.version>
-    <test.offheap.size>3g</test.offheap.size>
-    <test.heap.size>3g</test.heap.size>
+    <test.offheap.size>8g</test.offheap.size>
+    <test.heap.size>8g</test.heap.size>
   </properties>
 
   <build>

--- a/nd4j/samediff-import/samediff-import-onnx/pom.xml
+++ b/nd4j/samediff-import/samediff-import-onnx/pom.xml
@@ -84,6 +84,12 @@
       <artifactId>nd4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>onnx-platform</artifactId>
+      <version>1.9.0-1.5.6</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/OnnxConverter.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/OnnxConverter.kt
@@ -39,7 +39,7 @@ class OnnxConverter {
         val converter = DefaultVersionConverter()
         val bytes = ByteBuffer.wrap(IOUtils.toByteArray(BufferedInputStream(FileInputStream(inputModel))))
         val bytePointer = BytePointer(bytes)
-        val proto = org.bytedeco.onnx.ModelProto(bytes.capacity().toLong())
+        val proto = ModelProto()
         //val operatorSet = Onnx.OperatorSetIdProto()
         proto.ParseFromString(bytePointer)
         val initialId = OpSetID(0)

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/OnnxConverter.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/OnnxConverter.kt
@@ -1,0 +1,65 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.samediff.frameworkimport.onnx
+
+import lombok.SneakyThrows
+import onnx.Onnx
+import onnx.Onnx.OperatorSetIdProto
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.IOUtils
+import org.bytedeco.javacpp.BytePointer
+import org.bytedeco.onnx.*
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.ByteBuffer
+
+class OnnxConverter {
+
+    @SneakyThrows
+    fun convertModel(inputModel: File,outputModelFilePath: File)  {
+        val converter = DefaultVersionConverter()
+        val bytes = ByteBuffer.wrap(IOUtils.toByteArray(BufferedInputStream(FileInputStream(inputModel))))
+        val bytePointer = BytePointer(bytes)
+        val proto = org.bytedeco.onnx.ModelProto(bytes.capacity().toLong())
+        //val operatorSet = Onnx.OperatorSetIdProto()
+        proto.ParseFromString(bytePointer)
+        val initialId = OpSetID(0)
+        for(i in 0 until proto.opset_import_size()) {
+            val opSetImport = proto.opset_import(i)
+            if(!opSetImport.has_domain() || opSetImport.domain().string == "ai.onnx") {
+                //approximates default opset from https://github.com/onnx/onnx/blob/master/onnx/version_converter/convert.cc#L14
+                initialId.setVersion(opSetImport.version().toInt())
+                break
+
+            }
+        }
+
+        val convertVersion = converter.convert_version(proto, initialId, OpSetID(13))
+        val save = convertVersion.SerializeAsString()
+        IOUtils.write(save.stringBytes, FileOutputStream(outputModelFilePath))
+
+    }
+
+
+
+
+}

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/OnnxFrameworkImporter.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/OnnxFrameworkImporter.kt
@@ -76,9 +76,10 @@ class OnnxFrameworkImporter: FrameworkImporter {
         val graph = irGraph as OnnxIRGraph
         val ret = HashMap<String,INDArray>()
         for(i in 0 until graph.inputList.size) {
-            val inputShape = graph.shapeOfInput(graph.inputAt(i))
+            var inputShape = graph.shapeOfInput(graph.inputAt(i))
             val dType = graph.dataTypeForVariable(graph.inputAt(i))
             if(inputShape != null) {
+                graph.shapeOfInput(graph.inputAt(i))!!.map { input -> if(input < 0) 1 else input }.toLongArray()
                 ret[graph.inputAt(i)] = Nd4j.ones(dType.nd4jDataType(),*inputShape)
             }
         }

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/OnnxFrameworkImporter.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/OnnxFrameworkImporter.kt
@@ -79,7 +79,7 @@ class OnnxFrameworkImporter: FrameworkImporter {
             var inputShape = graph.shapeOfInput(graph.inputAt(i))
             val dType = graph.dataTypeForVariable(graph.inputAt(i))
             if(inputShape != null) {
-                graph.shapeOfInput(graph.inputAt(i))!!.map { input -> if(input < 0) 1 else input }.toLongArray()
+                inputShape = graph.shapeOfInput(graph.inputAt(i))!!.map { input -> if(input < 0) 1 else input }.toLongArray()
                 ret[graph.inputAt(i)] = Nd4j.ones(dType.nd4jDataType(),*inputShape)
             }
         }

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/resources/onnx-mapping-ruleset.pbtxt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/resources/onnx-mapping-ruleset.pbtxt
@@ -4775,7 +4775,6 @@ mappings {
       }
       transformerArgs {
         name: "padding"
-        int64Value: 1
         argType: INT64
         argIndex: 4
       }
@@ -4788,7 +4787,6 @@ mappings {
       }
       transformerArgs {
         name: "padding"
-        int64Value: 1
         argType: INT64
         argIndex: 4
       }

--- a/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/TestOnnxConverter.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/TestOnnxConverter.kt
@@ -1,0 +1,20 @@
+package org.nd4j.samediff.frameworkimport.onnx
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.nd4j.common.io.ClassPathResource
+import java.io.File
+
+class TestOnnxConverter {
+
+    @Test
+    fun upgradeModel() {
+        val onnxConverter = OnnxConverter()
+        val inputModel = ClassPathResource("lenet.onnx").file
+        val outputFile = File(System.getProperty("java.io.tmpdir"),"output.onnx")
+        onnxConverter.convertModel(inputModel,outputFile)
+        assertTrue(outputFile.exists())
+        outputFile.delete()
+    }
+
+}

--- a/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/TestOnnxIR.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/TestOnnxIR.kt
@@ -154,7 +154,7 @@ class TestOnnxIR {
 
         val onnxIRGraph = OnnxIRGraph(graphToRun,onnxOpRegistry)
         val onnxGraphRunner = OnnxIRGraphRunner(onnxIRGraph,listOf("x","W"),listOf("y"))
-        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,HashMap(),onnxOpRegistry)
+        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null, convertToOnnxTensors(mutableMapOf("W" to w,"x" to inputTensor)),onnxOpRegistry)
         val inputs = mapOf("x" to inputTensor,"W" to w)
         val assertion = onnxGraphRunner.run(inputs)
         val result = importedGraph.output(inputs,"y")
@@ -169,6 +169,7 @@ class TestOnnxIR {
         sd.isEagerMode = true
         val result = sd.math().add(sd.constant(Nd4j.ones(1)),sd.constant(Nd4j.ones(1)))
         val result2 = sd.math().add(result,1.0)
+        sd.outputAll(emptyMap())
         println(result2)
     }
 
@@ -285,7 +286,7 @@ class TestOnnxIR {
 
         val onnxIRGraph = OnnxIRGraph(graphToRun,onnxOpRegistry)
         val onnxGraphRunner = OnnxIRGraphRunner(onnxIRGraph,listOf("x","W"),listOf("y"))
-        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,HashMap(),onnxOpRegistry)
+        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null, convertToOnnxTensors(mutableMapOf("x" to inputTensor,"W" to w)),onnxOpRegistry)
         val inputs = mapOf("x" to inputTensor,"W" to w)
         val assertion = onnxGraphRunner.run(inputs)
         val result = importedGraph.output(inputs,"y")
@@ -343,7 +344,7 @@ class TestOnnxIR {
 
         val onnxIRGraph = OnnxIRGraph(graphToRun,onnxOpRegistry)
         val onnxGraphRunner = OnnxIRGraphRunner(onnxIRGraph,listOf("x","W"),listOf("y"))
-        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,HashMap(),onnxOpRegistry)
+        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,convertToOnnxTensors(mutableMapOf("x" to inputTensor,"W" to w)),onnxOpRegistry)
         val inputs = mapOf("x" to inputTensor,"W" to w)
         val assertion = onnxGraphRunner.run(inputs)
         val result = importedGraph.output(inputs,"y")
@@ -401,7 +402,7 @@ class TestOnnxIR {
 
         val onnxIRGraph = OnnxIRGraph(graphToRun,onnxOpRegistry)
         val onnxGraphRunner = OnnxIRGraphRunner(onnxIRGraph,listOf("x","W"),listOf("y"))
-        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,HashMap(),onnxOpRegistry)
+        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,convertToOnnxTensors(mutableMapOf("x" to inputTensor,"W" to w)),onnxOpRegistry)
         val inputs = mapOf("x" to inputTensor,"W" to w)
         val assertion = onnxGraphRunner.run(inputs)
         val result = importedGraph.output(inputs,"y")
@@ -493,7 +494,7 @@ class TestOnnxIR {
 
         val onnxIRGraph = OnnxIRGraph(graphToRun,onnxOpRegistry)
         val onnxGraphRunner = OnnxIRGraphRunner(onnxIRGraph,listOf("x"),listOf("y"))
-        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,HashMap(),onnxOpRegistry)
+        val importedGraph = importGraph.importGraph(onnxIRGraph,null,null,convertToOnnxTensors(mutableMapOf("x" to inputTensor)),onnxOpRegistry)
         val inputs = mapOf("x" to inputTensor)
         val assertion = onnxGraphRunner.run(inputs)
         val result = importedGraph.output(inputs,"y")
@@ -512,7 +513,7 @@ class TestOnnxIR {
             "newShape" to inputNewShape)
         val inputNames = listOf("data","newShape")
         val outputs = listOf("expanded")
-        val graph = createSingleNodeGraph(inputs,"Expand", emptyMap(),outputs,inputNames)
+        val graph = createSingleNodeGraph(inputs,"Expand",inputs,outputs,inputNames)
         runAssertion(graph,inputs,outputs)
 
     }

--- a/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
@@ -79,4 +79,14 @@ class TestOnnxFrameworkImporter {
     }
 
 
+    @Test
+    fun testV9() {
+        Nd4j.getExecutioner().enableVerboseMode(true)
+        Nd4j.getExecutioner().enableDebugMode(true)
+        val importer = OnnxFrameworkImporter()
+        val file = File("C:\\Users\\agibs\\Downloads\\V9\\V9\\best_bracket.onnx")
+        val result  = importer.runImport(file.absolutePath, emptyMap(),suggestDynamicVariables = true)
+        //result.outputAll(Collections.singletonMap("input.1",Nd4j.ones(1,3,224,224)))
+    }
+
 }

--- a/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/test/kotlin/org/nd4j/samediff/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
@@ -46,6 +46,8 @@ class TestOnnxFrameworkImporter {
 
     @Test
     fun testMobileNet() {
+        Nd4j.getExecutioner().enableVerboseMode(true)
+        Nd4j.getExecutioner().enableDebugMode(true)
         val importer = OnnxFrameworkImporter()
         val file = ClassPathResource("mobilenet.onnx").file
         val result  = importer.runImport(file.absolutePath, emptyMap(),suggestDynamicVariables = true)

--- a/nd4j/samediff-import/samediff-import-tensorflow/pom.xml
+++ b/nd4j/samediff-import/samediff-import-tensorflow/pom.xml
@@ -36,6 +36,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <test.offheap.size>8g</test.offheap.size>
+    <test.heap.size>8g</test.heap.size>
   </properties>
 
   <build>

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/importer/TensorflowFrameworkImporter.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/importer/TensorflowFrameworkImporter.kt
@@ -37,6 +37,8 @@ import org.nd4j.shade.protobuf.ProtocolMessageEnum
 import org.tensorflow.framework.*
 import java.io.File
 import java.nio.file.Files
+import java.util.*
+import kotlin.collections.HashMap
 
 class TensorflowFrameworkImporter: FrameworkImporter {
 
@@ -86,7 +88,7 @@ class TensorflowFrameworkImporter: FrameworkImporter {
         val irGraph = irGraph as TensorflowIRGraph
         val ret = HashMap<String,INDArray>()
         for(i in 0 until irGraph.inputs.size) {
-            val shape = irGraph.shapeOfInput(irGraph.inputs[i])
+            val shape = irGraph.shapeOfInput(irGraph.inputs[i])!!.map { input -> if(input < 0) 1 else input }.toLongArray()
             if(shape != null) {
                 val dtype = irGraph.dataTypeForVariable(irGraph.inputAt(i))
                 ret[irGraph.inputAt(i)] = Nd4j.ones(dtype.nd4jDataType(),*shape)

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRGraph.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRGraph.kt
@@ -130,9 +130,7 @@ class TensorflowIRGraph(graphDef: GraphDef, opDef: OpList
         val shapeAvailable = attrMap.containsKey("shape")
         var shape: LongArray?
         shape = if (shapeAvailable) {
-            val dimList =  attrMap["shape"]!!.shape.dimList.map { input -> input.size }.toLongArray()
-            dimList
-
+            attrMap["shape"]!!.shape.dimList.map { input -> input.size }.toLongArray()
         } else {
             //Some placeholders don't have any shape restrictions - i.e., accept anything...
             null

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRGraph.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRGraph.kt
@@ -130,7 +130,8 @@ class TensorflowIRGraph(graphDef: GraphDef, opDef: OpList
         val shapeAvailable = attrMap.containsKey("shape")
         var shape: LongArray?
         shape = if (shapeAvailable) {
-            attrMap["shape"]!!.list.iList.toLongArray()
+            val dimList =  attrMap["shape"]!!.shape.dimList.map { input -> input.size }.toLongArray()
+            dimList
 
         } else {
             //Some placeholders don't have any shape restrictions - i.e., accept anything...

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/test/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/importer/TestTensorflowImporter.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/test/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/importer/TestTensorflowImporter.kt
@@ -36,6 +36,6 @@ class TestTensorflowImporter {
         //note this is just a test to make sure everything runs, we test the underlying import elsewhere
         assertNotNull(graph)
     }
-    
+
 
 }

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/test/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/importer/TestTensorflowImporter.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/test/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/importer/TestTensorflowImporter.kt
@@ -36,5 +36,6 @@ class TestTensorflowImporter {
         //note this is just a test to make sure everything runs, we test the underlying import elsewhere
         assertNotNull(graph)
     }
+    
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Placeholder shapes are often less than 0 (-1 being a valid shape for placeholders to represent variable batch sizes)
When suggesting variables, this will set that variable batch size to 1 when the importer encounters it.

This also fixes shape discovery for tensorflow models.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
