### PR TITLE
Fix matrix multiply backprop

### DIFF
--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Linalg.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/Linalg.kt
@@ -114,14 +114,20 @@ fun Linalg() =  Namespace("Linalg") {
 
         Input(DataType.NUMERIC, "a") {description = "input tensor"}
         Input(DataType.NUMERIC, "b") {description = "input tensor"}
+        Arg(DataType.FLOATING_POINT,"alpha",{defaultValue = 1.0; description = "Defaults to 1.0: the scalar multiplier for the product of a* b "})
+        Arg(DataType.FLOATING_POINT,"beta",{defaultValue = 1.0; description = "Defaults to 1.0: the scalar multiplier for c "})
+        Arg(DataType.BOOL,"transA",{defaultValue = false; description = "Whether to transpose a when running multiply "})
+        Arg(DataType.BOOL,"transB",{defaultValue = false; description = "Whether to transpose b when running multiply "})
         Output(DataType.FLOATING_POINT, "output")
 
         Doc(Language.ANY, DocScope.ALL){
             """
-             Performs matrix mutiplication on input tensors.
+             Performs matrix multiplication on input tensors.
             """.trimIndent()
         }
     }
+
+
 
     Op("Qr") {
         javaPackage = "org.nd4j.linalg.api.ops.impl.transforms.custom"

--- a/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/NeuralNetwork.kt
+++ b/contrib/codegen-tools/codegen/src/main/ops/org/nd4j/codegen/ops/NeuralNetwork.kt
@@ -204,7 +204,9 @@ fun NN() = Namespace("NN") {
         Input(NUMERIC, "input") { description = "Input data" }
         Input(NUMERIC, "weights") { description = "Weights variable, shape [nIn, nOut]" }
         Input(NUMERIC, "bias") { description = "Optional bias variable (may be null)" /*; optional = true*/ }
-
+        Arg(BOOL,"transposeA") { description = "Whether to transpose input or not"; defaultValue= false}
+        Arg(BOOL,"transposeB") { description = "Whether to transpose second input or not"; defaultValue= false}
+        Arg(BOOL,"transposeC") { description = "Whether to transpose result or not"; defaultValue= false}
         Output(NUMERIC, "output") { description = "Output variable" }
 
         Doc(Language.ANY, DocScope.ALL) {
@@ -214,6 +216,7 @@ fun NN() = Namespace("NN") {
             """.trimIndent()
         }
     }
+
 
     Op("logSigmoid", transformStrict) {
         Doc(Language.ANY, DocScope.ALL) {

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -4668,8 +4668,10 @@ void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k
 void NDArray::addRowVector(const NDArray &row, NDArray &target) const {
   if (isS()) throw std::runtime_error("NDArray::addRowVector: you can't use this method on String array!");
   if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.lengthOf())
+      !row.isRowVector() || columns() != row.lengthOf()) {
+    sd_printf("NDArray::addiRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
     throw std::invalid_argument("NDArray::addRowVector: wrong arguments !");
+  }
   if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()) &&
       !(isR() && row.isR() && target.isR()))
     throw std::invalid_argument("NDArray::addRowVector: wrong type of target array !");
@@ -4691,8 +4693,10 @@ void NDArray::addRowVector(const NDArray &row, NDArray &target) const {
 void NDArray::subRowVector(const NDArray &row, NDArray &target) const {
   if (isS()) throw std::runtime_error("NDArray::addRowVector: you can't use this method on String array!");
   if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.lengthOf())
+      !row.isRowVector() || columns() != row.lengthOf()) {
+    sd_printf("NDArray::addRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
     throw std::invalid_argument("NDArray::addRowVector: wrong arguments !");
+  }
   if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()) &&
       !(isR() && row.isR() && target.isR()))
     throw std::invalid_argument("NDArray::addRowVector: wrong type of target array !");
@@ -4714,8 +4718,10 @@ void NDArray::subRowVector(const NDArray &row, NDArray &target) const {
 void NDArray::mulRowVector(const NDArray &row, NDArray &target) const {
   if (isS()) throw std::runtime_error("NDArray::mulRowVector: you can't use this method on String array!");
   if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.columns())
+      !row.isRowVector() || columns() != row.columns()) {
+    sd_printf("NDArray::mulRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
     throw std::invalid_argument("NDArray::mulRowVector: wrong arguments !");
+  }
   if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()))
     throw std::invalid_argument("NDArray::mulRowVector: wrong type of target array !");
 
@@ -4737,8 +4743,10 @@ void NDArray::divRowVector(const NDArray &row, NDArray &target) const {
   if (isS()) throw std::runtime_error("NDArray::divRowVector: you can't use this method on String array!");
   if (row.isB()) throw std::runtime_error("NDArray::divRowVector: you can't divide by bool row!");
   if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.columns())
+      !row.isRowVector() || columns() != row.columns()) {
+    sd_printf("NDArray::divRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
     throw std::invalid_argument("NDArray::divRowVector: wrong arguments !");
+    }
   if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()))
     throw std::invalid_argument("NDArray::divRowVector: wrong type of target array !");
 
@@ -4759,9 +4767,10 @@ void NDArray::divRowVector(const NDArray &row, NDArray &target) const {
 // This method adds given row to all rows in this NDArray, this array becomes affected
 void NDArray::addiRowVector(const NDArray &row) {
   if (isS()) throw std::runtime_error("NDArray::addiRowVector: you can't use this method on String array!");
-  if (rankOf() != 2 || !row.isRowVector() || columns() != row.lengthOf())
+  if (rankOf() != 2 || !row.isRowVector() || columns() != row.lengthOf()) {
+    sd_printf("NDArray::addiRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
     throw std::invalid_argument("NDArray::addiRowVector: wrong arguments !");
-
+  }
   int dimension = 1;
 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
@@ -4779,8 +4788,10 @@ void NDArray::addiRowVector(const NDArray &row) {
 void NDArray::addColumnVector(const NDArray &column, NDArray &target) const {
   if (isS()) throw std::runtime_error("NDArray::addColumnVector: you can't use this method on String array!");
   if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !column.isColumnVector() || rows() != column.lengthOf())
+      !column.isColumnVector() || rows() != column.lengthOf()) {
+    sd_printf("NDArray::addColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
     throw std::invalid_argument("NDArray::addColumnVector: wrong arguments !");
+  }
   if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), column.dataType()))
     throw std::invalid_argument("NDArray::addColumnVector: wrong type of target array !");
 
@@ -4801,8 +4812,10 @@ void NDArray::addColumnVector(const NDArray &column, NDArray &target) const {
 // This method adds given column to all columns in this NDArray, this array becomes affected
 void NDArray::addiColumnVector(const NDArray &column) {
   if (isS()) throw std::runtime_error("NDArray::addiColumnVector: you can't use this method on String array!");
-  if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf())
+  if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf()) {
+    sd_printf("NDArray::addiColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
     throw std::invalid_argument("NDArray::addiColumnVector: wrong arguments !");
+  }
 
   int dimension = 0;
 
@@ -4821,9 +4834,10 @@ void NDArray::addiColumnVector(const NDArray &column) {
 // This method multiplies each column of this array by given argument-column, this array becomes affected
 void NDArray::muliColumnVector(const NDArray &column) {
   if (isS()) throw std::runtime_error("NDArray::muliColumnVector: you can't use this method on String array!");
-  if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf())
+  if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf()) {
+    sd_printf("NDArray::muliColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
     throw std::invalid_argument("NDArray::muliColumnVector: wrong arguments !");
-
+  }
   int dimension = 0;
 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDLinalg.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDLinalg.java
@@ -146,7 +146,45 @@ public class SDLinalg extends SDOps {
   }
 
   /**
-   * Performs matrix mutiplication on input tensors.<br>
+   * Performs matrix multiplication on input tensors.<br>
+   *
+   * @param a input tensor (NUMERIC type)
+   * @param b input tensor (NUMERIC type)
+   * @param alpha Defaults to 1.0: the scalar multiplier for the product of a* b 
+   * @param beta Defaults to 1.0: the scalar multiplier for c 
+   * @param transA Whether to transpose a when running multiply 
+   * @param transB Whether to transpose b when running multiply 
+   * @return output  (FLOATING_POINT type)
+   */
+  public SDVariable matmul(SDVariable a, SDVariable b, double alpha, double beta, boolean transA,
+      boolean transB) {
+    SDValidation.validateNumerical("Matmul", "a", a);
+    SDValidation.validateNumerical("Matmul", "b", b);
+    return new org.nd4j.linalg.api.ops.impl.reduce.Mmul(sd,a, b, alpha, beta, transA, transB).outputVariable();
+  }
+
+  /**
+   * Performs matrix multiplication on input tensors.<br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param a input tensor (NUMERIC type)
+   * @param b input tensor (NUMERIC type)
+   * @param alpha Defaults to 1.0: the scalar multiplier for the product of a* b 
+   * @param beta Defaults to 1.0: the scalar multiplier for c 
+   * @param transA Whether to transpose a when running multiply 
+   * @param transB Whether to transpose b when running multiply 
+   * @return output  (FLOATING_POINT type)
+   */
+  public SDVariable matmul(String name, SDVariable a, SDVariable b, double alpha, double beta,
+      boolean transA, boolean transB) {
+    SDValidation.validateNumerical("Matmul", "a", a);
+    SDValidation.validateNumerical("Matmul", "b", b);
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.reduce.Mmul(sd,a, b, alpha, beta, transA, transB).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
+   * Performs matrix multiplication on input tensors.<br>
    *
    * @param a input tensor (NUMERIC type)
    * @param b input tensor (NUMERIC type)
@@ -155,11 +193,11 @@ public class SDLinalg extends SDOps {
   public SDVariable matmul(SDVariable a, SDVariable b) {
     SDValidation.validateNumerical("Matmul", "a", a);
     SDValidation.validateNumerical("Matmul", "b", b);
-    return new org.nd4j.linalg.api.ops.impl.reduce.Mmul(sd,a, b).outputVariable();
+    return new org.nd4j.linalg.api.ops.impl.reduce.Mmul(sd,a, b, 1.0, 1.0, false, false).outputVariable();
   }
 
   /**
-   * Performs matrix mutiplication on input tensors.<br>
+   * Performs matrix multiplication on input tensors.<br>
    *
    * @param name name May be null. Name for the output variable
    * @param a input tensor (NUMERIC type)
@@ -169,7 +207,7 @@ public class SDLinalg extends SDOps {
   public SDVariable matmul(String name, SDVariable a, SDVariable b) {
     SDValidation.validateNumerical("Matmul", "a", a);
     SDValidation.validateNumerical("Matmul", "b", b);
-    SDVariable out =  new org.nd4j.linalg.api.ops.impl.reduce.Mmul(sd,a, b).outputVariable();
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.reduce.Mmul(sd,a, b, 1.0, 1.0, false, false).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDNN.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/ops/SDNN.java
@@ -582,13 +582,55 @@ public class SDNN extends SDOps {
    * @param input Input data (NUMERIC type)
    * @param weights Weights variable, shape [nIn, nOut] (NUMERIC type)
    * @param bias Optional bias variable (may be null) (NUMERIC type)
+   * @param transposeA Whether to transpose input or not
+   * @param transposeB Whether to transpose second input or not
+   * @param transposeC Whether to transpose result or not
+   * @return output Output variable (NUMERIC type)
+   */
+  public SDVariable linear(SDVariable input, SDVariable weights, SDVariable bias,
+      boolean transposeA, boolean transposeB, boolean transposeC) {
+    SDValidation.validateNumerical("linear", "input", input);
+    SDValidation.validateNumerical("linear", "weights", weights);
+    SDValidation.validateNumerical("linear", "bias", bias);
+    return new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(sd,input, weights, bias, transposeA, transposeB, transposeC).outputVariable();
+  }
+
+  /**
+   * Linear layer operation: out = mmul(in,w) + bias<br>
+   * Note that bias array is optional<br>
+   *
+   * @param name name May be null. Name for the output variable
+   * @param input Input data (NUMERIC type)
+   * @param weights Weights variable, shape [nIn, nOut] (NUMERIC type)
+   * @param bias Optional bias variable (may be null) (NUMERIC type)
+   * @param transposeA Whether to transpose input or not
+   * @param transposeB Whether to transpose second input or not
+   * @param transposeC Whether to transpose result or not
+   * @return output Output variable (NUMERIC type)
+   */
+  public SDVariable linear(String name, SDVariable input, SDVariable weights, SDVariable bias,
+      boolean transposeA, boolean transposeB, boolean transposeC) {
+    SDValidation.validateNumerical("linear", "input", input);
+    SDValidation.validateNumerical("linear", "weights", weights);
+    SDValidation.validateNumerical("linear", "bias", bias);
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(sd,input, weights, bias, transposeA, transposeB, transposeC).outputVariable();
+    return sd.updateVariableNameAndReference(out, name);
+  }
+
+  /**
+   * Linear layer operation: out = mmul(in,w) + bias<br>
+   * Note that bias array is optional<br>
+   *
+   * @param input Input data (NUMERIC type)
+   * @param weights Weights variable, shape [nIn, nOut] (NUMERIC type)
+   * @param bias Optional bias variable (may be null) (NUMERIC type)
    * @return output Output variable (NUMERIC type)
    */
   public SDVariable linear(SDVariable input, SDVariable weights, SDVariable bias) {
     SDValidation.validateNumerical("linear", "input", input);
     SDValidation.validateNumerical("linear", "weights", weights);
     SDValidation.validateNumerical("linear", "bias", bias);
-    return new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(sd,input, weights, bias).outputVariable();
+    return new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(sd,input, weights, bias, false, false, false).outputVariable();
   }
 
   /**
@@ -605,7 +647,7 @@ public class SDNN extends SDOps {
     SDValidation.validateNumerical("linear", "input", input);
     SDValidation.validateNumerical("linear", "weights", weights);
     SDValidation.validateNumerical("linear", "bias", bias);
-    SDVariable out =  new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(sd,input, weights, bias).outputVariable();
+    SDVariable out =  new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(sd,input, weights, bias, false, false, false).outputVariable();
     return sd.updateVariableNameAndReference(out, name);
   }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/Mmul.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/Mmul.java
@@ -277,7 +277,7 @@ public class Mmul extends DynamicCustomOp {
 
     @Override
     public List<SDVariable> doDiff(List<SDVariable> gradients) {
-        return Arrays.asList(new MmulBp(sameDiff, larg(), rarg(), gradients.get(0), mt).outputVariables());
+        return Arrays.asList(new MmulBp(sameDiff, arg(0), arg(1), gradients.get(0), mt).outputVariables());
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/Mmul.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/Mmul.java
@@ -150,6 +150,30 @@ public class Mmul extends DynamicCustomOp {
     public Mmul() {
     }
 
+    public Mmul(SameDiff sd, SDVariable a, SDVariable b, double alpha, double beta, boolean transA, boolean transB) {
+        super(null,sd,new SDVariable[]{a,b});
+        addIArgument(ArrayUtil.fromBoolean(transA),
+                ArrayUtil.fromBoolean(transB),
+                ArrayUtil.fromBoolean(false));
+        this.alpha = alpha;
+        this.beta = beta;
+        addTArgument(alpha, beta);
+        mt = MMulTranspose.builder().transposeA(transA).transposeB(transB).transposeResult(false).build();
+
+    }
+
+    public Mmul(INDArray a, INDArray b, double alpha, double beta, boolean transA, boolean transB) {
+        addInputArgument(a, b);
+        addIArgument(ArrayUtil.fromBoolean(transA),
+                ArrayUtil.fromBoolean(transB),
+                ArrayUtil.fromBoolean(false));
+        this.alpha = alpha;
+        this.beta = beta;
+        addTArgument(alpha, beta);
+        mt = MMulTranspose.builder().transposeA(transA).transposeB(transB).transposeResult(false).build();
+
+    }
+
     @Override
     public Object getValue(Field property) {
         if (mt == null) {
@@ -311,8 +335,8 @@ public class Mmul extends DynamicCustomOp {
 
     @Override
     public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes) {
-       if(!dArguments.isEmpty())
-           return Collections.singletonList(dArguments.get(0));
+        if(!dArguments.isEmpty())
+            return Collections.singletonList(dArguments.get(0));
         Preconditions.checkState(dataTypes != null && dataTypes.size() >= 2, "Expected at least 2 inputs to mmul op, got %s", dataTypes);
         Preconditions.checkState(dataTypes.get(0).isFPType() && dataTypes.get(1).isFPType(), "Inputs to mmul op must both be a floating" +
                 "point type: got %s", dataTypes);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDLinalg.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDLinalg.java
@@ -85,7 +85,25 @@ public class NDLinalg {
   }
 
   /**
-   * Performs matrix mutiplication on input tensors.<br>
+   * Performs matrix multiplication on input tensors.<br>
+   *
+   * @param a input tensor (NUMERIC type)
+   * @param b input tensor (NUMERIC type)
+   * @param alpha Defaults to 1.0: the scalar multiplier for the product of a* b 
+   * @param beta Defaults to 1.0: the scalar multiplier for c 
+   * @param transA Whether to transpose a when running multiply 
+   * @param transB Whether to transpose b when running multiply 
+   * @return output  (FLOATING_POINT type)
+   */
+  public INDArray matmul(INDArray a, INDArray b, double alpha, double beta, boolean transA,
+      boolean transB) {
+    NDValidation.validateNumerical("Matmul", "a", a);
+    NDValidation.validateNumerical("Matmul", "b", b);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.reduce.Mmul(a, b, alpha, beta, transA, transB))[0];
+  }
+
+  /**
+   * Performs matrix multiplication on input tensors.<br>
    *
    * @param a input tensor (NUMERIC type)
    * @param b input tensor (NUMERIC type)
@@ -94,7 +112,7 @@ public class NDLinalg {
   public INDArray matmul(INDArray a, INDArray b) {
     NDValidation.validateNumerical("Matmul", "a", a);
     NDValidation.validateNumerical("Matmul", "b", b);
-    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.reduce.Mmul(a, b))[0];
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.reduce.Mmul(a, b, 1.0, 1.0, false, false))[0];
   }
 
   /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDNN.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/ops/NDNN.java
@@ -295,13 +295,33 @@ public class NDNN {
    * @param input Input data (NUMERIC type)
    * @param weights Weights variable, shape [nIn, nOut] (NUMERIC type)
    * @param bias Optional bias variable (may be null) (NUMERIC type)
+   * @param transposeA Whether to transpose input or not
+   * @param transposeB Whether to transpose second input or not
+   * @param transposeC Whether to transpose result or not
+   * @return output Output variable (NUMERIC type)
+   */
+  public INDArray linear(INDArray input, INDArray weights, INDArray bias, boolean transposeA,
+      boolean transposeB, boolean transposeC) {
+    NDValidation.validateNumerical("linear", "input", input);
+    NDValidation.validateNumerical("linear", "weights", weights);
+    NDValidation.validateNumerical("linear", "bias", bias);
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(input, weights, bias, transposeA, transposeB, transposeC))[0];
+  }
+
+  /**
+   * Linear layer operation: out = mmul(in,w) + bias<br>
+   * Note that bias array is optional<br>
+   *
+   * @param input Input data (NUMERIC type)
+   * @param weights Weights variable, shape [nIn, nOut] (NUMERIC type)
+   * @param bias Optional bias variable (may be null) (NUMERIC type)
    * @return output Output variable (NUMERIC type)
    */
   public INDArray linear(INDArray input, INDArray weights, INDArray bias) {
     NDValidation.validateNumerical("linear", "input", input);
     NDValidation.validateNumerical("linear", "weights", weights);
     NDValidation.validateNumerical("linear", "bias", bias);
-    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(input, weights, bias))[0];
+    return Nd4j.exec(new org.nd4j.linalg.api.ops.impl.transforms.custom.XwPlusB(input, weights, bias, false, false, false))[0];
   }
 
   /**

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native-preset/pom.xml
@@ -207,8 +207,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/OnnxOpDeclarations.kt
@@ -447,16 +447,12 @@ val nonZero = OnnxMappingProcess(
 )
 
 
+//uses the Gemm Rule implementation instead
 val gemm = OnnxMappingProcess(
         opMappingRegistry = onnxOpRegistry,
         inputFrameworkOpName = "Gemm",
-        opName = "matmul",
-        tensorMappingRules = listOf(mappingNDArrayInputs(mutableMapOf("input" to "A","y" to "B"))),
-        attributeMappingRules = listOf(valueMappings(mapOf("alpha" to "alpha","beta" to "beta",
-                "transposeX" to "transA", "transposeY" to "transB")),
-                booleanConstant(inputName = "transZ",constantValue = false,argumentIndex = 2)[0],
-                booleanConstant(inputName = "transposeZ",constantValue = false,argumentIndex = 2)[0])
-)
+        opName = "noop")
+
 //note: no ops are mostly just stubs for ops implemented as pre processors
 //These are implemented using the PreImportHook found: https://github.com/eclipse/deeplearning4j/tree/master/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations
 val globalAveragePooling = OnnxMappingProcess(

--- a/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/Gemm.kt
+++ b/nd4j/samediff-import/samediff-import-onnx/src/main/kotlin/org/nd4j/samediff/frameworkimport/onnx/definitions/implementations/Gemm.kt
@@ -1,0 +1,78 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.samediff.frameworkimport.onnx.definitions.implementations
+
+import org.nd4j.autodiff.samediff.SDVariable
+import org.nd4j.autodiff.samediff.SameDiff
+import org.nd4j.autodiff.samediff.internal.SameDiffOp
+import org.nd4j.samediff.frameworkimport.ImportGraph
+import org.nd4j.samediff.frameworkimport.hooks.PreImportHook
+import org.nd4j.samediff.frameworkimport.hooks.annotations.PreHookRule
+import org.nd4j.samediff.frameworkimport.registry.OpMappingRegistry
+import org.nd4j.shade.protobuf.GeneratedMessageV3
+import org.nd4j.shade.protobuf.ProtocolMessageEnum
+
+/**
+ * A port of cast.py from onnx tensorflow for samediff:
+ * https://github.com/onnx/onnx-tensorflow/blob/master/onnx_tf/handlers/backend/cast.py
+ *
+ * @author Adam Gibson
+ */
+@PreHookRule(nodeNames = [],opNames = ["Gemm"],frameworkName = "onnx")
+class Gemm : PreImportHook  {
+
+    override fun doImport(
+        sd: SameDiff,
+        attributes: Map<String, Any>,
+        outputNames: List<String>,
+        op: SameDiffOp,
+        mappingRegistry: OpMappingRegistry<GeneratedMessageV3, GeneratedMessageV3, GeneratedMessageV3, GeneratedMessageV3, ProtocolMessageEnum, GeneratedMessageV3, GeneratedMessageV3>,
+        importGraph: ImportGraph<GeneratedMessageV3, GeneratedMessageV3, GeneratedMessageV3, GeneratedMessageV3, GeneratedMessageV3, GeneratedMessageV3, ProtocolMessageEnum>,
+        dynamicVariables: Map<String, GeneratedMessageV3>
+    ): Map<String, List<SDVariable>> {
+        // Parameter docs below are from the onnx operator docs:
+        // https://github.com/onnx/onnx/blob/master/docs/Operators.md#gemm
+        //this is actually linear, pytorch is capable of exporting a linear operator
+        //as Gemm despite it not actually being linear...
+        if(op.inputsToOp.size > 2) {
+           val lastVar = sd.getVariable(op.inputsToOp[2])
+            val len = lastVar.length()
+            val transA = attributes.getOrDefault("transA",0L) as Long
+            val transB = attributes.getOrDefault("transB",0L) as Long
+            val outputVar = sd.nn().linear(outputNames[0],
+                sd.getVariable(op.inputsToOp[0])
+                ,sd.getVariable(op.inputsToOp[1])
+                ,lastVar,transA > 0,transB > 0,false)
+            return mapOf(outputVar.name() to listOf(outputVar))
+
+        } else {
+            val alpha = attributes.getOrDefault("alpha", 1.0) as Double
+            val beta = attributes.getOrDefault("beta",1.0) as Double
+            val transA = attributes.getOrDefault("transA",0L) as Long
+            val transB = attributes.getOrDefault("transB",0L) as Long
+
+            val outputVar = sd.linalg().matmul(sd.getVariable(op.inputsToOp[0]),
+                sd.getVariable(op.inputsToOp[1]),alpha,beta,transA > 0,transB > 0)
+            return mapOf(outputVar.name() to listOf(outputVar))
+        }
+    }
+
+
+}

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/TestOnnxConverter.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/frameworkimport/onnx/TestOnnxConverter.java
@@ -21,22 +21,65 @@ package org.eclipse.deeplearning4j.frameworkimport.frameworkimport.onnx;
 
 import onnx.Onnx;
 import org.apache.commons.io.IOUtils;
+import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.autodiff.samediff.TrainingConfig;
 import org.nd4j.common.io.ClassPathResource;
 import org.nd4j.common.tests.tags.TagNames;
+import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.learning.config.Adam;
 import org.nd4j.samediff.frameworkimport.onnx.OnnxConverter;
+import org.nd4j.samediff.frameworkimport.onnx.importer.OnnxFrameworkImporter;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 @Tag(TagNames.ONNX)
 public class TestOnnxConverter {
 
     @TempDir
     Path tempDir;
+
+
+    @Test
+    public void testOnnxTraining() throws Exception {
+        ClassPathResource classPathResource = new ClassPathResource("onnx_graphs/output_cnn_mnist.onnx");
+        OnnxFrameworkImporter onnxFrameworkImporter = new OnnxFrameworkImporter();
+        Map<String, INDArray> arr = new HashMap<>();
+        arr.put("label", Nd4j.ones(10));
+        arr.put("input.1",Nd4j.ones(1,1,28,28));
+        SameDiff sameDiff = onnxFrameworkImporter.runImport(classPathResource.getFile().getAbsolutePath(),arr, true);
+        SDVariable labels = sameDiff.placeHolder("labels", DataType.FLOAT);
+        sameDiff.setEagerMode(false);
+
+        SDVariable sdVariable = sameDiff.loss().softmaxCrossEntropy(labels, sameDiff.getVariable("22"),sameDiff.constant(1.0f));
+        TrainingConfig trainingConfig = TrainingConfig.builder()
+                .dataSetFeatureMapping("input.1")
+                .dataSetLabelMapping(labels.name())
+                .updater(new Adam())
+                .lossVariables(Collections.singletonList(sdVariable.name()))
+                .build();
+        sameDiff.setTrainingConfig(trainingConfig);
+        sameDiff.prepareForTraining();
+        System.out.println(sameDiff.summary(true));
+        DataSetIterator setIterator = new MnistDataSetIterator(10,10,true);
+        setIterator.setPreProcessor((DataSetPreProcessor) toPreProcess -> toPreProcess.setFeatures(toPreProcess.getFeatures().reshape(10,1,28,28)));
+
+        sameDiff.fit(setIterator,1);
+    }
 
     @Test
     public void test() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix matrix multiply backprop to use arg(1) rather than rarg() to avoid errors when num args are > 2.
Update x * w + b gradient to use c++
Add better debug messages to row/column vector broadcast ops
Update Gemm to allow import of biases from onnx
Add dynamic resolution of needed variables for differentiation


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
