### PR TITLE
Fix 9531: Confusion matrices not incrementing their results properly

### DIFF
--- a/libnd4j/include/ops/declarable/helpers/cpu/confusion.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/confusion.cpp
@@ -36,7 +36,8 @@ static void _confusionFunctor(NDArray* labels, NDArray* predictions, NDArray* we
       auto label = labels->e<sd::LongType>(j);
       auto pred = predictions->e<sd::LongType>(j);
       T value = (weights == nullptr ? (T)1.0f : weights->e<T>(j));
-      arrs.at(label)->p<T>(pred, value);
+      T curr = arrs.at(label)->e<T>(pred);
+      arrs.at(label)->p<T>(pred, curr + value);
     }
   };
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/confusion.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/confusion.cu
@@ -63,7 +63,9 @@ SD_KERNEL static void confusionFunctorKernel(sd::LongType* labelsBuffer, sd::Lon
     T val = (weightsBuffer == nullptr ? (T)1.0f : w[t]);
 
     auto idx = shape::getIndexOffset(pred, tadShape);
-    tZ[idx] = val;
+    //increment the value by the weight
+    tZ[idx] += val;
+
   }
 }
 

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/custom/CustomOpsTests.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/custom/CustomOpsTests.java
@@ -111,6 +111,31 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
         return 'c';
     }
 
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testConfusionMatrix(Nd4jBackend backend) {
+        Nd4j.getExecutioner().enableDebugMode(true);
+        Nd4j.getExecutioner().enableVerboseMode(true);
+
+        INDArray classes = Nd4j.createFromArray(0, 0, 0, 1, 1, 2);
+        INDArray clusters = Nd4j.createFromArray(0, 0, 0, 1, 1, 1);
+
+        INDArray confMatrix = Nd4j.math().confusionMatrix(
+              classes,clusters,3
+        );
+
+        INDArray assertion = Nd4j.create(new double[][]{
+                {3,0,0},
+                {0,2,0},
+                {0,1,0}
+        }).castTo(DataType.INT32);
+        assertEquals(assertion,confMatrix);
+
+    }
+
+
+
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testNonInplaceOp1(Nd4jBackend backend) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes https://github.com/eclipse/deeplearning4j/issues/9531
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
