### PR TITLE
Fix lombok Thread.builder clash with jdk 17

### DIFF
--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/ParallelInference.java
@@ -22,7 +22,6 @@ package org.deeplearning4j.parallelism;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.deeplearning4j.nn.api.Model;
 import org.deeplearning4j.nn.api.ModelAdapter;
 import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
@@ -91,7 +90,7 @@ public class ParallelInference {
      */
     public void updateModel(@NonNull Model model) {
         if (zoo != null) {
-            for (val w: zoo)
+            for (var w: zoo)
                 w.updateModel(model);
         } else {
             // if zoo wasn't initialized yet - just replace model
@@ -109,9 +108,9 @@ public class ParallelInference {
         if (zoo == null)
             return new Model[0];
 
-        val models = new Model[zoo.length];
+        var models = new Model[zoo.length];
         int cnt = 0;
-        for (val w:zoo) {
+        for (var w:zoo) {
             models[cnt++] = w.replicatedModel;
         }
 
@@ -420,7 +419,7 @@ public class ParallelInference {
          */
         public ParallelInference build() {
             if (this.inferenceMode == InferenceMode.INPLACE) {
-                val inf = new InplaceParallelInference();
+                var inf = new InplaceParallelInference();
                 inf.inferenceMode = this.inferenceMode;
                 inf.model = this.model;
                 inf.layersToOutputTo = this.layersToOutputTo;

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/DefaultTrainerContext.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/DefaultTrainerContext.java
@@ -61,8 +61,9 @@ public class DefaultTrainerContext implements TrainerContext {
                         .uuid(uuid + "_thread_" + threadId)
                         .averagingFrequency(averagingFrequency).build();
 
-        trainer.setName("DefaultTrainer thread " + threadId);
-        trainer.setDaemon(true);
+        Thread trainer2 = new Thread(trainer);
+        trainer2.setName("DefaultTrainer thread " + threadId);
+        trainer2.setDaemon(true);
 
         return trainer;
     }

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/SymmetricTrainerContext.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/factory/SymmetricTrainerContext.java
@@ -57,12 +57,12 @@ public class SymmetricTrainerContext implements TrainerContext {
      */
     @Override
     public Trainer create(String uuid, int threadId, Model model, int rootDevice, boolean useMDS, ParallelWrapper wrapper,
-                    WorkspaceMode mode, int averagingFrequency) {
+                          WorkspaceMode mode, int averagingFrequency) {
 
         SymmetricTrainer trainer = new SymmetricTrainer(model, uuid, threadId, mode, wrapper, useMDS);
-
-        trainer.setName("SymmetricTrainer thread " + threadId);
-        trainer.setDaemon(true);
+        Thread t2 = new Thread(trainer);
+        t2.setName("SymmetricTrainer thread " + threadId);
+        t2.setDaemon(true);
 
         return trainer;
     }

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservable.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/inference/observers/BatchedInferenceObservable.java
@@ -21,7 +21,6 @@
 package org.deeplearning4j.parallelism.inference.observers;
 
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.deeplearning4j.parallelism.inference.InferenceObservable;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.api.DataSetUtil;
@@ -187,8 +186,8 @@ public class BatchedInferenceObservable extends BasicInferenceObservable impleme
             }
             int examplesSoFar = 0;
             for( int inNum = 0; inNum < numSplits; inNum++) {
-                val inSizeEx = inputs.get(firstInputComponent + inNum)[0].size(0);
-                indices[0] = NDArrayIndex.interval(examplesSoFar, examplesSoFar+inSizeEx);
+                var inSizeEx = inputs.get(firstInputComponent + inNum)[0].size(0);
+                indices[0] = NDArrayIndex.interval(examplesSoFar, examplesSoFar + inSizeEx);
                 out[inNum] = netOutput.get(indices);
                 examplesSoFar += inSizeEx;
             }

--- a/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/DefaultTrainer.java
+++ b/deeplearning4j/deeplearning4j-scaleout/deeplearning4j-scaleout-parallelwrapper/src/main/java/org/deeplearning4j/parallelism/trainer/DefaultTrainer.java
@@ -54,7 +54,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @Slf4j
 @NoArgsConstructor
 @AllArgsConstructor
-public class DefaultTrainer extends Thread implements Trainer {
+public class DefaultTrainer implements Trainer,Runnable {
 
     protected Model replicatedModel;
 
@@ -72,7 +72,8 @@ public class DefaultTrainer extends Thread implements Trainer {
     protected Exception thrownException;
     @Builder.Default
     protected volatile boolean useMDS = false;
-    @Getter protected String uuid;
+    @Getter
+    protected String uuid;
     @Builder.Default
     protected boolean onRootModel = false;
     @Builder.Default
@@ -469,6 +470,16 @@ public class DefaultTrainer extends Thread implements Trainer {
 
             LockSupport.parkNanos(1000L);
         }
+    }
+
+    @Override
+    public void setUncaughtExceptionHandler(Thread.UncaughtExceptionHandler handler) {
+
+    }
+
+    @Override
+    public void start() {
+
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix Thread.builder clash with jdk 17.
Convert Trainer to runnable and set up using normal Thread constructor.
Fix lombok.val usage in ParallelWrapper module
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
