### PR TITLE
Build fixes

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,4 +5,9 @@
         <artifactId>project-settings-extension</artifactId>
         <version>0.2.3</version>
     </extension>
+    <extension>
+        <groupId>fish.payara.maven.extensions</groupId>
+        <artifactId>regex-profile-activator</artifactId>
+        <version>0.2</version>
+    </extension>
 </extensions>

--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -59,6 +59,8 @@
         <libnd4j.datatypes></libnd4j.datatypes>
         <libnd4j.sanitize>OFF</libnd4j.sanitize>
         <libnd4j.arch></libnd4j.arch>
+        <openblas.artifactId></openblas.artifactId>
+        <openblas.classifier></openblas.classifier>
     </properties>
 
     <build>
@@ -95,8 +97,9 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.bytedeco</groupId>
-                        <artifactId>openblas-platform</artifactId>
+                        <artifactId>${openblas.artifactId}</artifactId>
                         <version>${openblas.version}-${javacpp-presets.version}</version>
+                        <classifier>${openblas.classifier}</classifier>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -226,6 +229,35 @@
     </build>
 
     <profiles>
+
+        <profile>
+            <id>compat-profile</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.extension</name>
+                    <!-- Using the maven build extension (see ./mvn/extensions.xml) use regex to check for any value that isn't empty-->
+                    <value>/.+/</value>
+                </property>
+            </activation>
+            <properties>
+                <openblas.artifactid>openblas-platform</openblas.artifactid>
+                <openblas.classifier></openblas.classifier>
+
+            </properties>
+        </profile>
+        <profile>
+            <id>default-javacpp</id>
+            <activation>
+                <property>
+                    <name>!javacpp.platform.extension</name>
+                </property>
+            </activation>
+            <properties>
+                <openblas.artifactId>openblas</openblas.artifactId>
+                <openblas.classifier>${javacpp.platform}</openblas.classifier>
+            </properties>
+        </profile>
+
         <!-- Build on windows can use sh rather than bash due to WSL clashing with msys2 -->
         <profile>
             <id>build-windows</id>

--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -240,8 +240,8 @@
                 </property>
             </activation>
             <properties>
-                <openblas.artifactId>openblas-platform</openblas.artifactId>
-                <openblas.classifier></openblas.classifier>
+                <openblas.artifactId>openblas</openblas.artifactId>
+                <openblas.classifier>${javacpp.platform}</openblas.classifier>
 
             </properties>
         </profile>
@@ -253,8 +253,7 @@
                 </property>
             </activation>
             <properties>
-                <openblas.artifactId>openblas</openblas.artifactId>
-                <openblas.classifier>${javacpp.platform}</openblas.classifier>
+                <openblas.artifactId>openblas-platform</openblas.artifactId>
             </properties>
         </profile>
 

--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -240,7 +240,7 @@
                 </property>
             </activation>
             <properties>
-                <openblas.artifactid>openblas-platform</openblas.artifactid>
+                <openblas.artifactId>openblas-platform</openblas.artifactId>
                 <openblas.classifier></openblas.classifier>
 
             </properties>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-aurora/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-aurora/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+0<?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-aurora/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-aurora/pom.xml
@@ -1,4 +1,4 @@
-0<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -376,7 +376,8 @@
             <activation>
                 <property>
                     <name>javacpp.platform.extension</name>
-                    <value>compat</value>
+                    <!-- Using the maven build extension (see ./mvn/extensions.xml) use regex to check for any value that isn't empty-->
+                    <value>/.+/</value>
                 </property>
             </activation>
             <dependencies>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -55,22 +55,7 @@
             <groupId>org.bytedeco</groupId>
             <artifactId>javacpp</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.bytedeco</groupId>
-            <artifactId>javacpp</artifactId>
-            <classifier>${dependency.platform}</classifier>
-        </dependency>
-        <dependency>
-            <groupId>org.bytedeco</groupId>
-            <artifactId>openblas</artifactId>
-            <version>${openblas.version}-${javacpp-presets.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bytedeco</groupId>
-            <artifactId>openblas</artifactId>
-            <version>${openblas.version}-${javacpp-presets.version}</version>
-            <classifier>${dependency.platform}</classifier>
-        </dependency>
+
         <dependency>
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-api</artifactId>
@@ -385,6 +370,63 @@
     </build>
 
     <profiles>
+        <!-- profile only enabled for compat which does not have a matching classifier for dependencies-->
+        <profile>
+            <id>compat-profile</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.extension</name>
+                    <value>compat</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>javacpp</artifactId>
+                    <classifier>linux-x86_64</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>openblas</artifactId>
+                    <version>${openblas.version}-${javacpp-presets.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>openblas</artifactId>
+                    <version>${openblas.version}-${javacpp-presets.version}</version>
+                    <classifier>linux-x86_64</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>default-javacpp</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.extension</name>
+                    <value>!compat</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>javacpp</artifactId>
+                    <classifier>${dependency.platform}</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>openblas</artifactId>
+                    <version>${openblas.version}-${javacpp-presets.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>openblas</artifactId>
+                    <version>${openblas.version}-${javacpp-presets.version}</version>
+                    <classifier>${dependency.platform}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+
+
         <profile>
             <!-- This causes build failure on osx due to memory issues. For now, just skip this since we publish javadoc from other platforms fine.-->
             <id>skip-javadoc-on-osx</id>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -384,7 +384,7 @@
                 <dependency>
                     <groupId>org.bytedeco</groupId>
                     <artifactId>javacpp</artifactId>
-                    <classifier>linux-x86_64</classifier>
+                    <version>${javacpp.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.bytedeco</groupId>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -402,8 +402,7 @@
             <id>default-javacpp</id>
             <activation>
                 <property>
-                    <name>javacpp.platform.extension</name>
-                    <value>!compat</value>
+                    <name>!javacpp.platform.extension</name>
                 </property>
             </activation>
             <dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix github actions builds:
Javacpp classifier extensions were being propagated to openblas dependencies causing it to not find the dependencies with classifiers. This ensures that based on whether an extension is defined or not it omits the extension as part of the classifier for the openblas dependency.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
