### PR TITLE
Add missing `tf.keras` loss functions aliases

### DIFF
--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/config/KerasLayerConfiguration.java
@@ -344,24 +344,32 @@ public class KerasLayerConfiguration {
 
     /* Keras loss functions. */
     private final String KERAS_LOSS_MEAN_SQUARED_ERROR = "mean_squared_error";
+    private final String TF_KERAS_LOSS_MEAN_SQUARED_ERROR = "meansquarederror";
     private final String KERAS_LOSS_MSE = "mse";
     private final String KERAS_LOSS_MEAN_ABSOLUTE_ERROR = "mean_absolute_error";
+    private final String TF_KERAS_LOSS_MEAN_ABSOLUTE_ERROR = "meanabsoluteerror";
     private final String KERAS_LOSS_MAE = "mae";
     private final String KERAS_LOSS_MEAN_ABSOLUTE_PERCENTAGE_ERROR = "mean_absolute_percentage_error";
+    private final String TF_KERAS_LOSS_MEAN_ABSOLUTE_PERCENTAGE_ERROR = "meanabsolutepercentageerror";
     private final String KERAS_LOSS_MAPE = "mape";
     private final String KERAS_LOSS_MEAN_SQUARED_LOGARITHMIC_ERROR = "mean_squared_logarithmic_error";
+    private final String TF_KERAS_LOSS_MEAN_SQUARED_LOGARITHMIC_ERROR = "meansquaredlogarithmicerror";
     private final String KERAS_LOSS_MSLE = "msle";
     private final String KERAS_LOSS_SQUARED_HINGE = "squared_hinge";
+    private final String TF_KERAS_LOSS_SQUARED_HINGE = "squaredhinge";
     private final String KERAS_LOSS_HINGE = "hinge";
     private final String KERAS_LOSS_CATEGORICAL_HINGE = "categorical_hinge"; // keras 2 only
     private final String KERAS_LOSS_BINARY_CROSSENTROPY = "binary_crossentropy";
+    private final String TF_KERAS_LOSS_BINARY_CROSSENTROPY = "binarycrossentropy";
     private final String KERAS_LOSS_CATEGORICAL_CROSSENTROPY = "categorical_crossentropy";
     private final String KERAS_LOSS_SPARSE_CATEGORICAL_CROSSENTROPY = "sparse_categorical_crossentropy";
     private final String TF_KERAS_LOSS_SPARSE_CATEGORICAL_CROSS_ENTROPY = "sparsecategoricalcrossentropy";
     private final String KERAS_LOSS_KULLBACK_LEIBLER_DIVERGENCE = "kullback_leibler_divergence";
+    private final String TF_KERAS_LOSS_KLDIVERGENCE = "kldivergence";
     private final String KERAS_LOSS_KLD = "kld";
     private final String KERAS_LOSS_POISSON = "poisson";
     private final String KERAS_LOSS_COSINE_PROXIMITY = "cosine_proximity";
+    private final String TF_KERAS_LOSS_COSINE_SIMILARITY = "cosinesimilarity";
     private final String KERAS_LOSS_LOG_COSH = "logcosh"; // keras 2 only
 
 }

--- a/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLossUtils.java
+++ b/deeplearning4j/deeplearning4j-modelimport/src/main/java/org/deeplearning4j/nn/modelimport/keras/utils/KerasLossUtils.java
@@ -63,33 +63,42 @@ public class KerasLossUtils {
         LossFunctions.LossFunction dl4jLoss;
         kerasLoss = kerasLoss.toLowerCase();
         if (kerasLoss.equals(conf.getKERAS_LOSS_MEAN_SQUARED_ERROR()) ||
-                kerasLoss.equals(conf.getKERAS_LOSS_MSE())) {
+                kerasLoss.equals(conf.getKERAS_LOSS_MSE()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_MEAN_SQUARED_ERROR())) {
             dl4jLoss = LossFunctions.LossFunction.SQUARED_LOSS;
         } else if (kerasLoss.equals(conf.getKERAS_LOSS_MEAN_ABSOLUTE_ERROR()) ||
-                kerasLoss.equals(conf.getKERAS_LOSS_MAE())) {
+                kerasLoss.equals(conf.getKERAS_LOSS_MAE()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_MEAN_ABSOLUTE_ERROR())) {
             dl4jLoss = LossFunctions.LossFunction.MEAN_ABSOLUTE_ERROR;
         } else if (kerasLoss.equals(conf.getKERAS_LOSS_MEAN_ABSOLUTE_PERCENTAGE_ERROR()) ||
-                kerasLoss.equals(conf.getKERAS_LOSS_MAPE())) {
+                kerasLoss.equals(conf.getKERAS_LOSS_MAPE()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_MEAN_ABSOLUTE_PERCENTAGE_ERROR())) {
             dl4jLoss = LossFunctions.LossFunction.MEAN_ABSOLUTE_PERCENTAGE_ERROR;
         } else if (kerasLoss.equals(conf.getKERAS_LOSS_MEAN_SQUARED_LOGARITHMIC_ERROR()) ||
-                kerasLoss.equals(conf.getKERAS_LOSS_MSLE())) {
+                kerasLoss.equals(conf.getKERAS_LOSS_MSLE()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_MEAN_SQUARED_LOGARITHMIC_ERROR())) {
             dl4jLoss = LossFunctions.LossFunction.MEAN_SQUARED_LOGARITHMIC_ERROR;
-        } else if (kerasLoss.equals(conf.getKERAS_LOSS_SQUARED_HINGE())) {
+        } else if (kerasLoss.equals(conf.getKERAS_LOSS_SQUARED_HINGE()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_SQUARED_HINGE())) {
             dl4jLoss = LossFunctions.LossFunction.SQUARED_HINGE;
         } else if (kerasLoss.equals(conf.getKERAS_LOSS_HINGE())) {
             dl4jLoss = LossFunctions.LossFunction.HINGE;
-        } else if (kerasLoss.equals(conf.getKERAS_LOSS_SPARSE_CATEGORICAL_CROSSENTROPY()) || kerasLoss.equals(conf.getTF_KERAS_LOSS_SPARSE_CATEGORICAL_CROSS_ENTROPY())) {
+        } else if (kerasLoss.equals(conf.getKERAS_LOSS_SPARSE_CATEGORICAL_CROSSENTROPY()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_SPARSE_CATEGORICAL_CROSS_ENTROPY())) {
             dl4jLoss = LossFunctions.LossFunction.SPARSE_MCXENT;
-        } else if (kerasLoss.equals(conf.getKERAS_LOSS_BINARY_CROSSENTROPY())) {
+        } else if (kerasLoss.equals(conf.getKERAS_LOSS_BINARY_CROSSENTROPY()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_BINARY_CROSSENTROPY())) {
             dl4jLoss = LossFunctions.LossFunction.XENT;
         } else if (kerasLoss.equals(conf.getKERAS_LOSS_CATEGORICAL_CROSSENTROPY())) {
             dl4jLoss = LossFunctions.LossFunction.MCXENT;
         } else if (kerasLoss.equals(conf.getKERAS_LOSS_KULLBACK_LEIBLER_DIVERGENCE()) ||
-                kerasLoss.equals(conf.getKERAS_LOSS_KLD())) {
+                kerasLoss.equals(conf.getKERAS_LOSS_KLD()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_KLDIVERGENCE())) {
             dl4jLoss = LossFunctions.LossFunction.KL_DIVERGENCE;
         } else if (kerasLoss.equals(conf.getKERAS_LOSS_POISSON())) {
             dl4jLoss = LossFunctions.LossFunction.POISSON;
-        } else if (kerasLoss.equals(conf.getKERAS_LOSS_COSINE_PROXIMITY())) {
+        } else if (kerasLoss.equals(conf.getKERAS_LOSS_COSINE_PROXIMITY()) ||
+                kerasLoss.equals(conf.getTF_KERAS_LOSS_COSINE_SIMILARITY())) {
             dl4jLoss = LossFunctions.LossFunction.COSINE_PROXIMITY;
         } else {
             ILossFunction lossClass = customLoss.get(kerasLoss);


### PR DESCRIPTION
Signed-off-by: Thang Bui <buinnthang@gmail.com>

## What changes were proposed in this pull request?

Fix #9699 - This PR adds aliases of those `tf.keras` loss functions that PR #9702 missed.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
