### PR TITLE
Add constant import fix for onnx

### DIFF
--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRGraph.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRGraph.kt
@@ -188,8 +188,6 @@ class OnnxIRGraph(graphDef: Onnx.GraphProto,opMappingRegistry: OpMappingRegistry
         outputList.addAll(graphDef.outputList.filter { valueInfo -> !outputList.contains(valueInfo.name) }.map { input -> input.name })
         val frameworkList =  OpDescriptorLoaderHolder.listForFramework<Onnx.NodeProto>("onnx")
         graphDef.nodeList.forEach {
-
-
             val opDefOrNull = if(!frameworkList.containsKey(it.opType)) {
                 //use Constant as a placeholder for any op that resolves to noop, this is probably an op handled by the custom implementation
                 frameworkList["Constant"]!!

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRNode.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRNode.kt
@@ -82,7 +82,7 @@ class OnnxIRNode(inputNode: Onnx.NodeProto, inputOpDef: Onnx.NodeProto,opMapping
 
     override fun outputAt(index: Int): String {
         //Identity's output is just its node name and has no output
-        if(nodeDef.opType == "Identity"  || nodeDef.opType == "Placeholder" || nodeDef.opType == "Constant" && index == 0) {
+        if(nodeDef.outputCount < 1) {
             return nodeDef.name
         } else if(nodeDef.opType == "Identity" && index > 0) {
             throw IllegalArgumentException("Invalid index for Identity op. Only 0 is valid, received $index")

--- a/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
+++ b/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
@@ -12,11 +12,21 @@ import org.nd4j.linalg.dataset.DataSet
 import org.nd4j.linalg.factory.Nd4j
 import org.nd4j.linalg.learning.config.Adam
 import org.nd4j.samediff.frameworkimport.onnx.importer.OnnxFrameworkImporter
+import java.io.File
 import java.util.*
 
 @Tag(TagNames.ONNX)
 class TestOnnxFrameworkImporter {
 
+
+
+    @Test
+    fun testRecentUnsqueeze() {
+        val importer = OnnxFrameworkImporter()
+        val file = File("/home/agibsonccc/Documents/GitHub/kompile/kompile_pytorch/tests/output_cnn_mnist.onnx")
+        val output = importer.runImport(file.absolutePath, suggestDynamicVariables = true)
+
+    }
 
 
     @Test

--- a/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
+++ b/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
@@ -1,11 +1,11 @@
 package org.eclipse.deeplearning4j.frameworkimport.frameworkimport.onnx.importer
 
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.nd4j.autodiff.samediff.TrainingConfig
 import org.nd4j.common.io.ClassPathResource
+import org.nd4j.common.resources.Resources
 import org.nd4j.common.tests.tags.TagNames
 import org.nd4j.linalg.api.buffer.DataType
 import org.nd4j.linalg.dataset.DataSet
@@ -21,11 +21,14 @@ class TestOnnxFrameworkImporter {
 
 
     @Test
-    fun testRecentUnsqueeze() {
+    fun testConstantInitialization() {
         val importer = OnnxFrameworkImporter()
-        val file = File("/home/agibsonccc/Documents/GitHub/kompile/kompile_pytorch/tests/output_cnn_mnist.onnx")
+        val file = Resources.asFile("onnx_graphs/output_cnn_mnist.onnx")
+        //tests model import with constant initializers where an output of a constant node is
+        //defined
         val output = importer.runImport(file.absolutePath, suggestDynamicVariables = true)
-
+        //ensure that the graph with an eager mode can automatically import the model
+        assertNotNull(output)
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Our model import was not fully importing constants correctly.
On onnx nodes when we define a constant it has an output name.
This was then used as inputs in other nodes.
This adds a test and model import case that reflects defined constants
with proper output name propagation.

Before we use to get an undefined variable error.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
