### PR TITLE
Correct parentheses for loading enums

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
@@ -362,7 +362,7 @@ public abstract class DifferentialFunction {
                        value = DataType.values()[idxConverted];
                 }
 
-                if(target.getType().isEnum() && value instanceof Long || value instanceof Integer && !target.getType().equals(int.class) && !target.getType().equals(long.class)) {
+                if(target.getType().isEnum() && (value instanceof Long || value instanceof Integer && !target.getType().equals(int.class) && !target.getType().equals(long.class))) {
                     Class<? extends Enum> enumType = (Class<? extends Enum>) target.getType();
                     Method method = enumType.getMethod("values");
                     method.setAccessible(true);

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/FailingSameDiffTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/FailingSameDiffTests.java
@@ -95,7 +95,7 @@ public class FailingSameDiffTests extends BaseNd4jTestWithBackends {
 
         SDVariable input = sd.var("input", ia);
 
-        SDVariable res = sd.nn().dropout(input, p);
+        SDVariable res = sd.nn().dropout(input, false,p);
         Map<String, INDArray> output = sd.outputAll(Collections.emptyMap());
         assertTrue(!output.isEmpty());
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/FlatBufferSerdeTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/FlatBufferSerdeTest.java
@@ -33,6 +33,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.samediff.TrainingConfig;
 import org.nd4j.autodiff.samediff.VariableType;
+import org.nd4j.common.resources.Resources;
 import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.graph.FlatConfiguration;
@@ -94,6 +95,14 @@ public class FlatBufferSerdeTest extends BaseNd4jTestWithBackends {
         return 'c';
     }
 
+
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testEnum(Nd4jBackend backend) {
+        SameDiff sameDiff = SameDiff.load(Resources.asFile("onnx_graphs/output_cnn_mnist.fb"),true);
+        assertNotNull(sameDiff);
+    }
 
 
     @ParameterizedTest


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes logic issue when dealing with enums and Integer/Longs.
This was found specifically on LogSoftmax which uses an Integer for dimension rather than an int.

## How was this patch tested?
Adds test model to prevent regressions.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
