### PR TITLE
Fix issue reported on forums for multiple inputs

### DIFF
--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Math.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Math.kt
@@ -1576,7 +1576,7 @@ fun Math() =  Namespace("Math") {
         javaPackage = "org.nd4j.linalg.api.ops.impl.shape.tensorops"
         javaOpClass = "EmbeddingLookup"
         Input(NUMERIC, "x") {description = "Input tensor"}
-        Input(INT, "indices") {description = "A Tensor containing the ids to be looked up."}
+        Input(INT, "indices") {count = AtLeast(1); description = "A Tensor containing the ids to be looked up."}
         Arg(ENUM, "PartitionMode") { possibleValues = listOf( "MOD","DIV"); description ="partition_mode == 0 - i.e. 'mod' , 1 - 'div'"}
         Output(NUMERIC, "output") {description = "Shifted output"}
 

--- a/libnd4j/include/ops/declarable/generic/nn/embedding_lookup.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/embedding_lookup.cpp
@@ -59,7 +59,7 @@ CUSTOM_OP_IMPL(embedding_lookup, 2, 1, false, 0, 1) {
   } else {
     int indexRank = indices->rankOf();
     REQUIRE_TRUE(indexRank > 0, 0,
-                 "embeded_lookup: input array of indexes can't be single scalar, the requirement is: rank > 0 !");
+                 "embedded_lookup: input array of indexes can't be single scalar, the requirement is: rank > 0 !");
 
     int inputRank = input->rankOf();
     int lastIndDim = indices->lengthOf();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDMath.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDMath.java
@@ -75,9 +75,11 @@ public class SDMath extends SDOps {
    * @param PartitionMode partition_mode == 0 - i.e. 'mod' , 1 - 'div'
    * @return output Shifted output (NUMERIC type)
    */
-  public SDVariable embeddingLookup(SDVariable x, SDVariable indices, PartitionMode PartitionMode) {
+  public SDVariable embeddingLookup(SDVariable x, SDVariable[] indices,
+      PartitionMode PartitionMode) {
     SDValidation.validateNumerical("EmbeddingLookup", "x", x);
     SDValidation.validateInteger("EmbeddingLookup", "indices", indices);
+    Preconditions.checkArgument(indices.length >= 1, "indices has incorrect size/length. Expected: indices.length >= 1, got %s", indices.length);
     return new org.nd4j.linalg.api.ops.impl.shape.tensorops.EmbeddingLookup(sd,x, indices, PartitionMode).outputVariable();
   }
 
@@ -90,10 +92,11 @@ public class SDMath extends SDOps {
    * @param PartitionMode partition_mode == 0 - i.e. 'mod' , 1 - 'div'
    * @return output Shifted output (NUMERIC type)
    */
-  public SDVariable embeddingLookup(String name, SDVariable x, SDVariable indices,
+  public SDVariable embeddingLookup(String name, SDVariable x, SDVariable[] indices,
       PartitionMode PartitionMode) {
     SDValidation.validateNumerical("EmbeddingLookup", "x", x);
     SDValidation.validateInteger("EmbeddingLookup", "indices", indices);
+    Preconditions.checkArgument(indices.length >= 1, "indices has incorrect size/length. Expected: indices.length >= 1, got %s", indices.length);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.tensorops.EmbeddingLookup(sd,x, indices, PartitionMode).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/enums/PartitionMode.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/enums/PartitionMode.java
@@ -23,7 +23,8 @@
 package org.nd4j.enums;
 
 /**
- * partition_mode == 0 - i.e. 'mod' , 1 - 'div' */
+ * partition_mode == 0 - i.e. 'mod' , 1 - 'div'
+ */
 public enum PartitionMode {
   MOD,
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/tensorops/EmbeddingLookup.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/tensorops/EmbeddingLookup.java
@@ -24,6 +24,7 @@ import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.common.util.ArrayUtil;
 import org.nd4j.enums.PartitionMode;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -35,7 +36,12 @@ import java.util.List;
 
 @NoArgsConstructor
 public class EmbeddingLookup extends DynamicCustomOp {
+    public EmbeddingLookup(SameDiff sd, SDVariable x, SDVariable[] indices, PartitionMode partitionMode) {
+        super(null, sd, ArrayUtil.concat(SDVariable.class,
+                new SDVariable[]{x},indices));
+        addIArgument(partitionMode.ordinal());
 
+    }
      public EmbeddingLookup(@NonNull SameDiff sameDiff, @NonNull SDVariable in, @NonNull SDVariable indices, PartitionMode partitionMode) {
         super("embedding_lookup", sameDiff, new SDVariable[]{in, indices});
         addIArgument(partitionMode.ordinal());
@@ -47,12 +53,14 @@ public class EmbeddingLookup extends DynamicCustomOp {
 
     }
 
-    public EmbeddingLookup(@NonNull INDArray in, INDArray output, PartitionMode partitionMode, @NonNull int... indices) {
-        super("embedding_lookup", new INDArray[]{in, Nd4j.createFromArray(indices)}, wrapOrNull(output));
+    public EmbeddingLookup(INDArray in,@NonNull INDArray[] indices, PartitionMode partitionMode) {
+        super("embedding_lookup", ArrayUtil.concat(INDArray.class,
+                new INDArray[]{in},indices), null);
         addIArgument(partitionMode.ordinal());
-
-
     }
+
+
+
 
     @Override
     public String opName() {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDMath.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDMath.java
@@ -58,9 +58,10 @@ public class NDMath {
    * @param PartitionMode partition_mode == 0 - i.e. 'mod' , 1 - 'div'
    * @return output Shifted output (NUMERIC type)
    */
-  public INDArray embeddingLookup(INDArray x, INDArray indices, PartitionMode PartitionMode) {
+  public INDArray embeddingLookup(INDArray x, INDArray[] indices, PartitionMode PartitionMode) {
     NDValidation.validateNumerical("EmbeddingLookup", "x", x);
     NDValidation.validateInteger("EmbeddingLookup", "indices", indices);
+    Preconditions.checkArgument(indices.length >= 1, "indices has incorrect size/length. Expected: indices.length >= 1, got %s", indices.length);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.tensorops.EmbeddingLookup(x, indices, PartitionMode))[0];
   }
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestMiscOpValidation.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestMiscOpValidation.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.internal.matchers.Same;
 import org.nd4j.autodiff.samediff.SDIndex;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
@@ -36,6 +37,7 @@ import org.nd4j.autodiff.validation.OpValidation;
 import org.nd4j.autodiff.validation.TestCase;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.common.tests.tags.TagNames;
+import org.nd4j.enums.PartitionMode;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -818,6 +820,26 @@ public class TestMiscOpValidation extends BaseOpValidation {
         SDVariable[] res3 = sd.batchMmul(sd.constant(a).add(0),sd.constant(b).add(0),
                 new SDVariable[]{sd.constant(a).add(0),sd.constant(a).add(0)}, new SDVariable[]{sd.constant(b).add(0),sd.constant(b).add(0)}); // throws exception
         assertEquals(assertion,res3[0].eval());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testEmbedding() {
+        SameDiff sd = SameDiff.create();
+        SDVariable input = sd.placeHolder("input", DataType.INT32, -1, 2);
+        SDVariable input2 = sd.placeHolder("input2", INT32,2,2);
+        SDVariable lookUpDict = sd.var("lookUpDict",new XavierInitScheme('c', 4, 8), DataType.FLOAT, 4, 8);
+        SDVariable embeddingResult = sd.math.embeddingLookup("embeddingResult", lookUpDict, new SDVariable[]{input}, PartitionMode.MOD);
+        //
+        Map<String,INDArray> map = new HashMap<>();
+        INDArray inputArr = Nd4j.createFromArray(0, 3);
+        INDArray inputArr2 = Nd4j.createFromArray(2,3);
+        System.out.println(inputArr.shapeInfoToString());
+        map.put("input", inputArr);
+        map.put("input2",inputArr2);
+        //forward
+        Map<String,INDArray> result = sd.output(map, "embeddingResult");
+        System.out.println(result);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What changes were proposed in this pull request?
Issue reported here:
https://community.konduit.ai/t/fail-to-get-batch-output-from-sd-math-embeddinglookup/2016

This turned out to be an interface issue. Each index should be an input instead of a matrix.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
