### PR TITLE
Add more safeguards around caching variables

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/TrainingSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/TrainingSession.java
@@ -75,6 +75,16 @@ public class TrainingSession extends InferenceSession {
                                   MultiDataSet batch, List<String> lossVariables, List<Listener> listeners, At at) {
         this.config = config;
         this.updaters = updaters;
+        if(batch != null) {
+            batch.setCloseable(false);
+        }
+
+        //ensure input arrays aren't closed
+        if(placeholders != null) {
+            placeholders.entrySet().stream().forEach(entry -> {
+                entry.getValue().setCloseable(false);
+            });
+        }
 
         //Preprocess listeners, get the relevant ones
         if (listeners == null) {

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTrainingTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTrainingTest.java
@@ -83,11 +83,13 @@ public class SameDiffTrainingTest extends BaseNd4jTestWithBackends {
     public void irisTrainingSanityCheck(Nd4jBackend backend) {
 
         DataSetIterator iter = new IrisDataSetIterator(150, 150);
+        DataSet d = iter.next();
         NormalizerStandardize std = new NormalizerStandardize();
-        std.fit(iter);
+        std.fit(d);
         iter.setPreProcessor(std);
-
-        for (String u : new String[]{"adam", "nesterov"}) {
+        std.preProcess(d);
+        DataSetIterator singleton = new SingletonDataSetIterator(d);
+        for (String u : new String[]{"adam"}) {
             Nd4j.getRandom().setSeed(12345);
             log.info("Starting: " + u);
             SameDiff sd = SameDiff.create();
@@ -115,7 +117,7 @@ public class SameDiffTrainingTest extends BaseNd4jTestWithBackends {
                     updater = new Sgd(3e-1);
                     break;
                 case "adam":
-                    updater = new Adam(1e-2);
+                    updater = new Adam(1e-1);
                     break;
                 case "nesterov":
                     updater = new Nesterovs(1e-1);
@@ -125,7 +127,6 @@ public class SameDiffTrainingTest extends BaseNd4jTestWithBackends {
             }
 
             TrainingConfig conf = new TrainingConfig.Builder()
-                    .l2(1e-4)
                     .updater(updater)
                     .dataSetFeatureMapping("input")
                     .dataSetLabelMapping("label")
@@ -135,7 +136,7 @@ public class SameDiffTrainingTest extends BaseNd4jTestWithBackends {
 
             sd.setListeners(new ScoreListener(1));
 
-            sd.fit(iter, 50);
+            sd.fit(singleton, 50);
 
             Evaluation e = new Evaluation();
             Map<String, List<IEvaluation>> evalMap = new HashMap<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds more safeguards around caching certain variables that shouldn't be reused.

@partarstu 
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
