### PR TITLE
Minor improvements to debugging for samediff summary, invoke, remove setCacheable(false) from training to allow faster training

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -6458,10 +6458,26 @@ public class SameDiff extends SDBaseOps {
      * Reports variables, ops, SameDiff function instances, and (where possible) array shapes.<br>
      * For ops, the input and output variables are reported.<br>
      * For variables, the ops that they are inputs to - or outputs of - are also reported
+     * Note there is also {@link #summary(boolean) } which allows
+     * printing full sub graphs if more output is needed.
+     * This summary() call defaults to false for printing the sub graphs.
      *
      * @return A String representation of the SameDiff instance
      */
     public String summary() {
+        return summary(false);
+    }
+
+
+    /**
+     * Generate and return a String representation of the current SameDiff instance<br>
+     * Reports variables, ops, SameDiff function instances, and (where possible) array shapes.<br>
+     * For ops, the input and output variables are reported.<br>
+     * For variables, the ops that they are inputs to - or outputs of - are also reported
+     *
+     * @return A String representation of the SameDiff instance
+     */
+    public String summary(boolean printSubGraphs) {
 
         Map<String, SDVariable> varMap = variableMap();
         DifferentialFunction[] functions = ops();
@@ -6582,7 +6598,18 @@ public class SameDiff extends SDBaseOps {
             sb.append(String.format(format, i, fnName, df.getClass().getSimpleName(), dfInputStr.get(i), dfOutputStr.get(i))).append("\n");
         }
 
-        if (sameDiffFunctionInstances.size() > 0) {
+        if (sameDiffFunctionInstances.size() > 0 && printSubGraphs) {
+            sb.append("\n\n--- SameDiff Defined Functions ---\n");
+            format = "%-20s%-15s%-15s%-15s";
+            sb.append(String.format(format, "- Name -", "- Variables -", "- Functions -", "- Fn Defs -")).append("\n");
+            for (Map.Entry<String, SameDiff> e : sameDiffFunctionInstances.entrySet()) {
+                SameDiff sd = e.getValue();
+                sb.append("Function of name \n" + e.getKey());
+                sb.append("-----------------------------------------------------------------\n");
+                sb.append(sd.summary(printSubGraphs)).append("\n");
+                sb.append("-----------------------------------------------------------------\n");
+            }
+        } else if(printSubGraphs) {
             sb.append("\n\n--- SameDiff Defined Functions ---\n");
             format = "%-20s%-15s%-15s%-15s";
             sb.append(String.format(format, "- Name -", "- Variables -", "- Functions -", "- Fn Defs -")).append("\n");
@@ -6598,6 +6625,7 @@ public class SameDiff extends SDBaseOps {
 
         return sb.toString();
     }
+
 
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -2203,11 +2203,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 dims[i] = specifiedIdxDims.get(i);
             }
 
-            /**
-             * TODO: Resolve both indexing testSpecifiedIndexPut and
-             * the need to persist a difference reference.
-             * Note: https://github.com/eclipse/deeplearning4j/pull/9552
-             */
+
             NdIndexIterator iter = new NdIndexIterator(counts);
             while(iter.hasNext()) {
                 long[] iterationIdxs = iter.next();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Invoke.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Invoke.java
@@ -22,6 +22,7 @@ package org.nd4j.linalg.api.ops.custom;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.nd4j.autodiff.functions.DifferentialFunction;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
@@ -43,6 +44,7 @@ import java.util.*;
 /**
  * Invoke is an op
  */
+@Slf4j
 public class Invoke extends DynamicCustomOp {
 
     @Getter
@@ -92,9 +94,12 @@ public class Invoke extends DynamicCustomOp {
         Invoke invoke = (Invoke) op;
         String funcName = invoke.getFunctionName();
         SameDiff instance = op.getSameDiff().getFunction(funcName);
-        //invoke can have state bugs and should not free arrays on its own
-        instance.setEnableCache(false);
+
         SDVariable[] args = op.args();
+        if(Nd4j.getExecutioner().isDebug()) {
+            log.info("Invoke with function name " + funcName + " being invoked with input variables from parent graph: " + Arrays.toString(op.argNames()));
+        }
+
         String[] inputVarNameMappings = invoke.getInputVarNames();
 
         String[] subGraphInputNames = invoke.subGraphInputVarNames;
@@ -146,6 +151,10 @@ public class Invoke extends DynamicCustomOp {
                 }
             }
 
+            if(Nd4j.getExecutioner().isDebug()) {
+                log.info("Returning graph outputs from function name " + funcName + " and output names " + relevantOutputNames);
+            }
+
             return ExecutionResult.builder()
                     .outputs(ExecutionResult.pack(output))
                     .build();
@@ -164,6 +173,10 @@ public class Invoke extends DynamicCustomOp {
                 result.put(outputs[i].name(), valueOutputs.get(subGraphOutputNames[i]));
             }
 
+
+            if(Nd4j.getExecutioner().isDebug()) {
+                log.info("Returning graph outputs from function name " + funcName + " and output names " + relevantOutputNames);
+            }
             return ExecutionResult.builder()
                     .valueOutputs(result)
                     .build();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Minor improvements to samediff's summary allowing more verbose printing of subgraphs when debugging training and other functions where subgraphs are relevant. Also improves lambda calls.

Due to previous PRs also removes 
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
