### PR TITLE
Fixes #9864/dropout values

### DIFF
--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/custom/CustomOpsTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/custom/CustomOpsTests.java
@@ -158,6 +158,19 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
         assertEquals(exp, arrayZ);
     }
 
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testSameDiffDropout(Nd4jBackend backend) {
+        INDArray in = Nd4j.ones(4, 8);
+        INDArray res1 = Nd4j.nn.dropout(in, false, 0.2);
+       for(int i = 0; i < res1.rows(); i++) {
+           for(int j = 0;  j < res1.columns(); j++) {
+               assertTrue(res1.getInt(i,j) == 0 || res1.getInt(i,j) == 1);
+           }
+       }
+    }
+
     /**
      * This test works inplace, but without inplace declaration
      */


### PR DESCRIPTION
Fixes #9864
Fixes dropout value outputs for new dropout kernel.
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
