### PR TITLE
Fix transformers models: fix reduce shape computation for keepDims

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseOp.java
@@ -314,7 +314,13 @@ public abstract class BaseOp extends DifferentialFunction implements Op {
                 if( dimensions == null)
                     setZ(Nd4j.zeros(x.shape()).castTo(newVars[0].dataType()));
                 else {
-                    setZ(Nd4j.create(Shape.reductionShape(x,dimensions,true,false)).castTo(newVars[0].dataType()));
+                    if(this instanceof BaseReduceOp) {
+                        BaseReduceOp baseReduceOp = (BaseReduceOp) this;
+                        setZ(Nd4j.create(Shape.reductionShape(x,dimensions,true,baseReduceOp.keepDims)).castTo(newVars[0].dataType()));
+                    } else {
+                        setZ(Nd4j.create(Shape.reductionShape(x,dimensions,true,false)).castTo(newVars[0].dataType()));
+
+                    }
                 }
             }
 

--- a/omnihub/src/main/java/org/eclipse/deeplearning4j/omnihub/api/ModelType.java
+++ b/omnihub/src/main/java/org/eclipse/deeplearning4j/omnihub/api/ModelType.java
@@ -1,0 +1,37 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  * See the NOTICE file distributed with this work for additional
+ *  * information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.eclipse.deeplearning4j.omnihub.api;
+
+public enum ModelType {
+    COMP_GRAPH,SEQUENTIAL;
+
+    public static ModelType fromString(String namespace) {
+        switch(namespace.toLowerCase()) {
+            case "comp_graph":
+                return COMP_GRAPH;
+            case "sequential":
+                return SEQUENTIAL;
+            default:
+                return null;
+        }
+    }
+
+
+}

--- a/omnihub/src/main/java/org/eclipse/deeplearning4j/omnihub/models/Pretrained.java
+++ b/omnihub/src/main/java/org/eclipse/deeplearning4j/omnihub/models/Pretrained.java
@@ -1,0 +1,41 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.eclipse.deeplearning4j.omnihub.models;
+
+/**
+ * Top level class for accessing pretrained mdoels from Omnihub
+ * separated by dl4j and samediff.
+ *
+ * @author Adam Gibson
+ */
+public class Pretrained {
+    private static Dl4jModels dl4j = new Dl4jModels();
+    private static SameDiffModels samediff = new SameDiffModels();
+
+
+    public static SameDiffModels samediff() {
+        return samediff;
+    }
+
+    public static Dl4jModels dl4j() {
+        return dl4j;
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes keepDims computation during eager compute import.

Also adds back missing ModelType
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
