### PR TITLE
 Fixes https://github.com/deeplearning4j/deeplearning4j/issues/9802

### DIFF
--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/SDBaseOps.kt
@@ -1017,7 +1017,7 @@ fun SDBaseOps() =  Namespace("BaseOps"){
     Op("setShape")  {
         javaPackage = "org.nd4j.linalg.api.ops.impl.shape"
         javaOpClass = "SetShape"
-        Input(NUMERIC,"input") {description = "The input to set the shape of" }
+        Input(NDARRAY,"input") {description = "The input to set the shape of" }
         Input(NUMERIC, "shape") { description = "The shape to set the input to" }
         Doc(Language.ANY, DocScope.ALL){
             """
@@ -1612,7 +1612,7 @@ fun SDBaseOps() =  Namespace("BaseOps"){
 
     Op("shape") {
         javaPackage = "org.nd4j.linalg.api.ops.impl.shape"
-        Input(NUMERIC, "input") { description = "Input variable" }
+        Input(NDARRAY, "input") { description = "Input variable" }
         Output(NUMERIC, "output"){ description = "1D output variable with contents equal to the shape of the input" }
         Doc(Language.ANY, DocScope.ALL){
             """
@@ -1623,7 +1623,7 @@ fun SDBaseOps() =  Namespace("BaseOps"){
 
     Op("size") {
         javaPackage = "org.nd4j.linalg.api.ops.impl.shape"
-        Input(NUMERIC, "in") { description = "Input variable" }
+        Input(NDARRAY, "in") { description = "Input variable" }
         Output(NUMERIC, "output"){ description = "0D (scalar) output variable with value equal to the number of elements in the specified array" }
         Doc(Language.ANY, DocScope.ALL){
             """ 
@@ -1634,7 +1634,7 @@ fun SDBaseOps() =  Namespace("BaseOps"){
 
     Op("sizeAt") {
         javaPackage = "org.nd4j.linalg.api.ops.impl.shape"
-        Input(NUMERIC, "in") { description = "Input variable" }
+        Input(NDARRAY, "in") { description = "Input variable" }
         Arg(INT, "dimension") { description = "Dimension to get size of" }
         Output(NUMERIC, "output"){ description = "Scalar INDArray  for size at specified variable" }
         Doc(Language.ANY, DocScope.ALL){

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDBaseOps.java
@@ -4271,11 +4271,10 @@ public class SDBaseOps {
   /**
    * Sets an inplace shape on the passed in input.<br>
    *
-   * @param input The input to set the shape of (NUMERIC type)
+   * @param input The input to set the shape of (NDARRAY type)
    * @param shape The shape to set the input to (NUMERIC type)
    */
   public SDVariable[] setShape(SDVariable input, SDVariable shape) {
-    SDValidation.validateNumerical("setShape", "input", input);
     SDValidation.validateNumerical("setShape", "shape", shape);
     return new org.nd4j.linalg.api.ops.impl.shape.SetShape(sd,input, shape).outputVariables();
   }
@@ -4284,11 +4283,10 @@ public class SDBaseOps {
    * Sets an inplace shape on the passed in input.<br>
    *
    * @param names names May be null. Arrays of names for the output variables.
-   * @param input The input to set the shape of (NUMERIC type)
+   * @param input The input to set the shape of (NDARRAY type)
    * @param shape The shape to set the input to (NUMERIC type)
    */
   public SDVariable[] setShape(String[] names, SDVariable input, SDVariable shape) {
-    SDValidation.validateNumerical("setShape", "input", input);
     SDValidation.validateNumerical("setShape", "shape", shape);
     SDVariable[] out =  new org.nd4j.linalg.api.ops.impl.shape.SetShape(sd,input, shape).outputVariables();
     return sd.updateVariableNamesAndReferences(out, names);
@@ -4297,11 +4295,10 @@ public class SDBaseOps {
   /**
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
-   * @param input Input variable (NUMERIC type)
+   * @param input Input variable (NDARRAY type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public SDVariable shape(SDVariable input) {
-    SDValidation.validateNumerical("shape", "input", input);
     return new org.nd4j.linalg.api.ops.impl.shape.Shape(sd,input).outputVariable();
   }
 
@@ -4309,11 +4306,10 @@ public class SDBaseOps {
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
    * @param name name May be null. Name for the output variable
-   * @param input Input variable (NUMERIC type)
+   * @param input Input variable (NDARRAY type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public SDVariable shape(String name, SDVariable input) {
-    SDValidation.validateNumerical("shape", "input", input);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.Shape(sd,input).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
@@ -4321,11 +4317,10 @@ public class SDBaseOps {
   /**
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
-   * @param in Input variable (NUMERIC type)
+   * @param in Input variable (NDARRAY type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public SDVariable size(SDVariable in) {
-    SDValidation.validateNumerical("size", "in", in);
     return new org.nd4j.linalg.api.ops.impl.shape.Size(sd,in).outputVariable();
   }
 
@@ -4333,11 +4328,10 @@ public class SDBaseOps {
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
    * @param name name May be null. Name for the output variable
-   * @param in Input variable (NUMERIC type)
+   * @param in Input variable (NDARRAY type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public SDVariable size(String name, SDVariable in) {
-    SDValidation.validateNumerical("size", "in", in);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.Size(sd,in).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
@@ -4346,12 +4340,11 @@ public class SDBaseOps {
    * Returns a rank 0 (scalar) variable for the size of the specified dimension.<br>
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
-   * @param in Input variable (NUMERIC type)
+   * @param in Input variable (NDARRAY type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public SDVariable sizeAt(SDVariable in, int dimension) {
-    SDValidation.validateNumerical("sizeAt", "in", in);
     return new org.nd4j.linalg.api.ops.impl.shape.SizeAt(sd,in, dimension).outputVariable();
   }
 
@@ -4360,12 +4353,11 @@ public class SDBaseOps {
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
    * @param name name May be null. Name for the output variable
-   * @param in Input variable (NUMERIC type)
+   * @param in Input variable (NDARRAY type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public SDVariable sizeAt(String name, SDVariable in, int dimension) {
-    SDValidation.validateNumerical("sizeAt", "in", in);
     SDVariable out =  new org.nd4j.linalg.api.ops.impl.shape.SizeAt(sd,in, dimension).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDBase.java
@@ -2023,11 +2023,10 @@ public class NDBase {
   /**
    * Sets an inplace shape on the passed in input.<br>
    *
-   * @param input The input to set the shape of (NUMERIC type)
+   * @param input The input to set the shape of (NDARRAY type)
    * @param shape The shape to set the input to (NUMERIC type)
    */
   public INDArray[] setShape(INDArray input, INDArray shape) {
-    NDValidation.validateNumerical("setShape", "input", input);
     NDValidation.validateNumerical("setShape", "shape", shape);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.SetShape(input, shape));
   }
@@ -2035,22 +2034,20 @@ public class NDBase {
   /**
    * Returns the shape of the specified INDArray  as a 1D INDArray <br>
    *
-   * @param input Input variable (NUMERIC type)
+   * @param input Input variable (NDARRAY type)
    * @return output 1D output variable with contents equal to the shape of the input (NUMERIC type)
    */
   public INDArray shape(INDArray input) {
-    NDValidation.validateNumerical("shape", "input", input);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.Shape(input))[0];
   }
 
   /**
    * Returns the size (number of elements, i.e., prod(shape)) of the specified INDArray  as a 0D scalar variable<br>
    *
-   * @param in Input variable (NUMERIC type)
+   * @param in Input variable (NDARRAY type)
    * @return output 0D (scalar) output variable with value equal to the number of elements in the specified array (NUMERIC type)
    */
   public INDArray size(INDArray in) {
-    NDValidation.validateNumerical("size", "in", in);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.Size(in))[0];
   }
 
@@ -2058,12 +2055,11 @@ public class NDBase {
    * Returns a rank 0 (scalar) variable for the size of the specified dimension.<br>
    * For example, if X has shape [10,20,30] then sizeAt(X,1)=20. Similarly, sizeAt(X,-1)=30<br>
    *
-   * @param in Input variable (NUMERIC type)
+   * @param in Input variable (NDARRAY type)
    * @param dimension Dimension to get size of
    * @return output Scalar INDArray  for size at specified variable (NUMERIC type)
    */
   public INDArray sizeAt(INDArray in, int dimension) {
-    NDValidation.validateNumerical("sizeAt", "in", in);
     return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.shape.SizeAt(in, dimension))[0];
   }
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTests.java
@@ -142,6 +142,15 @@ public class SameDiffTests extends BaseNd4jTestWithBackends {
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testSameDiffShapeNonNumerical() {
+        SameDiff sd = SameDiff.create();
+        SDVariable var = sd.create(null, sd.constant(8), DataType.BOOL);
+        assertEquals(8,var.shape().eval().getLong(0)); // throws exception    }
+        sd.setShape(var,var.shape())[0].eval();
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testSameDiffCreate() {
         SameDiff sd = SameDiff.create();
         SDVariable var = sd.create(null, sd.constant(8), DataType.INT32);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes #9802  - allows determining the shape of non numerical arrays as well as setting the shape of the same
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
