### PR TITLE
Fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in DL4J. Our goal is to bring fast, open-source deep le
 
 Deeplearning4j's [open issues are here](https://github.com/eclipse/deeplearning4j/issues). In time, we'll tag issues that would make a good first pull request for new contributors. An easy way to get started helping the project is to *file an issue*. You can do that on the Deeplearning4j issues page by clicking on the green button at the right. Issues can include bugs to fix, features to add, or documentation that looks outdated. 
 
-Note that you will need to [build dl4j from source](https://deeplearning4j.org/docs/latest/deeplearning4j-build-from-source)
+Note that you will need to [build dl4j from source](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/build-from-source)
 
 For some tips on contributing to open source, this [post is helpful](https://smartbear.com/blog/test-and-monitor/14-ways-to-contribute-to-open-source-without-being/).
 
@@ -48,4 +48,4 @@ All code in this repository is released under the Apache Software Foundation Lic
 
 ## Eclipse Contributor Agreement and Commit Signing
 
-Please see the following page for details: [https://deeplearning4j.konduit.ai/getting-started/contribute/eclipse-contributors](https://deeplearning4j.konduit.ai/getting-started/contribute/eclipse-contributors)
+Please see the following page for details: [https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors)


### PR DESCRIPTION
Fixes "build from source" and "Eclipse Contributor Agreement" broken links.

## What changes were proposed in this pull request?

The document was updated to fix "build from source" and "Eclipse Contributor Agreement" broken links.

## How was this patch tested?

The new links were obtained from the deeplearning4j.konduit.ai site.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
