### PR TITLE
Fix up build on intel systems

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -134,7 +134,7 @@
                 <!-- By default protoc provided binaries don't need a protocCommand. One is downloaded. Protoc plugin does not support
                 protoc yet. This means we need to use a system protoc on non intel platforms. -->
                 <os>
-                    <arch>x86_64</arch>
+                    <arch>amd64</arch>
                 </os>
             </activation>
             <id>protoc-provided-binaries</id>
@@ -172,6 +172,32 @@
                             </execution>
                         </executions>
                     </plugin>
+
+                    <plugin>
+                        <groupId>com.google.code.maven-replacer-plugin</groupId>
+                        <artifactId>replacer</artifactId>
+                        <version>${maven-replacer-plugin.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>${project.build.sourceDirectory}/org/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/onnx/**</include>
+                                <include>${project.build.sourceDirectory}/org/nd4j/ir/**</include>
+                            </includes>
+                            <token>com.google.protobuf.</token>
+                            <value>org.nd4j.shade.protobuf.</value>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>replace-imports</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>replace</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                 </plugins>
             </build>
 
@@ -220,6 +246,32 @@
 
                         </executions>
                     </plugin>
+
+                    <plugin>
+                        <groupId>com.google.code.maven-replacer-plugin</groupId>
+                        <artifactId>replacer</artifactId>
+                        <version>${maven-replacer-plugin.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>${project.build.sourceDirectory}/org/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/onnx/**</include>
+                                <include>${project.build.sourceDirectory}/org/nd4j/ir/**</include>
+                            </includes>
+                            <token>com.google.protobuf.</token>
+                            <value>org.nd4j.shade.protobuf.</value>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>replace-imports</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>replace</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                 </plugins>
             </build>
             <activation>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix up build on intel systems.  Both the code replacer
and the protoc generation need to be co located in the same profile 
in order to run in the appropriate order.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
