### PR TITLE
Add  better numpy i/o Fixes #9891

### DIFF
--- a/libnd4j/CMakePresets.json
+++ b/libnd4j/CMakePresets.json
@@ -5,7 +5,6 @@
             "name": "base_cpu",
             "displayName": "Configure preset for the base",
             "description": "Sets generator, build and install directory",
-            "hidden": true,
             "generator": "Unix Makefiles",
             "binaryDir": "${sourceDir}/blasbuild/cpu",
             "cacheVariables": {
@@ -34,6 +33,7 @@
                 "COMPUTE": "auto"
             }
         },
+
         {
             "name": "veda_vednn_base",
             "displayName": "Configure preset for the Veda and Vednn",
@@ -98,6 +98,13 @@
         }
     ],
     "buildPresets": [
+        {
+            "name": "cpu_build",
+            "description": "",
+            "displayName": "",
+            "configurePreset": "base_cpu",
+            "jobs": 64
+        },
         {
             "name": "veda_vednn_debug_build",
             "description": "",

--- a/libnd4j/include/cnpy/cnpy.h
+++ b/libnd4j/include/cnpy/cnpy.h
@@ -110,9 +110,10 @@ SD_LIB_EXPORT std::vector<char> createNpyHeader(const void *data, const unsigned
  * @param fp the file to parse from
  * @param wordSize the size of
  * the individual elements
- * @param shape
- * @param ndims
- * @param fortranOrder
+ * @param shape the shape of the array
+ * @param ndims the number of dimensions in the array
+ * @param fortranOrder whether the array is fortran ordered or not
+ * @param dtype the datatype of the array
  */
 SD_LIB_EXPORT void parseNpyHeader(FILE *fp, unsigned int &wordSize, unsigned int *&shape, unsigned int &ndims,
                                   bool &fortranOrder);
@@ -124,9 +125,9 @@ SD_LIB_EXPORT void parseNpyHeader(FILE *fp, unsigned int &wordSize, unsigned int
  * @param header the file to parse from
  * @param word_size the size of
  * the individual elements
- * @param shape
- * @param ndims
- * @param fortran_order
+ * @param shape the shape of the array
+ * @param ndims the number of dimensions of the ndarray
+ * @param fortran_order whether the array is fortran ordered or not
  */
 SD_LIB_EXPORT void parseNpyHeaderPointer(const char *header, unsigned int &word_size, unsigned int *&shape,
                                          unsigned int &ndims, bool &fortran_order);
@@ -162,9 +163,9 @@ SD_LIB_EXPORT NpyArray npyLoad(std::string fname);
  * @param fp the file to parse from
  * @param wordSize the size of
  * the individual elements
- * @param shape
- * @param ndims
- * @param fortranOrder
+ * @param shape the shape of the array
+ * @param ndims the number of dimensions of the shape
+ * @param fortranOrder whether the array is fortran ordered or c ordered
  */
 SD_LIB_EXPORT void parseNpyHeaderStr(std::string header, unsigned int &wordSize, unsigned int *&shape,
                                      unsigned int &ndims, bool &fortranOrder);
@@ -243,7 +244,7 @@ SD_INLINE std::string tostring(T i, int pad = 0, char padval = ' ') {
 }
 
 template <typename T>
-SD_LIB_EXPORT void npy_save(std::string fname, const T *data, const unsigned int *shape, const unsigned int ndims,
+SD_LIB_EXPORT void npy_save(std::string fname, const void *data, const unsigned int *shape, const unsigned int ndims,
                             std::string mode = "w");
 
 }  // namespace cnpy

--- a/libnd4j/include/helpers/impl/shape.cpp
+++ b/libnd4j/include/helpers/impl/shape.cpp
@@ -1568,15 +1568,7 @@ SD_HOST sd::LongType *shapeBufferOfNpy(cnpy::NpyArray arr) {
   return shape::shapeBufferOfNpy(arr.shape.size(), (unsigned int *)arr.shape.data(), arr.fortranOrder);
 }
 
-//    SD_HOST sd::LongType *shapeBufferOfNpyBuffer(char *buffer) {
-//        unsigned sd::LongType *shape;
-//        unsigned int ndims, wordSize;
-//        bool fortranOrder;
-//        cnpy::parseNpyHeaderStr(std::string(buffer),wordSize,shape,ndims,fortranOrder);
-//        sd::LongType * ret =  shape::shapeBufferOfNpy(ndims,shape,fortranOrder);
-//        delete[] shape;
-//        return ret;
-//    }
+
 
 SD_HOST sd::LongType *shapeBufferOfNpy(int rank, unsigned int *shape, bool fortranOrder) {
   if (fortranOrder) {

--- a/libnd4j/include/legacy/NativeOps.h
+++ b/libnd4j/include/legacy/NativeOps.h
@@ -47,6 +47,20 @@ typedef sd::InteropDataBuffer OpaqueDataBuffer;
 
 extern "C" {
 
+
+SD_LIB_EXPORT void saveNpy(std::string fname, const OpaqueDataBuffer *data, const unsigned int *shape, const unsigned int ndims,
+                          std::string mode = "w");
+
+/**
+ * Copy n elements from the buffer from the src
+ * buffer to the target buffer
+ * @param target the target buffer
+ * @param n the number of elements
+ * @param from the src buffer
+ * @param fromOffset the starting offset for the source
+ * @param targetOffset the starting offset for the target
+ */
+SD_LIB_EXPORT void copyBuffer(OpaqueDataBuffer *target, long n,  OpaqueDataBuffer *from, long fromOffset, long targetOffset);
 /**
  * This function returns last error code stored,
  * @return non-zero if something bad happened
@@ -58,6 +72,7 @@ SD_LIB_EXPORT int lastErrorCode();
  * @return
  */
 SD_LIB_EXPORT const char* lastErrorMessage();
+
 
 /**
  *

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -2747,7 +2747,7 @@ void deleteRandomGenerator(sd::graph::RandomGenerator *ptr) { delete ptr; }
 void saveNpy(std::string fname, const InteropDataBuffer *data, const unsigned int *shape, const unsigned int ndims,
              std::string mode) {
   auto dtype = data->getDataBuffer()->getDataType();
-  BUILD_SINGLE_SELECTOR(dtype,cnpy::npy_save,(fname,data->primaryAsT(),shape,ndims,mode),SD_COMMON_TYPES);
+  BUILD_SINGLE_SELECTOR(dtype,cnpy::npy_save,(fname,data->getDataBuffer()->primary(),shape,ndims,mode),SD_COMMON_TYPES);
 }
 
 int dataTypeFromNpyHeader(void *header) { return (int)cnpy::dataTypeFromHeader(reinterpret_cast<char *>(header)); }

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -134,6 +134,15 @@ static bool execHelperScalar(int opNum, OpaqueDataBuffer *dbX, const sd::LongTyp
 
 #endif
 
+
+void copyBuffer(OpaqueDataBuffer *target, long n,  OpaqueDataBuffer *from, long fromOffset, long targetOffset) {
+   OpaqueDataBuffer *copyFrom = dbCreateView(from,n,fromOffset);
+   OpaqueDataBuffer *targetView = dbCreateView(target,n,targetOffset);
+   const DataBuffer targetBuf = *copyFrom->dataBuffer().get();
+   const DataBuffer srcBuf = *targetView->dataBuffer().get();
+   DataBuffer::memcpy(targetBuf,srcBuf);
+}
+
 /**
  *
  * @param opNum
@@ -2733,6 +2742,12 @@ double getRandomGeneratorNextDouble(sd::graph::RandomGenerator *ptr) {
 }
 
 void deleteRandomGenerator(sd::graph::RandomGenerator *ptr) { delete ptr; }
+
+
+void saveNpy(std::string fname, const InteropDataBuffer *data, const unsigned int *shape, const unsigned int ndims,
+             std::string mode) {
+  cnpy::npy_save(fname,data->primary(),shape,ndims,mode);
+}
 
 int dataTypeFromNpyHeader(void *header) { return (int)cnpy::dataTypeFromHeader(reinterpret_cast<char *>(header)); }
 

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -2746,7 +2746,8 @@ void deleteRandomGenerator(sd::graph::RandomGenerator *ptr) { delete ptr; }
 
 void saveNpy(std::string fname, const InteropDataBuffer *data, const unsigned int *shape, const unsigned int ndims,
              std::string mode) {
-  cnpy::npy_save(fname,data->primary(),shape,ndims,mode);
+  auto dtype = data->getDataBuffer()->getDataType();
+  BUILD_SINGLE_SELECTOR(dtype,cnpy::npy_save,(fname,data->primaryAsT(),shape,ndims,mode),SD_COMMON_TYPES);
 }
 
 int dataTypeFromNpyHeader(void *header) { return (int)cnpy::dataTypeFromHeader(reinterpret_cast<char *>(header)); }

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -60,6 +60,19 @@ int minThreads = 32;
 
 __constant__ char deviceConstantMemory[49152];
 
+void copyBuffer(OpaqueDataBuffer *target, long n,  OpaqueDataBuffer *from, long fromOffset, long targetOffset) {
+  OpaqueDataBuffer *copyFrom = dbCreateView(from,n,fromOffset);
+  OpaqueDataBuffer *targetView = dbCreateView(target,n,targetOffset);
+  const DataBuffer targetBuf = *copyFrom->dataBuffer().get();
+  const DataBuffer srcBuf = *targetView->dataBuffer().get();
+  DataBuffer::memcpy(targetBuf,srcBuf);
+}
+
+void saveNpy(std::string fname, const InteropDataBuffer *data, const unsigned int *shape, const unsigned int ndims,
+             std::string mode) {
+  cnpy::npy_save(fname,data->primary(),shape,ndims,mode);
+}
+
 // this method just does type conversion in fancy way
 int getDeviceId(sd::Pointer ptrToDeviceId) { return (int)(sd::LongType)ptrToDeviceId; }
 

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -1316,6 +1316,12 @@ void specialConcat(sd::Pointer *extraPointers, int dimension, int numArrays, sd:
   }
 }
 
+void saveNpy(std::string fname, const InteropDataBuffer *data, const unsigned int *shape, const unsigned int ndims,
+             std::string mode) {
+  auto dtype = data->getDataBuffer()->getDataType();
+  BUILD_SINGLE_SELECTOR(dtype,cnpy::npy_save,(fname,data->primaryAsT(),shape,ndims,mode),SD_COMMON_TYPES);
+}
+
 /**
  * This method saves
  */

--- a/libnd4j/include/legacy/impl/cnpy.cpp
+++ b/libnd4j/include/legacy/impl/cnpy.cpp
@@ -111,7 +111,7 @@ sd::DataType cnpy::dataTypeFromHeader(char *data) {
   const int st = 10;
   const int ti = 22;
   const int si = 23;
-
+  printf("Reading datatype from header %s\n",data);
   // read first char to make sure it looks like a header
   if (data == nullptr || data[st] != '{')
     throw std::runtime_error(
@@ -143,8 +143,10 @@ sd::DataType cnpy::dataTypeFromHeader(char *data) {
         case '2':
           return sd::DataType::HALF;
         case '4':
+          printf("Returning float data type\n",0);
           return sd::DataType::FLOAT32;
         case '8':
+          printf("Returning double data type\n",0);
           return sd::DataType::DOUBLE;
         default:
           throw std::runtime_error("Only data sizes of [1, 2, 4, 8] are supported for Float data types import");
@@ -218,7 +220,6 @@ char *cnpy::loadFile(const char *path) {
   char *buffer = 0;
   long length;
   FILE *f = fopen(path, "rb");  // was "rb"
-
   if (f) {
     fseek(f, 0, SEEK_END);
     length = ftell(f);
@@ -280,12 +281,11 @@ void cnpy::parseNpyHeaderStr(std::string header, unsigned int &wordSize, unsigne
   bool littleEndian = (header[loc1] == '<' || header[loc1] == '|' ? true : false);
   assert(littleEndian);
 
-  // char type = header[loc1+1];
-  // assert(type == map_type(T));
-
   std::string str_ws = header.substr(loc1 + 2);
   loc2 = str_ws.find("'");
+  printf("Header for word size %s complete header is %s\n",str_ws.c_str(),header.c_str());
   wordSize = atoi(str_ws.substr(0, loc2).c_str());
+  printf("Obtained word size of %d\n",wordSize);
 }
 
 /**
@@ -579,10 +579,9 @@ cnpy::NpyArray cnpy::npyLoad(std::string fname) {
  * @param mode the mode for writing
  */
 template <typename T>
-void cnpy::npy_save(std::string fname, const T *data, const unsigned int *shape, const unsigned int ndims,
+void cnpy::npy_save(std::string fname, const void *data, const unsigned int *shape, const unsigned int ndims,
                     std::string mode) {
   FILE *fp = NULL;
-
   if (mode == "a") fp = fopen(fname.c_str(), "r+b");
 
   if (fp) {
@@ -615,16 +614,19 @@ void cnpy::npy_save(std::string fname, const T *data, const unsigned int *shape,
     tmp_shape[0] += shape[0];
 
     fseek(fp, 0, SEEK_SET);
-    std::vector<char> header = createNpyHeader<T>(data, tmp_shape, ndims);
+    std::vector<char> header = createNpyHeader<T>(data, tmp_shape, ndims,sizeof(T));
     fwrite(&header[0], sizeof(char), header.size(), fp);
     fseek(fp, 0, SEEK_END);
 
     delete[] tmp_shape;
   } else {
     fp = fopen(fname.c_str(), "wb");
-    std::vector<char> header = createNpyHeader<T>(data, shape, ndims);
+    std::vector<char> header = createNpyHeader<T>(data, shape, ndims,sizeof(T));
     fwrite(&header[0], sizeof(char), header.size(), fp);
   }
+
+
+  printf("Saving data type %s with size of %d\n",typeid(T).name(),sizeof(T));
 
   unsigned long long nels = 1;
   for (int i = 0; i < ndims; i++) nels *= shape[i];
@@ -644,7 +646,6 @@ void cnpy::npy_save(std::string fname, const T *data, const unsigned int *shape,
 template <typename T>
 std::vector<char> cnpy::createNpyHeader(const void *vdata, const unsigned int *shape, const unsigned int ndims,
                                         unsigned int wordSize) {
-  auto data = reinterpret_cast<const T *>(vdata);
 
   std::vector<char> dict;
   dict += "{'descr': '";
@@ -685,5 +686,5 @@ BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT std::vector<char> cnpy::createNpyHe
                       SD_COMMON_TYPES);
 // template SD_LIB_EXPORT std::vector<char> cnpy::createNpyHeader<void>(const void *data, const unsigned int *shape,
 // const unsigned int ndims, unsigned int wordSize);
-template SD_LIB_EXPORT void cnpy::npy_save<float>(std::string fname, const float *data, const unsigned int *shape,
-                                                  const unsigned int ndims, std::string mode);
+BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void cnpy::npy_save,(std::string fname, const void *data, const unsigned int *shape,
+    const unsigned int ndims, std::string mode),SD_COMMON_TYPES);

--- a/libnd4j/include/legacy/impl/cnpy.cpp
+++ b/libnd4j/include/legacy/impl/cnpy.cpp
@@ -111,7 +111,6 @@ sd::DataType cnpy::dataTypeFromHeader(char *data) {
   const int st = 10;
   const int ti = 22;
   const int si = 23;
-  printf("Reading datatype from header %s\n",data);
   // read first char to make sure it looks like a header
   if (data == nullptr || data[st] != '{')
     throw std::runtime_error(
@@ -143,10 +142,8 @@ sd::DataType cnpy::dataTypeFromHeader(char *data) {
         case '2':
           return sd::DataType::HALF;
         case '4':
-          printf("Returning float data type\n",0);
           return sd::DataType::FLOAT32;
         case '8':
-          printf("Returning double data type\n",0);
           return sd::DataType::DOUBLE;
         default:
           throw std::runtime_error("Only data sizes of [1, 2, 4, 8] are supported for Float data types import");
@@ -283,9 +280,7 @@ void cnpy::parseNpyHeaderStr(std::string header, unsigned int &wordSize, unsigne
 
   std::string str_ws = header.substr(loc1 + 2);
   loc2 = str_ws.find("'");
-  printf("Header for word size %s complete header is %s\n",str_ws.c_str(),header.c_str());
   wordSize = atoi(str_ws.substr(0, loc2).c_str());
-  printf("Obtained word size of %d\n",wordSize);
 }
 
 /**
@@ -626,7 +621,6 @@ void cnpy::npy_save(std::string fname, const void *data, const unsigned int *sha
   }
 
 
-  printf("Saving data type %s with size of %d\n",typeid(T).name(),sizeof(T));
 
   unsigned long long nels = 1;
   for (int i = 0; i < ndims; i++) nels *= shape[i];

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.api.buffer;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.indexer.Indexer;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.nativeblas.OpaqueDataBuffer;
 
 import java.io.*;
 import java.nio.ByteBuffer;
@@ -53,6 +54,12 @@ public interface DataBuffer extends Serializable, AutoCloseable {
 
         MIXED_DATA_TYPES, // latest generation of INDArrays support multiple data types, with information stored within shapeInfo "offset" field.
     }
+
+    /**
+     * Returns the underlying opaque buffer for this data buffer
+     * @return
+     */
+    OpaqueDataBuffer opaqueBuffer();
 
     /**
      * Returns an underlying pointer if one exists

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
@@ -1086,7 +1086,7 @@ public interface NDArrayFactory {
     INDArray createUninitialized(long[] shape, char ordering);
 
     INDArray createUninitialized(DataType dataType, long[] shape, char ordering, MemoryWorkspace workspace);
-    
+
     /**
      * Create an uninitialized ndArray. Detached from workspace.
      * @param dataType data type. Exceptions will be thrown for UTF8, COMPRESSED and UNKNOWN data types.
@@ -1402,6 +1402,21 @@ public interface NDArrayFactory {
      * a pointer to a numpy header
      */
     Pointer convertToNumpy(INDArray array);
+
+    /**
+     * Convert an {@link INDArray}
+     * to a numpy array.
+     * This will usually be used
+     * for writing out to an external source.
+     * Note that this will create a zero copy reference
+     * to this ndarray's underlying data.
+     *
+     *
+     * @param array the array to convert
+     * @returnthe created pointer representing
+     * a pointer to a numpy header
+     */
+    DataBuffer convertToNumpyBuffer(INDArray array);
 
     INDArray create(float[] data, long[] shape, long[] stride, long offset, char ordering);
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -5604,6 +5604,9 @@ public class Nd4j {
      */
     @SuppressWarnings("WeakerAccess")
     public static void writeAsNumpy(INDArray arr, File file) throws IOException {
+       if(arr.dataType() == DataType.BFLOAT16 || arr.dataType() == DataType.BFLOAT16 || arr.dataType() == DataType.UTF8)
+           throw new IllegalArgumentException("Unable to write array data type of " + arr.dataType());
+
         NativeOpsHolder.getInstance().getDeviceNativeOps().saveNpy(file.getAbsolutePath(),arr.data().opaqueBuffer(),ArrayUtil.toInts(arr.shape()),arr.rank());
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -27,6 +27,7 @@ import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMin;
 import org.nd4j.common.config.ND4JClassLoading;
 import org.nd4j.linalg.factory.ops.*;
 import org.nd4j.linalg.profiler.UnifiedProfiler;
+import org.nd4j.nativeblas.NativeOpsHolder;
 import org.nd4j.shade.guava.primitives.Ints;
 import org.nd4j.shade.guava.primitives.Longs;
 import lombok.NonNull;
@@ -2978,7 +2979,7 @@ public class Nd4j {
      * @return the random ndarray with the specified shape
      */
     public static INDArray rand(@NonNull org.nd4j.linalg.api.rng.Random rng, @NonNull long... shape) {
-        INDArray ret = createUninitialized(shape, Nd4j.order()).castTo(Nd4j.defaultFloatingPointType()); 
+        INDArray ret = createUninitialized(shape, Nd4j.order()).castTo(Nd4j.defaultFloatingPointType());
         return rand(ret, rng);
     }
 
@@ -5603,7 +5604,7 @@ public class Nd4j {
      */
     @SuppressWarnings("WeakerAccess")
     public static void writeAsNumpy(INDArray arr, File file) throws IOException {
-        writeAsNumpy(arr, new FileOutputStream(file));
+        NativeOpsHolder.getInstance().getDeviceNativeOps().saveNpy(file.getAbsolutePath(),arr.data().opaqueBuffer(),ArrayUtil.toInts(arr.shape()),arr.rank());
     }
 
 
@@ -5644,8 +5645,11 @@ public class Nd4j {
     public static long writeAsNumpy(Pointer asNumpy, OutputStream writeTo,boolean closeFlush) throws IOException {
         if(closeFlush) {
             try(BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(writeTo)) {
-                WritableByteChannel channel = Channels.newChannel(bufferedOutputStream);
-
+                WritableByteChannel channel = Channels.newChannel(writeTo);
+                ByteBuffer byteBuffer = asNumpy.asByteBuffer();
+                if(byteBuffer == null) {
+                    throw new IllegalStateException("Unable to allocate numpy array byte buffer. Too large in size.");
+                }
                 int written = channel.write(asNumpy.asByteBuffer());
                 if(written != asNumpy.capacity()) {
                     throw new IllegalStateException("Not all bytes were written! Original capacity " + asNumpy.capacity() + " but wrote " + written);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -22,11 +22,39 @@ package org.nd4j.nativeblas;
 
 import org.bytedeco.javacpp.*;
 import org.bytedeco.javacpp.annotation.Cast;
+import org.bytedeco.javacpp.annotation.Const;
+import org.bytedeco.javacpp.annotation.StdString;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 
+import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 
 
 public interface NativeOps {
+
+    void copyBuffer(org.nd4j.nativeblas.OpaqueDataBuffer target, long n,  org.nd4j.nativeblas.OpaqueDataBuffer from, long fromOffset, long targetOffset);
+
+
+    void saveNpy( BytePointer fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntPointer shape,  int ndims,
+                                BytePointer mode/*="w"*/);
+    void saveNpy( BytePointer fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntPointer shape,  int ndims);
+    void saveNpy( String fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntBuffer shape,  int ndims,
+                                String mode/*="w"*/);
+    void saveNpy( String fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntBuffer shape,  int ndims);
+    void saveNpy( BytePointer fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  int[] shape,  int ndims,
+                                BytePointer mode/*="w"*/);
+    void saveNpy( BytePointer fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  int[] shape,  int ndims);
+    void saveNpy( String fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntPointer shape,  int ndims,
+                                String mode/*="w"*/);
+    void saveNpy( String fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntPointer shape,  int ndims);
+    void saveNpy( BytePointer fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntBuffer shape,  int ndims,
+                                BytePointer mode/*="w"*/);
+    void saveNpy( BytePointer fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  IntBuffer shape,  int ndims);
+    void saveNpy( String fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  int[] shape,  int ndims,
+                                String mode/*="w"*/);
+    void saveNpy( String fname, org.nd4j.nativeblas.OpaqueDataBuffer data,  int[] shape,  int ndims);
+
+
     /**
      * This method allows you to specify minimal number of elements per thread/block during op call
      * PLEASE NOTE: Changing this value might and will affect performance.
@@ -1224,18 +1252,18 @@ public interface NativeOps {
 
 
 
-     void setGraphContextInputArrays(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
-                                                  PointerPointer specialBuffer, PointerPointer specialShapeInfo);
-     void setGraphContextOutputArrays(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
-                                                   PointerPointer specialBuffer, PointerPointer specialShapeInfo);
-     void setGraphContextInputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
-                                                   PointerPointer specialShapeInfo);
-     void setGraphContextInputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays,  org.nd4j.nativeblas.OpaqueDataBuffer buffer, PointerPointer shapeInfo,
-                                                   PointerPointer specialShapeInfo);
-     void setGraphContextOutputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
-                                                    PointerPointer specialShapeInfo);
-     void setGraphContextOutputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays,  org.nd4j.nativeblas.OpaqueDataBuffer buffer, PointerPointer shapeInfo,
-                                                    PointerPointer specialShapeInfo);
+    void setGraphContextInputArrays(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
+                                    PointerPointer specialBuffer, PointerPointer specialShapeInfo);
+    void setGraphContextOutputArrays(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
+                                     PointerPointer specialBuffer, PointerPointer specialShapeInfo);
+    void setGraphContextInputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
+                                     PointerPointer specialShapeInfo);
+    void setGraphContextInputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays,  org.nd4j.nativeblas.OpaqueDataBuffer buffer, PointerPointer shapeInfo,
+                                     PointerPointer specialShapeInfo);
+    void setGraphContextOutputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays, PointerPointer buffer, PointerPointer shapeInfo,
+                                      PointerPointer specialShapeInfo);
+    void setGraphContextOutputBuffers(org.nd4j.nativeblas.OpaqueContext ptr, int numArrays,  org.nd4j.nativeblas.OpaqueDataBuffer buffer, PointerPointer shapeInfo,
+                                      PointerPointer specialShapeInfo);
 
 
     void setShapeBuffer( LongPointer inputShapeData, int dt, LongPointer bufferToSet,char order,int elementWiseStride);
@@ -1266,7 +1294,7 @@ public interface NativeOps {
     long getRandomGeneratorNextLong(OpaqueRandomGenerator ptr);
     void deleteRandomGenerator(OpaqueRandomGenerator ptr);
 
-  
+
 
     long getCachedMemory(int deviceId);
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
@@ -125,7 +125,7 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
 
         DataBuffer shapeBuffer = Nd4j.createBuffer(
                 newPointer,
-                DataType.LONG,
+                DataType.INT64,
                 length,
                 LongIndexer.create(newPointer));
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
@@ -22,6 +22,7 @@ package org.nd4j.nativeblas;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.io.FileUtils;
 import org.bytedeco.javacpp.*;
 import org.bytedeco.javacpp.indexer.*;
 import org.nd4j.linalg.api.buffer.DataBuffer;
@@ -61,9 +62,8 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
     public BaseNativeNDArrayFactory() {}
 
 
-
     @Override
-    public Pointer convertToNumpy(INDArray array) {
+    public DataBuffer convertToNumpyBuffer(INDArray array) {
         val size = new LongPointer(1);
         Pointer header = NativeOpsHolder
                 .getInstance().getDeviceNativeOps()
@@ -76,24 +76,20 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
         val headerSize = size.get() - 1;
         header.capacity(headerSize);
         header.position(0);
-
-
-
-        BytePointer bytePointer = new BytePointer((int) (headerSize + (array.data().getElementSize() * array.data().length())));
         BytePointer headerCast = new BytePointer(header);
-        val indexer = ByteIndexer.create(headerCast);
+        DataBuffer buffer = Nd4j.createBuffer(DataType.INT8, (headerSize + (array.data().getElementSize() * array.data().length())), false);
+        DataBuffer headCopyFrom = Nd4j.createBuffer(headerCast,headerSize,DataType.INT8);
         int pos = 0;
-        bytePointer.position(pos);
-        Pointer.memcpy(bytePointer, headerCast,headerCast.capacity());
+        buffer.copyAtStride(headCopyFrom,headCopyFrom.length(),1,1,0,0);
         pos += (headerCast.capacity());
-        bytePointer.position(pos);
-
-        // make sure data is copied to the host memory
+        buffer.copyAtStride(array.data(),array.data().length(),1,1,pos,0);
         Nd4j.getAffinityManager().ensureLocation(array, AffinityManager.Location.HOST);
+        return buffer;
+    }
 
-        Pointer.memcpy(bytePointer,array.data().pointer(),(array.data().getElementSize() * array.data().length()));
-        bytePointer.position(0);
-        return bytePointer;
+    @Override
+    public Pointer convertToNumpy(INDArray array) {
+        return convertToNumpyBuffer(array).pointer();
     }
 
     /**
@@ -529,7 +525,7 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
                 is.read(new byte[extraFieldLength]);
             }
             is.read(new byte[11]);
-            
+
             String headerStr = "";
             int b;
             while((b = is.read()) != ((int)'\n')){

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
@@ -40,7 +40,6 @@ import static org.nd4j.linalg.api.buffer.DataType.INT8;
 
 public abstract class BaseCpuDataBuffer extends BaseDataBuffer implements Deallocatable {
 
-    protected transient OpaqueDataBuffer ptrDataBuffer;
     protected transient Pointer addressPointer;
 
     private transient final long instanceId = Nd4j.getDeallocatorService().nextValue();

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -73,7 +73,6 @@ import java.util.Collection;
  * @author raver119@gmail.com
  */
 public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCudaBuffer, Deallocatable {
-    protected transient OpaqueDataBuffer ptrDataBuffer;
 
     @Getter
     protected transient volatile AllocationPoint allocationPoint;
@@ -1803,7 +1802,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         int fbits = Float.floatToIntBits( fval );
         int sign = fbits >>> 16 & 0x8000;          // sign only
         int val = ( fbits & 0x7fffffff ) + 0x1000; // rounded value
-    
+
         if( val >= 0x47800000 )               // might be or become NaN/Inf
         {                                     // avoid Inf due to rounding
             if( ( fbits & 0x7fffffff ) >= 0x47800000 )

--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -68,7 +68,7 @@
         <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
         <log4j2.version>2.17.2</log4j2.version>
         <netty.version>4.1.74.Final</netty.version>
-        <test.heap.size>12g</test.heap.size>
+        <test.heap.size>14g</test.heap.size>
         <test.offheap.size>24g</test.offheap.size>
         <test.nogc>false</test.nogc>
         <dokka.version>1.4.30</dokka.version>

--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dl4j.version>1.0.0-SNAPSHOT</dl4j.version>
         <platform.classifier>${javacpp.platform}</platform.classifier>
-        <backend.artifactId>nd4j-cuda-11.6</backend.artifactId>
+        <backend.artifactId>nd4j-native</backend.artifactId>
         <lombok.version>1.18.24</lombok.version>
         <derby.version>10.13.1.1</derby.version>
         <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/factory/Nd4jTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/factory/Nd4jTest.java
@@ -274,8 +274,11 @@ public class Nd4jTest extends BaseNd4jTestWithBackends {
     }
 
     @Test
+    @Disabled("Test is very large compared to most tests. It needs to be to test the limits of memcpy/heap space.")
     public void testLargeNumpyWrite() throws Exception {
-        Arrays.stream(DataType.values()).forEach(dataType -> {
+        Arrays.stream(DataType.values()).filter(input ->
+                       input != DataType.BFLOAT16 && input != DataType.COMPRESSED && input != DataType.UTF8)
+                .forEach(dataType -> {
             System.out.println("Trying with data type " + dataType);
             INDArray largeArr = Nd4j.create(dataType,115240, 2400);
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/factory/Nd4jTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/factory/Nd4jTest.java
@@ -45,6 +45,7 @@ import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.nativeblas.NativeOpsHolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -274,13 +275,22 @@ public class Nd4jTest extends BaseNd4jTestWithBackends {
 
     @Test
     public void testLargeNumpyWrite() throws Exception {
-        INDArray largeArr = Nd4j.create(DataType.FLOAT,115240, 2400);
-        File tempFile = new File("large-npy.npy");
-        tempFile.deleteOnExit();
-        Nd4j.writeAsNumpy(largeArr,tempFile);
-        assertTrue(tempFile.exists());
-        INDArray read = Nd4j.createFromNpyFile(tempFile);
-        assertEquals(largeArr,read);
+        Arrays.stream(DataType.values()).forEach(dataType -> {
+            System.out.println("Trying with data type " + dataType);
+            INDArray largeArr = Nd4j.create(dataType,115240, 2400);
+
+            File tempFile = new File("large-npy-" + dataType.name() + ".npy");
+            tempFile.deleteOnExit();
+            try {
+                Nd4j.writeAsNumpy(largeArr,tempFile);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            assertTrue(tempFile.exists());
+            INDArray read = Nd4j.createFromNpyFile(tempFile);
+            assertEquals(largeArr,read);
+        });
+
     }
 
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/factory/Nd4jTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/factory/Nd4jTest.java
@@ -52,8 +52,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  */
@@ -271,6 +270,17 @@ public class Nd4jTest extends BaseNd4jTestWithBackends {
         INDArray numpyFromFile = Nd4j.createFromNpyFile(tmpFile);
         assertEquals(linspace,numpyFromFile);
 
+    }
+
+    @Test
+    public void testLargeNumpyWrite() throws Exception {
+        INDArray largeArr = Nd4j.create(DataType.FLOAT,115240, 2400);
+        File tempFile = new File("large-npy.npy");
+        tempFile.deleteOnExit();
+        Nd4j.writeAsNumpy(largeArr,tempFile);
+        assertTrue(tempFile.exists());
+        INDArray read = Nd4j.createFromNpyFile(tempFile);
+        assertEquals(largeArr,read);
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adds new numpy i/o that uses cnpy in c++ directly
Adds new data buffer copy method using opaque data buffer
Exposes opaque databuffer for usage in other methods in the underlying data buffer abstraction
Enables writing of larger ndarrays where javacpp's Pointer.memcpy crashes.
Add new methods for read/writing numpy arrays
Add new cpu preset for cmake enabling easier integration with c++ ides
Fixes #9891 

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
