### PR TITLE
Fixes training history propagation

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -620,7 +620,7 @@ public class SameDiff extends SDBaseOps {
         Map<Integer, Integer> thisVertexIdToNew = new HashMap<>();
         int idx = 1;
         Map<String,SDVariable> allVars = new LinkedHashMap<>();
-        for (val var : variables()) {
+        for (SDVariable var : variables()) {
             //NOTE: the var call may not always be the same name, ensure that the samediff instance is aware of both
             SDVariable clone = var.clone(this);
             SDVariable newVar = sameDiff.var(clone);
@@ -1580,6 +1580,18 @@ public class SameDiff extends SDBaseOps {
         return Collections.unmodifiableList(this.lossVariables);
     }
 
+
+    /**
+     * Clear/remove any existing loss variables, and set the loss variables to the specified variable names.<br>
+     * See {@link #addLossVariable(String)} for more details
+     *
+     * @param lossVariableNames Names of variables to be loss function variables
+     */
+    public void setLossVariables(@NonNull Collection<String> lossVariableNames) {
+        this.setLossVariables(lossVariableNames.toArray(new String[lossVariableNames.size()]));
+    }
+
+
     /**
      * Clear/remove any existing loss variables, and set the loss variables to the specified variable names.<br>
      * See {@link #addLossVariable(String)} for more details
@@ -1595,6 +1607,8 @@ public class SameDiff extends SDBaseOps {
         // function is defined with respect to specific loss function variables
         sameDiffFunctionInstances.remove("grad");
     }
+
+
 
     /**
      * See {@link #setLossVariables(String...)}
@@ -1642,6 +1656,7 @@ public class SameDiff extends SDBaseOps {
      */
     public void setTrainingConfig(TrainingConfig trainingConfig) {
         this.trainingConfig = trainingConfig;
+        this.setLossVariables(trainingConfig.getLossVariables());
     }
 
     /**
@@ -1873,9 +1888,9 @@ public class SameDiff extends SDBaseOps {
 
 
         TrainingSession ts = new TrainingSession(gradInstance);
-        gradInstance.setTrainingConfig(trainingConfig);     //In case any listeners want to use it
+        gradInstance.setTrainingConfig(this.trainingConfig);     //In case any listeners want to use it
 
-        for(Listener l : activeListeners){
+        for(Listener l : activeListeners) {
             l.operationStart(gradInstance, Operation.TRAINING);
         }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/TrainingConfig.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/TrainingConfig.java
@@ -396,7 +396,7 @@ public class TrainingConfig {
             return this;
         }
 
-        public Builder minimize(String... lossVariables){
+        public Builder minimize(String... lossVariables) {
             this.lossVariables = Arrays.asList(lossVariables);
             return this;
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -318,7 +318,8 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
         List<String> outVarNames = o.getOutputsOfOp();
         for (int i = 0; i < out.numResults(); i++) {
             if (out.hasSingle() && out.resultAt(i) == null   || out.hasValues()
-                    && out.valueWithKeyAtIndex(i, false) == null && o.getOp() instanceof Switch)
+                    && out.valueWithKeyAtIndex(i, false) == null
+                    && o.getOp() instanceof Switch)
                 continue;   //Switch case: we only ever get one of 2 outputs, other is null (branch not executed)
             String name = outVarNames.get(i);
             Variable v = sameDiff.getVariables().get(name);
@@ -380,7 +381,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                         log.trace("Found array id {} (output of {}) not required anywhere, deallocating", array.getTensorValue().getId(), o.getName());
                 }
 
-                if(array != null && array.getTensorValue() != null && !freedArrays.contains(array.getTensorValue().getId())) {
+                if(!outVarNames.contains(name) && array != null && array.getTensorValue() != null && !freedArrays.contains(array.getTensorValue().getId())) {
                     mmgr.release(array.getTensorValue());
                     freedArrays.add(array.getTensorValue().getId());
                 }
@@ -393,7 +394,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                         log.trace("Found array id {} (output of {}) not required anywhere, deallocating", array.getId(), o.getName());
                 }
 
-                if(array != null && !freedArrays.contains(array.getId())) {
+                if(!outVarNames.contains(name) && array != null && !freedArrays.contains(array.getId())) {
                     mmgr.release(array);
                     freedArrays.add(array.getId());
                 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/TrainingSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/TrainingSession.java
@@ -125,6 +125,10 @@ public class TrainingSession extends InferenceSession {
             requiredActivations.addAll(config.getTrainEvaluations().keySet());
         }
 
+        if(config.getLossVariables() != null) {
+            requiredActivations.addAll(config.getLossVariables());
+        }
+
         //Set up losses
         lossVarsToLossIdx = new LinkedHashMap<>();
         List<String> lossVars;

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRGraph.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRGraph.kt
@@ -188,8 +188,6 @@ class OnnxIRGraph(graphDef: Onnx.GraphProto,opMappingRegistry: OpMappingRegistry
         outputList.addAll(graphDef.outputList.filter { valueInfo -> !outputList.contains(valueInfo.name) }.map { input -> input.name })
         val frameworkList =  OpDescriptorLoaderHolder.listForFramework<Onnx.NodeProto>("onnx")
         graphDef.nodeList.forEach {
-
-
             val opDefOrNull = if(!frameworkList.containsKey(it.opType)) {
                 //use Constant as a placeholder for any op that resolves to noop, this is probably an op handled by the custom implementation
                 frameworkList["Constant"]!!

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRNode.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/ir/OnnxIRNode.kt
@@ -82,7 +82,7 @@ class OnnxIRNode(inputNode: Onnx.NodeProto, inputOpDef: Onnx.NodeProto,opMapping
 
     override fun outputAt(index: Int): String {
         //Identity's output is just its node name and has no output
-        if(nodeDef.opType == "Identity"  || nodeDef.opType == "Placeholder" || nodeDef.opType == "Constant" && index == 0) {
+        if(nodeDef.outputCount < 1) {
             return nodeDef.name
         } else if(nodeDef.opType == "Identity" && index > 0) {
             throw IllegalArgumentException("Invalid index for Identity op. Only 0 is valid, received $index")

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTrainingTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTrainingTest.java
@@ -144,7 +144,7 @@ public class SameDiffTrainingTest extends BaseNd4jTestWithBackends {
         sd.setTrainingConfig(config);
         sd.setListeners(new ScoreListener(1));
         History hist = sd.fit(trainIter, epoches);
-        System.out.println(hist.getLossCurve().getLossValues());
+        assertTrue(hist.getLossCurve().getLossValues().sumNumber().doubleValue() > 0.0);
     }
 
     @ParameterizedTest

--- a/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
+++ b/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
@@ -12,11 +12,21 @@ import org.nd4j.linalg.dataset.DataSet
 import org.nd4j.linalg.factory.Nd4j
 import org.nd4j.linalg.learning.config.Adam
 import org.nd4j.samediff.frameworkimport.onnx.importer.OnnxFrameworkImporter
+import java.io.File
 import java.util.*
 
 @Tag(TagNames.ONNX)
 class TestOnnxFrameworkImporter {
 
+
+
+    @Test
+    fun testRecentUnsqueeze() {
+        val importer = OnnxFrameworkImporter()
+        val file = File("/home/agibsonccc/Documents/GitHub/kompile/kompile_pytorch/tests/output_cnn_mnist.onnx")
+        val output = importer.runImport(file.absolutePath, suggestDynamicVariables = true)
+
+    }
 
 
     @Test

--- a/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
+++ b/platform-tests/src/test/kotlin/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/importer/TestOnnxFrameworkImporter.kt
@@ -1,11 +1,11 @@
 package org.eclipse.deeplearning4j.frameworkimport.frameworkimport.onnx.importer
 
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.nd4j.autodiff.samediff.TrainingConfig
 import org.nd4j.common.io.ClassPathResource
+import org.nd4j.common.resources.Resources
 import org.nd4j.common.tests.tags.TagNames
 import org.nd4j.linalg.api.buffer.DataType
 import org.nd4j.linalg.dataset.DataSet
@@ -21,11 +21,14 @@ class TestOnnxFrameworkImporter {
 
 
     @Test
-    fun testRecentUnsqueeze() {
+    fun testConstantInitialization() {
         val importer = OnnxFrameworkImporter()
-        val file = File("/home/agibsonccc/Documents/GitHub/kompile/kompile_pytorch/tests/output_cnn_mnist.onnx")
+        val file = Resources.asFile("onnx_graphs/output_cnn_mnist.onnx")
+        //tests model import with constant initializers where an output of a constant node is
+        //defined
         val output = importer.runImport(file.absolutePath, suggestDynamicVariables = true)
-
+        //ensure that the graph with an eager mode can automatically import the model
+        assertNotNull(output)
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes history to ensure loss variables get executed and history gets propagated.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
