### PR TITLE
Update build-deploy-windows.yml

### DIFF
--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -128,7 +128,7 @@ jobs:
             } elseif ( "${{ matrix.helper }}" -ne "" ) {
                 $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64   deploy -DskipTests"
             }  elseif ( "${{ matrix.extension }}" -ne "" ) {
-                 $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64   -Dlibnd4j.platform=windows-x86_64    deploy -DskipTests"
+                 $mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }} -Dlibnd4j.classifier=windows-x86_64-${{ matrix.extension }}"
             } else {
                $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64"
             }

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -120,7 +120,7 @@ jobs:
               $modules=":nd4j-native-preset,:nd4j-native,libnd4j"
             }  elseif ( "${{ matrix.extension }}" -ne "" ) {
               $modules=":nd4j-native-preset,:nd4j-native,libnd4j"
-          }  else {
+            }  else {
               $modules=":nd4j-native-preset,:nd4j-native,libnd4j,:nd4j-native-platform"
             }
           

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -126,9 +126,9 @@ jobs:
             if ( "${{ matrix.helper }}" -ne ""  -And "${{ matrix.extension }}" -ne "" ) {
                $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-${{ matrix.helper }}-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.helper }}-${{ matrix.extension }}  -Dlibnd4j.helper=${{ matrix.helper }}  -Dlibnd4j.platform=windows-x86_64    deploy -DskipTests"
             } elseif ( "${{ matrix.helper }}" -ne "" ) {
-                $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Dlibnd4j.buildthreads=${{ github.event.inputs.buildThreads }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64   deploy -DskipTests"
+                $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-${{ matrix.helper }} -Dlibnd4j.extension=${{ matrix.helper }} -Djavacpp.platform.extension=-${{ matrix.helper }} -Djavacpp.platform=windows-x86_64  -Dlibnd4j.helper=${{ matrix.helper }} -Dlibnd4j.platform=windows-x86_64   deploy -DskipTests"
             }  elseif ( "${{ matrix.extension }}" -ne "" ) {
-                 $mvn_ext=" -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }} -Dlibnd4j.classifier=windows-x86_64-${{ matrix.extension }}"
+                  $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64-${{matrix.extension}} -Dlibnd4j.extension=${{ matrix.extension }} -Djavacpp.platform.extension=-${{ matrix.extension }}"
             } else {
                $mvn_ext=" -Dlibnd4j.classifier=windows-x86_64"
             }

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -118,7 +118,9 @@ jobs:
               $modules=" :nd4j-native-preset,:nd4j-native"
             } elseif ( "${{ matrix.helper }}" -ne "" ) {
               $modules=":nd4j-native-preset,:nd4j-native,libnd4j"
-            } else {
+            }  elseif ( "${{ matrix.extension }}" -ne "" ) {
+              $modules=":nd4j-native-preset,:nd4j-native,libnd4j"
+          }  else {
               $modules=":nd4j-native-preset,:nd4j-native,libnd4j,:nd4j-native-platform"
             }
           


### PR DESCRIPTION
## What changes were proposed in this pull request?
Windows build update for avx builds (no helper just classifier) assigning right modules. 
We need to prevent a bug from classifiers being pulled down with nonexistent extensions.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
