### PR TITLE
Fix deallocation issue race condition with shape info buffers

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
@@ -1086,7 +1086,6 @@ public class ParagraphVectors extends Word2Vec {
 
         @Override
         public ParagraphVectors build() {
-            System.out.println(UnifiedProfiler.getInstance().printCurrentStats());
             presetTables();
             if(configuration == null) {
                 configurationSpecified = false;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
@@ -21,6 +21,7 @@
 package org.deeplearning4j.models.paragraphvectors;
 
 import org.deeplearning4j.models.sequencevectors.SequenceVectors;
+import org.nd4j.linalg.profiler.UnifiedProfiler;
 import org.nd4j.shade.guava.collect.Lists;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -1085,6 +1086,7 @@ public class ParagraphVectors extends Word2Vec {
 
         @Override
         public ParagraphVectors build() {
+            System.out.println(UnifiedProfiler.getInstance().printCurrentStats());
             presetTables();
             if(configuration == null) {
                 configurationSpecified = false;
@@ -1217,6 +1219,13 @@ public class ParagraphVectors extends Word2Vec {
                 elementsLearningAlgorithm.configure(vocabCache,lookupTable,configuration);
             if(this.sequenceLearningAlgorithm != null)
                 sequenceLearningAlgorithm.configure(vocabCache,lookupTable,configuration);
+
+           if(existingVectors!= null) {
+               ret.lookupTable = existingVectors.lookupTable();
+               ret.vocab = existingVectors.vocab();
+           }
+
+
             return ret;
         }
 

--- a/libnd4j/include/array/ArrayOptions.h
+++ b/libnd4j/include/array/ArrayOptions.h
@@ -158,9 +158,6 @@ SD_INLINE SD_HOST_DEVICE bool ArrayOptions::isUnsigned(sd::LongType *shapeInfo) 
 }
 
 SD_INLINE SD_HOST_DEVICE sd::DataType ArrayOptions::dataType(const sd::LongType *shapeInfo) {
-  /*if (hasPropertyBitSet(shapeInfo, ARRAY_QUANTIZED))
-      return sd::DataType::QINT8;
-  else */
   if (hasPropertyBitSet(shapeInfo, ARRAY_FLOAT))
     return sd::DataType::FLOAT32;
   else if (hasPropertyBitSet(shapeInfo, ARRAY_DOUBLE))
@@ -208,7 +205,6 @@ SD_INLINE SD_HOST_DEVICE sd::DataType ArrayOptions::dataType(const sd::LongType 
   else if (hasPropertyBitSet(shapeInfo, ARRAY_UTF32))
     return sd::DataType::UTF32;
   else {
-    // shape::printShapeInfoLinear("Bad signed datatype (not)stored in shape", const_cast<sd::LongType*>(shapeInfo));
 #ifndef __CUDA_ARCH__
     throw std::runtime_error("Bad datatype B");
 #endif

--- a/libnd4j/include/graph/impl/Context.cpp
+++ b/libnd4j/include/graph/impl/Context.cpp
@@ -381,9 +381,16 @@ namespace sd {
         void Context::setInputArray(int index, void *vdatabuffer, void const *shapeInfo, void const *specialShapeInfo) {
             auto dataBuffer = reinterpret_cast<InteropDataBuffer *>(vdatabuffer);
             auto shapeInfoCast = reinterpret_cast<sd::LongType const *>(shapeInfo);
+            if(shape::rank(shapeInfoCast) > SD_MAX_RANK || shape::rank(shapeInfoCast) < 0) {
+              std::string error;
+              error += std::string("Shape Buffer at index ");
+              error += std::string(" " + index);
+              error += std::string(" was corrupt! This is likely due to deallocation. Please double check the passed in shape  buffer.");
+              throw std::runtime_error(error.c_str());
+            }
             if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
             NDArray *array;
-            if (dataBuffer != nullptr && !shape::isEmpty(reinterpret_cast<sd::LongType const *>(shapeInfo))) {
+            if (dataBuffer != nullptr && !shape::isEmpty(shapeInfoCast)) {
                 array = new NDArray(dataBuffer->dataBuffer(), shapeInfoCast,
                                     sd::LaunchContext::defaultContext(),
                                     dataBuffer->offset() / DataTypeUtils::sizeOf(ArrayOptions::dataType(

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -2665,6 +2665,18 @@ void setGraphContextInputBuffer(OpaqueContext *ptr, int index, OpaqueDataBuffer 
                                 void *specialShapeInfo) {
   if(ptr == nullptr)
     throw std::runtime_error("Context pointer is null!");
+  sd::LongType *shapeInfoCast = reinterpret_cast<sd::LongType *>(shapeInfo);
+  sd_printf("Setting input buffer %d\n",index);
+  if(shape::rank(shapeInfoCast) > SD_MAX_RANK || shape::rank(shapeInfoCast) < 0) {
+    std::string error;
+    error += std::string("Shape Buffer at index ");
+    error += std::string(" ");
+    error += std::to_string(index);
+    error += std::string(" ");
+    error += std::string(" was corrupt! This is likely due to deallocation. Please double check the passed in shape  buffer.");
+    throw std::runtime_error(error.c_str());
+  }
+
   ptr->setInputArray(index, buffer, shapeInfo, specialShapeInfo);
 }
 

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -2666,7 +2666,6 @@ void setGraphContextInputBuffer(OpaqueContext *ptr, int index, OpaqueDataBuffer 
   if(ptr == nullptr)
     throw std::runtime_error("Context pointer is null!");
   sd::LongType *shapeInfoCast = reinterpret_cast<sd::LongType *>(shapeInfo);
-  sd_printf("Setting input buffer %d\n",index);
   if(shape::rank(shapeInfoCast) > SD_MAX_RANK || shape::rank(shapeInfoCast) < 0) {
     std::string error;
     error += std::string("Shape Buffer at index ");

--- a/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
@@ -47,14 +47,12 @@ CUSTOM_OP_IMPL(concat, -1, 1, false, 0, 0) {
   auto rankOfFirstArr = block.width() > 0 ? INPUT_VARIABLE(0)->rankOf() : 0;
   auto typeOfFirstArr = block.width() > 0 ? INPUT_VARIABLE(0)->dataType() : block.dataType();
 
+
   for (int i = 0; i < numOfInArrs; ++i) {
     auto input = INPUT_VARIABLE(i);
     auto currentRank = input->rankOf();
+    auto *shapeInfoCast = input->shapeInfo();
 
-    // TODO: follow two lines are in accordance to current tf.concat spec. Commented for compatibility with legacy
-    //        REQUIRE_TRUE(currentRank > 0, 0, "Rank of input variable %i must be greater 0, but is %lld instead.", i,
-    //        currentRank); REQUIRE_TRUE(rankOfFirstArr == currentRank, 0, "Number of dimensions in concat should be
-    //        equals, but for %i input variable %lld != %lld appears.", i, currentRank, rankOfFirstArr);
     if (!input->isEmpty()) {
       allOfSameType &= (typeOfFirstArr == input->dataType());
 
@@ -95,7 +93,7 @@ CUSTOM_OP_IMPL(concat, -1, 1, false, 0, 0) {
     if(nonEmptyArrs[i]->rankOf() != rank) {
       std::string error;
       error += std::string("CONCAT op: array at index: ");
-      error += std::string("" + i );
+      error += std::to_string(i);
       error += std::string(" ");
       error += std::string(" did not have same rank. Expected rank: " + rank);
       error += std::string(" but was: " + nonEmptyArrs[i]->rankOf());
@@ -107,7 +105,7 @@ CUSTOM_OP_IMPL(concat, -1, 1, false, 0, 0) {
         if(nonEmptyArrs[i]->sizeAt(dim) != nonEmptyArrs[0]->sizeAt(dim)) {
           std::string error;
           error += std::string("CONCAT op: array at index: ");
-          error += std::string("" + i );
+          error += std::to_string(i);
           error += std::string(" ");
           error += std::string(" did not have same dimension. Expected dimension : " + nonEmptyArrs[0]->sizeAt(dim));
           error += std::string(" but was: " + nonEmptyArrs[i]->sizeAt(dim));

--- a/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
@@ -91,20 +91,38 @@ CUSTOM_OP_IMPL(concat, -1, 1, false, 0, 0) {
   REQUIRE_TRUE(0 <= axis && (axis < rank || (axis == 0 && rank == 0)), 0,
                "CONCAT op: input axis must be in range [0, %i], but got %i instead!", rank - 1, axis);
 
-  for (int i = 1; i < numOfNonEmptyArrs; ++i)
-    REQUIRE_TRUE(nonEmptyArrs[i]->rankOf() == rank, 0, "CONCAT op: all input arrays must have the same rank !");
-
   for (int i = 1; i < numOfNonEmptyArrs; ++i) {
-    for (int dim = 0; dim < rank; ++dim)
-      if (dim != axis)
-        REQUIRE_TRUE(nonEmptyArrs[i]->sizeAt(dim) == nonEmptyArrs[0]->sizeAt(dim), 0,
-                     "CONCAT op: all input arrays must have the same dimensions (except those on input axis) !");
+    if(nonEmptyArrs[i]->rankOf() != rank) {
+      std::string error;
+      error += std::string("CONCAT op: array at index: ");
+      error += std::string("" + i );
+      error += std::string(" ");
+      error += std::string(" did not have same rank. Expected rank: " + rank);
+      error += std::string(" but was: " + nonEmptyArrs[i]->rankOf());
+      REQUIRE_TRUE(nonEmptyArrs[i]->rankOf() == rank, 0,error.c_str());
+    }
+
+    for (int dim = 0; dim < rank; ++dim) {
+      if (dim != axis) {
+        if(nonEmptyArrs[i]->sizeAt(dim) != nonEmptyArrs[0]->sizeAt(dim)) {
+          std::string error;
+          error += std::string("CONCAT op: array at index: ");
+          error += std::string("" + i );
+          error += std::string(" ");
+          error += std::string(" did not have same dimension. Expected dimension : " + nonEmptyArrs[0]->sizeAt(dim));
+          error += std::string(" but was: " + nonEmptyArrs[i]->sizeAt(dim));
+          REQUIRE_TRUE(nonEmptyArrs[i]->rankOf() == rank, 0,error.c_str());
+        }
+      }
+    }
+
   }
+
   // ******** end of input validation ******** //
 
   auto output = OUTPUT_VARIABLE(0);
 
- 
+
   helpers::concat(block.launchContext(), nonEmptyArrs, *output, axis);
 
   // delete dynamically allocated vectors with length=1
@@ -160,15 +178,33 @@ DECLARE_SHAPE_FN(concat) {
   REQUIRE_TRUE(0 <= axis && axis < rank, 0, "CONCAT op: input axis must be in range [0, %i], but got %i instead!",
                rank - 1, axis);
 
-  for (int i = 1; i < numOfNonEmptyArrs; ++i)
-    REQUIRE_TRUE(shape::rank(arrShapes.at(i)) == rank, 0, "CONCAT op: all input arrays must have the same rank !");
 
   for (int i = 1; i < numOfNonEmptyArrs; ++i) {
-    for (int dim = 0; dim < rank; ++dim)
-      if (dim != axis)
-        REQUIRE_TRUE(arrShapes.at(i)[dim + 1] == arrShapes.at(0)[dim + 1], 0,
-                     "CONCAT op: all input arrays must have the same dimensions (except those on input axis) !");
+    if (shape::rank(arrShapes.at(i)) != rank) {
+      std::string error;
+      error += std::string("CONCAT op: array at index: ");
+      error += std::string("" + i);
+      error += std::string(" ");
+      error += std::string(" did not have same rank. Expected rank: " + rank);
+      error += std::string(" but was: " + shape::rank(arrShapes.at(i)));
+      throw std::runtime_error(error.c_str());
+    }
+
+    for (int dim = 0; dim < rank; ++dim) {
+      if (dim != axis) {
+        if (arrShapes.at(i)[dim + 1] != arrShapes.at(0)[dim + 1]) {
+          std::string error;
+          error += std::string("CONCAT op: array at index: ");
+          error += std::string("" + i);
+          error += std::string(" ");
+          error += std::string(" did not have same dimension. Expected dimension : " + arrShapes.at(0)[dim + 1]);
+          error += std::string(" but was: " + arrShapes.at(0)[dim + 1]);
+          throw std::runtime_error(error.c_str());
+        }
+      }
+    }
   }
+
   // ******** end of input validation ******** //
 
   sd::LongType* outShapeInfo(nullptr);
@@ -184,190 +220,11 @@ DECLARE_SHAPE_FN(concat) {
 
   ShapeUtils::updateStridesAndType(outShapeInfo, arrShapes.at(0), shape::order(arrShapes.at(0)));
 
-  // delete dynamically allocated vectors shapes with length=1
-  //    for(int index : shapesToDelete)
-  //        RELEASE(arrShapes[index], block.getWorkspace());
 
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(outShapeInfo));
   RELEASE(outShapeInfo, block.getWorkspace());
   return SHAPELIST(result);
 }
-
-// //////////////////////////////////////////////////////////////////////////
-// CUSTOM_OP_IMPL(concat, -1, 1, false, 0, -2){
-//     // do something here{
-//     NDArray<T> *last = INPUT_VARIABLE((int) block.width() - 1);
-
-//     int _dimension = 0;
-//     if (block.numI() > 0)
-//         _dimension = INT_ARG(0);
-//     else {
-//         _dimension = (int) last->e(0);
-//     }
-
-//     // we want to ensure that all
-//     NDArray<T> *first = nullptr;
-//     auto output = OUTPUT_VARIABLE(0);
-
-//     int elements = 0;
-
-//     for (int e = 0; e < block.width(); e++) {
-//         auto arr = INPUT_VARIABLE(e);
-//         if (!arr->isEmpty())
-//             elements++;
-
-//         // we must find first non-empty element here
-//         if (!arr->isEmpty() && first == nullptr)
-//             first = arr;
-//     }
-
-//     REQUIRE_TRUE(first != nullptr, 0, "Concat: at least 1 non-empty input required!");
-
-//     // it's possible to get into situation when your input has only 1 input. That's just assign
-//     if (elements == 1) {
-//         output->assign(first);
-//         return sd::Status::OK;
-//     }
-
-//     bool oldScalars = first->rankOf() == 2 && first->isScalar();
-
-//     auto buffers = new sd::Pointer[elements];
-//     auto shapes = new sd::Pointer[elements];
-
-//     buffers[0] = (sd::Pointer) first->buffer();
-//     shapes[0] = (sd::Pointer) first->shapeInfo();
-
-//     if (_dimension < 0)
-//         _dimension += first->rankOf();
-
-//     if (sd::Environment::getInstance().isDebugAndVerbose()) {
-//         printf("Shape %i: ", 0);
-//         shape::printShapeInfoLinear((sd::LongType *) shapes[0]);
-//     }
-
-//     int er = 0;
-//     for (int e = 0; e < block.width(); e++) {
-//         Variable<T> *var = block.variable(e);
-//         auto array = var->getNDArray();
-
-//         if (array->isEmpty())
-//             continue;
-
-//         buffers[er] = reinterpret_cast<sd::Pointer>(array->buffer());
-//         shapes[er++] = reinterpret_cast<sd::Pointer>(array->shapeInfo());
-
-//         oldScalars &= array->rankOf() == 2 && array->isScalar();
-
-//         if (sd::Environment::getInstance().isDebugAndVerbose()) {
-//             printf("Shape %i: ", e);
-//             shape::printShapeInfoLinear(array->shapeInfo());
-//         }
-//     }
-//     if (sd::Environment::getInstance().isDebugAndVerbose())
-//         fflush(stdout);
-
-//     if (oldScalars) {
-//         sd_debug("OLD_SCALARS!\n","");
-//         _dimension = 1;
-//     }
-
-//     sd::SpecialMethods<T>::concatCpuGeneric(_dimension, elements, buffers, shapes, output->buffer(),
-//     output->shapeInfo());
-
-//     STORE_RESULT(*output);
-
-//     if (sd::Environment::getInstance().isDebugAndVerbose())
-//         output->printShapeInfo("Concat result shape");
-
-//     delete[] buffers;
-//     delete[] shapes;
-
-//     return sd::Status::OK;
-// }
-
-// DECLARE_SYN(ParallelConcat, concat);
-// DECLARE_SYN(concat_v2, concat);
-// DECLARE_SYN(concatv2, concat);
-
-// DECLARE_SHAPE_FN(concat) {
-//     auto inp = inputShape->at(0);
-//     int _dimension = INT_ARG(0);
-
-//     NDArray<T>* first = nullptr;
-//     auto last = inputShape->at(inputShape->size() - 1);
-
-//     sd::LongType elements = 0;
-//     sd::LongType *newShape;
-
-//     for (int  e = 0; e < inputShape->size(); e++) {
-//         auto s = INPUT_VARIABLE(e);
-
-//         if (!s->isEmpty()) {
-//             elements++;
-
-//             if (first == nullptr)
-//                 first = s;
-//         }
-//     }
-
-//     { // special cases for 0D concat
-//         bool allScalars = true;
-//         bool hasScalars = false;
-//         for (int e = 0; e < block.width(); e++) {
-//             auto c = INPUT_VARIABLE(e);
-
-//             if (c->isEmpty())
-//                 continue;
-
-//             allScalars &= c->rankOf() == 0;
-//             hasScalars |= c->rankOf() == 0;
-//         }
-
-//         // all scalars
-//         if (allScalars) {
-//             ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(1), sd::LongType);
-
-//             shape::shapeBuffer(1, &elements, newShape);
-//             return SHAPELIST(newShape);
-//         }
-
-//         // any scalar
-//         if (hasScalars) {
-//             ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(1), sd::LongType);
-//             sd::LongType length = shape::length(inp);
-//             for (int i = 1; i < block.width(); i++) {
-//                 auto c = INPUT_VARIABLE(i);
-//                 if (c->isEmpty())
-//                     continue;
-
-//                 length += c->lengthOf();
-//             }
-
-//             shape::shapeBuffer(1, &length, newShape);
-//             return SHAPELIST(newShape);
-//         }
-//     }
-
-//     ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(first->shapeInfo()), sd::LongType);
-
-//     if (_dimension < 0)
-//         _dimension += first->rankOf();
-
-//     std::memcpy(newShape, first->shapeInfo(), shape::shapeInfoByteLength(first->shapeInfo()));
-//     for (int i = 0; i < inputShape->size(); i++) {
-//         auto s = INPUT_VARIABLE(i);
-
-//         // FIXME: s == first is bad, but fast. alternatively we can subtract first size out of result
-//         if (s->isEmpty() || s == first)
-//             continue;
-
-//         newShape[_dimension + 1] += shape::shapeOf(inputShape->at(i))[_dimension];
-//     }
-
-//     shape::updateStrides(newShape, first->ordering());
-
-//     return SHAPELIST(newShape);
-// }
 
 //////////////////////////////////////////////////////////////////////////
 CUSTOM_OP_IMPL(concat_bp, -1, -1, false, 0, 0) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -23,15 +23,15 @@ package org.nd4j.linalg.api.buffer;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.bytedeco.javacpp.*;
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.indexer.*;
 import org.nd4j.common.config.ND4JSystemProperties;
-import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.common.primitives.AtomicBoolean;
 import org.nd4j.common.primitives.AtomicDouble;
 import org.nd4j.common.primitives.Triple;
 import org.nd4j.common.util.ArrayUtil;
-import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.nativeblas.NativeOpsHolder;
 import org.nd4j.nativeblas.OpaqueDataBuffer;
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/Deallocatable.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/Deallocatable.java
@@ -21,6 +21,15 @@
 package org.nd4j.linalg.api.memory;
 
 public interface Deallocatable {
+
+    /**
+     * Whether the reference should be deallocated or not.
+     * @return
+     */
+    default boolean shouldDeAllocate() {
+        return false;
+    }
+
     /**
      * This method returns unique ID for this instance
      * @return

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/abstracts/DummyWorkspace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/abstracts/DummyWorkspace.java
@@ -27,6 +27,7 @@ import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
 import org.nd4j.linalg.api.memory.enums.MemoryKind;
 import org.nd4j.linalg.api.memory.pointers.PagedPointer;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
 
 public class DummyWorkspace implements MemoryWorkspace {
 
@@ -269,6 +270,11 @@ public class DummyWorkspace implements MemoryWorkspace {
             @Override
             public void deallocate() {
                 // no-op
+            }
+
+            @Override
+            public LogEvent logEvent() {
+                return null;
             }
         };
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
@@ -48,7 +48,7 @@ public class DeallocatorService {
     public DeallocatorService() {
         // we need to have at least 2 threads, but for CUDA we'd need at least numDevices threads, due to thread->device affinity
         int numDevices = Nd4j.getAffinityManager().getNumberOfDevices();
-        int numThreads = Math.max(2, numDevices * 2);;
+        int numThreads = Math.max(2, numDevices * 2);
 
         for (int e = 0; e < numDevices; e++)
             deviceMap.add(new ArrayList<>());

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
@@ -48,7 +48,7 @@ public class DeallocatorService {
     public DeallocatorService() {
         // we need to have at least 2 threads, but for CUDA we'd need at least numDevices threads, due to thread->device affinity
         int numDevices = Nd4j.getAffinityManager().getNumberOfDevices();
-        int numThreads = 1;
+        int numThreads = Math.max(2, numDevices * 2);;
 
         for (int e = 0; e < numDevices; e++)
             deviceMap.add(new ArrayList<>());

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -4513,6 +4513,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     public DataBuffer shapeInfoDataBuffer() {
         Nd4j.getCompressor().autoDecompress(this);
         val si = Nd4j.getShapeInfoProvider().createShapeInformation(jvmShapeInfo.shape, jvmShapeInfo.stride,  jvmShapeInfo.ews, jvmShapeInfo.order, ArrayOptionsHelper.dataType(jvmShapeInfo.javaShapeInformation), Shape.isEmpty(jvmShapeInfo.javaShapeInformation));
+        si.getFirst().setConstant(true);
         return si.getFirst();
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
@@ -66,12 +66,14 @@ public abstract class BaseShapeInfoProvider implements ShapeInfoProvider {
     @Override
     public Pair<DataBuffer, long[]> createShapeInformation(long[] shape, long[] stride, long elementWiseStride, char order, DataType dataType, boolean empty) {
         DataBuffer buffer = Shape.createShapeInformation(shape, stride, elementWiseStride, order, dataType, empty);
+        buffer.setConstant(true);
         return Pair.create(buffer, buffer.asLong());
     }
 
     @Override
     public Pair<DataBuffer, long[]> createShapeInformation(long[] shape, long[] stride, long elementWiseStride, char order, long extras) {
         DataBuffer buffer = Shape.createShapeInformation(shape, stride, elementWiseStride, order, extras);
+        buffer.setConstant(true);
         return Pair.create(buffer, buffer.asLong());
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
@@ -66,14 +66,12 @@ public abstract class BaseShapeInfoProvider implements ShapeInfoProvider {
     @Override
     public Pair<DataBuffer, long[]> createShapeInformation(long[] shape, long[] stride, long elementWiseStride, char order, DataType dataType, boolean empty) {
         DataBuffer buffer = Shape.createShapeInformation(shape, stride, elementWiseStride, order, dataType, empty);
-        buffer.setConstant(true);
         return Pair.create(buffer, buffer.asLong());
     }
 
     @Override
     public Pair<DataBuffer, long[]> createShapeInformation(long[] shape, long[] stride, long elementWiseStride, char order, long extras) {
         DataBuffer buffer = Shape.createShapeInformation(shape, stride, elementWiseStride, order, extras);
-        buffer.setConstant(true);
         return Pair.create(buffer, buffer.asLong());
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
@@ -68,6 +68,7 @@ public class UnifiedProfiler {
                 .build();
         Nd4j.getExecutioner().setProfilingConfig(profilerConfig);
         OpProfiler.getInstance().setConfig(profilerConfig);
+        EventLogger.getInstance().setEnabled(true);
 
     }
 
@@ -83,6 +84,8 @@ public class UnifiedProfiler {
                 .build();
         Nd4j.getExecutioner().setProfilingConfig(profilerConfig);
         OpProfiler.getInstance().setConfig(profilerConfig);
+        EventLogger.getInstance().setEnabled(false);
+
 
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/UnifiedProfiler.java
@@ -26,6 +26,7 @@ import org.nd4j.linalg.api.memory.enums.AllocationKind;
 import org.nd4j.linalg.api.ndarray.INDArrayStatistics;
 import org.nd4j.linalg.api.ops.performance.PerformanceTracker;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
 
 import java.util.List;
 import java.util.Map;
@@ -152,6 +153,22 @@ public class UnifiedProfiler {
         return AllocationsTracker.getInstance().memoryPerDevice();
     }
 
+
+    /**
+     * Whether to enable log events.
+     * Events include timestamped events of:
+     * allocations
+     * deallocations
+     * Note this will log A LOT of information.
+     * This logger should only be used when trying to debug
+     * something like a crash where VERY fine grained information
+     * is needed to make sense of off heap events that are not provided
+     * by pre existing java tools.
+     * @param enableLogEvents
+     */
+    public void enableLogEvents(boolean enableLogEvents) {
+        EventLogger.getInstance().setEnabled(enableLogEvents);
+    }
 
     public static UnifiedProfiler getInstance() {
         return INSTANCE;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogListener.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogListener.java
@@ -1,0 +1,38 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.linalg.profiler.data.eventlogger;
+
+/**
+ * Custom listener for log events.
+ *
+ * @author Adam Gibson
+ */
+public interface EventLogListener {
+
+
+    /**
+     * The {@link EventLogger}
+     * will call listeners when its own
+     * {@link EventLogger#log(LogEvent)}
+     * is called
+     * @param logEvent the log event that occurred
+     */
+    void onLogEvent(LogEvent logEvent);
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogger.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogger.java
@@ -1,0 +1,74 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.nd4j.linalg.profiler.data.eventlogger;
+
+import lombok.extern.slf4j.Slf4j;
+import org.nd4j.common.primitives.AtomicBoolean;
+
+@Slf4j
+public class EventLogger {
+
+    private static EventLogger SINGLETON = new EventLogger();
+    private AtomicBoolean enabled = new AtomicBoolean(false);
+    protected EventLogger() {}
+
+
+    /**
+     * Returns whether the event logger is enabled or not.
+     * @return
+     */
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+    /**
+     * Set enabled.
+     * @param enabled whether the logger should be enabled.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
+    }
+
+    /**
+     * Log the event with slf4j using INFO.
+     * Note that in order to enable this logging
+     * configuring your slf4j backend is required.
+     * This usually means setting the:
+     * org.nd4j.linalg.profiler.data.eventlogger
+     * to INFO
+     * @param logEvent
+     */
+    public void log(LogEvent logEvent) {
+        if(enabled.get())
+            log.info("{},{},{},{},{},{},{}",
+                    logEvent.getEventTimeMs(),
+                    logEvent.getEventType(),
+                    logEvent.getObjectAllocationType(),
+                    logEvent.getAssociatedWorkspace(),
+                    logEvent.getThreadName(),
+                    logEvent.getDataType(),
+                    logEvent.getBytes());
+    }
+
+    public static EventLogger getInstance() {
+        return SINGLETON;
+    }
+
+
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogger.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogger.java
@@ -197,15 +197,29 @@ public class EventLogger {
     public void log(LogEvent logEvent) {
         if(enabled.get() && eventTypesToLog.contains(logEvent.getEventType()) &&
                 this.allocationTypesToLog.contains(logEvent.getObjectAllocationType()))
-            logStream.println(String.format("%s,%s,%s,%s,%s,%s,%s",
+            logStream.println(String.format("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s",
                     formatTimeAsDate.get() ?  new Timestamp(logEvent.getEventTimeMs()) : logEvent.getEventTimeMs(),
                     logEvent.getEventType(),
                     logEvent.getObjectAllocationType(),
                     logEvent.getAssociatedWorkspace(),
                     logEvent.getThreadName(),
                     logEvent.getDataType(),
-                    logEvent.getBytes()));
+                    logEvent.getBytes(),
+                    logEvent.isAttached(),
+                    logEvent.isConstant(),
+                    logEvent.getObjectId()));
+
+        if(listeners != null) {
+            for(EventLogListener listener : listeners) {
+                if(listener != null) {
+                    listener.onLogEvent(logEvent);
+                }
+            }
+        }
+
     }
+
+
 
     public static EventLogger getInstance() {
         return SINGLETON;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventType.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventType.java
@@ -17,25 +17,9 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *  *****************************************************************************
  */
+package org.nd4j.linalg.profiler.data.eventlogger;
 
-package org.nd4j.linalg.api.memory;
-
-import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
-
-public interface Deallocator {
-    /**
-     * This method does actual deallocation
-     */
-    void deallocate();
-
-    /**
-     * Log event for a deallocation.
-     * Only used when {@link org.nd4j.linalg.profiler.data.eventlogger.EventLogger#enabled}
-     * is true. We store events on deallocators to retain metadata
-     * about a be to be deleted buffer without the need to retain a reference
-     * to the deallocatable object. This is to avoid conflict with {@link java.lang.ref.WeakReference}
-     *
-     * @return
-     */
-    LogEvent logEvent();
+public enum EventType {
+    ALLOCATION,
+    DEALLOCATION
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/LogEvent.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/LogEvent.java
@@ -52,5 +52,8 @@ public class LogEvent {
     private long eventTimeMs;
     private String associatedWorkspace;
     private long bytes;
+    private boolean attached;
+    private boolean isConstant;
+    private String objectId;
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/LogEvent.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/LogEvent.java
@@ -17,25 +17,26 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *  *****************************************************************************
  */
+package org.nd4j.linalg.profiler.data.eventlogger;
 
-package org.nd4j.linalg.api.memory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.nd4j.linalg.api.buffer.DataType;
 
-import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LogEvent {
 
-public interface Deallocator {
-    /**
-     * This method does actual deallocation
-     */
-    void deallocate();
+    private DataType dataType;
+    private EventType eventType;
+    private ObjectAllocationType objectAllocationType;
+    private String threadName;
+    private long eventTimeMs;
+    private String associatedWorkspace;
+    private long bytes;
 
-    /**
-     * Log event for a deallocation.
-     * Only used when {@link org.nd4j.linalg.profiler.data.eventlogger.EventLogger#enabled}
-     * is true. We store events on deallocators to retain metadata
-     * about a be to be deleted buffer without the need to retain a reference
-     * to the deallocatable object. This is to avoid conflict with {@link java.lang.ref.WeakReference}
-     *
-     * @return
-     */
-    LogEvent logEvent();
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/LogEvent.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/LogEvent.java
@@ -24,7 +24,21 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.nd4j.linalg.api.buffer.DataType;
+import org.nd4j.linalg.api.memory.provider.BasicWorkspaceManager;
 
+/**
+ * A log event reflects what a user might want to see in log output.
+ * This will include the following:
+ * 1. the timestamp for the event
+ * 2. the event type (usually allocation or deallocation) {@link EventType}
+ * 3. object type (the type of object being acted on like a databuffer or op context): {@link ObjectAllocationType}
+ * 4. The associated workspace if any, this is usually {@link BasicWorkspaceManager#getWorkspaceForCurrentThread()}
+ * 5. The thread name if any
+ * 6. The data type of the object if any (eg: long, int, float,..)
+ * 7. The bytes of the object
+ *
+ * @author Adam Gibson
+ */
 @Data
 @Builder
 @AllArgsConstructor

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/ObjectAllocationType.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/ObjectAllocationType.java
@@ -17,25 +17,10 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *  *****************************************************************************
  */
+package org.nd4j.linalg.profiler.data.eventlogger;
 
-package org.nd4j.linalg.api.memory;
-
-import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
-
-public interface Deallocator {
-    /**
-     * This method does actual deallocation
-     */
-    void deallocate();
-
-    /**
-     * Log event for a deallocation.
-     * Only used when {@link org.nd4j.linalg.profiler.data.eventlogger.EventLogger#enabled}
-     * is true. We store events on deallocators to retain metadata
-     * about a be to be deleted buffer without the need to retain a reference
-     * to the deallocatable object. This is to avoid conflict with {@link java.lang.ref.WeakReference}
-     *
-     * @return
-     */
-    LogEvent logEvent();
+public enum ObjectAllocationType {
+    OP_CONTEXT,
+    DATA_BUFFER,
+    WORKSPACE
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
@@ -49,32 +49,7 @@ public class DirectShapeInfoProvider extends BaseShapeInfoProvider {
 
     @Override
     public Pair<DataBuffer, long[]> createShapeInformation(long[] shape, long[] stride,  long elementWiseStride, char order, long extras) {
-        // We enforce offset to 0 in shapeBuffer, since we need it for cache efficiency + we don't actually use offset value @ native side
-        // We also enforce elementWiseStride = 0
-        if (elementWiseStride < 0)
-            elementWiseStride = 0;
-
-        LongShapeDescriptor descriptor = new LongShapeDescriptor(shape, stride, 0, elementWiseStride, order, extras);
-        if (!longCache.containsKey(descriptor)) {
-            if (counter.get() < MAX_ENTRIES) {
-                synchronized (this) {
-                    if (!longCache.containsKey(descriptor)) {
-                        counter.incrementAndGet();
-                        Pair<DataBuffer, long[]> buffer = super.createShapeInformation(shape, stride, elementWiseStride, order, extras);
-                        longCache.put(descriptor, buffer);
-
-                        bytes.addAndGet(buffer.getFirst().length() * 8 * 2);
-                        AllocationsTracker.getInstance().markAllocated(AllocationKind.CONSTANT,0, buffer.getFirst().length() * 8 * 2);
-                        return buffer;
-                    } else
-                        return longCache.get(descriptor);
-                }
-            } else {
-                return super.createShapeInformation(shape, stride, elementWiseStride, order, extras);
-            }
-        }
-
-        return longCache.get(descriptor);
+        return super.createShapeInformation(shape, stride, elementWiseStride, order, extras);
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
@@ -49,7 +49,32 @@ public class DirectShapeInfoProvider extends BaseShapeInfoProvider {
 
     @Override
     public Pair<DataBuffer, long[]> createShapeInformation(long[] shape, long[] stride,  long elementWiseStride, char order, long extras) {
-        return super.createShapeInformation(shape, stride, elementWiseStride, order, extras);
+        // We enforce offset to 0 in shapeBuffer, since we need it for cache efficiency + we don't actually use offset value @ native side
+        // We also enforce elementWiseStride = 0
+        if (elementWiseStride < 0)
+            elementWiseStride = 0;
+
+        LongShapeDescriptor descriptor = new LongShapeDescriptor(shape, stride, 0, elementWiseStride, order, extras);
+        if (!longCache.containsKey(descriptor)) {
+            if (counter.get() < MAX_ENTRIES) {
+                synchronized (this) {
+                    if (!longCache.containsKey(descriptor)) {
+                        counter.incrementAndGet();
+                        Pair<DataBuffer, long[]> buffer = super.createShapeInformation(shape, stride, elementWiseStride, order, extras);
+                        longCache.put(descriptor, buffer);
+
+                        bytes.addAndGet(buffer.getFirst().length() * 8 * 2);
+                        AllocationsTracker.getInstance().markAllocated(AllocationKind.CONSTANT,0, buffer.getFirst().length() * 8 * 2);
+                        return buffer;
+                    } else
+                        return longCache.get(descriptor);
+                }
+            } else {
+                return super.createShapeInformation(shape, stride, elementWiseStride, order, extras);
+            }
+        }
+
+        return longCache.get(descriptor);
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
@@ -48,6 +48,10 @@ public abstract class BaseCpuDataBuffer extends BaseDataBuffer implements Deallo
 
     }
 
+    @Override
+    public boolean shouldDeAllocate() {
+        return !released && !constant;
+    }
 
     @Override
     public String getUniqueId() {

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
@@ -39,6 +39,9 @@ public class CpuDeallocator implements Deallocator {
         opaqueDataBuffer = buffer.getOpaqueDataBuffer();
         if(EventLogger.getInstance().isEnabled()) {
             logEvent = LogEvent.builder()
+                    .attached(buffer.isAttached())
+                    .objectId(buffer.getUniqueId())
+                    .isConstant(buffer.isConstant())
                     .bytes(buffer.getElementSize() * buffer.length())
                     .dataType(buffer.dataType())
                     .eventType(EventType.DEALLOCATION)
@@ -58,6 +61,7 @@ public class CpuDeallocator implements Deallocator {
         //perform logging
         if(logEvent != null) {
             logEvent.setEventTimeMs(System.currentTimeMillis());
+            logEvent.setThreadName(Thread.currentThread().getName());
             EventLogger.getInstance().log(logEvent);
         }
         NativeOpsHolder.getInstance().getDeviceNativeOps().deleteDataBuffer(opaqueDataBuffer);

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
@@ -21,25 +21,50 @@
 package org.nd4j.linalg.cpu.nativecpu.buffer;
 
 import lombok.extern.slf4j.Slf4j;
-import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.memory.Deallocator;
+import org.nd4j.linalg.api.ops.impl.transforms.strict.Log;
+import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
+import org.nd4j.linalg.profiler.data.eventlogger.EventType;
+import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
+import org.nd4j.linalg.profiler.data.eventlogger.ObjectAllocationType;
 import org.nd4j.nativeblas.NativeOpsHolder;
 import org.nd4j.nativeblas.OpaqueDataBuffer;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 @Slf4j
 public class CpuDeallocator implements Deallocator {
     private final transient OpaqueDataBuffer opaqueDataBuffer;
+    private LogEvent logEvent;
+
     public CpuDeallocator(BaseCpuDataBuffer buffer) {
         opaqueDataBuffer = buffer.getOpaqueDataBuffer();
+        if(EventLogger.getInstance().isEnabled()) {
+            logEvent = LogEvent.builder()
+                    .bytes(buffer.getElementSize() * buffer.length())
+                    .dataType(buffer.dataType())
+                    .eventType(EventType.DEALLOCATION)
+                    .objectAllocationType(ObjectAllocationType.DATA_BUFFER)
+                    .associatedWorkspace(buffer.getParentWorkspace().getId())
+                    .build();
+
+        }
     }
 
     @Override
     public void deallocate() {
         if (opaqueDataBuffer == null)
             throw new RuntimeException("opaqueDataBuffer is null");
+
+        //update the log event with the actual time of de allocation and then
+        //perform logging
+        if(logEvent != null) {
+            logEvent.setEventTimeMs(System.currentTimeMillis());
+            EventLogger.getInstance().log(logEvent);
+        }
         NativeOpsHolder.getInstance().getDeviceNativeOps().deleteDataBuffer(opaqueDataBuffer);
+    }
+
+    @Override
+    public LogEvent logEvent() {
+        return logEvent;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
@@ -22,7 +22,7 @@ package org.nd4j.linalg.cpu.nativecpu.buffer;
 
 import lombok.extern.slf4j.Slf4j;
 import org.nd4j.linalg.api.memory.Deallocator;
-import org.nd4j.linalg.api.ops.impl.transforms.strict.Log;
+import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
 import org.nd4j.linalg.profiler.data.eventlogger.EventType;
 import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
@@ -43,7 +43,7 @@ public class CpuDeallocator implements Deallocator {
                     .dataType(buffer.dataType())
                     .eventType(EventType.DEALLOCATION)
                     .objectAllocationType(ObjectAllocationType.DATA_BUFFER)
-                    .associatedWorkspace(buffer.getParentWorkspace().getId())
+                    .associatedWorkspace(Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread().getId())
                     .build();
 
         }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.cpu.nativecpu.ops;
 import lombok.NonNull;
 import lombok.val;
 import org.bytedeco.javacpp.*;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.Deallocatable;
 import org.nd4j.linalg.api.memory.Deallocator;
@@ -189,7 +190,10 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
         for(int i = 0; i < arrays.size(); i++) {
             INDArray array = arrays.get(i);
             buffers.put(i,array.isEmpty() ? null : ((BaseCpuDataBuffer) array.data()).getOpaqueDataBuffer());
-            shapeInfoBuffer.put(i,array.shapeInfoDataBuffer().addressPointer());
+            DataBuffer dataBuffer = array.shapeInfoDataBuffer();
+            Pointer addressPointer = dataBuffer.pointer();
+            addressPointer.retainReference();
+            shapeInfoBuffer.put(i,addressPointer);
             fastpath_in.put(i,array.isEmpty() ? null : array);
         }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContextDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContextDeallocator.java
@@ -21,18 +21,45 @@
 package org.nd4j.linalg.cpu.nativecpu.ops;
 
 import org.nd4j.linalg.api.memory.Deallocator;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
+import org.nd4j.linalg.profiler.data.eventlogger.EventType;
+import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
+import org.nd4j.linalg.profiler.data.eventlogger.ObjectAllocationType;
 import org.nd4j.nativeblas.NativeOpsHolder;
 import org.nd4j.nativeblas.OpaqueContext;
 
 public class CpuOpContextDeallocator implements Deallocator {
     private transient final OpaqueContext context;
+    private LogEvent logEvent;
 
     public CpuOpContextDeallocator(CpuOpContext ctx) {
         context = (OpaqueContext) ctx.contextPointer();
+
+        if(EventLogger.getInstance().isEnabled()) {
+            logEvent = LogEvent.builder()
+                    .eventType(EventType.DEALLOCATION)
+                    .objectAllocationType(ObjectAllocationType.OP_CONTEXT)
+                    .associatedWorkspace(Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread().getId())
+                    .build();
+
+        }
     }
 
     @Override
     public void deallocate() {
+        //update the log event with the actual time of de allocation and then
+        //perform logging
+        if(logEvent != null) {
+            logEvent.setEventTimeMs(System.currentTimeMillis());
+            EventLogger.getInstance().log(logEvent);
+        }
+
         NativeOpsHolder.getInstance().getDeviceNativeOps().deleteGraphContext(context);
+    }
+
+    @Override
+    public LogEvent logEvent() {
+        return logEvent;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContextDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContextDeallocator.java
@@ -52,6 +52,7 @@ public class CpuOpContextDeallocator implements Deallocator {
         //perform logging
         if(logEvent != null) {
             logEvent.setEventTimeMs(System.currentTimeMillis());
+            logEvent.setThreadName(Thread.currentThread().getName());
             EventLogger.getInstance().log(logEvent);
         }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
@@ -115,10 +115,18 @@ public class CpuWorkspaceDeallocator implements Deallocator {
                 Nd4j.getMemoryManager().release(pair.getDevicePointer(), MemoryKind.DEVICE);
         }
 
+
+        //update the log event with the actual time of de allocation and then
+        //perform logging
+        if(logEvent != null) {
+            logEvent.setEventTimeMs(System.currentTimeMillis());
+            EventLogger.getInstance().log(logEvent);
+        }
+
     }
 
     @Override
     public LogEvent logEvent() {
-        return null;
+        return logEvent;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
@@ -120,6 +120,7 @@ public class CpuWorkspaceDeallocator implements Deallocator {
         //perform logging
         if(logEvent != null) {
             logEvent.setEventTimeMs(System.currentTimeMillis());
+            logEvent.setThreadName(Thread.currentThread().getName());
             EventLogger.getInstance().log(logEvent);
         }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
@@ -29,6 +29,10 @@ import org.nd4j.linalg.api.memory.enums.LocationPolicy;
 import org.nd4j.linalg.api.memory.enums.MemoryKind;
 import org.nd4j.linalg.api.memory.pointers.PointersPair;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
+import org.nd4j.linalg.profiler.data.eventlogger.EventType;
+import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
+import org.nd4j.linalg.profiler.data.eventlogger.ObjectAllocationType;
 import org.nd4j.nativeblas.NativeOpsHolder;
 
 import java.util.List;
@@ -41,13 +45,21 @@ public class CpuWorkspaceDeallocator implements Deallocator {
     private List<PointersPair> externalPointers;
     private LocationPolicy location;
     private Pair<LongPointer, Long> mmapInfo;
+    private LogEvent logEvent;
 
     public CpuWorkspaceDeallocator(@NonNull CpuWorkspace workspace) {
         this.pointersPair = workspace.workspace();
         this.pinnedPointers = workspace.pinnedPointers();
         this.externalPointers = workspace.externalPointers();
         this.location = workspace.getWorkspaceConfiguration().getPolicyLocation();
+        if(EventLogger.getInstance().isEnabled()) {
+            logEvent = LogEvent.builder()
+                    .eventType(EventType.DEALLOCATION)
+                    .objectAllocationType(ObjectAllocationType.WORKSPACE)
+                    .associatedWorkspace(workspace.getId())
+                    .build();
 
+        }
         if (workspace.mappedFileSize() > 0)
             this.mmapInfo = Pair.makePair(workspace.mmap, workspace.mappedFileSize());
     }
@@ -103,5 +115,10 @@ public class CpuWorkspaceDeallocator implements Deallocator {
                 Nd4j.getMemoryManager().release(pair.getDevicePointer(), MemoryKind.DEVICE);
         }
 
+    }
+
+    @Override
+    public LogEvent logEvent() {
+        return null;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/impl/CudaDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/impl/CudaDeallocator.java
@@ -40,6 +40,8 @@ public class CudaDeallocator implements Deallocator {
         opaqueDataBuffer = buffer.getOpaqueDataBuffer();
         if(EventLogger.getInstance().isEnabled()) {
             logEvent = LogEvent.builder()
+                    .isAttached(buffer.isAttached())
+                    .isConstant(buffer.isConstant())
                     .eventType(EventType.DEALLOCATION)
                     .objectAllocationType(ObjectAllocationType.DATA_BUFFER)
                     .associatedWorkspace(Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread().getId())

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContextDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContextDeallocator.java
@@ -19,18 +19,36 @@
 package org.nd4j.linalg.jcublas.ops.executioner;
 
 import org.nd4j.linalg.api.memory.Deallocator;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
+import org.nd4j.linalg.profiler.data.eventlogger.EventType;
+import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
+import org.nd4j.linalg.profiler.data.eventlogger.ObjectAllocationType;
 import org.nd4j.nativeblas.NativeOpsHolder;
 import org.nd4j.nativeblas.OpaqueContext;
 
 public class CudaOpContextDeallocator implements Deallocator {
     private transient final OpaqueContext context;
+    private transient LogEvent logEvent;
 
     public CudaOpContextDeallocator(CudaOpContext ctx) {
-        context = (OpaqueContext) ctx.contextPointer();
+        context = (OpaqueContext) ctx.contextPointer(); if(EventLogger.getInstance().isEnabled()) {
+            logEvent = LogEvent.builder()
+                    .eventType(EventType.DEALLOCATION)
+                    .objectAllocationType(ObjectAllocationType.OP_CONTEXT)
+                    .associatedWorkspace(Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread().getId())
+                    .build();
+
+        }
     }
 
     @Override
     public void deallocate() {
         NativeOpsHolder.getInstance().getDeviceNativeOps().deleteGraphContext(context);
+    }
+
+    @Override
+    public LogEvent logEvent() {
+        return logEvent;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContextDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContextDeallocator.java
@@ -32,7 +32,8 @@ public class CudaOpContextDeallocator implements Deallocator {
     private transient LogEvent logEvent;
 
     public CudaOpContextDeallocator(CudaOpContext ctx) {
-        context = (OpaqueContext) ctx.contextPointer(); if(EventLogger.getInstance().isEnabled()) {
+        context = (OpaqueContext) ctx.contextPointer();
+        if(EventLogger.getInstance().isEnabled()) {
             logEvent = LogEvent.builder()
                     .eventType(EventType.DEALLOCATION)
                     .objectAllocationType(ObjectAllocationType.OP_CONTEXT)

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/common/config/ND4JSystemProperties.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/common/config/ND4JSystemProperties.java
@@ -225,6 +225,19 @@ public class ND4JSystemProperties {
      */
     public final static String LARGE_ARRAY_MAX_MULTIPLE = "org.nd4j.cache.large_array_max_multiple";
 
+    /**
+     * For usage with the EventLogger. When the event logger is enabled, extra information will be tracked
+     * including allocations, deallocations and other difficult to track down events.
+     * Note that enabling this will add a certain amount of overhead.
+     */
+    public final static String EVENT_LOGGER_ENABLED = "org.nd4j.linalg.profiler.eventlogger.enabled";
+
+    /**
+     * For usage with the EventLogger. Tells the event logger to
+     * format its log output as a date instead of the default nanoseconds.
+     */
+    public final static String EVENT_LOGGER_FORMAT_AS_DATE = "org.nd4j.linalg.profiler.eventlogger.logdate";
+
     private ND4JSystemProperties() {
     }
 }

--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -79,7 +79,9 @@
         <surefire.threads>8</surefire.threads>
         <tests>samediff,rng,java-only,dl4j-old-api,ndarray-indexing,compression,loss-functions,keras,python,tensorflow,onnx</tests>
         <excludedTests>large-resources,downloads,long-running-test</excludedTests>
+<!--
         <preload>/usr/lib64/libjemalloc.so.2</preload>
+-->
     </properties>
 
     <dependencyManagement>

--- a/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -943,9 +943,6 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     @ParameterizedTest
     public void testParallelLoading(Nd4jBackend backend) throws Exception {
-        Nd4j.getProfiler().start();
-        EventLogger.getInstance().setEventTypesToLog(Arrays.asList(EventType.DEALLOCATION));
-        EventLogger.getInstance().setFormatTimeAsDate(true);
         int numThreads = 16;
         boolean isIntegration = isIntegrationTests();
         Executor executor = Executors.newFixedThreadPool(numThreads);
@@ -980,7 +977,6 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
             File write = new File("pv_" + i + ".zip");
             System.out.println(UnifiedProfiler.getInstance().printCurrentStats());
             WordVectorSerializer.writeParagraphVectors(pv,write.getAbsolutePath());
-            System.out.println(UnifiedProfiler.getInstance().printCurrentStats());
 
         }
 
@@ -994,10 +990,7 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
                     @SneakyThrows
                     @Override
                     public void run() {
-                        System.out.println(UnifiedProfiler.getInstance().printCurrentStats());
                         WordVectorSerializer.readParagraphVectors(write);
-                        Nd4j.getWorkspaceManager().printAllocationStatisticsForCurrentThread();
-                        System.out.println(UnifiedProfiler.getInstance().printCurrentStats());
                     }
                 });
             }
@@ -1007,7 +1000,6 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
         }
 
 
-        //  Nd4j.getProfiler().stop();
 
     }
 

--- a/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -68,6 +68,8 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.ops.transforms.Transforms;
 import org.nd4j.linalg.profiler.UnifiedProfiler;
+import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
+import org.nd4j.linalg.profiler.data.eventlogger.EventType;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -941,7 +943,9 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     @ParameterizedTest
     public void testParallelLoading(Nd4jBackend backend) throws Exception {
-
+        Nd4j.getProfiler().start();
+        EventLogger.getInstance().setEventTypesToLog(Arrays.asList(EventType.DEALLOCATION));
+        EventLogger.getInstance().setFormatTimeAsDate(true);
         int numThreads = 12;
         boolean isIntegration = isIntegrationTests();
         Executor executor = Executors.newFixedThreadPool(numThreads);
@@ -960,7 +964,7 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
 
         UnifiedProfiler.getInstance().start();
 
-      Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread().enableDebug(true);
+        Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread().enableDebug(true);
         Word2Vec wordVectors = new Word2Vec.Builder().minWordFrequency(1).batchSize(250).iterations(1).epochs(1)
                 .learningRate(0.025).layerSize(150).minLearningRate(0.001)
                 .elementsLearningAlgorithm(new SkipGram<>()).useHierarchicSoftmax(true).windowSize(5)
@@ -1002,6 +1006,9 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
             Thread.sleep(1000);
             count++;
         }
+
+
+        Nd4j.getProfiler().stop();
 
     }
 

--- a/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -946,7 +946,7 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
         Nd4j.getProfiler().start();
         EventLogger.getInstance().setEventTypesToLog(Arrays.asList(EventType.DEALLOCATION));
         EventLogger.getInstance().setFormatTimeAsDate(true);
-        int numThreads = 12;
+        int numThreads = 16;
         boolean isIntegration = isIntegrationTests();
         Executor executor = Executors.newFixedThreadPool(numThreads);
         File resource = Resources.asFile("/big/raw_sentences.txt");
@@ -962,7 +962,6 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
         TokenizerFactory t = new DefaultTokenizerFactory();
         t.setTokenPreProcessor(new CommonPreprocessor());
 
-        UnifiedProfiler.getInstance().start();
 
         Nd4j.getWorkspaceManager().getWorkspaceForCurrentThread().enableDebug(true);
         Word2Vec wordVectors = new Word2Vec.Builder().minWordFrequency(1).batchSize(250).iterations(1).epochs(1)
@@ -1008,7 +1007,7 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
         }
 
 
-        Nd4j.getProfiler().stop();
+        //  Nd4j.getProfiler().stop();
 
     }
 

--- a/platform-tests/src/test/resources/log4j.properties
+++ b/platform-tests/src/test/resources/log4j.properties
@@ -35,7 +35,7 @@ log4j.appender.org.apache.uima=OFF
 log4j.appender.org.cleartk=OFF
 
 log4j.logger.org.springframework=INFO
-log4j.logger.org.nd4j=DEBUG
+log4j.logger.org.nd4j=TRACE
 log4j.logger.org.deeplearning4j=INFO
 log4j.logger.opennlp.uima.util=OFF
 log4j.logger.org.apache.uima=OFF

--- a/platform-tests/src/test/resources/logback-test.xml
+++ b/platform-tests/src/test/resources/logback-test.xml
@@ -39,7 +39,7 @@
     <logger name="org.springframework" level="DEBUG" />
     <logger name="org.deeplearning4j" level="INFO" />
     <logger name="org.datavec" level="INFO" />
-    <logger name="org.nd4j" level="INFO" />
+    <logger name="org.nd4j" level="TRACE" />
     <logger name="opennlp.uima.util" level="OFF" />
     <logger name="org.apache.uima" level="OFF" />
     <logger name="org.cleartk" level="OFF" />

--- a/platform-tests/src/test/resources/logback.xml
+++ b/platform-tests/src/test/resources/logback.xml
@@ -41,7 +41,7 @@
     <logger name="org.springframework" level="DEBUG" />
     <logger name="org.deeplearning4j" level="INFO" />
     <logger name="org.canova" level="INFO" />
-    <logger name="org.nd4j" level="DEBUG" />
+    <logger name="org.nd4j" level="TRACE" />
     <logger name="opennlp.uima.util" level="OFF" />
     <logger name="org.apache.uima" level="OFF" />
     <logger name="org.cleartk" level="OFF" />


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes a race condition where a shape buffer gets deleted but then used.
This race condition happens when the shape info data buffer is returned
but then deallocated due to the scope ending for the original method.

Also adds a new event logger to track allocations and deallocations.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
