### PR TITLE
Fixes https://github.com/eclipse/deeplearning4j/issues/9694

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/indexing/BooleanIndexing.java
@@ -267,7 +267,7 @@ public class BooleanIndexing {
         if (!(condition instanceof BaseCondition))
             throw new UnsupportedOperationException("Only static Conditions are supported");
 
-        Nd4j.getExecutioner().exec(new CompareAndSet(to, set.doubleValue(), condition));
+        Nd4j.getExecutioner().exec(new CompareAndSet(to,set.doubleValue(), condition));
     }
 
     /**

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
@@ -478,6 +478,13 @@ public static final int
 
   public native void setPrimaryBuffer(Pointer buffer, @Cast("size_t") long length);
   public native void setSpecialBuffer(Pointer buffer, @Cast("size_t") long length);
+// #ifndef __JAVACPP_HACK__
+// #endif
+
+  public native void showBufferLimited();
+  //for Debug purposes
+  public native void showCounters(@Cast("char*") String msg1, @Cast("char*") String msg2);
+  public native void showCounters(@Cast("char*") BytePointer msg1, @Cast("char*") BytePointer msg2);
 
   /**
    * This method deletes buffers, if we're owners
@@ -3974,6 +3981,7 @@ public static final int
   public native void syncToDevice();
   public native void syncShape();
 
+
   /**
    * This method can be used on architectures that use special buffers
    * @param writeList
@@ -3993,6 +4001,15 @@ public static final int
                                   @Const @ByRef(nullValue = "std::vector<const sd::NDArray*>{}") ConstNDArrayVector readList, @Cast("bool") boolean synchronizeWritables/*=false*/);
   public native void preparePrimaryUse(@Const @ByRef ConstNDArrayVector writeList);
 
+// #ifndef __JAVACPP_HACK__
+// #if defined(HAVE_VEDA)
+//   static void registerVedaUse(const std::vector<const NDArray *> &writeList,
+//                                  const std::vector<const NDArray *> &readList = {});
+//   static void prepareVedaUse(const std::vector<const NDArray *> &writeList,
+//                                 const std::vector<const NDArray *> &readList = {}, bool synchronizeWritables = false);
+
+// #endif
+// #endif
   /**
    * This method returns buffer pointer offset by given number of elements, wrt own data type
    * @param offset
@@ -9069,9 +9086,6 @@ public static final int
 // #include <system/common.h>
 
 // #include <vector>
-// #if defined(__NEC__)
-public static final int SHAPE_LIST_MAX_SIZE = 64;
-// #endif
 @Namespace("sd") @NoOffset public static class ShapeList extends Pointer {
     static { Loader.load(); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/cache/ConstantBuffersCache.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/cache/ConstantBuffersCache.java
@@ -132,7 +132,7 @@ public class ConstantBuffersCache extends BasicConstantHandler {
         ArrayDescriptor descriptor = new ArrayDescriptor(array, dataType);
 
         if (!buffersCache.containsKey(descriptor)) {
-            DataBuffer buffer = Nd4j.createBufferDetached(array);
+            DataBuffer buffer = Nd4j.createTypedBufferDetached(array,dataType);
 
             if (counter.get() < MAX_ENTRIES) {
                 counter.incrementAndGet();

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/indexing/BooleanIndexingTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/indexing/BooleanIndexingTest.java
@@ -55,6 +55,23 @@ public class BooleanIndexingTest extends BaseNd4jTestWithBackends {
         1D array checks
      */
 
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testDifferentDataType(Nd4jBackend backend) {
+        Nd4j.getExecutioner().enableVerboseMode(true);
+        Nd4j.getExecutioner().enableDebugMode(true);
+        INDArray test =
+                Nd4j.create(new double[] {1.0, 1.0, 2.0, 1.0}, new long[] {2, 2}, DataType.INT32);
+        INDArray intTest = test.dup();
+        BooleanIndexing.replaceWhere(intTest, 0, Conditions.greaterThan(0)); // test not updated
+        assertEquals(Nd4j.zeros(test.shape()).castTo(DataType.INT32),intTest);
+        INDArray testCasted = test.dup().castTo(DataType.FLOAT);
+        BooleanIndexing.replaceWhere(testCasted, 0.0, Conditions.greaterThan(0)); // testCasted is updated
+        assertEquals(Nd4j.zeros(test.shape()).castTo(DataType.FLOAT),test);
+    }
+
+
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testAnd1(Nd4jBackend backend) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes https://github.com/eclipse/deeplearning4j/issues/9694 with extra args and int arguments.
Ensures  properly typed buffers are created when accessing the constant buffer for extra args creation.

Mainly impacts CompareAndSet for BooleanIndexing.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
