### PR TITLE
Add missing ops to sd.linalg(), fixes #9592

### DIFF
--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Linalg.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Linalg.kt
@@ -199,6 +199,24 @@ fun Linalg() =  Namespace("Linalg") {
         }
     }
 
+
+
+
+    Op("matrixDeterminant") {
+        javaPackage = "org.nd4j.linalg.api.ops.impl.transforms.custom"
+        javaOpClass = "MatrixDeterminant"
+
+        Input(DataType.NUMERIC, "input") {"Input tensor"}
+        Output(FLOATING_POINT, "output")
+
+        Doc(Language.ANY, DocScope.ALL){
+            """
+             Calculates matrix determinant.
+            """.trimIndent()
+        }
+    }
+
+
     Op("logdet") {
         javaPackage = "org.nd4j.linalg.api.ops.custom"
         javaOpClass = "Logdet"
@@ -209,6 +227,22 @@ fun Linalg() =  Namespace("Linalg") {
         Doc(Language.ANY, DocScope.ALL){
             """
              Calculates log of determinant.
+            """.trimIndent()
+        }
+    }
+
+
+    Op("eig") {
+        javaPackage = "org.nd4j.linalg.eigen"
+        javaOpClass = "Eigen"
+
+        Input(DataType.NUMERIC, "input") {"Input tensor"}
+        Output(FLOATING_POINT, "eigenValues")
+        Output(FLOATING_POINT, "eigenVectors")
+
+        Doc(Language.ANY, DocScope.ALL){
+            """
+             Calculates eigen values
             """.trimIndent()
         }
     }
@@ -242,7 +276,7 @@ fun Linalg() =  Namespace("Linalg") {
 
         Output(FLOATING_POINT, "output")
 
-        Doc(Language.ANY, DocScope.ALL){
+        Doc(Language.ANY, DocScope.ALL) {
             """
              An array with ones at and below the given diagonal and zeros elsewhere.
             """.trimIndent()

--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Linalg.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Linalg.kt
@@ -231,10 +231,24 @@ fun Linalg() =  Namespace("Linalg") {
         }
     }
 
+    Op("matrixInverse") {
+        javaPackage = "org.nd4j.linalg.api.ops.impl.transforms.custom"
+        javaOpClass = "MatrixInverse"
+
+        Input(DataType.NUMERIC, "input") {"Input tensor"}
+        Output(FLOATING_POINT, "output")
+
+        Doc(Language.ANY, DocScope.ALL){
+            """
+             Inverts a matrix
+            """.trimIndent()
+        }
+    }
+
 
     Op("eig") {
-        javaPackage = "org.nd4j.linalg.eigen"
-        javaOpClass = "Eigen"
+        javaPackage = "org.nd4j.linalg.api.ops.custom"
+        javaOpClass = "Eig"
 
         Input(DataType.NUMERIC, "input") {"Input tensor"}
         Output(FLOATING_POINT, "eigenValues")

--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
@@ -1245,6 +1245,20 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         }
     }
 
+
+    Op("flatten") {
+        javaPackage = "org.nd4j.linalg.api.ops.custom"
+        javaOpClass = "Flatten"
+        val inputs = Input(NDARRAY, "inputs") {count = AtLeast(1); description = "Input variables" }
+        Arg(STRING, "order") { description = "ordering for the variable"; defaultValue = "\"c\"" }
+        Output(NUMERIC, "output"){ description = "Output variable" }
+        Doc(Language.ANY, DocScope.ALL){
+            """
+             Return a flattened variable with the specified ordering
+            """.trimIndent()
+        }
+    }
+
     Op("reshape") {
         javaPackage = "org.nd4j.linalg.api.ops.impl.shape"
         Input(NDARRAY, "x") { description = "Input variable" }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
@@ -291,28 +291,6 @@ public class SDBaseOps {
   }
 
   /**
-   * Asserts the input array is true for all elements. <br>
-   *
-   * @param x A boolean array to assert the state of (NDARRAY type)
-   * @return output The state to assert (NUMERIC type)
-   */
-  public SDVariable assertOp(SDVariable x) {
-    return new org.nd4j.linalg.api.ops.impl.transforms.Assert(sd,x).outputVariable();
-  }
-
-  /**
-   * Asserts the input array is true for all elements. <br>
-   *
-   * @param name name May be null. Name for the output variable
-   * @param x A boolean array to assert the state of (NDARRAY type)
-   * @return output The state to assert (NUMERIC type)
-   */
-  public SDVariable assertOp(String name, SDVariable x) {
-    SDVariable out =  new org.nd4j.linalg.api.ops.impl.transforms.Assert(sd,x).outputVariable();
-    return sd.updateVariableNameAndReference(out, name);
-  }
-
-  /**
    * Assign the contents of y to x.<br>
    * Y must be broadcastable to x or the same shape.<br>
    *
@@ -1072,30 +1050,6 @@ public class SDBaseOps {
   public SDVariable fill(String name, SDVariable shape, DataType dataType, double value) {
     SDValidation.validateInteger("fill", "shape", shape);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.transforms.custom.Fill(sd,shape, dataType, value).outputVariable();
-    return sd.updateVariableNameAndReference(out, name);
-  }
-
-  /**
-   * Returns a flattened 1d array with the length of the input.<br>
-   *
-   * @param input Input variable (NDARRAY type)
-   * @param order ordering of the array
-   * @return output outputs the 1d array with a length equal to the input's length (NDARRAY type)
-   */
-  public SDVariable flatten(SDVariable input, String order) {
-    return new org.nd4j.linalg.api.ops.custom.Flatten(sd,input, order).outputVariable();
-  }
-
-  /**
-   * Returns a flattened 1d array with the length of the input.<br>
-   *
-   * @param name name May be null. Name for the output variable
-   * @param input Input variable (NDARRAY type)
-   * @param order ordering of the array
-   * @return output outputs the 1d array with a length equal to the input's length (NDARRAY type)
-   */
-  public SDVariable flatten(String name, SDVariable input, String order) {
-    SDVariable out =  new org.nd4j.linalg.api.ops.custom.Flatten(sd,input, order).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
 
@@ -4088,10 +4042,11 @@ public class SDBaseOps {
   /**
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
-   * @param input Input variable (NDARRAY type)
+   * @param input Input variable (NUMERIC type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public SDVariable shape(SDVariable input) {
+    SDValidation.validateNumerical("shape", "input", input);
     return new org.nd4j.linalg.api.ops.impl.shape.Shape(sd,input).outputVariable();
   }
 
@@ -4099,10 +4054,11 @@ public class SDBaseOps {
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
    * @param name name May be null. Name for the output variable
-   * @param input Input variable (NDARRAY type)
+   * @param input Input variable (NUMERIC type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public SDVariable shape(String name, SDVariable input) {
+    SDValidation.validateNumerical("shape", "input", input);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.Shape(sd,input).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
@@ -4110,10 +4066,11 @@ public class SDBaseOps {
   /**
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public SDVariable size(SDVariable in) {
+    SDValidation.validateNumerical("size", "in", in);
     return new org.nd4j.linalg.api.ops.impl.shape.Size(sd,in).outputVariable();
   }
 
@@ -4121,10 +4078,11 @@ public class SDBaseOps {
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
    * @param name name May be null. Name for the output variable
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public SDVariable size(String name, SDVariable in) {
+    SDValidation.validateNumerical("size", "in", in);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.Size(sd,in).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
@@ -4133,11 +4091,12 @@ public class SDBaseOps {
    * Returns a rank 0 (scalar) variable for the size of the specified dimension.<br>
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public SDVariable sizeAt(SDVariable in, int dimension) {
+    SDValidation.validateNumerical("sizeAt", "in", in);
     return new org.nd4j.linalg.api.ops.impl.shape.SizeAt(sd,in, dimension).outputVariable();
   }
 
@@ -4146,11 +4105,12 @@ public class SDBaseOps {
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
    * @param name name May be null. Name for the output variable
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public SDVariable sizeAt(String name, SDVariable in, int dimension) {
+    SDValidation.validateNumerical("sizeAt", "in", in);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.SizeAt(sd,in, dimension).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
@@ -1054,6 +1054,56 @@ public class SDBaseOps {
   }
 
   /**
+   * Return a flattened variable with the specified ordering<br>
+   *
+   * @param inputs Input variables (NDARRAY type)
+   * @param order ordering for the variable
+   * @return output Output variable (NUMERIC type)
+   */
+  public SDVariable flatten(SDVariable[] inputs, String order) {
+    Preconditions.checkArgument(inputs.length >= 1, "inputs has incorrect size/length. Expected: inputs.length >= 1, got %s", inputs.length);
+    return new org.nd4j.linalg.api.ops.custom.Flatten(sd,inputs, order).outputVariable();
+  }
+
+  /**
+   * Return a flattened variable with the specified ordering<br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param inputs Input variables (NDARRAY type)
+   * @param order ordering for the variable
+   * @return output Output variable (NUMERIC type)
+   */
+  public SDVariable flatten(String name, SDVariable[] inputs, String order) {
+    Preconditions.checkArgument(inputs.length >= 1, "inputs has incorrect size/length. Expected: inputs.length >= 1, got %s", inputs.length);
+    SDVariable out =  new org.nd4j.linalg.api.ops.custom.Flatten(sd,inputs, order).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
+   * Return a flattened variable with the specified ordering<br>
+   *
+   * @param inputs Input variables (NDARRAY type)
+   * @return output Output variable (NUMERIC type)
+   */
+  public SDVariable flatten(SDVariable... inputs) {
+    Preconditions.checkArgument(inputs.length >= 1, "inputs has incorrect size/length. Expected: inputs.length >= 1, got %s", inputs.length);
+    return new org.nd4j.linalg.api.ops.custom.Flatten(sd,inputs, "c").outputVariable();
+  }
+
+  /**
+   * Return a flattened variable with the specified ordering<br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param inputs Input variables (NDARRAY type)
+   * @return output Output variable (NUMERIC type)
+   */
+  public SDVariable flatten(String name, SDVariable... inputs) {
+    Preconditions.checkArgument(inputs.length >= 1, "inputs has incorrect size/length. Expected: inputs.length >= 1, got %s", inputs.length);
+    SDVariable out =  new org.nd4j.linalg.api.ops.custom.Flatten(sd,inputs, "c").outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
    * Gather slices from the input variable where the indices are specified as fixed int[] values.<br>
    * Output shape is same as input shape, except for axis dimension, which has size equal to indices.length.<br>
    *

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDLinalg.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDLinalg.java
@@ -414,6 +414,28 @@ public class SDLinalg extends SDOps {
   }
 
   /**
+   * Calculates eigen values<br>
+   *
+   * @param input  (NUMERIC type)
+   */
+  public SDVariable[] eig(SDVariable input) {
+    SDValidation.validateNumerical("eig", "input", input);
+    return new org.nd4j.linalg.api.ops.custom.Eig(sd,input).outputVariables();
+  }
+
+  /**
+   * Calculates eigen values<br>
+   *
+   * @param names names May be null. Arrays of names for the output variables.
+   * @param input  (NUMERIC type)
+   */
+  public SDVariable[] eig(String[] names, SDVariable input) {
+    SDValidation.validateNumerical("eig", "input", input);
+    SDVariable[] out =  new org.nd4j.linalg.api.ops.custom.Eig(sd,input).outputVariables();
+    return sd.updateVariableNamesAndReferences(out, names);
+  }
+
+  /**
    * Calculates log of determinant.<br>
    *
    * @param input  (NUMERIC type)
@@ -434,6 +456,54 @@ public class SDLinalg extends SDOps {
   public SDVariable logdet(String name, SDVariable input) {
     SDValidation.validateNumerical("logdet", "input", input);
     SDVariable out =  new org.nd4j.linalg.api.ops.custom.Logdet(sd,input).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
+   * Calculates matrix determinant.<br>
+   *
+   * @param input  (NUMERIC type)
+   * @return output  (FLOATING_POINT type)
+   */
+  public SDVariable matrixDeterminant(SDVariable input) {
+    SDValidation.validateNumerical("matrixDeterminant", "input", input);
+    return new org.nd4j.linalg.api.ops.impl.transforms.custom.MatrixDeterminant(sd,input).outputVariable();
+  }
+
+  /**
+   * Calculates matrix determinant.<br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param input  (NUMERIC type)
+   * @return output  (FLOATING_POINT type)
+   */
+  public SDVariable matrixDeterminant(String name, SDVariable input) {
+    SDValidation.validateNumerical("matrixDeterminant", "input", input);
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.transforms.custom.MatrixDeterminant(sd,input).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
+   * Inverts a matrix<br>
+   *
+   * @param input  (NUMERIC type)
+   * @return output  (FLOATING_POINT type)
+   */
+  public SDVariable matrixInverse(SDVariable input) {
+    SDValidation.validateNumerical("matrixInverse", "input", input);
+    return new org.nd4j.linalg.api.ops.impl.transforms.custom.MatrixInverse(sd,input).outputVariable();
+  }
+
+  /**
+   * Inverts a matrix<br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param input  (NUMERIC type)
+   * @return output  (FLOATING_POINT type)
+   */
+  public SDVariable matrixInverse(String name, SDVariable input) {
+    SDValidation.validateNumerical("matrixInverse", "input", input);
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.transforms.custom.MatrixInverse(sd,input).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Eig.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Eig.java
@@ -1,0 +1,72 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.linalg.api.ops.custom;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+
+import java.util.List;
+
+public class Eig extends DynamicCustomOp {
+
+    public Eig(SameDiff sameDiff, SDVariable arg) {
+        super(sameDiff, arg);
+    }
+
+    public Eig(SameDiff sameDiff, SDVariable[] args) {
+        super(null, sameDiff, args);
+    }
+
+
+
+    public Eig(INDArray[] inputs, INDArray[] outputs, List<Double> tArguments, int[] iArguments) {
+        super(null, inputs, outputs, tArguments, iArguments);
+    }
+
+    public Eig(INDArray[] inputs, INDArray[] outputs, List<Double> tArguments, List<Integer> iArguments) {
+        super(null, inputs, outputs, tArguments, iArguments);
+    }
+
+    public Eig(INDArray[] inputs, INDArray[] outputs) {
+        super(null, inputs, outputs);
+    }
+
+    public Eig(INDArray input) {
+        this(new INDArray[]{input},null);
+    }
+
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> f1) {
+        throw new UnsupportedOperationException("Derivative of op Eig not supported");
+    }
+
+    @Override
+    public String opName() {
+        return "eig";
+    }
+
+
+
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Flatten.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Flatten.java
@@ -68,6 +68,16 @@ public class Flatten extends DynamicCustomOp {
         addIArgument(order.charAt(0));
     }
 
+    public Flatten(INDArray[] inputs, String order) {
+        super(inputs,null);
+        addIArgument(order.charAt(0));
+    }
+
+    public Flatten(SameDiff sd, SDVariable[] inputs, String order) {
+        super(sd,inputs,false);
+        addIArgument(order.charAt(0));
+    }
+
     @Override
     public String opName() {
         return "flatten";

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/floating/SqrtM.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/floating/SqrtM.java
@@ -1,0 +1,74 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.linalg.api.ops.impl.transforms.floating;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.BaseTransformFloatOp;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SqrtM extends DynamicCustomOp {
+
+    public SqrtM(SameDiff sameDiff, SDVariable arg) {
+        super(sameDiff, arg);
+    }
+
+    public SqrtM(SameDiff sameDiff, SDVariable[] args) {
+        super(null, sameDiff, args);
+    }
+
+
+
+    public SqrtM(INDArray[] inputs, INDArray[] outputs, List<Double> tArguments, int[] iArguments) {
+        super(null, inputs, outputs, tArguments, iArguments);
+    }
+
+    public SqrtM( INDArray[] inputs, INDArray[] outputs, List<Double> tArguments, List<Integer> iArguments) {
+        super(null, inputs, outputs, tArguments, iArguments);
+    }
+
+    public SqrtM( INDArray[] inputs, INDArray[] outputs) {
+        super(null, inputs, outputs);
+    }
+
+    public SqrtM(INDArray input) {
+        this(new INDArray[]{input},null);
+    }
+
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> f1) {
+        throw new UnsupportedOperationException("Derivative of op SqrtM not supported");
+    }
+
+    @Override
+    public String opName() {
+        return "sqrtm";
+    }
+
+
+
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/eigen/Eigen.java
@@ -29,6 +29,7 @@ public class Eigen {
 
     public static INDArray dummy = Nd4j.scalar(1);
 
+
     /**
      * Compute generalized eigenvalues of the problem A x = L x.
      * Matrix A is modified in the process, holding eigenvectors after execution.

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -119,6 +119,14 @@ public class Nd4j {
      * Bitwise namespace - operations related to bitwise manipulation of arrays
      */
     public static final NDBitwise bitwise = new NDBitwise();
+
+
+    /**
+     * Bitwise namespace - operations related to bitwise manipulation of arrays
+     */
+    public static final NDLinalg linalg = new NDLinalg();
+
+
     /**
      * Math namespace - general mathematical operations
      */
@@ -166,6 +174,13 @@ public class Nd4j {
         return math;
     }
 
+
+    /**
+     * Linalg namespace - operations related to linear algebra (lapack operations)
+     */
+    public static NDLinalg linalg() { return linalg; }
+
+
     /**
      * Random namespace - (pseudo) random number generation methods
      */
@@ -183,7 +198,7 @@ public class Nd4j {
     /**
      * Loss function namespace - operations related to loss functions.
      */
-    public static NDLoss loss(){ return loss; }
+    public static NDLoss loss() { return loss; }
 
     /**
      * Convolutional network namespace - operations related to convolutional neural networks

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
@@ -157,16 +157,6 @@ public class NDBase {
   }
 
   /**
-   * Asserts the input array is true for all elements. <br>
-   *
-   * @param x A boolean array to assert the state of (NDARRAY type)
-   * @return output The state to assert (NUMERIC type)
-   */
-  public INDArray assertOp(INDArray x) {
-    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.transforms.Assert(x))[0];
-  }
-
-  /**
    * Assign the contents of y to x.<br>
    * Y must be broadcastable to x or the same shape.<br>
    *
@@ -520,17 +510,6 @@ public class NDBase {
   public INDArray fill(INDArray shape, DataType dataType, double value) {
     NDValidation.validateInteger("fill", "shape", shape);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.transforms.custom.Fill(shape, dataType, value))[0];
-  }
-
-  /**
-   * Returns a flattened 1d array with the length of the input.<br>
-   *
-   * @param input Input variable (NDARRAY type)
-   * @param order ordering of the array
-   * @return output outputs the 1d array with a length equal to the input's length (NDARRAY type)
-   */
-  public INDArray flatten(INDArray input, String order) {
-    return Nd4j.exec(new org.nd4j.linalg.api.ops.custom.Flatten(input, order))[0];
   }
 
   /**
@@ -1936,20 +1915,22 @@ public class NDBase {
   /**
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
-   * @param input Input variable (NDARRAY type)
+   * @param input Input variable (NUMERIC type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public INDArray shape(INDArray input) {
+    NDValidation.validateNumerical("shape", "input", input);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.Shape(input))[0];
   }
 
   /**
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public INDArray size(INDArray in) {
+    NDValidation.validateNumerical("size", "in", in);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.Size(in))[0];
   }
 
@@ -1957,11 +1938,12 @@ public class NDBase {
    * Returns a rank 0 (scalar) variable for the size of the specified dimension.<br>
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public INDArray sizeAt(INDArray in, int dimension) {
+    NDValidation.validateNumerical("sizeAt", "in", in);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.SizeAt(in, dimension))[0];
   }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
@@ -513,6 +513,29 @@ public class NDBase {
   }
 
   /**
+   * Return a flattened variable with the specified ordering<br>
+   *
+   * @param inputs Input variables (NDARRAY type)
+   * @param order ordering for the variable
+   * @return output Output variable (NUMERIC type)
+   */
+  public INDArray flatten(INDArray[] inputs, String order) {
+    Preconditions.checkArgument(inputs.length >= 1, "inputs has incorrect size/length. Expected: inputs.length >= 1, got %s", inputs.length);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.custom.Flatten(inputs, order))[0];
+  }
+
+  /**
+   * Return a flattened variable with the specified ordering<br>
+   *
+   * @param inputs Input variables (NDARRAY type)
+   * @return output Output variable (NUMERIC type)
+   */
+  public INDArray flatten(INDArray... inputs) {
+    Preconditions.checkArgument(inputs.length >= 1, "inputs has incorrect size/length. Expected: inputs.length >= 1, got %s", inputs.length);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.custom.Flatten(inputs, "c"))[0];
+  }
+
+  /**
    * Gather slices from the input variable where the indices are specified as fixed int[] values.<br>
    * Output shape is same as input shape, except for axis dimension, which has size equal to indices.length.<br>
    *

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDLinalg.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDLinalg.java
@@ -208,6 +208,16 @@ public class NDLinalg {
   }
 
   /**
+   * Calculates eigen values<br>
+   *
+   * @param input  (NUMERIC type)
+   */
+  public INDArray[] eig(INDArray input) {
+    NDValidation.validateNumerical("eig", "input", input);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.custom.Eig(input));
+  }
+
+  /**
    * Calculates log of determinant.<br>
    *
    * @param input  (NUMERIC type)
@@ -216,6 +226,28 @@ public class NDLinalg {
   public INDArray logdet(INDArray input) {
     NDValidation.validateNumerical("logdet", "input", input);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.custom.Logdet(input))[0];
+  }
+
+  /**
+   * Calculates matrix determinant.<br>
+   *
+   * @param input  (NUMERIC type)
+   * @return output  (FLOATING_POINT type)
+   */
+  public INDArray matrixDeterminant(INDArray input) {
+    NDValidation.validateNumerical("matrixDeterminant", "input", input);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.transforms.custom.MatrixDeterminant(input))[0];
+  }
+
+  /**
+   * Inverts a matrix<br>
+   *
+   * @param input  (NUMERIC type)
+   * @return output  (FLOATING_POINT type)
+   */
+  public INDArray matrixInverse(INDArray input) {
+    NDValidation.validateNumerical("matrixInverse", "input", input);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.transforms.custom.MatrixInverse(input))[0];
   }
 
   /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/inverse/InvertMatrix.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/inverse/InvertMatrix.java
@@ -39,7 +39,7 @@ public class InvertMatrix {
      * @return the inverted matrix
      */
     public static INDArray invert(INDArray arr, boolean inPlace) {
-        if(arr.rank() == 2 && arr.length() == 1){
+        if(arr.rank() == 2 && arr.length() == 1) {
             //[1,1] edge case. Matrix inversion: [x] * [1/x] = [1]
             if(inPlace){
                 return arr.rdivi(1.0);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/inverse/InvertMatrix.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/inverse/InvertMatrix.java
@@ -27,6 +27,7 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.SingularMatrixException;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.checkutil.CheckUtil;
+import org.nd4j.linalg.factory.Nd4j;
 
 public class InvertMatrix {
 
@@ -50,22 +51,8 @@ public class InvertMatrix {
             throw new IllegalArgumentException("invalid array: must be square matrix");
         }
 
-        //FIX ME: Please
-       /* int[] IPIV = new int[arr.length() + 1];
-        int LWORK = arr.length() * arr.length();
-        INDArray WORK = Nd4j.create(new double[LWORK]);
-        INDArray inverse = inPlace ? arr : arr.dup();
-        Nd4j.getBlasWrapper().lapack().getrf(arr);
-        Nd4j.getBlasWrapper().lapack().getri(arr.size(0),inverse,arr.size(0),IPIV,WORK,LWORK,0);*/
 
-        RealMatrix rm = CheckUtil.convertToApacheMatrix(arr);
-        RealMatrix rmInverse = new LUDecomposition(rm).getSolver().getInverse();
-
-
-        INDArray inverse = CheckUtil.convertFromApacheMatrix(rmInverse, arr.dataType());
-        if (inPlace)
-            arr.assign(inverse);
-        return inverse;
+        return Nd4j.linalg().matrixInverse(arr);
 
     }
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/inverse/TestInvertMatrices.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/inverse/TestInvertMatrices.java
@@ -201,7 +201,7 @@ public class TestInvertMatrices extends BaseNd4jTestWithBackends {
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testRightPseudoInvertWithNonFullRowRank(Nd4jBackend backend) {
-        assertThrows(IllegalArgumentException.class,() -> {
+        assertThrows(RuntimeException.class,() -> {
             INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 6}, {5, 10}}).transpose();
             INDArray rightInverse = InvertMatrix.pRightInvert(X, false);
         });
@@ -214,7 +214,7 @@ public class TestInvertMatrices extends BaseNd4jTestWithBackends {
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testLeftPseudoInvertWithNonFullColumnRank(Nd4jBackend backend) {
-        assertThrows(IllegalArgumentException.class,() -> {
+        assertThrows(RuntimeException.class,() -> {
             INDArray X = Nd4j.create(new double[][]{{1, 2}, {3, 6}, {5, 10}});
             INDArray leftInverse = InvertMatrix.pLeftInvert(X, false);
         });


### PR DESCRIPTION
Fixes #9592 


## What changes were proposed in this pull request?

Adds missing ops to NDMath/SDMath namespace to conform with blas/lapack standards.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
