### PR TITLE
Add using fast path for results as well

### DIFF
--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -731,8 +731,8 @@ sd::Status sd::ops::DeclarableOp::execute(Context *block) {
       auto p = fp->profile();
       if (p != nullptr) {
         sd::LongType memoryAfter = block->workspace() == nullptr
-                                       ? 0L
-                                       : block->workspace()->getSpilledSize() + block->workspace()->getUsedSize();
+                                   ? 0L
+                                   : block->workspace()->getSpilledSize() + block->workspace()->getUsedSize();
         sd::LongType memoryUsed = memoryAfter - memoryBefore;
         p->nodeById(block->nodeId())->setPreparationTime(prepTime);
         p->nodeById(block->nodeId())->setExecutionTime(outerTime);
@@ -776,14 +776,13 @@ sd::Status sd::ops::DeclarableOp::execute(Context *block) {
 }
 
 void DeclarableOp::overwriteResult(Context &block, int outputIdx, NDArray *array, bool remove) {
-  sd_printf("Pushing variable\n", 0);
+  sd_debug("Pushing variable\n", 0);
   if (block.isFastPath()) {
     if (remove && block.fastpath_out()[outputIdx] != nullptr) {
       // delete reference/call destrucotr if remove is true
       delete block.fastpath_out()[outputIdx];
     }
-    sd_printf("In fast path, setting variable\n", 0);
-    array->printIndexedBuffer("setting variable\n");
+    sd_debug("In fast path, setting variable\n", 0);
     block.fastpath_out()[outputIdx] = array;
   } else if (block.getVariableSpace() == nullptr) {
     throw std::runtime_error("Var space should not be null before pushing variable!");
@@ -1158,21 +1157,28 @@ sd::ResultSet DeclarableOp::evaluate(const std::vector<NDArray *> &inputs, const
   if (status != sd::Status::OK) return arrayList;
 
   if (!isInplace) {
-    for (int e = 0; e < DataTypeUtils::max<int>(); e++) {
-      std::pair<int, int> pair(1, e);
-      if (variableSpace.hasVariable(pair)) {
-        auto var = variableSpace.getVariable(pair);
-        auto arr = var->getNDArray();
-        if (!arr->isAttached()) {
-          var->markRemovable(false);
-          arr->setContext(sd::LaunchContext::defaultContext());
-          arrayList.push_back(arr);
-        } else {
-          arrayList.push_back(arr->detach());
-        }
-      } else
-        break;
+    if(block.isFastPath()) {
+      for(int e = 0; e < block.fastpath_out().size(); e++) {
+        arrayList.push_back(block.fastpath_out()[e]);
+      }
+    } else {
+      for (int e = 0; e < DataTypeUtils::max<int>(); e++) {
+        std::pair<int, int> pair(1, e);
+        if (variableSpace.hasVariable(pair)) {
+          auto var = variableSpace.getVariable(pair);
+          auto arr = var->getNDArray();
+          if (!arr->isAttached()) {
+            var->markRemovable(false);
+            arr->setContext(sd::LaunchContext::defaultContext());
+            arrayList.push_back(arr);
+          } else {
+            arrayList.push_back(arr->detach());
+          }
+        } else
+          break;
+      }
     }
+
   } else {
     for (auto v : inputs) {
       arrayList.push_back(v);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes issue with create_view and return results from c++. Ensures that fast path can be used as a return result when relevant. This can enable consistency with java and c++ getting results from the same place.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
