### PR TITLE
Revert long databuffer set change from earlier tests

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -31,6 +31,7 @@ import org.nd4j.common.primitives.AtomicBoolean;
 import org.nd4j.common.primitives.AtomicDouble;
 import org.nd4j.common.primitives.Triple;
 import org.nd4j.common.util.ArrayUtil;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.nativeblas.NativeOpsHolder;
 import org.nd4j.nativeblas.OpaqueDataBuffer;
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
@@ -463,7 +463,7 @@ public abstract class DefaultOpExecutioner implements OpExecutioner {
         }
         for (val arr: outArgs) {
             if(arr == null)
-                continue;;
+                continue;
 
             if (arr.wasClosed())
                 throw new IllegalStateException("One of Output arguments was closed before call");

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/api/buffer/DataBufferTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/api/buffer/DataBufferTests.java
@@ -295,12 +295,10 @@ public class DataBufferTests extends BaseNd4jTestWithBackends {
                     continue;
                 }
 
-//                log.info("Testing source [{}]; target: [{}]", sourceType, dt);
 
                 for (boolean useWs : new boolean[]{false, true}) {
 
                     try (MemoryWorkspace ws = (useWs ? workspace.notifyScopeEntered() : null)) {
-
                         DataBuffer db1;
                         DataBuffer db2;
                         switch (sourceType) {
@@ -339,10 +337,10 @@ public class DataBufferTests extends BaseNd4jTestWithBackends {
                         checkTypes(dt, db1, 3);
                         checkTypes(dt, db2, 3);
 
-                        assertEquals(useWs, db1.isAttached());
+                        assertEquals(useWs, db1.isAttached(),"useWs: " + useWs + " db1 data type " + db1.dataType() + " sourceType: " + sourceType);
                         assertFalse(db2.isAttached());
 
-                        if(!sourceType.equals("boolean")){
+                        if(!sourceType.equals("boolean")) {
                             testDBOps(db1);
                             testDBOps(db2);
                         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Revert long databuffer set change from earlier tests
Earlier experiments in bug hunting lead to a change that prevents databuffers that start as pointers
from being used properly. This reverts that change for where the experiments happened.


(Please fill in changes proposed in this fix)

## How was this patch tested?
Rerunning cpu tests
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
