### PR TITLE
Increase performance of  skipgram/cbow allocation on batch size 1

### DIFF
--- a/codegen/op-codegen/src/main/ops/org/nd4j/codegen/ops/RNN.kt
+++ b/codegen/op-codegen/src/main/ops/org/nd4j/codegen/ops/RNN.kt
@@ -20,11 +20,10 @@
 
 package org.nd4j.codegen.ops
 
-import org.nd4j.codegen.api.AtLeast
+import org.nd4j.codegen.api.DataType.*
 import org.nd4j.codegen.api.Language
 import org.nd4j.codegen.api.doc.DocScope
 import org.nd4j.codegen.dsl.*
-import org.nd4j.codegen.api.DataType.*
 
 fun SDRNN() = Namespace("RNN") {
 

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
@@ -363,23 +363,23 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
         boolean useHS = configuration.isUseHierarchicSoftmax();
         boolean useNegative = configuration.getNegative() > 0;
 
-        int[] intCodes = new int[codes.length];
+        byte[] intCodes = new byte[codes.length];
         for (int i = 0; i < codes.length; ++i) {
             intCodes[i] = codes[i];
         }
 
         List<INDArray> release = new ArrayList<>();
         if (useHS && useNegative) {
-            INDArray allocate = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
-            INDArray targetArr = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
-            INDArray alphaArr = arrayCacheMemoryMgr.allocate(true,syn0.get().dataType(),1);
+            INDArray allocate = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
+            INDArray targetArr = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
+            INDArray alphaArr = arrayCacheMemoryMgr.allocate(false,syn0.get().dataType(),1);
             INDArray nextRandomArr = arrayCacheMemoryMgr.allocate(true,DataType.INT64,1);
             allocate.putScalar(0,lastWord.getIndex());
             targetArr.putScalar(0,target);
             alphaArr.putScalar(0,alpha);
             if(nextRandom != null)
                 nextRandomArr.putScalar(0,nextRandom.get());
-            INDArray idxSyn1Arr = arrayCacheMemoryMgr.allocate(true,DataType.INT32,idxSyn1.length);
+            INDArray idxSyn1Arr = arrayCacheMemoryMgr.allocate(false,DataType.INT32,idxSyn1.length);
 
           sg = SkipGramRound.builder()
                   .target(allocate)
@@ -391,7 +391,7 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
                   .negTable(table.get())
                   .nsRounds(0)
                   .indices(idxSyn1Arr)
-                  .codes(Nd4j.create(intCodes))
+                  .codes(Nd4j.createFromArray(intCodes))
                   .randomValue(nextRandomArr)
                   .inferenceVector(inferenceVector != null ? inferenceVector : Nd4j.empty(syn0.get().dataType()))
                   .alpha(alphaArr)
@@ -406,11 +406,11 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
 
         }
         else if (useHS) {
-            INDArray lastWordIdx = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
-            INDArray targetArr = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
-            INDArray alphaArr = arrayCacheMemoryMgr.allocate(true,syn0.get().dataType(),1);
-            INDArray nextRandomArr = arrayCacheMemoryMgr.allocate(true,DataType.INT64,1);
-            INDArray ngStarter = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
+            INDArray lastWordIdx = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
+            INDArray targetArr = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
+            INDArray alphaArr = arrayCacheMemoryMgr.allocate(false,syn0.get().dataType(),1);
+            INDArray nextRandomArr = arrayCacheMemoryMgr.allocate(false,DataType.INT64,1);
+            INDArray ngStarter = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
             ngStarter.putScalar(0,-1);
             lastWordIdx.putScalar(0,lastWord.getIndex());
             targetArr.putScalar(0,target);
@@ -429,7 +429,7 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
                     .alpha(alphaArr)
                     .randomValue(nextRandomArr)
                     .inferenceVector(inferenceVector != null ? inferenceVector : Nd4j.empty(syn0.get().dataType()))
-                    .codes( Nd4j.createFromArray(intCodes).castTo(DataType.INT8))
+                    .codes( Nd4j.createFromArray(intCodes))
                     .indices(Nd4j.createFromArray(idxSyn1))
                     .preciseMode(configuration.isPreciseMode())
                     .numWorkers(workers)
@@ -444,12 +444,12 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
 
         }
         else if (useNegative) {
-            INDArray lastWordIdx = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
-            INDArray targetArr = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
-            INDArray alphaArr = arrayCacheMemoryMgr.allocate(true,syn0.get().dataType(),1);
-            INDArray nextRandomArr = arrayCacheMemoryMgr.allocate(true,DataType.INT64,1);
-            INDArray ngStarter = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
-            INDArray negativeArr = arrayCacheMemoryMgr.allocate(true,DataType.INT32,1);
+            INDArray lastWordIdx = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
+            INDArray targetArr = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
+            INDArray alphaArr = arrayCacheMemoryMgr.allocate(false,syn0.get().dataType(),1);
+            INDArray nextRandomArr = arrayCacheMemoryMgr.allocate(false,DataType.INT64,1);
+            INDArray ngStarter = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
+            INDArray negativeArr = arrayCacheMemoryMgr.allocate(false,DataType.INT32,1);
             negativeArr.putScalar(0,negative);
             ngStarter.putScalar(0,target);
             lastWordIdx.putScalar(0,lastWord.getIndex());

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/sequence/DBOW.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/sequence/DBOW.java
@@ -117,7 +117,6 @@ public class DBOW<T extends SequenceElement> implements SequenceLearningAlgorith
     protected void dbow(int i, Sequence<T> sequence, int b, AtomicLong nextRandom, double alpha, boolean isInference,
                     INDArray inferenceVector, BatchSequences<T> batchSequences) {
 
-        //final T word = sequence.getElements().get(i);
         List<T> sentence = skipGram.applySubsampling(sequence, nextRandom).getElements();
 
 
@@ -131,7 +130,6 @@ public class DBOW<T extends SequenceElement> implements SequenceLearningAlgorith
             return;
 
         int batchSize = configuration.getBatchSize();
-
         for (T lastWord : labels) {
             for (T word : sentence) {
                 if (word == null)
@@ -163,18 +161,15 @@ public class DBOW<T extends SequenceElement> implements SequenceLearningAlgorith
     public INDArray inferSequence(Sequence<T> sequence, long nextRandom, double learningRate, double minLearningRate,
                     int iterations) {
         AtomicLong nr = new AtomicLong(nextRandom);
-
-        // we probably don't want subsampling here
-        // Sequence<T> seq = cbow.applySubsampling(sequence, nextRandom);
-        // if (sequence.getSequenceLabel() == null) throw new IllegalStateException("Label is NULL");
-
         if (sequence.isEmpty())
             return null;
 
 
+
+
         Random random = Nd4j.getRandomFactory().getNewRandomInstance(configuration.getSeed() * sequence.hashCode(),
                         lookupTable.layerSize() + 1);
-        INDArray ret = Nd4j.rand(new int[] {1, lookupTable.layerSize()}, random).subi(0.5)
+        INDArray ret = Nd4j.rand(random,new long[] {1, lookupTable.layerSize()}).subi(0.5)
                         .divi(lookupTable.layerSize());
 
         for (int iter = 0; iter < iterations; iter++) {

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/loader/WordVectorSerializer.java
@@ -111,60 +111,6 @@ public class WordVectorSerializer {
     }
 
     /**
-     * @param modelFile
-     * @return
-     * @throws FileNotFoundException
-     * @throws IOException
-     * @throws NumberFormatException
-     */
-    /*private static Word2Vec readTextModel(File modelFile) throws IOException, NumberFormatException {
-        InMemoryLookupTable lookupTable;
-        VocabCache cache;
-        INDArray syn0;
-        Word2Vec ret = new Word2Vec();
-        try (BufferedReader reader =
-                     new BufferedReader(new InputStreamReader(GzipUtils.isCompressedFilename(modelFile.getName())
-                             ? new GZIPInputStream(new FileInputStream(modelFile))
-                             : new FileInputStream(modelFile), "UTF-8"))) {
-            String line = reader.readLine();
-            String[] initial = line.split(" ");
-            int words = Integer.parseInt(initial[0]);
-            int layerSize = Integer.parseInt(initial[1]);
-            syn0 = Nd4j.create(words, layerSize);
-
-            cache = new InMemoryLookupCache(false);
-
-            int currLine = 0;
-            while ((line = reader.readLine()) != null) {
-                String[] split = line.split(" ");
-                Preconditions.checkState(split.length == layerSize + 1, "Expected %s values, got %s", layerSize + 1, split.length);
-                String word = split[0].replaceAll(WHITESPACE_REPLACEMENT, " ");
-
-                float[] vector = new float[split.length - 1];
-                for (int i = 1; i < split.length; i++) {
-                    vector[i - 1] = Float.parseFloat(split[i]);
-                }
-
-                syn0.putRow(currLine, Nd4j.create(vector));
-
-                cache.addWordToIndex(cache.numWords(), word);
-                cache.addToken(new VocabWord(1, word));
-                cache.putVocabWord(word);
-
-                currLine++;
-            }
-
-            lookupTable = (InMemoryLookupTable) new InMemoryLookupTable.Builder().cache(cache).vectorLength(layerSize)
-                    .build();
-            lookupTable.setSyn0(syn0);
-
-            ret.setVocab(cache);
-            ret.setLookupTable(lookupTable);
-        }
-        return ret;
-    }*/
-
-    /**
      * Read a binary word2vec from input stream.
      *
      * @param inputStream input stream to read

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/wordvectors/WordVectorsImpl.java
@@ -55,24 +55,52 @@ public class WordVectorsImpl<T extends SequenceElement> implements WordVectors {
     @Getter
     protected transient ModelUtils<T> modelUtils = new BasicModelUtils<>();
     private boolean initDone = false;
-
+    @Getter
+    @Setter
     protected int numIterations = 1;
+    @Getter
+    @Setter
     protected int numEpochs = 1;
+    @Getter
+    @Setter
     protected double negative = 0;
+    @Getter
+    @Setter
     protected double sampling = 0;
     protected AtomicDouble learningRate = new AtomicDouble(0.025);
+    @Getter
+    @Setter
     protected double minLearningRate = 0.01;
     @Getter
+    @Setter
     protected int window = 5;
+    @Getter
+    @Setter
     protected int batchSize;
+    @Getter
+    @Setter
     protected int learningRateDecayWords;
+    @Getter
+    @Setter
     protected boolean resetModel;
     protected boolean useAdeGrad;
-    protected int workers = 1; //Runtime.getRuntime().availableProcessors();
+    @Getter
+    @Setter
+    protected int workers = 1;
+    @Getter
+    @Setter
     protected boolean trainSequenceVectors = false;
+    @Getter
+    @Setter
     protected boolean trainElementsVectors = true;
+    @Getter
+    @Setter
     protected long seed;
+    @Getter
+    @Setter
     protected boolean useUnknown = false;
+    @Getter
+    @Setter
     protected int[] variableWindows;
 
 

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/sequencevectors/SequenceVectors.java
@@ -1301,9 +1301,8 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                     .cyclesBeforeInitialization(3)
                     .initialSize(25L * 1024L * 1024L)
                     .build();
-            val workspace_id = "sequence_vectors_training_" + java.util.UUID.randomUUID().toString();
+            val workspace_id = "sequence_vectors_training_" + UUID.randomUUID();
 
-            Nd4j.getAffinityManager().getDeviceForCurrentThread();
             while (digitizer.hasMoreLines()) {
                 try {
                     // get current sentence as list of VocabularyWords
@@ -1316,6 +1315,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                             }
                         }
                     }
+
                     double alpha = 0.025;
 
                     if (sequences.isEmpty()) {
@@ -1331,7 +1331,7 @@ public class SequenceVectors<T extends SequenceElement> extends WordVectorsImpl<
                             try (val ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(conf, workspace_id)) {
                                 Sequence<T> sequence = sequences.get(x);
 
-                                //log.info("LR before: {}; wordsCounter: {}; totalWordsCount: {}", learningRate.get(), this.wordsCounter.get(), this.totalWordsCount);
+                                log.debug("LR before: {}; wordsCounter: {}; totalWordsCount: {}", learningRate.get(), this.wordsCounter.get(), this.totalWordsCount);
                                 alpha = Math.max(minLearningRate,
                                         learningRate.get() * (1 - (1.0 * this.wordsCounter.get()
                                                 / ((double) this.totalWordsCount) / (numIterations

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/conf/layers/InputTypeUtil.java
@@ -170,7 +170,7 @@ public class InputTypeUtil {
 
         int sD = stride[0];
         int sH = stride[1];
-        int sW = stride[1];
+        int sW = stride[2];
 
         if (sH <= 0 || sW <= 0 || sD <= 0) {
             throw new DL4JInvalidConfigException(getConfigErrorCommonLine(layerIdx, layerName, layerClass, sH <= 0)

--- a/libnd4j/include/array/impl/NDArrayFactory.cpp
+++ b/libnd4j/include/array/impl/NDArrayFactory.cpp
@@ -293,8 +293,6 @@ NDArray NDArrayFactory::create(sd::DataType type, const T scalar, sd::LaunchCont
 
   return res;
 }
-//    BUILD_DOUBLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArrayFactory::create, (DataType type, const T scalar,
-//    sd::LaunchContext * context), SD_COMMON_TYPES_ALL);
 
 #define TMPL_INSTANTIATE_CREATE_D(TYPE) \
 template SD_LIB_EXPORT NDArray NDArrayFactory::create<TYPE>(DataType type, const TYPE scalar, sd::LaunchContext* context);

--- a/libnd4j/include/ops/declarable/generic/nlp/cbow.cpp
+++ b/libnd4j/include/ops/declarable/generic/nlp/cbow.cpp
@@ -28,6 +28,152 @@
 
 namespace sd {
 namespace ops {
+
+
+
+
+CONFIGURABLE_OP_IMPL(cbow_inference, 6, 6, true, -2, -2) {
+  //construct codes and indices from the IARGS
+  //we do this to avoid serialization overhead from the JVM for frequently created small arrays
+  auto numCodes = I_ARG(0);
+  auto numIndices = I_ARG(1);
+  auto numContext = I_ARG(2);
+  auto numLockedWords = I_ARG(3);
+  //2 for the codes, indices, context, locked words, 4 for the mandatory args such as target
+  auto numMin = numIndices + numCodes + numCodes + numLockedWords + 4 + 4;
+  std::vector<sd::LongType> *codes = new std::vector<sd::LongType>();
+  std::vector<sd::LongType> *indices = new std::vector<sd::LongType>();
+  std::vector<sd::LongType> *context = new std::vector<sd::LongType>();
+  std::vector<sd::LongType> *lockedWords = new std::vector<sd::LongType>();
+
+  int currIdx = 4;
+  for(int i = 0; i < numCodes; i++) {
+    codes->push_back(I_ARG(currIdx));
+    currIdx++;
+  }
+
+  for(int i = 0; i < numIndices; i++) {
+    indices->push_back(I_ARG(currIdx));
+    currIdx++;
+  }
+
+
+  for(int i = 0; i < numContext; i++) {
+    context->push_back(I_ARG(currIdx));
+    currIdx++;
+  }
+
+  for(int i = 0; i < numLockedWords; i++) {
+    lockedWords->push_back(I_ARG(currIdx));
+    currIdx++;
+  }
+
+
+
+  const std::vector<sd::LongType> *indicesVec = indices;
+  const std::vector<sd::LongType> *codesVec = codes;
+  const std::vector<sd::LongType> *contextVec = context;
+  const std::vector<sd::LongType> *lockedWordsVec = lockedWords;
+
+  std::vector<sd::LongType> *indicesSize = new std::vector<sd::LongType>();
+  indicesSize->push_back(indices->size());
+  const std::vector<sd::LongType> *indicesShape = indicesSize;
+
+
+  std::vector<sd::LongType> *codesSize = new std::vector<sd::LongType>();
+  codesSize->push_back(codes->size());
+  const std::vector<sd::LongType> *codesShape = codesSize;
+
+  std::vector<sd::LongType> *contextSize = new std::vector<sd::LongType>();
+  contextSize->push_back(contextSize->size());
+  const std::vector<sd::LongType> *contextShape = contextSize;
+
+  std::vector<sd::LongType> *lockedWordsSize = new std::vector<sd::LongType>();
+  contextSize->push_back(lockedWords->size());
+  const std::vector<sd::LongType> *lockedWordsShape = lockedWordsSize;
+
+
+  auto indicesArrOne = NDArrayFactory::create('c',*indicesShape,*indicesVec);
+  auto indicesArr = new NDArray(indicesArrOne);
+
+  auto codesArrOne = NDArrayFactory::create('c',*codesShape,*codesVec);
+  auto codesArr = new NDArray(codesArrOne);
+
+  auto contextArrOne = NDArrayFactory::create('c',*contextShape,*contextVec);
+  auto contextArr = new NDArray(contextArrOne);
+
+
+  auto lockedWordsOne = NDArrayFactory::create('c',*lockedWordsShape,*lockedWordsVec);
+  auto lockedWordsArr = new NDArray(lockedWordsOne);
+
+  auto target = I_ARG(currIdx++);
+  auto ngStarter = I_ARG(currIdx++);
+  auto numLabels = I_ARG(currIdx++);
+  auto randomValue = I_ARG(currIdx++);
+  auto numWorkers = block.numI() > 0 ? INT_ARG(3) : omp_get_max_threads();
+  auto nsRounds = block.numI() > 1 ? INT_ARG(4) : 0;
+
+  auto alpha = T_ARG(0);
+
+
+
+
+  auto syn0 = INPUT_VARIABLE(0);
+  auto syn1 = INPUT_VARIABLE(1);
+  auto syn1neg = INPUT_VARIABLE(2);
+
+  auto expTable = INPUT_VARIABLE(3);
+  auto negTable = INPUT_VARIABLE(4);
+
+  auto inferenceVector = INPUT_VARIABLE(5);
+
+
+
+  auto trainWords = block.numB() > 0 ? B_ARG(0) : true;
+  auto isInference = block.numB() > 1 ? B_ARG(1) : false;
+
+  REQUIRE_TRUE(block.isInplace(), 0, "CBOW: this operation requires inplace execution only");
+
+  REQUIRE_TRUE(syn0->dataType() == syn1->dataType() && syn0->dataType() == syn1neg->dataType(), 0,
+               "CBOW: all syn tables must have the same data type");
+  REQUIRE_TRUE(syn0->dataType() == expTable->dataType(), 0,
+               "CBOW: expTable must have the same data type as syn0 table");
+
+  sd::ops::helpers::cbowInference(
+                                 *syn0,
+                                  *syn1,
+                                *syn1neg,
+                                   *expTable,
+                                    *negTable,
+                                    target,
+                                  ngStarter,
+                                   nsRounds,
+                                 *contextArr,
+                                *lockedWordsArr,
+                              *indicesArr,
+                              *codesArr,
+                                 alpha,
+                              randomValue,
+                              numLabels,
+                           *inferenceVector,
+                              trainWords,
+                                 numWorkers);
+
+  return sd::Status::OK;
+}
+
+DECLARE_TYPES(cbow_inference) {
+  getOpDescriptor()
+      ->setAllowedInputTypes(0, {ALL_FLOATS})
+      ->setAllowedInputTypes(1, {ALL_FLOATS})
+      ->setAllowedInputTypes(2, {ALL_FLOATS})
+      ->setAllowedInputTypes(3, {ALL_FLOATS})
+      ->setAllowedInputTypes(4, {ALL_FLOATS})
+      ->setAllowedInputTypes(5, {ALL_FLOATS})
+      ->setAllowedOutputTypes(sd::DataType::ANY);
+}
+
+
 CONFIGURABLE_OP_IMPL(cbow, 15, 15, true, 0, 0) {
   auto target = INPUT_VARIABLE(0);
   auto ngStarter = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/generic/nlp/skipgram.cpp
+++ b/libnd4j/include/ops/declarable/generic/nlp/skipgram.cpp
@@ -28,6 +28,125 @@
 
 namespace sd {
 namespace ops {
+
+
+CONFIGURABLE_OP_IMPL(skipgram_inference, 6, 6, true, -2, -2) {
+ //construct codes and indices from the IARGS
+ //we do this to avoid serialization overhead from the JVM for frequently created small arrays
+  auto numCodes = I_ARG(0);
+  auto numIndices = I_ARG(1);
+  //2 for the number of indices/codes 3 for the mandatory args
+ auto numMin = numIndices + numCodes + 2 + 3;
+   std::vector<sd::LongType> *codes = new std::vector<sd::LongType>();
+   std::vector<sd::LongType> *indices = new std::vector<sd::LongType>();
+
+  int currIdx = 2;
+  for(int i = 0; i < numCodes; i++) {
+    codes->push_back(I_ARG(currIdx));
+    currIdx++;
+  }
+
+  for(int i = 0; i < numIndices; i++) {
+    indices->push_back(I_ARG(currIdx));
+    currIdx++;
+  }
+
+  const std::vector<sd::LongType> *indicesVec = indices;
+  const std::vector<sd::LongType> *codesVec = codes;
+
+  std::vector<sd::LongType> *indicesSize = new std::vector<sd::LongType>();
+  indicesSize->push_back(indices->size());
+  const std::vector<sd::LongType> *indicesShape = indicesSize;
+
+
+  std::vector<sd::LongType> *codesSize = new std::vector<sd::LongType>();
+  codesSize->push_back(codes->size());
+  const std::vector<sd::LongType> *codesShape = codesSize;
+
+
+  auto indicesArrOne = NDArrayFactory::create('c',*indicesShape,*indicesVec);
+  auto indicesArr = new NDArray(indicesArrOne);
+  auto codesArrOne = NDArrayFactory::create('c',*codesShape,*codesVec);
+  auto codesArr = new NDArray(codesArrOne);
+
+
+
+  auto target = I_ARG(currIdx++);
+  auto ngStarter = I_ARG(currIdx++);
+  auto randomValue = I_ARG(currIdx++);
+  auto numWorkers = block.numI() > numMin ? INT_ARG(currIdx++) : omp_get_max_threads();
+  auto nsRounds = block.numI() > numMin + 1 ? INT_ARG(currIdx++) : 0;
+
+  auto alpha = T_ARG(0);
+
+  // required part
+
+
+  auto syn0 = INPUT_VARIABLE(0);
+  auto syn1 = INPUT_VARIABLE(1);
+  auto syn1neg = INPUT_VARIABLE(2);
+
+  auto expTable = INPUT_VARIABLE(3);
+  auto negTable = INPUT_VARIABLE(4);
+
+
+  auto inferenceVector = INPUT_VARIABLE(5);
+
+
+
+
+
+  auto isInference = block.numB() > 0 ? B_ARG(0) : false;
+  auto isPreciseMode = block.numB() > 1 ? B_ARG(1) : false;
+
+  REQUIRE_TRUE(block.isInplace(), 0, "SkipGram: this operation requires inplace execution only");
+
+  REQUIRE_TRUE(syn0->dataType() == syn1->dataType() && syn0->dataType() == syn1neg->dataType(), 0,
+               "SkipGram: all syn tables must have the same data type");
+  REQUIRE_TRUE(syn0->dataType() == expTable->dataType(), 0,
+               "SkipGram: expTable must have the same data type as syn0 table");
+
+
+
+
+
+  sd::ops::helpers::skipgramInference(*syn0,
+                                      *syn1,
+                                      *syn1neg,
+                                      *expTable,
+                                      *negTable,
+                                      target,
+                                      ngStarter,
+                                      nsRounds,
+                                      *indicesArr,
+                                      *codesArr,
+                                      alpha,
+                                      randomValue,
+                                      *inferenceVector,
+                                      isPreciseMode,
+                                      numWorkers);
+
+ delete codes;
+ delete indices;
+  delete indicesArr;
+  delete codesArr;
+
+  return sd::Status::OK;
+}
+
+
+DECLARE_TYPES(skipgram_inference) {
+  getOpDescriptor()
+      ->setAllowedInputTypes(0, {ALL_FLOATS})
+      ->setAllowedInputTypes(1, {ALL_FLOATS})
+      ->setAllowedInputTypes(2, {ALL_FLOATS})
+      ->setAllowedInputTypes(3, {ALL_FLOATS})
+      ->setAllowedInputTypes(4, {ALL_FLOATS})
+      ->setAllowedInputTypes(5, {ALL_FLOATS})
+      ->setAllowedOutputTypes(sd::DataType::ANY);
+}
+
+
 CONFIGURABLE_OP_IMPL(skipgram, 12, 12, true, 0, 0) {
   auto target = INPUT_VARIABLE(0);
   auto ngStarter = INPUT_VARIABLE(1);

--- a/libnd4j/include/ops/declarable/headers/nlp.h
+++ b/libnd4j/include/ops/declarable/headers/nlp.h
@@ -31,8 +31,16 @@ namespace ops {
 DECLARE_CONFIGURABLE_OP(skipgram, 12, 12, true, 0, 0);
 #endif
 
+#if NOT_EXCLUDED(OP_skipgram_inference)
+DECLARE_CONFIGURABLE_OP(skipgram_inference, 6, 6, true, -2, -2);
+#endif
+
 #if NOT_EXCLUDED(OP_cbow)
 DECLARE_CONFIGURABLE_OP(cbow, 15, 15, true, 0, 0);
+#endif
+
+#if NOT_EXCLUDED(OP_cbow_inference)
+DECLARE_CONFIGURABLE_OP(cbow_inference,6, 6, true, -2, -2);
 #endif
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/helpers/sg_cb.h
+++ b/libnd4j/include/ops/declarable/helpers/sg_cb.h
@@ -29,15 +29,30 @@
 namespace sd {
 namespace ops {
 namespace helpers {
+
+
+
 SD_LIB_HIDDEN void skipgram(NDArray &syn0, NDArray &syn1, NDArray &syn1Neg, NDArray &expTable, NDArray &negTable,
                             NDArray &target, NDArray &ngStarter, int nsRounds, NDArray &indices, NDArray &codes,
                             NDArray &alpha, NDArray &randomValue, NDArray &inferenceVector, const bool preciseMode,
                             const int numWorkers);
 
+
+SD_LIB_HIDDEN void  skipgramInference(NDArray &syn0, NDArray &syn1, NDArray &syn1Neg, NDArray &expTable, NDArray &negTable, int target,
+                       int ngStarter, int nsRounds, NDArray &indices, NDArray &codes, double alpha, sd::LongType randomValue,
+                       NDArray &inferenceVector, const bool preciseMode, const int numWorkers);
+
 SD_LIB_HIDDEN void cbow(NDArray &syn0, NDArray &syn1, NDArray &syn1Neg, NDArray &expTable, NDArray &negTable,
                         NDArray &target, NDArray &ngStarter, int nsRounds, NDArray &context, NDArray &lockedWords,
                         NDArray &indices, NDArray &codes, NDArray &alpha, NDArray &randomValue, NDArray &numLabels,
                         NDArray &inferenceVector, const bool trainWords, const int numWorkers);
+
+
+
+SD_LIB_HIDDEN void cbowInference(NDArray &syn0, NDArray &syn1, NDArray &syn1Neg, NDArray &expTable, NDArray &negTable, int target,
+                                 int ngStarter, int nsRounds, NDArray &context, NDArray &lockedWords, NDArray &indices, NDArray &codes,
+                                 double alpha, sd::LongType randomValue, int numLabels, NDArray &inferenceVector, const bool trainWords,
+                                 int numWorkers);
 
 SD_LIB_HIDDEN int binarySearch(const int *haystack, const int needle, const int totalElements);
 }  // namespace helpers

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
@@ -88,7 +88,7 @@ public abstract class DifferentialFunction {
     protected boolean ownNameSetWithDefault = false;
 
     public DifferentialFunction() {
-        this(true);
+        this(false);
     }
 
     public DifferentialFunction(boolean sameDiff) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/SameDiff.java
@@ -168,9 +168,6 @@ public class SameDiff extends SDBaseOps {
     ////////////////////////////////////////
 
 
-    // counter for auto-naming variables
-    private int variableId = 0;
-
     ////////////////////////////////////////
 
     /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/ArrayCacheMemoryMgr.java
@@ -198,7 +198,8 @@ public class ArrayCacheMemoryMgr extends AbstractMemoryMgr {
         }
 
         // Allocation failed, allocate new array
-        INDArray ret = Nd4j.createUninitializedDetached(dataType, shape);
+        //switch to using current workspace rather than detached
+        INDArray ret = detached ? Nd4j.createUninitializedDetached(dataType,shape) : Nd4j.create(dataType, shape);
         return ret;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/serde/FlatBuffersMapper.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/serde/FlatBuffersMapper.java
@@ -518,7 +518,7 @@ public class FlatBuffersMapper {
             }
             /*
             Op types that don't need any extra/special mapping:
-            TRANSFORM_BOOL - BooleanNot, IsFinite, IsInf, IsNaN, MatchConditionTransorm
+            TRANSFORM_BOOL - BooleanNot, IsFinite, IsInf, IsNaN, MatchConditionTransform
             TRANSFORM_ANY - IsMax, Assign
             TRANSFORM_FLOAT - Histogram, Sqrt
             TRANSFORM_STRICT - Cos, Log, Sigmoid, etc
@@ -970,6 +970,9 @@ public class FlatBuffersMapper {
         int i = 0;
         for (String s : outVarNames) {
             SDVariable v = sameDiff.getVariable(s);
+            if(v == null) {
+                throw new IllegalStateException("Unknown output variable " + s);
+            }
             outTypes[i++] = FlatBuffersMapper.getDataTypeAsByte(v.dataType());
         }
         int outTypesOffset = FlatNode.createOutputTypesVector(bufferBuilder, outTypes);
@@ -979,7 +982,7 @@ public class FlatBuffersMapper {
 
         int opCds = 0;
         int[] opCdsArr = mapOrNull(sdo.getControlDeps(), bufferBuilder);
-        if(opCdsArr != null){
+        if(opCdsArr != null) {
             opCds = FlatNode.createControlDepsVector(bufferBuilder, opCdsArr);
         }
 
@@ -991,7 +994,7 @@ public class FlatBuffersMapper {
 
         int cdsFor = 0;
         int[] cdsForArr = mapOrNull(sdo.getControlDepFor(), bufferBuilder);
-        if(cdsForArr != null){
+        if(cdsForArr != null) {
             cdsFor = FlatNode.createControlDepForVector(bufferBuilder, cdsForArr);
         }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/validation/OpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/validation/OpValidation.java
@@ -24,6 +24,8 @@ import org.nd4j.common.config.ND4JClassLoading;
 import org.nd4j.linalg.api.ops.custom.*;
 import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMax;
 import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMin;
+import org.nd4j.linalg.api.ops.impl.nlp.CbowInference;
+import org.nd4j.linalg.api.ops.impl.nlp.SkipGramInference;
 import org.nd4j.linalg.api.ops.impl.reduce.HashCode;
 import org.nd4j.shade.guava.collect.ImmutableSet;
 import org.nd4j.shade.guava.reflect.ClassPath;
@@ -962,6 +964,8 @@ public class OpValidation {
                 SpTreeCell.class,
                 CbowRound.class,
                 SkipGramRound.class,
+                SkipGramInference.class,
+                CbowInference.class,
                 HashCode.class,
                 HashCode.class,
                 BitCast.class,

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/nlp/CbowInference.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/nlp/CbowInference.java
@@ -1,0 +1,117 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.linalg.api.ops.impl.nlp;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.val;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+
+public class CbowInference extends DynamicCustomOp {
+
+
+
+
+    @Override
+    public String opName() {
+        return "cbow_inference";
+    }
+
+    public CbowInference(){ }
+
+
+
+    /**
+     * full constructor
+     */
+    @Builder
+    public CbowInference(@NonNull int target,
+                         @NonNull int ngStarter,
+                         @NonNull INDArray syn0,
+                         @NonNull INDArray syn1,
+                         @NonNull INDArray syn1Neg,
+                         @NonNull INDArray expTable,
+                         @NonNull INDArray negTable,
+                         int nsRounds,
+                         @NonNull int[] indices,
+                         @NonNull int[] lockedWords,
+                         @NonNull int[] context,
+                         @NonNull byte[] codes,
+                         @NonNull double alpha,
+                         @NonNull int randomValue,
+                         INDArray inferenceVector,
+                         boolean preciseMode,
+                         int numWorkers,
+                         int numLabels) {
+
+        inputArguments.add(syn0);
+        inputArguments.add(syn1);
+        inputArguments.add(syn1Neg);
+        inputArguments.add(expTable);
+        inputArguments.add(negTable);
+        inputArguments.add(inferenceVector);
+
+
+        iArguments.add((long) codes.length);
+        iArguments.add((long) indices.length);
+        iArguments.add((long) context.length);
+        iArguments.add((long) lockedWords.length);
+
+        for(int i = 0; i < codes.length; i++) {
+            iArguments.add((long) codes[i]);
+        }
+
+        for(int i = 0; i < indices.length; i++) {
+            iArguments.add((long) indices[i]);
+        }
+
+
+        for(int i = 0; i < context.length; i++) {
+            iArguments.add((long) context[i]);
+        }
+
+
+        for(int i = 0; i < lockedWords.length; i++) {
+            iArguments.add((long) lockedWords[i]);
+        }
+
+        // couple of options
+        iArguments.add((long) target);
+        iArguments.add((long) ngStarter);
+        iArguments.add((long) numLabels);
+        iArguments.add((long) randomValue);
+        iArguments.add((long) numWorkers);
+        iArguments.add((long) nsRounds);
+
+        tArguments.add(alpha);
+
+        bArguments.add(!inferenceVector.isEmpty());
+        bArguments.add(preciseMode);
+
+        // this op is always inplace
+        setInPlace(true);
+        setInplaceCall(true);
+
+        for (val in:inputArguments)
+            outputArguments.add(in);
+    }
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/nlp/CbowRound.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/nlp/CbowRound.java
@@ -20,6 +20,7 @@
 
 package org.nd4j.linalg.api.ops.impl.nlp;
 
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.val;
 import org.nd4j.linalg.api.buffer.DataType;
@@ -44,7 +45,7 @@ public class CbowRound extends DynamicCustomOp {
      * @param inferenceVector
      */
     public CbowRound(int target, @NonNull int[] context, @NonNull int[] lockedWords, @NonNull INDArray syn0, @NonNull INDArray syn1, @NonNull INDArray expTable, @NonNull int[] indices, @NonNull byte[] codes, double alpha, long nextRandom, @NonNull INDArray inferenceVector, int numLabels) {
-        this(Nd4j.scalar(target), Nd4j.createFromArray(context), Nd4j.createFromArray(lockedWords), Nd4j.empty(DataType.INT), syn0, syn1, Nd4j.empty(syn1.dataType()), expTable, Nd4j.empty(syn1.dataType()), Nd4j.createFromArray(indices), Nd4j.createFromArray(codes), 0, Nd4j.scalar(alpha), Nd4j.scalar(nextRandom), inferenceVector, Nd4j.scalar(numLabels), inferenceVector.isEmpty(), 1);
+        this(Nd4j.scalar(target), Nd4j.createFromArray(context), Nd4j.createFromArray(lockedWords), Nd4j.empty(DataType.INT32), syn0, syn1, Nd4j.empty(syn1.dataType()), expTable, Nd4j.empty(syn1.dataType()), Nd4j.createFromArray(indices), Nd4j.createFromArray(codes), 0, Nd4j.scalar(alpha), Nd4j.scalar(nextRandom), inferenceVector, Nd4j.scalar(numLabels), inferenceVector.isEmpty(), 1);
     }
 
     /**
@@ -62,7 +63,7 @@ public class CbowRound extends DynamicCustomOp {
      * @param inferenceVector
      */
     public CbowRound(int target, @NonNull int[] context, @NonNull int[] lockedWords, int ngStarter, @NonNull INDArray syn0, @NonNull INDArray syn1Neg, @NonNull INDArray expTable, @NonNull INDArray negTable, int nsRounds, double alpha, long nextRandom, @NonNull INDArray inferenceVector, int numLabels) {
-        this(Nd4j.scalar(target), Nd4j.createFromArray(context), Nd4j.createFromArray(lockedWords), Nd4j.scalar(ngStarter), syn0, Nd4j.empty(syn0.dataType()), syn1Neg, expTable, negTable, Nd4j.empty(DataType.INT), Nd4j.empty(DataType.BYTE), nsRounds, Nd4j.scalar(alpha), Nd4j.scalar(nextRandom), inferenceVector, Nd4j.scalar(numLabels), inferenceVector.isEmpty(), 1);
+        this(Nd4j.scalar(target), Nd4j.createFromArray(context), Nd4j.createFromArray(lockedWords), Nd4j.scalar(ngStarter), syn0, Nd4j.empty(syn0.dataType()), syn1Neg, expTable, negTable, Nd4j.empty(DataType.INT32), Nd4j.empty(DataType.INT8), nsRounds, Nd4j.scalar(alpha), Nd4j.scalar(nextRandom), inferenceVector, Nd4j.scalar(numLabels), inferenceVector.isEmpty(), 1);
     }
 
     /**
@@ -80,6 +81,7 @@ public class CbowRound extends DynamicCustomOp {
      * @param nextRandom
      * @param inferenceVector
      */
+    @Builder
     public CbowRound(@NonNull INDArray target, @NonNull INDArray context, @NonNull INDArray lockedWords, @NonNull INDArray ngStarter, @NonNull INDArray syn0, @NonNull INDArray syn1, @NonNull INDArray syn1Neg, @NonNull INDArray expTable, @NonNull INDArray negTable, @NonNull INDArray indices, @NonNull INDArray codes, int nsRounds, @NonNull INDArray alpha, @NonNull INDArray nextRandom, @NonNull INDArray inferenceVector, @NonNull INDArray numLabels, boolean trainWords, int numWorkers) {
 
         inputArguments.add(target);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/nlp/SkipGramInference.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/nlp/SkipGramInference.java
@@ -1,0 +1,101 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.nd4j.linalg.api.ops.impl.nlp;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.val;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.DynamicCustomOp;
+
+public class SkipGramInference extends DynamicCustomOp {
+
+
+
+
+    @Override
+    public String opName() {
+        return "skipgram_inference";
+    }
+
+    public SkipGramInference(){ }
+
+
+
+    /**
+     * full constructor
+     */
+    @Builder
+    public SkipGramInference(@NonNull int target,
+                             @NonNull int ngStarter,
+                             @NonNull INDArray syn0,
+                             @NonNull INDArray syn1,
+                             @NonNull INDArray syn1Neg,
+                             @NonNull INDArray expTable,
+                             @NonNull INDArray negTable,
+                             int nsRounds,
+                             @NonNull int[] indices,
+                             @NonNull byte[] codes,
+                             @NonNull double alpha,
+                             @NonNull int randomValue,
+                             INDArray inferenceVector,
+                             boolean preciseMode,
+                             int numWorkers) {
+
+        inputArguments.add(syn0);
+        inputArguments.add(syn1);
+        inputArguments.add(syn1Neg);
+        inputArguments.add(expTable);
+        inputArguments.add(negTable);
+        inputArguments.add(inferenceVector);
+
+
+        iArguments.add((long) codes.length);
+        iArguments.add((long) indices.length);
+
+        for(int i = 0; i < codes.length; i++) {
+            iArguments.add((long) codes[i]);
+        }
+
+        for(int i = 0; i < indices.length; i++) {
+            iArguments.add((long) indices[i]);
+        }
+
+        // couple of options
+        iArguments.add((long) target);
+        iArguments.add((long) ngStarter);
+        iArguments.add((long) randomValue);
+        iArguments.add((long) numWorkers);
+        iArguments.add((long) nsRounds);
+
+        tArguments.add(alpha);
+
+        bArguments.add(!inferenceVector.isEmpty());
+        bArguments.add(preciseMode);
+
+        // this op is always inplace
+        setInPlace(true);
+        setInplaceCall(true);
+
+        for (val in:inputArguments)
+            outputArguments.add(in);
+    }
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/resources/META-INF/native-image/reflect-config.json
@@ -117,5 +117,84 @@
   "allDeclaredConstructors":true,
   "allDeclaredClasses" : true,
   "allPublicClasses" : true
-}
+},
+  {
+    "name":"org.nd4j.autodiff.samediff.SameDiff",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name":"org.nd4j.autodiff.samediff.ops.SDMath",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name":"org.nd4j.autodiff.samediff.ops.SDRandom",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name":"org.nd4j.autodiff.samediff.ops.SDNN",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name":"oorg.nd4j.autodiff.samediff.ops.SDCNN",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  }, {
+  "name":"org.nd4j.autodiff.samediff.ops.SDCNN",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true,
+  "allDeclaredClasses" : true,
+  "allPublicClasses" : true
+},
+  {
+    "name":"org.nd4j.autodiff.samediff.ops.SDLoss",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name":"org.nd4j.autodiff.samediff.ops.SDImage",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name":"org.nd4j.autodiff.samediff.ops.SDBitwise",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  },
+  {
+    "name": "org.nd4j.autodiff.samediff.ops.SDLinalg",
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  }
 ]

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
@@ -458,20 +458,34 @@ public abstract class BaseCpuDataBuffer extends BaseDataBuffer implements Deallo
         switch (this.type) {
             case DOUBLE:
                 addressPointer = tempPtr.asDoublePointer();
+                break;
             case FLOAT:
                 addressPointer = tempPtr.asFloatPointer();
+                break;
             case UINT16:
             case SHORT:
             case BFLOAT16:
-            case HALF: addressPointer = tempPtr.asShortPointer();
+            case HALF:
+                addressPointer = tempPtr.asShortPointer();
+                break;
             case UINT32:
-            case INT: addressPointer = tempPtr.asIntPointer();
+            case INT:
+                addressPointer = tempPtr.asIntPointer();
+                break;
             case UBYTE:
-            case BYTE: addressPointer = tempPtr.asBytePointer();
+            case BYTE:
+                addressPointer = tempPtr.asBytePointer();
+                break;
             case UINT64:
-            case LONG: addressPointer = tempPtr.asLongPointer();
-            case BOOL: addressPointer = tempPtr.asBoolPointer();
-            default: addressPointer = tempPtr.asBytePointer();
+            case LONG:
+                addressPointer = tempPtr.asLongPointer();
+                break;
+            case BOOL:
+                addressPointer = tempPtr.asBoolPointer();
+                break;
+            default:
+                addressPointer = tempPtr.asBytePointer();
+                break;
         }
 
         return addressPointer;

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -1021,7 +1021,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
             // putting arguments pointers
 
-            PointerPointer ptrPtr = new PointerPointer(pointer);//extraz.get().put(pointer);
+            PointerPointer ptrPtr = new PointerPointer(pointer);
 
             for (int e = 0; e < op.getArguments().size(); e++) {
                 idx = argsPos + i * batch.getSample().maxArguments();

--- a/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -42,10 +42,7 @@ import org.deeplearning4j.models.word2vec.Word2Vec;
 import org.deeplearning4j.models.word2vec.wordstore.VocabCache;
 import org.deeplearning4j.models.word2vec.wordstore.inmemory.AbstractCache;
 import org.deeplearning4j.models.word2vec.wordstore.inmemory.InMemoryLookupCache;
-import org.deeplearning4j.text.documentiterator.FileLabelAwareIterator;
-import org.deeplearning4j.text.documentiterator.LabelAwareIterator;
-import org.deeplearning4j.text.documentiterator.LabelledDocument;
-import org.deeplearning4j.text.documentiterator.LabelsSource;
+import org.deeplearning4j.text.documentiterator.*;
 import org.deeplearning4j.text.sentenceiterator.*;
 import org.deeplearning4j.text.sentenceiterator.interoperability.SentenceIteratorConverter;
 import org.deeplearning4j.text.tokenization.tokenizer.preprocessor.CommonPreprocessor;
@@ -76,6 +73,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -99,6 +97,7 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
     public DataType getDefaultFPDataType() {
         return DataType.FLOAT;
     }
+
 
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes #9112 
Delete commented code
Substantially increase the performance of cbow and skip gram on batch size 1 by removing ndarray allocation of scalars
introduced with new op.



(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
