### PR TITLE
Add caching for dependency tracker

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/SDValue.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/SDValue.java
@@ -22,6 +22,7 @@ package org.nd4j.autodiff.samediff.config;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
@@ -38,6 +39,15 @@ import java.util.*;
 @Getter
 @EqualsAndHashCode
 public class SDValue {
+
+
+    private static Map<INDArray,SDValue> values = new LinkedHashMap<>();
+    private static Map<Collection<INDArray>,SDValue> listValues = new LinkedHashMap<>();
+
+
+    private static Map<Map<String,INDArray>,SDValue> dictValues = new LinkedHashMap<>();
+
+   
 
     private SDValueType sdValueType;
     private INDArray tensorValue;
@@ -89,8 +99,8 @@ public class SDValue {
      * @return
      */
     public List<INDArray> getListValue() {
-       if(tensorValue != null)
-           return Arrays.asList(tensorValue);
+        if(tensorValue != null)
+            return Arrays.asList(tensorValue);
         return listValue;
     }
 
@@ -101,9 +111,13 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(INDArray inputValue) {
+        if(values.containsKey(inputValue))
+            return values.get(inputValue);
+
         SDValue sdValue = new SDValue();
         sdValue.tensorValue = inputValue;
         sdValue.sdValueType = SDValueType.TENSOR;
+        values.put(inputValue,sdValue);
         return sdValue;
     }
 
@@ -115,9 +129,12 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(Collection<INDArray> inputValue) {
+        if(listValues.containsKey(inputValue))
+            return listValues.get(inputValue);
         SDValue sdValue = new SDValue();
         sdValue.listValue = (List<INDArray>) inputValue;
         sdValue.sdValueType = SDValueType.LIST;
+        listValues.put(inputValue,sdValue);
         return sdValue;
     }
 
@@ -128,9 +145,12 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(List<INDArray> inputValue) {
+        if(listValues.containsKey(inputValue))
+            return listValues.get(inputValue);
         SDValue sdValue = new SDValue();
         sdValue.listValue = inputValue;
         sdValue.sdValueType = SDValueType.LIST;
+        listValues.put(inputValue,sdValue);
         return sdValue;
     }
 
@@ -141,9 +161,12 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(Map<String,INDArray> inputValue) {
+        if(dictValues.containsKey(inputValue))
+            return dictValues.get(inputValue);
         SDValue sdValue = new SDValue();
         sdValue.dictValue = inputValue;
         sdValue.sdValueType = SDValueType.DICT;
+        dictValues.put(inputValue,sdValue);
         return sdValue;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/IdentityDependencyTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/IdentityDependencyTracker.java
@@ -40,7 +40,7 @@ public class IdentityDependencyTracker<T, D> extends AbstractDependencyTracker<T
 
     @Override
     protected String toStringT(T t) {
-        if(t instanceof INDArray){
+        if(t instanceof INDArray) {
             INDArray i = (INDArray)t;
             return System.identityHashCode(t) + " - id=" + i.getId() + ", " + i.shapeInfoToString();
         } else {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -359,8 +359,6 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
 
             if (OUTER_FRAME.equals(outputFrameIter.getFrame()) && allReqVariables.contains(name)) {
                 //This variable is an output, record that in the array use tracker, so we don't deallocate it
-                //TODO: figure out why name of step dependency is not consistent with list input
-                //TODO: we could skil this but it's useful to know how to associate the step with
                 //the specific value here
                 addToArrayTracker(out,i,new ReqOutputDep(name));
             } else if ((inputsForOps == null || inputsForOps.isEmpty()) && out.getValueOutputs() != null && !arrayUseTracker.hasDependency(out.valueWithKeyAtIndex(i,false))) {
@@ -373,7 +371,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                 }
 
                 if(array != null && array.getTensorValue() != null)
-                    mmgr.release(array.getTensorValue() );
+                    mmgr.release(array.getTensorValue());
             } else if ((inputsForOps == null || inputsForOps.isEmpty()) && out.getOutputs() != null && !arrayUseTracker.hasDependency(SDValue.create(out.resultAt(i)))) {
                 //This particular array is not actually needed anywhere, so we can deallocate in immediately
                 //Possibly only a control dependency, or only one of the outputs of a multi-output op is used
@@ -383,7 +381,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                         log.trace("Found array id {} (output of {}) not required anywhere, deallocating", array.getId(), o.getName());
                 }
 
-                if(array != null && array != null)
+                if(array != null)
                     mmgr.release(array);
             }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds caching for dependency tracker and SDValue so that values are consistent when using the same ndarray references.

This will allow inference session to better release memory even with the new SDValue based architecture.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
