### PR TITLE
Fix namespace issue for release

### DIFF
--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -5,7 +5,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.deeplearning4j</groupId>
+    <groupId>org.deeplearning4j</groupId>
     <artifactId>platform-tests</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reverts namespace on platform-tests to org.deeplearning4j for release artifact
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
