### PR TITLE
Fix https://github.com/deeplearning4j/deeplearning4j/issues/9773

### DIFF
--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
@@ -2142,6 +2142,8 @@ fun SDBaseOps() =  Namespace("BaseOps"){
 
     Op("batchMmul"){
         javaPackage = "org.nd4j.linalg.api.ops.impl.reduce.custom"
+        Input(NUMERIC, "alphas"){  description = "Alphas for the gemm equation."}
+        Input(NUMERIC, "betas"){  description = "Betas for the gemm equation."}
         Input(NUMERIC, "inputsA"){ count = AtLeast(1); description = "First array of input matrices, all of shape (M, N) or (N, M)"}
         Input(NUMERIC, "inputsB"){ count = AtLeast(1); description = " Second array of input matrices, all of shape (N, K) or (K, N)"}
         Arg(BOOL, "transposeA"){ description = "Whether to transpose A arrays or not"; defaultValue=false}

--- a/libnd4j/pi_build.sh
+++ b/libnd4j/pi_build.sh
@@ -81,6 +81,15 @@ LIBND4J_PLATFORM_EXT_LIST=( armhf arm64 arm arm64 x86 x86_64 arm64)
 PREFIXES=( arm-linux-gnueabihf aarch64-linux-gnu arm-linux-androideabi aarch64-linux-android  i686-linux-android x86_64-linux-android aarch64-linux-gnu)
 TARGET_INDEX=-1
 
+if [ ${CURRENT_TARGET} == "linux-arm64" ];then
+    export CURRENT_TARGET="arm64"
+fi
+
+
+if [ ${CURRENT_TARGET} == "linux-arm32" ];then
+    export CURRENT_TARGET="arm32"
+fi
+
 for i in "${!TARGET_ARRS[@]}"; do
    if [[ "${TARGET_ARRS[$i]}" = "${CURRENT_TARGET}" ]]; then
        TARGET_INDEX="${i}"
@@ -172,10 +181,10 @@ function download_extract_base {
         message "download ${down_url}"
         wget  --show-progress -O "${down_file}" "${down_url}"
     fi
- 
+
     message "extract $@"
     #extract
-    mkdir -p "${down_dir}" 
+    mkdir -p "${down_dir}"
     if [ ${xtract_arg} = "-unzip" ]; then
         command="unzip -qq \"${down_file}\" -d \"${down_dir}\" "
     else
@@ -203,7 +212,7 @@ function git_check {
     command=
     if [ -n "$3" ]; then
         command="git clone --quiet --depth 1 --branch \"${3}\" \"${1}\" \"${2}\""
-    else 
+    else
     command="git clone --quiet \"${1}\" \"${2}\""
     fi
     message "$command"
@@ -219,7 +228,7 @@ function fix_pi_linker {
   fi
   rm -f "${1}/ld"
   printf '#!/usr/bin/env bash\n'"\"${1}\"/ld.gold --long-plt \"\$@\"">"${1}/ld"
-  chmod +x "${1}/ld" 
+  chmod +x "${1}/ld"
 }
 
 function cuda_cross_setup {
@@ -240,10 +249,10 @@ function cuda_cross_setup {
         if [ ! -d "${loc_DIR}/cuda/bin" ];then
             mkdir -p "${loc_DIR}/cuda/bin"
             cd "${CUDA_DIR}/bin/"
-            # we are obliged to symlink inner files and folders to avoid errors happening 
-            # when  relative folders are used from symlinks 
+            # we are obliged to symlink inner files and folders to avoid errors happening
+            # when  relative folders are used from symlinks
             for i in $(find . -maxdepth 1)
-            do 
+            do
                 ln -s "${CUDA_DIR}/bin/""${i}" "${loc_DIR}/cuda/bin/""${i}"
             done
             cd -
@@ -288,7 +297,7 @@ if [ "${TARGET_OS}" = "android" ];then
         SUFFIX=${ANDROID_VERSION}
         ABI_PREFIX="v7a"
     fi
-    
+
     COMPILER_PREFIX_DIR="${ANDROID_TOOLCHAIN}/bin/"
     NDK_TARGET="${PREFIX}${SUFFIX}"
     export TOOLCHAIN_PREFIX="${ANDROID_TOOLCHAIN}/bin/${PREFIX}"
@@ -302,7 +311,7 @@ if [ "${TARGET_OS}" = "android" ];then
     export CXX_EXE="clang++"
     export AR="${TOOLCHAIN_PREFIX}-ar"
     export RANLIB="${TOOLCHAIN_PREFIX}-ranlib"
-    export COMPILER="${COMPILER_PREFIX}-${CC_EXE}"    
+    export COMPILER="${COMPILER_PREFIX}-${CC_EXE}"
     export BLAS_XTRA="CC=\"${COMPILER}\" AR=\"${AR}\" RANLIB=\"${RANLIB}\" ${BLAS_XTRA}"
 else
     export BINUTILS_BIN="${CROSS_COMPILER_DIR}/${PREFIX}/bin"
@@ -322,14 +331,14 @@ fi
 check_requirements "${COMPILER}"
 
 if [ -z "${BUILD_USING_MAVEN}" ] ;then
-#lets build OpenBlas 
+#lets build OpenBlas
 if [ ! -d "${OPENBLAS_DIR}" ]; then
     message "download OpenBLAS"
     git_check "${OPENBLAS_GIT_URL}" "${OPENBLAS_DIR}" "v0.3.19"
 fi
 
 if [ ! -f "${THIRD_PARTY}/lib/libopenblas.so" ]; then
-    message "build and install OpenBLAS" 
+    message "build and install OpenBLAS"
     cd "${OPENBLAS_DIR}"
 
     command="make TARGET=${BLAS_TARGET_NAME} HOSTCC=gcc  NOFORTRAN=1 ${BLAS_XTRA} "
@@ -364,9 +373,9 @@ if [ ! -d "${SCONS_LOCAL_DIR}" ]; then
 fi
 check_requirements "${SCONS_LOCAL_DIR}"/scons.py
 
-if [ ! -d "${ARMCOMPUTE_DIR}" ]; then 
-    message "download ArmCompute Source" 
-    git_check ${ARMCOMPUTE_GIT_URL} "${ARMCOMPUTE_DIR}" "${ARMCOMPUTE_TAG}" 
+if [ ! -d "${ARMCOMPUTE_DIR}" ]; then
+    message "download ArmCompute Source"
+    git_check ${ARMCOMPUTE_GIT_URL} "${ARMCOMPUTE_DIR}" "${ARMCOMPUTE_TAG}"
 fi
 
 #build armcompute
@@ -374,7 +383,7 @@ if [ ! -f "${ARMCOMPUTE_DIR}/build/libarm_compute-static.a" ]; then
 message "build arm compute"
 cd "${ARMCOMPUTE_DIR}"
 command="CC=\"${CC_EXE}\" CXX=\"${CXX_EXE}\" python3 \"${SCONS_LOCAL_DIR}/scons.py\" Werror=1 -j$(nproc) toolchain_prefix=\"${TOOLCHAIN_PREFIX}-\"  compiler_prefix=\"${COMPILER_PREFIX}-\" debug=${ARMCOMPUTE_DEBUG}  neon=1 opencl=0 extra_cxx_flags=-fPIC os=${TARGET_OS} build=cross_compile arch=${ARMCOMPUTE_TARGET} "
-message $command 
+message $command
 eval $command &>/dev/null
 cd "${BASE_DIR}"
 fi
@@ -424,7 +433,7 @@ fi
 
 if [ -z "${BUILD_USING_MAVEN}" ] ;then
 message "Building using bash script"
-bash ./buildnativeoperations.sh -o ${LIBND4J_PLATFORM} -t -j $(nproc) ${XTRA_ARGS} 
+bash ./buildnativeoperations.sh -o ${LIBND4J_PLATFORM} -t -j $(nproc) ${XTRA_ARGS}
 else
 message "cd $BASE_DIR/.. "
 cd "$BASE_DIR/.."

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
@@ -904,4 +904,9 @@ public abstract class DifferentialFunction {
      * Clear the input and output INDArrays, if any are set
      */
     public abstract void clearArrays();
+
+    public boolean needsConfigure() {
+        return false;
+    }
+
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SDVariable.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SDVariable.java
@@ -187,7 +187,7 @@ public class SDVariable implements Serializable {
      * @return Shape of the variable
      */
     public long[] getShape() {
-        if (variableType == VariableType.PLACEHOLDER  || sameDiff.isEagerMode() && shape != null) {
+        if (variableType == VariableType.PLACEHOLDER  || shape != null) {
             return shape;
         } else if(variableType == VariableType.VARIABLE || variableType == VariableType.CONSTANT) {
             if(getArr() != null)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -4377,6 +4377,10 @@ public class SameDiff extends SDBaseOps {
      * @return the set of names generated for each output of the function.
      */
     public SDVariable[] generateOutputVariableForOp(DifferentialFunction function, String baseName, boolean isImport) {
+
+        if(function.needsConfigure()) {
+            function.configureWithSameDiff(this);
+        }
         if (baseName == null)
             baseName = function.getOwnName();
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -6085,11 +6085,6 @@ public class SameDiff extends SDBaseOps {
             } else {
                 sd.ops.put(name, SameDiffOp.builder().name(name).op(df).build());
             }
-            //note we configure the samediff instance for the function after we are sure the graph
-            //knows about this op. The goal would be to configure left over variables that aren't properties
-            //like LSTM weights, but maybe suitable in other circumstances as well.
-            df.configureWithSameDiff(sd);
-
 
             int outLength = fn.outputLength();
             int[] outs = new int[outLength];
@@ -6212,7 +6207,17 @@ public class SameDiff extends SDBaseOps {
                     variablesByNodeAndOutNum.put(p, sd.getVariable(varNames[i]));
                 }
             }
+
+
+            //note we configure the samediff instance for the function after we are sure the graph
+            //knows about this op. The goal would be to configure left over variables that aren't properties
+            //like LSTM weights, but maybe suitable in other circumstances as well.
+            df.configureWithSameDiff(sd);
         }
+
+
+
+
 
         //Reconstruct loss variables
         if (fg.lossVariablesLength() > 0) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -1332,6 +1332,16 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
             }
         }
 
+        if(df.needsConfigure()) {
+            SDVariable[] vars = df.args();
+            for(int i = 0; i < vars.length; i++) {
+                vars[i].setShape(args[i].shape());
+            }
+
+            df.configureWithSameDiff(sameDiff);
+        }
+
+
         //Set the op inputs and output arguments
         //Note that when we are in a loop (and non-first iteration), we want to allocate new arrays even if shapes are
         // ok: this is because we need the values in past iterations for backprop (potentially)

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
@@ -325,18 +325,22 @@ public class SDBaseOps {
    * The result of this operation will be a batch of multiplied matrices. The<br>
    * result has the same length as both input batches and each output matrix is of shape (M, K).<br>
    *
+   * @param alphas Alphas for the gemm equation. (NUMERIC type)
+   * @param betas Betas for the gemm equation. (NUMERIC type)
    * @param inputsA First array of input matrices, all of shape (M, N) or (N, M) (NUMERIC type)
    * @param inputsB  Second array of input matrices, all of shape (N, K) or (K, N) (NUMERIC type)
    * @param transposeA Whether to transpose A arrays or not
    * @param transposeB Whether to transpose B arrays or not
    */
-  public SDVariable[] batchMmul(SDVariable[] inputsA, SDVariable[] inputsB, boolean transposeA,
-      boolean transposeB) {
+  public SDVariable[] batchMmul(SDVariable alphas, SDVariable betas, SDVariable[] inputsA,
+      SDVariable[] inputsB, boolean transposeA, boolean transposeB) {
+    SDValidation.validateNumerical("batchMmul", "alphas", alphas);
+    SDValidation.validateNumerical("batchMmul", "betas", betas);
     SDValidation.validateNumerical("batchMmul", "inputsA", inputsA);
     Preconditions.checkArgument(inputsA.length >= 1, "inputsA has incorrect size/length. Expected: inputsA.length >= 1, got %s", inputsA.length);
     SDValidation.validateNumerical("batchMmul", "inputsB", inputsB);
     Preconditions.checkArgument(inputsB.length >= 1, "inputsB has incorrect size/length. Expected: inputsB.length >= 1, got %s", inputsB.length);
-    return new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,inputsA, inputsB, transposeA, transposeB).outputVariables();
+    return new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,alphas, betas, inputsA, inputsB, transposeA, transposeB).outputVariables();
   }
 
   /**
@@ -349,18 +353,22 @@ public class SDBaseOps {
    * result has the same length as both input batches and each output matrix is of shape (M, K).<br>
    *
    * @param names names May be null. Arrays of names for the output variables.
+   * @param alphas Alphas for the gemm equation. (NUMERIC type)
+   * @param betas Betas for the gemm equation. (NUMERIC type)
    * @param inputsA First array of input matrices, all of shape (M, N) or (N, M) (NUMERIC type)
    * @param inputsB  Second array of input matrices, all of shape (N, K) or (K, N) (NUMERIC type)
    * @param transposeA Whether to transpose A arrays or not
    * @param transposeB Whether to transpose B arrays or not
    */
-  public SDVariable[] batchMmul(String[] names, SDVariable[] inputsA, SDVariable[] inputsB,
-      boolean transposeA, boolean transposeB) {
+  public SDVariable[] batchMmul(String[] names, SDVariable alphas, SDVariable betas,
+      SDVariable[] inputsA, SDVariable[] inputsB, boolean transposeA, boolean transposeB) {
+    SDValidation.validateNumerical("batchMmul", "alphas", alphas);
+    SDValidation.validateNumerical("batchMmul", "betas", betas);
     SDValidation.validateNumerical("batchMmul", "inputsA", inputsA);
     Preconditions.checkArgument(inputsA.length >= 1, "inputsA has incorrect size/length. Expected: inputsA.length >= 1, got %s", inputsA.length);
     SDValidation.validateNumerical("batchMmul", "inputsB", inputsB);
     Preconditions.checkArgument(inputsB.length >= 1, "inputsB has incorrect size/length. Expected: inputsB.length >= 1, got %s", inputsB.length);
-    SDVariable[] out =  new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,inputsA, inputsB, transposeA, transposeB).outputVariables();
+    SDVariable[] out =  new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,alphas, betas, inputsA, inputsB, transposeA, transposeB).outputVariables();
     return sd.updateVariableNamesAndReferences(out, names);
   }
 
@@ -373,15 +381,20 @@ public class SDBaseOps {
    * The result of this operation will be a batch of multiplied matrices. The<br>
    * result has the same length as both input batches and each output matrix is of shape (M, K).<br>
    *
+   * @param alphas Alphas for the gemm equation. (NUMERIC type)
+   * @param betas Betas for the gemm equation. (NUMERIC type)
    * @param inputsA First array of input matrices, all of shape (M, N) or (N, M) (NUMERIC type)
    * @param inputsB  Second array of input matrices, all of shape (N, K) or (K, N) (NUMERIC type)
    */
-  public SDVariable[] batchMmul(SDVariable[] inputsA, SDVariable... inputsB) {
+  public SDVariable[] batchMmul(SDVariable alphas, SDVariable betas, SDVariable[] inputsA,
+      SDVariable... inputsB) {
+    SDValidation.validateNumerical("batchMmul", "alphas", alphas);
+    SDValidation.validateNumerical("batchMmul", "betas", betas);
     SDValidation.validateNumerical("batchMmul", "inputsA", inputsA);
     Preconditions.checkArgument(inputsA.length >= 1, "inputsA has incorrect size/length. Expected: inputsA.length >= 1, got %s", inputsA.length);
     SDValidation.validateNumerical("batchMmul", "inputsB", inputsB);
     Preconditions.checkArgument(inputsB.length >= 1, "inputsB has incorrect size/length. Expected: inputsB.length >= 1, got %s", inputsB.length);
-    return new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,inputsA, inputsB, false, false).outputVariables();
+    return new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,alphas, betas, inputsA, inputsB, false, false).outputVariables();
   }
 
   /**
@@ -394,15 +407,20 @@ public class SDBaseOps {
    * result has the same length as both input batches and each output matrix is of shape (M, K).<br>
    *
    * @param names names May be null. Arrays of names for the output variables.
+   * @param alphas Alphas for the gemm equation. (NUMERIC type)
+   * @param betas Betas for the gemm equation. (NUMERIC type)
    * @param inputsA First array of input matrices, all of shape (M, N) or (N, M) (NUMERIC type)
    * @param inputsB  Second array of input matrices, all of shape (N, K) or (K, N) (NUMERIC type)
    */
-  public SDVariable[] batchMmul(String[] names, SDVariable[] inputsA, SDVariable... inputsB) {
+  public SDVariable[] batchMmul(String[] names, SDVariable alphas, SDVariable betas,
+      SDVariable[] inputsA, SDVariable... inputsB) {
+    SDValidation.validateNumerical("batchMmul", "alphas", alphas);
+    SDValidation.validateNumerical("batchMmul", "betas", betas);
     SDValidation.validateNumerical("batchMmul", "inputsA", inputsA);
     Preconditions.checkArgument(inputsA.length >= 1, "inputsA has incorrect size/length. Expected: inputsA.length >= 1, got %s", inputsA.length);
     SDValidation.validateNumerical("batchMmul", "inputsB", inputsB);
     Preconditions.checkArgument(inputsB.length >= 1, "inputsB has incorrect size/length. Expected: inputsB.length >= 1, got %s", inputsB.length);
-    SDVariable[] out =  new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,inputsA, inputsB, false, false).outputVariables();
+    SDVariable[] out =  new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(sd,alphas, betas, inputsA, inputsB, false, false).outputVariables();
     return sd.updateVariableNamesAndReferences(out, names);
   }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
@@ -177,18 +177,22 @@ public class NDBase {
    * The result of this operation will be a batch of multiplied matrices. The<br>
    * result has the same length as both input batches and each output matrix is of shape (M, K).<br>
    *
+   * @param alphas Alphas for the gemm equation. (NUMERIC type)
+   * @param betas Betas for the gemm equation. (NUMERIC type)
    * @param inputsA First array of input matrices, all of shape (M, N) or (N, M) (NUMERIC type)
    * @param inputsB  Second array of input matrices, all of shape (N, K) or (K, N) (NUMERIC type)
    * @param transposeA Whether to transpose A arrays or not
    * @param transposeB Whether to transpose B arrays or not
    */
-  public INDArray[] batchMmul(INDArray[] inputsA, INDArray[] inputsB, boolean transposeA,
-      boolean transposeB) {
+  public INDArray[] batchMmul(INDArray alphas, INDArray betas, INDArray[] inputsA,
+      INDArray[] inputsB, boolean transposeA, boolean transposeB) {
+    NDValidation.validateNumerical("batchMmul", "alphas", alphas);
+    NDValidation.validateNumerical("batchMmul", "betas", betas);
     NDValidation.validateNumerical("batchMmul", "inputsA", inputsA);
     Preconditions.checkArgument(inputsA.length >= 1, "inputsA has incorrect size/length. Expected: inputsA.length >= 1, got %s", inputsA.length);
     NDValidation.validateNumerical("batchMmul", "inputsB", inputsB);
     Preconditions.checkArgument(inputsB.length >= 1, "inputsB has incorrect size/length. Expected: inputsB.length >= 1, got %s", inputsB.length);
-    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(inputsA, inputsB, transposeA, transposeB));
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(alphas, betas, inputsA, inputsB, transposeA, transposeB));
   }
 
   /**
@@ -200,15 +204,20 @@ public class NDBase {
    * The result of this operation will be a batch of multiplied matrices. The<br>
    * result has the same length as both input batches and each output matrix is of shape (M, K).<br>
    *
+   * @param alphas Alphas for the gemm equation. (NUMERIC type)
+   * @param betas Betas for the gemm equation. (NUMERIC type)
    * @param inputsA First array of input matrices, all of shape (M, N) or (N, M) (NUMERIC type)
    * @param inputsB  Second array of input matrices, all of shape (N, K) or (K, N) (NUMERIC type)
    */
-  public INDArray[] batchMmul(INDArray[] inputsA, INDArray... inputsB) {
+  public INDArray[] batchMmul(INDArray alphas, INDArray betas, INDArray[] inputsA,
+      INDArray... inputsB) {
+    NDValidation.validateNumerical("batchMmul", "alphas", alphas);
+    NDValidation.validateNumerical("batchMmul", "betas", betas);
     NDValidation.validateNumerical("batchMmul", "inputsA", inputsA);
     Preconditions.checkArgument(inputsA.length >= 1, "inputsA has incorrect size/length. Expected: inputsA.length >= 1, got %s", inputsA.length);
     NDValidation.validateNumerical("batchMmul", "inputsB", inputsB);
     Preconditions.checkArgument(inputsB.length >= 1, "inputsB has incorrect size/length. Expected: inputsB.length >= 1, got %s", inputsB.length);
-    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(inputsA, inputsB, false, false));
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.reduce.custom.BatchMmul(alphas, betas, inputsA, inputsB, false, false));
   }
 
   /**

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/common/util/ArrayUtil.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/common/util/ArrayUtil.java
@@ -43,6 +43,27 @@ public class ArrayUtil {
 
 
     /**
+     * Concat all the elements
+     * @param arrs the input arrays
+     * @return
+     * @param <T>
+     */
+    public static <T> T[] concat(Class<T> clazz,T[]...arrs) {
+        int totalLength = 0;
+        for(T[] arr : arrs) totalLength += arr.length;
+        T[] ret  = (T[]) Array.newInstance(clazz,totalLength);
+        int count = 0;
+        for(T[] arr : arrs) {
+            for(T input : arr) {
+                ret[count] = input;
+                count++;
+            }
+        }
+
+        return ret;
+    }
+
+    /**
      * Returns true if any array elements are negative.
      * If the array is null, it returns false
      * @param arr the array to test
@@ -184,10 +205,10 @@ public class ArrayUtil {
     }
 
     /**
-     * Returns true if all of the elements in the
+     * Returns true if all the elements in the
      * given int array are unique
      * @param toTest the array to test
-     * @return true if all o fthe items
+     * @return true if all the items
      * are unique false otherwise
      */
     public static boolean allUnique(int[] toTest) {
@@ -295,7 +316,7 @@ public class ArrayUtil {
     public static long[] toLongs(byte[] data) {
         val ret = new long[data.length];
         for (int i = 0; i < ret.length; i++) {
-            ret[i] = (long) data[i];
+            ret[i] = data[i];
         }
         return ret;
     }
@@ -311,7 +332,7 @@ public class ArrayUtil {
     public static long[] toLongs(short[] data) {
         val ret = new long[data.length];
         for (int i = 0; i < ret.length; i++) {
-            ret[i] = (long) data[i];
+            ret[i] = data[i];
         }
         return ret;
     }
@@ -319,7 +340,7 @@ public class ArrayUtil {
     public static long[] toLongs(int[] data) {
         val ret = new long[data.length];
         for (int i = 0; i < ret.length; i++) {
-            ret[i] = (long) data[i];
+            ret[i] = data[i];
         }
         return ret;
     }
@@ -1288,8 +1309,8 @@ public class ArrayUtil {
         int offset = 0;
         /*
             workaround for non-existent indexes (such as Integer.MAX_VALUE)
-        
-        
+
+
         for (int i = 0; i < index.length; i ++) {
             if (index[i] >= data.length || index[i] < 0) offset++;
         }
@@ -2524,9 +2545,9 @@ public class ArrayUtil {
     public static boolean[][][] reshapeBoolean(boolean[] in, int d0, int d1, int d2){
         boolean[][][] out = new boolean[d0][d1][d2];
         int x = 0;
-        for(int i=0; i<d0; i++ ){
-            for( int j=0; j<d1; j++ ){
-                for( int k=0; k<d2; k++ ) {
+        for(int i = 0; i < d0; i++) {
+            for( int j = 0; j < d1; j++) {
+                for( int k = 0; k < d2; k++) {
                     out[i][j][k] = in[x++];
                 }
             }
@@ -2537,8 +2558,8 @@ public class ArrayUtil {
     public static <T> T[][] reshapeObject(T[] in, int rows, int cols){
         Object[][] out = new Object[rows][cols];
         int x = 0;
-        for(int i=0; i<rows; i++ ){
-            for( int j=0; j<cols; j++ ){
+        for(int i = 0; i < rows; i++) {
+            for( int j = 0; j<cols; j++) {
                 out[i][j] = in[x++];
             }
         }
@@ -2548,9 +2569,9 @@ public class ArrayUtil {
     public static <T> T[][][] reshapeObject(T[] in, int d0, int d1, int d2){
         Object[][][] out = new Object[d0][d1][d2];
         int x = 0;
-        for(int i=0; i<d0; i++ ){
-            for( int j=0; j<d1; j++ ){
-                for( int k=0; k<d2; k++ ) {
+        for(int i = 0; i < d0; i++) {
+            for( int j = 0; j < d1; j++) {
+                for( int k=0; k < d2; k++) {
                     out[i][j][k] = in[x++];
                 }
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes up batch gemm and introduces new test based on 
#9773 

1. Fixes parameter ordering so that M,N, and K were correct. K was actually wrong and was causing the inner loop to skip too many elements.
2. The API exposed was brittle and not very clear. Now we expose a clearer api that shows that alphas/betas as separate matrices followed by the as and bs to be multiplied.
3. Updates the code gen to add the new parameters
4. Adds new semi eager mode for shapes  allowing ops to be configured right before they execute.
(Please fill in changes proposed in this fix)

## How was this patch tested?
Adds new test
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
