### PR TITLE
Update cuda builds

### DIFF
--- a/.github/actions/remove-unneeded-tools-linux/action.yml
+++ b/.github/actions/remove-unneeded-tools-linux/action.yml
@@ -12,7 +12,7 @@ runs:
            sudo rm -rf /usr/local/share/gecko_driver*
            sudo rm -rf /usr/local/lib/lein*
            sudo rm -rf /usr/share/miniconda*
-           sudo apt remove -y apache2-bin* azure-cli dotnet-* ghc-* google-cloud-sdk* heroku* libboost-* libmono-* libobjc-* moby-* mono-* mysql* postgresql* r-* ruby* sqlite3* swig*
+           sudo apt remove -y apache2-bin* azure-cli dotnet-* ghc-* google-cloud-sdk*  libboost-* libmono-* libobjc-* moby-* mono-* mysql* postgresql* r-* ruby* sqlite3* swig*
            sudo apt-get autoclean
            sudo rm -rf "/usr/local/share/boost"
            sudo rm -rf "$AGENT_TOOLSDIRECTORY"

--- a/.github/actions/update-deps-linux/action.yml
+++ b/.github/actions/update-deps-linux/action.yml
@@ -10,7 +10,7 @@ runs:
           sudo apt-get install ca-certificates libgomp1
 
 
-          wget https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
+          wget https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.37.tar.bz2
           tar jxf libgpg-error-1.36.tar.bz2
           cd libgpg-error-1.36
           ./configure

--- a/.github/actions/update-deps-linux/action.yml
+++ b/.github/actions/update-deps-linux/action.yml
@@ -11,8 +11,8 @@ runs:
 
 
           wget https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.37.tar.bz2
-          tar jxf libgpg-error-1.36.tar.bz2
-          cd libgpg-error-1.36
+          tar jxf libgpg-error-1.37.tar.bz2
+          cd libgpg-error-1.37
           ./configure
           make
           sudo make install

--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-22.04
+        default: ubuntu-20.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-20.04
+        default: ubuntu-18.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-20.04
+        default: ubuntu-22.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-18.04
+        default: ubuntu-20.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -147,17 +147,6 @@ jobs:
           path: /opt/cmake
           key: ${{ matrix.runs_on }}-cmake
           restore-keys: ${{ matrix.runs_on }}-cmake
-      - name: Work around cuda caching permissions issue
-        run: |
-              sudo mkdir /usr/local/cuda-11.4 && sudo chmod 755 /usr/local/cuda-11.4
-              sudo mkdir /usr/local/cuda && sudo chmod 755 /usr/local/cuda
-      - name: Cache cuda install
-        uses: actions/cache@v2
-        id: cache-cuda-114
-        with:
-          path: /usr/local/cuda-11.4
-          key: ${{ matrix.runs_on }}-cuda-11.4-${{ matrix.helper }}
-          restore-keys: ${{ matrix.runs_on }}-cuda-11.4-${{ matrix.helper }}
       - name: Cache protobuf install
         uses: actions/cache@v2
         id: cache-protobuf

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -44,7 +44,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-20.04
+        default: ubuntu-22.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -44,7 +44,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-18.04
+        default: ubuntu-20.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -147,6 +147,10 @@ jobs:
           path: /opt/cmake
           key: ${{ matrix.runs_on }}-cmake
           restore-keys: ${{ matrix.runs_on }}-cmake
+      - name: Work around cuda caching permissions issue
+        run: |
+              sudo mkdir /usr/local/cuda-11.4 && chmod 755 /usr/local/cuda-11.4
+              sudo mkdir /usr/local/cuda && chmod 755 /usr/local/cuda
       - name: Cache cuda install
         uses: actions/cache@v2
         id: cache-cuda-114

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -44,7 +44,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-22.04
+        default: ubuntu-20.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -44,7 +44,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-20.04
+        default: ubuntu-18.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -149,8 +149,8 @@ jobs:
           restore-keys: ${{ matrix.runs_on }}-cmake
       - name: Work around cuda caching permissions issue
         run: |
-              sudo mkdir /usr/local/cuda-11.4 && chmod 755 /usr/local/cuda-11.4
-              sudo mkdir /usr/local/cuda && chmod 755 /usr/local/cuda
+              sudo mkdir /usr/local/cuda-11.4 && sudo chmod 755 /usr/local/cuda-11.4
+              sudo mkdir /usr/local/cuda && sudo chmod 755 /usr/local/cuda
       - name: Cache cuda install
         uses: actions/cache@v2
         id: cache-cuda-114

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-22.04
+        default: ubuntu-20.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-20.04
+        default: ubuntu-18.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -159,6 +159,10 @@ jobs:
         if: steps.cache-protobuf.outputs.cache-hit != 'true'
       - uses: ./.github/actions/install-cmake-linux
         if: steps.cache-cmake.outputs.cache-hit != 'true'
+      - name: Work around cuda caching permissions issue
+        run: |
+             sudo mkdir /usr/local/cuda-11.6 && chmod 755 /usr/local/cuda-11.6
+             sudo mkdir /usr/local/cuda && chmod 755 /usr/local/cuda
       - name: Cache cuda install
         uses: actions/cache@v2
         id:  cache-cuda-116

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-20.04
+        default: ubuntu-22.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -46,7 +46,7 @@ on:
       runsOn:
         description: 'System to run on'
         required: false
-        default: ubuntu-18.04
+        default: ubuntu-20.04
 
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -161,8 +161,8 @@ jobs:
         if: steps.cache-cmake.outputs.cache-hit != 'true'
       - name: Work around cuda caching permissions issue
         run: |
-             sudo mkdir /usr/local/cuda-11.6 && chmod 755 /usr/local/cuda-11.6
-             sudo mkdir /usr/local/cuda && chmod 755 /usr/local/cuda
+             sudo mkdir /usr/local/cuda-11.6 && sudo chmod 755 /usr/local/cuda-11.6
+             sudo mkdir /usr/local/cuda && sudo chmod 755 /usr/local/cuda
       - name: Cache cuda install
         uses: actions/cache@v2
         id:  cache-cuda-116

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -159,17 +159,6 @@ jobs:
         if: steps.cache-protobuf.outputs.cache-hit != 'true'
       - uses: ./.github/actions/install-cmake-linux
         if: steps.cache-cmake.outputs.cache-hit != 'true'
-      - name: Work around cuda caching permissions issue
-        run: |
-             sudo mkdir /usr/local/cuda-11.6 && sudo chmod 755 /usr/local/cuda-11.6
-             sudo mkdir /usr/local/cuda && sudo chmod 755 /usr/local/cuda
-      - name: Cache cuda install
-        uses: actions/cache@v2
-        id:  cache-cuda-116
-        with:
-          path: /usr/local/cuda-11.6
-          key:  ${{ matrix.runs_on }}-cuda-11.6-${{ matrix.helper }}
-          restore-keys: ${{ matrix.runs_on }}-cuda-11.6-${{ matrix.helper }}
       - name: Set up Java for publishing to GitHub Packages
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/build-deploy-windows-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.4.yml
@@ -120,7 +120,7 @@ jobs:
                   $modules=":nd4j-cuda-11.4-preset,:nd4j-cuda-11.4,libnd4j"
               }
               
-              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute=\`"5.0 5.2 6.1 7.5 8.6\`" -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute=`"5.0 5.2 6.1 7.5 8.6`" -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
     
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                     $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.4-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"

--- a/.github/workflows/build-deploy-windows-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.4.yml
@@ -120,7 +120,7 @@ jobs:
                   $modules=":nd4j-cuda-11.4-preset,:nd4j-cuda-11.4,libnd4j"
               }
               
-              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute=\\"5.0 5.2 6.1 7.5 8.6\\" -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute=\`"5.0 5.2 6.1 7.5 8.6\`" -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
     
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                     $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.4-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"

--- a/.github/workflows/build-deploy-windows-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.4.yml
@@ -120,7 +120,7 @@ jobs:
                   $modules=":nd4j-cuda-11.4-preset,:nd4j-cuda-11.4,libnd4j"
               }
               
-              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute='5.0 5.2 6.1 7.5 8.6' -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute=\"5.0 5.2 6.1 7.5 8.6\" -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
     
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                     $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.4-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"

--- a/.github/workflows/build-deploy-windows-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.4.yml
@@ -120,7 +120,7 @@ jobs:
                   $modules=":nd4j-cuda-11.4-preset,:nd4j-cuda-11.4,libnd4j"
               }
               
-              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute=\"5.0 5.2 6.1 7.5 8.6\" -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn ${{ matrix.mvn_ext }}  -Pcuda --also-make -pl  $modules -Dlibnd4j.compute=\\"5.0 5.2 6.1 7.5 8.6\\" -Dlibnd4j.cpu.compile.skip=true  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
     
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                     $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.4-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"

--- a/.github/workflows/build-deploy-windows-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.6.yml
@@ -122,7 +122,7 @@ jobs:
                 $modules=":nd4j-cuda-11.6-preset,:nd4j-cuda-11.6,libnd4j"
               }
           
-              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute='5.0 5.2 6.1 7.5 8.6' -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute=\"5.0 5.2 6.1 7.5 8.6\" -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                  $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.6-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
                  $libnd4j_download_file_url="windows-cuda-11.6-${{ matrix.extension }}-${{ matrix.helper }}"

--- a/.github/workflows/build-deploy-windows-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.6.yml
@@ -122,7 +122,7 @@ jobs:
                 $modules=":nd4j-cuda-11.6-preset,:nd4j-cuda-11.6,libnd4j"
               }
           
-              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute=\`"5.0 5.2 6.1 7.5 8.6\`" -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute=`"5.0 5.2 6.1 7.5 8.6`" -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                  $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.6-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
                  $libnd4j_download_file_url="windows-cuda-11.6-${{ matrix.extension }}-${{ matrix.helper }}"

--- a/.github/workflows/build-deploy-windows-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.6.yml
@@ -122,7 +122,7 @@ jobs:
                 $modules=":nd4j-cuda-11.6-preset,:nd4j-cuda-11.6,libnd4j"
               }
           
-              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute=\\"5.0 5.2 6.1 7.5 8.6\\" -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute=\`"5.0 5.2 6.1 7.5 8.6\`" -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                  $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.6-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
                  $libnd4j_download_file_url="windows-cuda-11.6-${{ matrix.extension }}-${{ matrix.helper }}"

--- a/.github/workflows/build-deploy-windows-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.6.yml
@@ -122,7 +122,7 @@ jobs:
                 $modules=":nd4j-cuda-11.6-preset,:nd4j-cuda-11.6,libnd4j"
               }
           
-              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute=\"5.0 5.2 6.1 7.5 8.6\" -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
+              $command="mvn  ${{ matrix.mvn_ext }}   --also-make -pl $modules -Dlibnd4j.compute=\\"5.0 5.2 6.1 7.5 8.6\\" -Dlibnd4j.cpu.compile.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3  -Possrh  -Dlibnd4j.buildthreads=${{ matrix.build_threads }} -Djavacpp.platform=windows-x86_64    -Dlibnd4j.platform=windows-x86_64  -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
               if ( "${{ matrix.helper }}" -ne "" -And "${{ matrix.extension }}" -ne "" ) {
                  $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-cuda-11.6-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}   -Dlibnd4j.helper=${{ matrix.helper }}   -Pcuda -Dlibnd4j.chip=cuda  deploy -DskipTests"
                  $libnd4j_download_file_url="windows-cuda-11.6-${{ matrix.extension }}-${{ matrix.helper }}"

--- a/libnd4j/include/array/cuda/NDArray.cu
+++ b/libnd4j/include/array/cuda/NDArray.cu
@@ -129,7 +129,7 @@ SD_KERNEL static void fillAsTriangularCuda(const void* vx, const sd::LongType* x
 
 ///////////////////////////////////////////////////////////////////
 template <typename T>
-void NDArray::fillAsTriangular(const float val, int lower, int upper, NDArray& target, const char direction) {
+void NDArray::fillAsTriangular(const float val, int lower, int upper, NDArray& target, const char direction,const bool includeEdges) {
   if (isS()) throw std::runtime_error("NDArray::fillAsTriangular: you can't use this method on String array!");
 
   if (!isSameShape(target) &&
@@ -156,7 +156,7 @@ void NDArray::fillAsTriangular(const float val, int lower, int upper, NDArray& t
   manager.synchronize();
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::fillAsTriangular,
-                      (const float val, int lower, int upper, NDArray& target, const char direction), SD_COMMON_TYPES);
+                      (const float val, int lower, int upper, NDArray& target, const char direction,const bool includeEdges), SD_COMMON_TYPES);
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Removes caching (fails due to permissions on cache)
2. Update fillAsTriangular cuda signature for compilation
3. Update cuda windows files to properly escape CC versions
4. Update linux builds to work with ubuntu 20.04
5. Remove deprecated dependencies from linux dependency pruning (saves disk space on cuda builds)



(Please fill in changes proposed in this fix)

## How was this patch tested?

Builds finish but time out. Can vary due to number of threads configured for compilation. 
## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
