### PR TITLE
Fix up tensor mmul, axis serialization when configuring from arguments

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/util/ndarray/RecordConverter.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/util/ndarray/RecordConverter.java
@@ -195,13 +195,13 @@ public class RecordConverter {
                     throw new UnsupportedOperationException("NDArrayWritable must have leading dimension 1 for this " +
                             "method. Received array with shape: " + Arrays.toString(a.shape()));
                 }
-                if(toConcat == null){
+                if(toConcat == null) {
                     toConcat = new ArrayList<>();
                 }
                 toConcat.add(a);
             } else {
                 //Assume all others are single value
-                if(list == null){
+                if(list == null) {
                     list = new DoubleArrayList();
                 }
                 list.add(w.toDouble());

--- a/deeplearning4j/deeplearning4j-data/deeplearning4j-datavec-iterators/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
+++ b/deeplearning4j/deeplearning4j-data/deeplearning4j-datavec-iterators/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
@@ -129,9 +129,9 @@ public class RecordReaderDataSetIterator implements DataSetIterator {
     public RecordReaderDataSetIterator(RecordReader recordReader, int batchSize, int labelIndexFrom, int labelIndexTo,
                                        boolean regression) {
 		this(recordReader, new SelfWritableConverter(), batchSize, labelIndexFrom, labelIndexTo, -1, -1, regression);
-		if (!regression) { 
+		if (!regression) {
             throw new IllegalArgumentException("This constructor is only for creating regression iterators. " +
-                                               "If you're doing classification you need to use another constructor that " + 
+                                               "If you're doing classification you need to use another constructor that " +
                                                "(implicitly) specifies numPossibleLabels");
         }
     }
@@ -189,7 +189,7 @@ public class RecordReaderDataSetIterator implements DataSetIterator {
         this.collectMetaData = collectMetaData;
     }
 
-    private void initializeUnderlying(){
+    private void initializeUnderlying() {
         if (underlying == null) {
             Record next = recordReader.nextRecord();
             initializeUnderlying(next);
@@ -228,7 +228,7 @@ public class RecordReaderDataSetIterator implements DataSetIterator {
             builder.addOutputOneHot(READER_KEY, labelIndex, numPossibleLabels);
         }
 
-        //Inputs: assume to be all of the other writables
+        //Inputs: assume to be all the other writables
         //In general: can't assume label indices are all at the start or end (event though 99% of the time they are)
         //If they are: easy. If not: use 2 inputs in the underlying as a workaround, and concat them
 

--- a/deeplearning4j/deeplearning4j-data/deeplearning4j-datavec-iterators/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderMultiDataSetIterator.java
+++ b/deeplearning4j/deeplearning4j-data/deeplearning4j-datavec-iterators/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderMultiDataSetIterator.java
@@ -137,7 +137,7 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator, S
                 List<List<Writable>> batchWritables = rr.next(num);
 
                 List<INDArray> batch;
-                if(batchWritables instanceof NDArrayRecordBatch){
+                if(batchWritables instanceof NDArrayRecordBatch) {
                     //ImageRecordReader etc case
                     batch = ((NDArrayRecordBatch)batchWritables).getArrays();
                 } else {
@@ -145,11 +145,12 @@ public class RecordReaderMultiDataSetIterator implements MultiDataSetIterator, S
                     batch = new ArrayList<>();
                     List<Writable> temp = new ArrayList<>();
                     int sz = batchWritables.get(0).size();
-                    for( int i=0; i<sz; i++ ){
+                    for( int i = 0; i < sz; i++) {
                         temp.clear();
-                        for( int j=0; j<batchWritables.size(); j++ ){
+                        for( int j = 0; j < batchWritables.size(); j++) {
                             temp.add(batchWritables.get(j).get(i));
                         }
+
                         batch.add(RecordConverter.toMinibatchArray(temp));
                     }
                 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/util/SameDiffUtils.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/util/SameDiffUtils.java
@@ -63,7 +63,7 @@ public class SameDiffUtils {
         }
 
         Map<String, INDArray> ret = new HashMap<>();
-        for(String k : outs.keySet()){
+        for(String k : outs.keySet()) {
             try {
                 ret.put(k, Nd4j.concat(0, outs.get(k).toArray(new INDArray[0])));
             } catch(Exception e){

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/TensorMmul.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/TensorMmul.java
@@ -116,15 +116,15 @@ public class TensorMmul extends DynamicCustomOp {
         this.sameDiff = sameDiff;
         this.axes = new int[][]{dimensionsX, dimensionsY};
         addIArgument(dimensionsX.length);
-        addIArgument(dimensionsX[0]);
+        addIArgument(dimensionsX);
         addIArgument(dimensionsY.length);
-        addIArgument(dimensionsY[0]);
+        addIArgument(dimensionsY);
         addBArgument(transposeX, transposeY, transposeZ);
     }
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> gradients) {
-        return Arrays.asList(new TensorMmulBp(sameDiff, larg(), rarg(), gradients.get(0), axes ).outputVariables());
+        return Arrays.asList(new TensorMmulBp(sameDiff, larg(), rarg(), gradients.get(0), axes).outputVariables());
     }
 
     @Override
@@ -136,32 +136,6 @@ public class TensorMmul extends DynamicCustomOp {
     @Override
     public void initFromTensorFlow(NodeDef nodeDef, SameDiff initWith, Map<String, AttrValue> attributesForNode, GraphDef graph) {
         super.initFromTensorFlow(nodeDef, initWith, attributesForNode, graph);
-        /**
-         * name: "MatMul"
-         op: "MatMul"
-         input: "input"
-         input: "Variable/read"
-         attr {
-         key: "transpose_b"
-         value {
-         b: false
-         }
-         }
-         attr {
-         key: "transpose_a"
-         value {
-         b: false
-         }
-         }
-         attr {
-         key: "T"
-         value {
-         type: DT_FLOAT
-         }
-         }
-
-         */
-
         val isTransposeA = attributesForNode.get("transpose_a").getB();
         val isTransposeB = attributesForNode.get("transpose_b").getB();
         MMulTranspose mMulTranspose = MMulTranspose.builder()
@@ -209,13 +183,17 @@ public class TensorMmul extends DynamicCustomOp {
             long numDimensionsX = iArguments.get(0);
             List<Long> xDims = new ArrayList<>();
             List<Long> yDims = new ArrayList<>();
+            int currCount = 1;
             for(int i = 0; i < numDimensionsX; i++) {
                 xDims.add(iArguments.get(i));
+                currCount++;
             }
 
-            long numDimensionsY = iArguments.get((int) numDimensionsX + 1);
+            long numDimensionsY = iArguments.get(currCount);
+            currCount++;
             for(int i = 0; i < numDimensionsY; i++) {
-                yDims.add(i + numDimensionsX + 1);
+                yDims.add(iArguments.get(currCount));
+                currCount++;
             }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/TensorMmulBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/TensorMmulBp.java
@@ -48,7 +48,7 @@ public class TensorMmulBp  extends DynamicCustomOp  {
     }
 
     public TensorMmulBp(INDArray x, INDArray y, INDArray gradAtOutput, int[][] axes) {
-        this(x, y, gradAtOutput, axes[0], axes[1] );
+        this(x, y, gradAtOutput, axes[0], axes[1]);
     }
 
     public TensorMmulBp(INDArray x, INDArray y, INDArray gradAtOutput, int[] axesX, int[] axesY ) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/TensorMmulBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/TensorMmulBp.java
@@ -40,7 +40,6 @@ public class TensorMmulBp  extends DynamicCustomOp  {
 
     public TensorMmulBp(SameDiff samediff, SDVariable x, SDVariable y, SDVariable gradAtOutput, int[] axesX, int[] axesY ) {
         super(null, samediff, new SDVariable[]{x,y, gradAtOutput});
-        int[][] axes = new int[][]{axesX, axesY};
         addIArgument(axesX.length);
         addIArgument(axesX);
         addIArgument(axesY.length);
@@ -53,7 +52,6 @@ public class TensorMmulBp  extends DynamicCustomOp  {
 
     public TensorMmulBp(INDArray x, INDArray y, INDArray gradAtOutput, int[] axesX, int[] axesY ) {
         super(null,new INDArray[]{x, y, gradAtOutput},null);
-        int[][] axes = new int[][]{axesX, axesY};
         addIArgument(axesX.length);
         addIArgument(axesX);
         addIArgument(axesY.length);
@@ -66,7 +64,6 @@ public class TensorMmulBp  extends DynamicCustomOp  {
 
     public TensorMmulBp(INDArray x, INDArray y, INDArray gradAtOutput, INDArray dldx, INDArray dldy, int[] axesX, int[] axesY  ) {
             super(null, new INDArray[]{x, y, gradAtOutput}, new INDArray[]{dldx, dldy});
-            int[][] axes = new int[][]{axesX, axesY};
             addIArgument(axesX.length);
             addIArgument(axesX);
             addIArgument(axesY.length);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/9775
We were miscounting axes when using configureFromArguments which propagated to the backpropagation
causing an axes error.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
