### PR TITLE
Fixes shape info data buffer caching

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -99,7 +99,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     private static final long serialVersionUID = 3285982317165542614L;
 
-    protected transient volatile DataBuffer shapeInformation;
     protected transient volatile DataBuffer data;
     //protected transient DataBuffer shape;
     //protected transient DataBuffer stride;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -53,7 +53,6 @@ import org.nd4j.linalg.api.ops.impl.reduce3.EuclideanDistance;
 import org.nd4j.linalg.api.ops.impl.reduce3.ManhattanDistance;
 import org.nd4j.linalg.api.ops.impl.reduce.longer.MatchCondition;
 import org.nd4j.linalg.api.ops.impl.broadcast.*;
-import org.nd4j.linalg.api.ops.impl.controlflow.Where;
 import org.nd4j.linalg.api.ops.impl.scalar.*;
 import org.nd4j.linalg.api.ops.impl.scalar.comparison.*;
 import org.nd4j.linalg.api.ops.impl.shape.Tile;
@@ -183,7 +182,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         this.data = offset > 0 ? Nd4j.createBuffer(buffer, offset, Shape.lengthOfBuffer(shape, stride)) : buffer;
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape, stride, ews, ordering, buffer.dataType(), false ));
         init(shape, stride);
-        // Shape.setElementWiseStride(this.shapeInfo(),Shape.elementWiseStride(shape, stride, ordering == 'f'));
     }
 
     public BaseNDArray(DataBuffer buffer, long[] shape, long[] stride, long offset,  char ordering, DataType dataType) {
@@ -201,7 +199,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape, stride,
                 Shape.elementWiseStride(shape, stride, ordering == 'f'), ordering, type, false));
         init(shape, stride);
-        // Shape.setElementWiseStride(this.shapeInfo(),Shape.elementWiseStride(shape, stride, ordering == 'f'));
     }
 
     public BaseNDArray(DataBuffer buffer, long[] shape, long[] stride, char ordering, DataType type, MemoryWorkspace workspace) {
@@ -209,7 +206,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape, stride,
                 Shape.elementWiseStride(shape, stride, ordering == 'f'), ordering, type, false));
         init(shape, stride);
-        // Shape.setElementWiseStride(this.shapeInfo(),Shape.elementWiseStride(shape, stride, ordering == 'f'));
     }
 
     public BaseNDArray(DataBuffer buffer,  DataType dataType, long[] shape, long[] stride, long offset, char ordering) {
@@ -217,7 +213,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape, stride,
                 Shape.elementWiseStride(shape, stride, ordering == 'f'), ordering, dataType, false));
         init(shape, stride);
-        // Shape.setElementWiseStride(this.shapeInfo(),Shape.elementWiseStride(shape, stride, ordering == 'f'));
     }
 
     /**
@@ -468,7 +463,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(ArrayUtil.toLongArray(shape), ArrayUtil.toLongArray(stride),
                 Shape.elementWiseStride(shape, stride, ordering == 'f'), ordering, slices.get(0).dataType(), false));
         init(shape, stride);
-        //    Shape.setElementWiseStride(this.shapeInfo(),Shape.elementWiseStride(shape, stride, ordering == 'f'));
 
         if (slices.get(0).isScalar()) {
             for (int i = 0; i < length(); i++) {
@@ -483,15 +477,11 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
 
     public BaseNDArray(List<INDArray> slices, long[] shape, long[] stride, char ordering) {
-        DataBuffer ret = Nd4j.createBuffer(slices.get(0).dataType(), Shape.lengthOf(shape), false); /*slices.get(0).data().dataType() == (DataType.FLOAT)
-                ? Nd4j.createBuffer(new float[ArrayUtil.prod(shape)])
-                : Nd4j.createBuffer(new double[ArrayUtil.prod(shape)]);
-                */
+        DataBuffer ret = Nd4j.createBuffer(slices.get(0).dataType(), Shape.lengthOf(shape), false);
         this.data = ret;
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(shape, stride,
                 Shape.elementWiseStride(shape, stride, ordering == 'f'), ordering, slices.get(0).dataType(), false));
         init(shape, stride);
-        //    Shape.setElementWiseStride(this.shapeInfo(),Shape.elementWiseStride(shape, stride, ordering == 'f'));
 
         if (slices.get(0).isScalar()) {
             for (int i = 0; i < length(); i++) {
@@ -580,9 +570,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(ArrayUtil.toLongArray(shape), ArrayUtil.toLongArray(stride),
                 Shape.elementWiseStride(shape, stride, Nd4j.order() == 'f'), Nd4j.order(), data.dataType(), false));
         init(shape, stride);
-        //  Shape.setElementWiseStride(this.shapeInfo(),Shape.elementWiseStride(shape, stride, Nd4j.order() == 'f'));
-
-
     }
 
     /**
@@ -1030,11 +1017,11 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         val ews = shapeInfo.getLong(jShapeInfo[0] * 2 + 2);
         char tadOrder = (char) shapeInfo.getInt(jShapeInfo[0] * 2 + 3);
         val toTad = Nd4j.create(data(), shape, stride, offset, ews, tadOrder);
+        toTad.setCloseable(false);
         return toTad;
     }
 
     private void setShapeInformation(Pair<DataBuffer, long[]> shapeInfo) {
-        this.shapeInformation = shapeInfo.getFirst();
         this.jvmShapeInfo = new JvmShapeInfo(shapeInfo.getSecond());
     }
 
@@ -1719,6 +1706,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     public INDArray dup(char order) {
         WorkspaceUtils.assertValidArray(this, "Cannot duplicate INDArray");
+
         if (this.isCompressed() && this.ordering() == order) {
             INDArray ret = Nd4j.createArrayFromShapeBuffer(data().dup(), this.shapeInfoDataBuffer());
             ret.markAsCompressed(true);
@@ -1737,7 +1725,6 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
             return Nd4j.create(list, this.shape(), this.ordering());
         }
-
         val z = Nd4j.createUninitialized(this.dataType(), this.shape(), order);
         z.assign(this);
         return z;
@@ -2287,7 +2274,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     protected void init(int[] shape, int[] stride) {
         //null character
-        if (shapeInformation == null || jvmShapeInfo == null || ordering() == '\u0000') {
+        if (jvmShapeInfo == null || ordering() == '\u0000') {
             //Shape.setOrder(shapeInfo(), Nd4j.order());
             val si = Nd4j.getShapeInfoProvider().createShapeInformation(ArrayUtil.toLongArray(shape), ArrayUtil.toLongArray(stride), 1, Nd4j.order(), this.dataType(), false);
             setShapeInformation(si);
@@ -2297,7 +2284,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     protected void init(long[] shape, long[] stride) {
         //null character
-        if (shapeInformation == null || jvmShapeInfo == null || ordering() == '\u0000') {
+        if (jvmShapeInfo == null || ordering() == '\u0000') {
             val si = Nd4j.getShapeInfoProvider().createShapeInformation(shape,stride, 1, Nd4j.order(), this.dataType(), false);
             setShapeInformation(si);
         }
@@ -3121,7 +3108,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     public INDArray mmuli(INDArray other, INDArray result) {
         validateNumericalArray("mmuli", false);
         LinAlgExceptions.assertMultiplies(this, other);
-        if(other.rank() == 1){
+        if(other.rank() == 1) {
             //GEMV edge case
             Preconditions.checkState(result.length() == this.size(0) && this.size(1) == other.size(0),
                     "Invalid matrix multiplication: %ndShape x %ndShape with result shape %ndShape", this, other, result);
@@ -3798,11 +3785,9 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
 
 
-
         INDArray reshapeAttempt = Shape.newShapeNoCopy(this, shape, order == 'f');
+
         if (reshapeAttempt != null) {
-            // kinda strange get/set usage
-            //  reshapeAttempt.setOrder(Shape.getOrder(reshapeAttempt));
             return reshapeAttempt;
         }
 
@@ -3817,10 +3802,14 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             ret.setData(dup(order).data());
             return ret;
         } else if (this.isEmpty()) {
-            return Nd4j.create(this.dataType(), shape);
+            INDArray ret = Nd4j.create(this.dataType(), shape);
+            return ret;
+
         } else {
             INDArray ret = this.dup(order);
-            return Nd4j.create(ret.data(), shape);
+            INDArray ret2 =  Nd4j.create(ret.data(), shape);
+            return ret2;
+
         }
     }
 
@@ -4337,9 +4326,9 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
 
 
-
         char order = Shape.getOrder(outShape, outStrides, -1);
         INDArray out = create(data, outShape, outStrides, offset, order);
+        out.setCloseable(false);
         return out;
     }
 
@@ -4393,6 +4382,12 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             return false;
 
         INDArray n = (INDArray) o;
+        if(n.wasClosed())
+            throw new IllegalStateException("Passed in array was closed. Unable to determine equality.");
+
+        if(wasClosed())
+            throw new IllegalStateException("This array is closed. Unable to determine equality.");
+
         Nd4j.getCompressor().autoDecompress(n);
 
         if (n == this)
@@ -4484,13 +4479,13 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     }
 
     @Override
-    public boolean equalShapes(@NonNull INDArray other){
+    public boolean equalShapes(@NonNull INDArray other) {
         if(isEmpty() != other.isEmpty())
             return false;
         if(rank() != other.rank())
             return false;
-        for( int i=0; i<rank(); i++ ){
-            if(size(i) != other.size(i)){
+        for( int i = 0; i < rank(); i++) {
+            if(size(i) != other.size(i)) {
                 return false;
             }
         }
@@ -4517,12 +4512,13 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public DataBuffer shapeInfoDataBuffer() {
-        return shapeInformation;
+        DataBuffer buffer = Nd4j.createBuffer(jvmShapeInfo.javaShapeInformation);
+        return buffer;
     }
 
     @Override
     public LongBuffer shapeInfo() {
-        return shapeInformation.asNioLong();
+        return shapeInfoDataBuffer().asNioLong();
     }
 
     public long[] shape() {
@@ -4834,8 +4830,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         val newStride = doPermuteSwap(stride(), rearrange);
 
         char newOrder = Shape.getOrder(newShape, newStride, 1);
-
         INDArray value = create(data(), newShape, newStride, offset(), newOrder);
+        value.setCloseable(false);
         return value;
     }
 
@@ -5179,7 +5175,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             copy.shapeInfoDataBuffer().write(out);
             copy.data().write(out);
         } else {
-            shapeInformation.write(out);
+            shapeInfoDataBuffer().write(out);
             data().write(out);
         }
     }
@@ -5188,11 +5184,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     protected void read(ObjectInputStream s) {
         val headerShape = BaseDataBuffer.readHeader(s);
 
-        shapeInformation = Nd4j.createBuffer(new int[Shape.shapeInfoLength(rank())]);
-        shapeInformation.read(s, headerShape.getLeft(), headerShape.getMiddle(), headerShape.getRight());
-
-        setShapeInformation(Pair.create(shapeInformation, shapeInformation.asLong()));
-
+        init(shape(),stride());
         val headerData = BaseDataBuffer.readHeader(s);
         data = Nd4j.createBuffer(headerData.getRight(), headerData.getMiddle(), false);
         data().read(s, headerData.getLeft(), headerData.getMiddle(), headerData.getRight());
@@ -5310,7 +5302,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 DataBuffer buffer = Nd4j.createBuffer(this.length(), false);
                 Nd4j.getMemoryManager().memcpy(buffer, this.data());
 
-                copy = Nd4j.createArrayFromShapeBuffer(buffer, this.shapeInfoDataBuffer());
+                copy = Nd4j.createArrayFromShapeBuffer(buffer, this.jvmShapeInfo.javaShapeInformation);
             } else {
                 copy = this.dup(this.ordering());
                 Nd4j.getExecutioner().commit();

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2552,6 +2552,27 @@ public class Nd4j {
         return ret;
     }
 
+
+    /**
+     * Create array based in data buffer and shape info,
+     *
+     * @param data Data buffer.
+     * @param shapeInfo shape information.
+     * @return new INDArray.
+     */
+    public static INDArray createArrayFromShapeBuffer(DataBuffer data, long[] shapeInfo) {
+        val jvmShapeInfo = shapeInfo;
+        val dataType = ArrayOptionsHelper.dataType(jvmShapeInfo);
+        val shape = Shape.shape(jvmShapeInfo);
+        val strides = Shape.stridesOf(jvmShapeInfo);
+        val order = Shape.order(jvmShapeInfo);
+        INDArray result = Nd4j.create(data, shape, strides, 0, order, dataType);
+        if (data instanceof CompressedDataBuffer)
+            result.markAsCompressed(true);
+
+        return result;
+    }
+
     /**
      * Create array based in data buffer and shape info,
      *

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/BaseWorkspaceMgr.java
@@ -26,6 +26,7 @@ import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.HashMap;
@@ -85,7 +86,7 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
     public MemoryWorkspace notifyScopeEntered(@NonNull T arrayType) {
         validateConfig(arrayType);
 
-        if(isScopedOut(arrayType)){
+        if(isScopedOut(arrayType)) {
             return Nd4j.getWorkspaceManager().scopeOutOfWorkspaces();
         } else {
             MemoryWorkspace ws = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(
@@ -108,7 +109,7 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
         validateConfig(arrayType);
         enforceExistsAndActive(arrayType);
 
-        if(scopeOutOfWs.contains(arrayType)){
+        if(scopeOutOfWs.contains(arrayType)) {
             return Nd4j.getWorkspaceManager().scopeOutOfWorkspaces();
         } else {
             MemoryWorkspace ws = Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(
@@ -129,7 +130,7 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
 
     @Override
     public void setWorkspace(@NonNull T forEnum, @NonNull String wsName, @NonNull WorkspaceConfiguration configuration) {
-        if(scopeOutOfWs.contains(forEnum)){
+        if(scopeOutOfWs.contains(forEnum)) {
             scopeOutOfWs.remove(forEnum);
         }
         setWorkspaceName(forEnum, wsName);
@@ -258,20 +259,20 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
     }
 
     @Override
-    public INDArray createUninitialized(T arrayType, DataType dataType, long... shape){
+    public INDArray createUninitialized(T arrayType, DataType dataType, long... shape) {
         return createUninitialized(arrayType, dataType, shape, Nd4j.order());
     }
 
     @Override
     public INDArray createUninitialized(@NonNull T arrayType, @NonNull DataType dataType, @NonNull long[] shape, char order) {
         enforceExistsAndActive(arrayType);
-        try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)){
+        try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)) {
             return Nd4j.createUninitialized(dataType, shape, order);
         }
     }
 
     @Override
-    public INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup, char order){
+    public INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup, char order) {
         enforceExistsAndActive(arrayType);
         try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)){
             return toDup.dup(order);
@@ -279,29 +280,29 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
     }
 
     @Override
-    public INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup){
+    public INDArray dup(@NonNull T arrayType, @NonNull INDArray toDup) {
         return dup(arrayType, toDup, toDup.ordering());
     }
 
     @Override
-    public INDArray castTo(@NonNull T arrayType, @NonNull DataType dataType, @NonNull INDArray toCast, boolean dupIfCorrectType){
-        if(toCast.dataType() == dataType){
-            if(!dupIfCorrectType){
+    public INDArray castTo(@NonNull T arrayType, @NonNull DataType dataType, @NonNull INDArray toCast, boolean dupIfCorrectType) {
+        if(toCast.dataType() == dataType) {
+            if(!dupIfCorrectType) {
                 //Check if we can avoid duping... if not in workspace, or already in correct workspace
-                if(!toCast.isAttached() || toCast.data().getParentWorkspace().getId().equals(workspaceNames.get(arrayType))){
+                if(!toCast.isAttached() || toCast.data().getParentWorkspace().getId().equals(workspaceNames.get(arrayType))) {
                     return toCast;
                 }
             }
             return dup(arrayType, toCast);
         } else {
-            try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)){
+            try(MemoryWorkspace ws = notifyScopeBorrowed(arrayType)) {
                 return toCast.castTo(dataType);
             }
         }
     }
 
 
-    private void validateConfig(@NonNull T arrayType){
+    private void validateConfig(@NonNull T arrayType) {
         if(scopeOutOfWs.contains(arrayType)){
             return;
         }
@@ -314,13 +315,13 @@ public abstract class BaseWorkspaceMgr<T extends Enum<T>> implements WorkspaceMg
         }
     }
 
-    private void enforceExistsAndActive(@NonNull T arrayType){
+    private void enforceExistsAndActive(@NonNull T arrayType) {
         validateConfig(arrayType);
         if(scopeOutOfWs.contains(arrayType)){
             return;
         }
 
-        if(!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(workspaceNames.get(arrayType))){
+        if(!Nd4j.getWorkspaceManager().checkIfWorkspaceExistsAndActive(workspaceNames.get(arrayType))) {
             throw new ND4JWorkspaceException("Workspace \"" + workspaceNames.get(arrayType) + "\" for array type " + arrayType
                     + " is not open");
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceUtils.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/workspace/WorkspaceUtils.java
@@ -22,7 +22,9 @@ package org.nd4j.linalg.workspace;
 
 import lombok.NonNull;
 import lombok.val;
+import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.memory.abstracts.Nd4jWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.api.memory.abstracts.DummyWorkspace;
@@ -134,5 +136,23 @@ public class WorkspaceUtils {
             }
         }
         return workspaces;
+    }
+
+    public static int getAligned(int requiredMemory) {
+        long div = requiredMemory % Nd4jWorkspace.alignmentBase;
+        if (div != 0) requiredMemory += (Nd4jWorkspace.alignmentBase - div);
+        return requiredMemory;
+    }
+
+    public static int getAligned(long requiredMemory) {
+        return  getAligned((int) requiredMemory);
+    }
+
+    public static int getShapeBufferRequireMemoryForWorkspace(INDArray arr) {
+        return  getAligned(arr.shapeInfoJava().length * DataType.INT64.width());
+    }
+
+    public static int getTotalRequiredMemoryForWorkspace(INDArray arr) {
+        return getAligned(arr.length() * arr.dataType().width()) + getAligned(arr.shapeInfoJava().length * DataType.INT64.width());
     }
 }

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/workspace/DebugModeTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/workspace/DebugModeTests.java
@@ -44,6 +44,7 @@ import org.nd4j.linalg.api.memory.enums.SpillPolicy;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.api.memory.abstracts.Nd4jWorkspace;
+import org.nd4j.linalg.workspace.WorkspaceUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -105,7 +106,7 @@ public class DebugModeTests extends BaseNd4jTestWithBackends {
             assertEquals(0, ws.getDeviceOffset());
 
             // array buffer should be spilled now
-            assertEquals(10 * 10 * Nd4j.sizeOfDataType(DataType.DOUBLE), ws.getSpilledSize());
+            assertEquals(1024, ws.getSpilledSize());
         }
     }
 
@@ -133,7 +134,7 @@ public class DebugModeTests extends BaseNd4jTestWithBackends {
             assertEquals(0, ws.getDeviceOffset());
 
             // array buffer should be spilled now
-            assertEquals(10 * 10 * Nd4j.sizeOfDataType(DataType.DOUBLE), ws.getSpilledSize());
+            assertEquals(WorkspaceUtils.getTotalRequiredMemoryForWorkspace(array) + WorkspaceUtils.getShapeBufferRequireMemoryForWorkspace(array) * 3 - 32 , ws.getSpilledSize());
         }
 
         try (val ws = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getAndActivateWorkspace(basicConfig, "R_119_1992")) {

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/workspace/WorkspaceProviderTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/workspace/WorkspaceProviderTests.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.linalg.BaseNd4jTestWithBackends;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
@@ -140,13 +141,15 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         Nd4jWorkspace ws1 =
                 (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(configuration, "ITER");
 
-        long requiredMemory = 100 * Nd4j.sizeOfDataType();
+        long requiredMemory = getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,100));
+        //policy adds 30% to buffer size when reaching end of cycle
         long shiftedSize = ((long) (requiredMemory * 1.3)) + (8 - (((long) (requiredMemory * 1.3)) % 8));
 
         for (int x = 0; x < 100; x++) {
             try (Nd4jWorkspace wsI = (Nd4jWorkspace) Nd4j.getWorkspaceManager()
                     .getWorkspaceForCurrentThread(configuration, "ITER").notifyScopeEntered()) {
                 INDArray array = Nd4j.create(DataType.DOUBLE,100);
+                long bytes = getTotalRequiredMemoryForWorkspace(array);
             }
 
             // only checking after workspace is initialized
@@ -169,10 +172,12 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testUnboundedLoop1(Nd4jBackend backend) {
         WorkspaceConfiguration configuration = WorkspaceConfiguration.builder()
-                .initialSize(100 * 100 * Nd4j.sizeOfDataType()).policyReset(ResetPolicy.ENDOFBUFFER_REACHED)
+                .initialSize(100 * 100 * DataType.DOUBLE.width()).policyReset(ResetPolicy.ENDOFBUFFER_REACHED)
                 .policyAllocation(AllocationPolicy.STRICT).build();
 
-        for (int x = 0; x < 100; x++) {
+        //end of buffer reached at 92, anything passed that does a reset
+       int numArraysAllocated = 92;
+        for (int x = 0; x < numArraysAllocated; x++) {
             try (Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager()
                     .getWorkspaceForCurrentThread(configuration, "ITER").notifyScopeEntered()) {
 
@@ -181,13 +186,13 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
 
             Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(configuration,
                     "ITER");
-
-            assertEquals((x + 1) * 100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
+            INDArray array = Nd4j.create(DataType.DOUBLE, 100);
+            assertEquals((x + 1) * getTotalRequiredMemoryForWorkspace(array), ws1.getPrimaryOffset(),"Failed equals at x " + x);
         }
 
         Nd4jWorkspace ws1 =
                 (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(configuration, "ITER");
-        assertEquals(100 * 100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
+        assertEquals(numArraysAllocated * getTotalRequiredMemoryForWorkspace( Nd4j.create(DataType.DOUBLE, 100)), ws1.getPrimaryOffset());
 
         // just to trigger reset
         ws1.notifyScopeEntered();
@@ -246,14 +251,14 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
             INDArray array = Nd4j.create(new double[] {6f, 3f, 1f, 9f, 21f});
             INDArray array3 = null;
 
-            long reqMem = getAligned(5 * Nd4j.sizeOfDataType(DataType.DOUBLE));
+            long reqMem = getTotalRequiredMemoryForWorkspace(array);
             assertEquals(reqMem + reqMem % 16, ws1.getPrimaryOffset());
             try (Nd4jWorkspace ws2 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2")
                     .notifyScopeEntered()) {
 
                 INDArray array2 = Nd4j.create(new double[] {1f, 2f, 3f, 4f, 5f});
 
-                reqMem = getAligned(5 * Nd4j.sizeOfDataType(DataType.DOUBLE));
+                reqMem = getTotalRequiredMemoryForWorkspace(array2);
                 assertEquals(reqMem + reqMem % 16, ws1.getPrimaryOffset());
                 assertEquals(reqMem + reqMem % 16, ws2.getPrimaryOffset());
 
@@ -344,7 +349,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
                 assertEquals(1.0f, restored.meanNumber().floatValue(), 1.0f);
 
                 // we want to ensure it's the same cached shapeInfo used here
-                assertEquals(array.shapeInfoDataBuffer().addressPointer().address(), restored.shapeInfoDataBuffer().addressPointer().address());
+                assertEquals(array.shapeInfoDataBuffer(), restored.shapeInfoDataBuffer().addressPointer());
             }
         }
     }
@@ -369,14 +374,14 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
             DataInputStream dis = new DataInputStream(bis);
             restored = Nd4j.read(dis);
 
-            long requiredMemory = getAligned(10 * DataType.DOUBLE.width());
+            long requiredMemory = getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,10)) * 2;
             assertEquals(requiredMemory + requiredMemory % 8, workspace.getPrimaryOffset());
 
             assertEquals(array.length(), restored.length());
             assertEquals(1.0f, restored.meanNumber().floatValue(), 1.0f);
 
             // we want to ensure it's the same cached shapeInfo used here
-            assertEquals(array.shapeInfoDataBuffer().addressPointer().address(), restored.shapeInfoDataBuffer().addressPointer().address());
+            assertEquals(array.shapeInfoDataBuffer(), restored.shapeInfoDataBuffer());
         }
     }
 
@@ -400,7 +405,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
             assertEquals(1.0f, restored.meanNumber().floatValue(), 1.0f);
 
             // we want to ensure it's the same cached shapeInfo used here
-            assertEquals(array.shapeInfoDataBuffer().addressPointer().address(), restored.shapeInfoDataBuffer().addressPointer().address());
+            assertEquals(array.shapeInfoDataBuffer(), restored.shapeInfoDataBuffer());
         }
     }
 
@@ -414,24 +419,21 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace("WSR_1")) {
             Nd4j.create(10000);
             assertEquals(0, workspace.getCurrentSize());
-            assertEquals(1, workspace.getNumberOfExternalAllocations());
+            //note: 1 allocation of the array and a shape buffer should be the allocations here
+            assertEquals(2, workspace.getNumberOfExternalAllocations());
         }
 
         assertEquals(10 * 1024L * 1024L, workspace.getCurrentSize());
         assertEquals(0, workspace.getPrimaryOffset());
-        assertEquals(1, workspace.getNumberOfExternalAllocations());
+        //note: 1 allocation of the array and a shape buffer should be the allocations here
+        assertEquals(2, workspace.getNumberOfExternalAllocations());
 
-        for (int i = 0; i < 11 * 1024 * 1024; i += 10000 * Nd4j.sizeOfDataType()) {
+        for (int i = 0; i < 11 * 1024 * 1024; i += 10000 * DataType.DOUBLE.width()) {
             try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace("WSR_1")) {
                 Nd4j.create(10000);
             }
 
-            /*
-            if (i < 10480000)
-                assertEquals("I: " + i,1, workspace.getNumberOfExternalAllocations());
-            else
-                assertEquals(0, workspace.getNumberOfExternalAllocations());
-                */
+
         }
 
         assertEquals(0, workspace.getNumberOfExternalAllocations());
@@ -452,9 +454,9 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
             array1 = Nd4j.create(DataType.DOUBLE, 8, 128, 100);
         }
 
-        long requiredMemory = 8 * 128 * 100 * Nd4j.sizeOfDataType(DataType.DOUBLE);
+        long requiredMemory = getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE, 8, 128, 100));
         long shiftedSize = ((long) (requiredMemory * 1.3)) + (8 - (((long) (requiredMemory * 1.3)) % 8));
-        assertEquals(shiftedSize, workspace.getInitialBlockSize());
+        assertEquals( shiftedSize, workspace.getInitialBlockSize());
         assertEquals(shiftedSize * 4, workspace.getCurrentSize());
         assertEquals(0, workspace.getPrimaryOffset());
         assertEquals(0, workspace.getDeviceOffset());
@@ -465,7 +467,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
 
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(adsiConfiguration, "ADSI")) {
             // allocating same shape
-            array1 = Nd4j.create(8, 128, 100);
+            array1 = Nd4j.create(DataType.DOUBLE,8, 128, 100);
         }
 
         assertEquals(workspace.getInitialBlockSize(), workspace.getPrimaryOffset());
@@ -483,8 +485,8 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         // offsets should be intact, allocation happened as pinned
         assertEquals(workspace.getInitialBlockSize(), workspace.getPrimaryOffset());
         assertEquals(workspace.getInitialBlockSize(), workspace.getDeviceOffset());
-
-        assertEquals(1, workspace.getNumberOfPinnedAllocations());
+        //shape buffer + data buffer
+        assertEquals(2, workspace.getNumberOfPinnedAllocations());
 
         assertEquals(3, workspace.getCyclesCount());
         assertEquals(0, workspace.getStepNumber());
@@ -495,7 +497,8 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
             array1 = Nd4j.create(DataType.DOUBLE, 8, 128, 100);
         }
 
-        assertEquals(2, workspace.getNumberOfPinnedAllocations());
+        //shape buffer + data buffer * 2
+        assertEquals(4, workspace.getNumberOfPinnedAllocations());
         assertEquals(0, workspace.getStepNumber());
         assertEquals(4, workspace.getCyclesCount());
 
@@ -503,8 +506,8 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
             // allocating same shape
             array1 = Nd4j.create(DataType.DOUBLE, 8, 128, 100);
         }
-
-        assertEquals(3, workspace.getNumberOfPinnedAllocations());
+        //shape buffer + data buffer * 3
+        assertEquals(6, workspace.getNumberOfPinnedAllocations());
         assertEquals(1, workspace.getStepNumber());
         assertEquals(5, workspace.getCyclesCount());
 
@@ -536,12 +539,12 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         for (int i = 1; i <= 10; i++) {
             try (MemoryWorkspace ws = Nd4j.getWorkspaceManager()
                     .getAndActivateWorkspace(reallocateUnspecifiedConfiguration, "WS_1")) {
-                INDArray array = Nd4j.create(100 * i);
+                INDArray array = Nd4j.create(DataType.DOUBLE,100 * i);
             }
 
             if (i == 3) {
                 workspace.initializeWorkspace();
-                assertEquals(100 * i * Nd4j.sizeOfDataType(), workspace.getCurrentSize(),"Failed on iteration " + i);
+                assertEquals(getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,100 * i)), workspace.getCurrentSize(),"Failed on iteration " + i);
             }
         }
 
@@ -550,12 +553,12 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         for (int i = 10; i > 0; i--) {
             try (MemoryWorkspace ws = Nd4j.getWorkspaceManager()
                     .getAndActivateWorkspace(reallocateUnspecifiedConfiguration, "WS_1")) {
-                INDArray array = Nd4j.create(100 * i);
+                INDArray array = Nd4j.create(DataType.DOUBLE,100 * i);
             }
         }
 
         workspace.initializeWorkspace();
-        assertEquals(100 * 10 * Nd4j.sizeOfDataType(), workspace.getCurrentSize(),"Failed on final");
+        assertEquals(getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,100 * 10)), workspace.getCurrentSize(),"Failed on final");
     }
 
     @ParameterizedTest
@@ -567,11 +570,11 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         for (int i = 1; i <= 10; i++) {
             try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(reallocateDelayedConfiguration,
                     "WS_1")) {
-                INDArray array = Nd4j.create(100 * i);
+                INDArray array = Nd4j.create(DataType.DOUBLE,100 * i);
             }
 
             if (i >= 3)
-                assertEquals(100 * i * Nd4j.sizeOfDataType(), workspace.getCurrentSize(),"Failed on iteration " + i);
+                assertEquals(getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,100 * i)), workspace.getCurrentSize(),"Failed on iteration " + i);
             else
                 assertEquals(0, workspace.getCurrentSize());
         }
@@ -613,21 +616,21 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
                 .getWorkspaceForCurrentThread(reallocateConfiguration, "WS_1");
         workspace.initializeWorkspace();
 
-        assertEquals(100 * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        assertEquals(getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,100)), workspace.getCurrentSize());
 
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(reallocateConfiguration, "WS_1")) {
             INDArray array = Nd4j.create(DataType.DOUBLE,1000);
         }
 
-        assertEquals(1000 * Nd4j.sizeOfDataType(), workspace.getMaxCycleAllocations());
+        assertEquals(getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,1000)), workspace.getMaxCycleAllocations());
 
         workspace.initializeWorkspace();
 
-        assertEquals(1000 * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        assertEquals(getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,1000)), workspace.getCurrentSize());
 
         // now we're working on reallocated array, that should be able to hold >100 elements
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(reallocateConfiguration, "WS_1")) {
-            INDArray array = Nd4j.create(500).assign(1.0);
+            INDArray array = Nd4j.create(DataType.DOUBLE,500).assign(1.0);
 
             assertEquals(1.0, array.meanNumber().doubleValue(), 0.01);
         }
@@ -666,7 +669,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
                     INDArray array2 = Nd4j.create(100 * x);
                     try (MemoryWorkspace ws3 = Nd4j.getWorkspaceManager()
                             .getWorkspaceForCurrentThread(basicConfiguration, "WS_1").notifyScopeBorrowed()) {
-                        INDArray array3 = Nd4j.create(100 * x);
+                        INDArray array3 = Nd4j.create(DataType.DOUBLE,100 * x);
                     }
 
                 }
@@ -681,15 +684,16 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         for (int x = 1; x < 10; x++) {
             try (MemoryWorkspace ws =
                          Nd4j.getWorkspaceManager().getAndActivateWorkspace(delayedConfiguration, "WS_1")) {
-                INDArray array = Nd4j.create(100 * x);
+                INDArray array = Nd4j.create(DataType.DOUBLE,100 * x);
             }
         }
 
         Nd4jWorkspace workspace = (Nd4jWorkspace) Nd4j.getWorkspaceManager()
                 .getWorkspaceForCurrentThread(delayedConfiguration, "WS_1");
         workspace.initializeWorkspace();
+        INDArray array = Nd4j.create(DataType.DOUBLE,300);
 
-        assertEquals(300 * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        assertEquals(getTotalRequiredMemoryForWorkspace(array), workspace.getCurrentSize());
     }
 
 
@@ -697,7 +701,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testNestedWorkspaces8(Nd4jBackend backend) {
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(loopConfiguration, "WS_1")) {
-            INDArray array = Nd4j.create(100);
+            INDArray array = Nd4j.create(DataType.DOUBLE,100);
         }
 
 
@@ -706,15 +710,17 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
                 .getWorkspaceForCurrentThread(loopConfiguration, "WS_1");
         workspace.initializeWorkspace();
 
-        assertEquals(100 * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        INDArray array2 = Nd4j.create(DataType.DOUBLE,100);
+
+        assertEquals(getTotalRequiredMemoryForWorkspace(array2), workspace.getCurrentSize());
 
         try (MemoryWorkspace ws = Nd4j.getWorkspaceManager().getAndActivateWorkspace(loopConfiguration, "WS_1")) {
-            INDArray array = Nd4j.create(1000);
+            INDArray array = Nd4j.create(DataType.DOUBLE,1000);
         }
 
         Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(loopConfiguration, "WS_1").initializeWorkspace();
 
-        assertEquals(100 * Nd4j.sizeOfDataType(), workspace.getCurrentSize());
+        assertEquals(getTotalRequiredMemoryForWorkspace(array2), workspace.getCurrentSize());
     }
 
     @ParameterizedTest
@@ -764,7 +770,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
 
         try (Nd4jWorkspace wsExternal = (Nd4jWorkspace) Nd4j.getWorkspaceManager()
                 .getAndActivateWorkspace(firstConfiguration, "External")) {
-            INDArray array1 = Nd4j.create(10);
+            INDArray array1 = Nd4j.create(DataType.DOUBLE,10);
             INDArray array2 = null;
             INDArray array3 = null;
             INDArray array4 = null;
@@ -777,7 +783,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
 
                 try (Nd4jWorkspace borrowed = (Nd4jWorkspace) Nd4j.getWorkspaceManager()
                         .getWorkspaceForCurrentThread("External").notifyScopeBorrowed()) {
-                    array3 = Nd4j.create(10);
+                    array3 = Nd4j.create(DataType.DOUBLE,10);
 
                     assertTrue(wsExternal == array3.data().getParentWorkspace());
                 }
@@ -785,7 +791,7 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
                 assertEquals(true, array3.isAttached());
 
                 try (MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
-                    array4 = Nd4j.create(10);
+                    array4 = Nd4j.create(DataType.DOUBLE,10);
                 }
 
                 assertEquals(false, array4.isAttached());
@@ -804,19 +810,20 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         try (Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS1")
                 .notifyScopeEntered()) {
 
-            INDArray array1 = Nd4j.create(100);
+            INDArray array1 = Nd4j.create(DataType.DOUBLE,100);
             try (Nd4jWorkspace ws2 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS1")
                     .notifyScopeEntered()) {
 
-                INDArray array2 = Nd4j.create(100);
+                INDArray array2 = Nd4j.create(DataType.DOUBLE,100);
             }
 
-            long reqMem = 200 * Nd4j.sizeOfDataType();
-            assertEquals(reqMem + reqMem % 8, ws1.getPrimaryOffset());
+            INDArray array3 = Nd4j.create(DataType.DOUBLE,100);
 
-            INDArray array3 = Nd4j.create(100);
+            long reqMem = getTotalRequiredMemoryForWorkspace(array3) * 3;
+            assertEquals((int) (reqMem + reqMem % 8), ws1.getPrimaryOffset());
 
-            reqMem = 300 * Nd4j.sizeOfDataType();
+
+            reqMem = getTotalRequiredMemoryForWorkspace(array3) * 3;
             assertEquals(reqMem + reqMem % 8, ws1.getPrimaryOffset());
         }
 
@@ -831,29 +838,29 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         try (Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS1")
                 .notifyScopeEntered()) {
 
-            INDArray array1 = Nd4j.create(100);
+            INDArray array1 = Nd4j.create(DataType.DOUBLE,100);
 
             try (Nd4jWorkspace ws2 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2")
                     .notifyScopeEntered()) {
-                INDArray array2 = Nd4j.create(100);
+                INDArray array2 = Nd4j.create(DataType.DOUBLE,100);
 
                 try (Nd4jWorkspace ws3 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS3")
                         .notifyScopeEntered()) {
-                    INDArray array3 = Nd4j.create(100);
+                    INDArray array3 = Nd4j.create(DataType.DOUBLE,100);
 
-                    assertEquals(100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
-                    assertEquals(100 * Nd4j.sizeOfDataType(), ws2.getPrimaryOffset());
-                    assertEquals(100 * Nd4j.sizeOfDataType(), ws3.getPrimaryOffset());
+                    assertEquals(getTotalRequiredMemoryForWorkspace(array3), ws1.getPrimaryOffset());
+                    assertEquals(getTotalRequiredMemoryForWorkspace(array3), ws2.getPrimaryOffset());
+                    assertEquals(getTotalRequiredMemoryForWorkspace(array3), ws3.getPrimaryOffset());
                 }
 
-                INDArray array2b = Nd4j.create(100);
+                INDArray array2b = Nd4j.create(DataType.DOUBLE,100);
 
-                assertEquals(200 * Nd4j.sizeOfDataType(), ws2.getPrimaryOffset());
+                assertEquals(getTotalRequiredMemoryForWorkspace(array2b) * 2, ws2.getPrimaryOffset());
             }
 
-            INDArray array1b = Nd4j.create(100);
+            INDArray array1b = Nd4j.create(DataType.DOUBLE,100);
 
-            assertEquals(200 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
+            assertEquals(getTotalRequiredMemoryForWorkspace(array1b) * 2, ws1.getPrimaryOffset());
         }
 
         Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS1");
@@ -861,9 +868,9 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         Nd4jWorkspace ws3 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS3");
 
 
-        assertEquals(0 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
-        assertEquals(0 * Nd4j.sizeOfDataType(), ws2.getPrimaryOffset());
-        assertEquals(0 * Nd4j.sizeOfDataType(), ws3.getPrimaryOffset());
+        assertEquals(0 * DataType.DOUBLE.width(), ws1.getPrimaryOffset());
+        assertEquals(0 * DataType.DOUBLE.width(), ws2.getPrimaryOffset());
+        assertEquals(0 * DataType.DOUBLE.width(), ws3.getPrimaryOffset());
 
         assertNull(Nd4j.getMemoryManager().getCurrentWorkspace());
     }
@@ -878,36 +885,37 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         try (Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS1")
                 .notifyScopeEntered()) {
 
-            INDArray array1 = Nd4j.create(100);
+            INDArray array1 = Nd4j.create(DataType.DOUBLE,100);
 
-            assertEquals(100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
+            assertEquals(getTotalRequiredMemoryForWorkspace(array1), ws1.getPrimaryOffset());
 
             // we open first nested workspace
             try (Nd4jWorkspace ws2 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2")
                     .notifyScopeEntered()) {
-                assertEquals(0 * Nd4j.sizeOfDataType(), ws2.getPrimaryOffset());
+                assertEquals(0 * DataType.DOUBLE.width(), ws2.getPrimaryOffset());
 
-                INDArray array2 = Nd4j.create(100);
+                INDArray array2 = Nd4j.create(DataType.DOUBLE,100);
 
-                assertEquals(100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
-                assertEquals(100 * Nd4j.sizeOfDataType(), ws2.getPrimaryOffset());
+                assertEquals(getTotalRequiredMemoryForWorkspace(array2), ws1.getPrimaryOffset());
+                assertEquals(getTotalRequiredMemoryForWorkspace(array2), ws2.getPrimaryOffset());
             }
 
             // and second nexted workspace
             try (Nd4jWorkspace ws3 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS3")
                     .notifyScopeEntered()) {
-                assertEquals(0 * Nd4j.sizeOfDataType(), ws3.getPrimaryOffset());
+                assertEquals(0 * DataType.DOUBLE.width(), ws3.getPrimaryOffset());
 
-                INDArray array2 = Nd4j.create(100);
+                INDArray array2 = Nd4j.create(DataType.DOUBLE,100);
 
-                assertEquals(100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
-                assertEquals(100 * Nd4j.sizeOfDataType(), ws3.getPrimaryOffset());
+                assertEquals(getTotalRequiredMemoryForWorkspace(array2), ws1.getPrimaryOffset());
+                assertEquals(getTotalRequiredMemoryForWorkspace(array2), ws3.getPrimaryOffset());
             }
 
             // this allocation should happen within top-level workspace
-            INDArray array1b = Nd4j.create(100);
+            INDArray array1b = Nd4j.create(DataType.DOUBLE,100);
 
-            assertEquals(200 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
+            //we allocated 2 arrays + 2 shape buffers
+            assertEquals(getTotalRequiredMemoryForWorkspace(array1b) * 2, ws1.getPrimaryOffset());
         }
 
         assertEquals(null, Nd4j.getMemoryManager().getCurrentWorkspace());
@@ -923,23 +931,25 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         try (Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS1")
                 .notifyScopeEntered()) {
 
-            INDArray array1 = Nd4j.create(100).castTo(DataType.DOUBLE);
+            INDArray array1 = Nd4j.create(DataType.DOUBLE,100);
 
-            assertEquals(100 * DataType.DOUBLE.width(), ws1.getPrimaryOffset());
+
+            assertEquals(getTotalRequiredMemoryForWorkspace(array1), ws1.getPrimaryOffset());
 
             for (int x = 1; x <= 100; x++) {
                 try (Nd4jWorkspace ws2 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread(loopConfiguration, "WS2").notifyScopeEntered()) {
-                    INDArray array2 = Nd4j.create(x);
+                    INDArray array2 = Nd4j.create(DataType.DOUBLE,x);
                 }
 
                 Nd4jWorkspace ws2 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2");
-                long reqMemory = getAligned(x *  DataType.DOUBLE.width());
-                assertEquals(reqMemory + reqMemory % 16, ws2.getLastCycleAllocations());
+                long reqMemory = getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,x));
+                assertEquals((int) (reqMemory + reqMemory % 16), ws2.getLastCycleAllocations());
             }
 
             Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2").initializeWorkspace();
+            long reqMemory = getTotalRequiredMemoryForWorkspace(Nd4j.create(DataType.DOUBLE,100));
 
-            assertEquals(getAligned(100 * DataType.DOUBLE.width()), Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2").getCurrentSize());
+            assertEquals(reqMemory, Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2").getCurrentSize());
         }
 
         assertNull(Nd4j.getMemoryManager().getCurrentWorkspace());
@@ -954,18 +964,18 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         try (Nd4jWorkspace ws1 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS1")
                 .notifyScopeEntered()) {
 
-            INDArray array1 = Nd4j.create(100);
+            INDArray array1 = Nd4j.create(DataType.DOUBLE,100);
 
-            assertEquals(100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
+            assertEquals(getTotalRequiredMemoryForWorkspace(array1) , ws1.getPrimaryOffset());
 
             try (Nd4jWorkspace ws2 = (Nd4jWorkspace) Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread("WS2")
                     .notifyScopeEntered()) {
-                assertEquals(0 * Nd4j.sizeOfDataType(), ws2.getPrimaryOffset());
+                assertEquals(0 * DataType.DOUBLE.width(), ws2.getPrimaryOffset());
 
-                INDArray array2 = Nd4j.create(100);
+                INDArray array2 = Nd4j.create(DataType.DOUBLE,100);
 
-                assertEquals(100 * Nd4j.sizeOfDataType(), ws1.getPrimaryOffset());
-                assertEquals(100 * Nd4j.sizeOfDataType(), ws2.getPrimaryOffset());
+                assertEquals(getTotalRequiredMemoryForWorkspace(array2), ws1.getPrimaryOffset());
+                assertEquals(getTotalRequiredMemoryForWorkspace(array2), ws2.getPrimaryOffset());
             }
         }
 
@@ -974,6 +984,11 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         Nd4j.getWorkspaceManager().destroyAllWorkspacesForCurrentThread();
     }
 
+
+
+    public int getTotalRequiredMemoryForWorkspace(INDArray arr) {
+        return getAligned(arr.length() * arr.dataType().width()) + getAligned(arr.shapeInfoJava().length * DataType.INT64.width());
+    }
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testNewWorkspace1(Nd4jBackend backend) {
@@ -1047,6 +1062,11 @@ public class WorkspaceProviderTests extends BaseNd4jTestWithBackends {
         if (div != 0) requiredMemory += (Nd4jWorkspace.alignmentBase - div);
         return requiredMemory;
     }
+
+    public int getAligned(long requiredMemory) {
+        return  getAligned((int) requiredMemory);
+    }
+
 
     @Override
     public char ordering() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed shape info data buffer caching.
Shape info data buffer caching clashes with workspaces causing left over buffers to be collected.
This converts the shape info behavior to remove caching
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
