### PR TITLE
Fix standardize to avoid divide by zero

### DIFF
--- a/codegen/op-codegen/pom.xml
+++ b/codegen/op-codegen/pom.xml
@@ -6,7 +6,13 @@
 
     <groupId>org.nd4j</groupId>
     <artifactId>op-codegen</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+
+
+    <parent>
+        <groupId>org.deeplearning4j</groupId>
+        <artifactId>codegen</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -17,6 +17,7 @@
     <name>codegen</name>
     <modules>
         <module>op-codegen</module>
+        <module>libnd4j-gen</module>
     </modules>
 
 

--- a/libnd4j/include/ops/declarable/generic/nn/layer_norm.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/layer_norm.cpp
@@ -63,11 +63,8 @@ CONFIGURABLE_OP_IMPL(layer_norm, 2, 1, false, 0, -1) {
   std::vector<bool> bargs = {};
   standardizeOp.execute(inputs, outputs, targs, longAxis, bargs);
 
-  // output->applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), gain, output);
   output->applyBroadcast(sd::broadcast::Multiply, {dimC}, *gain, *output);
   if (bias != nullptr) {
-    // output->applyTrueBroadcast(sd::BroadcastOpsTuple::Add(), bias, output);
-    // output->applyBroadcast(sd::broadcast::Add, {dimC}, bias);
     helpers::addBias(block, *output, *bias, *output, isNCHW);
   }
 

--- a/libnd4j/include/ops/declarable/generic/transforms/standardize.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/standardize.cpp
@@ -47,9 +47,9 @@ CONFIGURABLE_OP_IMPL(standardize, 1, 1, true, 0, -2) {
   shape::checkDimensions(input->rankOf(), axis);
 
   auto means = input->reduceAlongDimension(reduce::Mean, axis, true);
-  auto stdev = input->varianceAlongDimension(variance::SummaryStatsStandardDeviation, false, axis);
+  auto stdev = input->varianceAlongDimension(variance::SummaryStatsStandardDeviation, false, axis) + 1e-12;
   stdev.reshapei(means.getShapeAsVector());
-
+  stdev.printBuffer("Standard deviation\n");
   input->applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), means, *output, false);
   output->applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), stdev, *output, false);
   output->applyScalar(sd::scalar::ReplaceNans, 0, *output);

--- a/libnd4j/include/ops/declarable/generic/transforms/standardize.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/standardize.cpp
@@ -49,7 +49,6 @@ CONFIGURABLE_OP_IMPL(standardize, 1, 1, true, 0, -2) {
   auto means = input->reduceAlongDimension(reduce::Mean, axis, true);
   auto stdev = input->varianceAlongDimension(variance::SummaryStatsStandardDeviation, false, axis) + 1e-12;
   stdev.reshapei(means.getShapeAsVector());
-  stdev.printBuffer("Standard deviation\n");
   input->applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), means, *output, false);
   output->applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), stdev, *output, false);
   output->applyScalar(sd::scalar::ReplaceNans, 0, *output);

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <module>omnihub</module>
         <module>resources</module>
         <module>codegen</module>
-        <module>codegen/libnd4j-gen</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
Fix standardize to avoid divide by zero
Clean up commented old code present in standardize
Fixes #9821 
Fix codegen module layout

## What changes were proposed in this pull request?

Fix standardize to avoid divide by zero
Clean up commented old code present in standardize
## How was this patch tested?

Adds test that  triggers nan/inf validation to avoid the divide y zero
## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
