### PR TITLE
Fix up matrix multiply backprop vector case, svd

### DIFF
--- a/libnd4j/include/array/NDArray.h
+++ b/libnd4j/include/array/NDArray.h
@@ -637,10 +637,19 @@ class SD_LIB_EXPORT NDArray {
    */
   NDArray dup(const char newOrder = 'a') const;
 
+
+
   /**
    *  returns sum of all elements of array
    */
   NDArray sumNumber() const;
+
+
+  /**
+   *  returns prod of all elements of array
+   */
+  NDArray prodNumber() const;
+
 
   /**
    *  returns mean number of array

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -1201,6 +1201,22 @@ NDArray NDArray::varianceNumber(sd::variance::Ops op, bool biasCorrected) {
 }
 
 //////////////////////////////////////////////////////////////////////////
+
+
+
+NDArray NDArray::prodNumber() const {
+  if (isS()) throw std::runtime_error("NDArray::sumNumber: you can't use this method on String array!");
+  NDArray res(dataType(), getContext());
+
+  NDArray::prepareSpecialUse({&res}, {this});
+  NativeOpExecutioner::execReduceSameScalar(getContext(), sd::reduce::SameOps::Prod, buffer(), shapeInfo(),
+                                            specialBuffer(), specialShapeInfo(), nullptr, res.buffer(), res.shapeInfo(),
+                                            res.specialBuffer(), res.specialShapeInfo());
+  NDArray::registerSpecialUse({&res}, {this});
+
+  return res;
+}
+
 // This method returns sum of all elements of this NDArray
 NDArray NDArray::sumNumber() const {
   if (isS()) throw std::runtime_error("NDArray::sumNumber: you can't use this method on String array!");
@@ -2216,12 +2232,12 @@ NDArray NDArray::asS() const {
                                                : unicode::offsetUtf8StringInUtf32(data + start, stop);
     } else if (dataType() == DataType::UTF16) {
       dataLength += (dtype == DataType::UTF32)
-                        ? unicode::offsetUtf16StringInUtf32(data + start, (stop / sizeof(char16_t)))
-                        : unicode::offsetUtf16StringInUtf8(data + start, (stop / sizeof(char16_t)));
+                    ? unicode::offsetUtf16StringInUtf32(data + start, (stop / sizeof(char16_t)))
+                    : unicode::offsetUtf16StringInUtf8(data + start, (stop / sizeof(char16_t)));
     } else {
       dataLength += (dtype == DataType::UTF16)
-                        ? unicode::offsetUtf32StringInUtf16(data + start, (stop / sizeof(char32_t)))
-                        : unicode::offsetUtf32StringInUtf8(data + start, (stop / sizeof(char32_t)));
+                    ? unicode::offsetUtf32StringInUtf16(data + start, (stop / sizeof(char32_t)))
+                    : unicode::offsetUtf32StringInUtf8(data + start, (stop / sizeof(char32_t)));
     }
   }
   offsets[lengthOf()] = dataLength;
@@ -2700,8 +2716,8 @@ void NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other,
   if (checkTargetShape) {
     const sd::LongType *newShapeInfo = nullptr;
     if (!ShapeUtils::evalBroadcastShapeInfo(
-            *this, other, true, newShapeInfo,
-            getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
+        *this, other, true, newShapeInfo,
+        getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
       throw std::runtime_error(
           "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
           "operation !");
@@ -2755,8 +2771,8 @@ void NDArray::applyTrueBroadcast(sd::BroadcastBoolOpsTuple op, const NDArray &ot
   if (checkTargetShape) {
     const sd::LongType *newShapeInfo = nullptr;
     if (!ShapeUtils::evalBroadcastShapeInfo(
-            *this, other, true, newShapeInfo,
-            getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
+        *this, other, true, newShapeInfo,
+        getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
       throw std::runtime_error(
           "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
           "operation !");
@@ -2814,8 +2830,8 @@ void NDArray::applyTrueBroadcast(sd::BroadcastIntOpsTuple op, const NDArray &oth
   if (checkTargetShape) {
     const sd::LongType *newShapeInfo = nullptr;
     if (!ShapeUtils::evalBroadcastShapeInfo(
-            *this, other, false, newShapeInfo,
-            getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
+        *this, other, false, newShapeInfo,
+        getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
       throw std::runtime_error(
           "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
           "operation !");
@@ -3720,7 +3736,7 @@ T NDArray::e(const sd::LongType i, const sd::LongType j, const sd::LongType k, c
 }
 BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT,
                                 NDArray::e(const sd::LongType, const sd::LongType, const sd::LongType,
-                                           const sd::LongType) const,
+                                    const sd::LongType) const,
                                 SD_COMMON_TYPES_ALL);
 
 //////////////////////////////////////////////////////////////////////////
@@ -4838,8 +4854,8 @@ ResultSet NDArray::allExamples() const {
 ////////////////////////////////////////////////////////////////////////
 sd::LongType NDArray::getOffset(const sd::LongType i) const {
   if (i >= lengthOf()) {
-      sd_debug("NDArray::getOffset: input index %d array length %d\n",i,lengthOf());
-      throw std::invalid_argument("NDArray::getOffset: input index %d is out of array length %d!");
+    sd_debug("NDArray::getOffset: input index %d array length %d\n",i,lengthOf());
+    throw std::invalid_argument("NDArray::getOffset: input index %d is out of array length %d!");
   }
 
   return shape::getIndexOffset(i, _shapeInfo);
@@ -4903,10 +4919,10 @@ NDArray NDArray::diagonal(const char type) const {
 ////////////////////////////////////////////////////////////////////////
 ResultSet NDArray::allTensorsAlongDimension(const std::vector<int> &dimensions) const {
   ResultSet result;
-
-  if (dimensions.size() == 0 || isScalar())
+  if(dimensions.size() == 0) {
     return result;
-  else if (dimensions.back() == rankOf()) {
+  }
+  if (dimensions.back() == rankOf() || isScalar() && dimensions.size() == 1 && dimensions[0] == 0) {
     auto array = new NDArray(_buffer, this->shapeInfo(), getContext(), bufferOffset());
     array->_isView = true;
     result.push_back(array);

--- a/libnd4j/include/array/cpu/NDArray.cpp
+++ b/libnd4j/include/array/cpu/NDArray.cpp
@@ -112,10 +112,8 @@ void NDArray::fillAsTriangular(const float val, int lower, int upper, NDArray& t
       }
 
       if(!areSameOffsets && rankOf() < 2) {
-        sd_printf("X vector offset is %d\n",vectorCoord[0]);
         //rotate count of elements based on how many times accessed
         xOffset = shape::getOffset(shapeInfo(),vectorCoord);
-        sd_printf("X vector offset output is %d\n",xOffset);
       } else if(areSameOffsets) {
         xOffset = zOffset;
       } else {

--- a/libnd4j/include/graph/execution/impl/LogicMerge.cpp
+++ b/libnd4j/include/graph/execution/impl/LogicMerge.cpp
@@ -63,12 +63,9 @@ sd::Status LogicMerge::processNode(Graph *graph, Node *node) {
       else
         lvar = new Variable(nullptr, node->getName()->c_str(), node->id(), 0);
 
-      //                    if (lvar->hasNDArray())
-      //                        delete lvar->getNDArray();
 
       auto array = var->getNDArray();
 
-      // array->printIndexedBuffer("propagated");
 
       lvar->setNDArray(array);
       lvar->markReadOnly(true);

--- a/libnd4j/include/graph/execution/impl/LogicSwitch.cpp
+++ b/libnd4j/include/graph/execution/impl/LogicSwitch.cpp
@@ -74,8 +74,7 @@ sd::Status LogicSwitch::processNode(Graph* graph, Node* node) {
     auto input = ctx.variable(0)->getNDArray();
     auto boolean = ctx.variable(1)->getNDArray();
 
-    // input->printIndexedBuffer("0");
-    // boolean->printIndexedBuffer("1");
+
 
     std::pair<int, int> pair0(node->id(), 0);
     std::pair<int, int> pair1(node->id(), 1);

--- a/libnd4j/include/helpers/cpu/svd.cpp
+++ b/libnd4j/include/helpers/cpu/svd.cpp
@@ -401,7 +401,7 @@ void SVD<T>::calcSingVals(const NDArray& col0, const NDArray& diag, const NDArra
     bool useBisection = fPrev * fCur > (T)0.;
     while (fCur != (T).0 &&
            math::sd_abs<T>(muCur - muPrev) >
-               (T)8. * DataTypeUtils::eps<T>() * math::sd_max<T>(math::sd_abs<T>(muCur), math::sd_abs<T>(muPrev)) &&
+           (T)8. * DataTypeUtils::eps<T>() * math::sd_max<T>(math::sd_abs<T>(muCur), math::sd_abs<T>(muPrev)) &&
            math::sd_abs<T>(fCur - fPrev) > DataTypeUtils::eps<T>() && !useBisection) {
       T a = (fCur - fPrev) / ((T)1. / muCur - (T)1. / muPrev);
       T jac = fCur - a / muCur;
@@ -439,7 +439,7 @@ void SVD<T>::calcSingVals(const NDArray& col0, const NDArray& diag, const NDArra
 
       while (rightShifted - leftShifted >
              (T)2.f * DataTypeUtils::eps<T>() *
-                 math::sd_max<T>(math::sd_abs<T>(leftShifted), math::sd_abs<T>(rightShifted))) {
+             math::sd_max<T>(math::sd_abs<T>(leftShifted), math::sd_abs<T>(rightShifted))) {
         T midShifted = (leftShifted + rightShifted) / (T)2.;
         fMid = secularEq(midShifted, col0, diag, permut, diagShifted, shift);
         if (fLeft * fMid < (T)0.)
@@ -756,6 +756,7 @@ void SVD<T>::evalData(const NDArray& matrix) {
 
   if (matrix.sizeAt(1) < _switchSize) {
     JacobiSVD<T> jac(matrix, _calcU, _calcV, _fullUV);
+    sd_debug("Executed jacobian switch size early eval %d\n",0);
 
     if (_calcU) _u = jac._u;
     if (_calcV) _v = jac._v;

--- a/libnd4j/include/helpers/impl/HessenbergAndSchur.cpp
+++ b/libnd4j/include/helpers/impl/HessenbergAndSchur.cpp
@@ -82,7 +82,7 @@ void Hessenberg<T>::evalData() {
   hhSeq.applyTo_<T>(_Q);
 
   // fill down with zeros starting at first subdiagonal
-  _H.fillAsTriangular<T>(0, -1, 0, _H, 'l');
+  _H.fillAsTriangular<T>(0, -1, -1, _H, 'l',false);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/helpers/impl/jacobiSVD.cpp
+++ b/libnd4j/include/helpers/impl/jacobiSVD.cpp
@@ -263,12 +263,12 @@ void JacobiSVD<T>::evalData(const NDArray& matrix) {
   const T almostZero = DataTypeUtils::min_positive<T>();
 
   T scale = matrix.reduceNumber(reduce::AMax).template t<T>(0);
-  if (scale == (T)0.f) scale = (T)1.f;
+  if (scale <   (T)1.f) scale = (T)1.f;
 
   if (_rows > _cols) {
     HHcolPivQR qr(matrix / scale);
     _m.assign(qr._qr({0, _cols, 0, _cols}));
-    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l');
+    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l',false);
 
     HHsequence hhSeg(qr._qr, qr._coeffs, 'u');
 
@@ -283,7 +283,7 @@ void JacobiSVD<T>::evalData(const NDArray& matrix) {
   } else if (_rows < _cols) {
     HHcolPivQR qr(matrix.transpose() / scale);
     _m.assign(qr._qr({0, _rows, 0, _rows}));
-    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l');
+    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l',false);
     _m.transposei();
 
     HHsequence hhSeg(qr._qr, qr._coeffs, 'u');  // type = 'u' is not mistake here !

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -2506,11 +2506,6 @@ static SD_INLINE sd::Status realExec(sd::ops::DeclarableOp *op, sd::Pointer *ext
 
   if (!isInplace)
     for (int e = 0; e < numOutputs; e++) {
-      // shape::printShapeInfoLinear("JVM output shape", (int *) outputShapes[e]);
-      // shape::printShapeInfoLinear("C++ output shape", (int *) outputs[e]->shapeInfo());
-      // outputs[e]->printIndexedBuffer("C++ raw output");
-      // outputs[e]->printBuffer("C++ indexed output");
-
       if (outputs[e]->ordering() != shape::order(reinterpret_cast<sd::LongType *>(outputShapes[e])))
         outputs[e]->streamline(shape::order(reinterpret_cast<sd::LongType *>(outputShapes[e])));
     }

--- a/libnd4j/include/ops/declarable/generic/list/size_list.cpp
+++ b/libnd4j/include/ops/declarable/generic/list/size_list.cpp
@@ -32,11 +32,7 @@ LIST_OP_IMPL(size_list, 1, 1, 0, 0) {
 
   auto result = NDArrayFactory::create_<int>(list->height(), block.launchContext());
 
-  // sd_printf("List size: [%i]\n", list->height());
-  result->printIndexedBuffer("actual height");
 
-  // sd_printf("List size: [%i]\n", list->height());
-  result->printIndexedBuffer("actual height");
 
   // OVERWRITE_RESULT(result);
   setupResult(result, block);

--- a/libnd4j/include/ops/declarable/generic/list/write_list.cpp
+++ b/libnd4j/include/ops/declarable/generic/list/write_list.cpp
@@ -38,13 +38,10 @@ LIST_OP_IMPL(write_list, 2, 1, 0, -2) {
 
     REQUIRE_TRUE(idx->isScalar(), 0, "Index should be Scalar");
 
-    // sd_printf("Writing [%i]:\n", idx->e<int>(0));
-    // input->printShapeInfo("input shape");
-    // input->printIndexedBuffer("input buffer");
+
     sd::Status result = list->write(idx->e<int>(0), new NDArray(input->dup()));
 
     auto res = NDArrayFactory::create_(list->counter(), block.launchContext());
-    // res->printShapeInfo("Write_list 2 output shape");
 
     setupResult(res, block);
     //                OVERWRITE_RESULT(res);

--- a/libnd4j/include/ops/declarable/generic/parity_ops/normalize_moments.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/normalize_moments.cpp
@@ -49,7 +49,6 @@ CUSTOM_OP_IMPL(normalize_moments, 3, 2, false, 1, 0) {
 
   squareMeans.applyTransform(transform::Square, squareMeans, nullptr);
   variances->applyScalarArr(scalar::Divide, *counts, tempVariances);
-  //            tempVariances.printIndexedBuffer("varianced divided by count");
   tempVariances.applyPairwiseTransform(pairwise::Subtract, squareMeans, *resVariances);
 
   if (shift.e<double>(0) != 0) {

--- a/libnd4j/include/ops/declarable/generic/reduce/norm.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/norm.cpp
@@ -42,7 +42,6 @@ REDUCTION_OP_IMPL(norm, 1, 1, false, 1, -2) {
     auto axisVector = INPUT_VARIABLE(1);
     dims.resize(axisVector->lengthOf());
     helpers::adjustAxis(input->rankOf(), axisVector, dims);
-    axisVector->printIndexedBuffer("AXIS");
     auto shape = ShapeUtils::evalReduceShapeInfo(input->ordering(), dims, *input, false, false);
     if (!shape::equalsStrict(shape, output->shapeInfo())) {
       output = new NDArray(shape, false, block.launchContext());

--- a/libnd4j/include/ops/declarable/helpers/cpu/compare_and_bitpack.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/compare_and_bitpack.cpp
@@ -124,7 +124,6 @@ void compareAndBitpack_(const NDArray& input, const NDArray& thresholdScalar, ND
       auto outLastStride = outStrides[rank - 1];
       FUNC_1D func = [buff, outBuff, inLastStride, outLastStride, threshold](uint64_t thread_id, int64_t start,
                                                                              int64_t stop, int64_t increment) -> void {
-        // sd_printf("rankkk s: %i e: %i \n", (int)start,(int)stop);
         auto buffPart = buff + start * 8 * inLastStride;
         auto outBuffPart = outBuff + start * outLastStride;
         auto len = stop - start;

--- a/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
@@ -552,8 +552,6 @@ sd::Status cholesky_(LaunchContext* context, NDArray* input, NDArray* output, bo
       T diagonalSum = 0;
       for (sd::LongType k = 0; k < col; ++k) diagonalSum += lowerMatrix->e<T>(col, k) * lowerMatrix->e<T>(col, k);
       lowerMatrix->p(col, col, sd::math::sd_sqrt<T, T>(matrix->e<T>(col, col) - diagonalSum));
-      // sd_printf("%i: ", col);
-      // lowerMatrix->printIndexedBuffer("Lower matrix");
     }
     for (int k = e * n2, l = 0; k < (e + 1) * n2; k++) {
       output->p(k, lowerMatrix->e<T>(l++));

--- a/libnd4j/include/ops/declarable/helpers/cpu/qr.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/qr.cpp
@@ -68,7 +68,6 @@ void qrSingle(NDArray* matrix, NDArray* Q, NDArray* R, bool const fullMatricies)
   for (sd::LongType k = 0; k < N && k < M - 1; k++) {  // loop for columns, but not further then row number
     e.nullify();
     z = matrixMinor<T>(z, k);  // minor computing for current column with given matrix z (initally is a input matrix)
-                               //            z.printIndexedBuffer("Minor!!!");
 
     auto currentColumn = z({0, 0, k, k + 1});  // retrieve k column from z to x buffer
     auto norm = currentColumn.reduceAlongDimension(reduce::Norm2, {0});
@@ -77,7 +76,7 @@ void qrSingle(NDArray* matrix, NDArray* Q, NDArray* R, bool const fullMatricies)
     // e.t<T>(k) = T(1.f); // e - is filled by 0 vector except diagonal element (filled by 1)
     // auto tE = e;
     // tE *= norm;
-    //            norm.printIndexedBuffer("Norm!!!");
+
     e.p(k, norm);
     e += currentColumn;  //  e += tE; // e[i] = x[i] + a * e[i] for each i from 0 to n - 1
     auto normE = e.reduceAlongDimension(reduce::Norm2, {0});

--- a/libnd4j/include/ops/declarable/helpers/cpu/top_k.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/top_k.cpp
@@ -48,9 +48,7 @@ static sd::Status topKFunctor_(const NDArray* input, NDArray* values, NDArray* i
   if (k == 1) {
     for (sd::LongType e = 0; e < numOfSubArrs; ++e) {
       auto trial = (*input)(e, dimsToExclude);
-      // int maxPos = //lastDimList->at(e)->argMax();
       sd::LongType maxPos = 0;
-      // trial.printIndexedBuffer("TRIAL:");
       T maxVal = trial.e<T>(0);
       for (sd::LongType pos = 1; pos < trial.lengthOf(); pos++)
         if (maxVal < trial.e<T>(pos)) {
@@ -124,7 +122,6 @@ static sd::Status topKFunctor_(const NDArray* input, NDArray* values, NDArray* i
       if (values) (*values)(e, dimsToExclude).assign(topValues);
       if (indices) (*indices)(e, dimsToExclude).assign(topIndices);
     }
-    // indices->printIndexedBuffer("Indices as is");
   }
   return sd::Status::OK;
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/histogram.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/histogram.cu
@@ -132,8 +132,6 @@ void histogramHelper(sd::LaunchContext *context, NDArray &input, NDArray &output
 
   auto min_val = input.reduceNumber(reduce::SameOps::Min);
   auto max_val = input.reduceNumber(reduce::SameOps::Max);
-  //                min_val.printIndexedBuffer("MIN");
-  //                max_val.printIndexedBuffer("MAX");
   BUILD_DOUBLE_SELECTOR(
       input.dataType(), output.dataType(), histogram_,
       (context, input.specialBuffer(), input.shapeInfo(), input.specialShapeInfo(), output.specialBuffer(),

--- a/libnd4j/include/ops/declarable/helpers/cuda/lup.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/lup.cu
@@ -729,21 +729,16 @@ static sd::Status inverse_(sd::LaunchContext *context, NDArray *input, NDArray *
                                                      matrix.specialBuffer(), matrix.specialShapeInfo(), n);
     lower.tickWriteDevice();
     upper.tickWriteDevice();
-    //                lower.printIndexedBuffer("LOWER");
-    //                upper.printIndexedBuffer("UPPER");
+
     matrix.assign(0);
     invertUpperMatrix(context, &upper, &matrix);  // U^{-1}
     matrix.tickWriteDevice();
-    //                matrix.printIndexedBuffer("Upper Inverted");
     compound.assign(0);
     invertLowerMatrix(context, &lower, &compound);  // L{-1}
     compound.tickWriteDevice();
-    //                compound.printIndexedBuffer("Lower Inverted");
-    //                matrix.tickWriteDevice();
-    //                compound.tickWriteDevice();
+
     sd::MmulHelper::mmul(&matrix, &compound, &upper, 1.0, 0.0);
     upper.tickWriteDevice();
-    //                upper.printIndexedBuffer("Full inverted");
     returnMatrix<T><<<1, n2, 1024, *stream>>>(output->specialBuffer(), output->specialShapeInfo(),
                                               upper.specialBuffer(), upper.specialShapeInfo(), i * n2, n);
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/random.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/random.cu
@@ -192,7 +192,6 @@ static void fillRandomGamma_(LaunchContext* context, graph::RandomGenerator& rng
   // fill up uniform with given length
   RandomLauncher::fillUniform(context, rng, &uniform, 0.0000000001, 0.9999999999);
   uniform.syncToDevice();
-  //        uniform.printIndexedBuffer("Uniform");
   fillGammaKernel<T><<<128, 128, 256, *stream>>>(
       uniform.dataBuffer()->specialAsT<T>(), shift, copyAlpha->dataBuffer()->specialAsT<T>(),
       copyAlpha->specialShapeInfo(), beta ? copyBeta->dataBuffer()->specialAsT<T>() : (T const*)nullptr,

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceBoolOp.cpp
@@ -106,11 +106,10 @@ sd::Status LegacyReduceBoolOp::validateAndExecute(Context& block) {
     auto indices = INPUT_VARIABLE(1);
     if (indices->lengthOf() == x->rankOf()) allAxes = true;
 
-    // indices->printIndexedBuffer("indices");
 
     std::vector<int> dims(indices->lengthOf());
     for (sd::LongType e = 0; e < indices->lengthOf(); e++) {
-      // lol otherwise we segfault on macOS
+      //segfault on macOS
       int f = indices->e<int>(e);
       dims[e] = f >= 0 ? f : f += x->rankOf();
     }

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceFloatOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceFloatOp.cpp
@@ -102,11 +102,10 @@ sd::Status LegacyReduceFloatOp::validateAndExecute(Context& block) {
     auto indices = INPUT_VARIABLE(1);
     if (indices->lengthOf() == x->rankOf()) allAxes = true;
 
-    // indices->printIndexedBuffer("indices");
 
     std::vector<int> dims(indices->lengthOf());
     for (int e = 0; e < indices->lengthOf(); e++) {
-      // lol otherwise we segfault on macOS
+      // segfault on macOS if not like this
       int f = indices->e<int>(e);
       dims[e] = f >= 0 ? f : f += x->rankOf();
     }

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceLongOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceLongOp.cpp
@@ -107,11 +107,10 @@ sd::Status LegacyReduceLongOp::validateAndExecute(Context& block) {
     auto indices = INPUT_VARIABLE(1);
     if (indices->lengthOf() == x->rankOf()) allAxes = true;
 
-    // indices->printIndexedBuffer("indices");
 
     std::vector<int> dims(indices->lengthOf());
     for (int e = 0; e < indices->lengthOf(); e++) {
-      // lol otherwise we segfault on macOS
+      // segfault on macOS if not like this
       int f = indices->e<int>(e);
       dims[e] = f >= 0 ? f : f += x->rankOf();
     }

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceOp.cpp
@@ -78,8 +78,6 @@ sd::Status LegacyReduceOp::validateAndExecute(Context &block) {
     auto indices = INPUT_VARIABLE(1);
     if (indices->lengthOf() == x->rankOf()) allAxes = true;
 
-    // indices->printIndexedBuffer("indices");
-
     std::vector<int> axis(indices->lengthOf());
     for (int e = 0; e < indices->lengthOf(); e++) {
       // lol otherwise we segfault on macOS
@@ -94,7 +92,6 @@ sd::Status LegacyReduceOp::validateAndExecute(Context &block) {
       auto s = x->shapeInfo();
       auto e = block.numT() > 0 ? block.getTArguments()->data() : nullptr;
 
-      // x->printIndexedBuffer("x");
 
       // scalar
       NativeOpExcutioner::execReduceFloatScalar(opNum, b, s, e, z->buffer(), z->shapeInfo());

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceSameOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceSameOp.cpp
@@ -105,11 +105,10 @@ sd::Status LegacyReduceSameOp::validateAndExecute(Context& block) {
     auto indices = INPUT_VARIABLE(1);
     if (indices->lengthOf() == x->rankOf()) allAxes = true;
 
-    // indices->printIndexedBuffer("indices");
 
     std::vector<int> dims(indices->lengthOf());
     for (int e = 0; e < indices->lengthOf(); e++) {
-      // lol otherwise we segfault on macOS
+      // segfault on macOS if not like this
       int f = indices->e<int>(e);
       dims[e] = f >= 0 ? f : f += x->rankOf();
     }

--- a/libnd4j/tests_cpu/layers_tests/BroadcastableOpsTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/BroadcastableOpsTests.cpp
@@ -41,7 +41,6 @@ TEST_F(BroadcastableOpsTests, Test_Add_1) {
   y.linspace(1);
   exp.linspace(1);
 
-  // exp.printIndexedBuffer("E B");
 
   exp.applyBroadcast(broadcast::Add, {1}, y, exp);
 
@@ -52,8 +51,6 @@ TEST_F(BroadcastableOpsTests, Test_Add_1) {
 
   auto z = result.at(0);
 
-  // exp.printIndexedBuffer("E A");
-  // z->printIndexedBuffer("Z");
 
   ASSERT_TRUE(exp.isSameShape(z));
   ASSERT_TRUE(exp.equalsTo(z));
@@ -516,7 +513,6 @@ TEST_F(BroadcastableOpsTests, broadcast_equals_1) {
 
   sd::ops::equals op;
   auto status = op.execute({&x, &y}, {&z});
-  // z.printIndexedBuffer();
 
   ASSERT_EQ(sd::Status::OK, status);
   ASSERT_TRUE(z.equalsTo(exp));
@@ -684,7 +680,6 @@ TEST_F(BroadcastableOpsTests, broadcast_bool_1) {
 
   ASSERT_EQ(sd::Status::OK, status);
 
-  // z.printIndexedBuffer("Z");
 
   ASSERT_TRUE(z.isSameShape(e));
   ASSERT_TRUE(z.equalsTo(e));
@@ -706,7 +701,6 @@ TEST_F(BroadcastableOpsTests, broadcast_bool_2) {
 
   ASSERT_EQ(sd::Status::OK, status);
 
-  // z.printIndexedBuffer("Z");
 
   ASSERT_TRUE(z.isSameShape(e));
   ASSERT_TRUE(z.equalsTo(e));
@@ -725,7 +719,6 @@ TEST_F(BroadcastableOpsTests, broadcast_bool_3) {
 
   ASSERT_EQ(sd::Status::OK, status);
 
-  // z.printIndexedBuffer("Z");
 
   ASSERT_TRUE(z.isSameShape(e));
   ASSERT_TRUE(z.equalsTo(e));
@@ -747,7 +740,6 @@ TEST_F(BroadcastableOpsTests, broadcast_2) {
 
   ASSERT_EQ(sd::Status::OK, status);
 
-  // z.printIndexedBuffer("Z");
 
   ASSERT_TRUE(z.isSameShape(e));
   ASSERT_TRUE(z.equalsTo(e));
@@ -764,7 +756,6 @@ TEST_F(BroadcastableOpsTests, broadcast_3) {
 
   ASSERT_EQ(sd::Status::OK, status);
 
-  // z.printIndexedBuffer("Z");
 
   ASSERT_TRUE(z.isSameShape(e));
   ASSERT_TRUE(z.equalsTo(e));
@@ -780,22 +771,9 @@ TEST_F(BroadcastableOpsTests, test_bert_multiply_1) {
   y.assign(1.f);
   z.assign(119.f);
   e.assign(0.f);
-  /*
-      Context ctx(1);
-      ctx.setInputArray(0, &x);
-      ctx.setInputArray(1, &y);
-      ctx.setOutputArray(0, &z);
-
-      sd::ops::multiply op;
-      auto status = op.execute(&ctx);
-      ASSERT_EQ(sd::Status::OK, status);
-
-      z.printIndexedBuffer();
-  */
 
   x.applyTrueBroadcast(BroadcastOpsTuple::Multiply(), y, z);
 
-  // z.printIndexedBuffer();
 
   ASSERT_EQ(e, z);
 }

--- a/libnd4j/tests_cpu/layers_tests/ConstantShapeHelperTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ConstantShapeHelperTests.cpp
@@ -180,7 +180,6 @@ TEST_F(ConstantShapeHelperTests, basic_test_7) {
   auto strided = array->subarray(indices);
   strided.assign(1.0f);
 
-  // strided->printIndexedBuffer("column");
 
   delete array;
 }

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
@@ -404,14 +404,6 @@ TEST_F(DeclarableOpsTests1, TestTensorDot8) {
 
 ////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, TestTensorDot9) {
-  // NDArray z('f',{2,2,3}, sd::DataType::DOUBLE);
-  // z.linspace(1);
-  // z.printShapeInfo();
-  // z.printIndexedBuffer();
-  // z.reshapei('c', {4,3});
-  // z.printShapeInfo();
-  // z.printIndexedBuffer();
-
   auto x = NDArrayFactory::create<double>(
       'f', {2, 3, 4}, {1, 3, 5, 7, 9, 11, 13, 15, 1, 3, 5, 7, 9, 11, 13, 15, 1, 3, 5, 7, 9, 11, 13, 15});
   auto y = NDArrayFactory::create<double>(
@@ -2113,38 +2105,7 @@ TEST_F(DeclarableOpsTests1, Pnormpool2d1) {
   delete block;
 }
 
-/*/////////////////////////////////////////////////////////////////////
-TEST_F(DeclarableOpsTests1, IsMax1) {
 
-    float xBuff[]   = {1,2,3,4,5,6,7,8,9};
-    sd::LongType xShape[]    = {2,3,3,3,1,0,1,99};
-    bool expBuff[] = {0,0,1,0,0,1,0,0,1};
-    ArrayOptions::setDataType(xShape, sd::DataType::BOOL);
-
-    auto x = new NDArray(xBuff, xShape);
-    NDArray exp(expBuff, xShape);
-
-    auto variableSpace = new VariableSpace();
-    variableSpace->putVariable(-1, x);
-
-    auto block = new Context(1, variableSpace, false);
-    block->fillInputs({-1});
-    std::vector<int>* argI = block->getIArguments();
-//    *argI = {1};                                        // dimensions
-    argI->push_back(1); // = {1};                                        // dimensions
-
-    sd::ops::ismax ismaxOp;
-    sd::Status status = ismaxOp.execute(block);
-    ASSERT_EQ(sd::Status::OK, status);
-
-    auto result = variableSpace->getVariable(block->getNodeId())->getNDArray();
-    result->printIndexedBuffer("IS_MAX");
-    ASSERT_TRUE(exp.equalsTo(result));
-
-    delete variableSpace;
-    delete block;
-}
-*/
 
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, IsMax1) {
@@ -2162,7 +2123,6 @@ TEST_F(DeclarableOpsTests1, IsMax1) {
   ASSERT_EQ(sd::Status::OK, result.status());
 
   auto res = result.at(0);
-  // res->printIndexedBuffer("IS_MAX");
   ASSERT_TRUE(exp.equalsTo(res));
 }
 
@@ -2182,7 +2142,6 @@ TEST_F(DeclarableOpsTests1, IsMax2) {
   ASSERT_EQ(sd::Status::OK, result.status());
 
   auto res = result.at(0);
-  // res->printIndexedBuffer("IS_MAX");
   ASSERT_TRUE(exp.equalsTo(res));
 }
 
@@ -2192,9 +2151,6 @@ TEST_F(DeclarableOpsTests1, IsMax3) {
                                                      //    NDArray exp('c', {3, 3}, sd::DataType::BOOL);
   NDArray exp = NDArrayFactory::create<float>(1.f);  //, sd::DataType::FLOAT32); //'c', {3, 3}, sd::DataType::FLOAT32);
   x.linspace(1);
-  // exp.p<bool>(0, 2, true);
-  // exp.p<bool>(1, 2, true);
-  // exp.p<bool>(2, 2, true);
 
   sd::ops::ismax ismaxOp;
   auto result = ismaxOp.evaluate({&x}, {}, {0});
@@ -2202,7 +2158,6 @@ TEST_F(DeclarableOpsTests1, IsMax3) {
   ASSERT_EQ(sd::Status::OK, result.status());
 
   auto res = result.at(0);
-  // res->printIndexedBuffer("IS_MAX");
   ASSERT_TRUE(exp.equalsTo(res));
 }
 
@@ -2220,44 +2175,6 @@ TEST_F(DeclarableOpsTests1, IsMax4) {
 }
 
 ////////////////////////////////////////////////////////////////////
-// TEST_F(DeclarableOpsTests1, sru_old_test1) {
-
-//     const int bS = 2;
-//     const int K = 3;
-//     const int N = 4;
-
-//     NDArray input('c', {bS,K,N}, sd::DataType::DOUBLE);
-//     NDArray weights('c', {3*K,K}, sd::DataType::DOUBLE);
-//     NDArray bias('c', {1,2*K}, sd::DataType::DOUBLE);
-//     NDArray init('c', {bS,K}, sd::DataType::DOUBLE);
-//     NDArray mask('c', {bS,K}, sd::DataType::DOUBLE);
-//     NDArray expState('c', {bS,K,N}, {0.847983, 0.874549, 0.896109, 0.913715, 0.847983, 0.874549, 0.896109, 0.913715,
-//     0.847983, 0.874549, 0.896109, 0.913715, 0.847983, 0.874549, 0.896109, 0.913715, 0.847983, 0.874549, 0.896109,
-//     0.913715, 0.847983, 0.874549, 0.896109, 0.913715}, sd::DataType::DOUBLE); NDArray expOut('c', {bS,K,N},
-//     {1.090533, 1.174509, 1.252403, 1.324656, 1.090533, 1.174509, 1.252403, 1.324656, 1.090533, 1.174509, 1.252403, 1.324656,
-//     1.090533, 1.174509, 1.252403, 1.324656, 1.090533, 1.174509, 1.252403, 1.324656, 1.090533, 1.174509, 1.252403, 1.324656},
-//     sd::DataType::DOUBLE);
-
-//     input.assign(1.5);
-//     weights.assign(0.5);
-//     bias.assign(0.3) ;
-//     init.assign(1.);
-//     mask.assign(1.);
-
-//     sd::ops::sru_old op;
-//     auto  results = op.execute({&input, &weights, &bias, &init, &mask}, {}, {});
-//     ASSERT_TRUE(results.size() == 2);
-
-//     auto state  = results.at(0);
-//     auto output = results.at(1);
-//     // state->printBuffer();
-//     // expState.printIndexedBuffer("EXP STATE");
-//     // state->printIndexedBuffer("OUT STATE");
-//     ASSERT_TRUE(expState.equalsTo(state));
-//     ASSERT_TRUE(expOut.equalsTo(output));
-
-//
-// }
 
 //////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests1, sru_test1) {
@@ -2694,7 +2611,6 @@ TEST_F(DeclarableOpsTests1, OneHotTests_3) {
 
   auto z = result.at(0);
 
-  // z->printIndexedBuffer("z");
 
   ASSERT_TRUE(exp.isSameShape(z));
   ASSERT_TRUE(exp.equalsTo(z));
@@ -2793,7 +2709,6 @@ TEST_F(DeclarableOpsTests1, Test_Range_Integer_1) {
   ASSERT_EQ(1, result.size());
 
   auto array = result.at(0);
-  // array->printIndexedBuffer("Range integer 1");
   ASSERT_TRUE(exp.isSameShape(array));
   ASSERT_TRUE(exp.equalsTo(array));
 }

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
@@ -106,9 +106,6 @@ TEST_F(DeclarableOpsTests3, Test_Unique_1) {
 
   auto v = result.at(0);
   auto i = result.at(1);
-  // v->printIndexedBuffer("Values");
-  // i->printIndexedBuffer("Indices");
-  // i->printShapeInfo("Indices shape");
   ASSERT_TRUE(expV.isSameShape(v));
   ASSERT_TRUE(expV.equalsTo(v));
 
@@ -132,12 +129,7 @@ TEST_F(DeclarableOpsTests3, Test_Unique_2) {
   auto i = result.at(1);
   auto c = result.at(2);
 
-  // v->printShapeInfo();
-  // v->printIndexedBuffer("Values");
-  // i->printShapeInfo();
-  // i->printIndexedBuffer("Indices");
-  // c->printShapeInfo();
-  // c->printIndexedBuffer("Counts");
+
 
   ASSERT_TRUE(expV.isSameShape(v));
   ASSERT_TRUE(expV.equalsTo(v));
@@ -180,11 +172,7 @@ TEST_F(DeclarableOpsTests3, Test_Norm_1) {
   auto result1 = op.evaluate({&x}, {1.}, {1});
   ASSERT_EQ(result1.status(), sd::Status::OK);
   auto z1 = result1.at(0);
-  // z1->printIndexedBuffer("Z1");
   auto exp1 = x.reduceAlongDimension(reduce::Norm2, dims);
-  // exp1.printIndexedBuffer("EXP1");
-  // z1->printShapeInfo("Z1 shape");
-  // exp1.printShapeInfo("EXP1 shape");
   ASSERT_TRUE(exp1.isSameShape(z1));
   ASSERT_TRUE(exp1.equalsTo(z1));
 
@@ -425,10 +413,6 @@ TEST_F(DeclarableOpsTests3, Test_Batched_Gemm_1) {
 
   for (int e = 0; e < 3; e++) {
     auto z = result.at(e);
-
-    //        exp->printIndexedBuffer("e");
-    //        z->printIndexedBuffer("z");
-
     ASSERT_TRUE(exp->isSameShape(z));
     ASSERT_TRUE(exp->equalsTo(z));
   }
@@ -453,8 +437,6 @@ TEST_F(DeclarableOpsTests3, Test_Batched_Gemm_2) {
   for (int e = 0; e < 3; e++) {
     auto z = result.at(e);
 
-    // exp->printIndexedBuffer("e");
-    // z->printIndexedBuffer("z");
 
     ASSERT_TRUE(exp->isSameShape(z));
     ASSERT_TRUE(exp->equalsTo(z));

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests4.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests4.cpp
@@ -459,10 +459,6 @@ TYPED_TEST(TypedDeclarableOpsTests4, avgpool2d_10) {
   ASSERT_EQ(sd::Status::OK, result.status());
 
   auto z = result.at(0);
-
-  // z->printIndexedBuffer("z");
-  // exp.printIndexedBuffer("e");
-
   ASSERT_TRUE(exp.isSameShape(z));
   ASSERT_TRUE(exp.equalsTo(z));
 }
@@ -562,10 +558,6 @@ TEST_F(DeclarableOpsTests4, avgpool2d_12) {
   auto output = results.at(0);
 
   ASSERT_EQ(sd::Status::OK, results.status());
-
-  // output->printIndexedBuffer("output");
-  // expected.printIndexedBuffer("expected");
-
   ASSERT_TRUE(expected.isSameShape(output));
   ASSERT_TRUE(expected.equalsTo(output));
 }
@@ -716,10 +708,6 @@ TEST_F(DeclarableOpsTests4, avgpool2d_16) {
   auto status = op.execute({&input}, {&output}, {}, {kH, kW, sH, sW, pH, pW, dH, dW, paddingMode, 0, dataFormat}, {});
 
   ASSERT_EQ(sd::Status::OK, status);
-
-  // output.printBuffer();
-  // expected.printIndexedBuffer("expected");
-
   ASSERT_TRUE(expected.equalsTo(output));
 }
 

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests7.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests7.cpp
@@ -468,8 +468,6 @@ TEST_F(DeclarableOpsTests7, TestRandomCrop_1) {
 
   auto result = op.evaluate({&x, &shape}, {}, {});
   ASSERT_EQ(result.status(), sd::Status::OK);
-  // result.at(0)->printIndexedBuffer("Output");
-  //    ASSERT_TRUE(z.equalsTo(result.at(0)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3676,7 +3674,6 @@ TEST_F(DeclarableOpsTests7, percentile_test11) {
   auto input = NDArrayFactory::create<double>('c', {dim0}, {100.});
 
   auto expected = NDArrayFactory::create<double>('c', {1}, {100.});
-
   sd::ops::percentile op;
   // q,  interpolation, keepDims
   auto result = op.evaluate({&input}, {10, 2, 1}, {0});

--- a/libnd4j/tests_cpu/layers_tests/EmptyTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/EmptyTests.cpp
@@ -94,9 +94,6 @@ TEST_F(EmptyTests, Test_Concat_2) {
 
   auto z = result.at(0);
 
-  //    z->printShapeInfo("z shape");
-  //    z->printIndexedBuffer("z buffr");
-
   ASSERT_EQ(exp, *z);
 
   delete empty;

--- a/libnd4j/tests_cpu/layers_tests/HelpersTests2.cpp
+++ b/libnd4j/tests_cpu/layers_tests/HelpersTests2.cpp
@@ -56,10 +56,17 @@ TEST_F(HelpersTests2, Hessenberg_1) {
 TEST_F(HelpersTests2, Hessenberg_2) {
   NDArray x('c', {2, 2}, {1.5, -2, 17, 5}, sd::DataType::DOUBLE);
   NDArray expQ('c', {2, 2}, {1, 0, 0, 1}, sd::DataType::DOUBLE);
-
   ops::helpers::Hessenberg<double> hess(x);
 
-  // hess._H.printBuffer();
+
+
+  x.printIndexedBuffer("expected x");
+  hess._H.printIndexedBuffer("output h");
+
+
+  expQ.printIndexedBuffer("expected q");
+  hess._Q.printIndexedBuffer("output q");
+
 
   ASSERT_TRUE(hess._H.isSameShape(&x));
   ASSERT_TRUE(hess._H.equalsTo(&x));

--- a/libnd4j/tests_cpu/layers_tests/JavaInteropTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/JavaInteropTests.cpp
@@ -552,8 +552,7 @@ nullptr, 0, exp, 11, nullptr, 0, false);
     }
     m /= c;
 
-    //z.printIndexedBuffer("z buffer", 100);
-    //m.printIndexedBuffer("m buffer", 100);
+
     int cnt = 0;
     int lim = 10;
     for (int e = 0; e < z.lengthOf() && cnt < lim; e++) {

--- a/libnd4j/tests_cpu/layers_tests/ListOperationsTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ListOperationsTests.cpp
@@ -383,9 +383,6 @@ TEST_F(ListOperationsTests, BasicTest_Gather_1) {
 
   ASSERT_TRUE(exp.isSameShape(z));
 
-  // exp.printIndexedBuffer("e");
-  // z->printIndexedBuffer("z");
-
   ASSERT_TRUE(exp.equalsTo(z));
 }
 

--- a/libnd4j/tests_cpu/layers_tests/NDArrayTests2.cpp
+++ b/libnd4j/tests_cpu/layers_tests/NDArrayTests2.cpp
@@ -364,7 +364,6 @@ TEST_F(NDArrayTest2, tileToShape_test3) {
   auto exp = NDArrayFactory::create<double>('c', {2, 2, 2}, {1, 2, 3, 4, 1, 2, 3, 4});
 
   x.tileToShape({2, 2, 2}, result);
-  // result.printIndexedBuffer();
 
   ASSERT_TRUE(result.isSameShape(&exp));
   ASSERT_TRUE(result.equalsTo(&exp));
@@ -552,9 +551,7 @@ TEST_F(NDArrayTest2, Test_PermuteEquality_5) {
 TEST_F(NDArrayTest2, fillAsTriangular_test1) {
   auto x = NDArrayFactory::create<double>('c', {4, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
   auto exp = NDArrayFactory::create<double>('c', {4, 4}, {1, 0, 0, 0, 5, 6, 0, 0, 9, 10, 11, 0, 13, 14, 15, 16});
-
-  x.fillAsTriangular<double>(0., 0, 0, x, 'u');
-
+  x.fillAsTriangular<double>(0., 0, 0, x, 'u',false);
   ASSERT_TRUE(exp.isSameShape(&x));
   ASSERT_TRUE(exp.equalsTo(&x));
 }
@@ -575,7 +572,7 @@ TEST_F(NDArrayTest2, fillAsTriangular_test3) {
   auto x = NDArrayFactory::create<double>('c', {4, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
   auto exp = NDArrayFactory::create<double>('c', {4, 4}, {1, 2, 3, 4, 0, 6, 7, 8, 0, 0, 11, 12, 0, 0, 0, 16});
 
-  x.fillAsTriangular<double>(0., 0, 0, x, 'l');
+  x.fillAsTriangular<double>(0., 0, 0, x, 'l',false);
 
   ASSERT_TRUE(exp.isSameShape(&x));
   ASSERT_TRUE(exp.equalsTo(&x));
@@ -739,9 +736,6 @@ TEST_F(NDArrayTest2, allTensorsAlongDimension_test1) {
   auto exp = NDArrayFactory::create<double>('c', {4}, {1, 2, 3, 4});
 
   auto set = x.allTensorsAlongDimension({0});
-  // set->at(0)->printShapeInfo();
-  // set->at(0)->printIndexedBuffer();
-
   ASSERT_TRUE(set.size() == 1);
   ASSERT_TRUE(exp.isSameShape(set.at(0)));
   ASSERT_TRUE(exp.equalsTo(set.at(0)));
@@ -1144,10 +1138,6 @@ TEST_F(NDArrayTest2, trueBroadcast_1) {
 
   auto exp = x - y;
   x.applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), y, z);
-
-  // exp.printIndexedBuffer();
-  // z.printIndexedBuffer();
-
   ASSERT_TRUE(exp.equalsTo(z));
 }
 
@@ -1174,10 +1164,6 @@ TEST_F(NDArrayTest2, reduce_1) {
     }
   }
 
-  // arr6s->printShapeInfo();
-  // exp.printShapeInfo();
-  // exp.printIndexedBuffer();
-  // arr6s->printIndexedBuffer();
 
   ASSERT_TRUE(exp.equalsTo(arr6s));
 }
@@ -1227,10 +1213,8 @@ TEST_F(NDArrayTest2, test_subarray_followed_by_reshape_1) {
 
   auto s = x({2, 3, 0, 0, 0, 0});
 
-  // s.printIndexedBuffer("s");
 
   auto r = s.reshape(x.ordering(), {1, 3});
-  // r.printIndexedBuffer("r");
 
   ASSERT_EQ(e, r);
 }

--- a/libnd4j/tests_cpu/layers_tests/RNGTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/RNGTests.cpp
@@ -848,15 +848,12 @@ TEST_F(RNGTests, Test_GammaDistribution_4) {
   ASSERT_EQ(Status::OK, result.status());
 
   auto z = result.at(0);
-  //    z->printIndexedBuffer("Gamma distribution");
   ASSERT_TRUE(exp0.isSameShape(z));
   ASSERT_FALSE(exp0.equalsTo(z));
   sd::ops::reduce_mean testOps1;
   sd::ops::reduce_variance testOps2;
   auto testRes1 = testOps1.evaluate({z});
   auto testRes2 = testOps2.evaluate({z});
-  //    testRes1[0]->printBuffer("Mean (expected 1.0)");
-  //    testRes2[0]->printBuffer("Variance (expected 0.5)");
   ASSERT_NEAR(testRes1[0]->t<float>(0), 1.0f, 0.01);
   ASSERT_NEAR(testRes2[0]->t<float>(0), 0.5f, 0.02);
 }
@@ -875,16 +872,12 @@ TEST_F(RNGTests, Test_GammaDistribution_5) {
   ASSERT_EQ(Status::OK, result.status());
 
   auto z = result.at(0);
-  //    z->printIndexedBuffer("Gamma distribution");
   ASSERT_TRUE(exp0.isSameShape(z));
   ASSERT_FALSE(exp0.equalsTo(z));
-  //    z->printIndexedBuffer("Gamma distributed");
   sd::ops::reduce_mean testOps1;
   sd::ops::reduce_variance testOps2;
   auto testRes1 = testOps1.evaluate({z});
   auto testRes2 = testOps2.evaluate({z});
-  //    testRes1[0]->printBuffer("Mean (expected 0.1)");
-  //    testRes2[0]->printBuffer("Variance (expected 0.05)");
   ASSERT_NEAR(testRes1[0]->t<float>(0), 0.1f, 0.02);
   ASSERT_NEAR(testRes2[0]->t<float>(0), 0.05f, 0.02);
 }
@@ -1016,7 +1009,6 @@ TEST_F(RNGTests, Test_Uniform_4) {
 
   /* Check up distribution */
   auto mean = x1.reduceNumber(reduce::Mean);
-  // mean.printIndexedBuffer("Mean should be 1.5");
   auto sumA = x1 - mean;  //.reduceNumber(reduce::Sum);
 
   auto deviation = x1.varianceNumber(variance::SummaryStatsVariance, false);

--- a/libnd4j/tests_cpu/layers_tests/SortCudaTests.cu
+++ b/libnd4j/tests_cpu/layers_tests/SortCudaTests.cu
@@ -82,7 +82,6 @@ TEST_F(SortCudaTests, test_linear_sort_by_val_2) {
               v.specialBuffer(), v.specialShapeInfo(), true);
   k.tickWriteDevice();
   v.tickWriteDevice();
-  // k.printIndexedBuffer("KEYS");
   ASSERT_EQ(ek, k);
   ASSERT_EQ(ev, v);
 }
@@ -105,9 +104,6 @@ TEST_F(SortCudaTests, test_tad_sort_by_key_1) {
                v.specialBuffer(), v.specialShapeInfo(), &axis, 1, false);
   k.tickWriteDevice();
   v.tickWriteDevice();
-
-  // k.printIndexedBuffer("k");
-  // v.printIndexedBuffer("v");
 
   ASSERT_EQ(ek, k);
   ASSERT_EQ(ev, v);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
@@ -140,8 +140,6 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
     public void release(@NonNull INDArray array) {
         //Check for multiple releases of the array
         long id = array.getId();
-        if(!lruCache.contains(id))
-            return;
         Preconditions.checkState(!lruCache.contains(id), "Array was released multiple times: id=%s, shape=%ndShape", id, array);
 
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
@@ -1073,6 +1073,10 @@ public static final int
 // #include <atomic>
 // #include <stdexcept>
 // #include <vector>
+// #include <config.h>
+
+// #ifndef __JAVACPP_HACK__
+// #endif
 @Namespace("sd") @NoOffset public static class Environment extends Pointer {
     static { Loader.load(); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
@@ -1155,6 +1159,11 @@ public static final int
   public native int blasPatchVersion();
 
   public native @StdVector Pair capabilities();
+
+  public native @Cast("char*") String getVedaDeviceDir();
+
+  public native void setVedaDeviceDir(@StdString BytePointer dir);
+  public native void setVedaDeviceDir(@StdString String dir);
 }
   // namespace sd
 
@@ -3150,6 +3159,9 @@ public native int optimalLevel();
 
 public native @Cast("bool") boolean isMinimalRequirementsMet();
 public native @Cast("bool") boolean isOptimalRequirementsMet();
+
+public native void setVedaDeviceLibFolder(@StdString BytePointer path);
+public native void setVedaDeviceLibFolder(@StdString String path);
 
 // #endif  // NATIVEOPERATIONS_NATIVEOPS_H
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
@@ -4247,10 +4247,19 @@ public static final int
   public native @ByVal NDArray dup(byte newOrder/*='a'*/);
   public native @ByVal NDArray dup();
 
+
+
   /**
    *  returns sum of all elements of array
    */
   public native @ByVal NDArray sumNumber();
+
+
+  /**
+   *  returns prod of all elements of array
+   */
+  public native @ByVal NDArray prodNumber();
+
 
   /**
    *  returns mean number of array


### PR DESCRIPTION
## What changes were proposed in this pull request?

More tests fixes. All libnd4j tests pass now.
Also fixes up SVD related bugs due to a missing op call update to fillTriangular

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
