### PR TITLE
Fixes #9835, initializles DataSetIteratorSplitter correctly

### DIFF
--- a/deeplearning4j/deeplearning4j-data/deeplearning4j-utility-iterators/src/main/java/org/deeplearning4j/datasets/iterator/DataSetIteratorSplitter.java
+++ b/deeplearning4j/deeplearning4j-data/deeplearning4j-utility-iterators/src/main/java/org/deeplearning4j/datasets/iterator/DataSetIteratorSplitter.java
@@ -50,7 +50,6 @@ public class DataSetIteratorSplitter {
     protected AtomicBoolean resetPending = new AtomicBoolean(false);
     protected DataSet firstTrain = null;
 
-    protected int partNumber = 0;
 
     /**
      * The only constructor
@@ -73,11 +72,15 @@ public class DataSetIteratorSplitter {
         this.backedIterator = baseIterator;
         this.totalExamples = totalBatches;
         this.ratio = ratio;
-        this.ratios = null;
+        ratios = new double[]{ratio, 1 - ratio};
         this.numTrain = (long) (totalExamples * ratio);
         this.numTest = totalExamples - numTrain;
         this.numArbitrarySets = 2;
-        this.splits = null;
+        this.splits = new int[this.ratios.length];
+        for (int i = 0; i < this.splits.length; ++i) {
+            this.splits[i] = (int)(totalExamples * ratios[i]);
+        }
+
 
         log.warn("IteratorSplitter is used: please ensure you don't use randomization/shuffle in underlying iterator!");
     }
@@ -112,10 +115,6 @@ public class DataSetIteratorSplitter {
     }
 
     public DataSetIteratorSplitter(@NonNull DataSetIterator baseIterator, int[] splits) {
-
-        /*if (!(simpleRatio > 0.0 && simpleRatio < 1.0))
-           throw new ND4JIllegalStateException("Ratio value should be in range of 0.0 > X < 1.0");*/
-
         int totalBatches = 0;
         for (val v:splits)
             totalBatches += v;
@@ -132,8 +131,8 @@ public class DataSetIteratorSplitter {
         this.ratio = 0.0;
         this.ratios = null;
 
-        this.numTrain = 0; //(long) (totalExamples * ratio);
-        this.numTest = 0; //totalExamples - numTrain;
+        this.numTrain = 0;
+        this.numTest = 0;
         this.splits = splits;
         this.numArbitrarySets = splits.length;
 
@@ -146,7 +145,11 @@ public class DataSetIteratorSplitter {
         int bottom = 0;
         for (final int split : splits) {
                 ScrollableDataSetIterator partIterator =
-                        new ScrollableDataSetIterator(partN++, backedIterator, counter, resetPending, firstTrain,
+                        new ScrollableDataSetIterator(partN++,
+                                backedIterator,
+                                counter,
+                                resetPending,
+                                firstTrain,
                                 new int[]{bottom,split});
                 bottom += split;
                 retVal.add(partIterator);

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/dl4jcore/datasets/iterator/DataSetSplitterTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/dl4jcore/datasets/iterator/DataSetSplitterTests.java
@@ -21,7 +21,11 @@
 package org.eclipse.deeplearning4j.dl4jcore.datasets.iterator;
 
 import lombok.val;
+import org.datavec.api.records.reader.RecordReader;
+import org.datavec.api.records.reader.impl.collection.CollectionRecordReader;
+import org.datavec.api.writable.IntWritable;
 import org.deeplearning4j.BaseDL4JTest;
+import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
 import org.deeplearning4j.datasets.iterator.DataSetIteratorSplitter;
 import org.eclipse.deeplearning4j.dl4jcore.datasets.iterator.tools.DataSetGenerator;
 import org.junit.jupiter.api.Tag;
@@ -31,6 +35,7 @@ import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -401,4 +406,19 @@ public class DataSetSplitterTests extends BaseDL4JTest {
         }
         assertEquals(5, valCnt);
     }
+
+
+    @Test
+    public void testSplitter9835() {
+        RecordReader reader = new CollectionRecordReader(Collections.nCopies(4, Collections.nCopies(4, new IntWritable(1))));
+        DataSetIterator baseIterator = new RecordReaderDataSetIterator(reader, 1, 3, 3, true);
+        DataSetIteratorSplitter splitter = new DataSetIteratorSplitter(baseIterator, 4, 0.5);
+        List<DataSetIterator> iterators = splitter.getIterators(); // throws exception
+        DataSetIterator iterator0 = iterators.get(0);
+        DataSetIterator iterator1 = iterators.get(1);
+        assertNotNull(iterator0);
+        assertNotNull(iterator1);
+
+    }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes #9835 
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
