### PR TITLE
Fixes https://github.com/eclipse/deeplearning4j/issues/9709

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -1012,6 +1012,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             if (dimension[0] == 0 && isColumnVector()) {
                 return this.transpose();
             } else if (dimension[0] == 1 && isRowVector()) {
+                if(this.rank() > 1)
+                    return this.reshape(length());
                 return this;
             }
         }
@@ -4367,9 +4369,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public INDArray getRow(long r) {
-        if (isRowVector() && r == 0)
-            return this;
-        else if (isRowVector() && r > 0)
+        if (isRowVector() && r > 0)
             throw new IllegalArgumentException("Illegal index for row: requested row " + r + " but this.size(0)=" + this.size(0));
 
         Preconditions.checkArgument(rank() == 2, "getRow() can be called on 2D arrays only");

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/api/indexing/IndexingTestsC.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/api/indexing/IndexingTestsC.java
@@ -292,6 +292,21 @@ public class IndexingTestsC extends BaseNd4jTestWithBackends {
         assertEquals(1.0, test.getScalar(0, 0, -1).sumNumber());
     }
 
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testGetRowSingle(Nd4jBackend backend) {
+        INDArray ones = Nd4j.ones(1, 8);
+        System.out.println(ones.shapeInfoToString());
+        ones = ones.getRow(0);
+        assertArrayEquals(new long[]{8},ones.shape());
+
+        ones = Nd4j.ones(2, 8);
+        System.out.println(ones.shapeInfoToString());
+        ones = ones.getRow(0);
+        assertArrayEquals(new long[]{8},ones.shape());
+    }
+
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testGetIndices2d(Nd4jBackend backend) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes https://github.com/eclipse/deeplearning4j/issues/9709

Ensures that getRow always has consistent behavior whether it's 1 row or multiple rows.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
