### PR TITLE
Add workspaces to skipgram/cbow

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/ElementsLearningAlgorithm.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/ElementsLearningAlgorithm.java
@@ -27,11 +27,27 @@ import org.deeplearning4j.models.sequencevectors.interfaces.SequenceIterator;
 import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.sequence.SequenceElement;
 import org.deeplearning4j.models.word2vec.wordstore.VocabCache;
+import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
+import org.nd4j.linalg.api.memory.enums.AllocationPolicy;
+import org.nd4j.linalg.api.memory.enums.LearningPolicy;
+import org.nd4j.linalg.api.memory.enums.ResetPolicy;
+import org.nd4j.linalg.api.memory.enums.SpillPolicy;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 public interface ElementsLearningAlgorithm<T extends SequenceElement> {
+    default WorkspaceConfiguration workspaceConfig() {
+       return  WorkspaceConfiguration.builder()
+                .initialSize(0)
+                .overallocationLimit(0.02)
+                .policyLearning(LearningPolicy.OVER_TIME)
+                .cyclesBeforeInitialization(2)
+                .policyReset(ResetPolicy.BLOCK_LEFT)
+                .policySpill(SpillPolicy.REALLOCATE)
+                .policyAllocation(AllocationPolicy.OVERALLOCATE)
+                .build();
+    }
 
     String getCodeName();
 

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -263,9 +263,7 @@ NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const ShapeDescriptor &desc
                  const sd::LongType offset) {
   _context = context;
   _offset = offset;
-
   setShapeInfo(descriptor);
-
   _buffer = buffer;
 
   _isView = offset > 0 || _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();

--- a/libnd4j/include/graph/impl/Context.cpp
+++ b/libnd4j/include/graph/impl/Context.cpp
@@ -384,14 +384,14 @@ void Context::setInputArray(int index, void *vdatabuffer, void const *shapeInfo,
   if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
 
   NDArray *array;
-  if (dataBuffer != nullptr)
+  if (dataBuffer != nullptr) {
     array = new NDArray(dataBuffer->dataBuffer(), reinterpret_cast<sd::LongType const *>(shapeInfo),
                         sd::LaunchContext::defaultContext(),
                         dataBuffer->offset() / DataTypeUtils::sizeOf(ArrayOptions::dataType(
                                                    reinterpret_cast<sd::LongType const *>(shapeInfo))));
-  else
+  } else {
     array = new NDArray(nullptr, nullptr, reinterpret_cast<sd::LongType const *>(shapeInfo));
-
+  }
   _fastpath_in[index] = array;
   _handles.emplace_back(array);
 

--- a/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
@@ -829,13 +829,14 @@ void NativeOpExecutioner::execScalar(sd::LaunchContext *lc, int opNum, const voi
   auto xType = sd::ArrayOptions::dataType(hXShapeInfo);
   auto yType = sd::ArrayOptions::dataType(hScalarShapeInfo);
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
-
   if (shape::isEmpty(hXShapeInfo) || shape::isEmpty(hScalarShapeInfo)) return;
 
 #ifdef SD_EXPERIMENTAL_ENABLED
   BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform,
                           ::transform(opNum, hX, hXShapeInfo, hZ, hZShapeInfo, hScalar, extraParams), SD_COMMON_TYPES,
                           SD_COMMON_TYPES_ALL);
+  sd_printf("execScalar: RAfter unning experimental transform\n",0);
+
 #else
   if (xType != yType || xType != zType)
     throw sd::datatype_exception::build("NativeOpExecutioner::execScalar", zType, xType, yType);
@@ -853,6 +854,7 @@ void NativeOpExecutioner::execScalar(sd::LaunchContext *lc, int opNum, const voi
           ? 1
           : sd::math::sd_max<int>(
                 1, sd::math::sd_min<int>(zLen / 1024, sd::Environment::getInstance().maxMasterThreads())));
+
 
 #endif
 }
@@ -1233,10 +1235,8 @@ void NativeOpExecutioner::execRandom(sd::LaunchContext *lc, int opNum, sd::Point
                                      const sd::LongType *hZShapeInfo, void *dZ, const sd::LongType *dZShapeInfo,
                                      void *extraArguments) {
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
-
   BUILD_SINGLE_SELECTOR(zType, functions::random::RandomFunction,
                         ::execTransform(opNum, state, hZ, hZShapeInfo, extraArguments), SD_FLOAT_TYPES);
-
   auto rng = reinterpret_cast<sd::graph::RandomGenerator *>(state);
   rng->rewindH(shape::length(hZShapeInfo));
 }

--- a/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
@@ -835,7 +835,6 @@ void NativeOpExecutioner::execScalar(sd::LaunchContext *lc, int opNum, const voi
   BUILD_PAIRWISE_SELECTOR(xType, yType, zType, functions::scalar::ScalarTransform,
                           ::transform(opNum, hX, hXShapeInfo, hZ, hZShapeInfo, hScalar, extraParams), SD_COMMON_TYPES,
                           SD_COMMON_TYPES_ALL);
-  sd_printf("execScalar: RAfter unning experimental transform\n",0);
 
 #else
   if (xType != yType || xType != zType)

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -290,8 +290,8 @@ void  setGraphContextInputBuffers(OpaqueContext* ptr, int numArrays, OpaqueDataB
   for(int i = 0; i < numArrays; i++) {
   if(inputShapeBuffers[i] == nullptr)
     throw std::runtime_error("Input shape at index was null!");
-
     setGraphContextInputBuffer(ptr,i,buffer != nullptr  && buffer[i] != nullptr ? buffer[i] : nullptr,inputShapeBuffers[i],specialShapeInfo != nullptr ? specialShapeInfo[i] : nullptr);
+
   }
 
 }
@@ -1853,7 +1853,6 @@ int calculateOutputShapesAndFill(sd::graph::Context *ctx, sd::LongType hash, voi
   }
 
   if (*handleState != nullptr) {
-    // sd_printf("%s\n","handle");
     sHandle = reinterpret_cast<ShapeFillerHandle *>(*handleState);
     shapeList = sHandle->shapeList;
   } else {
@@ -2640,6 +2639,8 @@ void setGraphContextOutputArray(sd::graph::Context *ptr, int index, void *buffer
 
 void setGraphContextInputBuffer(OpaqueContext *ptr, int index, OpaqueDataBuffer *buffer, void *shapeInfo,
                                 void *specialShapeInfo) {
+  if(ptr == nullptr)
+    throw std::runtime_error("Context pointer is null!");
   ptr->setInputArray(index, buffer, shapeInfo, specialShapeInfo);
 }
 

--- a/libnd4j/include/legacy/impl/Environment.cpp
+++ b/libnd4j/include/legacy/impl/Environment.cpp
@@ -257,9 +257,8 @@ int Environment::maxThreads() { return _maxThreads.load(); }
 int Environment::maxMasterThreads() { return _maxMasterThreads.load(); }
 
 void Environment::setMaxThreads(int max) {
-  // FIXME: not possible at this moment, since maxThreads is limited by number of threads in pool. however we can
-  // allocate more threads if we want
-  //_maxThreads.store(max);
+  // allocate more threads if we want or limit number of threads
+  _maxThreads.store(max);
 }
 
 void Environment::setMaxMasterThreads(int max) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/AllocationsTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/AllocationsTracker.java
@@ -84,6 +84,12 @@ public class AllocationsTracker {
     }
 
 
+    /**
+     * Print on/off heap memory information.
+     * This information is a mix of what's available from
+     * the {@link Pointer} and heap information from {@link Runtime}
+     * @return
+     */
     public String memoryPerDevice() {
         StringBuilder stringBuilder = new StringBuilder();
         if(devices.isEmpty()) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/AllocationsTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/AllocationsTracker.java
@@ -121,7 +121,7 @@ public class AllocationsTracker {
 
             Arrays.stream(MemoryKind.values()).forEach(memoryKind -> {
                 if(workspaceAllocationsTracker1.currentBytes(memoryKind) > 0) {
-                    stringBuilder.append("Memory kind: " + workspaceAllocationsTracker1.currentBytes(memoryKind) + "\n");
+                    stringBuilder.append("Memory kind: " + memoryKind + " " + workspaceAllocationsTracker1.currentBytes(memoryKind) + "\n");
                 }
             });
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/AllocationsTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/AllocationsTracker.java
@@ -22,6 +22,7 @@ package org.nd4j.linalg.api.memory;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.bytedeco.javacpp.Pointer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.enums.AllocationKind;
 import org.nd4j.linalg.api.memory.enums.MemoryKind;
@@ -98,6 +99,17 @@ public class AllocationsTracker {
         });
 
         return stringBuilder.toString();
+    }
+
+    public String memoryInfo() {
+        StringBuilder ret = new StringBuilder();
+        ret.append("Javacpp pointer max bytes: " + Pointer.maxBytes() + "\n");
+        ret.append("Javacpp pointer max physical bytes: " + Pointer.maxPhysicalBytes() + "\n");
+        ret.append("Javacpp available physical bytes: " + Pointer.availablePhysicalBytes() + "\n");
+        ret.append("Javacpp max physical bytes " + Pointer.maxPhysicalBytes() + "\n");
+        ret.append("Java free memory: " + Runtime.getRuntime().freeMemory() + "\n");
+        ret.append("Java max memory: " + Runtime.getRuntime().maxMemory() + "\n");
+        return ret.toString();
     }
 
     /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/DeviceAllocationsTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/DeviceAllocationsTracker.java
@@ -20,6 +20,7 @@
 
 package org.nd4j.linalg.api.memory;
 
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -31,6 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 public class DeviceAllocationsTracker {
+    @Getter
     private Map<AllocationKind, AtomicLong> bytesMap = new HashMap<>();
 
     public DeviceAllocationsTracker() {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/MemoryWorkspace.java
@@ -186,7 +186,7 @@ public interface MemoryWorkspace extends AutoCloseable, Deallocatable {
     long getMaxCycleAllocations();
 
     /**
-     * This methos returns current allocated size of this workspace
+     * This method returns current allocated size of this workspace
      *
      * @return
      */

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/WorkspaceAllocationsTracker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/WorkspaceAllocationsTracker.java
@@ -1,0 +1,79 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.linalg.api.memory;
+
+import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.memory.enums.MemoryKind;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class WorkspaceAllocationsTracker {
+
+    private Map<MemoryKind,AtomicLong> bytesTracked = new HashMap<>();
+    private Map<DataType,AtomicLong> dataTypeCounts = new HashMap<>();
+
+    public WorkspaceAllocationsTracker() {
+        Arrays.stream(DataType.values()).forEach(dataType -> {
+            dataTypeCounts.put(dataType,new AtomicLong(0));
+        });
+
+        Arrays.stream(MemoryKind.values()).forEach(memoryKind -> {
+            bytesTracked.put(memoryKind,new AtomicLong(0));
+        });
+
+    }
+
+
+
+    public long currentBytes(MemoryKind memoryKind) {
+        return bytesTracked.get(memoryKind).get();
+    }
+
+    public long currentDataTypeCount(DataType toCount) {
+        return dataTypeCounts.get(toCount).get();
+    }
+
+
+    /**
+     * Allocate bytes in the workspace tracking
+     * @param dataType the data type to add
+     * @param memoryKind  the kind of memory to add allocation for
+     * @param bytes the bytes to add to the workspace
+     */
+    public void allocate(DataType dataType, MemoryKind memoryKind, long bytes) {
+        dataTypeCounts.get(dataType).incrementAndGet();
+        bytesTracked.get(memoryKind).addAndGet(bytes);
+    }
+
+    /**
+     * DeAllocate bytes in the workspace tracking
+     * @param dataType the data type to add
+     * @param memoryKind the kind of memory to de allocate
+     * @param bytes the bytes to add to the workspace
+     */
+    public void deAllocate(DataType dataType,MemoryKind memoryKind,long bytes) {
+        dataTypeCounts.get(dataType).incrementAndGet();
+        bytesTracked.get(memoryKind).addAndGet(-bytes);
+    }
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseScalarOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseScalarOp.java
@@ -50,9 +50,8 @@ public abstract class BaseScalarOp extends BaseOp implements ScalarOp {
         if (x.isCompressed())
             Nd4j.getCompressor().decompressi(x);
 
-        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
-            this.scalarValue = Nd4j.scalar(x.dataType(), num);
-        }
+        this.scalarValue = Nd4j.scalar(x.dataType(), num);
+
     }
 
     public BaseScalarOp(INDArray x, Number num) {
@@ -60,9 +59,8 @@ public abstract class BaseScalarOp extends BaseOp implements ScalarOp {
         if (x.isCompressed())
             Nd4j.getCompressor().decompressi(x);
 
-        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
-            this.scalarValue = Nd4j.scalar(x.dataType(), num);
-        }
+        this.scalarValue = Nd4j.scalar(x.dataType(), num);
+
 
     }
     public BaseScalarOp(INDArray x, INDArray z, Number set) {
@@ -70,9 +68,8 @@ public abstract class BaseScalarOp extends BaseOp implements ScalarOp {
         if (x.isCompressed())
             Nd4j.getCompressor().decompressi(x);
 
-        try(MemoryWorkspace ws = Nd4j.getMemoryManager().scopeOutOfWorkspaces()) {
-            this.scalarValue = Nd4j.scalar(x.dataType(), set);
-        }
+        this.scalarValue = Nd4j.scalar(x.dataType(), set);
+
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -26,6 +26,7 @@ import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMax;
 import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMin;
 import org.nd4j.common.config.ND4JClassLoading;
 import org.nd4j.linalg.factory.ops.*;
+import org.nd4j.linalg.profiler.UnifiedProfiler;
 import org.nd4j.shade.guava.primitives.Ints;
 import org.nd4j.shade.guava.primitives.Longs;
 import lombok.NonNull;
@@ -5324,6 +5325,16 @@ public class Nd4j {
      */
     public static MemoryManager getMemoryManager() {
         return memoryManager;
+    }
+
+
+    /**
+     * Returns the {@link UnifiedProfiler}
+     * containing methods for both op execution and memory.
+     * @return
+     */
+    public static UnifiedProfiler getProfiler() {
+        return UnifiedProfiler.getInstance();
     }
 
     /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/RandomFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/RandomFactory.java
@@ -57,7 +57,7 @@ public class RandomFactory {
     }
 
     /**
-     * This method returns new onject implementing Random interface, initialized with System.currentTimeMillis() as seed
+     * This method returns new object implementing Random interface, initialized with System.currentTimeMillis() as seed
      *
      * @return object implementing Random interface
      */
@@ -67,7 +67,7 @@ public class RandomFactory {
 
 
     /**
-     * This method returns new onject implementing Random interface, initialized with seed value
+     * This method returns new object implementing Random interface, initialized with seed value
      *
      * @param seed seed for this rng object
      * @return object implementing Random interface

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/OpProfiler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/OpProfiler.java
@@ -305,10 +305,6 @@ public class OpProfiler {
 
         updatePairs(op.opName(), opClass);
 
-        // TODO: to be implemented
-        //for (OpProfilerListener listener : listeners) {
-        //  listener.invoke(op);
-        //}
     }
 
     /**
@@ -322,15 +318,15 @@ public class OpProfiler {
         PenaltyCause[] causes = processTADOperands(tadBuffers);
         for (PenaltyCause cause : causes) {
             switch (cause) {
-               case TAD_NON_EWS_ACCESS:
-                  tadNonEwsAggregator.incrementCount();
-                   break;
-               case TAD_STRIDED_ACCESS:
-                  tadStridedAggregator.incrementCount();
-                  break;
-               case NONE:
-               default:
-                   break;
+                case TAD_NON_EWS_ACCESS:
+                    tadNonEwsAggregator.incrementCount();
+                    break;
+                case TAD_STRIDED_ACCESS:
+                    tadStridedAggregator.incrementCount();
+                    break;
+                case NONE:
+                default:
+                    break;
             }
         }
     }
@@ -409,75 +405,61 @@ public class OpProfiler {
      * This method prints out dashboard state
      */
     public void printOutDashboard() {
-        log.info("---Total Op Calls: {}", invocationsCount.get());
-        System.out.println();
-        log.info("--- OpClass calls statistics: ---");
-        System.out.println(classCounter.asString());
-        System.out.println();
-        log.info("--- OpClass pairs statistics: ---");
-        System.out.println(classPairsCounter.asString());
-        System.out.println();
-        log.info("--- Individual Op calls statistics: ---");
-        System.out.println(opCounter.asString());
-        System.out.println();
-        log.info("--- Matching Op calls statistics: ---");
-        System.out.println(matchingCounter.asString());
-        System.out.println();
-        log.info("--- Matching detailed Op calls statistics: ---");
-        System.out.println(matchingCounterDetailed.asString());
-        System.out.println();
-        log.info("--- Matching inverts Op calls statistics: ---");
-        System.out.println(matchingCounterInverted.asString());
-        System.out.println();
-        log.info("--- Time for OpClass calls statistics: ---");
-        System.out.println(classAggergator.asString());
-        System.out.println();
-        log.info("--- Time for long Op calls statistics: ---");
-        System.out.println(longAggergator.asString());
-        System.out.println();
-        log.info("--- Time spent for Op calls statistics: ---");
-        System.out.println(classAggergator.asPercentageString());
-        System.out.println();
-        log.info("--- Time spent for long Op calls statistics: ---");
-        System.out.println(longAggergator.asPercentageString());
-        System.out.println();
-        log.info("--- Time spent within methods: ---");
-        methodsAggregator.renderTree(true);
-        System.out.println();
-        log.info("--- Bad strides stack tree: ---");
-        System.out.println("Unique entries: " + stridedAggregator.getUniqueBranchesNumber());
-        stridedAggregator.renderTree();
-        System.out.println();
-        log.info("--- non-EWS access stack tree: ---");
-        System.out.println("Unique entries: " + nonEwsAggregator.getUniqueBranchesNumber());
-        nonEwsAggregator.renderTree();
-        System.out.println();
-        log.info("--- Mixed orders access stack tree: ---");
-        System.out.println("Unique entries: " + mixedOrderAggregator.getUniqueBranchesNumber());
-        mixedOrderAggregator.renderTree();
-        System.out.println();
-        log.info("--- TAD bad strides stack tree: ---");
-        System.out.println("Unique entries: " + tadStridedAggregator.getUniqueBranchesNumber());
-        tadStridedAggregator.renderTree();
-        System.out.println();
-        log.info("--- TAD non-EWS access stack tree: ---");
-        System.out.println("Unique entries: " + tadNonEwsAggregator.getUniqueBranchesNumber());
-        tadNonEwsAggregator.renderTree();
-        System.out.println();
-        log.info("--- Scalar access stack tree: ---");
-        System.out.println("Unique entries: " + scalarAggregator.getUniqueBranchesNumber());
-        scalarAggregator.renderTree(false);
-        System.out.println();
-        log.info("--- Blas GEMM odrders count: ---");
-        System.out.println(blasOrderCounter.asString());
-        System.out.println();
-        log.info("--- BLAS access stack trace: ---");
-        System.out.println("Unique entries: " + blasAggregator.getUniqueBranchesNumber());
-        blasAggregator.renderTree(false);
-        System.out.println();
-
+        log.info(statsAsString());
     }
 
+
+
+    public String statsAsString() {
+        StringBuffer stringBuffer = new StringBuffer();
+        stringBuffer.append("---Total Op Calls: +  invocationsCount.get()\n");
+        stringBuffer.append("--- OpClass calls statistics: ---\n");
+        stringBuffer.append(classCounter.asString() + "\n");
+        stringBuffer.append("--- OpClass pairs statistics: ---");
+        stringBuffer.append(classPairsCounter.asString() + "\n");
+        stringBuffer.append("--- Individual Op calls statistics: ---\n");
+        stringBuffer.append(opCounter.asString() + "\n");
+        stringBuffer.append("--- Matching Op calls statistics: ---");
+        stringBuffer.append(matchingCounter.asString() + "\n");
+        stringBuffer.append("--- Matching detailed Op calls statistics: ---\n");
+        stringBuffer.append(matchingCounterDetailed.asString() + "\n");
+        stringBuffer.append("--- Matching inverts Op calls statistics: ---\n");
+        stringBuffer.append(matchingCounterInverted.asString()  + "\n");
+        stringBuffer.append("--- Time for OpClass calls statistics: ---\n");
+        stringBuffer.append(classAggergator.asString() + "\n");
+        stringBuffer.append("--- Time for long Op calls statistics: ---\n");
+        stringBuffer.append(longAggergator.asString() + "\n");
+        stringBuffer.append("--- Time spent for Op calls statistics: ---\n");
+        stringBuffer.append(classAggergator.asPercentageString() + "\n");
+        stringBuffer.append("--- Time spent for long Op calls statistics: ---\n");
+        stringBuffer.append(longAggergator.asPercentageString() + "\n");
+        stringBuffer.append("--- Time spent within methods: ---\n");
+        stringBuffer.append(methodsAggregator.renderTree(true) + "\n");
+        stringBuffer.append("--- Bad strides stack tree: ---\n");
+        stringBuffer.append("Unique entries: " + stridedAggregator.getUniqueBranchesNumber() + "\n");
+        stringBuffer.append(stridedAggregator.renderTree());
+        stringBuffer.append("--- non-EWS access stack tree: ---\n");
+        stringBuffer.append("Unique entries: " + nonEwsAggregator.getUniqueBranchesNumber() + "\n");
+        stringBuffer.append(nonEwsAggregator.renderTree());
+        stringBuffer.append("--- Mixed orders access stack tree: ---\n");
+        stringBuffer.append("Unique entries: " + mixedOrderAggregator.getUniqueBranchesNumber() + "\n");
+        stringBuffer.append(mixedOrderAggregator.renderTree());
+        stringBuffer.append("--- TAD bad strides stack tree: ---\n");
+        stringBuffer.append("Unique entries: " + tadStridedAggregator.getUniqueBranchesNumber() + "\n");
+        stringBuffer.append(tadStridedAggregator.renderTree());
+        stringBuffer.append("--- TAD non-EWS access stack tree: ---");
+        stringBuffer.append("Unique entries: " + tadNonEwsAggregator.getUniqueBranchesNumber());
+        stringBuffer.append(tadNonEwsAggregator.renderTree());
+        stringBuffer.append("--- Scalar access stack tree: ---\n");
+        stringBuffer.append("Unique entries: " + scalarAggregator.getUniqueBranchesNumber() + "\n");
+        stringBuffer.append(scalarAggregator.renderTree(false));
+        stringBuffer.append("--- Blas GEMM odrders count: ---\n");
+        stringBuffer.append(blasOrderCounter.asString() + "\n");
+        stringBuffer.append("--- BLAS access stack trace: ---\n");
+        stringBuffer.append("Unique entries: " + blasAggregator.getUniqueBranchesNumber() + "\n");
+        stringBuffer.append(blasAggregator.renderTree(false) + "\n");
+        return stringBuffer.toString();
+    }
 
 
     public long getInvocationsCount() {
@@ -553,7 +535,7 @@ public class OpProfiler {
                     case NONE: {
                         blasAggregator.incrementCount();
                     }
-                        break;
+                    break;
                     case MIXED_ORDER: // we wo nothing for gemm in this case
                     default:
                         break;
@@ -626,7 +608,7 @@ public class OpProfiler {
             int ews = tadBuffer.getInt(length - 2);
 
             if ((ews < 1 || rank > 2 || (rank == 2 && tadBuffer.getInt(1) > 1 && tadBuffer.getInt(2) > 1))
-                            && !causes.contains(PenaltyCause.TAD_NON_EWS_ACCESS))
+                    && !causes.contains(PenaltyCause.TAD_NON_EWS_ACCESS))
                 causes.add(PenaltyCause.TAD_NON_EWS_ACCESS);
             else if (ews > 1 && !causes.contains(PenaltyCause.TAD_STRIDED_ACCESS))
                 causes.add(PenaltyCause.TAD_STRIDED_ACCESS);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
@@ -1,0 +1,139 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.linalg.profiler;
+
+import org.nd4j.linalg.api.memory.AllocationsTracker;
+import org.nd4j.linalg.api.memory.enums.AllocationKind;
+import org.nd4j.linalg.api.ndarray.INDArrayStatistics;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.List;
+
+/**
+ * A unified profiler covering both memory and op execution timing.
+ * This provides a single entry point in to profiling anything about running nd4j calculations
+ *
+ * @author Adam Gibson
+ */
+public class UnifiedProfiler {
+
+
+    private static final UnifiedProfiler INSTANCE = new UnifiedProfiler();
+
+    protected UnifiedProfiler() {
+
+    }
+
+
+
+    public List<String> currentWorkspacesForThread() {
+        return Nd4j.getWorkspaceManager().getAllWorkspacesIdsForCurrentThread();
+    }
+
+    public long executionTimeForOp(String opName) {
+        return OpProfiler.getInstance().getOpCounter().getCount(opName);
+    }
+
+    public void start() {
+        ProfilerConfig profilerConfig = ProfilerConfig.builder()
+                .nativeStatistics(true)
+                .checkForINF(true)
+                .checkForNAN(true)
+                .checkElapsedTime(true)
+                .checkWorkspaces(true)
+                .checkLocality(true)
+                .build();
+        Nd4j.getExecutioner().setProfilingConfig(profilerConfig);
+        OpProfiler.getInstance().setConfig(profilerConfig);
+
+    }
+
+    public void stop() {
+        ProfilerConfig profilerConfig = ProfilerConfig.builder()
+                .nativeStatistics(false)
+                .checkForINF(false)
+                .checkForNAN(false)
+                .checkElapsedTime(false)
+                .checkWorkspaces(false)
+                .checkLocality(false)
+                .build();
+        Nd4j.getExecutioner().setProfilingConfig(profilerConfig);
+        OpProfiler.getInstance().setConfig(profilerConfig);
+
+    }
+
+
+    /**
+     * Prints full current state including workspace info,
+     * memory stats, op execution status
+     * @return
+     */
+    public String printCurrentStats() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(workspaceInfo());
+        stringBuilder.append(memoryStats());
+        stringBuilder.append(executionStats());
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Workspace allocation information
+     * @return
+     */
+    public String workspaceInfo() {
+        return AllocationsTracker.getInstance().memoryPerWorkspace();
+    }
+
+    /**
+     * Op execution information
+     * @return
+     */
+    public String executionStats() {
+        return OpProfiler.getInstance().statsAsString();
+    }
+
+    /**
+     * Memory stats per device
+     * @return
+     */
+    public String memoryStats() {
+        return AllocationsTracker.getInstance().memoryPerDevice();
+    }
+
+
+    public static UnifiedProfiler getInstance() {
+        return INSTANCE;
+    }
+
+
+    public static INDArrayStatistics statistics() {
+        return OpProfiler.getInstance().getStatistics();
+    }
+
+    public long getBytesForAllocationKind(AllocationKind allocationKind,int deviceId) {
+        return AllocationsTracker.getInstance().bytesOnDevice(allocationKind,deviceId);
+    }
+
+    public long getBytesAllocatedForDevice(int deviceId) {
+        return AllocationsTracker.getInstance().bytesOnDevice(deviceId);
+    }
+
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
@@ -90,6 +90,7 @@ public class UnifiedProfiler {
         stringBuilder.append(workspaceInfo());
         stringBuilder.append(memoryStats());
         stringBuilder.append(executionStats());
+        stringBuilder.append(AllocationsTracker.getInstance().memoryInfo());
         return stringBuilder.toString();
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/StackAggregator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/StackAggregator.java
@@ -30,12 +30,12 @@ public class StackAggregator {
         // nothing to do here so far
     }
 
-    public void renderTree() {
-        tree.renderTree(false);
+    public String renderTree() {
+        return tree.renderTree(false);
     }
 
-    public void renderTree(boolean displayCounts) {
-        tree.renderTree(displayCounts);
+    public String renderTree(boolean displayCounts) {
+        return tree.renderTree(displayCounts);
     }
 
     public void reset() {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/StringAggregator.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/StringAggregator.java
@@ -43,12 +43,10 @@ public class StringAggregator {
 
     public void reset() {
         for (String key : times.keySet()) {
-            //            times.remove(key);
             times.put(key, new TimeSet());
         }
 
         for (String key : longCalls.keySet()) {
-            //          longCalls.remove(key);
             longCalls.put(key, new ComparableAtomicLong(0));
         }
     }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuMemoryManager.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/CpuMemoryManager.java
@@ -50,7 +50,6 @@ public class CpuMemoryManager extends BasicMemoryManager {
         if (ptr == null || ptr.address() == 0L)
             throw new OutOfMemoryError("Failed to allocate [" + bytes + "] bytes");
 
-        //log.info("Allocating {} bytes at MemoryManager", bytes);
 
         if (initialize)
             Pointer.memset(ptr, 0, bytes);

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
@@ -37,9 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 public class DirectShapeInfoProvider extends BaseShapeInfoProvider {
-    // TODO: to be removed
-    private Map<ShapeDescriptor, Pair<DataBuffer, long[]>> shapeCache = new ConcurrentHashMap<>();
-
     private Map<LongShapeDescriptor, Pair<DataBuffer, long[]>> longCache = new ConcurrentHashMap<>();
     private AtomicInteger counter = new AtomicInteger(0);
     private static final int MAX_ENTRIES = 1000;
@@ -82,6 +79,5 @@ public class DirectShapeInfoProvider extends BaseShapeInfoProvider {
 
     @Override
     public void purgeCache() {
-        shapeCache = new ConcurrentHashMap<>();
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspace.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspace.java
@@ -168,7 +168,6 @@ public class CpuWorkspace extends Nd4jWorkspace implements Deallocatable {
         if (workspaceConfiguration.getPolicyLocation() == LocationPolicy.RAM) {
             if (workspace.getHostPointer() != null) {
                 NativeOpsHolder.getInstance().getDeviceNativeOps().freeHost(workspace.getHostPointer());
-
                 AllocationsTracker.getInstance().markReleased(AllocationKind.WORKSPACE, 0, sizez);
             }
         } else if (workspaceConfiguration.getPolicyLocation() == LocationPolicy.MMAP) {

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/workspace/CudaWorkspace.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/workspace/CudaWorkspace.java
@@ -275,14 +275,11 @@ public class CudaWorkspace extends Nd4jWorkspace {
                     return alloc(requiredMemory, kind, type, initialize);
                 }
 
-                val shape = new AllocationShape(requiredMemory / Nd4j.sizeOfDataType(type), Nd4j.sizeOfDataType(type), type);
 
                 switch (workspaceConfiguration.getPolicySpill()) {
                     case REALLOCATE:
                     case EXTERNAL:
                         if (!trimmer) {
-                            //memoryManager.allocate(requiredMemory, MemoryKind.HOST, true)
-                            //AtomicAllocator.getInstance().getMemoryHandler().getMemoryProvider().malloc(shape, null, AllocationStatus.DEVICE).getDevicePointer()
                             PagedPointer pointer = new PagedPointer(memoryManager.allocate(requiredMemory, MemoryKind.HOST, initialize), numElements);
 
                             externalAllocations.add(new PointersPair(pointer, null));
@@ -303,7 +300,6 @@ public class CudaWorkspace extends Nd4jWorkspace {
             }
         } else throw new ND4JIllegalStateException("Unknown MemoryKind was passed in: " + kind);
 
-        //throw new ND4JIllegalStateException("Shouldn't ever reach this line");
     }
 
     @Override
@@ -390,24 +386,6 @@ public class CudaWorkspace extends Nd4jWorkspace {
 
     @Override
     protected void resetWorkspace() {
-        if (currentSize.get() < 1)
-            return;
-
-
-/*
-        if (Nd4j.getExecutioner() instanceof GridExecutioner)
-            ((GridExecutioner) Nd4j.getExecutioner()).flushQueueBlocking();
-
-        CudaContext context = (CudaContext) AtomicAllocator.getInstance().getDeviceContext().getContext();
-
-        //log.info("workspace: {}, size: {}", workspace.getDevicePointer().address(), currentSize.get());
-
-        NativeOpsHolder.getInstance().getDeviceNativeOps().memsetAsync(workspace.getDevicePointer(), 0, currentSize.get() + SAFETY_OFFSET, 0, context.getSpecialStream());
-
-        Pointer.memset(workspace.getHostPointer(), 0, currentSize.get() + SAFETY_OFFSET);
-
-        context.getSpecialStream().synchronize();
-        */
     }
 
     protected PointersPair workspace() {

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/UnifiedProfilerTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/UnifiedProfilerTests.java
@@ -1,0 +1,84 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.eclipse.deeplearning4j.nd4j.autodiff.samediff;
+
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.datasets.iterator.RandomDataSetIterator;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.nd4j.autodiff.samediff.SDVariable;
+import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.autodiff.samediff.TrainingConfig;
+import org.nd4j.common.tests.tags.NativeTag;
+import org.nd4j.common.tests.tags.TagNames;
+import org.nd4j.linalg.BaseNd4jTestWithBackends;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.factory.Nd4jBackend;
+import org.nd4j.linalg.learning.config.Adam;
+import org.nd4j.linalg.profiler.UnifiedProfiler;
+import org.nd4j.weightinit.impl.XavierInitScheme;
+import org.nd4j.weightinit.impl.ZeroInitScheme;
+
+import static org.deeplearning4j.datasets.iterator.RandomDataSetIterator.Values.INTEGER_0_10;
+import static org.nd4j.linalg.api.buffer.DataType.FLOAT;
+
+@Slf4j
+@NativeTag
+@Tag(TagNames.TRAINING)
+@Tag(TagNames.SAMEDIFF)
+public class UnifiedProfilerTests extends BaseNd4jTestWithBackends {
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testProfiler(Nd4jBackend backend) {
+        Nd4j.getProfiler().start();
+        System.out.println(Nd4j.getProfiler().printCurrentStats());
+        int batchSize = 4;
+        int modelDim = 8;
+
+        SameDiff sd = SameDiff.create();
+
+        SDVariable features = sd.placeHolder("features", FLOAT, batchSize, modelDim);
+        SDVariable labels = sd.placeHolder("labels", FLOAT, batchSize, modelDim);
+        SDVariable weights = sd.var("weights", new XavierInitScheme('c', modelDim, modelDim), FLOAT, modelDim, modelDim);
+        SDVariable bias = sd.var("bias", new ZeroInitScheme('c'), FLOAT, modelDim);
+        SDVariable predictions = sd.nn.linear("predictions", features, weights, bias);
+        SDVariable loss = sd.loss.meanSquaredError("loss", labels, predictions, null);
+        loss.markAsLoss();
+        TrainingConfig config = new TrainingConfig.Builder()
+                .updater(new Adam(0.1))
+                .dataSetFeatureMapping("features")
+                .dataSetLabelMapping("labels")
+                .build();
+        sd.setTrainingConfig(config);
+
+        DataSetIterator iterator = new RandomDataSetIterator(1, new long[]{batchSize, modelDim}, new long[]{batchSize, modelDim}, INTEGER_0_10, INTEGER_0_10);
+
+        sd.fit(iterator, 10);
+
+        System.out.println(Nd4j.getProfiler().printCurrentStats());
+
+
+        Nd4j.getProfiler().stop();
+
+    }
+
+}


### PR DESCRIPTION
Add new unified profiler for reporting op execution and memory
Add new workspace reporting to allocations tracker
 Remove extra workspace declaration for scalar value, allow it to fall within current workspace Allow stack aggregators to return strings from their renderTree calls for printing
 Migrate printing of op profiler op dashboard to a string we can print wherever we want 
Misc code clean up (delete commented code etc)
Spacing

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
