### PR TITLE
Fixes #9786

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Create.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Create.java
@@ -84,12 +84,14 @@ public class Create extends DynamicCustomOp {
         addDArgument(dataType);
         addBArgument(false);
         addIArgument((int) 'c', dataType.toInt());
+        this.outputType = dataType;
     }
 
     public Create(SameDiff sd, SDVariable shape, DataType dataType, String order, boolean initialize) {
         this(sd,shape,dataType);
         addIArgument((int) order.charAt(0),dataType.toInt());
         addBArgument(initialize);
+        this.outputType = dataType;
     }
 
     public Create(INDArray shape, DataType dataType, String order, boolean initialize) {
@@ -101,6 +103,13 @@ public class Create extends DynamicCustomOp {
     protected void addArgs() {
         addBArgument(initialize);
         addIArgument((int) order,outputType.toInt());
+    }
+
+    @Override
+    public void configureFromArguments() {
+        if(!iArguments.isEmpty()) {
+            this.outputType = DataType.fromInt(iArguments.get(0).intValue());
+        }
     }
 
     @Override

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTests.java
@@ -108,6 +108,7 @@ public class SameDiffTests extends BaseNd4jTestWithBackends {
         return 999999999L;
     }
 
+
     @BeforeEach
     public void before() {
         Nd4j.create(1);
@@ -137,6 +138,15 @@ public class SameDiffTests extends BaseNd4jTestWithBackends {
         inputMap.put("w", weights);
         inputMap.put("y", labels);
         return inputMap;
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testSameDiffCreate() {
+        SameDiff sd = SameDiff.create();
+        SDVariable var = sd.create(null, sd.constant(8), DataType.INT32);
+        assertEquals(DataType.INT, var.eval().dataType());
+        assertEquals(DataType.INT,var.dataType());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes #9786 

Adds proper data type serialization to constructor as well as configureFromArguments() for serialization.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
