### PR TITLE
fix up views in deepelearning4j-nn, fix dup in ndarrayindexall

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -4190,7 +4190,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         int outIdx = 0;     //Axis number counter for output array
         int inIdx = 0;      //Axis number counter for input array
         for( int i = 0; i < indexes.length; i++) {
-            if(offset >= length() || inIdx >= rank()) {
+            if(i > 0 && offset >= length() || inIdx >= rank()) {
                 if(offset >= length())
                     return Nd4j.empty();
                 else {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/NDArrayIndexAll.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/NDArrayIndexAll.java
@@ -40,10 +40,23 @@ public class NDArrayIndexAll extends IntervalIndex {
     @Override
     public void init(INDArray arr, long begin, int dimension) {
         initialized = true;
-
+        inclusive = false;
         this.begin = 0;
         this.end = arr.size(dimension);
         this.length = (end - begin) / stride + 1;
+    }
+
+    @Override
+    public INDArrayIndex dup() {
+        NDArrayIndexAll all = new NDArrayIndexAll();
+        all.inclusive = this.inclusive;
+        all.begin = this.begin;
+        all.end = this.begin;
+        all.initialized = this.initialized;
+        all.index = this.index;
+        all.length = this.length;
+        all.stride = this.stride;
+        return all;
     }
 
     @Override

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/crash/SpecialTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/crash/SpecialTests.java
@@ -301,7 +301,7 @@ public class SpecialTests extends BaseNd4jTestWithBackends {
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testBroadcastLt2(){
-        for( int i=0; i<10; i++) {
+        for( int i = 0; i < 10; i++) {
             INDArray orig = Nd4j.create(DataType.DOUBLE, 1, 7, 4, 4);
             INDArray y = orig.get(all(), interval(0,2), all(), all());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Misc test fixes:
1. Fixes ndarrayindex all's dup method to return a proper all instance
2. Streamline's deeplearning4j-nn's use of indexing during parameter retrieval
3. Allows views in get(...): the new changes didn't account for views.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
