### PR TITLE
Fix model import with empty tensor array shapes (signals no validation)

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -911,7 +911,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                 long[] inputShapeArr = tensorArray1.requiredShape();
                 for(int j = 0; j < list.size(); j++) {
                     if(list.get(j) != null)
-                        if(!Arrays.equals(inputShapeArr,list.get(j).shape())) {
+                        if(!Arrays.equals(inputShapeArr,list.get(j).shape()) && inputShapeArr.length > 0) {
                             throw new IllegalArgumentException("Element " + j  + " of list " + v.getVariable() + " did not have correct shape of " + Arrays.toString(inputShapeArr) + " was shape " + Arrays.toString(list.get(j).shape()));
                         }
 
@@ -965,8 +965,8 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
             tArr = new VarId(tArrOp.outputVariable().name(),OUTER_FRAME,0,null);
             if(tArrOp.args().length > 1) {
                 long[] shape = tArrOp.arg(1).getArr().toLongVector();
-                if(!Arrays.equals(arr.shape(),shape)) {
-                    throw new IllegalArgumentException("Unable to write array of shape " + Arrays.toString(arr.shape()) + " must be " + shape + " for op " + op.getOwnName() + " and tensor array " + tArrOp.getOwnName());
+                if(!Arrays.equals(arr.shape(),shape) && shape.length > 0) {
+                    throw new IllegalArgumentException("Unable to write array of shape " + Arrays.toString(arr.shape()) + " must be " + Arrays.toString(shape) + " for op " + op.getOwnName() + " and tensor array " + tArrOp.getOwnName());
                 }
             }
 
@@ -1123,7 +1123,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                 INDArray get = mmgr.dup(getView);
                 if(ta.args().length > 1) {
                     long[] shape = ta.arg(1).getArr().toLongVector();
-                    if(!Arrays.equals(get.shape(),shape)) {
+                    if(!Arrays.equals(get.shape(),shape) && shape.length > 0) {
                         throw new IllegalArgumentException("Unable to write array of shape " + Arrays.toString(get.shape()) + " must be " + shape + " for op " + op.getOwnName() + " and tensor array " + ta.getOwnName());
                     }
                 }

--- a/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/ImportGraph.kt
+++ b/nd4j/samediff-import/samediff-import-api/src/main/kotlin/org/nd4j/samediff/frameworkimport/ImportGraph.kt
@@ -442,7 +442,7 @@ open class ImportGraph <GRAPH_TYPE: GeneratedMessageV3,
                             //Get array, create a constant
                             val arr = irGraph.getConstantArrayForName(name)
                             //probably implicit output like in tensorflow
-                            if(nd.numOutputs() < 1)
+                            if(nd.numOutputs() < 1 || irGraph.frameworkName().contains("tensorflow"))
                                 sd.constant(name, arr)
                             else //onnx case
                                 sd.constant(nd.outputAt(0),arr)

--- a/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRAttr.kt
+++ b/nd4j/samediff-import/samediff-import-tensorflow/src/main/kotlin/org/nd4j/samediff/frameworkimport/tensorflow/ir/TensorflowIRAttr.kt
@@ -77,7 +77,7 @@ class TensorflowIRAttr(inputAttributeDef: OpDef.AttrDef, inputAttributeValue: At
     }
 
     override fun listDataTypes(): List<TensorNamespace.DataType> {
-        throw UnsupportedOperationException("Unable to map list of data types")
+        return attributeValue.list.typeList.map { input -> TensorflowIRDataType(input).nameSpaceDataType() }
     }
 
     override fun attributeValueType(): AttributeValueType {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes model import issue where an exception is thrown when a shape is empty signaling no validation.
(Please fill in changes proposed in this fix)

## How was this patch tested?
Ran model import tests
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
