### PR TITLE
Allows adding a labelsSource as part of the Builder

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BagOfWordsVectorizer.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/bagofwords/vectorizer/BagOfWordsVectorizer.java
@@ -178,6 +178,11 @@ public class BagOfWordsVectorizer extends BaseTextVectorizer {
             return this;
         }
 
+        public Builder labelsSource(@NonNull LabelsSource source) {
+            this.labelsSource = source;
+            return this;
+        }
+
         public BagOfWordsVectorizer build() {
             BagOfWordsVectorizer vectorizer = new BagOfWordsVectorizer();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

BagOfWordVectorizer was missing the option to set the labels

## How was this patch tested?

It hasn't been tested but the added code is directly copied from  ParagraphVectors.java that does offer this option.
