### PR TITLE
Fixes Global Pooling collapse dimension cases with rnns in keras import.

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/GlobalPoolingLayer.java
@@ -34,6 +34,7 @@ import org.deeplearning4j.nn.conf.preprocessor.FeedForwardToRnnPreProcessor;
 import org.deeplearning4j.nn.params.EmptyParamInitializer;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.util.ValidationUtils;
+import org.nd4j.enums.RnnDataFormat;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
@@ -98,6 +99,9 @@ public class GlobalPoolingLayer extends NoParamLayer {
             case RNN:
                 InputType.InputTypeRecurrent recurrent = (InputType.InputTypeRecurrent) inputType;
                 //Return 3d activations, with shape [minibatch, timeStepSize, 1]
+                if(collapseDimensions) {
+                    return InputType.feedForward(recurrent.getSize(), recurrent.getFormat());
+                }
                 return recurrent;
             case CNN:
                 InputType.InputTypeConvolutional conv = (InputType.InputTypeConvolutional) inputType;

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/BaseLayer.java
@@ -323,7 +323,7 @@ public abstract class BaseLayer<LayerConfT extends org.deeplearning4j.nn.conf.la
         input.castTo(ret.dataType()).mmuli(W, ret);     //TODO Can we avoid this cast? (It sohuld be a no op if not required, however)
 
         INDArray preNorm = ret;
-        if(hasLayerNorm()){
+        if(hasLayerNorm()) {
             preNorm = (forBackprop ? ret.dup(ret.ordering()) : ret);
             Nd4j.getExecutioner().exec(new LayerNorm(preNorm, g, ret, true, 1));
         }

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/preprocessors/KerasFlattenRnnPreprocessor.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/preprocessors/KerasFlattenRnnPreprocessor.java
@@ -46,7 +46,7 @@ public class KerasFlattenRnnPreprocessor extends BaseInputPreProcessor {
     @Override
     public INDArray preProcess(INDArray input, int miniBatchSize, LayerWorkspaceMgr workspaceMgr) {
         INDArray output = workspaceMgr.dup(ArrayType.ACTIVATIONS, input, 'c');
-        return output.reshape(input.size(0), depth * tsLength);
+        return output.reshape(input.size(0), -1);
     }
 
     @Override

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/keras/layers/pooling/KerasGlobalPoolingTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/keras/layers/pooling/KerasGlobalPoolingTest.java
@@ -3,6 +3,9 @@ package org.eclipse.deeplearning4j.frameworkimport.keras.layers.pooling;
 import org.deeplearning4j.BaseDL4JTest;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.modelimport.keras.KerasModelImport;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.InvalidKerasConfigurationException;
+import org.deeplearning4j.nn.modelimport.keras.exceptions.UnsupportedKerasConfigurationException;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -11,6 +14,11 @@ import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
@@ -29,5 +37,23 @@ public class KerasGlobalPoolingTest extends BaseDL4JTest {
         assertArrayEquals(new long[]{1,400,512},output[0].shape());
 
     }
+
+    @Test
+    public void testCollapseDimensions() throws IOException, UnsupportedKerasConfigurationException, InvalidKerasConfigurationException {
+        File modelPath = Resources.asFile("modelimport/keras/tfkeras/test-sequential.h5");
+        MultiLayerNetwork model  =
+                KerasModelImport.importKerasSequentialModelAndWeights(modelPath.getAbsolutePath());
+        System.out.println(model.summary());
+        List<Integer> list = Arrays.asList(1,2,3,4,5,6,7,8,9,10);
+        int inputs = 10;
+        INDArray features = Nd4j.create(1,inputs);
+        for (int i =0 ; i < list.size(); i++) {
+            features.putScalar(i, list.get(i));
+        }
+        System.out.println(features);
+        INDArray pred = model.output(features);
+        assertArrayEquals(new long[]{1,7},pred.shape());
+    }
+
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes Global Pooling collapse dimension cases with rnns in keras import.
Keras's global pooling collapses dimensions. We have a flag for this. We weren't triggering that flag
for rnns in keras import just cnns. This PR addresses that issue.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
