### PR TITLE
Disables caching of arrays that are inputs/outputs allowing proper use

### DIFF
--- a/libnd4j/pi_build.sh
+++ b/libnd4j/pi_build.sh
@@ -81,6 +81,15 @@ LIBND4J_PLATFORM_EXT_LIST=( armhf arm64 arm arm64 x86 x86_64 arm64)
 PREFIXES=( arm-linux-gnueabihf aarch64-linux-gnu arm-linux-androideabi aarch64-linux-android  i686-linux-android x86_64-linux-android aarch64-linux-gnu)
 TARGET_INDEX=-1
 
+if [ ${CURRENT_TARGET} == "linux-arm64" ];then
+    export CURRENT_TARGET="arm64"
+fi
+
+
+if [ ${CURRENT_TARGET} == "linux-arm32" ];then
+    export CURRENT_TARGET="arm32"
+fi
+
 for i in "${!TARGET_ARRS[@]}"; do
    if [[ "${TARGET_ARRS[$i]}" = "${CURRENT_TARGET}" ]]; then
        TARGET_INDEX="${i}"
@@ -172,10 +181,10 @@ function download_extract_base {
         message "download ${down_url}"
         wget  --show-progress -O "${down_file}" "${down_url}"
     fi
- 
+
     message "extract $@"
     #extract
-    mkdir -p "${down_dir}" 
+    mkdir -p "${down_dir}"
     if [ ${xtract_arg} = "-unzip" ]; then
         command="unzip -qq \"${down_file}\" -d \"${down_dir}\" "
     else
@@ -203,7 +212,7 @@ function git_check {
     command=
     if [ -n "$3" ]; then
         command="git clone --quiet --depth 1 --branch \"${3}\" \"${1}\" \"${2}\""
-    else 
+    else
     command="git clone --quiet \"${1}\" \"${2}\""
     fi
     message "$command"
@@ -219,7 +228,7 @@ function fix_pi_linker {
   fi
   rm -f "${1}/ld"
   printf '#!/usr/bin/env bash\n'"\"${1}\"/ld.gold --long-plt \"\$@\"">"${1}/ld"
-  chmod +x "${1}/ld" 
+  chmod +x "${1}/ld"
 }
 
 function cuda_cross_setup {
@@ -240,10 +249,10 @@ function cuda_cross_setup {
         if [ ! -d "${loc_DIR}/cuda/bin" ];then
             mkdir -p "${loc_DIR}/cuda/bin"
             cd "${CUDA_DIR}/bin/"
-            # we are obliged to symlink inner files and folders to avoid errors happening 
-            # when  relative folders are used from symlinks 
+            # we are obliged to symlink inner files and folders to avoid errors happening
+            # when  relative folders are used from symlinks
             for i in $(find . -maxdepth 1)
-            do 
+            do
                 ln -s "${CUDA_DIR}/bin/""${i}" "${loc_DIR}/cuda/bin/""${i}"
             done
             cd -
@@ -288,7 +297,7 @@ if [ "${TARGET_OS}" = "android" ];then
         SUFFIX=${ANDROID_VERSION}
         ABI_PREFIX="v7a"
     fi
-    
+
     COMPILER_PREFIX_DIR="${ANDROID_TOOLCHAIN}/bin/"
     NDK_TARGET="${PREFIX}${SUFFIX}"
     export TOOLCHAIN_PREFIX="${ANDROID_TOOLCHAIN}/bin/${PREFIX}"
@@ -302,7 +311,7 @@ if [ "${TARGET_OS}" = "android" ];then
     export CXX_EXE="clang++"
     export AR="${TOOLCHAIN_PREFIX}-ar"
     export RANLIB="${TOOLCHAIN_PREFIX}-ranlib"
-    export COMPILER="${COMPILER_PREFIX}-${CC_EXE}"    
+    export COMPILER="${COMPILER_PREFIX}-${CC_EXE}"
     export BLAS_XTRA="CC=\"${COMPILER}\" AR=\"${AR}\" RANLIB=\"${RANLIB}\" ${BLAS_XTRA}"
 else
     export BINUTILS_BIN="${CROSS_COMPILER_DIR}/${PREFIX}/bin"
@@ -322,14 +331,14 @@ fi
 check_requirements "${COMPILER}"
 
 if [ -z "${BUILD_USING_MAVEN}" ] ;then
-#lets build OpenBlas 
+#lets build OpenBlas
 if [ ! -d "${OPENBLAS_DIR}" ]; then
     message "download OpenBLAS"
     git_check "${OPENBLAS_GIT_URL}" "${OPENBLAS_DIR}" "v0.3.19"
 fi
 
 if [ ! -f "${THIRD_PARTY}/lib/libopenblas.so" ]; then
-    message "build and install OpenBLAS" 
+    message "build and install OpenBLAS"
     cd "${OPENBLAS_DIR}"
 
     command="make TARGET=${BLAS_TARGET_NAME} HOSTCC=gcc  NOFORTRAN=1 ${BLAS_XTRA} "
@@ -364,9 +373,9 @@ if [ ! -d "${SCONS_LOCAL_DIR}" ]; then
 fi
 check_requirements "${SCONS_LOCAL_DIR}"/scons.py
 
-if [ ! -d "${ARMCOMPUTE_DIR}" ]; then 
-    message "download ArmCompute Source" 
-    git_check ${ARMCOMPUTE_GIT_URL} "${ARMCOMPUTE_DIR}" "${ARMCOMPUTE_TAG}" 
+if [ ! -d "${ARMCOMPUTE_DIR}" ]; then
+    message "download ArmCompute Source"
+    git_check ${ARMCOMPUTE_GIT_URL} "${ARMCOMPUTE_DIR}" "${ARMCOMPUTE_TAG}"
 fi
 
 #build armcompute
@@ -374,7 +383,7 @@ if [ ! -f "${ARMCOMPUTE_DIR}/build/libarm_compute-static.a" ]; then
 message "build arm compute"
 cd "${ARMCOMPUTE_DIR}"
 command="CC=\"${CC_EXE}\" CXX=\"${CXX_EXE}\" python3 \"${SCONS_LOCAL_DIR}/scons.py\" Werror=1 -j$(nproc) toolchain_prefix=\"${TOOLCHAIN_PREFIX}-\"  compiler_prefix=\"${COMPILER_PREFIX}-\" debug=${ARMCOMPUTE_DEBUG}  neon=1 opencl=0 extra_cxx_flags=-fPIC os=${TARGET_OS} build=cross_compile arch=${ARMCOMPUTE_TARGET} "
-message $command 
+message $command
 eval $command &>/dev/null
 cd "${BASE_DIR}"
 fi
@@ -424,7 +433,7 @@ fi
 
 if [ -z "${BUILD_USING_MAVEN}" ] ;then
 message "Building using bash script"
-bash ./buildnativeoperations.sh -o ${LIBND4J_PLATFORM} -t -j $(nproc) ${XTRA_ARGS} 
+bash ./buildnativeoperations.sh -o ${LIBND4J_PLATFORM} -t -j $(nproc) ${XTRA_ARGS}
 else
 message "cd $BASE_DIR/.. "
 cd "$BASE_DIR/.."

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/EvaluationConfig.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/EvaluationConfig.java
@@ -91,9 +91,9 @@ public class EvaluationConfig {
      * @param param     The param to evaluate
      * @param evaluations The evaluations to preform
      */
-    public EvaluationConfig evaluate(@NonNull String param, @NonNull IEvaluation... evaluations){
+    public EvaluationConfig evaluate(@NonNull String param, @NonNull IEvaluation... evaluations) {
         if(this.evaluations.get(param) == null){
-            this.evaluations.put(param, new ArrayList<IEvaluation>());
+            this.evaluations.put(param, new ArrayList<>());
         }
 
         this.evaluations.get(param).addAll(Arrays.asList(evaluations));
@@ -161,7 +161,7 @@ public class EvaluationConfig {
         return this;
     }
 
-    private void validateConfig(){
+    private void validateConfig() {
         Preconditions.checkNotNull(data, "Must specify data.  It may not be null.");
 
         if(!singleInput){

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/ExecutionResult.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/ExecutionResult.java
@@ -21,6 +21,24 @@ public class ExecutionResult {
 
 
 
+    public void setCloseable(boolean closeable) {
+        if(valueOutputs != null) {
+            for(Map.Entry<String,SDValue> outputValue : valueOutputs.entrySet()) {
+                outputValue.getValue().setCloseable(closeable);
+            }
+        }
+
+        if(outputs != null) {
+            for(Map.Entry<String,Optional<INDArray>> entry : outputs.entrySet()) {
+                if(entry.getValue().isPresent()) {
+                    entry.getValue().get().setCloseable(closeable);
+                }
+            }
+        }
+
+    }
+
+
     public static  ExecutionResult createFrom(List<String> names,List<INDArray> input) {
         Preconditions.checkState(names.size() == input.size(),"Inputs and names must be equal size!");
         Map<String,Optional<INDArray>> outputs = new LinkedHashMap<>();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/SDValue.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/config/SDValue.java
@@ -50,6 +50,25 @@ public class SDValue implements IDependeeGroup<INDArray> {
     private SDValue() {
     }
 
+    public void setCloseable(boolean closeable) {
+        if(tensorValue != null) {
+            tensorValue.setCloseable(closeable);
+        }
+
+        if(listValue != null) {
+            for(INDArray arr : listValue) {
+                if(arr != null)
+                    arr.setCloseable(closeable);
+            }
+        }
+
+        if(dictValue != null) {
+            for(Map.Entry<String,INDArray> entry : dictValue.entrySet()) {
+                entry.getValue().setCloseable(closeable);
+            }
+        }
+    }
+
     public long getId() {
         return id;
     }
@@ -61,7 +80,7 @@ public class SDValue implements IDependeeGroup<INDArray> {
     /**
      * Create an empty value for the given
      * {@link DataType}
-     * 
+     *
      * @param valueType the value type to create {@link SDValue} for
      * @param dataType  the data type of the empty value
      * @return an empty ({@link Nd4j#empty(DataType)} for {@link SDValueType#TENSOR}
@@ -85,7 +104,7 @@ public class SDValue implements IDependeeGroup<INDArray> {
      * if the value type is {@link SDValueType#LIST}
      * and the number of elements is 1 otherwise
      * return the {@link #tensorValue}
-     * 
+     *
      * @return
      */
     public INDArray getTensorValue() {
@@ -98,7 +117,7 @@ public class SDValue implements IDependeeGroup<INDArray> {
      * Return an {@link INDArray[]}
      * if the value type is {@link SDValueType#TENSOR}
      * else return the list type
-     * 
+     *
      * @return
      */
     public List<INDArray> getListValue() {
@@ -110,7 +129,7 @@ public class SDValue implements IDependeeGroup<INDArray> {
     /**
      * Wrap an {@link INDArray} in a tensor
      * with an {@link SDValueType#TENSOR} type
-     * 
+     *
      * @param inputValue the input value for the {@link SDValue}
      * @return the created value
      */
@@ -124,7 +143,7 @@ public class SDValue implements IDependeeGroup<INDArray> {
     /**
      * Wrap an {@link INDArray[]} in a value
      * with an {@link SDValueType#LIST} type
-     * 
+     *
      * @param inputValue the input value
      * @return the created value
      */
@@ -138,7 +157,7 @@ public class SDValue implements IDependeeGroup<INDArray> {
     /**
      * Wrap an {@link INDArray[]} in a value
      * with an {@link SDValueType#LIST} type
-     * 
+     *
      * @param inputValue the input value
      * @return the created value
      */
@@ -152,7 +171,7 @@ public class SDValue implements IDependeeGroup<INDArray> {
     /**
      * Wrap an {@link Map<String<INDArray>} in a value
      * with an {@link SDValueType#DICT} type
-     * 
+     *
      * @param inputValue the input value
      * @return the created value
      */

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/MultiDataSet.java
@@ -122,6 +122,35 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
 
 
     @Override
+    public void setCloseable(boolean closeable) {
+        if(features != null) {
+            for(INDArray arr : features) {
+                arr.setCloseable(closeable);
+            }
+        }
+
+        if(labels != null) {
+            for(INDArray label : labels) {
+                label.setCloseable(closeable);
+            }
+        }
+
+
+        if(labelsMaskArrays != null) {
+            for (INDArray arr : labelsMaskArrays) {
+                arr.setCloseable(closeable);
+            }
+        }
+
+        if(featuresMaskArrays != null) {
+            for(INDArray arr : featuresMaskArrays) {
+                arr.setCloseable(closeable);
+            }
+        }
+
+    }
+
+    @Override
     public int numFeatureArrays() {
         return (features != null ? features.length : 0);
     }
@@ -301,7 +330,7 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
             if(i == 1){
                 ObjectInputStream ois = new ObjectInputStream(dis);
                 try{
-                this.exampleMetaData = (List<Serializable>)ois.readObject();
+                    this.exampleMetaData = (List<Serializable>)ois.readObject();
                 } catch (ClassNotFoundException e){
                     throw new RuntimeException("Error reading metadata from serialized MultiDataSet");
                 }
@@ -336,7 +365,7 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
             INDArray[] thisFeatures = new INDArray[features.length];
             INDArray[] thisLabels = new INDArray[labels.length];
             INDArray[] thisFeaturesMaskArray =
-                            (featuresMaskArrays != null ? new INDArray[featuresMaskArrays.length] : null);
+                    (featuresMaskArrays != null ? new INDArray[featuresMaskArrays.length] : null);
             INDArray[] thisLabelsMaskArray = (labelsMaskArrays != null ? new INDArray[labelsMaskArrays.length] : null);
 
             for (int j = 0; j < features.length; j++) {
@@ -378,7 +407,7 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
                 return array.get(NDArrayIndex.interval(idx, idx, true), NDArrayIndex.all(), NDArrayIndex.all());
             case 4:
                 return array.get(NDArrayIndex.interval(idx, idx, true), NDArrayIndex.all(), NDArrayIndex.all(),
-                                NDArrayIndex.all());
+                        NDArrayIndex.all());
             default:
                 throw new IllegalStateException("Cannot get subset for rank " + array.rank() + " array");
         }
@@ -425,7 +454,7 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
                 return (MultiDataSet) mds;
             else
                 return new MultiDataSet(mds.getFeatures(), mds.getLabels(), mds.getFeaturesMaskArrays(),
-                                mds.getLabelsMaskArrays());
+                        mds.getLabelsMaskArrays());
         }
 
         List<org.nd4j.linalg.dataset.api.MultiDataSet> list;
@@ -463,15 +492,15 @@ public class MultiDataSet implements org.nd4j.linalg.dataset.api.MultiDataSet {
 
             if (features[i] == null || features[i].length != nInArrays) {
                 throw new IllegalStateException(
-                                "Cannot merge MultiDataSets with different number of input arrays: toMerge[0] has "
-                                                + nInArrays + " input arrays; toMerge[" + i + "] has "
-                                                + (features[i] != null ? features[i].length : null) + " arrays");
+                        "Cannot merge MultiDataSets with different number of input arrays: toMerge[0] has "
+                                + nInArrays + " input arrays; toMerge[" + i + "] has "
+                                + (features[i] != null ? features[i].length : null) + " arrays");
             }
             if (labels[i] == null || labels[i].length != nOutArrays) {
                 throw new IllegalStateException(
-                                "Cannot merge MultiDataSets with different number of output arrays: toMerge[0] has "
-                                                + nOutArrays + " output arrays; toMerge[" + i + "] has "
-                                                + (labels[i] != null ? labels[i].length : null) + " arrays");
+                        "Cannot merge MultiDataSets with different number of output arrays: toMerge[0] has "
+                                + nOutArrays + " output arrays; toMerge[" + i + "] has "
+                                + (labels[i] != null ? labels[i].length : null) + " arrays");
             }
 
             i++;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/MultiDataSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/api/MultiDataSet.java
@@ -28,6 +28,14 @@ import java.util.List;
 public interface MultiDataSet extends Serializable {
 
     /**
+     * Marks every array in the dataset closeable or not.
+     * This mainly affects samediff graphs and does not need to be
+     * used by the user directly.
+     * @param closeable whether every array should be closeable or not.
+     */
+    void setCloseable(boolean closeable);
+
+    /**
      * Number of arrays of features/input data in the MultiDataSet
      */
     int numFeatureArrays();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Prevents arrays from being reused that are passed in externally or marked as outputs.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
