### PR TITLE
Upgrade protobuf to 3.21.2

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/pom.xml
@@ -134,7 +134,7 @@
                 <!-- By default protoc provided binaries don't need a protocCommand. One is downloaded. Protoc plugin does not support
                 protoc yet. This means we need to use a system protoc on non intel platforms. -->
                 <os>
-                    <arch>x86_64</arch>
+                    <arch>amd64</arch>
                 </os>
             </activation>
             <id>protoc-provided-binaries</id>
@@ -172,6 +172,32 @@
                             </execution>
                         </executions>
                     </plugin>
+
+                    <plugin>
+                        <groupId>com.google.code.maven-replacer-plugin</groupId>
+                        <artifactId>replacer</artifactId>
+                        <version>${maven-replacer-plugin.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>${project.build.sourceDirectory}/org/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/onnx/**</include>
+                                <include>${project.build.sourceDirectory}/org/nd4j/ir/**</include>
+                            </includes>
+                            <token>com.google.protobuf.</token>
+                            <value>org.nd4j.shade.protobuf.</value>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>replace-imports</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>replace</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                 </plugins>
             </build>
 
@@ -220,6 +246,32 @@
 
                         </executions>
                     </plugin>
+
+                    <plugin>
+                        <groupId>com.google.code.maven-replacer-plugin</groupId>
+                        <artifactId>replacer</artifactId>
+                        <version>${maven-replacer-plugin.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>${project.build.sourceDirectory}/org/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/tensorflow/**</include>
+                                <include>${project.build.sourceDirectory}/onnx/**</include>
+                                <include>${project.build.sourceDirectory}/org/nd4j/ir/**</include>
+                            </includes>
+                            <token>com.google.protobuf.</token>
+                            <value>org.nd4j.shade.protobuf.</value>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>replace-imports</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>replace</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                 </plugins>
             </build>
             <activation>

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/ir/MapperNamespace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/ir/MapperNamespace.java
@@ -686,9 +686,11 @@ public final class MapperNamespace {
      * <code>map&lt;string, string&gt; inputToOutput = 17;</code>
      */
 
-    java.lang.String getInputToOutputOrDefault(
+    /* nullable */
+java.lang.String getInputToOutputOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue);
+        /* nullable */
+java.lang.String defaultValue);
     /**
      * <code>map&lt;string, string&gt; inputToOutput = 17;</code>
      */
@@ -992,6 +994,8 @@ public final class MapperNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -1669,7 +1673,7 @@ public final class MapperNamespace {
     @java.lang.Override
     public boolean containsInputToOutput(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetInputToOutput().getMap().containsKey(key);
     }
     /**
@@ -1696,7 +1700,7 @@ public final class MapperNamespace {
     public java.lang.String getInputToOutputOrDefault(
         java.lang.String key,
         java.lang.String defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetInputToOutput().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -1708,7 +1712,7 @@ public final class MapperNamespace {
 
     public java.lang.String getInputToOutputOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetInputToOutput().getMap();
       if (!map.containsKey(key)) {
@@ -1847,10 +1851,10 @@ public final class MapperNamespace {
     @java.lang.Override
     public void writeTo(org.nd4j.shade.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getRuleNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(ruleName_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 1, ruleName_);
       }
-      if (!getFunctionNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(functionName_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 2, functionName_);
       }
       for (int i = 0; i < inputStringAttrName_.size(); i++) {
@@ -1901,13 +1905,13 @@ public final class MapperNamespace {
           internalGetInputToOutput(),
           InputToOutputDefaultEntryHolder.defaultEntry,
           17);
-      if (!getRuleTypeBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(ruleType_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 18, ruleType_);
       }
       for (int i = 0; i < transformerArgs_.size(); i++) {
         output.writeMessage(19, transformerArgs_.get(i));
       }
-      if (!getInputFrameworkOpNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(inputFrameworkOpName_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 20, inputFrameworkOpName_);
       }
       unknownFields.writeTo(output);
@@ -1919,10 +1923,10 @@ public final class MapperNamespace {
       if (size != -1) return size;
 
       size = 0;
-      if (!getRuleNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(ruleName_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(1, ruleName_);
       }
-      if (!getFunctionNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(functionName_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(2, functionName_);
       }
       {
@@ -2047,14 +2051,14 @@ public final class MapperNamespace {
         size += org.nd4j.shade.protobuf.CodedOutputStream
             .computeMessageSize(17, inputToOutput__);
       }
-      if (!getRuleTypeBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(ruleType_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(18, ruleType_);
       }
       for (int i = 0; i < transformerArgs_.size(); i++) {
         size += org.nd4j.shade.protobuf.CodedOutputStream
           .computeMessageSize(19, transformerArgs_.get(i));
       }
-      if (!getInputFrameworkOpNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(inputFrameworkOpName_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(20, inputFrameworkOpName_);
       }
       size += unknownFields.getSerializedSize();
@@ -4493,7 +4497,7 @@ public final class MapperNamespace {
       @java.lang.Override
       public boolean containsInputToOutput(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         return internalGetInputToOutput().getMap().containsKey(key);
       }
       /**
@@ -4520,7 +4524,7 @@ public final class MapperNamespace {
       public java.lang.String getInputToOutputOrDefault(
           java.lang.String key,
           java.lang.String defaultValue) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         java.util.Map<java.lang.String, java.lang.String> map =
             internalGetInputToOutput().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -4532,7 +4536,7 @@ public final class MapperNamespace {
 
       public java.lang.String getInputToOutputOrThrow(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         java.util.Map<java.lang.String, java.lang.String> map =
             internalGetInputToOutput().getMap();
         if (!map.containsKey(key)) {
@@ -4552,7 +4556,7 @@ public final class MapperNamespace {
 
       public Builder removeInputToOutput(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         internalGetMutableInputToOutput().getMutableMap()
             .remove(key);
         return this;
@@ -4571,8 +4575,11 @@ public final class MapperNamespace {
       public Builder putInputToOutput(
           java.lang.String key,
           java.lang.String value) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
-        if (value == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
+        if (value == null) {
+  throw new NullPointerException("map value");
+}
+
         internalGetMutableInputToOutput().getMutableMap()
             .put(key, value);
         return this;
@@ -5146,6 +5153,8 @@ public final class MapperNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -5262,7 +5271,7 @@ public final class MapperNamespace {
     @java.lang.Override
     public void writeTo(org.nd4j.shade.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getKeyBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(key_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 1, key_);
       }
       for (int i = 0; i < transformerArgs_.size(); i++) {
@@ -5277,7 +5286,7 @@ public final class MapperNamespace {
       if (size != -1) return size;
 
       size = 0;
-      if (!getKeyBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(key_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(1, key_);
       }
       for (int i = 0; i < transformerArgs_.size(); i++) {
@@ -6105,6 +6114,8 @@ public final class MapperNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -7222,6 +7233,8 @@ public final class MapperNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -7546,13 +7559,13 @@ public final class MapperNamespace {
     @java.lang.Override
     public void writeTo(org.nd4j.shade.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getFrameworkNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(frameworkName_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 1, frameworkName_);
       }
-      if (!getOpNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(opName_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 2, opName_);
       }
-      if (!getInputFrameworkOpNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(inputFrameworkOpName_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 3, inputFrameworkOpName_);
       }
       for (int i = 0; i < rule_.size(); i++) {
@@ -7576,13 +7589,13 @@ public final class MapperNamespace {
       if (size != -1) return size;
 
       size = 0;
-      if (!getFrameworkNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(frameworkName_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(1, frameworkName_);
       }
-      if (!getOpNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(opName_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(2, opName_);
       }
-      if (!getInputFrameworkOpNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(inputFrameworkOpName_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(3, inputFrameworkOpName_);
       }
       for (int i = 0; i < rule_.size(); i++) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/ir/OpNamespace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/ir/OpNamespace.java
@@ -303,6 +303,8 @@ public final class OpNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -774,13 +776,13 @@ public final class OpNamespace {
     @java.lang.Override
     public void writeTo(org.nd4j.shade.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
-      if (floatValue_ != 0F) {
+      if (java.lang.Float.floatToRawIntBits(floatValue_) != 0) {
         output.writeFloat(2, floatValue_);
       }
-      if (doubleValue_ != 0D) {
+      if (java.lang.Double.doubleToRawLongBits(doubleValue_) != 0) {
         output.writeDouble(3, doubleValue_);
       }
       if (int32Value_ != 0) {
@@ -807,7 +809,7 @@ public final class OpNamespace {
       if (argIndex_ != 0) {
         output.writeInt32(11, argIndex_);
       }
-      if (!getStringValueBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(stringValue_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 12, stringValue_);
       }
       if (argOptional_ != false) {
@@ -828,14 +830,14 @@ public final class OpNamespace {
       if (size != -1) return size;
 
       size = 0;
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
-      if (floatValue_ != 0F) {
+      if (java.lang.Float.floatToRawIntBits(floatValue_) != 0) {
         size += org.nd4j.shade.protobuf.CodedOutputStream
           .computeFloatSize(2, floatValue_);
       }
-      if (doubleValue_ != 0D) {
+      if (java.lang.Double.doubleToRawLongBits(doubleValue_) != 0) {
         size += org.nd4j.shade.protobuf.CodedOutputStream
           .computeDoubleSize(3, doubleValue_);
       }
@@ -871,7 +873,7 @@ public final class OpNamespace {
         size += org.nd4j.shade.protobuf.CodedOutputStream
           .computeInt32Size(11, argIndex_);
       }
-      if (!getStringValueBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(stringValue_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(12, stringValue_);
       }
       if (argOptional_ != false) {
@@ -2298,6 +2300,8 @@ public final class OpNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2631,7 +2635,7 @@ public final class OpNamespace {
     @java.lang.Override
     public void writeTo(org.nd4j.shade.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
       for (int i = 0; i < argDescriptor_.size(); i++) {
@@ -2649,7 +2653,7 @@ public final class OpNamespace {
       if (size != -1) return size;
 
       size = 0;
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
       for (int i = 0; i < argDescriptor_.size(); i++) {
@@ -3513,6 +3517,8 @@ public final class OpNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/ir/TensorNamespace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/ir/TensorNamespace.java
@@ -470,6 +470,8 @@ public final class TensorNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -581,10 +583,10 @@ public final class TensorNamespace {
     @java.lang.Override
     public void writeTo(org.nd4j.shade.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getKeyBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(key_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 2, value_);
       }
       unknownFields.writeTo(output);
@@ -596,10 +598,10 @@ public final class TensorNamespace {
       if (size != -1) return size;
 
       size = 0;
-      if (!getKeyBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(key_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(2, value_);
       }
       size += unknownFields.getSerializedSize();
@@ -1202,6 +1204,8 @@ public final class TensorNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -1339,6 +1343,8 @@ public final class TensorNamespace {
           }
         } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
           throw e.setUnfinishedMessage(this);
+        } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
           throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
@@ -2519,8 +2525,9 @@ public final class TensorNamespace {
         } else {
           if (valueCase_ == 1) {
             tensorTypeBuilder_.mergeFrom(value);
+          } else {
+            tensorTypeBuilder_.setMessage(value);
           }
-          tensorTypeBuilder_.setMessage(value);
         }
         valueCase_ = 1;
         return this;
@@ -2755,6 +2762,8 @@ public final class TensorNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -2785,10 +2794,24 @@ public final class TensorNamespace {
 
       /**
        * <code>int64 dim_value = 1;</code>
+       * @return Whether the dimValue field is set.
+       */
+      boolean hasDimValue();
+      /**
+       * <code>int64 dim_value = 1;</code>
        * @return The dimValue.
        */
       long getDimValue();
 
+      /**
+       * <pre>
+       * namespace Shape
+       * </pre>
+       *
+       * <code>string dim_param = 2;</code>
+       * @return Whether the dimParam field is set.
+       */
+      boolean hasDimParam();
       /**
        * <pre>
        * namespace Shape
@@ -2857,8 +2880,8 @@ public final class TensorNamespace {
                 done = true;
                 break;
               case 8: {
-                valueCase_ = 1;
                 value_ = input.readInt64();
+                valueCase_ = 1;
                 break;
               }
               case 18: {
@@ -2878,6 +2901,8 @@ public final class TensorNamespace {
           }
         } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
           throw e.setUnfinishedMessage(this);
+        } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
           throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
@@ -2943,6 +2968,14 @@ public final class TensorNamespace {
       public static final int DIM_VALUE_FIELD_NUMBER = 1;
       /**
        * <code>int64 dim_value = 1;</code>
+       * @return Whether the dimValue field is set.
+       */
+      @java.lang.Override
+      public boolean hasDimValue() {
+        return valueCase_ == 1;
+      }
+      /**
+       * <code>int64 dim_value = 1;</code>
        * @return The dimValue.
        */
       @java.lang.Override
@@ -2954,6 +2987,17 @@ public final class TensorNamespace {
       }
 
       public static final int DIM_PARAM_FIELD_NUMBER = 2;
+      /**
+       * <pre>
+       * namespace Shape
+       * </pre>
+       *
+       * <code>string dim_param = 2;</code>
+       * @return Whether the dimParam field is set.
+       */
+      public boolean hasDimParam() {
+        return valueCase_ == 2;
+      }
       /**
        * <pre>
        * namespace Shape
@@ -3373,6 +3417,13 @@ public final class TensorNamespace {
 
         /**
          * <code>int64 dim_value = 1;</code>
+         * @return Whether the dimValue field is set.
+         */
+        public boolean hasDimValue() {
+          return valueCase_ == 1;
+        }
+        /**
+         * <code>int64 dim_value = 1;</code>
          * @return The dimValue.
          */
         public long getDimValue() {
@@ -3405,6 +3456,18 @@ public final class TensorNamespace {
           return this;
         }
 
+        /**
+         * <pre>
+         * namespace Shape
+         * </pre>
+         *
+         * <code>string dim_param = 2;</code>
+         * @return Whether the dimParam field is set.
+         */
+        @java.lang.Override
+        public boolean hasDimParam() {
+          return valueCase_ == 2;
+        }
         /**
          * <pre>
          * namespace Shape
@@ -4405,6 +4468,8 @@ public final class TensorNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -4570,13 +4635,13 @@ public final class TensorNamespace {
     @java.lang.Override
     public void writeTo(org.nd4j.shade.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
       if (type_ != null) {
         output.writeMessage(2, getType());
       }
-      if (!getDocStringBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(docString_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 3, docString_);
       }
       unknownFields.writeTo(output);
@@ -4588,14 +4653,14 @@ public final class TensorNamespace {
       if (size != -1) return size;
 
       size = 0;
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
       if (type_ != null) {
         size += org.nd4j.shade.protobuf.CodedOutputStream
           .computeMessageSize(2, getType());
       }
-      if (!getDocStringBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(docString_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(3, docString_);
       }
       size += unknownFields.getSerializedSize();
@@ -6136,6 +6201,8 @@ public final class TensorNamespace {
         }
       } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
+      } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
@@ -6389,6 +6456,8 @@ public final class TensorNamespace {
           }
         } catch (org.nd4j.shade.protobuf.InvalidProtocolBufferException e) {
           throw e.setUnfinishedMessage(this);
+        } catch (org.nd4j.shade.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(this);
         } catch (java.io.IOException e) {
           throw new org.nd4j.shade.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
@@ -7641,7 +7710,7 @@ public final class TensorNamespace {
       for (int i = 0; i < int64Data_.size(); i++) {
         output.writeInt64NoTag(int64Data_.getLong(i));
       }
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 8, name_);
       }
       if (!rawData_.isEmpty()) {
@@ -7661,7 +7730,7 @@ public final class TensorNamespace {
       for (int i = 0; i < uint64Data_.size(); i++) {
         output.writeUInt64NoTag(uint64Data_.getLong(i));
       }
-      if (!getDocStringBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(docString_)) {
         org.nd4j.shade.protobuf.GeneratedMessageV3.writeString(output, 12, docString_);
       }
       for (int i = 0; i < externalData_.size(); i++) {
@@ -7763,7 +7832,7 @@ public final class TensorNamespace {
         }
         int64DataMemoizedSerializedSize = dataSize;
       }
-      if (!getNameBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(8, name_);
       }
       if (!rawData_.isEmpty()) {
@@ -7795,7 +7864,7 @@ public final class TensorNamespace {
         }
         uint64DataMemoizedSerializedSize = dataSize;
       }
-      if (!getDocStringBytes().isEmpty()) {
+      if (!org.nd4j.shade.protobuf.GeneratedMessageV3.isStringEmpty(docString_)) {
         size += org.nd4j.shade.protobuf.GeneratedMessageV3.computeStringSize(12, docString_);
       }
       for (int i = 0; i < externalData_.size(); i++) {

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <geo.jackson.version>2.8.7</geo.jackson.version>
         <lombok.version>1.18.22</lombok.version>
         <json.versiounitn>20131018</json.versiounitn>
-        <google.protobuf.version>3.12.2</google.protobuf.version>
+        <google.protobuf.version>3.21.2</google.protobuf.version>
         <google.protobuf.solr.version>2.6.1</google.protobuf.solr.version>
         <failIfNoTests>false</failIfNoTests>
         <!-- Hadoop version used by Spark 1.6.3 and 2.2.1 (and likely others) -->


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrades protobuf and protoc generated classes to 3.21.2
Follow up to recent mac osx changes to make it easier to work with protoc on macosx arm64.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
