### PR TITLE
Scatter update fixes

### DIFF
--- a/contrib/codegen-tools/codegen/pom.xml
+++ b/contrib/codegen-tools/codegen/pom.xml
@@ -85,6 +85,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-common</artifactId>
+            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
@@ -60,7 +60,7 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         Input(NUMERIC, "ref") { description = "Initial/source variable" }
         Input(NUMERIC, "indices") { description = "Indices array" }
         Input(NUMERIC, "updates") { description = "Updates to add to the initial/source array" }
-        Output(NUMERIC, "output"){ description = "The updated variable" }
+        Output(NUMERIC, "output") { description = "The updated variable" }
     }
 
     val scatterDoc = Mixin("scatterDoc "){
@@ -1461,6 +1461,36 @@ fun SDBaseOps() =  Namespace("BaseOps"){
     }
 
     Op("scatterUpdate") {
+        useMixin(scatterOp)
+        Doc(Language.ANY, DocScope.ALL){
+            """
+                Scatter update operation.
+            """.trimIndent()
+        }
+        useMixin(scatterDoc)
+    }
+
+    Op("scatterNdAdd") {
+        useMixin(scatterOp)
+        Doc(Language.ANY, DocScope.ALL){
+            """
+                Scatter update operation.
+            """.trimIndent()
+        }
+        useMixin(scatterDoc)
+    }
+
+    Op("scatterNdSub") {
+        useMixin(scatterOp)
+        Doc(Language.ANY, DocScope.ALL){
+            """
+                Scatter update operation.
+            """.trimIndent()
+        }
+        useMixin(scatterDoc)
+    }
+
+    Op("scatterNdUpdate") {
         useMixin(scatterOp)
         Doc(Language.ANY, DocScope.ALL){
             """

--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
@@ -1425,6 +1425,8 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         Doc(Language.ANY, DocScope.ALL){
             """
                 Scatter max operation.
+                Maximizes values from the input tensor
+                along the indices specified.
             """.trimIndent()
         }
         useMixin(scatterDoc)
@@ -1435,6 +1437,8 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         Doc(Language.ANY, DocScope.ALL){
             """
                 Scatter min operation.
+                 Minimizes values from the input tensor
+                along the indices specified.
             """.trimIndent()
         }
         useMixin(scatterDoc)
@@ -1445,6 +1449,8 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         Doc(Language.ANY, DocScope.ALL){
             """
                 Scatter multiplication operation.
+                 Multiplies values from the input tensor
+                along the indices specified.
             """.trimIndent()
         }
         useMixin(scatterDoc)
@@ -1455,6 +1461,8 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         Doc(Language.ANY, DocScope.ALL){
             """
                 Scatter subtraction operation.
+                 Subtracts values from the input tensor
+                along the indices specified.
             """.trimIndent()
         }
         useMixin(scatterDoc)
@@ -1465,6 +1473,8 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         Doc(Language.ANY, DocScope.ALL){
             """
                 Scatter update operation.
+                 Assigns values from the input tensor
+                along the indices specified.
             """.trimIndent()
         }
         useMixin(scatterDoc)
@@ -1474,7 +1484,10 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         useMixin(scatterOp)
         Doc(Language.ANY, DocScope.ALL){
             """
-                Scatter update operation.
+                Scatter ND Add.
+                Multiple dimension version of scatter add
+                that allows addition along multi dimensional
+                indexes.
             """.trimIndent()
         }
         useMixin(scatterDoc)
@@ -1484,7 +1497,10 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         useMixin(scatterOp)
         Doc(Language.ANY, DocScope.ALL){
             """
-                Scatter update operation.
+                Scatter ND Subtraction operation.
+                 Subtract dimension version of scatter add
+                that allows addition along multi dimensional
+                indexes.
             """.trimIndent()
         }
         useMixin(scatterDoc)
@@ -1494,7 +1510,10 @@ fun SDBaseOps() =  Namespace("BaseOps"){
         useMixin(scatterOp)
         Doc(Language.ANY, DocScope.ALL){
             """
-                Scatter update operation.
+                Scatter ND update operation.
+                 Assign dimension version of scatter add
+                that allows addition along multi dimensional
+                indexes.
             """.trimIndent()
         }
         useMixin(scatterDoc)

--- a/libnd4j/include/ops/declarable/generic/transforms/scatter_update.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/scatter_update.cpp
@@ -41,27 +41,11 @@ namespace ops {
  * @tparam T
  */
 CONFIGURABLE_OP_IMPL(scatter_update, -2, 1, true, 0, -2) {
-  if(block.inputs()->size() < 3) {
-    auto operand = INPUT_VARIABLE(0);
-    auto updates = INPUT_VARIABLE(1);
+  //NOTE: DO NOT USE. USE scatter_upd instead.
+  auto operand = INPUT_VARIABLE(0);
+  auto updates = INPUT_VARIABLE(1);
 
-    helpers::scatterUpdate(block.launchContext(), *operand, *updates, block.getIArguments());
-
-  } else {
-    auto operand = INPUT_VARIABLE(0);
-    auto indices = INPUT_VARIABLE(1);
-    auto updates = INPUT_VARIABLE(2);
-    std::vector<int> *intIndices;
-    intIndices = new std::vector<int>();
-
-
-    for(LongType i = 0; i < indices->lengthOf(); i++) {
-      auto idx = indices->dataBuffer()->primaryAsT<int>()[i];
-      intIndices->push_back(idx);
-    }
-    helpers::scatterUpdate(block.launchContext(), *operand, *updates,intIndices);
-    delete[] intIndices;
-  }
+  helpers::scatterUpdate(block.launchContext(), *operand, *updates, block.getIArguments());
 
   return sd::Status::OK;
 }

--- a/libnd4j/include/ops/declarable/generic/transforms/scatter_update.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/scatter_update.cpp
@@ -40,11 +40,28 @@ namespace ops {
  *
  * @tparam T
  */
-CONFIGURABLE_OP_IMPL(scatter_update, 2, 1, true, 0, -1) {
-  auto operand = INPUT_VARIABLE(0);
-  auto updates = INPUT_VARIABLE(1);
+CONFIGURABLE_OP_IMPL(scatter_update, -2, 1, true, 0, -2) {
+  if(block.inputs()->size() < 3) {
+    auto operand = INPUT_VARIABLE(0);
+    auto updates = INPUT_VARIABLE(1);
 
-  helpers::scatterUpdate(block.launchContext(), *operand, *updates, block.getIArguments());
+    helpers::scatterUpdate(block.launchContext(), *operand, *updates, block.getIArguments());
+
+  } else {
+    auto operand = INPUT_VARIABLE(0);
+    auto indices = INPUT_VARIABLE(1);
+    auto updates = INPUT_VARIABLE(2);
+    std::vector<int> *intIndices;
+    intIndices = new std::vector<int>();
+
+
+    for(LongType i = 0; i < indices->lengthOf(); i++) {
+      auto idx = indices->dataBuffer()->primaryAsT<int>()[i];
+      intIndices->push_back(idx);
+    }
+    helpers::scatterUpdate(block.launchContext(), *operand, *updates,intIndices);
+    delete[] intIndices;
+  }
 
   return sd::Status::OK;
 }

--- a/libnd4j/include/ops/declarable/headers/transforms.h
+++ b/libnd4j/include/ops/declarable/headers/transforms.h
@@ -92,7 +92,7 @@ DECLARE_CUSTOM_OP(mergeavg_bp, 2, 1, false, 0, 0);
 #endif
 
 #if NOT_EXCLUDED(OP_scatter_update)
-DECLARE_CONFIGURABLE_OP(scatter_update, 2, 1, true, 0, -1);
+DECLARE_CONFIGURABLE_OP(scatter_update, -2, 1, true, 0, -2);
 #endif
 
 #if NOT_EXCLUDED(OP_Floor)

--- a/libnd4j/include/ops/declarable/helpers/cpu/scatterUpdateAndSimple.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/scatterUpdateAndSimple.cpp
@@ -47,7 +47,8 @@ void scatterUpdate(sd::LaunchContext* context, NDArray& input, NDArray& updates,
     for (auto i = start; i < stop; i++) {
       auto inSubArr = input(indices[i], dimsToExclude, true);
       auto updSubArr = updates(i, dimsToExclude, true);
-
+      inSubArr.printIndexedBuffer("In sub %d",i);
+      updSubArr.printIndexedBuffer("Up sub %d",i);
       if (inSubArr.lengthOf() != updSubArr.lengthOf()) continue;
 
       switch (opCode) {

--- a/libnd4j/tests_cpu/layers_tests/ParityOpsTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ParityOpsTests.cpp
@@ -1653,3 +1653,19 @@ TEST_F(ParityOpsTests, scatter_update_4) {
   ASSERT_TRUE(exp.isSameShape(x));
   ASSERT_TRUE(exp.equalsTo(x));
 }
+
+TEST_F(ParityOpsTests, scatter_update_5) {
+  NDArray x('c', {2, 2}, {1, 2, 3, 4}, sd::DataType::INT32);
+  NDArray indices('c',{6},{6, 1, 0, 2, 1, 0},sd::DataType::INT32);
+  NDArray updates('c', {2, 2}, {10, 20, 30, 40}, sd::DataType::INT32);
+
+  NDArray exp('c', {2, 2}, {20, 10, 40, 30}, sd::DataType::INT32);
+
+  sd::ops::scatter_update op;
+  auto results = op.evaluate({&x, &indices,&updates}, {}, {});
+
+  ASSERT_EQ(sd::Status::OK, results.status());
+
+  ASSERT_TRUE(exp.isSameShape(x));
+  ASSERT_TRUE(exp.equalsTo(x));
+}

--- a/libnd4j/tests_cpu/layers_tests/ParityOpsTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ParityOpsTests.cpp
@@ -1614,6 +1614,10 @@ TEST_F(ParityOpsTests, scatter_update_2) {
   NDArray exp('c', {2, 2}, {20, 10, 40, 30}, sd::DataType::INT32);
 
   sd::ops::scatter_update op;
+  //op type
+  //number of tads
+  //dimension of tad
+  //TAD indices to do update for
   auto results = op.evaluate({&x, &updates}, {}, {6, 1, 0, 2, 1, 0});
 
   ASSERT_EQ(sd::Status::OK, results.status());
@@ -1654,18 +1658,3 @@ TEST_F(ParityOpsTests, scatter_update_4) {
   ASSERT_TRUE(exp.equalsTo(x));
 }
 
-TEST_F(ParityOpsTests, scatter_update_5) {
-  NDArray x('c', {2, 2}, {1, 2, 3, 4}, sd::DataType::INT32);
-  NDArray indices('c',{6},{6, 1, 0, 2, 1, 0},sd::DataType::INT32);
-  NDArray updates('c', {2, 2}, {10, 20, 30, 40}, sd::DataType::INT32);
-
-  NDArray exp('c', {2, 2}, {20, 10, 40, 30}, sd::DataType::INT32);
-
-  sd::ops::scatter_update op;
-  auto results = op.evaluate({&x, &indices,&updates}, {}, {});
-
-  ASSERT_EQ(sd::Status::OK, results.status());
-
-  ASSERT_TRUE(exp.isSameShape(x));
-  ASSERT_TRUE(exp.equalsTo(x));
-}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
@@ -3581,6 +3581,8 @@ public class SDBaseOps {
 
   /**
    * Scatter max operation.<br>
+   * Maximizes values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3601,6 +3603,8 @@ public class SDBaseOps {
 
   /**
    * Scatter max operation.<br>
+   * Maximizes values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3624,6 +3628,8 @@ public class SDBaseOps {
 
   /**
    * Scatter min operation.<br>
+   *  Minimizes values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3644,6 +3650,8 @@ public class SDBaseOps {
 
   /**
    * Scatter min operation.<br>
+   *  Minimizes values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3667,6 +3675,8 @@ public class SDBaseOps {
 
   /**
    * Scatter multiplication operation.<br>
+   *  Multiplies values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3687,6 +3697,8 @@ public class SDBaseOps {
 
   /**
    * Scatter multiplication operation.<br>
+   *  Multiplies values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3709,7 +3721,10 @@ public class SDBaseOps {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND Add.<br>
+   * Multiple dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3729,7 +3744,10 @@ public class SDBaseOps {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND Add.<br>
+   * Multiple dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3752,7 +3770,10 @@ public class SDBaseOps {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND Subtraction operation.<br>
+   *  Subtract dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3772,7 +3793,10 @@ public class SDBaseOps {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND Subtraction operation.<br>
+   *  Subtract dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3795,7 +3819,10 @@ public class SDBaseOps {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND update operation.<br>
+   *  Assign dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3815,7 +3842,10 @@ public class SDBaseOps {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND update operation.<br>
+   *  Assign dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3839,6 +3869,8 @@ public class SDBaseOps {
 
   /**
    * Scatter subtraction operation.<br>
+   *  Subtracts values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3859,6 +3891,8 @@ public class SDBaseOps {
 
   /**
    * Scatter subtraction operation.<br>
+   *  Subtracts values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3882,6 +3916,8 @@ public class SDBaseOps {
 
   /**
    * Scatter update operation.<br>
+   *  Assigns values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -3902,6 +3938,8 @@ public class SDBaseOps {
 
   /**
    * Scatter update operation.<br>
+   *  Assigns values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
@@ -3709,6 +3709,135 @@ public class SDBaseOps {
   }
 
   /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public SDVariable scatterNdAdd(SDVariable ref, SDVariable indices, SDVariable updates) {
+    SDValidation.validateNumerical("scatterNdAdd", "ref", ref);
+    SDValidation.validateNumerical("scatterNdAdd", "indices", indices);
+    SDValidation.validateNumerical("scatterNdAdd", "updates", updates);
+    return new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdAdd(sd,ref, indices, updates).outputVariable();
+  }
+
+  /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public SDVariable scatterNdAdd(String name, SDVariable ref, SDVariable indices,
+      SDVariable updates) {
+    SDValidation.validateNumerical("scatterNdAdd", "ref", ref);
+    SDValidation.validateNumerical("scatterNdAdd", "indices", indices);
+    SDValidation.validateNumerical("scatterNdAdd", "updates", updates);
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdAdd(sd,ref, indices, updates).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public SDVariable scatterNdSub(SDVariable ref, SDVariable indices, SDVariable updates) {
+    SDValidation.validateNumerical("scatterNdSub", "ref", ref);
+    SDValidation.validateNumerical("scatterNdSub", "indices", indices);
+    SDValidation.validateNumerical("scatterNdSub", "updates", updates);
+    return new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdSub(sd,ref, indices, updates).outputVariable();
+  }
+
+  /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public SDVariable scatterNdSub(String name, SDVariable ref, SDVariable indices,
+      SDVariable updates) {
+    SDValidation.validateNumerical("scatterNdSub", "ref", ref);
+    SDValidation.validateNumerical("scatterNdSub", "indices", indices);
+    SDValidation.validateNumerical("scatterNdSub", "updates", updates);
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdSub(sd,ref, indices, updates).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public SDVariable scatterNdUpdate(SDVariable ref, SDVariable indices, SDVariable updates) {
+    SDValidation.validateNumerical("scatterNdUpdate", "ref", ref);
+    SDValidation.validateNumerical("scatterNdUpdate", "indices", indices);
+    SDValidation.validateNumerical("scatterNdUpdate", "updates", updates);
+    return new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdUpdate(sd,ref, indices, updates).outputVariable();
+  }
+
+  /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public SDVariable scatterNdUpdate(String name, SDVariable ref, SDVariable indices,
+      SDVariable updates) {
+    SDValidation.validateNumerical("scatterNdUpdate", "ref", ref);
+    SDValidation.validateNumerical("scatterNdUpdate", "indices", indices);
+    SDValidation.validateNumerical("scatterNdUpdate", "updates", updates);
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdUpdate(sd,ref, indices, updates).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
    * Scatter subtraction operation.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
@@ -4112,10 +4241,11 @@ public class SDBaseOps {
   /**
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
-   * @param input Input variable (NDARRAY type)
+   * @param input Input variable (NUMERIC type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public SDVariable shape(SDVariable input) {
+    SDValidation.validateNumerical("shape", "input", input);
     return new org.nd4j.linalg.api.ops.impl.shape.Shape(sd,input).outputVariable();
   }
 
@@ -4123,10 +4253,11 @@ public class SDBaseOps {
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
    * @param name name May be null. Name for the output variable
-   * @param input Input variable (NDARRAY type)
+   * @param input Input variable (NUMERIC type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public SDVariable shape(String name, SDVariable input) {
+    SDValidation.validateNumerical("shape", "input", input);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.Shape(sd,input).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
@@ -4134,10 +4265,11 @@ public class SDBaseOps {
   /**
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public SDVariable size(SDVariable in) {
+    SDValidation.validateNumerical("size", "in", in);
     return new org.nd4j.linalg.api.ops.impl.shape.Size(sd,in).outputVariable();
   }
 
@@ -4145,10 +4277,11 @@ public class SDBaseOps {
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
    * @param name name May be null. Name for the output variable
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public SDVariable size(String name, SDVariable in) {
+    SDValidation.validateNumerical("size", "in", in);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.Size(sd,in).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
@@ -4157,11 +4290,12 @@ public class SDBaseOps {
    * Returns a rank 0 (scalar) variable for the size of the specified dimension.<br>
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public SDVariable sizeAt(SDVariable in, int dimension) {
+    SDValidation.validateNumerical("sizeAt", "in", in);
     return new org.nd4j.linalg.api.ops.impl.shape.SizeAt(sd,in, dimension).outputVariable();
   }
 
@@ -4170,11 +4304,12 @@ public class SDBaseOps {
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
    * @param name name May be null. Name for the output variable
-   * @param in Input variable (NDARRAY type)
+   * @param in Input variable (NUMERIC type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public SDVariable sizeAt(String name, SDVariable in, int dimension) {
+    SDValidation.validateNumerical("sizeAt", "in", in);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.SizeAt(sd,in, dimension).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterNdAdd.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterNdAdd.java
@@ -26,6 +26,7 @@ import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
 import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
@@ -43,6 +44,10 @@ public class ScatterNdAdd extends DynamicCustomOp {
     }
 
     public ScatterNdAdd(){}
+
+    public ScatterNdAdd(INDArray ref, INDArray indices, INDArray updates) {
+        super(null,new INDArray[]{ref,indices,updates},null);
+    }
 
     @Override
     public String opName() {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterNdSub.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterNdSub.java
@@ -26,6 +26,7 @@ import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
 import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
@@ -43,6 +44,10 @@ public class ScatterNdSub extends DynamicCustomOp {
     }
 
     public ScatterNdSub(){}
+
+    public ScatterNdSub(INDArray ref, INDArray indices, INDArray updates) {
+        super(null,new INDArray[]{ref,indices,updates},null);
+    }
 
     @Override
     public String opName() {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterNdUpdate.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterNdUpdate.java
@@ -26,6 +26,7 @@ import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.imports.graphmapper.tf.TFGraphMapper;
 import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
@@ -43,6 +44,10 @@ public class ScatterNdUpdate extends DynamicCustomOp {
     }
 
     public ScatterNdUpdate(){}
+
+    public ScatterNdUpdate(INDArray ref, INDArray indices, INDArray updates) {
+        super(null,new INDArray[]{ref,indices,updates},null);
+    }
 
     @Override
     public String opName() {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterUpdate.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterUpdate.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 
 public class ScatterUpdate extends DynamicCustomOp {
-    public static enum UpdateOp {
+    public enum UpdateOp {
         ADD,
         SUBTRACT,
         MULTIPLY,

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterUpdate.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/scatter/ScatterUpdate.java
@@ -54,13 +54,13 @@ public class ScatterUpdate extends DynamicCustomOp {
 
     public ScatterUpdate(){}
 
-    public ScatterUpdate(INDArray ref, INDArray indices, INDArray update){
-        super(new INDArray[]{ref, indices, update}, null);
+    public ScatterUpdate(INDArray ref, INDArray indices, INDArray update) {
+        super(new INDArray[]{ref, indices, update},null);
     }
 
     @Override
     public String opName() {
-        return "scatter_update";
+        return "scatter_upd";
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -127,6 +127,10 @@ public class Nd4j {
      */
     public static final NDLinalg linalg = new NDLinalg();
 
+    /**
+     * Bitwise namespace - operations related to bitwise manipulation of arrays
+     */
+    public static final NDBase base = new NDBase();
 
     /**
      * Math namespace - general mathematical operations
@@ -175,6 +179,11 @@ public class Nd4j {
         return math;
     }
 
+
+    /**
+     * Linalg namespace - operations related to linear algebra (lapack operations)
+     */
+    public static NDBase base() { return base; }
 
     /**
      * Linalg namespace - operations related to linear algebra (lapack operations)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
@@ -1698,6 +1698,8 @@ public class NDBase {
 
   /**
    * Scatter max operation.<br>
+   * Maximizes values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -1718,6 +1720,8 @@ public class NDBase {
 
   /**
    * Scatter min operation.<br>
+   *  Minimizes values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -1738,6 +1742,8 @@ public class NDBase {
 
   /**
    * Scatter multiplication operation.<br>
+   *  Multiplies values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -1757,7 +1763,10 @@ public class NDBase {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND Add.<br>
+   * Multiple dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -1777,7 +1786,10 @@ public class NDBase {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND Subtraction operation.<br>
+   *  Subtract dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -1797,7 +1809,10 @@ public class NDBase {
   }
 
   /**
-   * Scatter update operation.<br>
+   * Scatter ND update operation.<br>
+   *  Assign dimension version of scatter add<br>
+   * that allows addition along multi dimensional<br>
+   * indexes.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -1818,6 +1833,8 @@ public class NDBase {
 
   /**
    * Scatter subtraction operation.<br>
+   *  Subtracts values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
@@ -1838,6 +1855,8 @@ public class NDBase {
 
   /**
    * Scatter update operation.<br>
+   *  Assigns values from the input tensor<br>
+   * along the indices specified.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
    * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
@@ -1757,6 +1757,66 @@ public class NDBase {
   }
 
   /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public INDArray scatterNdAdd(INDArray ref, INDArray indices, INDArray updates) {
+    NDValidation.validateNumerical("scatterNdAdd", "ref", ref);
+    NDValidation.validateNumerical("scatterNdAdd", "indices", indices);
+    NDValidation.validateNumerical("scatterNdAdd", "updates", updates);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdAdd(ref, indices, updates))[0];
+  }
+
+  /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public INDArray scatterNdSub(INDArray ref, INDArray indices, INDArray updates) {
+    NDValidation.validateNumerical("scatterNdSub", "ref", ref);
+    NDValidation.validateNumerical("scatterNdSub", "indices", indices);
+    NDValidation.validateNumerical("scatterNdSub", "updates", updates);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdSub(ref, indices, updates))[0];
+  }
+
+  /**
+   * Scatter update operation.<br>
+   *
+   * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>
+   * If indices is rank 1 (a vector), then for each position i, out[indices[i], ...] = out[indices[i], ...] + op(updates[i, ...])<br>
+   * If indices is rank 2+, then for each position (i,...,k), out[indices[i], ..., indices[k], ...] = out[indices[i], ..., indices[k], ...]  + op(updates[i, ..., k, ...]) <br>
+   * Note that if multiple indices refer to the same location, the contributions from each is handled correctly. <br>
+   *
+   * @param ref Initial/source variable (NUMERIC type)
+   * @param indices Indices array (NUMERIC type)
+   * @param updates Updates to add to the initial/source array (NUMERIC type)
+   * @return output The updated variable (NUMERIC type)
+   */
+  public INDArray scatterNdUpdate(INDArray ref, INDArray indices, INDArray updates) {
+    NDValidation.validateNumerical("scatterNdUpdate", "ref", ref);
+    NDValidation.validateNumerical("scatterNdUpdate", "indices", indices);
+    NDValidation.validateNumerical("scatterNdUpdate", "updates", updates);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.scatter.ScatterNdUpdate(ref, indices, updates))[0];
+  }
+
+  /**
    * Scatter subtraction operation.<br>
    *
    * If indices is rank 0 (a scalar), then out[index, ...] = out[index, ...] + op(updates[...])<br>

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestTransformOpValidation.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestTransformOpValidation.java
@@ -217,6 +217,15 @@ public class TestTransformOpValidation extends BaseOpValidation {
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+
+    public void testScatterUpdate(Nd4jBackend backend) {
+        INDArray v1 = Nd4j.zeros(5);
+        INDArray v2 = Nd4j.base().scatterUpdate(v1, Nd4j.scalar(2), Nd4j.scalar(1f));
+        System.out.println(v2); // expected result: [0, 0, 1, 0, 0]
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testScalarMulCF(Nd4jBackend backend) {
 
         INDArray in = Nd4j.linspace(1, 12, 12, DataType.DOUBLE).reshape('c', 3, 4);

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestTransformOpValidation.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestTransformOpValidation.java
@@ -219,9 +219,10 @@ public class TestTransformOpValidation extends BaseOpValidation {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
 
     public void testScatterUpdate(Nd4jBackend backend) {
-        INDArray v1 = Nd4j.zeros(5);
-        INDArray v2 = Nd4j.base().scatterUpdate(v1, Nd4j.scalar(2), Nd4j.scalar(1f));
-        System.out.println(v2); // expected result: [0, 0, 1, 0, 0]
+        INDArray v1 = Nd4j.zeros(DataType.FLOAT,5);
+        INDArray v2 = Nd4j.base().scatterUpdate(v1, Nd4j.createFromArray(2), Nd4j.createFromArray(1f));
+        INDArray assertion = Nd4j.createFromArray(0.0f, 0.0f, 1.0f, 0.0f, 0.0f);
+        assertEquals(assertion,v2);
     }
 
     @ParameterizedTest

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestTransformOpValidation.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestTransformOpValidation.java
@@ -217,7 +217,6 @@ public class TestTransformOpValidation extends BaseOpValidation {
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
-
     public void testScatterUpdate(Nd4jBackend backend) {
         INDArray v1 = Nd4j.zeros(DataType.FLOAT,5);
         INDArray v2 = Nd4j.base().scatterUpdate(v1, Nd4j.createFromArray(2), Nd4j.createFromArray(1f));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/9763
Adds new scatter update methods to codegen, fix up interface to scatter update
Fix up scatter update in java to point to correct scatter update op.
to reflect internal behavior.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
