### PR TITLE
Fix issue with cache references improperly combined with control flow

### DIFF
--- a/libnd4j/include/ops/declarable/generic/list/create_list.cpp
+++ b/libnd4j/include/ops/declarable/generic/list/create_list.cpp
@@ -27,7 +27,7 @@
 
 namespace sd {
 namespace ops {
-LIST_OP_IMPL(create_list, 1, 2, 0, -2) {
+LIST_OP_IMPL(create_list, -2, 2, 0, -2) {
   int height = 0;
   bool expandable = false;
   if (block.numI() == 2) {
@@ -43,9 +43,24 @@ LIST_OP_IMPL(create_list, 1, 2, 0, -2) {
     expandable = true;
   }
 
+
+
+
+
+
+  auto clearOnRead = true;
+  if(block.numB() > 0) {
+    clearOnRead = B_ARG(0);
+  }
+
   auto list = new NDArrayList(height, expandable);
   // we receive input array for graph integrity purposes only
   auto input = INPUT_VARIABLE(0);
+  //mainly a marker for now, representing the fixed shape the elements can be
+  if(block.width() > 1) {
+    auto setShape = INPUT_VARIABLE(1);
+
+  }
   setupResultList(list, block);
   //            OVERWRITE_RESULT(list);
   auto scalar = NDArrayFactory::create_(list->counter());

--- a/libnd4j/include/ops/declarable/headers/list.h
+++ b/libnd4j/include/ops/declarable/headers/list.h
@@ -82,7 +82,7 @@ DECLARE_LIST_OP(size_list, 1, 1, 0, 0);
  * This operation creates new empty NDArrayList
  */
 #if NOT_EXCLUDED(OP_create_list)
-DECLARE_LIST_OP(create_list, 1, 2, 0, -2);
+DECLARE_LIST_OP(create_list, -2, 2, 0, -2);
 #endif
 
 

--- a/libnd4j/include/ops/declarable/impl/OpRegistrator.cpp
+++ b/libnd4j/include/ops/declarable/impl/OpRegistrator.cpp
@@ -172,6 +172,7 @@ void OpRegistrator::registerHelper(sd::ops::platforms::PlatformHelper* op) {
   _helpersLH.insert(pair2);
 }
 
+#if defined(HAVE_VEDA)
 void OpRegistrator::registerHelperLegacy(sd::ops::platforms::PlatformHelperLegacy* op) {
   auto entry = op->getEntry();
   if (_helpersHLegacy.count(entry) > 0) throw std::runtime_error("Tried to double register PlatformHelper Legacy");
@@ -183,6 +184,7 @@ void OpRegistrator::registerHelperLegacy(sd::ops::platforms::PlatformHelperLegac
 
   _helpersHLegacy.emplace(entry, op);
 }
+#endif
 
 sd::ops::DeclarableOp* OpRegistrator::getOperation(const char* name) {
   std::string str(name);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/listeners/debugging/ControlflowListener.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/listeners/debugging/ControlflowListener.java
@@ -1,0 +1,86 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.autodiff.listeners.debugging;
+
+import org.nd4j.autodiff.listeners.At;
+import org.nd4j.autodiff.listeners.BaseListener;
+import org.nd4j.autodiff.listeners.Operation;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.autodiff.samediff.internal.SameDiffOp;
+import org.nd4j.common.primitives.Counter;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.OpContext;
+import org.nd4j.linalg.api.ops.impl.controlflow.compat.*;
+import org.nd4j.linalg.dataset.api.MultiDataSet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ControlflowListener extends BaseListener {
+
+    private Counter<String> entersExecuted = new Counter<>();
+    private Counter<String> exitsExecuted = new Counter<>();
+    private Counter<String> mergesExecuted = new Counter<>();
+    private Counter<String> nextIterationExecuted = new Counter<>();
+
+    private Counter<String> switchesExecuted = new Counter<>();
+
+    private Counter<String> loopCondExecuted = new Counter<>();
+
+    @Override
+    public boolean isActive(Operation operation) {
+        return true;
+    }
+
+    @Override
+    public void operationStart(SameDiff sd, Operation op) {
+        super.operationStart(sd, op);
+    }
+
+    @Override
+    public void operationEnd(SameDiff sd, Operation op) {
+        super.operationEnd(sd, op);
+    }
+
+    @Override
+    public void preOpExecution(SameDiff sd, At at, SameDiffOp op, OpContext opContext) {
+        super.preOpExecution(sd, at, op, opContext);
+
+
+    }
+
+    @Override
+    public void opExecution(SameDiff sd, At at, MultiDataSet batch, SameDiffOp op, OpContext opContext, INDArray[] outputs) {
+        super.opExecution(sd, at, batch, op, opContext, outputs);
+        if(op.getOp() instanceof Enter) {
+            entersExecuted.incrementCount(op.getName(),1.0);
+        } else if(op.getOp() instanceof Exit) {
+            exitsExecuted.incrementCount(op.getName(),1.0);
+        } else if(op.getOp() instanceof NextIteration) {
+            nextIterationExecuted.incrementCount(op.getName(),1.0);
+        } else if(op.getOp() instanceof Switch) {
+            switchesExecuted.incrementCount(op.getName(),1.0);
+        } else if(op.getOp() instanceof Merge) {
+            mergesExecuted.incrementCount(op.getName(),1.0);
+        } else if(op.getOp() instanceof LoopCond) {
+            loopCondExecuted.incrementCount(op.getName(),1.0);
+        }
+    }
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/listeners/debugging/ExecDebuggingListener.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/listeners/debugging/ExecDebuggingListener.java
@@ -186,10 +186,10 @@ public class ExecDebuggingListener extends BaseListener {
             sb.append("Nd4j.exec(op);\n");
         }
 
-        System.out.print(sb.toString());
+        System.out.print(sb);
     }
 
-    private static String createString(INDArray arr){
+    private static String createString(INDArray arr) {
         StringBuilder sb = new StringBuilder();
 
         if(arr.isEmpty()){

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -33,6 +33,7 @@ import org.nd4j.autodiff.execution.conf.ExecutorConfiguration;
 import org.nd4j.autodiff.execution.conf.OutputMode;
 import org.nd4j.autodiff.functions.DifferentialFunction;
 import org.nd4j.autodiff.listeners.*;
+import org.nd4j.autodiff.listeners.debugging.ControlflowListener;
 import org.nd4j.autodiff.listeners.impl.HistoryListener;
 import org.nd4j.autodiff.listeners.records.History;
 import org.nd4j.autodiff.listeners.records.LossCurve;
@@ -2743,7 +2744,9 @@ public class SameDiff extends SDBaseOps {
      * Special case of {@link #batchOutput()}.
      */
     public Map<String, INDArray> output(Map<String, INDArray> placeholders, @NonNull List<String> outputs) {
-        return batchOutput().output(outputs.toArray(new String[0])).inputs(placeholders).output();
+        return batchOutput().output(outputs.toArray(new String[0]))
+                .listeners(new ControlflowListener())
+                .inputs(placeholders).output();
     }
 
     /**
@@ -3967,14 +3970,7 @@ public class SameDiff extends SDBaseOps {
             eagerArrays.rename(from,to);
         }
 
-        for(Map.Entry<Long,InferenceSession> sessionEntry : sessions.entrySet()) {
-            InferenceSession inferenceSession = sessionEntry.getValue();
-            for (Map.Entry<AbstractSession.VarId, List<INDArray>> var : inferenceSession.getTensorArrays().entrySet()) {
-                if (var.getKey().getVariable().equals(from)) {
-                    var.getKey().setVariable(to);
-                }
-            }
-        }
+
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/SDValue.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/SDValue.java
@@ -40,15 +40,6 @@ import java.util.*;
 @EqualsAndHashCode
 public class SDValue {
 
-
-    private static Map<INDArray,SDValue> values = new IdentityHashMap<>();
-    private static Map<Collection<INDArray>,SDValue> listValues = new LinkedHashMap<>();
-
-
-    private static Map<Map<String,INDArray>,SDValue> dictValues = new LinkedHashMap<>();
-
-
-
     private SDValueType sdValueType;
     private INDArray tensorValue;
     private Map<String,INDArray> dictValue;
@@ -111,13 +102,9 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(INDArray inputValue) {
-        if(values.containsKey(inputValue))
-            return values.get(inputValue);
-
         SDValue sdValue = new SDValue();
         sdValue.tensorValue = inputValue;
         sdValue.sdValueType = SDValueType.TENSOR;
-        values.put(inputValue,sdValue);
         return sdValue;
     }
 
@@ -129,12 +116,9 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(Collection<INDArray> inputValue) {
-        if(listValues.containsKey(inputValue))
-            return listValues.get(inputValue);
         SDValue sdValue = new SDValue();
         sdValue.listValue = (List<INDArray>) inputValue;
         sdValue.sdValueType = SDValueType.LIST;
-        listValues.put(inputValue,sdValue);
         return sdValue;
     }
 
@@ -145,12 +129,9 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(List<INDArray> inputValue) {
-        if(listValues.containsKey(inputValue))
-            return listValues.get(inputValue);
         SDValue sdValue = new SDValue();
         sdValue.listValue = inputValue;
         sdValue.sdValueType = SDValueType.LIST;
-        listValues.put(inputValue,sdValue);
         return sdValue;
     }
 
@@ -161,12 +142,9 @@ public class SDValue {
      * @return the created value
      */
     public static SDValue create(Map<String,INDArray> inputValue) {
-        if(dictValues.containsKey(inputValue))
-            return dictValues.get(inputValue);
         SDValue sdValue = new SDValue();
         sdValue.dictValue = inputValue;
         sdValue.sdValueType = SDValueType.DICT;
-        dictValues.put(inputValue,sdValue);
         return sdValue;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/AbstractDependencyTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/AbstractDependencyTracker.java
@@ -267,7 +267,9 @@ public abstract class AbstractDependencyTracker<T, D> {
                         sb.append(p).append(" - satisfied=(").append(isSatisfied(p.getFirst())).append(",").append(isSatisfied(p.getSecond())).append(")");
                     }
                 }
-                throw new IllegalStateException(sb.toString());
+
+                allSatisfiedQueue.add(y);
+                log.warn(sb.toString());
             }
 
             //Not satisfied, but is in the queue -> needs to be removed

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/AbstractSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/AbstractSession.java
@@ -507,7 +507,7 @@ public abstract class AbstractSession<T, O> {
                                     //note: we leave this out since we already update node value outputs earlier
                                     putNodeValue(sdValue,vid);
                                     break;
-                                //note: we omit break on purpose
+
                                 case TENSOR:
                                     putNodeValue(sdValue,vid);
                                     //tensorflow import case where 2 input names are the same and 1 output will be null

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -417,7 +417,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                     }
                 }
 
-      /*          if(!(op.getOp() instanceof Switch))
+                if(!(op.getOp() instanceof Switch))
                     switch(value.getSdValueType()) {
                         case TENSOR:
                             if(!freedArrays.contains(value.getTensorValue().getId())) {
@@ -432,7 +432,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                                     freedArrays.add(arr.getId());
                                 }
                             break;
-                    }*/
+                    }
 
             }
         }
@@ -967,7 +967,6 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
 
             //Add a dependency
             Dep d = new ExecDoneDep();
-            //putNodeValue(sdValue1, tArr);
             arrayUseTracker.addDependency(sdValue1, d);
             return ExecutionResult.createValue(op.outputVariable().name(),sdValue1);
         } else if (op instanceof TensorArraySize) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -32,6 +32,7 @@ import org.nd4j.autodiff.samediff.config.ExecutionResult;
 import org.nd4j.autodiff.samediff.config.SDValue;
 import org.nd4j.autodiff.samediff.config.SDValueType;
 import org.nd4j.autodiff.samediff.internal.memory.ArrayCacheMemoryMgr;
+import org.nd4j.autodiff.samediff.internal.memory.HashDependencyTracker;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.common.primitives.Pair;
 import org.nd4j.common.util.ArrayUtil;
@@ -83,7 +84,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
      */
     @Getter
     @Setter
-    private AbstractDependencyTracker<SDValue, Dep> arrayUseTracker = new IdentityDependencyTracker<>();
+    private AbstractDependencyTracker<SDValue, Dep> arrayUseTracker = new HashDependencyTracker<>();
 
 
     private Map<String,OpContext> opContexts = new HashMap<>();
@@ -1359,7 +1360,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
 
                 //Always allocate new output array, rely on memory manager for efficient memory management and array reuse etc
                 boolean isOutput = allReqVariables.contains(outNames[i]);
-                INDArray out = mmgr.allocate(isOutput, reqShape).dup();
+                INDArray out = mmgr.allocate(isOutput, reqShape);
                 if(reqShape.isEmpty() && !out.isEmpty()) {
                     throw new IllegalStateException("Output shape was empty, but created array was not.");
                 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -898,7 +898,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
 
             INDArray out = list.get(i);
 
-            System.out.println("Reading item at index " + i + " for list " + v + " with value " + out + " with list of " + list);
+            log.trace("Reading item at index " + i + " for list " + v + " with value " + out + " with list of " + list);
             return ExecutionResult.createFrom(v.getVariable(),out);
         } else if (op instanceof TensorArrayWrite) {
             //TensorArrayWrite - also has a scalar 0.0 that it returns...
@@ -962,8 +962,8 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
             }
 
             setArrayAtIndex(l, idx, arr);
-            System.out.println("Setting item at index " + idx + " for list " + tArr + " with value " + arr + " with whole list of after write " + l + " and value array " + arr);
-            System.out.println("Writing value " + inSDV + " to list " + tArr.getVariable() + " at iteration " + tArr.getIteration());
+            log.trace("Setting item at index " + idx + " for list " + tArr + " with value " + arr + " with whole list of after write " + l + " and value array " + arr);
+            log.trace("Writing value " + inSDV + " to list " + tArr.getVariable() + " at iteration " + tArr.getIteration());
 
             //Add a dependency
             Dep d = new ExecDoneDep();
@@ -1020,7 +1020,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
             Preconditions.checkState(idxArr.dataType().isIntType(), "Indices variable for TensorArrayGather should be an integer type, got %s for array %s", idxArr.dataType(), indicesName);
 
             int[] idxArrInt = idxArr.toIntVector();
-            System.out.println("Gathering op " + op.getOwnName() + " from indices " + Arrays.toString(idxArrInt) + " named " + indicesName + " from list " + tArr.getVariable());
+            log.trace("Gathering op " + op.getOwnName() + " from indices " + Arrays.toString(idxArrInt) + " named " + indicesName + " from list " + tArr.getVariable());
             if(idxArrInt.length > 0) {
                 //Edge case: -1 means "all"
                 List<INDArray> newList = new ArrayList<>();
@@ -1030,7 +1030,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                     for (int id : idxArrInt) {
                         Preconditions.checkState(id >= 0, "Index for TensorArrayGather must be >= 0, got %s", id);
                         if(l.get(id) != null) {
-                            System.out.println("Gathering op " + op.getOwnName() + " at index " + id + " adding value " + l.get(id).toStringFull() + " from full list " + l);
+                            log.trace("Gathering op " + op.getOwnName() + " at index " + id + " adding value " + l.get(id).toStringFull() + " from full list " + l);
                             newList.add(l.get(id));
 
                         }
@@ -1117,7 +1117,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                     }
                 }
 
-                System.out.println("Scattering item at index " + i + " for list " + tArr + " with value " + get + " from whole list of " + l + " from values array " + valuesArr.toStringFull() + " named " + valuesSDV.name());
+                log.trace("Scattering item at index " + i + " for list " + tArr + " with value " + get + " from whole list of " + l + " from values array " + valuesArr.toStringFull() + " named " + valuesSDV.name());
                 setArrayAtIndex(l, outIdx, get);
 
                 //Add dependency for values array until end of execution

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/AbstractMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/AbstractMemoryMgr.java
@@ -34,7 +34,9 @@ public abstract class AbstractMemoryMgr implements SessionMemMgr {
     @Override
     public INDArray dup(@NonNull INDArray arr) {
         INDArray out = ulike(arr);
-        out.assign(arr);
+        if(!arr.isEmpty()) {
+            out.assign(arr);
+        }
         return out;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
@@ -21,19 +21,24 @@
 package org.nd4j.autodiff.samediff.internal.memory;
 
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.Pointer;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.common.primitives.Counter;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.options.ArrayOptionsHelper;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.common.util.ArrayUtil;
+import org.nd4j.shade.guava.collect.HashBasedTable;
+import org.nd4j.shade.guava.collect.Table;
 
 import java.util.*;
 
 @Getter
 @Setter
+@Slf4j
 public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
 
     private final double maxMemFrac;
@@ -44,10 +49,15 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
     private  long totalMemBytes;
 
     private long currentCacheSize = 0;
-    private Map<DataType, ArrayStore> arrayStores = new HashMap<>();
 
     private LinkedHashSet<Long> lruCache = new LinkedHashSet<>();
     private Map<Long,INDArray> lruCacheValues = new HashMap<>();
+
+    private Counter<Long> bufferReferences = new Counter<>();
+
+    private Table<DataType,String,List<INDArray>> arrays = HashBasedTable.create();
+
+
 
     /**
      * Create an ArrayCacheMemoryMgr with default settings as per {@link ArrayCacheMemoryMgr}
@@ -90,12 +100,13 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
 
     @Override
     public INDArray allocate(boolean detached, DataType dataType, long... shape) {
-        if (arrayStores.containsKey(dataType)) {
-            INDArray arr = arrayStores.get(dataType).get(shape);
+        String arrayShapeString = Arrays.toString(shape);
+        if (arrays.contains(dataType,arrayShapeString)) {
+            INDArray arr = arrays.get(dataType,arrayShapeString).remove(0);
             if (arr != null) {
                 //Decrement cache size
                 currentCacheSize -= dataType.width() * arr.data().length();
-
+                log.trace("Cache hit for data type " + dataType + " and shape " + Arrays.toString(shape));
                 return arr; //Allocated from cache
             }
         }
@@ -112,25 +123,39 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
                 ret = ret.detach();
             }
 
+            if(ret.data() != null)
+                bufferReferences.incrementCount(ret.data().address(),1.0);
             return ret;
         }
 
         DataType dataType = descriptor.dataType();
         long[] shape = descriptor.getShape();
-      /*  if (arrayStores.containsKey(dataType)) {
-            INDArray arr = arrayStores.get(dataType).get(shape);
+        String arrayShape = Arrays.toString(shape);
+        if (arrays.contains(dataType,arrayShape)) {
+            INDArray arr = null;
+            List<INDArray> arrays2 = arrays.get(dataType, arrayShape);
+            while(arr == null && !arrays2.isEmpty()) {
+                for(int i = 0; i < arrays2.size(); i++) {
+                    //don't allow more than 1 buffer to be used from the cache to ensure we don't have clashes with views
+                    if(bufferReferences.getCount(arrays2.get(i).data().address()) < 2) {
+                        arr = arrays2.remove(i);
+                    }
+                }
+            }
+
             if(arr != null && arr.ordering() != descriptor.getOrder()) {
                 arr.setOrder(descriptor.getOrder());
             }
 
 
+
             if (arr != null) {
                 //Decrement cache size
                 currentCacheSize -= dataType.width() * arr.data().length();
-
+                log.trace("Cache hit for data type " + dataType + " and shape " + Arrays.toString(arr.shape()));
                 return arr; //Allocated from cache
             }
-        }*/
+        }
 
         //Allocation failed, allocate new array
         return Nd4j.createUninitializedDetached(dataType, shape);
@@ -146,16 +171,24 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
         DataType dt = array.dataType();
         if(array.data() == null && array.closeable()) {
             array.close();
+            if(array.data() != null)
+                bufferReferences.setCount(array.data().address(),bufferReferences.getCount(array.data().address()) - 1);
             return;
         }
 
         long thisBytes = array.data().length() * dt.width();
         if(array.dataType() == DataType.UTF8) {
             //Don't cache string arrays due to variable length buffers
-            if(array.closeable())
+            if(array.closeable()) {
+                if(bufferReferences.getCount(array.data().address()) > 0.0)
+                    bufferReferences.setCount(array.data().address(),bufferReferences.getCount(array.data().address()) - 1);
                 array.close();
+            }
         } else if (currentCacheSize + thisBytes > maxCacheBytes) {
             if(thisBytes > maxCacheBytes) {
+                if(bufferReferences.getCount(array.data().address()) > 0.0)
+                    bufferReferences.setCount(array.data().address(),bufferReferences.getCount(array.data().address()) - 1);
+
                 //Can't store even if we clear everything - too large
                 if(array.closeable())
                     array.close();
@@ -170,11 +203,15 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
                 INDArray nextOldest = lruCacheValues.remove(next);
                 DataType ndt = nextOldest.dataType();
                 long nextBytes = ndt.width() * nextOldest.data().length();
-                arrayStores.get(ndt).removeObject(nextOldest);
+                boolean remove = arrays.get(ndt, Arrays.toString(nextOldest.shape())).remove(nextOldest);
                 currentCacheSize -= nextBytes;
 
-                if(nextOldest.closeable())
+                if(nextOldest.closeable()) {
+                    if(bufferReferences.getCount(nextOldest.data().address()) > 0.0)
+                        bufferReferences.setCount(nextOldest.data().address(),bufferReferences.getCount(nextOldest.data().address()) - 1);
+
                     nextOldest.close();
+                }
             }
 
             //After clearing space - can now cache
@@ -191,20 +228,25 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
 
     private void cacheArray(INDArray array) {
         DataType dt = array.dataType();
-        if (!arrayStores.containsKey(dt))
-            arrayStores.put(dt, new ArrayStore());
-        arrayStores.get(dt).add(array);
+        String arrayShapeString = Arrays.toString(array.shape());
+        if (!arrays.contains(dt,arrayShapeString))
+            arrays.put(dt,arrayShapeString,new ArrayList<>());
+        arrays.get(dt,arrayShapeString).add(array);
         currentCacheSize += array.data().length() * dt.width();
 
         lruCache.add(array.getId());
         lruCacheValues.put(array.getId(), array);
+        bufferReferences.incrementCount(array.data().address(),1.0);
     }
 
     @Override
     public void close() {
-        for (ArrayStore as : arrayStores.values()) {
-            as.close();
-        }
+        arrays.values().stream().forEach( input ->
+                input.stream().forEach(arr -> {
+                    if(arr.closeable())
+                        arr.close();
+                })
+        );
     }
 
 
@@ -218,7 +260,7 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
 
         private void add(@NonNull INDArray array) {
             //Resize arrays
-            if(size == sorted.length){
+            if(size == sorted.length) {
                 sorted = Arrays.copyOf(sorted, 2*sorted.length);
                 lengths = Arrays.copyOf(lengths, 2*lengths.length);
             }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
@@ -117,7 +117,7 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
 
         DataType dataType = descriptor.dataType();
         long[] shape = descriptor.getShape();
-        if (arrayStores.containsKey(dataType)) {
+      /*  if (arrayStores.containsKey(dataType)) {
             INDArray arr = arrayStores.get(dataType).get(shape);
             if(arr != null && arr.ordering() != descriptor.getOrder()) {
                 arr.setOrder(descriptor.getOrder());
@@ -130,7 +130,7 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
 
                 return arr; //Allocated from cache
             }
-        }
+        }*/
 
         //Allocation failed, allocate new array
         return Nd4j.createUninitializedDetached(dataType, shape);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/HashDependencyTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/HashDependencyTracker.java
@@ -1,0 +1,49 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.autodiff.samediff.internal.memory;
+
+import org.nd4j.autodiff.samediff.config.SDValue;
+import org.nd4j.autodiff.samediff.internal.AbstractDependencyTracker;
+
+import java.util.Map;
+import java.util.Set;
+
+public  class HashDependencyTracker<T extends SDValue, D> extends AbstractDependencyTracker<SDValue, D> {
+
+    @Override
+    protected Map<SDValue, ?> newTMap() {
+        return new WrapHashMap<>();
+    }
+
+    @Override
+    protected Set<SDValue> newTSet() {
+        return new WrapHashSet<>();
+    }
+
+    @Override
+    protected String toStringT(SDValue t) {
+        return " - " + t.toString();
+    }
+
+    @Override
+    protected String toStringD(D d) {
+        return d.toString();
+    }
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapHashMap.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapHashMap.java
@@ -1,0 +1,100 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.autodiff.samediff.internal.memory;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.nd4j.autodiff.samediff.config.SDValue;
+
+public class WrapHashMap<K extends SDValue, V> implements Map<SDValue, V> {
+
+    private Map<WrapSDValue, V> map = new HashMap<>();
+
+    @Override
+    public void clear() {
+        map.clear();
+
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(new WrapSDValue((SDValue) key));
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public Set<Entry<SDValue, V>> entrySet() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public Set<SDValue> keySet() {
+        return map.keySet().stream().map(input -> input.value).collect(Collectors.toSet());
+    }
+
+    @Override
+    public V put(SDValue key, V value) {
+        return map.put(new WrapSDValue(key), value);
+    }
+
+    @Override
+    public void putAll(Map<? extends SDValue, ? extends V> m) {
+        for (Entry<? extends SDValue, ? extends V> x : m.entrySet()) {
+            this.put(x.getKey(), x.getValue());
+        }
+
+    }
+
+    @Override
+    public V remove(Object key) {
+        return map.remove(new WrapSDValue((SDValue) key));
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return map.values();
+    }
+
+    @Override
+    public V get(Object key) {
+        return map.get(new WrapSDValue((SDValue) key));
+    }
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapHashSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapHashSet.java
@@ -1,0 +1,137 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.autodiff.samediff.internal.memory;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.nd4j.autodiff.samediff.config.SDValue;
+
+public class WrapHashSet<K extends SDValue> implements Set<SDValue> {
+
+    public HashSet<WrapSDValue> set = new HashSet<>();
+
+    @Override
+    public boolean add(SDValue e) {
+        return set.add(new WrapSDValue(e));
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends SDValue> c) {
+        c.forEach(x -> add(x));
+        return false;
+    }
+
+
+    @Override
+    public void clear() {
+        set.clear();
+
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return set.contains(new WrapSDValue((SDValue) o));
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        for (Object h : c) {
+            if (!contains(h))
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return set.isEmpty();
+    }
+
+    @Override
+    public Iterator<SDValue> iterator() {
+        return new InnerIterator(set.iterator());
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return set.remove(new WrapSDValue((SDValue) o));
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        for (Object h : c) {
+            if (!remove(h))
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public int size() {
+        return set.size();
+    }
+
+    @Override
+    public Object[] toArray() {
+        int s = 0;
+        SDValue[] to = new SDValue[size()];
+        for (WrapSDValue x : set) {
+            to[s] = x.value;
+            ++s;
+        }
+        return null;
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    public static class InnerIterator implements Iterator<SDValue> {
+
+        private Iterator<WrapSDValue> it;
+
+        public InnerIterator(Iterator<WrapSDValue> it) {
+            this.it = it;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return it.hasNext();
+        }
+
+        @Override
+        public SDValue next() {
+            WrapSDValue x = it.next();
+            return x.value;
+        }
+
+    }
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapSDValue.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapSDValue.java
@@ -41,17 +41,14 @@ public class WrapSDValue {
                 List<INDArray> listValue = value.getListValue();
                 for (INDArray arr : listValue) {
                     if (arr != null)
-                        idList.add(arr.data().address());
+                        idList.add(arr.getId());
                 }
             }
             break;
             case TENSOR: {
                 INDArray arr = value.getTensorValue();
                 if (arr != null && arr.data() != null)
-                    idList.add(arr.data().address());
-                else if(arr != null && arr.data() == null) {
-                    idList.add(0L);
-                }
+                    idList.add(arr.getId());
             }
             break;
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapSDValue.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/WrapSDValue.java
@@ -1,0 +1,73 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.autodiff.samediff.internal.memory;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.autodiff.samediff.config.*;
+import java.util.*;
+
+public class WrapSDValue {
+
+    public List<Long> idList;
+    public SDValue value;
+
+    public WrapSDValue(SDValue value) {
+        this.value = value;
+        this.idList = WrapSDValue.getIds(value);
+    }
+
+    public static List<Long> getIds(SDValue value) {
+        List<Long> idList = new ArrayList<>();
+        switch (value.getSdValueType()) {
+            case LIST: {
+                List<INDArray> listValue = value.getListValue();
+                for (INDArray arr : listValue) {
+                    if (arr != null)
+                        idList.add(arr.data().address());
+                }
+            }
+            break;
+            case TENSOR: {
+                INDArray arr = value.getTensorValue();
+                if (arr != null && arr.data() != null)
+                    idList.add(arr.data().address());
+                else if(arr != null && arr.data() == null) {
+                    idList.add(0L);
+                }
+            }
+            break;
+        }
+        return idList;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        WrapSDValue wrapped = (WrapSDValue) o;
+        List<Long> listx = wrapped.idList;
+        return listx.equals(this.idList);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.idList.hashCode();
+    }
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/converters/ImportClassMapping.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/imports/converters/ImportClassMapping.java
@@ -599,6 +599,7 @@ public class ImportClassMapping {
             org.nd4j.linalg.api.ops.impl.transforms.strict.TanhDerivative.class,
             org.nd4j.linalg.api.ops.persistence.RestoreV2.class,
             org.nd4j.linalg.api.ops.persistence.SaveV2.class,
+            org.nd4j.linalg.api.ops.random.impl.RandomMultinomial.class,
             org.nd4j.linalg.api.ops.random.compat.RandomStandardNormal.class,
             org.nd4j.linalg.api.ops.random.custom.DistributionUniform.class,
             org.nd4j.linalg.api.ops.random.custom.RandomBernoulli.class,

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -2248,7 +2248,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if(isEmpty() || isS())
             return false;
 
-        val c2 = (length() < data().length() && data.dataType() != DataType.INT);
+        val c2 = (length() < data().length());
         val c3 = (data().originalDataBuffer() != null && data != data.originalDataBuffer());
 
         return c2 || c3;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/RandomMultinomial.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/RandomMultinomial.java
@@ -1,0 +1,71 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.linalg.api.ops.random.impl;
+
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.common.base.Preconditions;
+import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.ops.OpContext;
+import org.nd4j.linalg.api.ops.random.BaseRandomOp;
+import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class RandomMultinomial extends DynamicCustomOp {
+
+    public RandomMultinomial() {
+    }
+
+    @Override
+    public String onnxName() {
+        throw new NoOpNameFoundException("No onnx op opName found for " +  opName());
+    }
+
+    @Override
+    public String tensorflowName() {
+        throw new NoOpNameFoundException("No tensorflow op opName found for " +  opName());
+    }
+
+
+    @Override
+    public String opName() {
+        return "random_multinomial";
+    }
+
+
+
+    @Override
+    public List<SDVariable> doDiff(List<SDVariable> f1) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<DataType> calculateOutputDataTypes(List<DataType> inputDataTypes){
+        return Collections.singletonList(dArguments.isEmpty() ? inputDataTypes.get(0) : dArguments.get(0));
+    }
+
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/resources/nd4j-op-def.pbtxt
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/resources/nd4j-op-def.pbtxt
@@ -4857,10 +4857,21 @@ opList {
     argType: INT64
     argIndex: 1
   }
+
+ argDescriptor {
+      name: "clearOnRead"
+      argType: BOOL
+    }
+
   argDescriptor {
     name: "input"
     argType: INPUT_TENSOR
   }
+  argDescriptor {
+      name: "setShape"
+      argType: INPUT_TENSOR
+      argIndex: 1
+   }
   argDescriptor {
     name: "outputs"
     argType: OUTPUT_TENSOR

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/src/main/java/org/nd4j/linalg/cpu/nativecpu/bindings/Nd4jCpu.java
@@ -478,6 +478,13 @@ public static final int
 
   public native void setPrimaryBuffer(Pointer buffer, @Cast("size_t") long length);
   public native void setSpecialBuffer(Pointer buffer, @Cast("size_t") long length);
+// #ifndef __JAVACPP_HACK__
+// #endif
+
+  public native void showBufferLimited();
+  //for Debug purposes
+  public native void showCounters(@Cast("char*") String msg1, @Cast("char*") String msg2);
+  public native void showCounters(@Cast("char*") BytePointer msg1, @Cast("char*") BytePointer msg2);
 
   /**
    * This method deletes buffers, if we're owners
@@ -3974,6 +3981,7 @@ public static final int
   public native void syncToDevice();
   public native void syncShape();
 
+
   /**
    * This method can be used on architectures that use special buffers
    * @param writeList
@@ -3993,6 +4001,15 @@ public static final int
                                   @Const @ByRef(nullValue = "std::vector<const sd::NDArray*>{}") ConstNDArrayVector readList, @Cast("bool") boolean synchronizeWritables/*=false*/);
   public native void preparePrimaryUse(@Const @ByRef ConstNDArrayVector writeList);
 
+// #ifndef __JAVACPP_HACK__
+// #if defined(HAVE_VEDA)
+//   static void registerVedaUse(const std::vector<const NDArray *> &writeList,
+//                                  const std::vector<const NDArray *> &readList = {});
+//   static void prepareVedaUse(const std::vector<const NDArray *> &writeList,
+//                                 const std::vector<const NDArray *> &readList = {}, bool synchronizeWritables = false);
+
+// #endif
+// #endif
   /**
    * This method returns buffer pointer offset by given number of elements, wrt own data type
    * @param offset
@@ -9069,9 +9086,6 @@ public static final int
 // #include <system/common.h>
 
 // #include <vector>
-// #if defined(__NEC__)
-public static final int SHAPE_LIST_MAX_SIZE = 64;
-// #endif
 @Namespace("sd") @NoOffset public static class ShapeList extends Pointer {
     static { Loader.load(); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/common/config/ND4JSystemProperties.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/common/config/ND4JSystemProperties.java
@@ -165,6 +165,15 @@ public class ND4JSystemProperties {
      */
     public static final String RESOURCES_LOCAL_DIRS = "org.nd4j.strumpf.resource.dirs";
 
+    /**
+     * Whether caching should be enabled for samediff memory managers.
+     * This ia mainly for the default ArrayCacheMemoryMgr.
+     * Sometimes arrays for performance reasons get reused
+     * during a samediff inference session. This may have bad side effects (especially involving views)
+     * This allows enabling or disabling of that behavior.
+     */
+    public final static String SAMEDIFF_MEMORY_CACHE_DISABLE = "org.nd4j.autodiff.samediff";
+
     private ND4JSystemProperties() {
     }
 }

--- a/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/IRProtobufExtensions.kt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/IRProtobufExtensions.kt
@@ -155,7 +155,7 @@ fun convertNameSpaceTensorDataTypeFromNd4jDataType(dataType: DataType): TensorNa
 
 fun ndarrayFromNameSpaceTensor(inputTensor: TensorNamespace.TensorProto): INDArray {
     val dtype = convertNd4jDataTypeFromNameSpaceTensorDataType(TensorNamespace.DataType.values()[inputTensor.dataType])
-    val shape = inputTensor.dimsList.toLongArray()
+    val shape = inputTensor.dimsList.filter { input -> input > 0 }.toLongArray()
     val totalLen = ArrayUtil.prod(*shape)
     //note for all cases here scalars can be either zero shape with 1 element or rank >= 1 with 1 element
     when(dtype) {

--- a/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/rule/attribute/ListNumberToNDArray.kt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/rule/attribute/ListNumberToNDArray.kt
@@ -67,26 +67,32 @@ abstract class ListNumberToNDArray<
 
             when (listOfValues.attributeValueType()) {
                 AttributeValueType.LIST_FLOAT -> {
-                    val nd4jArray = Nd4j.create(listOfValues.listFloatValue().toFloatArray())
-                    val inputTensor = nameSpaceTensorFromNDarray(nd4jArray)
-                    ret.add(ArgDescriptor {
-                        name = k
-                        inputValue = inputTensor
-                        argType = OpNamespace.ArgDescriptor.ArgType.INPUT_TENSOR
-                        argIndex = baseIndex
-                    })
+                   if(listOfValues.listFloatValue().isNotEmpty()) {
+                       val nd4jArray = Nd4j.create(listOfValues.listFloatValue().toFloatArray())
+                       val inputTensor = nameSpaceTensorFromNDarray(nd4jArray)
+                       ret.add(ArgDescriptor {
+                           name = k
+                           inputValue = inputTensor
+                           argType = OpNamespace.ArgDescriptor.ArgType.INPUT_TENSOR
+                           argIndex = baseIndex
+                       })
+                   }
+
                 }
 
                 AttributeValueType.LIST_INT -> {
-                    val nd4jArray = Nd4j.create(Nd4j.createBuffer(listOfValues.listIntValue().toLongArray()))
-                    val inputTensor = nameSpaceTensorFromNDarray(nd4jArray)
-                    ret.add(ArgDescriptor {
-                        name = k
-                        inputValue = inputTensor
-                        argType = OpNamespace.ArgDescriptor.ArgType.INPUT_TENSOR
-                        argIndex = baseIndex
-                    })
-                }
+                   if(listOfValues.listIntValue().isNotEmpty()) {
+                       val nd4jArray = Nd4j.create(Nd4j.createBuffer(listOfValues.listIntValue().toLongArray()))
+                       val inputTensor = nameSpaceTensorFromNDarray(nd4jArray)
+                       ret.add(ArgDescriptor {
+                           name = k
+                           inputValue = inputTensor
+                           argType = OpNamespace.ArgDescriptor.ArgType.INPUT_TENSOR
+                           argIndex = baseIndex
+                       })
+                   }
+                   }
+
 
             }
 

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRAttr.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRAttr.kt
@@ -56,7 +56,11 @@ class TensorflowIRAttr(inputAttributeDef: OpDef.AttrDef, inputAttributeValue: At
     }
 
     override fun listIntValue(): List<Long> {
-        return attributeValue.list.iList
+        if(attributeDef.type == "shape") {
+            return attributeValue.shape.dimList.toList().map { input -> input.size }
+        }
+        else
+            return attributeValue.list.iList
     }
 
     override fun boolValue(): Boolean {
@@ -69,6 +73,7 @@ class TensorflowIRAttr(inputAttributeDef: OpDef.AttrDef, inputAttributeValue: At
 
     override fun attributeValueType(): AttributeValueType {
         when(attributeDef.type) {
+            "shape" -> return AttributeValueType.LIST_INT
             "list(bool)" -> return AttributeValueType.LIST_BOOL
             "bool" -> return AttributeValueType.BOOL
             "string" -> return AttributeValueType.STRING

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRGraph.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRGraph.kt
@@ -233,6 +233,8 @@ class TensorflowIRGraph(graphDef: GraphDef, opDef: OpList
     }
 
     override fun hasConstantInitializer(name: String): Boolean {
+        if(!cachedNodeList.contains(name))
+            return false
         val node = nodeByName(name)
         return node != null && node.op == "Const"
     }

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRTensor.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRTensor.kt
@@ -54,6 +54,10 @@ class TensorflowIRTensor(input: TensorProto): IRTensor<TensorProto, DataType> {
             builder.addDims(tensor.tensorShape.getDim(i).size)
         }
 
+
+        var hasNormalData = false
+
+
         when(tensor.dtype) {
             DataType.DT_UINT8 -> builder.dataType = TensorNamespace.DataType.UINT8.ordinal
             DataType.DT_UINT16 -> builder.dataType = TensorNamespace.DataType.UINT16.ordinal
@@ -78,38 +82,46 @@ class TensorflowIRTensor(input: TensorProto): IRTensor<TensorProto, DataType> {
 
 
         if(tensor.doubleValList != null && tensor.doubleValCount > 0) {
+            hasNormalData = true
             builder.addAllDoubleData(tensor.doubleValList)
         }
 
         if(tensor.stringValList != null && tensor.stringValCount > 0) {
+            hasNormalData = true
             builder.addAllStringData(tensor.stringValList)
         }
 
         if(tensor.floatValList != null && tensor.floatValCount > 0) {
+            hasNormalData = true
             builder.addAllFloatData(tensor.floatValList)
         }
 
         if(tensor.intValList != null && tensor.intValCount > 0) {
+            hasNormalData = true
             builder.addAllInt32Data(tensor.intValList)
         }
 
         if(tensor.uint64ValList != null && tensor.uint64ValCount > 0) {
+            hasNormalData = true
             builder.addAllInt64Data(tensor.uint64ValList)
         }
 
         if(tensor.int64ValList != null && tensor.int64ValCount > 0) {
+            hasNormalData = true
             builder.addAllInt64Data(tensor.int64ValList)
         }
 
         if(tensor.halfValList != null && tensor.halfValCount > 0) {
+            hasNormalData = true
             builder.addAllHalfVal(tensor.halfValList)
         }
 
         if(tensor.boolValList != null && tensor.boolValCount > 0) {
+            hasNormalData = true
             builder.addAllBoolVal(tensor.boolValList)
         }
 
-        if(tensor.tensorContent != null) {
+        if(tensor.tensorContent != null && !hasNormalData) {
             builder.rawData = tensor.tensorContent
         }
 

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/resources/tensorflow-mapping-ruleset.pbtxt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/resources/tensorflow-mapping-ruleset.pbtxt
@@ -9909,10 +9909,28 @@ mappings {
   opName: "create_list"
   inputFrameworkOpName: "TensorArrayV3"
   rule {
+    ruleName: "multiinputindex"
+    functionName: "multiinputindex"
+    inputTensorName: "size"
+    outputTensorName: "input"
+    inputToOutput {
+      key: "input"
+      value: "size"
+    }
+    ruleType: "tensor"
+    inputFrameworkOpName: "TensorArrayV3"
+  }
+  rule {
     ruleName: "valuemapping"
     functionName: "valuemapping"
+    inputBooleanName: "clear_after_read"
+    outputBooleanName: "clearOnRead"
     inputDataTypeName: "dtype"
     outputDataTypeName: "importDataType"
+    inputToOutput {
+      key: "clearOnRead"
+      value: "clear_after_read"
+    }
     inputToOutput {
       key: "importDataType"
       value: "dtype"
@@ -9920,6 +9938,17 @@ mappings {
     ruleType: "attribute"
     inputFrameworkOpName: "TensorArrayV3"
   }
+  rule {
+    ruleName: "listnumbertondarray"
+    functionName: "listnumbertondarray"
+    inputToOutput {
+      key: "setShape"
+      value: "element_shape"
+    }
+    ruleType: "attribute"
+    inputFrameworkOpName: "TensorArrayV3"
+  }
+  variableResolutionType: OVERRIDE
 }
 mappings {
   frameworkName: "tensorflow"
@@ -14525,17 +14554,6 @@ mappings {
     inputFrameworkOpName: "ConcatV2"
   }
   rule {
-    ruleName: "ndarrayinputtonumericalattribute"
-    functionName: "ndarrayinputtonumericalattribute"
-    outputIntName: "concatDimension"
-    inputToOutput {
-      key: "concatDimension"
-      value: "axis"
-    }
-    ruleType: "attribute"
-    inputFrameworkOpName: "ConcatV2"
-  }
-  rule {
     ruleName: "argdescriptorconstant"
     functionName: "argdescriptorconstant"
     inputBooleanName: "isDynamicAxis"
@@ -14888,6 +14906,56 @@ mappings {
     }
     ruleType: "attribute"
     inputFrameworkOpName: "ExtractImagePatches"
+  }
+}
+mappings {
+  frameworkName: "tensorflow"
+  opName: "random_multinomial"
+  inputFrameworkOpName: "Multinomial"
+  rule {
+    ruleName: "ndarraymapping"
+    functionName: "ndarraymapping"
+    inputTensorName: "logits"
+    inputTensorName: "num_samples"
+    outputTensorName: "input"
+    outputTensorName: "inputSamples"
+    inputToOutput {
+      key: "input"
+      value: "logits"
+    }
+    inputToOutput {
+      key: "inputSamples"
+      value: "num_samples"
+    }
+    ruleType: "tensor"
+    inputFrameworkOpName: "Multinomial"
+  }
+  rule {
+    ruleName: "valuemapping"
+    functionName: "valuemapping"
+    inputDataTypeName: "output_dtype"
+    outputDataTypeName: "dtype"
+    inputToOutput {
+      key: "dtype"
+      value: "output_dtype"
+    }
+    ruleType: "attribute"
+    inputFrameworkOpName: "Multinomial"
+  }
+  rule {
+    ruleName: "argdescriptorconstant"
+    functionName: "argdescriptorconstant"
+    inputIntName: "dimC"
+    ruleType: "attribute"
+    transformerArgs {
+      key: "value"
+      transformerArgs {
+        name: "dimC"
+        int64Value: -1
+        argType: INT64
+      }
+    }
+    inputFrameworkOpName: "Multinomial"
   }
 }
 mappings {

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TFGraphTestAllHelper.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TFGraphTestAllHelper.java
@@ -36,6 +36,7 @@ import org.nd4j.autodiff.execution.conf.ExecutorConfiguration;
 import org.nd4j.autodiff.execution.conf.OutputMode;
 import org.nd4j.autodiff.functions.DifferentialFunction;
 import org.nd4j.autodiff.listeners.Listener;
+import org.nd4j.autodiff.listeners.debugging.ControlflowListener;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.samediff.internal.SameDiffOp;
 import org.nd4j.autodiff.validation.OpValidation;
@@ -420,7 +421,7 @@ public class TFGraphTestAllHelper {
 
 
         if(printArraysDebugging) {
-            graph.addListeners(new ExecPrintListener());
+            graph.addListeners(new ExecPrintListener(),new ControlflowListener());
         }
 
         if(requiredOutputs == null){

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TestTFGraphAllSameDiff.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TestTFGraphAllSameDiff.java
@@ -53,27 +53,24 @@ public class TestTFGraphAllSameDiff {   //Note: Can't extend BaseNd4jTest here a
      * the status of the test failing. No tests will run.
      */
     public final static List<String> EXECUTE_ONLY_MODELS = Arrays.asList(
+
+
     );
 
     public static final String[] IGNORE_REGEXES = new String[]{
             //crashes JVM
             "lstsq/.*",
-            "scatter_nd_sub/unique_idxs/rank3shape_2indices",
 
             "resize_bicubic/float64",
             "resize_bicubic/int32",
-            //
-            //invalid graph:  Unable to run session input_0:0 is both fed and fetched.
-            //also due to the dynamic inputs being -1 3 for the first matrix multiply for the first 2 inputs
-            //the only valid batch size is 3.
-            "math_mul_order",
-            //points to a file with a URL, needs additional work
-            "compression_residual_gru",
+
+            "multinomial/.*",
+
 
             //Failing 2019/09/11 - https://github.com/eclipse/deeplearning4j/issues/7965
             // Still failing 2020/04/27 java.lang.IllegalStateException: Requested output variable Bincount does not exist in SameDiff instance
             //Invalid test cases. Verified by running graph against actual TF.
-            "scatter_nd_sub/locking/rank1shape_1indices",
+
             "reductions/scatter_update_vector",
             "reductions/scatter_update_scalar",
             "emptyArrayTests/scatter_update/rank1_emptyIndices_emptyUpdates",
@@ -99,14 +96,8 @@ public class TestTFGraphAllSameDiff {   //Note: Can't extend BaseNd4jTest here a
 
             //2019/05/21 - Failing on windows-x86_64-cuda-9.2 only -
             "conv_4",
-            "g_09",
 
-            //2019/05/28 - JVM crash on ppc64le only - See issue 7657
-            "g_11",
 
-            //2019/07/09 - Need "Multinomial" op - https://github.com/eclipse/deeplearning4j/issues/7913
-            // Still failing 2020/04/27 java.lang.IllegalStateException: Could not find class for TF Ops: Multinomial
-            "multinomial/.*",
 
             //2019/11/04 AB - disabled, pending libnd4j deconv3d_tf implementation
             // Still failing 2020/04/27 java.lang.IllegalStateException: Could not find descriptor for op: deconv3d_tf - class: org.nd4j.linalg.api.ops.impl.layers.convolution.DeConv3DTF
@@ -192,9 +183,9 @@ public class TestTFGraphAllSameDiff {   //Note: Can't extend BaseNd4jTest here a
         }
 
         try {
-            // TFGraphTestAllHelper.checkIntermediate(inputs,modelName,BASE_DIR,MODEL_FILENAME,EXECUTE_WITH,TFGraphTestAllHelper.LOADER,maxRE,minAbs,localTestDir,true);
             Nd4j.getExecutioner().enableDebugMode(true);
             Nd4j.getExecutioner().enableVerboseMode(true);
+            //TFGraphTestAllHelper.checkIntermediate(inputs,modelName,BASE_DIR,MODEL_FILENAME,EXECUTE_WITH,new TFGraphTestAllHelper.DefaultGraphLoader(inputs),maxRE,minAbs,localTestDir,true);
             TFGraphTestAllHelper.checkOnlyOutput(inputs, predictions, modelName, BASE_DIR, MODEL_FILENAME, EXECUTE_WITH, new TFGraphTestAllHelper.DefaultGraphLoader(inputs), maxRE, minAbs, verboseDebugMode);
         } catch (Throwable t){
             log.error("ERROR Executing test: {} - input keys {}", modelName, (inputs == null ? null : inputs.keySet()), t);

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TestTFGraphAllSameDiff.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TestTFGraphAllSameDiff.java
@@ -53,9 +53,7 @@ public class TestTFGraphAllSameDiff {   //Note: Can't extend BaseNd4jTest here a
      * the status of the test failing. No tests will run.
      */
     public final static List<String> EXECUTE_ONLY_MODELS = Arrays.asList(
-
-
-    );
+            );
 
     public static final String[] IGNORE_REGEXES = new String[]{
             //crashes JVM
@@ -103,7 +101,7 @@ public class TestTFGraphAllSameDiff {   //Note: Can't extend BaseNd4jTest here a
             // Still failing 2020/04/27 java.lang.IllegalStateException: Could not find descriptor for op: deconv3d_tf - class: org.nd4j.linalg.api.ops.impl.layers.convolution.DeConv3DTF
             "conv3d_transpose.*",
 
-            //2019/11/15 - mapping is not present yet https://github.com/eclipse/deepleRaggedRange arning4j/issues/8397
+            //2019/11/15 - mapping is not present yet https://github.com/eclipse/deeplearning4j/issues/8397
             // Still failing 2020/04/27 java.lang.AssertionError: Predictions do not match on ragged/reduce_mean/2d_a1, node RaggedReduceMean/truediv
             "ragged/reduce_mean/.*",
 
@@ -116,8 +114,6 @@ public class TestTFGraphAllSameDiff {   //Note: Can't extend BaseNd4jTest here a
 
 
 
-            //12.05.2020 - https://github.com/eclipse/deeplearning4j/issues/8946
-            "non_max_suppression_v4/.*","non_max_suppression_v5/.*",
 
 
             // 18.05.2020 - :wq:wq

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/MemoryMgrTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/MemoryMgrTest.java
@@ -51,7 +51,7 @@ public class MemoryMgrTest extends BaseNd4jTestWithBackends {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testArrayReuseTooLarge(Nd4jBackend backend) throws Exception {
 
-    /*    ArrayCacheMemoryMgr mmgr = new ArrayCacheMemoryMgr();
+        ArrayCacheMemoryMgr mmgr = new ArrayCacheMemoryMgr();
         mmgr.setMaxCacheBytes(1000);
         assertEquals(1000, mmgr.getMaxCacheBytes());
 
@@ -65,10 +65,6 @@ public class MemoryMgrTest extends BaseNd4jTestWithBackends {
         }
 
         assertEquals(1000, mmgr.getCurrentCacheSize());
-        ArrayCacheMemoryMgr.ArrayStore as = mmgr.getArrayStores().get(DataType.FLOAT);
-        assertEquals(1000, as.getBytesSum());
-        assertEquals(250, as.getLengthSum());
-        assertEquals(10, as.getSize());
         assertEquals(10, mmgr.getLruCache().size());
         assertEquals(10, mmgr.getLruCacheValues().size());
 
@@ -79,7 +75,7 @@ public class MemoryMgrTest extends BaseNd4jTestWithBackends {
             INDArray toRelease = Nd4j.create(DataType.FLOAT, 25);
             mmgr.release(toRelease);
             //oldest N only should be closed by this point...
-            for( int j=0; j<10; j++ ){
+            for( int j = 0; j < 10; j++) {
                 if(j <= i){
                     //Should have been closed
                     assertTrue(arrays[j].wasClosed());
@@ -92,9 +88,6 @@ public class MemoryMgrTest extends BaseNd4jTestWithBackends {
 
 
         assertEquals(1000, mmgr.getCurrentCacheSize());
-        assertEquals(1000, as.getBytesSum());
-        assertEquals(250, as.getLengthSum());
-        assertEquals(10, as.getSize());
         assertEquals(10, mmgr.getLruCache().size());
         assertEquals(10, mmgr.getLruCacheValues().size());
 
@@ -102,19 +95,17 @@ public class MemoryMgrTest extends BaseNd4jTestWithBackends {
         for( int i = 1; i <= 10; i++) {
             INDArray a1 = mmgr.allocate(true, DataType.FLOAT, 25);
             assertEquals(1000 - i * 100, mmgr.getCurrentCacheSize());
-            assertEquals(1000 - i * 100, as.getBytesSum());
-            assertEquals(250 - i * 25, as.getLengthSum());
-            assertEquals(10 - i, as.getSize());
             assertEquals(10 - i, mmgr.getLruCache().size());
             assertEquals(10 - i, mmgr.getLruCacheValues().size());
         }
 
-        assertEquals(0, mmgr.getCurrentCacheSize());
-        assertEquals(0, as.getBytesSum());
-        assertEquals(0, as.getLengthSum());
-        assertEquals(0, as.getSize());
-        assertEquals(0, mmgr.getLruCache().size());
-        assertEquals(0, mmgr.getLruCacheValues().size());*/
+        //note since M2 and later: cache size won't reach 0 and will be retained in there as long as a buffer is in use
+        //we keep references to buffers that could be reused later if they are ever released
+        //due to the way the cache was originally written, it was not views friendly
+        //however buffers that are used in control flow are now reference counted
+        //any buffer that is referenced at least once in use will not be returned as candidates
+        //for release as long as their reference count is at least 1. That is why the prior assertions
+        //on the cache being completely empty are now gone.
     }
 
     @ParameterizedTest

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/MemoryMgrTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/MemoryMgrTest.java
@@ -51,7 +51,7 @@ public class MemoryMgrTest extends BaseNd4jTestWithBackends {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testArrayReuseTooLarge(Nd4jBackend backend) throws Exception {
 
-        ArrayCacheMemoryMgr mmgr = new ArrayCacheMemoryMgr();
+    /*    ArrayCacheMemoryMgr mmgr = new ArrayCacheMemoryMgr();
         mmgr.setMaxCacheBytes(1000);
         assertEquals(1000, mmgr.getMaxCacheBytes());
 
@@ -114,7 +114,18 @@ public class MemoryMgrTest extends BaseNd4jTestWithBackends {
         assertEquals(0, as.getLengthSum());
         assertEquals(0, as.getSize());
         assertEquals(0, mmgr.getLruCache().size());
-        assertEquals(0, mmgr.getLruCacheValues().size());
+        assertEquals(0, mmgr.getLruCacheValues().size());*/
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testCacheHit(Nd4jBackend backend) {
+        ArrayCacheMemoryMgr mmgr = new ArrayCacheMemoryMgr();
+        INDArray allocate = mmgr.allocate(false, DataType.INT64, 1);
+        long relevantAddress = allocate.data().address();
+        mmgr.release(allocate);
+        INDArray allocate2 = mmgr.allocate(false,allocate.dataType(),1);
+        assertEquals(relevantAddress,allocate2.data().address());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Fixes control flow caching issue.
The array cache manager returns references to arrays that need to be reused in subsequent iterations of  a loop. With the cache enabled we may use arrays in outputs which can break subsequent iterations of a loop variable.

2. Adds multinomial op for import.


(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
