### PR TITLE
Fix up VEDA inclusion

### DIFF
--- a/libnd4j/include/ops/declarable/platform/vednn/veda_vednn.vcpp
+++ b/libnd4j/include/ops/declarable/platform/vednn/veda_vednn.vcpp
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include <stdio.h>
-#include <veda/types.h>
+#include <veda/veda_types.h>
 #include <vednn.h>
 
 #include <cmath>

--- a/libnd4j/include/ops/declarable/platform/vednn/veda_vednn.vcpp
+++ b/libnd4j/include/ops/declarable/platform/vednn/veda_vednn.vcpp
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include <stdio.h>
-#include <veda/veda_types.h>
+#include <veda_device.h>
 #include <vednn.h>
 
 #include <cmath>


### PR DESCRIPTION
## What changes were proposed in this pull request?
One missing VEDA type was causing a compilation error in the vednn.cpp convolution operator
file. This PR includes the right file. Tested manually in a Vector Engine docker container.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
