### PR TITLE
Add deallocator references

### DIFF
--- a/.github/workflows/build-deploy-android-arm32.yml
+++ b/.github/workflows/build-deploy-android-arm32.yml
@@ -164,10 +164,7 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh android arm32
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled  }}
-
+ 
 
 
 

--- a/.github/workflows/build-deploy-android-arm32.yml
+++ b/.github/workflows/build-deploy-android-arm32.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-android-arm64.yml
+++ b/.github/workflows/build-deploy-android-arm64.yml
@@ -168,7 +168,7 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh android arm64
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-   var
+   
 
 
 

--- a/.github/workflows/build-deploy-android-arm64.yml
+++ b/.github/workflows/build-deploy-android-arm64.yml
@@ -168,10 +168,7 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh android arm64
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled  }}
-
+   var
 
 
 

--- a/.github/workflows/build-deploy-android-arm64.yml
+++ b/.github/workflows/build-deploy-android-arm64.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-android-x86.yml
+++ b/.github/workflows/build-deploy-android-x86.yml
@@ -166,6 +166,6 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh android x86
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-   var
+   
 
 

--- a/.github/workflows/build-deploy-android-x86.yml
+++ b/.github/workflows/build-deploy-android-x86.yml
@@ -166,9 +166,6 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh android x86
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled  }}
-
+   var
 
 

--- a/.github/workflows/build-deploy-android-x86.yml
+++ b/.github/workflows/build-deploy-android-x86.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-android-x86_64.yml
+++ b/.github/workflows/build-deploy-android-x86_64.yml
@@ -169,6 +169,6 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh android x86_64
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-   var
+   
 
 

--- a/.github/workflows/build-deploy-android-x86_64.yml
+++ b/.github/workflows/build-deploy-android-x86_64.yml
@@ -169,9 +169,6 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh android x86_64
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled  }}
-
+   var
 
 

--- a/.github/workflows/build-deploy-android-x86_64.yml
+++ b/.github/workflows/build-deploy-android-x86_64.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-cross-platform.yml
+++ b/.github/workflows/build-deploy-cross-platform.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Release version target'

--- a/.github/workflows/build-deploy-cross-platform.yml
+++ b/.github/workflows/build-deploy-cross-platform.yml
@@ -135,7 +135,4 @@ jobs:
                            eval "$command"
           fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && failure() }}
-
+   

--- a/.github/workflows/build-deploy-linux-arm32.yml
+++ b/.github/workflows/build-deploy-linux-arm32.yml
@@ -152,10 +152,7 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh linux arm32
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
+    
 
 
 

--- a/.github/workflows/build-deploy-linux-arm32.yml
+++ b/.github/workflows/build-deploy-linux-arm32.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-linux-arm64.yml
+++ b/.github/workflows/build-deploy-linux-arm64.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       serverId:
         description: 'Server id to publish to'

--- a/.github/workflows/build-deploy-linux-arm64.yml
+++ b/.github/workflows/build-deploy-linux-arm64.yml
@@ -161,9 +161,5 @@ jobs:
           
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
 
 

--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -150,9 +150,5 @@ jobs:
           bash ./bootstrap-libnd4j-from-url.sh linux cuda 10.2 arm64
           ${GITHUB_WORKSPACE}/libnd4j/pi_build.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
 
 

--- a/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
+++ b/.github/workflows/build-deploy-linux-cuda-10.2-arm64.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       serverId:
         description: 'Server id to publish to'

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -250,8 +250,5 @@ jobs:
                   eval "${COMMAND}"
           fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled  }}
-
+   
 

--- a/.github/workflows/build-deploy-linux-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.4.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -237,7 +237,3 @@ jobs:
                        eval "${COMMAND}"
           fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled  }}
-

--- a/.github/workflows/build-deploy-linux-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-11.6.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -194,10 +194,6 @@ jobs:
           EXTENSION: ${{ matrix.extension }}
           MAVEN_OPTS: -Xmx2g
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled }}
-
 
 
 

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -247,9 +247,5 @@ jobs:
                        eval "${COMMAND}"
           fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled}}
-
 
 

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-mac-arm64.yml
+++ b/.github/workflows/build-deploy-mac-arm64.yml
@@ -225,7 +225,3 @@ jobs:
                   eval "${COMMAND}"
           fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled }}
-

--- a/.github/workflows/build-deploy-mac-arm64.yml
+++ b/.github/workflows/build-deploy-mac-arm64.yml
@@ -15,7 +15,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -15,7 +15,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -226,7 +226,4 @@ jobs:
                   eval "${COMMAND}"
           fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled }}
-
+    

--- a/.github/workflows/build-deploy-windows-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.4.yml
@@ -252,7 +252,3 @@ jobs:
             )
           )
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled  }}
-

--- a/.github/workflows/build-deploy-windows-cuda-11.4.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.4.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-windows-cuda-11.6.yml
+++ b/.github/workflows/build-deploy-windows-cuda-11.6.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -231,8 +231,5 @@ jobs:
           EXTENSION: ${{ matrix.extension }}
           LIBND4J_FILE_NAME: ${{ matrix.libnd4j_file_download }}
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.debug_enabled  }}
 
 

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -14,7 +14,7 @@ on:
       releaseVersion:
         description: 'Release version target'
         required: false
-        default: 1.0.0-M2.1
+        default: 1.0.0-M3
 
       snapshotVersion:
         description: 'Snapshot version target'

--- a/libnd4j/include/array/NDArray.h
+++ b/libnd4j/include/array/NDArray.h
@@ -1611,9 +1611,7 @@ SD_INLINE R NDArray::templatedGet(void const *buffer, sd::LongType index) const 
 //////////////////////////////////////////////////////////////////////////
 void NDArray::setShapeInfo(sd::LongType *shapeInfo) {
   if (shapeInfo != nullptr) {
-    sd_printf("Setting shape info using input long type shape pointers\n",0);
     auto buffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo);
-    sd_printf("Created buffer to be set\n",0);
     if(buffer == nullptr) {
       throw std::runtime_error("Returned buffer from cache was null!");
     }
@@ -1626,9 +1624,7 @@ void NDArray::setShapeInfo(sd::LongType *shapeInfo) {
     if(_shapeInfo[0] > SD_MAX_RANK || _shapeInfo[0] < 0)
       throw std::runtime_error("Set shape info buffer was corrupt. Please check for deallocation.");
 
-    sd_printf("Setting access for buffer\n",0);
     _dataType = ArrayOptions::dataType(_shapeInfo);
-    sd_printf("Set data type\n",0);
     if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
       _length = 0;
     else
@@ -1638,7 +1634,6 @@ void NDArray::setShapeInfo(sd::LongType *shapeInfo) {
     _length = 0;
   }
 
-  sd_printf("After setting shape info using input long type shape pointers\n",0);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -379,7 +379,7 @@ namespace sd {
         _offset = 0;
 
         auto descriptor = new ShapeDescriptor(shapeInfo);
-        setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
+        setShapeInfo(descriptor);
         delete descriptor;
         if (!isEmpty() && buffer != nullptr)
             _buffer = std::make_shared<DataBuffer>(buffer != nullptr ? buffer : buffer,

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -108,9 +108,13 @@ namespace sd {
 
         if (shape.size() == 0) {
             if (data.size() == 0) {
-                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::emptyDescriptor(dtype)));
+              auto desc = ShapeDescriptor::emptyDescriptor(dtype);
+                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+                delete desc;
             } else {
-                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::scalarDescriptor(dtype)));
+              auto desc = ShapeDescriptor::scalarDescriptor(dtype);
+                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+                delete desc;
             }
         } else {
             auto desc = new ShapeDescriptor(dtype, order, shape);
@@ -224,8 +228,10 @@ namespace sd {
         _isAttached = getContext()->getWorkspace() != nullptr;
 
         if (isScalar) {
-            auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( ShapeDescriptor::scalarDescriptor(dtype));
+            auto desc = ShapeDescriptor::scalarDescriptor(dtype);
+            auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( desc);
             setShapeInfo(constDesc);
+            delete desc;
             _buffer = std::make_shared<DataBuffer>(sizeOfT(), dtype, getContext()->getWorkspace());
             _buffer->setToZeroBuffers();
         } else
@@ -374,7 +380,7 @@ namespace sd {
 
         auto descriptor = new ShapeDescriptor(shapeInfo);
         setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
-         delete descriptor;
+        delete descriptor;
         if (!isEmpty() && buffer != nullptr)
             _buffer = std::make_shared<DataBuffer>(buffer != nullptr ? buffer : buffer,
                                                    bufferD, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -109,16 +109,16 @@ namespace sd {
         if (shape.size() == 0) {
             if (data.size() == 0) {
               auto desc = ShapeDescriptor::emptyDescriptor(dtype);
-                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+                setShapeInfo( desc);
                 delete desc;
             } else {
               auto desc = ShapeDescriptor::scalarDescriptor(dtype);
-                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+                setShapeInfo( desc);
                 delete desc;
             }
         } else {
             auto desc = new ShapeDescriptor(dtype, order, shape);
-            setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+            setShapeInfo( desc);
             delete desc;
         }
 
@@ -333,8 +333,9 @@ namespace sd {
         _context = context;
         _isAttached = getContext()->getWorkspace() != nullptr;
         _offset = 0;
-
-        setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
+        auto descriptor = new ShapeDescriptor(shapeInfo);
+        setShapeInfo( descriptor);
+        delete descriptor;
 
         if (this->isEmpty()) {
             tickReadDevice();

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -82,9 +82,11 @@ namespace sd {
         _isAttached = _context->getWorkspace() != nullptr;
         _offset = 0;
 
-        if (shape.empty())
-            setShapeInfo(ShapeDescriptor::emptyDescriptor(dtype));
-        else {
+        if (shape.empty()) {
+            auto desc = ShapeDescriptor::emptyDescriptor(dtype);
+            setShapeInfo(desc);
+            delete desc;
+        } else {
             auto desc = new ShapeDescriptor(dtype, order, shape);
             auto desc2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
             setShapeInfo(desc2);
@@ -113,6 +115,7 @@ namespace sd {
         } else {
             auto desc = new ShapeDescriptor(dtype, order, shape);
             setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+            delete desc;
         }
 
         if (lengthOf() != data.size()) {
@@ -146,8 +149,8 @@ namespace sd {
         } else {
             auto newDesc = new ShapeDescriptor(other->dataType(), other->ordering(), other->shapeOf(), other->rankOf());
             auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(newDesc);
-            delete newDesc;
             setShapeInfo(constDesc);
+            delete newDesc;
         }
         if (!isEmpty())
             _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dataType(), getContext()->getWorkspace());
@@ -162,8 +165,7 @@ namespace sd {
         _offset = 0;
         _isAttached = getContext()->getWorkspace() != nullptr;
         auto desc = new ShapeDescriptor(dtype, order, shape);
-        auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-        setShapeInfo(constDesc);
+        setShapeInfo(desc);
         delete desc;
         _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
                                                getContext()->getWorkspace());
@@ -200,11 +202,12 @@ namespace sd {
             auto desc = new ShapeDescriptor(shapeInfo, dtype);
             auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( desc);
             setShapeInfo(constDesc);
+            delete desc;
         }else {
             auto desc = new ShapeDescriptor(dtype, shape::order(shapeInfo), shape::shapeOf(shapeInfo), shape::rank(shapeInfo));
             auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-            delete desc;
             setShapeInfo(constDesc);
+            delete desc;
         }
         if (!isEmpty()) {
             _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dtype, getContext()->getWorkspace());
@@ -276,7 +279,7 @@ namespace sd {
         _isView = isView;
         auto desc = new ShapeDescriptor(dtype, order, shape);
         setShapeInfo(desc);
-
+        delete desc;
         _buffer = buffer;
     }
 
@@ -369,9 +372,9 @@ namespace sd {
         _context = context;
         _offset = 0;
 
-        auto descriptor = ShapeDescriptor(shapeInfo);
+        auto descriptor = new ShapeDescriptor(shapeInfo);
         setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
-
+         delete descriptor;
         if (!isEmpty() && buffer != nullptr)
             _buffer = std::make_shared<DataBuffer>(buffer != nullptr ? buffer : buffer,
                                                    bufferD, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
@@ -392,7 +395,7 @@ namespace sd {
 
         auto desc = new ShapeDescriptor(buffer->getDataType(), order, shape);
         setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
-
+        delete desc;
         _buffer = buffer;
 
         _isView = _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
@@ -428,9 +431,9 @@ namespace sd {
         _context = context;
         _isAttached = getContext()->getWorkspace() != nullptr;
         _offset = 0;
-
-        setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
-
+        auto desc = ShapeDescriptor::scalarDescriptor(dtype);
+        setShapeInfo(desc);
+        delete desc;
         memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
 
         auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
@@ -476,9 +479,9 @@ namespace sd {
         _context = context;
         _isAttached = getContext()->getWorkspace() != nullptr;
         _offset = 0;
-
-        setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
-
+        auto desc = ShapeDescriptor::scalarDescriptor(dtype);
+        setShapeInfo(desc);
+        delete desc;
         memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
 
         auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
@@ -525,9 +528,9 @@ namespace sd {
         _context = context;
         _isAttached = getContext()->getWorkspace() != nullptr;
         _offset = 0;
-
-        setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
-
+        auto desc = ShapeDescriptor::scalarDescriptor(dtype);
+        setShapeInfo(desc);
+        delete desc;
         memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
 
         auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
@@ -582,7 +585,7 @@ namespace sd {
 
         auto desc = new ShapeDescriptor(dataType, 'c', shape);
         setShapeInfo(desc);
-
+        delete desc;
         _isView = false;
 
         setAttached(context->getWorkspace() != nullptr);
@@ -646,7 +649,7 @@ namespace sd {
 
         auto desc = new ShapeDescriptor(dataType, 'c', shape);
         setShapeInfo(desc);
-
+        delete desc;
         _isView = false;
 
         setAttached(context->getWorkspace() != nullptr);
@@ -709,7 +712,7 @@ namespace sd {
 
         auto desc = new ShapeDescriptor(dtype, 'c', shape);
         setShapeInfo(desc);
-
+        delete desc;
         _isView = false;
 
         setAttached(context->getWorkspace() != nullptr);
@@ -773,7 +776,7 @@ namespace sd {
 
         auto desc = new ShapeDescriptor(dtype, 'c', shape);
         setShapeInfo(desc);
-
+        delete desc;
         _isView = false;
 
         setAttached(context->getWorkspace() != nullptr);
@@ -835,7 +838,7 @@ namespace sd {
         _offset = 0;
         auto desc = new ShapeDescriptor(dtype, 'c', shape);
         setShapeInfo(desc);
-
+        delete desc;
         _isView = false;
 
         setAttached(context->getWorkspace() != nullptr);
@@ -899,7 +902,7 @@ namespace sd {
 
         auto desc = new ShapeDescriptor(dtype, 'c', shape);
         setShapeInfo(desc);
-
+        delete desc;
         _isView = _length * DataTypeUtils::sizeOf(_dataType) < _buffer->getLenInBytes();
 
         setAttached(context->getWorkspace() != nullptr);
@@ -938,7 +941,7 @@ namespace sd {
             _offset = 0;
             auto desc = new ShapeDescriptor(other.dataType(), other.ordering(), other.shapeOf(), other.rankOf());
             setShapeInfo(desc);
-
+            delete desc;
             if (!other.isEmpty()) {
                 _buffer = std::make_shared<DataBuffer>(other.lengthOf() * other.sizeOfT(), other.dataType(),
                                                        other.getContext()->getWorkspace());
@@ -1848,7 +1851,7 @@ namespace sd {
         auto desc = new ShapeDescriptor(shapeInfo());
         NDArray newArr(getDataBuffer(),desc, getContext(), bufferOffset());
         newArr.transposei();
-
+        delete desc;
         return newArr;
     }
 
@@ -1929,6 +1932,7 @@ namespace sd {
         char order = o == 'a' ? this->ordering() : o;
         auto desc = new ShapeDescriptor(dataType(), order, dimensions);
         setShapeInfo(desc);
+        delete desc;
     }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1956,7 +1960,7 @@ namespace sd {
         auto desc = new ShapeDescriptor(shapeInfo());
         NDArray newArr(getDataBuffer(), desc, getContext(), bufferOffset());
         newArr.reshapei(order, shape, copyToNewBuff);
-
+        delete desc;
         return newArr;
     }
 
@@ -5197,9 +5201,10 @@ namespace sd {
 
             _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-            _shapeInfoD = shapeBuffer.special();
+            _shapeInfoD = shapeBuffer->special();
 #endif
 
+            delete descriptor;
             if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
                 _length = 0;
             else
@@ -5222,7 +5227,7 @@ namespace sd {
 
             _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-            _shapeInfoD = shapeBuffer.special();
+            _shapeInfoD = shapeBuffer->special();
 #endif
 
             if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
@@ -5246,7 +5251,7 @@ namespace sd {
         auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(const_cast<ShapeDescriptor *>(descriptor));
         _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-        _shapeInfoD = shapeBuffer.special();
+        _shapeInfoD = shapeBuffer->special();
 #endif
 
         if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -314,10 +314,10 @@ NDArray::NDArray(void *buffer, void *bufferD, const sd::LongType *shapeInfo, sd:
     errorMessage += "[";
     int len = shape::shapeInfoLength(shape::rank(shapeInfo));
     for(int i = 0; i < len; i++) {
-           errorMessage += std::string(std::to_string(shapeInfo[i]));
-           if(i < len) {
-             errorMessage += std::string(",");
-           }
+      errorMessage += std::string(std::to_string(shapeInfo[i]));
+      if(i < len) {
+        errorMessage += std::string(",");
+      }
 
     }
 
@@ -1578,6 +1578,7 @@ void NDArray::reduceNumber(sd::reduce::LongOps op, NDArray &target, void *extraP
 NDArray NDArray::indexReduceNumber(sd::indexreduce::Ops op, ExtraArguments *extraParams) {
   if (isS()) throw std::runtime_error("NDArray::indexReduceNumber: you can't use this method on String array!");
 
+  sd_printf("indexReduceNumber before exec\n",0);
   auto res = NDArrayFactory::create<sd::LongType>(0);
 
   prepareUse({&res}, {this});
@@ -1586,6 +1587,8 @@ NDArray NDArray::indexReduceNumber(sd::indexreduce::Ops op, ExtraArguments *extr
       extraParams == nullptr ? nullptr : extraParams->argumentsAsT(this->dataType()), res.buffer(), res.shapeInfo(),
       res.specialBuffer(), res.specialShapeInfo());
   registerUse({&res}, {this});
+  sd_printf("After before exec\n",0);
+
 
   return res;
 }
@@ -1766,7 +1769,7 @@ void NDArray::printIndexedBuffer(const char *msg, sd::LongType limit) const {
   if (msg) printf("%s: ", msg);
 
   if (this->isEmpty()) {
-     printf("Empty\n");
+    printf("Empty\n");
   } else if (this->rankOf() == 0) {
     if (this->isZ())
       printf("%lld\n", this->e<sd::LongType>(0));
@@ -4783,7 +4786,7 @@ void NDArray::divRowVector(const NDArray &row, NDArray &target) const {
       !row.isRowVector() || columns() != row.columns()) {
     sd_printf("NDArray::divRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
     throw std::invalid_argument("NDArray::divRowVector: wrong arguments !");
-    }
+  }
   if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()))
     throw std::invalid_argument("NDArray::divRowVector: wrong type of target array !");
 
@@ -5199,8 +5202,16 @@ void NDArray::setShapeInfo(const sd::LongType *shapeInfo, const sd::DataType dty
 
 //////////////////////////////////////////////////////////////////////////
 void NDArray::setShapeInfo(const ShapeDescriptor &descriptor) {
-  auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(const_cast<ShapeDescriptor &>(descriptor));
+  if(descriptor == nullptr) {
+    throw std::runtime_error("Passed in descriptor can't be null!");
+  }
 
+
+  sd_printf("Descriptor about to set: rank %d data type %d is empty %d\n" ,descriptor.rank(),descriptor.dataType(),descriptor.isEmpty());
+  sd_printf("Before obtaining constant shape info for descriptor\n",0);
+
+  auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(const_cast<ShapeDescriptor &>(descriptor));
+  sd_printf("After obtaining constant shape info for descriptor\n",0);
   _shapeInfo = shapeBuffer.primary();
 #ifdef __CUDABLAS__
   _shapeInfoD = shapeBuffer.special();

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -30,5860 +30,5831 @@
 
 namespace sd {
 
-template <>
-SD_LIB_EXPORT utf8string NDArray::e(const sd::LongType i) const;
-template <>
-SD_LIB_EXPORT std::string NDArray::e(const sd::LongType i) const;
-template <>
-SD_LIB_EXPORT std::u16string NDArray::e(const sd::LongType i) const;
-template <>
-SD_LIB_EXPORT std::u32string NDArray::e(const sd::LongType i) const;
+    template <>
+    SD_LIB_EXPORT utf8string NDArray::e(const sd::LongType i) const;
+    template <>
+    SD_LIB_EXPORT std::string NDArray::e(const sd::LongType i) const;
+    template <>
+    SD_LIB_EXPORT std::u16string NDArray::e(const sd::LongType i) const;
+    template <>
+    SD_LIB_EXPORT std::u32string NDArray::e(const sd::LongType i) const;
 
-SD_INLINE void prepareUse(const std::vector<const NDArray *> &writeList, const std::vector<const NDArray *> &readList,
-                          bool synchronizeWritables = false) {
+    SD_INLINE void prepareUse(const std::vector<const NDArray *> &writeList, const std::vector<const NDArray *> &readList,
+                              bool synchronizeWritables = false) {
 #if defined(HAVE_VEDA)
-  NDArray::preparePrimaryUse(writeList, readList, synchronizeWritables);
+        NDArray::preparePrimaryUse(writeList, readList, synchronizeWritables);
 #else
-  NDArray::prepareSpecialUse(writeList, readList, synchronizeWritables);
+        NDArray::prepareSpecialUse(writeList, readList, synchronizeWritables);
 #endif
-}
+    }
 
-SD_INLINE void registerUse(const std::vector<const NDArray *> &writeList,
-                           const std::vector<const NDArray *> &readList) {
+    SD_INLINE void registerUse(const std::vector<const NDArray *> &writeList,
+                               const std::vector<const NDArray *> &readList) {
 #if defined(HAVE_VEDA)
-  NDArray::registerPrimaryUse(writeList, readList);
+        NDArray::registerPrimaryUse(writeList, readList);
 #else
-  NDArray::registerSpecialUse(writeList, readList);
+        NDArray::registerSpecialUse(writeList, readList);
 #endif
-}
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // copy constructor
-NDArray::NDArray(const NDArray &other) {
-  _context = other._context;
-  _offset = 0;
-  setShapeInfo(other.shapeInfo());
+    NDArray::NDArray(const NDArray &other) {
+        _context = other._context;
+        _offset = 0;
+        setShapeInfo(other.shapeInfo());
 
-  if (!isEmpty() && other.lengthOf() > 0) {
-    _buffer = std::make_shared<DataBuffer>(other.lengthOf() * other.sizeOfT(), other.dataType(),
-                                           other.getContext()->getWorkspace());
-    this->assign(&other);
-  } else {
-    _buffer = std::make_shared<DataBuffer>();
-  }
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,
-                 sd::LaunchContext *context) {
-  if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
-
-  _context = context;
-  _isAttached = _context->getWorkspace() != nullptr;
-  _offset = 0;
-
-  sd_printf("In NDArray constructor: const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,\n"
-            "                 sd::LaunchContext *context\n",0);
-  if (shape.empty())
-    setShapeInfo(ShapeDescriptor::emptyDescriptor(dtype));
-  else {
-    sd_printf("In NDArray constructor: creating non empty shape descriptor\n",0);
-    auto desc = new ShapeDescriptor(dtype, order, shape);
-    sd_printf("Created shape descriptor in NDArray constructor\n",0);
-    auto desc2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-    sd_printf("About to set shape buffer in NDArray constructor\n",0);
-    setShapeInfo(desc2);
-    sd_printf("Set shape info in ndarray constructor\n",0);
-
-  }
-  sd_printf("After NDArray constructor: const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,\n"
-            "                 sd::LaunchContext *context\n",0);
-  _buffer =
-      std::make_shared<DataBuffer>(lengthOf() * DataTypeUtils::sizeOf(dtype), dtype, getContext()->getWorkspace());
-  _buffer->setToZeroBuffers();
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const char order, const std::vector<sd::LongType> &shape, const std::vector<double> &data,
-                 sd::DataType dtype, sd::LaunchContext *context) {
-  if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
-
-  _context = context;
-  _offset = 0;
-
-  if (shape.size() == 0) {
-    if (data.size() == 0) {
-      setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::emptyDescriptor(dtype)));
-    } else {
-      setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::scalarDescriptor(dtype)));
+        if (!isEmpty() && other.lengthOf() > 0) {
+            _buffer = std::make_shared<DataBuffer>(other.lengthOf() * other.sizeOfT(), other.dataType(),
+                                                   other.getContext()->getWorkspace());
+            this->assign(&other);
+        } else {
+            _buffer = std::make_shared<DataBuffer>();
+        }
     }
-  } else {
-    auto desc = new ShapeDescriptor(dtype, order, shape);
-    setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
-  }
-
-  if (lengthOf() != data.size()) {
-    sd_printf("NDArray constructor: data size [%i] doesn't match shape length [%i]\n", data.size(), lengthOf());
-    throw std::runtime_error("Data size doesn't match shape");
-  }
-
-  _buffer = std::make_shared<DataBuffer>(lengthOf() * DataTypeUtils::sizeOf(dtype), dtype, getContext()->getWorkspace(),
-                                         true);
-
-  for (sd::LongType i = 0; i < lengthOf(); ++i) {
-    BUILD_SINGLE_PARTIAL_SELECTOR(
-        dtype, templatedDoubleAssign<, double>(buffer(), i, reinterpret_cast<const void *>(data.data()), i),
-        SD_COMMON_TYPES_ALL);
-  }
-  tickWriteHost();
-  syncToDevice();
-}
 
 ////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const NDArray *other, const bool copyStrides, sd::LaunchContext *context) {
-  _context = context;
-  _offset = 0;
-  _isAttached = getContext()->getWorkspace() != nullptr;
+    NDArray::NDArray(const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,
+                     sd::LaunchContext *context) {
+        if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
 
-  if (copyStrides) {
-    auto desc = new ShapeDescriptor(other->_shapeInfo);
-    sd_printf("Created shape descriptor in NDArray constructor\n",0);
-    auto desc2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-    setShapeInfo(desc2);
-  } else {
-    auto newDesc = new ShapeDescriptor(other->dataType(), other->ordering(), other->shapeOf(), other->rankOf());
-    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(newDesc);
-    setShapeInfo(constDesc);
-  }
-  if (!isEmpty())
-    _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dataType(), getContext()->getWorkspace());
-}
+        _context = context;
+        _isAttached = _context->getWorkspace() != nullptr;
+        _offset = 0;
+
+        if (shape.empty())
+            setShapeInfo(ShapeDescriptor::emptyDescriptor(dtype));
+        else {
+            auto desc = new ShapeDescriptor(dtype, order, shape);
+            auto desc2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+            setShapeInfo(desc2);
+            delete desc;
+        }
+
+        _buffer =
+                std::make_shared<DataBuffer>(lengthOf() * DataTypeUtils::sizeOf(dtype), dtype, getContext()->getWorkspace());
+        _buffer->setToZeroBuffers();
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(void *buffer, const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,
-                 sd::LaunchContext *context, const bool isBuffAlloc) {
-  if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
+    NDArray::NDArray(const char order, const std::vector<sd::LongType> &shape, const std::vector<double> &data,
+                     sd::DataType dtype, sd::LaunchContext *context) {
+        if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
 
-  _context = context;
-  _offset = 0;
-  _isAttached = getContext()->getWorkspace() != nullptr;
-  auto desc = new ShapeDescriptor(dtype, order, shape);
-  auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-  setShapeInfo(constDesc);
+        _context = context;
+        _offset = 0;
 
-  _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
-                                         getContext()->getWorkspace());
-}
+        if (shape.size() == 0) {
+            if (data.size() == 0) {
+                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::emptyDescriptor(dtype)));
+            } else {
+                setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::scalarDescriptor(dtype)));
+            }
+        } else {
+            auto desc = new ShapeDescriptor(dtype, order, shape);
+            setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+        }
 
-NDArray::NDArray(void *buffer, const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,
-                 sd::LaunchContext *context, const bool isBuffAlloc, const bool isView, sd::LongType offset) {
-  if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
+        if (lengthOf() != data.size()) {
+            sd_printf("NDArray constructor: data size [%i] doesn't match shape length [%i]\n", data.size(), lengthOf());
+            throw std::runtime_error("Data size doesn't match shape");
+        }
 
-  _context = context;
-  _offset = offset;
-  _isAttached = getContext()->getWorkspace() != nullptr;
-  _isView = isView;
-  auto desc = new ShapeDescriptor(dtype, order, shape);
-  auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-  setShapeInfo(constDesc);
+        _buffer = std::make_shared<DataBuffer>(lengthOf() * DataTypeUtils::sizeOf(dtype), dtype, getContext()->getWorkspace(),
+                                               true);
 
-  _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
-                                         getContext()->getWorkspace());
-}
+        for (sd::LongType i = 0; i < lengthOf(); ++i) {
+            BUILD_SINGLE_PARTIAL_SELECTOR(
+                    dtype, templatedDoubleAssign<, double>(buffer(), i, reinterpret_cast<const void *>(data.data()), i),
+                    SD_COMMON_TYPES_ALL);
+        }
+        tickWriteHost();
+        syncToDevice();
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray::NDArray(const NDArray *other, const bool copyStrides, sd::LaunchContext *context) {
+        _context = context;
+        _offset = 0;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+
+        if (copyStrides) {
+            auto desc = new ShapeDescriptor(other->_shapeInfo);
+            auto desc2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+            setShapeInfo(desc2);
+            delete desc;
+        } else {
+            auto newDesc = new ShapeDescriptor(other->dataType(), other->ordering(), other->shapeOf(), other->rankOf());
+            auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(newDesc);
+            delete newDesc;
+            setShapeInfo(constDesc);
+        }
+        if (!isEmpty())
+            _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dataType(), getContext()->getWorkspace());
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray::NDArray(void *buffer, const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,
+                     sd::LaunchContext *context, const bool isBuffAlloc) {
+        if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
+
+        _context = context;
+        _offset = 0;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+        auto desc = new ShapeDescriptor(dtype, order, shape);
+        auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+        setShapeInfo(constDesc);
+        delete desc;
+        _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
+                                               getContext()->getWorkspace());
+    }
+
+    NDArray::NDArray(void *buffer, const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,
+                     sd::LaunchContext *context, const bool isBuffAlloc, const bool isView, sd::LongType offset) {
+        if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
+
+        _context = context;
+        _offset = offset;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+        _isView = isView;
+        auto desc = new ShapeDescriptor(dtype, order, shape);
+        auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+        setShapeInfo(constDesc);
+        delete desc;
+        _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
+                                               getContext()->getWorkspace());
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // creates new NDArray using shape information from "shapeInfo" array, set all elements in new array to be zeros
-NDArray::NDArray(const sd::LongType *shapeInfo, const sd::DataType dtype, const bool copyStrides,
-                 sd::LaunchContext *context, const bool nullify) {
-  if (shapeInfo == nullptr) throw std::runtime_error("NDArray constructor: can't be initalized without shapeinfo");
+    NDArray::NDArray(const sd::LongType *shapeInfo, const sd::DataType dtype, const bool copyStrides,
+                     sd::LaunchContext *context, const bool nullify) {
+        if (shapeInfo == nullptr) throw std::runtime_error("NDArray constructor: can't be initalized without shapeinfo");
 
-  if ((int)shapeInfo[0] > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
+        if ((int)shapeInfo[0] > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
 
-  _context = context;
-  _offset = 0;
+        _context = context;
+        _offset = 0;
 
-  if (copyStrides) {
-    auto desc = new ShapeDescriptor(shapeInfo, dtype);
-    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( desc);
-    setShapeInfo(constDesc);
-  }else {
-    auto desc = new ShapeDescriptor(dtype, shape::order(shapeInfo), shape::shapeOf(shapeInfo), shape::rank(shapeInfo));
-    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-    setShapeInfo(constDesc);
-  }
-  if (!isEmpty()) {
-    _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dtype, getContext()->getWorkspace());
+        if (copyStrides) {
+            auto desc = new ShapeDescriptor(shapeInfo, dtype);
+            auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( desc);
+            setShapeInfo(constDesc);
+        }else {
+            auto desc = new ShapeDescriptor(dtype, shape::order(shapeInfo), shape::shapeOf(shapeInfo), shape::rank(shapeInfo));
+            auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+            delete desc;
+            setShapeInfo(constDesc);
+        }
+        if (!isEmpty()) {
+            _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dtype, getContext()->getWorkspace());
 
-    if (nullify) _buffer->setToZeroBuffers();
-  }
-}
+            if (nullify) _buffer->setToZeroBuffers();
+        }
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // scalar constructor
-NDArray::NDArray(sd::DataType dtype, sd::LaunchContext *context, const bool isScalar) {
-  _context = context;
-  _offset = 0;
-  _isAttached = getContext()->getWorkspace() != nullptr;
+    NDArray::NDArray(sd::DataType dtype, sd::LaunchContext *context, const bool isScalar) {
+        _context = context;
+        _offset = 0;
+        _isAttached = getContext()->getWorkspace() != nullptr;
 
-  if (isScalar) {
-    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( ShapeDescriptor::scalarDescriptor(dtype));
-    setShapeInfo(constDesc);
-    _buffer = std::make_shared<DataBuffer>(sizeOfT(), dtype, getContext()->getWorkspace());
-    _buffer->setToZeroBuffers();
-  } else
-    setShapeInfo(ConstantShapeHelper::getInstance().emptyShapeInfo(dtype));
-}
+        if (isScalar) {
+            auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( ShapeDescriptor::scalarDescriptor(dtype));
+            setShapeInfo(constDesc);
+            _buffer = std::make_shared<DataBuffer>(sizeOfT(), dtype, getContext()->getWorkspace());
+            _buffer->setToZeroBuffers();
+        } else
+            setShapeInfo(ConstantShapeHelper::getInstance().emptyShapeInfo(dtype));
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // move constructor
-NDArray::NDArray(NDArray &&other) noexcept {
-  _isView = other._isView;
-  _buffer = other._buffer;
-  _shapeInfo = other._shapeInfo;
-  _shapeInfoD = other._shapeInfoD;
-  _context = other._context;
-  _dataType = other._dataType;
-  _length = other._length;
-  _offset = other._offset;
+    NDArray::NDArray(NDArray &&other) noexcept {
+        _isView = other._isView;
+        _buffer = other._buffer;
+        _shapeInfo = other._shapeInfo;
+        _shapeInfoD = other._shapeInfoD;
+        _context = other._context;
+        _dataType = other._dataType;
+        _length = other._length;
+        _offset = other._offset;
 
-  other._buffer = std::make_shared<DataBuffer>();
-  other._shapeInfo = other._shapeInfoD = nullptr;
-  other._length = 0;
-}
+        other._buffer = std::make_shared<DataBuffer>();
+        other._shapeInfo = other._shapeInfoD = nullptr;
+        other._length = 0;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // constructor, create empty array at given workspace
-NDArray::NDArray(sd::LaunchContext *context) {
-  _buffer = std::make_shared<DataBuffer>();
-  _shapeInfo = nullptr;
-  _shapeInfoD = nullptr;
-  _offset = 0;
-  _context = context;
-  _length = 0;
-}
+    NDArray::NDArray(sd::LaunchContext *context) {
+        _buffer = std::make_shared<DataBuffer>();
+        _shapeInfo = nullptr;
+        _shapeInfoD = nullptr;
+        _offset = 0;
+        _context = context;
+        _length = 0;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // creates new NDArray using shape information from "shapeInfo" array, set all elements in new array to be zeros, set
 // dtype as array type
-NDArray::NDArray(const sd::LongType *shapeInfo, const bool copyStrides, sd::LaunchContext *context, const bool nullify)
-    : NDArray(shapeInfo, ArrayOptions::dataType(shapeInfo), copyStrides, context) {}
+    NDArray::NDArray(const sd::LongType *shapeInfo, const bool copyStrides, sd::LaunchContext *context, const bool nullify)
+            : NDArray(shapeInfo, ArrayOptions::dataType(shapeInfo), copyStrides, context) {}
 
 #ifndef __JAVACPP_HACK__
 
-NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const char order, const std::vector<sd::LongType> &shape,
-                 sd::DataType dtype, sd::LaunchContext *context, const bool isBuffAlloc, const bool isView,
-                 sd::LongType offset) {
-  if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
+    NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const char order, const std::vector<sd::LongType> &shape,
+                     sd::DataType dtype, sd::LaunchContext *context, const bool isBuffAlloc, const bool isView,
+                     sd::LongType offset) {
+        if ((int)shape.size() > SD_MAX_RANK) throw std::invalid_argument("Rank of NDArray can't exceed 32");
 
-  _context = context;
-  _offset = offset;
-  _isAttached = getContext()->getWorkspace() != nullptr;
-  _isView = isView;
-  auto desc = new ShapeDescriptor(dtype, order, shape);
-  setShapeInfo(desc);
+        _context = context;
+        _offset = offset;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+        _isView = isView;
+        auto desc = new ShapeDescriptor(dtype, order, shape);
+        setShapeInfo(desc);
 
-  _buffer = buffer;
-}
+        _buffer = buffer;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 
 
-NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, sd::LongType *shapeInfo, sd::LaunchContext *context,
-                 const sd::LongType offset) {
-  _context = context;
-  _offset = offset;
-  sd_printf("Setting shape info in long shape info constructor\n",0);
-  setShapeInfo(shapeInfo);
-  _buffer = buffer;
+    NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, sd::LongType *shapeInfo, sd::LaunchContext *context,
+                     const sd::LongType offset) {
+        _context = context;
+        _offset = offset;
+        setShapeInfo(shapeInfo);
+        _buffer = buffer;
 
-  _isView = offset > 0 || _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
-  sd_printf("Created ndarray shape info in long shape info constructor\n",0);
-}
+        _isView = offset > 0 || _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
+    }
 
-NDArray::NDArray(std::shared_ptr<DataBuffer> buffer,  ShapeDescriptor *descriptor, sd::LaunchContext *context,
-                 const sd::LongType offset) {
-  _context = context;
-  _offset = offset;
-  sd_printf("Setting shape info in descriptor to shape info constructor\n",0);
-  setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor));
-  _buffer = buffer;
+    NDArray::NDArray(std::shared_ptr<DataBuffer> buffer,  ShapeDescriptor *descriptor, sd::LaunchContext *context,
+                     const sd::LongType offset) {
+        _context = context;
+        _offset = offset;
+        setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor));
+        _buffer = buffer;
 
-  _isView = offset > 0 || _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
-  sd_printf("Created ndarray setting shape info in descriptor to shape info constructor\n",0);
-}
+        _isView = offset > 0 || _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
+    }
 
 #endif
 
-NDArray::NDArray(void *buffer, sd::LongType *shapeInfo, sd::LaunchContext *context, const bool isBuffAlloc)
-    : NDArray::NDArray(buffer, const_cast<const sd::LongType *>(shapeInfo), context, isBuffAlloc) {
+    NDArray::NDArray(void *buffer, sd::LongType *shapeInfo, sd::LaunchContext *context, const bool isBuffAlloc)
+            : NDArray::NDArray(buffer, const_cast<const sd::LongType *>(shapeInfo), context, isBuffAlloc) {
 
-}
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // do not allocate memory, memory for array is passed from outside
-NDArray::NDArray(void *buffer, const sd::LongType *shapeInfo, sd::LaunchContext *context, const bool isBuffAlloc) {
-  if (buffer == nullptr && ArrayOptions::arrayType(shapeInfo) != ArrayType::EMPTY)
-    throw std::runtime_error("NDArray constructor: can't be initialized with nullptr buffer !");
+    NDArray::NDArray(void *buffer, const sd::LongType *shapeInfo, sd::LaunchContext *context, const bool isBuffAlloc) {
+        if (buffer == nullptr && ArrayOptions::arrayType(shapeInfo) != ArrayType::EMPTY)
+            throw std::runtime_error("NDArray constructor: can't be initialized with nullptr buffer !");
 
-  if (shapeInfo == nullptr) throw std::runtime_error("NDArray constructor: can't be initialized without shapeinfo !");
+        if (shapeInfo == nullptr) throw std::runtime_error("NDArray constructor: can't be initialized without shapeinfo !");
 
-  if ((int)shapeInfo[0] > SD_MAX_RANK)
-    throw std::invalid_argument("NDArray constructor: rank of NDArray can't exceed 32 !");
+        if ((int)shapeInfo[0] > SD_MAX_RANK)
+            throw std::invalid_argument("NDArray constructor: rank of NDArray can't exceed 32 !");
 
-  _context = context;
-  _isAttached = getContext()->getWorkspace() != nullptr;
-  _offset = 0;
+        _context = context;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+        _offset = 0;
 
-  setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
+        setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
 
-  if (this->isEmpty()) {
-    tickReadDevice();
-    tickReadHost();
-  } else {
-    _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
-                                           getContext()->getWorkspace());
-  }
-}
+        if (this->isEmpty()) {
+            tickReadDevice();
+            tickReadHost();
+        } else {
+            _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
+                                                   getContext()->getWorkspace());
+        }
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // do not allocate memory, memory for array is passed from outside
 // we suppose the content of both (device and host) buffers is identical
-NDArray::NDArray(void *buffer, void *bufferD, const sd::LongType *shapeInfo, sd::LaunchContext *context,
-                 const bool isBuffAlloc, const bool isBuffDAlloc) {
-  if (shapeInfo == nullptr) throw std::runtime_error("NDArray constructor cuda: can't be initialized without shapeinfo");
+    NDArray::NDArray(void *buffer, void *bufferD, const sd::LongType *shapeInfo, sd::LaunchContext *context,
+                     const bool isBuffAlloc, const bool isBuffDAlloc) {
+        if (shapeInfo == nullptr) throw std::runtime_error("NDArray constructor cuda: can't be initialized without shapeinfo");
 
-  if (buffer == nullptr && ArrayOptions::arrayType(shapeInfo) != ArrayType::EMPTY) {
-    std::string errorMessage = "NDArray constructor: buffer was null but array shape info did not indicate empty! Shape buffer was: ";
-    errorMessage += "[";
-    int len = shape::shapeInfoLength(shape::rank(shapeInfo));
-    for(int i = 0; i < len; i++) {
-      errorMessage += std::string(std::to_string(shapeInfo[i]));
-      if(i < len) {
-        errorMessage += std::string(",");
-      }
+        if (buffer == nullptr && ArrayOptions::arrayType(shapeInfo) != ArrayType::EMPTY) {
+            std::string errorMessage = "NDArray constructor: buffer was null but array shape info did not indicate empty! Shape buffer was: ";
+            errorMessage += "[";
+            int len = shape::shapeInfoLength(shape::rank(shapeInfo));
+            for(int i = 0; i < len; i++) {
+                errorMessage += std::string(std::to_string(shapeInfo[i]));
+                if(i < len) {
+                    errorMessage += std::string(",");
+                }
 
+            }
+
+            ShapeDescriptor shapeDescriptor(shapeInfo);
+            errorMessage += std::string("]");
+            errorMessage += std::string(" wasEmpty: " + std::to_string(shapeDescriptor.isEmpty()));
+            errorMessage += std::string(" data type: " + DataTypeUtils::asString(shapeDescriptor.dataType()));
+            errorMessage += std::string( "order: " + shapeDescriptor.order());
+            throw std::runtime_error(errorMessage);
+        }
+
+        if ((int)shapeInfo[0] > SD_MAX_RANK)
+            throw std::invalid_argument("NDArray constructor: rank of NDArray can't exceed 32");
+
+        _context = context;
+        _offset = 0;
+
+        auto descriptor = ShapeDescriptor(shapeInfo);
+        setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
+
+        if (!isEmpty() && buffer != nullptr)
+            _buffer = std::make_shared<DataBuffer>(buffer != nullptr ? buffer : buffer,
+                                                   bufferD, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
+                                                   isBuffDAlloc, getContext()->getWorkspace());
     }
-
-    sd_printf("Assembling buffer for shape info error\n",0);
-    ShapeDescriptor shapeDescriptor(shapeInfo);
-    errorMessage += std::string("]");
-    errorMessage += std::string(" wasEmpty: " + std::to_string(shapeDescriptor.isEmpty()));
-    errorMessage += std::string(" data type: " + DataTypeUtils::asString(shapeDescriptor.dataType()));
-    errorMessage += std::string( "order: " + shapeDescriptor.order());
-    throw std::runtime_error(errorMessage);
-  }
-
-  if ((int)shapeInfo[0] > SD_MAX_RANK)
-    throw std::invalid_argument("NDArray constructor: rank of NDArray can't exceed 32");
-
-  _context = context;
-  _offset = 0;
-
-  sd_printf("Before creating descriptor with shape info\n",0);
-  auto descriptor = ShapeDescriptor(shapeInfo);
-  setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
-
-  if (!isEmpty() && buffer != nullptr)
-    _buffer = std::make_shared<DataBuffer>(buffer != nullptr ? buffer : buffer,
-                                           bufferD, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
-                                           isBuffDAlloc, getContext()->getWorkspace());
-}
 
 //////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const char order, const std::vector<sd::LongType> &shape,
-                 sd::LaunchContext *context) {
-  if (shape.empty()) {
-    throw std::runtime_error("NDArray constructor: input shape is empty !");
-  }
-  if ((int)shape.size() > SD_MAX_RANK)
-    throw std::invalid_argument("NDArray constructor: rank of NDArray can't exceed 32");
+    NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const char order, const std::vector<sd::LongType> &shape,
+                     sd::LaunchContext *context) {
+        if (shape.empty()) {
+            throw std::runtime_error("NDArray constructor: input shape is empty !");
+        }
+        if ((int)shape.size() > SD_MAX_RANK)
+            throw std::invalid_argument("NDArray constructor: rank of NDArray can't exceed 32");
 
-  _context = context;
-  _offset = 0;
+        _context = context;
+        _offset = 0;
 
-  auto desc = new ShapeDescriptor(buffer->getDataType(), order, shape);
-  setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
+        auto desc = new ShapeDescriptor(buffer->getDataType(), order, shape);
+        setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
 
-  _buffer = buffer;
+        _buffer = buffer;
 
-  _isView = _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
-}
+        _isView = _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
+    }
 /////////////////////////////////////////////////////////////////////////
 // u16 string constructors
-NDArray::NDArray(const std::u16string &u16string, sd::DataType dtype, sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dtype)) {
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
-  }
+    NDArray::NDArray(const std::u16string &u16string, sd::DataType dtype, sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dtype)) {
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+        }
 
-  if (!unicode::isStringValidU16(u16string.data(), u16string.data() + u16string.size())) {
-    throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
-  }
+        if (!unicode::isStringValidU16(u16string.data(), u16string.data() + u16string.size())) {
+            throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        }
 
-  // one word that is why used 1
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(1);
+        // one word that is why used 1
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(1);
 
-  sd::LongType dataLength = [&] {
-    if (dtype == DataType::UTF16) {
-      return static_cast<sd::LongType>(u16string.size() * sizeof(uint16_t));
+        sd::LongType dataLength = [&] {
+            if (dtype == DataType::UTF16) {
+                return static_cast<sd::LongType>(u16string.size() * sizeof(uint16_t));
+            }
+            if (dtype == DataType::UTF32) {
+                return unicode::offsetUtf16StringInUtf32(u16string.data(), u16string.size());
+            }
+            return unicode::offsetUtf16StringInUtf8(u16string.data(), u16string.size());
+        }();
+
+        sd::LongType offsets[2] = {0, dataLength};
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
+
+        _context = context;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+        _offset = 0;
+
+        setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
+
+        memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+        if (dtype == DataType::UTF8) {
+            unicode::utf16to8(u16string.data(), data, u16string.size());
+        } else if (dtype == DataType::UTF16) {
+            memcpy(data, u16string.data(), dataLength);
+        } else {
+            unicode::utf16to32(u16string.data(), data, u16string.size());
+        }
+
+        tickWriteHost();
+        syncToDevice();
     }
-    if (dtype == DataType::UTF32) {
-      return unicode::offsetUtf16StringInUtf32(u16string.data(), u16string.size());
-    }
-    return unicode::offsetUtf16StringInUtf8(u16string.data(), u16string.size());
-  }();
-
-  sd::LongType offsets[2] = {0, dataLength};
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
-
-  _context = context;
-  _isAttached = getContext()->getWorkspace() != nullptr;
-  _offset = 0;
-
-  setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
-
-  memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-  if (dtype == DataType::UTF8) {
-    unicode::utf16to8(u16string.data(), data, u16string.size());
-  } else if (dtype == DataType::UTF16) {
-    memcpy(data, u16string.data(), dataLength);
-  } else {
-    unicode::utf16to32(u16string.data(), data, u16string.size());
-  }
-
-  tickWriteHost();
-  syncToDevice();
-}
 
 /////////////////////////////////////////////////////////////////////////
 // u32 string constructors
-NDArray::NDArray(const std::u32string &u32string, sd::DataType dtype, sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dtype)) {
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
-  }
+    NDArray::NDArray(const std::u32string &u32string, sd::DataType dtype, sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dtype)) {
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+        }
 
-  if (!unicode::isStringValidU32(u32string.data(), u32string.data() + u32string.size())) {
-    throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
-  }
-  // one word that is why used 1
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(1);
+        if (!unicode::isStringValidU32(u32string.data(), u32string.data() + u32string.size())) {
+            throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        }
+        // one word that is why used 1
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(1);
 
-  sd::LongType dataLength = [&] {
-    if (dtype == DataType::UTF16) {
-      return unicode::offsetUtf32StringInUtf16(u32string.data(), u32string.size());
+        sd::LongType dataLength = [&] {
+            if (dtype == DataType::UTF16) {
+                return unicode::offsetUtf32StringInUtf16(u32string.data(), u32string.size());
+            }
+            if (dtype == DataType::UTF32) {
+                return static_cast<sd::LongType>(sizeof(uint32_t) * u32string.size());
+            }
+            return unicode::offsetUtf32StringInUtf8(u32string.data(), u32string.size());
+        }();
+
+        sd::LongType offsets[2] = {0, dataLength};
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
+
+        _context = context;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+        _offset = 0;
+
+        setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
+
+        memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+        if (dtype == DataType::UTF8) {
+            unicode::utf32to8(u32string.data(), data, u32string.size());
+        } else if (dtype == DataType::UTF16) {
+            unicode::utf32to16(u32string.data(), data, u32string.size());
+        } else {
+            memcpy(data, u32string.data(), u32string.size() * sizeof(uint32_t));
+        }
+
+        tickWriteHost();
+        syncToDevice();
     }
-    if (dtype == DataType::UTF32) {
-      return static_cast<sd::LongType>(sizeof(uint32_t) * u32string.size());
-    }
-    return unicode::offsetUtf32StringInUtf8(u32string.data(), u32string.size());
-  }();
-
-  sd::LongType offsets[2] = {0, dataLength};
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
-
-  _context = context;
-  _isAttached = getContext()->getWorkspace() != nullptr;
-  _offset = 0;
-
-  setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
-
-  memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-  if (dtype == DataType::UTF8) {
-    unicode::utf32to8(u32string.data(), data, u32string.size());
-  } else if (dtype == DataType::UTF16) {
-    unicode::utf32to16(u32string.data(), data, u32string.size());
-  } else {
-    memcpy(data, u32string.data(), u32string.size() * sizeof(uint32_t));
-  }
-
-  tickWriteHost();
-  syncToDevice();
-}
 
 /////////////////////////////////////////////////////////////////////////
 // u8 string constructors
-NDArray::NDArray(const std::string &str, sd::DataType dtype, sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dtype)) {
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
-  }
+    NDArray::NDArray(const std::string &str, sd::DataType dtype, sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dtype)) {
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+        }
 
-  if (!unicode::isStringValidU8(str.data(), str.data() + str.size())) {
-    throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
-  }
+        if (!unicode::isStringValidU8(str.data(), str.data() + str.size())) {
+            throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        }
 
-  // one word that is why used 1
-  auto headerLength = ShapeUtils::stringBufferHeaderRequirements(1);
+        // one word that is why used 1
+        auto headerLength = ShapeUtils::stringBufferHeaderRequirements(1);
 
-  sd::LongType dataLength = [&] {
-    if (dtype == DataType::UTF16) {
-      return unicode::offsetUtf8StringInUtf16(str.data(), str.size());
+        sd::LongType dataLength = [&] {
+            if (dtype == DataType::UTF16) {
+                return unicode::offsetUtf8StringInUtf16(str.data(), str.size());
+            }
+            if (dtype == DataType::UTF32) {
+                return unicode::offsetUtf8StringInUtf32(str.data(), str.size());
+            }
+            return static_cast<sd::LongType>(str.size());
+        }();
+
+        sd::LongType offsets[2] = {0, dataLength};
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
+
+        _context = context;
+        _isAttached = getContext()->getWorkspace() != nullptr;
+        _offset = 0;
+
+        setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
+
+        memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+
+        if (dtype == DataType::UTF8) {
+            memcpy(data, str.data(), str.size());
+        } else if (dtype == DataType::UTF16) {
+            unicode::utf8to16(str.data(), data, str.size());
+        } else {
+            unicode::utf8to32(str.data(), data, str.size());
+        }
+
+        tickWriteHost();
+        syncToDevice();
     }
-    if (dtype == DataType::UTF32) {
-      return unicode::offsetUtf8StringInUtf32(str.data(), str.size());
-    }
-    return static_cast<sd::LongType>(str.size());
-  }();
-
-  sd::LongType offsets[2] = {0, dataLength};
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
-
-  _context = context;
-  _isAttached = getContext()->getWorkspace() != nullptr;
-  _offset = 0;
-
-  setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
-
-  memcpy(bufferAsT<int8_t>(), &offsets[0], 2 * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-
-  if (dtype == DataType::UTF8) {
-    memcpy(data, str.data(), str.size());
-  } else if (dtype == DataType::UTF16) {
-    unicode::utf8to16(str.data(), data, str.size());
-  } else {
-    unicode::utf8to32(str.data(), data, str.size());
-  }
-
-  tickWriteHost();
-  syncToDevice();
-}
 /////////////////////////////////////////////////////////////////////////
 // constructors for vector of  strings
-NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const char *> &string,
-                 const sd::DataType dataType, sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dataType))
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+    NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const char *> &string,
+                     const sd::DataType dataType, sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dataType))
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
 
-  if (shape::prodLong(shape.data(), shape.size()) != string.size())
-    throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
+        if (shape::prodLong(shape.data(), shape.size()) != string.size())
+            throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
 
-  for (const auto &str : string) {
-    if (!unicode::isStringValidU8(str, str + std::char_traits<char>::length(str))) {
-      throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        for (const auto &str : string) {
+            if (!unicode::isStringValidU8(str, str + std::char_traits<char>::length(str))) {
+                throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+            }
+        }
+
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
+
+        std::vector<sd::LongType> offsets(string.size() + 1);
+        sd::LongType dataLength = 0;
+        for (int e = 0; e < string.size(); e++) {
+            offsets[e] = dataLength;
+            dataLength += [&] {
+                if (dataType == DataType::UTF16)
+                    return unicode::offsetUtf8StringInUtf16(string[e], std::char_traits<char>::length(string[e]));
+                if (dataType == DataType::UTF32)
+                    return unicode::offsetUtf8StringInUtf32(string[e], std::char_traits<char>::length(string[e]));
+                return static_cast<sd::LongType>(std::char_traits<char>::length(string[e]));
+            }();
+        }
+        offsets[string.size()] = dataLength;
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dataType, context->getWorkspace(), true);
+
+        _context = context;
+        _offset = 0;
+
+        auto desc = new ShapeDescriptor(dataType, 'c', shape);
+        setShapeInfo(desc);
+
+        _isView = false;
+
+        setAttached(context->getWorkspace() != nullptr);
+
+        memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+
+        auto func = PRAGMA_THREADS_FOR {
+            for (auto e = start; e < stop; e++) {
+                auto cdata = data + offsets[e];
+                if (dataType == DataType::UTF16) {
+                    unicode::utf8to16(string[e], cdata, std::char_traits<char>::length(string[e]));
+                } else if (dataType == DataType::UTF32) {
+                    unicode::utf8to32(string[e], cdata, std::char_traits<char>::length(string[e]));
+                } else {
+                    memcpy(cdata, string[e], std::char_traits<char>::length(string[e]));
+                }
+            }
+        };
+
+        samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+        tickWriteHost();
+        syncToDevice();
     }
-  }
-
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
-
-  std::vector<sd::LongType> offsets(string.size() + 1);
-  sd::LongType dataLength = 0;
-  for (int e = 0; e < string.size(); e++) {
-    offsets[e] = dataLength;
-    dataLength += [&] {
-      if (dataType == DataType::UTF16)
-        return unicode::offsetUtf8StringInUtf16(string[e], std::char_traits<char>::length(string[e]));
-      if (dataType == DataType::UTF32)
-        return unicode::offsetUtf8StringInUtf32(string[e], std::char_traits<char>::length(string[e]));
-      return static_cast<sd::LongType>(std::char_traits<char>::length(string[e]));
-    }();
-  }
-  offsets[string.size()] = dataLength;
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dataType, context->getWorkspace(), true);
-
-  _context = context;
-  _offset = 0;
-
-  auto desc = new ShapeDescriptor(dataType, 'c', shape);
-  setShapeInfo(desc);
-
-  _isView = false;
-
-  setAttached(context->getWorkspace() != nullptr);
-
-  memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (auto e = start; e < stop; e++) {
-      auto cdata = data + offsets[e];
-      if (dataType == DataType::UTF16) {
-        unicode::utf8to16(string[e], cdata, std::char_traits<char>::length(string[e]));
-      } else if (dataType == DataType::UTF32) {
-        unicode::utf8to32(string[e], cdata, std::char_traits<char>::length(string[e]));
-      } else {
-        memcpy(cdata, string[e], std::char_traits<char>::length(string[e]));
-      }
-    }
-  };
-
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-  tickWriteHost();
-  syncToDevice();
-}
 /////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::string> &string,
-                 const sd::DataType dataType, sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dataType))
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+    NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::string> &string,
+                     const sd::DataType dataType, sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dataType))
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
 
-  if (shape::prodLong(shape.data(), shape.size()) != string.size())
-    throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
+        if (shape::prodLong(shape.data(), shape.size()) != string.size())
+            throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
 
-  for (const auto &str : string) {
-    if (!unicode::isStringValidU8(str.data(), str.data() + str.size())) {
-      throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        for (const auto &str : string) {
+            if (!unicode::isStringValidU8(str.data(), str.data() + str.size())) {
+                throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+            }
+        }
+
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
+
+        std::vector<sd::LongType> offsets(string.size() + 1);
+        sd::LongType dataLength = 0;
+        for (int e = 0; e < string.size(); e++) {
+            offsets[e] = dataLength;
+            dataLength += [&] {
+                if (dataType == DataType::UTF16) return unicode::offsetUtf8StringInUtf16(string[e].data(), string[e].size());
+                if (dataType == DataType::UTF32) return unicode::offsetUtf8StringInUtf32(string[e].data(), string[e].size());
+                return static_cast<sd::LongType>(string[e].size());
+            }();
+        }
+
+        offsets[string.size()] = dataLength;
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dataType, context->getWorkspace(), true);
+
+        _context = context;
+        _offset = 0;
+
+        auto desc = new ShapeDescriptor(dataType, 'c', shape);
+        setShapeInfo(desc);
+
+        _isView = false;
+
+        setAttached(context->getWorkspace() != nullptr);
+
+        memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+
+        auto func = PRAGMA_THREADS_FOR {
+            for (auto e = start; e < stop; e++) {
+                auto cdata = data + offsets[e];
+                if (dataType == DataType::UTF16) {
+                    unicode::utf8to16(string[e].data(), cdata, string[e].size());
+                } else if (dataType == DataType::UTF32) {
+                    unicode::utf8to32(string[e].data(), cdata, string[e].size());
+                } else {
+                    memcpy(cdata, string[e].data(), string[e].size());
+                }
+            }
+        };
+
+        samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+        tickWriteHost();
+        syncToDevice();
     }
-  }
-
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
-
-  std::vector<sd::LongType> offsets(string.size() + 1);
-  sd::LongType dataLength = 0;
-  for (int e = 0; e < string.size(); e++) {
-    offsets[e] = dataLength;
-    dataLength += [&] {
-      if (dataType == DataType::UTF16) return unicode::offsetUtf8StringInUtf16(string[e].data(), string[e].size());
-      if (dataType == DataType::UTF32) return unicode::offsetUtf8StringInUtf32(string[e].data(), string[e].size());
-      return static_cast<sd::LongType>(string[e].size());
-    }();
-  }
-
-  offsets[string.size()] = dataLength;
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dataType, context->getWorkspace(), true);
-
-  _context = context;
-  _offset = 0;
-
-  auto desc = new ShapeDescriptor(dataType, 'c', shape);
-  setShapeInfo(desc);
-
-  _isView = false;
-
-  setAttached(context->getWorkspace() != nullptr);
-
-  memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (auto e = start; e < stop; e++) {
-      auto cdata = data + offsets[e];
-      if (dataType == DataType::UTF16) {
-        unicode::utf8to16(string[e].data(), cdata, string[e].size());
-      } else if (dataType == DataType::UTF32) {
-        unicode::utf8to32(string[e].data(), cdata, string[e].size());
-      } else {
-        memcpy(cdata, string[e].data(), string[e].size());
-      }
-    }
-  };
-
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-  tickWriteHost();
-  syncToDevice();
-}
 /////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::u16string> &string, sd::DataType dtype,
-                 sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dtype))
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+    NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::u16string> &string, sd::DataType dtype,
+                     sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dtype))
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
 
-  if (shape::prodLong(shape.data(), shape.size()) != string.size())
-    throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
+        if (shape::prodLong(shape.data(), shape.size()) != string.size())
+            throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
 
-  for (const auto &str : string) {
-    if (!unicode::isStringValidU16(str.data(), str.data() + str.size())) {
-      throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        for (const auto &str : string) {
+            if (!unicode::isStringValidU16(str.data(), str.data() + str.size())) {
+                throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+            }
+        }
+
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
+
+        std::vector<sd::LongType> offsets(string.size() + 1);
+        sd::LongType dataLength = 0;
+        for (int e = 0; e < string.size(); e++) {
+            offsets[e] = dataLength;
+            dataLength += [&] {
+                if (dtype == DataType::UTF16) return static_cast<sd::LongType>(sizeof(uint16_t) * string[e].size());
+                if (dtype == DataType::UTF32) return unicode::offsetUtf16StringInUtf32(string[e].data(), string[e].size());
+                return unicode::offsetUtf16StringInUtf8(string[e].data(), string[e].size());
+            }();
+        }
+        offsets[string.size()] = dataLength;
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
+
+        _context = context;
+        _offset = 0;
+
+        auto desc = new ShapeDescriptor(dtype, 'c', shape);
+        setShapeInfo(desc);
+
+        _isView = false;
+
+        setAttached(context->getWorkspace() != nullptr);
+
+        memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+
+        auto func = PRAGMA_THREADS_FOR {
+            for (auto e = start; e < stop; e++) {
+                auto cdata = data + offsets[e];
+                if (dtype == DataType::UTF16) {
+                    memcpy(cdata, string[e].data(), string[e].size() * sizeof(uint16_t));
+                } else if (dtype == DataType::UTF32) {
+                    unicode::utf16to32(string[e].data(), cdata, string[e].size());
+                } else {
+                    unicode::utf16to8(string[e].data(), cdata, string[e].size());
+                }
+            }
+        };
+        samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+        tickWriteHost();
+        syncToDevice();
     }
-  }
-
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
-
-  std::vector<sd::LongType> offsets(string.size() + 1);
-  sd::LongType dataLength = 0;
-  for (int e = 0; e < string.size(); e++) {
-    offsets[e] = dataLength;
-    dataLength += [&] {
-      if (dtype == DataType::UTF16) return static_cast<sd::LongType>(sizeof(uint16_t) * string[e].size());
-      if (dtype == DataType::UTF32) return unicode::offsetUtf16StringInUtf32(string[e].data(), string[e].size());
-      return unicode::offsetUtf16StringInUtf8(string[e].data(), string[e].size());
-    }();
-  }
-  offsets[string.size()] = dataLength;
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
-
-  _context = context;
-  _offset = 0;
-
-  auto desc = new ShapeDescriptor(dtype, 'c', shape);
-  setShapeInfo(desc);
-
-  _isView = false;
-
-  setAttached(context->getWorkspace() != nullptr);
-
-  memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (auto e = start; e < stop; e++) {
-      auto cdata = data + offsets[e];
-      if (dtype == DataType::UTF16) {
-        memcpy(cdata, string[e].data(), string[e].size() * sizeof(uint16_t));
-      } else if (dtype == DataType::UTF32) {
-        unicode::utf16to32(string[e].data(), cdata, string[e].size());
-      } else {
-        unicode::utf16to8(string[e].data(), cdata, string[e].size());
-      }
-    }
-  };
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-  tickWriteHost();
-  syncToDevice();
-}
 /////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const char16_t *> &string,
-                 sd::DataType dtype, sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dtype))
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+    NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const char16_t *> &string,
+                     sd::DataType dtype, sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dtype))
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
 
-  if (shape::prodLong(shape.data(), shape.size()) != string.size())
-    throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
+        if (shape::prodLong(shape.data(), shape.size()) != string.size())
+            throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
 
-  for (const auto &str : string) {
-    if (!unicode::isStringValidU16(str, str + std::char_traits<char16_t>::length(str))) {
-      throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        for (const auto &str : string) {
+            if (!unicode::isStringValidU16(str, str + std::char_traits<char16_t>::length(str))) {
+                throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+            }
+        }
+
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
+
+        std::vector<sd::LongType> offsets(string.size() + 1);
+        sd::LongType dataLength = 0;
+        for (int e = 0; e < string.size(); e++) {
+            offsets[e] = dataLength;
+            dataLength += [&] {
+                if (dtype == DataType::UTF16)
+                    return static_cast<sd::LongType>(sizeof(uint16_t) * std::char_traits<char16_t>::length(string[e]));
+                if (dtype == DataType::UTF32)
+                    return unicode::offsetUtf16StringInUtf32(string[e], std::char_traits<char16_t>::length(string[e]));
+                return unicode::offsetUtf16StringInUtf8(string[e], std::char_traits<char16_t>::length(string[e]));
+            }();
+        }
+        offsets[string.size()] = dataLength;
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
+
+        _context = context;
+        _offset = 0;
+
+        auto desc = new ShapeDescriptor(dtype, 'c', shape);
+        setShapeInfo(desc);
+
+        _isView = false;
+
+        setAttached(context->getWorkspace() != nullptr);
+
+        memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+
+        auto func = PRAGMA_THREADS_FOR {
+            for (auto e = start; e < stop; e++) {
+                auto cdata = data + offsets[e];
+                if (dtype == DataType::UTF16) {
+                    memcpy(cdata, string[e], std::char_traits<char16_t>::length(string[e]) * sizeof(uint16_t));
+                } else if (dtype == DataType::UTF32) {
+                    unicode::utf16to32(string[e], cdata, std::char_traits<char16_t>::length(string[e]));
+                } else {
+                    unicode::utf16to8(string[e], cdata, std::char_traits<char16_t>::length(string[e]));
+                }
+            }
+        };
+        samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+        tickWriteHost();
+        syncToDevice();
     }
-  }
-
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
-
-  std::vector<sd::LongType> offsets(string.size() + 1);
-  sd::LongType dataLength = 0;
-  for (int e = 0; e < string.size(); e++) {
-    offsets[e] = dataLength;
-    dataLength += [&] {
-      if (dtype == DataType::UTF16)
-        return static_cast<sd::LongType>(sizeof(uint16_t) * std::char_traits<char16_t>::length(string[e]));
-      if (dtype == DataType::UTF32)
-        return unicode::offsetUtf16StringInUtf32(string[e], std::char_traits<char16_t>::length(string[e]));
-      return unicode::offsetUtf16StringInUtf8(string[e], std::char_traits<char16_t>::length(string[e]));
-    }();
-  }
-  offsets[string.size()] = dataLength;
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
-
-  _context = context;
-  _offset = 0;
-
-  auto desc = new ShapeDescriptor(dtype, 'c', shape);
-  setShapeInfo(desc);
-
-  _isView = false;
-
-  setAttached(context->getWorkspace() != nullptr);
-
-  memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (auto e = start; e < stop; e++) {
-      auto cdata = data + offsets[e];
-      if (dtype == DataType::UTF16) {
-        memcpy(cdata, string[e], std::char_traits<char16_t>::length(string[e]) * sizeof(uint16_t));
-      } else if (dtype == DataType::UTF32) {
-        unicode::utf16to32(string[e], cdata, std::char_traits<char16_t>::length(string[e]));
-      } else {
-        unicode::utf16to8(string[e], cdata, std::char_traits<char16_t>::length(string[e]));
-      }
-    }
-  };
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-  tickWriteHost();
-  syncToDevice();
-}
 /////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::u32string> &string, sd::DataType dtype,
-                 sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dtype))
-    throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
+    NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::u32string> &string, sd::DataType dtype,
+                     sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dtype))
+            throw std::invalid_argument("NDArray::NDArray: invalid DataType, only string dataTypes have to be used");
 
-  if (shape::prodLong(shape.data(), shape.size()) != string.size())
-    throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
+        if (shape::prodLong(shape.data(), shape.size()) != string.size())
+            throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
 
-  for (auto str : string) {
-    if (!unicode::isStringValidU32(str.data(), str.data() + str.size())) {
-      throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        for (auto str : string) {
+            if (!unicode::isStringValidU32(str.data(), str.data() + str.size())) {
+                throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+            }
+        }
+
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
+
+        std::vector<sd::LongType> offsets(string.size() + 1);
+
+        sd::LongType dataLength = 0;
+        for (int e = 0; e < string.size(); e++) {
+            offsets[e] = dataLength;
+            dataLength += [&] {
+                if (dtype == DataType::UTF16) return unicode::offsetUtf32StringInUtf16(string[e].data(), string[e].size());
+                if (dtype == DataType::UTF32) return static_cast<sd::LongType>(sizeof(uint32_t) * string[e].size());
+                return unicode::offsetUtf32StringInUtf16(string[e].data(), string[e].size());
+            }();
+        }
+        offsets[string.size()] = dataLength;
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
+
+        _context = context;
+        _offset = 0;
+        auto desc = new ShapeDescriptor(dtype, 'c', shape);
+        setShapeInfo(desc);
+
+        _isView = false;
+
+        setAttached(context->getWorkspace() != nullptr);
+
+        memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+
+        auto func = PRAGMA_THREADS_FOR {
+            for (auto e = start; e < stop; e++) {
+                auto cdata = data + offsets[e];
+                if (dtype == DataType::UTF16) {
+                    unicode::utf32to16(string[e].data(), cdata, string[e].size());
+                } else if (dtype == DataType::UTF32) {
+                    memcpy(cdata, string[e].data(), string[e].size() * sizeof(uint32_t));
+                } else {
+                    unicode::utf32to8(string[e].data(), cdata, string[e].size());
+                }
+            }
+        };
+        samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+        tickWriteHost();
+        syncToDevice();
     }
-  }
-
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
-
-  std::vector<sd::LongType> offsets(string.size() + 1);
-
-  sd::LongType dataLength = 0;
-  for (int e = 0; e < string.size(); e++) {
-    offsets[e] = dataLength;
-    dataLength += [&] {
-      if (dtype == DataType::UTF16) return unicode::offsetUtf32StringInUtf16(string[e].data(), string[e].size());
-      if (dtype == DataType::UTF32) return static_cast<sd::LongType>(sizeof(uint32_t) * string[e].size());
-      return unicode::offsetUtf32StringInUtf16(string[e].data(), string[e].size());
-    }();
-  }
-  offsets[string.size()] = dataLength;
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
-
-  _context = context;
-  _offset = 0;
-  auto desc = new ShapeDescriptor(dtype, 'c', shape);
-  setShapeInfo(desc);
-
-  _isView = false;
-
-  setAttached(context->getWorkspace() != nullptr);
-
-  memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (auto e = start; e < stop; e++) {
-      auto cdata = data + offsets[e];
-      if (dtype == DataType::UTF16) {
-        unicode::utf32to16(string[e].data(), cdata, string[e].size());
-      } else if (dtype == DataType::UTF32) {
-        memcpy(cdata, string[e].data(), string[e].size() * sizeof(uint32_t));
-      } else {
-        unicode::utf32to8(string[e].data(), cdata, string[e].size());
-      }
-    }
-  };
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-  tickWriteHost();
-  syncToDevice();
-}
 /////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const char32_t *> &string,
-                 sd::DataType dtype, sd::LaunchContext *context) {
-  if (!DataTypeUtils::isS(dtype)) throw std::invalid_argument("NDArray::NDArray: invalid DataType used");
+    NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const char32_t *> &string,
+                     sd::DataType dtype, sd::LaunchContext *context) {
+        if (!DataTypeUtils::isS(dtype)) throw std::invalid_argument("NDArray::NDArray: invalid DataType used");
 
-  if (shape::prodLong(shape.data(), shape.size()) != string.size())
-    throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
+        if (shape::prodLong(shape.data(), shape.size()) != string.size())
+            throw std::invalid_argument("NDArray::NDArray: Number of strings should match length of array");
 
-  for (const auto &str : string) {
-    if (!unicode::isStringValidU32(str, str + std::char_traits<char32_t>::length(str))) {
-      throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+        for (const auto &str : string) {
+            if (!unicode::isStringValidU32(str, str + std::char_traits<char32_t>::length(str))) {
+                throw std::invalid_argument("NDArray::NDArray: invalid character in input string");
+            }
+        }
+
+        sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
+
+        std::vector<sd::LongType> offsets(string.size() + 1);
+
+        sd::LongType dataLength = 0;
+        for (int e = 0; e < string.size(); e++) {
+            offsets[e] = dataLength;
+            dataLength += [&] {
+                if (dtype == DataType::UTF16)
+                    return unicode::offsetUtf32StringInUtf16(string[e], std::char_traits<char32_t>::length(string[e]));
+                if (dtype == DataType::UTF32)
+                    return static_cast<sd::LongType>(sizeof(uint32_t) * std::char_traits<char32_t>::length(string[e]));
+                return unicode::offsetUtf32StringInUtf16(string[e], std::char_traits<char32_t>::length(string[e]));
+            }();
+        }
+        offsets[string.size()] = dataLength;
+
+        _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
+
+        _context = context;
+        _offset = 0;
+
+        auto desc = new ShapeDescriptor(dtype, 'c', shape);
+        setShapeInfo(desc);
+
+        _isView = _length * DataTypeUtils::sizeOf(_dataType) < _buffer->getLenInBytes();
+
+        setAttached(context->getWorkspace() != nullptr);
+
+        memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
+
+        auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
+
+        auto func = PRAGMA_THREADS_FOR {
+            for (auto e = start; e < stop; e++) {
+                auto cdata = data + offsets[e];
+                if (dtype == DataType::UTF16) {
+                    unicode::utf32to16(string[e], cdata, std::char_traits<char32_t>::length(string[e]));
+                } else if (dtype == DataType::UTF32) {
+                    memcpy(cdata, string[e], std::char_traits<char32_t>::length(string[e]) * sizeof(uint32_t));
+                } else {
+                    unicode::utf32to8(string[e], cdata, std::char_traits<char32_t>::length(string[e]));
+                }
+            }
+        };
+        samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+        tickWriteHost();
+        syncToDevice();
     }
-  }
-
-  sd::LongType headerLength = ShapeUtils::stringBufferHeaderRequirements(string.size());
-
-  std::vector<sd::LongType> offsets(string.size() + 1);
-
-  sd::LongType dataLength = 0;
-  for (int e = 0; e < string.size(); e++) {
-    offsets[e] = dataLength;
-    dataLength += [&] {
-      if (dtype == DataType::UTF16)
-        return unicode::offsetUtf32StringInUtf16(string[e], std::char_traits<char32_t>::length(string[e]));
-      if (dtype == DataType::UTF32)
-        return static_cast<sd::LongType>(sizeof(uint32_t) * std::char_traits<char32_t>::length(string[e]));
-      return unicode::offsetUtf32StringInUtf16(string[e], std::char_traits<char32_t>::length(string[e]));
-    }();
-  }
-  offsets[string.size()] = dataLength;
-
-  _buffer = std::make_shared<DataBuffer>(headerLength + dataLength, dtype, context->getWorkspace(), true);
-
-  _context = context;
-  _offset = 0;
-
-  auto desc = new ShapeDescriptor(dtype, 'c', shape);
-  setShapeInfo(desc);
-
-  _isView = _length * DataTypeUtils::sizeOf(_dataType) < _buffer->getLenInBytes();
-
-  setAttached(context->getWorkspace() != nullptr);
-
-  memcpy(bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
-
-  auto data = reinterpret_cast<int8_t *>(bufferAsT<int8_t>() + headerLength);
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (auto e = start; e < stop; e++) {
-      auto cdata = data + offsets[e];
-      if (dtype == DataType::UTF16) {
-        unicode::utf32to16(string[e], cdata, std::char_traits<char32_t>::length(string[e]));
-      } else if (dtype == DataType::UTF32) {
-        memcpy(cdata, string[e], std::char_traits<char32_t>::length(string[e]) * sizeof(uint32_t));
-      } else {
-        unicode::utf32to8(string[e], cdata, std::char_traits<char32_t>::length(string[e]));
-      }
-    }
-  };
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-  tickWriteHost();
-  syncToDevice();
-}
 
 ////////////////////////////////////////////////////////////////////////
 // assignment operator
-NDArray &NDArray::operator=(const NDArray &other) {
-  if (this == &other || (_shapeInfo == other._shapeInfo && _shapeInfo == nullptr)) return *this;
+    NDArray &NDArray::operator=(const NDArray &other) {
+        if (this == &other || (_shapeInfo == other._shapeInfo && _shapeInfo == nullptr)) return *this;
 
-  if (_shapeInfo != nullptr && shape::equalsTypesAndShapesSoft(_shapeInfo, other._shapeInfo)) {
-    if (!other.isEmpty()) this->assign(&other);
-  } else {
-    _context = other._context;
-    _offset = 0;
-    auto desc = new ShapeDescriptor(other.dataType(), other.ordering(), other.shapeOf(), other.rankOf());
-    setShapeInfo(desc);
+        if (_shapeInfo != nullptr && shape::equalsTypesAndShapesSoft(_shapeInfo, other._shapeInfo)) {
+            if (!other.isEmpty()) this->assign(&other);
+        } else {
+            _context = other._context;
+            _offset = 0;
+            auto desc = new ShapeDescriptor(other.dataType(), other.ordering(), other.shapeOf(), other.rankOf());
+            setShapeInfo(desc);
 
-    if (!other.isEmpty()) {
-      _buffer = std::make_shared<DataBuffer>(other.lengthOf() * other.sizeOfT(), other.dataType(),
-                                             other.getContext()->getWorkspace());
-      this->assign(&other);
-    } else
-      _buffer = std::make_shared<DataBuffer>();
-  }
-  return *this;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::isC() const {
-  // TODO: this method must be implemented once we add support for complex numbers
-  return false;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::isS() const {
-  return (dataType() == DataType::UTF8 || dataType() == DataType::UTF16 || dataType() == DataType::UTF32);
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::isR() const {
-  auto xType = ArrayOptions::dataType(this->_shapeInfo);
-  return xType == FLOAT32 || xType == HALF || xType == DOUBLE || xType == FLOAT8 || xType == BFLOAT16;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::isZ() const {
-  // TODO: decide if we really want to exclude Bool here
-  return !isC() && !isR() && !isB() && !isS();
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::isB() const { return ArrayOptions::dataType(this->_shapeInfo) == BOOL; }
-
-//////////////////////////////////////////////////////////////////////////
-template <typename T>
-std::string NDArray::toStringValue(T value) {
-  std::ostringstream os;
-  // throw the value into the string stream
-  os << value;
-  // convert the string stream into a string and return
-  return os.str();
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <>
-std::string NDArray::toStringValue(float16 value) {
-  std::ostringstream os;
-  // throw the value into the string stream
-  os << (float)value;
-  // convert the string stream into a string and return
-  return os.str();
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <>
-std::string NDArray::toStringValue(bfloat16 value) {
-  std::ostringstream os;
-  // throw the value into the string stream
-  os << (float)value;
-  // convert the string stream into a string and return
-  return os.str();
-}
-
-//////////////////////////////////////////////////////////////////////////
-std::string NDArray::asIndexedString(sd::LongType limit) {
-  std::ostringstream os;
-  os << "[";
-  if (limit < 1 || limit > this->lengthOf()) limit = this->lengthOf();
-  for (sd::LongType e = 0; e < limit; e++) {
-    os << toStringValue(this->e<float>(e));
-    if (e < limit - 1) os << ", ";
-  }
-  os << "]";
-  return os.str();
-}
-
-//////////////////////////////////////////////////////////////////////////
-std::string NDArray::asString(sd::LongType limit) {
-  std::ostringstream os;
-  os << "[";
-  if (limit < 1 || limit > this->lengthOf()) limit = this->lengthOf();
-  for (sd::LongType e = 0; e < limit; e++) {
-    if (this->isR())
-      os << toStringValue(this->e<float>(e));
-    else if (this->isZ())
-      os << toStringValue(this->e<sd::LongType>(e));
-    else if (this->isB())
-      os << toStringValue(this->e<bool>(e));
-    else if (this->isS())  // todo add utf16 and utf32
-      os << this->e<std::string>(e);
-    if (e < limit - 1) os << ", ";
-  }
-  os << "]";
-  return os.str();
-}
-
-////////////////////////////////////////////////////////////////////////
-template <typename T>
-std::vector<T> NDArray::getBufferAsVector() const {
-  std::vector<T> vector(lengthOf());
-  for (sd::LongType e = 0; e < lengthOf(); e++) vector[e] = this->e<T>(e);
-  return vector;
-}
-BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT std::vector, NDArray::getBufferAsVector() const, SD_COMMON_TYPES_ALL);
-
-////////////////////////////////////////////////////////////////////////
-std::vector<int64_t> NDArray::getShapeAsFlatVector() const {
-  std::vector<int64_t> vector(this->rankOf());
-  for (int e = 0; e < this->rankOf(); e++) vector[e] = static_cast<int64_t>(this->sizeAt(e));
-  return vector;
-}
-
-////////////////////////////////////////////////////////////////////////
-std::vector<sd::LongType> NDArray::getShapeAsVector() const {
-  std::vector<sd::LongType> vector(this->rankOf());
-  for (int e = 0; e < this->rankOf(); e++) vector[e] = this->sizeAt(e);
-
-  return vector;
-}
-
-////////////////////////////////////////////////////////////////////////
-std::vector<int> NDArray::getShapeAsVectorInt() const {
-  std::vector<int> vector(this->rankOf());
-  for (int e = 0; e < this->rankOf(); e++) vector[e] = static_cast<int>(this->sizeAt(e));
-
-  return vector;
-}
-
-////////////////////////////////////////////////////////////////////////
-std::vector<int64_t> NDArray::getShapeInfoAsFlatVector() const {
-  int magicNumber = shape::shapeInfoLength(this->rankOf());
-  std::vector<int64_t> vector(magicNumber);
-
-  for (int e = 0; e < magicNumber; e++) vector[e] = static_cast<int64_t>(_shapeInfo[e]);
-
-  return vector;
-}
-
-////////////////////////////////////////////////////////////////////////
-std::vector<sd::LongType> NDArray::getShapeInfoAsVector() const {
-  int magicNumber = shape::shapeInfoLength(this->rankOf());
-  std::vector<sd::LongType> vector(magicNumber);
-  for (int e = 0; e < magicNumber; e++) vector[e] = this->_shapeInfo[e];
-  return vector;
-}
-
-////////////////////////////////////////////////////////////////////////
-std::vector<int8_t> NDArray::asByteVector() {
-  if (isS()) {
-    // string data type requires special treatment
-    syncToHost();
-    auto numWords = this->lengthOf();
-    auto offsetsBuffer = this->bufferAsT<sd::LongType>();
-    auto headerLength = ShapeUtils::stringBufferHeaderRequirements(numWords);
-    auto dataLength = offsetsBuffer[numWords];
-    std::vector<int8_t> result(headerLength + dataLength);
-
-    memcpy(result.data(), buffer(), headerLength + dataLength);
-
-    return result;
-  } else {
-    // all other types are linear
-    std::vector<int8_t> result((unsigned long long)this->lengthOf() * sizeOfT());
-
-    if (this->isView()) {
-      auto tmp = this->dup(this->ordering());
-      syncToHost();
-      memcpy(result.data(), tmp.buffer(), (unsigned long long)lengthOf() * sizeOfT());
-    } else {
-      syncToHost();
-      memcpy(result.data(), buffer(), (unsigned long long)lengthOf() * sizeOfT());
+            if (!other.isEmpty()) {
+                _buffer = std::make_shared<DataBuffer>(other.lengthOf() * other.sizeOfT(), other.dataType(),
+                                                       other.getContext()->getWorkspace());
+                this->assign(&other);
+            } else
+                _buffer = std::make_shared<DataBuffer>();
+        }
+        return *this;
     }
-    return result;
-  }
-}
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::linspace(const double start) { linspace(start, 1); }
+    bool NDArray::isC() const {
+        // TODO: this method must be implemented once we add support for complex numbers
+        return false;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::linspace(const double start, const double step) {
-  if (isS()) throw std::runtime_error("NDArray::linspace: you can't use this method on String array!");
-  sd::LongType numElements = this->lengthOf();
-  for (sd::LongType e = 0; e < numElements; e++) this->p(e, start + (step * e));
-}
+    bool NDArray::isS() const {
+        return (dataType() == DataType::UTF8 || dataType() == DataType::UTF16 || dataType() == DataType::UTF32);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    bool NDArray::isR() const {
+        auto xType = ArrayOptions::dataType(this->_shapeInfo);
+        return xType == FLOAT32 || xType == HALF || xType == DOUBLE || xType == FLOAT8 || xType == BFLOAT16;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    bool NDArray::isZ() const {
+        // TODO: decide if we really want to exclude Bool here
+        return !isC() && !isR() && !isB() && !isS();
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    bool NDArray::isB() const { return ArrayOptions::dataType(this->_shapeInfo) == BOOL; }
+
+//////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    std::string NDArray::toStringValue(T value) {
+        std::ostringstream os;
+        // throw the value into the string stream
+        os << value;
+        // convert the string stream into a string and return
+        return os.str();
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    template <>
+    std::string NDArray::toStringValue(float16 value) {
+        std::ostringstream os;
+        // throw the value into the string stream
+        os << (float)value;
+        // convert the string stream into a string and return
+        return os.str();
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    template <>
+    std::string NDArray::toStringValue(bfloat16 value) {
+        std::ostringstream os;
+        // throw the value into the string stream
+        os << (float)value;
+        // convert the string stream into a string and return
+        return os.str();
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    std::string NDArray::asIndexedString(sd::LongType limit) {
+        std::ostringstream os;
+        os << "[";
+        if (limit < 1 || limit > this->lengthOf()) limit = this->lengthOf();
+        for (sd::LongType e = 0; e < limit; e++) {
+            os << toStringValue(this->e<float>(e));
+            if (e < limit - 1) os << ", ";
+        }
+        os << "]";
+        return os.str();
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    std::string NDArray::asString(sd::LongType limit) {
+        std::ostringstream os;
+        os << "[";
+        if (limit < 1 || limit > this->lengthOf()) limit = this->lengthOf();
+        for (sd::LongType e = 0; e < limit; e++) {
+            if (this->isR())
+                os << toStringValue(this->e<float>(e));
+            else if (this->isZ())
+                os << toStringValue(this->e<sd::LongType>(e));
+            else if (this->isB())
+                os << toStringValue(this->e<bool>(e));
+            else if (this->isS())  // todo add utf16 and utf32
+                os << this->e<std::string>(e);
+            if (e < limit - 1) os << ", ";
+        }
+        os << "]";
+        return os.str();
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::streamline(char o) {
-  char order = o == 'a' ? this->ordering() : o;
-  syncToDevice();
-  std::shared_ptr<DataBuffer> newBuffer =
-      std::make_shared<DataBuffer>(this->lengthOf() * sizeOfT(), dataType(), getContext()->getWorkspace());
-  auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(dataType(), order, rankOf(), shapeOf());
-  NativeOpExecutioner::execTransformSame(getContext(), transform::Copy, buffer(), shapeInfo(), specialBuffer(),
-                                         specialShapeInfo(), newBuffer->primary(), shapeBuffer->primary(),
-                                         newBuffer->special(), shapeBuffer->special(), nullptr, nullptr, nullptr);
-  setShapeInfo(shapeBuffer);
-  _buffer = newBuffer;
-  _offset = 0;
-  tickWriteDevice();
-}
+    template <typename T>
+    std::vector<T> NDArray::getBufferAsVector() const {
+        std::vector<T> vector(lengthOf());
+        for (sd::LongType e = 0; e < lengthOf(); e++) vector[e] = this->e<T>(e);
+        return vector;
+    }
+    BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT std::vector, NDArray::getBufferAsVector() const, SD_COMMON_TYPES_ALL);
+
+////////////////////////////////////////////////////////////////////////
+    std::vector<int64_t> NDArray::getShapeAsFlatVector() const {
+        std::vector<int64_t> vector(this->rankOf());
+        for (int e = 0; e < this->rankOf(); e++) vector[e] = static_cast<int64_t>(this->sizeAt(e));
+        return vector;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    std::vector<sd::LongType> NDArray::getShapeAsVector() const {
+        std::vector<sd::LongType> vector(this->rankOf());
+        for (int e = 0; e < this->rankOf(); e++) vector[e] = this->sizeAt(e);
+
+        return vector;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    std::vector<int> NDArray::getShapeAsVectorInt() const {
+        std::vector<int> vector(this->rankOf());
+        for (int e = 0; e < this->rankOf(); e++) vector[e] = static_cast<int>(this->sizeAt(e));
+
+        return vector;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    std::vector<int64_t> NDArray::getShapeInfoAsFlatVector() const {
+        int magicNumber = shape::shapeInfoLength(this->rankOf());
+        std::vector<int64_t> vector(magicNumber);
+
+        for (int e = 0; e < magicNumber; e++) vector[e] = static_cast<int64_t>(_shapeInfo[e]);
+
+        return vector;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    std::vector<sd::LongType> NDArray::getShapeInfoAsVector() const {
+        int magicNumber = shape::shapeInfoLength(this->rankOf());
+        std::vector<sd::LongType> vector(magicNumber);
+        for (int e = 0; e < magicNumber; e++) vector[e] = this->_shapeInfo[e];
+        return vector;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    std::vector<int8_t> NDArray::asByteVector() {
+        if (isS()) {
+            // string data type requires special treatment
+            syncToHost();
+            auto numWords = this->lengthOf();
+            auto offsetsBuffer = this->bufferAsT<sd::LongType>();
+            auto headerLength = ShapeUtils::stringBufferHeaderRequirements(numWords);
+            auto dataLength = offsetsBuffer[numWords];
+            std::vector<int8_t> result(headerLength + dataLength);
+
+            memcpy(result.data(), buffer(), headerLength + dataLength);
+
+            return result;
+        } else {
+            // all other types are linear
+            std::vector<int8_t> result((unsigned long long)this->lengthOf() * sizeOfT());
+
+            if (this->isView()) {
+                auto tmp = this->dup(this->ordering());
+                syncToHost();
+                memcpy(result.data(), tmp.buffer(), (unsigned long long)lengthOf() * sizeOfT());
+            } else {
+                syncToHost();
+                memcpy(result.data(), buffer(), (unsigned long long)lengthOf() * sizeOfT());
+            }
+            return result;
+        }
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::linspace(const double start) { linspace(start, 1); }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::linspace(const double start, const double step) {
+        if (isS()) throw std::runtime_error("NDArray::linspace: you can't use this method on String array!");
+        sd::LongType numElements = this->lengthOf();
+        for (sd::LongType e = 0; e < numElements; e++) this->p(e, start + (step * e));
+    }
+
+////////////////////////////////////////////////////////////////////////
+    void NDArray::streamline(char o) {
+        char order = o == 'a' ? this->ordering() : o;
+        syncToDevice();
+        std::shared_ptr<DataBuffer> newBuffer =
+                std::make_shared<DataBuffer>(this->lengthOf() * sizeOfT(), dataType(), getContext()->getWorkspace());
+        auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(dataType(), order, rankOf(), shapeOf());
+        NativeOpExecutioner::execTransformSame(getContext(), transform::Copy, buffer(), shapeInfo(), specialBuffer(),
+                                               specialShapeInfo(), newBuffer->primary(), shapeBuffer->primary(),
+                                               newBuffer->special(), shapeBuffer->special(), nullptr, nullptr, nullptr);
+        setShapeInfo(shapeBuffer);
+        _buffer = newBuffer;
+        _offset = 0;
+        tickWriteDevice();
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // move assignment operator
-NDArray &NDArray::operator=(NDArray &&other) noexcept {
-  if (this == &other) return *this;
+    NDArray &NDArray::operator=(NDArray &&other) noexcept {
+        if (this == &other) return *this;
 
-  _isView = other._isView;
-  _buffer = other._buffer;
-  _shapeInfo = other._shapeInfo;
-  _shapeInfoD = other._shapeInfoD;
-  _context = other._context;
-  _dataType = other._dataType;
-  _length = other._length;
-  _offset = other._offset;
+        _isView = other._isView;
+        _buffer = other._buffer;
+        _shapeInfo = other._shapeInfo;
+        _shapeInfoD = other._shapeInfoD;
+        _context = other._context;
+        _dataType = other._dataType;
+        _length = other._length;
+        _offset = other._offset;
 
-  other._buffer = std::make_shared<DataBuffer>();
-  other._shapeInfo = other._shapeInfoD = nullptr;
-  other._length = 0;
+        other._buffer = std::make_shared<DataBuffer>();
+        other._shapeInfo = other._shapeInfoD = nullptr;
+        other._length = 0;
 
-  return *this;
-}
+        return *this;
+    }
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-NDArray &NDArray::operator=(const T scalar) {
-  this->assign(scalar);
-  return *this;
-}
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const double scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const float scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const float16 scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const bfloat16 scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const sd::LongType scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const int scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const int8_t scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint8_t scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint16_t scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint32_t scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint64_t scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const int16_t scalar);
-template SD_LIB_EXPORT NDArray &NDArray::operator=(const bool scalar);
+    template <typename T>
+    NDArray &NDArray::operator=(const T scalar) {
+        this->assign(scalar);
+        return *this;
+    }
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const double scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const float scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const float16 scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const bfloat16 scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const sd::LongType scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const int scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const int8_t scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint8_t scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint16_t scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint32_t scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const uint64_t scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const int16_t scalar);
+    template SD_LIB_EXPORT NDArray &NDArray::operator=(const bool scalar);
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::copyBuffersContinuouslyFrom(const NDArray &other, size_t sizeToCopyInBytes, sd::LongType offsetThis,
-                                          sd::LongType offsetOther) {
-  if (offsetThis == 0) offsetThis = bufferOffset();
-  if (offsetOther == 0) offsetOther = other.bufferOffset();
+    void NDArray::copyBuffersContinuouslyFrom(const NDArray &other, size_t sizeToCopyInBytes, sd::LongType offsetThis,
+                                              sd::LongType offsetOther) {
+        if (offsetThis == 0) offsetThis = bufferOffset();
+        if (offsetOther == 0) offsetOther = other.bufferOffset();
 
-  dataBuffer()->copyBufferFrom(*other.getDataBuffer(), sizeToCopyInBytes, offsetThis, offsetOther);
-}
+        dataBuffer()->copyBufferFrom(*other.getDataBuffer(), sizeToCopyInBytes, offsetThis, offsetOther);
+    }
 
 ////////////////////////////////////////////////////////////////////
 // This method assigns values of given NDArray to this one
-void NDArray::assign(const NDArray &other, bool allowParallelism) {
-  if (this == &other) return;
+    void NDArray::assign(const NDArray &other, bool allowParallelism) {
+        if (this == &other) return;
 
-  if (other.isEmpty()) {
-    if (!isEmpty()) {
-      throw std::runtime_error("Cannot assign empty array to non-empty array");
+        if (other.isEmpty()) {
+            if (!isEmpty()) {
+                throw std::runtime_error("Cannot assign empty array to non-empty array");
+            }
+            return;
+        }
+
+        if (isEmpty()) {
+            *this = other;
+            return;
+        }
+
+        if (other.lengthOf() == 1) {
+            if (lengthOf() == 1) {
+                NDArray::preparePrimaryUse({this}, {&other});
+                BUILD_DOUBLE_SELECTOR(dataType(), other.dataType(), templatedDoubleAssign, (buffer(), 0, other.buffer(), 0),
+                                      SD_COMMON_TYPES, SD_COMMON_TYPES);
+                NDArray::registerPrimaryUse({this}, {&other});
+                this->syncToDevice();
+            } else {
+                if (dataType() != other.dataType()) {
+                    auto tmp = other.cast(dataType());
+                    prepareUse({this}, {&tmp});
+                    NativeOpExecutioner::execScalar(getContext(), scalar::CopyPws, buffer(), shapeInfo(), specialBuffer(),
+                                                    specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                    tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(), tmp.specialShapeInfo(),
+                                                    nullptr, allowParallelism);
+                    registerUse({this}, {});
+                } else {
+                    prepareUse({this}, {&other});
+                    NativeOpExecutioner::execScalar(getContext(), scalar::CopyPws, buffer(), shapeInfo(), specialBuffer(),
+                                                    specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                    other.buffer(), other.shapeInfo(), other.specialBuffer(),
+                                                    other.specialShapeInfo(), nullptr, allowParallelism);
+                    registerUse({this}, {&other});
+                }
+            }
+        } else {
+            if (other.lengthOf() != lengthOf() && !ShapeUtils::areShapesBroadcastable(other.shapeInfo(), this->shapeInfo())) {
+                auto shapeThis = ShapeUtils::shapeAsString(this);
+                auto shapeThat = ShapeUtils::shapeAsString(&other);
+                sd_printf("Can't assign array: this shape %s; other shape: %s\n", shapeThis.c_str(), shapeThat.c_str());
+                throw std::runtime_error("NDArray::assign: lengths of arrays are mismatched");
+            }
+
+            prepareUse({this}, {&other});
+
+            NativeOpExecutioner::execTransformAny(getContext(), transform::Assign, other.buffer(), other.shapeInfo(),
+                                                  other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
+                                                  specialBuffer(), specialShapeInfo(), nullptr, nullptr, nullptr,
+                                                  allowParallelism);
+
+
+            registerUse({this}, {&other});
+        }
     }
-    return;
-  }
-
-  if (isEmpty()) {
-    *this = other;
-    return;
-  }
-
-  if (other.lengthOf() == 1) {
-    if (lengthOf() == 1) {
-      NDArray::preparePrimaryUse({this}, {&other});
-      BUILD_DOUBLE_SELECTOR(dataType(), other.dataType(), templatedDoubleAssign, (buffer(), 0, other.buffer(), 0),
-                            SD_COMMON_TYPES, SD_COMMON_TYPES);
-      NDArray::registerPrimaryUse({this}, {&other});
-      this->syncToDevice();
-    } else {
-      if (dataType() != other.dataType()) {
-        auto tmp = other.cast(dataType());
-        prepareUse({this}, {&tmp});
-        NativeOpExecutioner::execScalar(getContext(), scalar::CopyPws, buffer(), shapeInfo(), specialBuffer(),
-                                        specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                        tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(), tmp.specialShapeInfo(),
-                                        nullptr, allowParallelism);
-        registerUse({this}, {});
-      } else {
-        prepareUse({this}, {&other});
-        NativeOpExecutioner::execScalar(getContext(), scalar::CopyPws, buffer(), shapeInfo(), specialBuffer(),
-                                        specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                        other.buffer(), other.shapeInfo(), other.specialBuffer(),
-                                        other.specialShapeInfo(), nullptr, allowParallelism);
-        registerUse({this}, {&other});
-      }
-    }
-  } else {
-    if (other.lengthOf() != lengthOf() && !ShapeUtils::areShapesBroadcastable(other.shapeInfo(), this->shapeInfo())) {
-      auto shapeThis = ShapeUtils::shapeAsString(this);
-      auto shapeThat = ShapeUtils::shapeAsString(&other);
-      sd_printf("Can't assign array: this shape %s; other shape: %s\n", shapeThis.c_str(), shapeThat.c_str());
-      throw std::runtime_error("NDArray::assign: lengths of arrays are mismatched");
-    }
-
-    prepareUse({this}, {&other});
-
-    printShapeInfo("Assigning array");
-    other.printShapeInfo("Other array being assigned to");
-    NativeOpExecutioner::execTransformAny(getContext(), transform::Assign, other.buffer(), other.shapeInfo(),
-                                          other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
-                                          specialBuffer(), specialShapeInfo(), nullptr, nullptr, nullptr,
-                                          allowParallelism);
-
-    printShapeInfo("Assigning array after assign");
-    other.printShapeInfo("Other array being assigned to after assign");
-    registerUse({this}, {&other});
-  }
-}
 
 //////////////////////////////////////////////////////////////////////////
 // This method assigns values of given NDArray to this one, wrt order
-void NDArray::assign(const NDArray *other, bool allowParallelism) { assign(*other, allowParallelism); }
+    void NDArray::assign(const NDArray *other, bool allowParallelism) { assign(*other, allowParallelism); }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-void NDArray::assign(const T &value, bool allowParallelism) {
-  // just fire scalar
-  auto temp = NDArrayFactory::create(dataType(), value, this->getContext());
+    template <typename T, typename>
+    void NDArray::assign(const T &value, bool allowParallelism) {
+        // just fire scalar
+        auto temp = NDArrayFactory::create(dataType(), value, this->getContext());
 
-  prepareUse(std::vector<const NDArray *>{this}, std::vector<const NDArray *>{&temp});
-  NativeOpExecutioner::execScalar(getContext(), sd::scalar::CopyPws, buffer(), shapeInfo(), specialBuffer(),
-                                  specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                  temp.buffer(), temp.shapeInfo(), temp.specialBuffer(), temp.specialShapeInfo(),
-                                  nullptr, allowParallelism);
-  registerUse(std::vector<const NDArray *>{this}, std::vector<const NDArray *>{&temp});
-}
-template SD_LIB_EXPORT void NDArray::assign(const double &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const float &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const float16 &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const bfloat16 &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const sd::LongType &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const int &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const int8_t &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const int16_t &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const uint8_t &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const uint16_t &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const uint32_t &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const uint64_t &value, bool allowParallelism);
-template SD_LIB_EXPORT void NDArray::assign(const bool &value, bool allowParallelism);
-
-//////////////////////////////////////////////////////////////////////////
-NDArray *NDArray::detach() {
-  if (!isAttached()) return this;
-
-  std::shared_ptr<DataBuffer> newBuffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dataType());
-  auto desc = new ShapeDescriptor(dataType(), ordering(), shapeOf(), rankOf());
-  auto constantBuff = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-  auto recastShapeInfo = const_cast<sd::LongType *>(constantBuff->primary());
-  auto result = new NDArray(newBuffer,recastShapeInfo,getContext());
-
-  result->assign(*this);
-
-  return result;
-}
+        prepareUse(std::vector<const NDArray *>{this}, std::vector<const NDArray *>{&temp});
+        NativeOpExecutioner::execScalar(getContext(), sd::scalar::CopyPws, buffer(), shapeInfo(), specialBuffer(),
+                                        specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                        temp.buffer(), temp.shapeInfo(), temp.specialBuffer(), temp.specialShapeInfo(),
+                                        nullptr, allowParallelism);
+        registerUse(std::vector<const NDArray *>{this}, std::vector<const NDArray *>{&temp});
+    }
+    template SD_LIB_EXPORT void NDArray::assign(const double &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const float &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const float16 &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const bfloat16 &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const sd::LongType &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const int &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const int8_t &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const int16_t &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const uint8_t &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const uint16_t &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const uint32_t &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const uint64_t &value, bool allowParallelism);
+    template SD_LIB_EXPORT void NDArray::assign(const bool &value, bool allowParallelism);
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::varianceNumber(sd::variance::Ops op, bool biasCorrected) {
-  NDArray res(DataTypeUtils::pickFloatingType(dataType()), getContext());
+    NDArray *NDArray::detach() {
+        if (!isAttached()) return this;
 
-  prepareUse({&res}, {this});
-  NativeOpExecutioner::execSummaryStatsScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                              specialShapeInfo(), nullptr, res.buffer(), res.shapeInfo(),
-                                              res.specialBuffer(), res.specialShapeInfo(), biasCorrected);
-  registerUse({&res}, {this});
+        std::shared_ptr<DataBuffer> newBuffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dataType());
+        auto desc = new ShapeDescriptor(dataType(), ordering(), shapeOf(), rankOf());
+        auto constantBuff = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+        auto recastShapeInfo = const_cast<sd::LongType *>(constantBuff->primary());
+        auto result = new NDArray(newBuffer,recastShapeInfo,getContext());
 
-  return res;
-}
+        result->assign(*this);
+
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::varianceNumber(sd::variance::Ops op, bool biasCorrected) {
+        NDArray res(DataTypeUtils::pickFloatingType(dataType()), getContext());
+
+        prepareUse({&res}, {this});
+        NativeOpExecutioner::execSummaryStatsScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                    specialShapeInfo(), nullptr, res.buffer(), res.shapeInfo(),
+                                                    res.specialBuffer(), res.specialShapeInfo(), biasCorrected);
+        registerUse({&res}, {this});
+
+        return res;
+    }
 
 //////////////////////////////////////////////////////////////////////////
 
-NDArray NDArray::prodNumber() const {
-  if (isS()) throw std::runtime_error("NDArray::prodNumber: you can't use this method on String array!");
+    NDArray NDArray::prodNumber() const {
+        if (isS()) throw std::runtime_error("NDArray::prodNumber: you can't use this method on String array!");
 
-  NDArray res(dataType(), getContext());
+        NDArray res(dataType(), getContext());
 
-  prepareUse({&res}, {this});
-  NativeOpExecutioner::execReduceSameScalar(getContext(), sd::reduce::SameOps::Prod, buffer(), shapeInfo(),
-                                            specialBuffer(), specialShapeInfo(), nullptr, res.buffer(), res.shapeInfo(),
-                                            res.specialBuffer(), res.specialShapeInfo());
-  registerUse({&res}, {this});
+        prepareUse({&res}, {this});
+        NativeOpExecutioner::execReduceSameScalar(getContext(), sd::reduce::SameOps::Prod, buffer(), shapeInfo(),
+                                                  specialBuffer(), specialShapeInfo(), nullptr, res.buffer(), res.shapeInfo(),
+                                                  res.specialBuffer(), res.specialShapeInfo());
+        registerUse({&res}, {this});
 
-  return res;
-}
+        return res;
+    }
 
 // This method returns sum of all elements of this NDArray
-NDArray NDArray::sumNumber() const {
-  if (isS()) throw std::runtime_error("NDArray::sumNumber: you can't use this method on String array!");
-  NDArray res(dataType(), getContext());
+    NDArray NDArray::sumNumber() const {
+        if (isS()) throw std::runtime_error("NDArray::sumNumber: you can't use this method on String array!");
+        NDArray res(dataType(), getContext());
 
-  prepareUse({&res}, {this});
-  NativeOpExecutioner::execReduceSameScalar(getContext(), sd::reduce::SameOps::Sum, buffer(), shapeInfo(),
-                                            specialBuffer(), specialShapeInfo(), nullptr, res.buffer(), res.shapeInfo(),
-                                            res.specialBuffer(), res.specialShapeInfo());
-  registerUse({&res}, {this});
+        prepareUse({&res}, {this});
+        NativeOpExecutioner::execReduceSameScalar(getContext(), sd::reduce::SameOps::Sum, buffer(), shapeInfo(),
+                                                  specialBuffer(), specialShapeInfo(), nullptr, res.buffer(), res.shapeInfo(),
+                                                  res.specialBuffer(), res.specialShapeInfo());
+        registerUse({&res}, {this});
 
-  return res;
-}
+        return res;
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // This method returns mean number of this NDArray
-NDArray NDArray::meanNumber() const {
-  if (isS()) throw std::runtime_error("NDArray::meanNumber: you can't use this method on String array!");
-  NDArray res(DataTypeUtils::pickFloatingType(dataType()), getContext());
+    NDArray NDArray::meanNumber() const {
+        if (isS()) throw std::runtime_error("NDArray::meanNumber: you can't use this method on String array!");
+        NDArray res(DataTypeUtils::pickFloatingType(dataType()), getContext());
 
-  prepareUse({&res}, {this});
-  NativeOpExecutioner::execReduceFloatScalar(getContext(), sd::reduce::FloatOps::Mean, buffer(), shapeInfo(),
-                                             specialBuffer(), specialShapeInfo(), nullptr, res.buffer(),
-                                             res.shapeInfo(), res.specialBuffer(), res.specialShapeInfo());
-  registerUse({&res}, {this});
-  return res;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::hasNaNs() {
-  if (isS()) throw std::runtime_error("NDArray::hasNaNs: you can't use this method on String array!");
-  return this->reduceNumber(sd::reduce::IsNan, nullptr).e<int>(0) > 0;
-}
+        prepareUse({&res}, {this});
+        NativeOpExecutioner::execReduceFloatScalar(getContext(), sd::reduce::FloatOps::Mean, buffer(), shapeInfo(),
+                                                   specialBuffer(), specialShapeInfo(), nullptr, res.buffer(),
+                                                   res.shapeInfo(), res.specialBuffer(), res.specialShapeInfo());
+        registerUse({&res}, {this});
+        return res;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-bool NDArray::hasInfs() {
-  if (isS()) throw std::runtime_error("NDArray::hasInfs: you can't use this method on String array!");
-  return this->reduceNumber(sd::reduce::IsInf, nullptr).e<int>(0) > 0;
-}
+    bool NDArray::hasNaNs() {
+        if (isS()) throw std::runtime_error("NDArray::hasNaNs: you can't use this method on String array!");
+        return this->reduceNumber(sd::reduce::IsNan, nullptr).e<int>(0) > 0;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-bool NDArray::isFinite() {
-  if (isS()) throw std::runtime_error("NDArray::isFinite: you can't use this method on String array!");
-  return this->reduceNumber(sd::reduce::IsInfOrNan, nullptr).e<int>(0) == 0;
-}
+    bool NDArray::hasInfs() {
+        if (isS()) throw std::runtime_error("NDArray::hasInfs: you can't use this method on String array!");
+        return this->reduceNumber(sd::reduce::IsInf, nullptr).e<int>(0) > 0;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T, typename Y>
-void NDArray::templatedSet(void *buffer, const sd::LongType *indices, const void *value) {
-  auto t = reinterpret_cast<T *>(buffer);
-  const auto y = *(reinterpret_cast<const Y *>(value));
-
-  auto xOffset = shape::getOffset(shapeInfo(), indices);
-  t[xOffset] = static_cast<T>(y);
-}
-BUILD_DOUBLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedSet,
-                      (void *buffer, const sd::LongType *indices, const void *value), SD_COMMON_TYPES, SD_COMMON_TYPES);
+    bool NDArray::isFinite() {
+        if (isS()) throw std::runtime_error("NDArray::isFinite: you can't use this method on String array!");
+        return this->reduceNumber(sd::reduce::IsInfOrNan, nullptr).e<int>(0) == 0;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T, typename Y>
-void NDArray::templatedSet(void *buffer, const sd::LongType offset, const void *value) {
-  auto t = reinterpret_cast<T *>(buffer);
-  const auto y = *(reinterpret_cast<const Y *>(value));
+    template <typename T, typename Y>
+    void NDArray::templatedSet(void *buffer, const sd::LongType *indices, const void *value) {
+        auto t = reinterpret_cast<T *>(buffer);
+        const auto y = *(reinterpret_cast<const Y *>(value));
 
-  t[offset] = static_cast<T>(y);
-}
-BUILD_DOUBLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedSet,
-                      (void *buffer, const sd::LongType offset, const void *value), SD_COMMON_TYPES, SD_COMMON_TYPES);
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::setContext(sd::LaunchContext *context) {
-  _context = context;
-  if (getContext() == nullptr) _context = sd::LaunchContext ::defaultContext();  // empty context for default cases
-}
+        auto xOffset = shape::getOffset(shapeInfo(), indices);
+        t[xOffset] = static_cast<T>(y);
+    }
+    BUILD_DOUBLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedSet,
+                          (void *buffer, const sd::LongType *indices, const void *value), SD_COMMON_TYPES, SD_COMMON_TYPES);
 
 //////////////////////////////////////////////////////////////////////////
-void const *NDArray::bufferWithOffset(sd::LongType offset) const {
-  return const_cast<int8_t *>(buffer() != nullptr ? static_cast<const int8_t *>(buffer()) + (offset * sizeOfT())
-                                                  : nullptr);
-}
+    template <typename T, typename Y>
+    void NDArray::templatedSet(void *buffer, const sd::LongType offset, const void *value) {
+        auto t = reinterpret_cast<T *>(buffer);
+        const auto y = *(reinterpret_cast<const Y *>(value));
+
+        t[offset] = static_cast<T>(y);
+    }
+    BUILD_DOUBLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedSet,
+                          (void *buffer, const sd::LongType offset, const void *value), SD_COMMON_TYPES, SD_COMMON_TYPES);
 
 //////////////////////////////////////////////////////////////////////////
-void *NDArray::bufferWithOffset(sd::LongType offset) {
-  return const_cast<int8_t *>(buffer() != nullptr ? static_cast<const int8_t *>(buffer()) + (offset * sizeOfT())
-                                                  : nullptr);
-}
+    void NDArray::setContext(sd::LaunchContext *context) {
+        _context = context;
+        if (getContext() == nullptr) _context = sd::LaunchContext ::defaultContext();  // empty context for default cases
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void const *NDArray::bufferWithOffset(sd::LongType offset) const {
+        return const_cast<int8_t *>(buffer() != nullptr ? static_cast<const int8_t *>(buffer()) + (offset * sizeOfT())
+                                                        : nullptr);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void *NDArray::bufferWithOffset(sd::LongType offset) {
+        return const_cast<int8_t *>(buffer() != nullptr ? static_cast<const int8_t *>(buffer()) + (offset * sizeOfT())
+                                                        : nullptr);
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // eventually method reduces array by excluding its shapes along axes present in dimensions vector
-NDArray NDArray::reduceAlongDimension(sd::reduce::FloatOps op, const std::vector<int> &dimensions,
-                                      const bool keepDims) const {
-  std::vector<int> copy(dimensions);
+    NDArray NDArray::reduceAlongDimension(sd::reduce::FloatOps op, const std::vector<int> &dimensions,
+                                          const bool keepDims) const {
+        std::vector<int> copy(dimensions);
 
-  auto newShape = ShapeUtils::evalReduceShapeInfo(
-      'c', copy, *this, isR() ? dataType() : Environment::getInstance().defaultFloatDataType(), keepDims, false,
-      getContext()->getWorkspace());
+        auto newShape = ShapeUtils::evalReduceShapeInfo(
+                'c', copy, *this, isR() ? dataType() : Environment::getInstance().defaultFloatDataType(), keepDims, false,
+                getContext()->getWorkspace());
 
-  NDArray result(newShape, true, getContext());
+        NDArray result(newShape, true, getContext());
 
-  this->reduceAlongDimension(op, result, copy, keepDims, false);
+        this->reduceAlongDimension(op, result, copy, keepDims, false);
 
-  return result;
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceAlongDimension(sd::reduce::SameOps op, const std::vector<int> &dimensions,
-                                      const bool keepDims) const {
-  std::vector<int> copy(dimensions);
-
-  auto newShape = ShapeUtils::evalReduceShapeInfo('c', copy, *this, keepDims, false, getContext()->getWorkspace());
-
-  NDArray result(newShape, true, getContext());
-
-  reduceAlongDimension(op, result, copy, keepDims, false);
-
-  return result;
-}
+        return result;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceAlongDimension(sd::reduce::BoolOps op, const std::vector<int> &dimensions,
-                                      const bool keepDims) const {
-  std::vector<int> copy(dimensions);
+    NDArray NDArray::reduceAlongDimension(sd::reduce::SameOps op, const std::vector<int> &dimensions,
+                                          const bool keepDims) const {
+        std::vector<int> copy(dimensions);
 
-  auto newShape =
-      ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataType::BOOL, keepDims, false, getContext()->getWorkspace());
+        auto newShape = ShapeUtils::evalReduceShapeInfo('c', copy, *this, keepDims, false, getContext()->getWorkspace());
 
-  NDArray result(newShape, true, getContext());
+        NDArray result(newShape, true, getContext());
 
-  reduceAlongDimension(op, result, copy, keepDims, false);
+        reduceAlongDimension(op, result, copy, keepDims, false);
 
-  return result;
-}
+        return result;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceAlongDimension(sd::reduce::LongOps op, const std::vector<int> &dimensions,
-                                      const bool keepDims) const {
-  std::vector<int> copy(dimensions);
+    NDArray NDArray::reduceAlongDimension(sd::reduce::BoolOps op, const std::vector<int> &dimensions,
+                                          const bool keepDims) const {
+        std::vector<int> copy(dimensions);
 
-  auto newShape =
-      ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataType::INT64, keepDims, false, getContext()->getWorkspace());
+        auto newShape =
+                ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataType::BOOL, keepDims, false, getContext()->getWorkspace());
 
-  NDArray result(newShape, true, getContext());
+        NDArray result(newShape, true, getContext());
 
-  reduceAlongDimension(op, result, copy, keepDims, false);
+        reduceAlongDimension(op, result, copy, keepDims, false);
 
-  return result;
-}
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceAlongDimension(sd::reduce::LongOps op, const std::vector<int> &dimensions,
+                                          const bool keepDims) const {
+        std::vector<int> copy(dimensions);
+
+        auto newShape =
+                ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataType::INT64, keepDims, false, getContext()->getWorkspace());
+
+        NDArray result(newShape, true, getContext());
+
+        reduceAlongDimension(op, result, copy, keepDims, false);
+
+        return result;
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // method reduces array by excluding its shapes along axes present in dimensions vector
-NDArray NDArray::reduceAlongDimension(sd::reduce::FloatOps op, const std::initializer_list<int> &dimensions,
-                                      const bool keepDims) const {
-  return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceAlongDimension(sd::reduce::SameOps op, const std::initializer_list<int> &dimensions,
-                                      const bool keepDims) const {
-  return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceAlongDimension(sd::reduce::BoolOps op, const std::initializer_list<int> &dimensions,
-                                      const bool keepDims) const {
-  return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceAlongDimension(sd::reduce::LongOps op, const std::initializer_list<int> &dimensions,
-                                      const bool keepDims) const {
-  return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceNumber(sd::reduce::FloatOps op, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber FloatOps: you can't use this method on String array!");
-
-  auto shape = ConstantShapeHelper::getInstance().scalarShapeInfo(DataTypeUtils::pickFloatingType(dataType()));
-  NDArray result(shape, true, this->getContext());
-
-  prepareUse({&result}, {this});
-  NativeOpExecutioner::execReduceFloatScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                             specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
-                                             result.specialBuffer(), result.specialShapeInfo());
-  registerUse({&result}, {this});
-
-  return result;
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceNumber(sd::reduce::SameOps op, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber SameOps: you can't use this method on String array!");
-
-  sd_printf("reduceNumber: before result creation\n",0);
-  NDArray result(dataType(), getContext());
-
-  prepareUse({&result}, {this});
-  NativeOpExecutioner::execReduceSameScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                            specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
-                                            result.specialBuffer(), result.specialShapeInfo());
-  registerUse({&result}, {this});
-
-  return result;
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceNumber(sd::reduce::BoolOps op, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber BoolOps: you can't use this method on String array!");
-
-  auto shape = ConstantShapeHelper::getInstance().scalarShapeInfo(DataType::BOOL);
-  NDArray result(shape, true, this->getContext());
-
-  prepareUse({&result}, {this});
-  NativeOpExecutioner::execReduceBoolScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                            specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
-                                            result.specialBuffer(), result.specialShapeInfo());
-  registerUse({&result}, {this});
-
-  return result;
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reduceNumber(sd::reduce::LongOps op, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber LongOps: you can't use this method on String array!");
-
-  auto shape = ConstantShapeHelper::getInstance().scalarShapeInfo(DataType::INT64);
-  NDArray result(shape, true, this->getContext());
-
-  prepareUse({&result}, {this});
-  NativeOpExecutioner::execReduceLongScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                            specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
-                                            result.specialBuffer(), result.specialShapeInfo());
-  registerUse({&result}, {this});
-
-  return result;
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::reduceNumber(sd::reduce::FloatOps op, NDArray &target, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber FloatOps: you can't use this method on String array!");
-  if (target.lengthOf() != 1 || target.dataType() != DataTypeUtils::pickFloatingType(dataType()))
-    throw std::invalid_argument(
-        "NDArray::reduceNumber FloatOps: target array should be scalar and have corresponding float type!");
-
-  prepareUse({&target}, {this});
-  NativeOpExecutioner::execReduceFloatScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                             specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
-                                             target.specialBuffer(), target.specialShapeInfo());
-  registerUse({&target}, {this});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::reduceNumber(sd::reduce::SameOps op, NDArray &target, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber SameOps: you can't use this method on String array!");
-  if (target.lengthOf() != 1 || target.dataType() != dataType())
-    throw std::invalid_argument(
-        "NDArray::reduceNumber SameOps: target array should be scalar and have same type as this array!");
-
-  prepareUse({&target}, {this});
-  NativeOpExecutioner::execReduceSameScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                            specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
-                                            target.specialBuffer(), target.specialShapeInfo());
-  registerUse({&target}, {this});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::reduceNumber(sd::reduce::BoolOps op, NDArray &target, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber BoolOps: you can't use this method on String array!");
-  if (target.lengthOf() != 1 || target.dataType() != DataType::BOOL)
-    throw std::invalid_argument("NDArray::reduceNumber BoolOps: target array should be scalar and have bool type!");
-
-  prepareUse({&target}, {this});
-  NativeOpExecutioner::execReduceBoolScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                            specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
-                                            target.specialBuffer(), target.specialShapeInfo());
-  registerUse({&target}, {this});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::reduceNumber(sd::reduce::LongOps op, NDArray &target, void *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::reduceNumber LongOps: you can't use this method on String array!");
-  if (target.lengthOf() != 1 || target.dataType() != DataType::INT64)
-    throw std::invalid_argument("NDArray::reduceNumber LongOps: target array should be scalar and have long type!");
-
-  prepareUse({&target}, {this});
-  NativeOpExecutioner::execReduceLongScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                            specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
-                                            target.specialBuffer(), target.specialShapeInfo());
-  registerUse({&target}, {this});
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::indexReduceNumber(sd::indexreduce::Ops op, ExtraArguments *extraParams) {
-  if (isS()) throw std::runtime_error("NDArray::indexReduceNumber: you can't use this method on String array!");
-
-  sd_printf("indexReduceNumber before exec\n",0);
-  auto res = NDArrayFactory::create<sd::LongType>(0);
-
-  prepareUse({&res}, {this});
-  NativeOpExecutioner::execIndexReduceScalar(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-      extraParams == nullptr ? nullptr : extraParams->argumentsAsT(this->dataType()), res.buffer(), res.shapeInfo(),
-      res.specialBuffer(), res.specialShapeInfo());
-  registerUse({&res}, {this});
-  sd_printf("After before exec\n",0);
-
-
-  return res;
-}
-
-//////////////////////////////////////////////////////////////////////////
-sd::LongType NDArray::tensorsAlongDimension(std::initializer_list<int> dimensions) const {
-  return tensorsAlongDimension(std::vector<int>(dimensions));
-}
-
-//////////////////////////////////////////////////////////////////////////
-sd::LongType NDArray::tensorsAlongDimension(const std::vector<int> &dimensions) const {
-  std::vector<int> copy(dimensions);
-  shape::checkDimensions(rankOf(), copy);
-
-  sd::LongType tadLength = shape::tadLength(this->_shapeInfo, copy.data(), copy.size());
-  sd::LongType numTads = this->lengthOf() / tadLength;
-
-  return numTads;
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::printShapeInfo(const char *msg) const {
-  int rank = shape::rank(_shapeInfo);
-  int lim = shape::shapeInfoLength(rank);
-
-  if (msg != nullptr) {
-    sd_printf("shapeInfo %s: [", msg);
-  } else {
-    sd_printf("shapeInfo: [%s", "");
-  }
-  sd_printf("%i,  ", rank);
-  for (int i = 1; i < shape::shapeInfoLength(rank) - 3; i++) {
-    if (i == rank + 1) sd_printf("  ", "");
-    sd_printf("%lld,", _shapeInfo[i]);
-  }
-  sd_printf("  %lld,", shape::type(_shapeInfo));
-  sd_printf("%lld,", shape::elementWiseStride(_shapeInfo));
-  sd_printf("%lld]\n", (sd::LongType)shape::order(_shapeInfo));
-
-  fflush(stdout);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::printBuffer(const char *msg, sd::LongType limit, const bool sync) const {
-  if (sync) syncToHost();
-
-  if (limit == -1) limit = (int)this->lengthOf();
-
-  if (msg != nullptr)
-    printf("%s: [", msg);
-  else
-    printf("[");
-  if (this->isR()) {
-    for (sd::LongType e = 0; e < limit; e++) {
-      if (e) printf(", ");
-      printf("%f", this->e<float>(e));
+    NDArray NDArray::reduceAlongDimension(sd::reduce::FloatOps op, const std::initializer_list<int> &dimensions,
+                                          const bool keepDims) const {
+        return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
     }
-  } else if (this->isZ()) {
-    for (sd::LongType e = 0; e < limit; e++) {
-      if (this->dataType() != sd::DataType::INT64 && this->dataType() != sd::DataType::UINT64)
-        printf("%d", this->e<int>(e));
-      else
-        printf("%llu", this->e<sd::LongType>(e));
-      if (e < limit - 1) printf(", ");
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceAlongDimension(sd::reduce::SameOps op, const std::initializer_list<int> &dimensions,
+                                          const bool keepDims) const {
+        return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
     }
-  } else if (this->isB()) {
-    for (sd::LongType e = 0; e < limit; e++) {
-      if (this->e<bool>(e))
-        printf("true");
-      else
-        printf("false");
-      if (e < limit - 1) printf(", ");
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceAlongDimension(sd::reduce::BoolOps op, const std::initializer_list<int> &dimensions,
+                                          const bool keepDims) const {
+        return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
     }
-  } else if (this->isS()) {
-    for (sd::LongType e = 0; e < limit; e++) {
-      printf("\"%s\"", this->e<std::string>(e).c_str());
-      if (e < limit - 1) printf(", ");
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceAlongDimension(sd::reduce::LongOps op, const std::initializer_list<int> &dimensions,
+                                          const bool keepDims) const {
+        return reduceAlongDimension(op, std::vector<int>(dimensions), keepDims);
     }
-  }
-  printf("]\n");
-  fflush(stdout);
-}
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceNumber(sd::reduce::FloatOps op, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber FloatOps: you can't use this method on String array!");
+
+        auto shape = ConstantShapeHelper::getInstance().scalarShapeInfo(DataTypeUtils::pickFloatingType(dataType()));
+        NDArray result(shape, true, this->getContext());
+
+        prepareUse({&result}, {this});
+        NativeOpExecutioner::execReduceFloatScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                   specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
+                                                   result.specialBuffer(), result.specialShapeInfo());
+        registerUse({&result}, {this});
+
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceNumber(sd::reduce::SameOps op, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber SameOps: you can't use this method on String array!");
+        NDArray result(dataType(), getContext());
+
+        prepareUse({&result}, {this});
+        NativeOpExecutioner::execReduceSameScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                  specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
+                                                  result.specialBuffer(), result.specialShapeInfo());
+        registerUse({&result}, {this});
+
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceNumber(sd::reduce::BoolOps op, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber BoolOps: you can't use this method on String array!");
+
+        auto shape = ConstantShapeHelper::getInstance().scalarShapeInfo(DataType::BOOL);
+        NDArray result(shape, true, this->getContext());
+
+        prepareUse({&result}, {this});
+        NativeOpExecutioner::execReduceBoolScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                  specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
+                                                  result.specialBuffer(), result.specialShapeInfo());
+        registerUse({&result}, {this});
+
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::reduceNumber(sd::reduce::LongOps op, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber LongOps: you can't use this method on String array!");
+
+        auto shape = ConstantShapeHelper::getInstance().scalarShapeInfo(DataType::INT64);
+        NDArray result(shape, true, this->getContext());
+
+        prepareUse({&result}, {this});
+        NativeOpExecutioner::execReduceLongScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                  specialShapeInfo(), extraParams, result.buffer(), result.shapeInfo(),
+                                                  result.specialBuffer(), result.specialShapeInfo());
+        registerUse({&result}, {this});
+
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::reduceNumber(sd::reduce::FloatOps op, NDArray &target, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber FloatOps: you can't use this method on String array!");
+        if (target.lengthOf() != 1 || target.dataType() != DataTypeUtils::pickFloatingType(dataType()))
+            throw std::invalid_argument(
+                    "NDArray::reduceNumber FloatOps: target array should be scalar and have corresponding float type!");
+
+        prepareUse({&target}, {this});
+        NativeOpExecutioner::execReduceFloatScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                   specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
+                                                   target.specialBuffer(), target.specialShapeInfo());
+        registerUse({&target}, {this});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::reduceNumber(sd::reduce::SameOps op, NDArray &target, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber SameOps: you can't use this method on String array!");
+        if (target.lengthOf() != 1 || target.dataType() != dataType())
+            throw std::invalid_argument(
+                    "NDArray::reduceNumber SameOps: target array should be scalar and have same type as this array!");
+
+        prepareUse({&target}, {this});
+        NativeOpExecutioner::execReduceSameScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                  specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
+                                                  target.specialBuffer(), target.specialShapeInfo());
+        registerUse({&target}, {this});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::reduceNumber(sd::reduce::BoolOps op, NDArray &target, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber BoolOps: you can't use this method on String array!");
+        if (target.lengthOf() != 1 || target.dataType() != DataType::BOOL)
+            throw std::invalid_argument("NDArray::reduceNumber BoolOps: target array should be scalar and have bool type!");
+
+        prepareUse({&target}, {this});
+        NativeOpExecutioner::execReduceBoolScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                  specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
+                                                  target.specialBuffer(), target.specialShapeInfo());
+        registerUse({&target}, {this});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::reduceNumber(sd::reduce::LongOps op, NDArray &target, void *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::reduceNumber LongOps: you can't use this method on String array!");
+        if (target.lengthOf() != 1 || target.dataType() != DataType::INT64)
+            throw std::invalid_argument("NDArray::reduceNumber LongOps: target array should be scalar and have long type!");
+
+        prepareUse({&target}, {this});
+        NativeOpExecutioner::execReduceLongScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                  specialShapeInfo(), extraParams, target.buffer(), target.shapeInfo(),
+                                                  target.specialBuffer(), target.specialShapeInfo());
+        registerUse({&target}, {this});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::indexReduceNumber(sd::indexreduce::Ops op, ExtraArguments *extraParams) {
+        if (isS()) throw std::runtime_error("NDArray::indexReduceNumber: you can't use this method on String array!");
+
+        auto res = NDArrayFactory::create<sd::LongType>(0);
+
+        prepareUse({&res}, {this});
+        NativeOpExecutioner::execIndexReduceScalar(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                extraParams == nullptr ? nullptr : extraParams->argumentsAsT(this->dataType()), res.buffer(), res.shapeInfo(),
+                res.specialBuffer(), res.specialShapeInfo());
+        registerUse({&res}, {this});
+
+
+        return res;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    sd::LongType NDArray::tensorsAlongDimension(std::initializer_list<int> dimensions) const {
+        return tensorsAlongDimension(std::vector<int>(dimensions));
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    sd::LongType NDArray::tensorsAlongDimension(const std::vector<int> &dimensions) const {
+        std::vector<int> copy(dimensions);
+        shape::checkDimensions(rankOf(), copy);
+
+        sd::LongType tadLength = shape::tadLength(this->_shapeInfo, copy.data(), copy.size());
+        sd::LongType numTads = this->lengthOf() / tadLength;
+
+        return numTads;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::printShapeInfo(const char *msg) const {
+        int rank = shape::rank(_shapeInfo);
+        int lim = shape::shapeInfoLength(rank);
+
+        if (msg != nullptr) {
+            sd_printf("shapeInfo %s: [", msg);
+        } else {
+            sd_printf("shapeInfo: [%s", "");
+        }
+        sd_printf("%i,  ", rank);
+        for (int i = 1; i < shape::shapeInfoLength(rank) - 3; i++) {
+            if (i == rank + 1) sd_printf("  ", "");
+            sd_printf("%lld,", _shapeInfo[i]);
+        }
+        sd_printf("  %lld,", shape::type(_shapeInfo));
+        sd_printf("%lld,", shape::elementWiseStride(_shapeInfo));
+        sd_printf("%lld]\n", (sd::LongType)shape::order(_shapeInfo));
+
+        fflush(stdout);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::printBuffer(const char *msg, sd::LongType limit, const bool sync) const {
+        if (sync) syncToHost();
+
+        if (limit == -1) limit = (int)this->lengthOf();
+
+        if (msg != nullptr)
+            printf("%s: [", msg);
+        else
+            printf("[");
+        if (this->isR()) {
+            for (sd::LongType e = 0; e < limit; e++) {
+                if (e) printf(", ");
+                printf("%f", this->e<float>(e));
+            }
+        } else if (this->isZ()) {
+            for (sd::LongType e = 0; e < limit; e++) {
+                if (this->dataType() != sd::DataType::INT64 && this->dataType() != sd::DataType::UINT64)
+                    printf("%d", this->e<int>(e));
+                else
+                    printf("%llu", this->e<sd::LongType>(e));
+                if (e < limit - 1) printf(", ");
+            }
+        } else if (this->isB()) {
+            for (sd::LongType e = 0; e < limit; e++) {
+                if (this->e<bool>(e))
+                    printf("true");
+                else
+                    printf("false");
+                if (e < limit - 1) printf(", ");
+            }
+        } else if (this->isS()) {
+            for (sd::LongType e = 0; e < limit; e++) {
+                printf("\"%s\"", this->e<std::string>(e).c_str());
+                if (e < limit - 1) printf(", ");
+            }
+        }
+        printf("]\n");
+        fflush(stdout);
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // print element by element consequently in a way they (elements) are stored in physical memory
-void NDArray::printLinearBuffer() const {
-  syncToHost();
+    void NDArray::printLinearBuffer() const {
+        syncToHost();
 
-  const auto ews = this->ews() > 0 ? this->ews() : 1;
-  const auto len = this->lengthOf();
+        const auto ews = this->ews() > 0 ? this->ews() : 1;
+        const auto len = this->lengthOf();
 
-  printf("[");
+        printf("[");
 
-  if (this->dataType() == sd::DataType::INT32) {
-    for (sd::LongType e = 0; e < len; e++) printf("%d, ", this->bufferAsT<int>()[e * ews]);
-  } else if (this->dataType() == sd::DataType::INT64) {
-    for (sd::LongType e = 0; e < len; e++) printf("%lld, ", this->bufferAsT<sd::LongType>()[e * ews]);
-  } else if (this->dataType() == sd::DataType::FLOAT32) {
-    for (sd::LongType e = 0; e < len; e++) printf("%.8f, ", this->bufferAsT<float>()[e * ews]);
-  } else if (this->dataType() == sd::DataType::DOUBLE) {
-    for (sd::LongType e = 0; e < len; e++) printf("%.8f, ", this->bufferAsT<double>()[e * ews]);
-  } else
-    throw std::invalid_argument("NDArray::printLinearBuffer: not implemented yet for this data type !");
+        if (this->dataType() == sd::DataType::INT32) {
+            for (sd::LongType e = 0; e < len; e++) printf("%d, ", this->bufferAsT<int>()[e * ews]);
+        } else if (this->dataType() == sd::DataType::INT64) {
+            for (sd::LongType e = 0; e < len; e++) printf("%lld, ", this->bufferAsT<sd::LongType>()[e * ews]);
+        } else if (this->dataType() == sd::DataType::FLOAT32) {
+            for (sd::LongType e = 0; e < len; e++) printf("%.8f, ", this->bufferAsT<float>()[e * ews]);
+        } else if (this->dataType() == sd::DataType::DOUBLE) {
+            for (sd::LongType e = 0; e < len; e++) printf("%.8f, ", this->bufferAsT<double>()[e * ews]);
+        } else
+            throw std::invalid_argument("NDArray::printLinearBuffer: not implemented yet for this data type !");
 
-  printf("]\n");
-  fflush(stdout);
-}
-//////////////////////////////////////////////////////////////////////////
-static void printFormatted(NDArray const *arr, int depth, int limit) {
-  if (arr->rankOf() == 1) {
-    printf("[ ");
-    for (sd::LongType i = 0; i < arr->lengthOf(); ++i) {
-      if (arr->isR())
-        printf("%f, ", arr->e<float>(i));
-      else if (arr->isZ())
-        printf("%lld, ", arr->e<sd::LongType>(i));
-      else if (arr->isB())
-        printf("%s, ", arr->e<bool>(i) ? "true" : "false");
-      else if (arr->isS()) {
-        printf("\"%s\", ", arr->e<std::string>(i).c_str());
-      }
-    }
-    printf("]\n");
-  } else if (arr->rankOf() == 2) {
-    sd::LongType rows = arr->rows();
-    sd::LongType cols = arr->columns();
-    char *padding = new char[depth + 1];
-    memset(padding, ' ', depth);
-    padding[depth] = 0;
-    printf("[");
-    for (sd::LongType row = 0; row < rows; ++row) {
-      if (row && depth > 0) printf("%s", padding);
-      printf("[");
-      sd::LongType colLimit = cols > limit ? cols : limit;
-      for (sd::LongType col = 0; col < colLimit; ++col) {
-        if (col) printf(", ");
-        if (arr->isR())
-          printf("%f", arr->e<float>(row, col));
-        else if (arr->isZ())
-          printf("%lld", arr->e<sd::LongType>(row, col));
-        else if (arr->isB())
-          printf("%s", arr->e<bool>(row, col) ? "true" : "false");
-        else if (arr->isS()) {
-          printf("\"%s\"", arr->e<std::string>(row * cols + col).c_str());
-        }
-      }
-      if (row < rows - 1)
         printf("]\n");
-      else
-        printf("]");
+        fflush(stdout);
     }
-    printf("]");
-    if (padding) delete[] padding;
-  } else {
-    size_t restCount = 2;
-    printf("[");
-    restCount = ShapeUtils::getNumOfSubArrs(arr->shapeInfo(), {0});
-    for (size_t arrIndex = 0; arrIndex < restCount; ++arrIndex) {
-      NDArray subArr = (*arr)(arrIndex, {0});
-      printFormatted(&subArr, depth + 1, limit);
-      if (arrIndex < restCount - 1) {
-        for (sd::LongType i = 1; i < arr->rankOf(); ++i) printf("\n");
-        for (sd::LongType i = 0; i < depth - 2; ++i) printf(" ");
-      }
+//////////////////////////////////////////////////////////////////////////
+    static void printFormatted(NDArray const *arr, int depth, int limit) {
+        if (arr->rankOf() == 1) {
+            printf("[ ");
+            for (sd::LongType i = 0; i < arr->lengthOf(); ++i) {
+                if (arr->isR())
+                    printf("%f, ", arr->e<float>(i));
+                else if (arr->isZ())
+                    printf("%lld, ", arr->e<sd::LongType>(i));
+                else if (arr->isB())
+                    printf("%s, ", arr->e<bool>(i) ? "true" : "false");
+                else if (arr->isS()) {
+                    printf("\"%s\", ", arr->e<std::string>(i).c_str());
+                }
+            }
+            printf("]\n");
+        } else if (arr->rankOf() == 2) {
+            sd::LongType rows = arr->rows();
+            sd::LongType cols = arr->columns();
+            char *padding = new char[depth + 1];
+            memset(padding, ' ', depth);
+            padding[depth] = 0;
+            printf("[");
+            for (sd::LongType row = 0; row < rows; ++row) {
+                if (row && depth > 0) printf("%s", padding);
+                printf("[");
+                sd::LongType colLimit = cols > limit ? cols : limit;
+                for (sd::LongType col = 0; col < colLimit; ++col) {
+                    if (col) printf(", ");
+                    if (arr->isR())
+                        printf("%f", arr->e<float>(row, col));
+                    else if (arr->isZ())
+                        printf("%lld", arr->e<sd::LongType>(row, col));
+                    else if (arr->isB())
+                        printf("%s", arr->e<bool>(row, col) ? "true" : "false");
+                    else if (arr->isS()) {
+                        printf("\"%s\"", arr->e<std::string>(row * cols + col).c_str());
+                    }
+                }
+                if (row < rows - 1)
+                    printf("]\n");
+                else
+                    printf("]");
+            }
+            printf("]");
+            if (padding) delete[] padding;
+        } else {
+            size_t restCount = 2;
+            printf("[");
+            restCount = ShapeUtils::getNumOfSubArrs(arr->shapeInfo(), {0});
+            for (size_t arrIndex = 0; arrIndex < restCount; ++arrIndex) {
+                NDArray subArr = (*arr)(arrIndex, {0});
+                printFormatted(&subArr, depth + 1, limit);
+                if (arrIndex < restCount - 1) {
+                    for (sd::LongType i = 1; i < arr->rankOf(); ++i) printf("\n");
+                    for (sd::LongType i = 0; i < depth - 2; ++i) printf(" ");
+                }
+            }
+            printf("]");
+        }
     }
-    printf("]");
-  }
-}
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::printIndexedBuffer(const char *msg, sd::LongType limit) const {
-  syncToHost();
+    void NDArray::printIndexedBuffer(const char *msg, sd::LongType limit) const {
+        syncToHost();
 
-  sd::LongType rank = this->rankOf();
+        sd::LongType rank = this->rankOf();
 
-  bool rowFlag = (rank < 2) || (rank == 2 && this->sizeAt(0) == 1);
+        bool rowFlag = (rank < 2) || (rank == 2 && this->sizeAt(0) == 1);
 
-  if (msg) printf("%s: ", msg);
+        if (msg) printf("%s: ", msg);
 
-  if (this->isEmpty()) {
-    printf("Empty\n");
-  } else if (this->rankOf() == 0) {
-    if (this->isZ())
-      printf("%lld\n", this->e<sd::LongType>(0));
-    else if (this->isR())
-      printf("%.8f\n", this->e<float>(0));
-    else if (this->isB()) {
-      printf("%s\n", this->e<bool>(0) ? "true" : "false");
-    } else if (this->isS()) {
-      sd_printf("\"%s\"\n", this->e<std::string>(0).c_str());
+        if (this->isEmpty()) {
+            printf("Empty\n");
+        } else if (this->rankOf() == 0) {
+            if (this->isZ())
+                printf("%lld\n", this->e<sd::LongType>(0));
+            else if (this->isR())
+                printf("%.8f\n", this->e<float>(0));
+            else if (this->isB()) {
+                printf("%s\n", this->e<bool>(0) ? "true" : "false");
+            } else if (this->isS()) {
+                sd_printf("\"%s\"\n", this->e<std::string>(0).c_str());
+            }
+        } else if (rowFlag && ews() == 1)
+            printBuffer(nullptr, limit);
+        else {
+            if (msg) printf("\n");
+            printFormatted(this, 1, limit);
+            printf("\n");
+        }
+        fflush(stdout);
     }
-  } else if (rowFlag && ews() == 1)
-    printBuffer(nullptr, limit);
-  else {
-    if (msg) printf("\n");
-    printFormatted(this, 1, limit);
-    printf("\n");
-  }
-  fflush(stdout);
-}
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-void *NDArray::templatedPointerShift(const sd::LongType offset) const {
-  return const_cast<T *>(reinterpret_cast<T const *>(buffer()) + offset);
-}
-BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void *NDArray::templatedPointerShift, (const sd::LongType offset) const,
-                      SD_COMMON_TYPES);
+    template <typename T>
+    void *NDArray::templatedPointerShift(const sd::LongType offset) const {
+        return const_cast<T *>(reinterpret_cast<T const *>(buffer()) + offset);
+    }
+    BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void *NDArray::templatedPointerShift, (const sd::LongType offset) const,
+                          SD_COMMON_TYPES);
 
 //////////////////////////////////////////////////////////////////////////
 // method makes copy of this array and applies to the copy transpose operation, this array remains unaffected
-NDArray NDArray::transpose() const & {
-  auto desc = new ShapeDescriptor(shapeInfo());
-  NDArray newArr(getDataBuffer(),desc, getContext(), bufferOffset());
-  newArr.transposei();
+    NDArray NDArray::transpose() const & {
+        auto desc = new ShapeDescriptor(shapeInfo());
+        NDArray newArr(getDataBuffer(),desc, getContext(), bufferOffset());
+        newArr.transposei();
 
-  return newArr;
-}
+        return newArr;
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // method makes copy of this array and applies to the copy transpose operation, this array remains unaffected
-NDArray NDArray::transpose() && {
-  this->transposei();
-  return std::move(*this);
-}
+    NDArray NDArray::transpose() && {
+        this->transposei();
+        return std::move(*this);
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // method performs transpose operation based on this array and store result in target, this array remains unaffected
-void NDArray::transpose(NDArray &target) const {
-  auto correctShape = ShapeUtils::evalTranspShapeInfo(*this, getContext()->getWorkspace());
-  if (!shape::equalsStrict(correctShape, target.shapeInfo()))
-    throw std::runtime_error("NDArray::transpose method: the shapeInfo of target array is wrong !");
+    void NDArray::transpose(NDArray &target) const {
+        auto correctShape = ShapeUtils::evalTranspShapeInfo(*this, getContext()->getWorkspace());
+        if (!shape::equalsStrict(correctShape, target.shapeInfo()))
+            throw std::runtime_error("NDArray::transpose method: the shapeInfo of target array is wrong !");
 
-  target._buffer = _buffer;
-  target._offset = _offset;
-  target._isView = true;
-}
+        target._buffer = _buffer;
+        target._offset = _offset;
+        target._isView = true;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // This method applies in-place transpose to this array, so this array becomes transposed
-void NDArray::transposei() {
-  std::vector<int> perm;
-  for (int e = this->rankOf() - 1; e >= 0; e--) perm.emplace_back(e);
+    void NDArray::transposei() {
+        std::vector<int> perm;
+        for (int e = this->rankOf() - 1; e >= 0; e--) perm.emplace_back(e);
 
-  this->permutei(perm);
-}
+        this->permutei(perm);
+    }
 
 ////////////////////////////////////////////////////////////////////////
-bool NDArray::equalsTo(const NDArray &other, double eps) const { return equalsTo(&other, eps); }
+    bool NDArray::equalsTo(const NDArray &other, double eps) const { return equalsTo(&other, eps); }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::setAttached(bool reallyAttached) { _isAttached = reallyAttached; };
+    void NDArray::setAttached(bool reallyAttached) { _isAttached = reallyAttached; };
 
 //////////////////////////////////////////////////////////////////////////
 // calculate strides
-void NDArray::updateStrides(const char order) { throw std::runtime_error("Forbidden method"); }
+    void NDArray::updateStrides(const char order) { throw std::runtime_error("Forbidden method"); }
 
 //////////////////////////////////////////////////////////////////////////
 // set new order and shape in case of suitable array length
-bool NDArray::reshapei(const char order, const std::initializer_list<sd::LongType> &shape, const bool copyToNewBuff) {
-  std::vector<sd::LongType> vShape(shape);
-  return reshapei(order, vShape, copyToNewBuff);
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::reshapei(const std::initializer_list<sd::LongType> &shape, const bool copyToNewBuff) {
-  return reshapei(ordering(), shape, copyToNewBuff);
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::reshapei(const std::vector<sd::LongType> &shape, const bool copyToNewBuff) {
-  return reshapei(ordering(), shape, copyToNewBuff);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::enforce(const std::initializer_list<sd::LongType> &dimensions, char order) {
-  std::vector<sd::LongType> dims(dimensions);
-  enforce(dims, order);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::enforce(std::vector<sd::LongType> &dimensions, char o) {
-  sd::LongType prod = 1;
-  for (int e = 0; e < dimensions.size(); e++) prod *= dimensions[e];
-
-  if (prod != this->lengthOf()) {
-    std::string current = ShapeUtils::shapeAsString(this);
-    std::string enforced = ShapeUtils::shapeAsString(dimensions);
-    sd_printf("Can't enforce new shape, lengths mismatch. Original shape: %s; Requested shape: %s\n", current.c_str(),
-              enforced.c_str());
-    throw std::runtime_error("Incompatible shape");
-  }
-
-  char order = o == 'a' ? this->ordering() : o;
-  auto desc = new ShapeDescriptor(dataType(), order, dimensions);
-  setShapeInfo(desc);
-}
-
-//////////////////////////////////////////////////////////////////////////
-sd::LongType NDArray::argMax(std::initializer_list<int> dimensions) {
-  if (isS()) throw std::runtime_error("NDArray::argMax: you can't use this method on String array!");
-
-  if (dimensions.size() == 0) {
-    sd::LongType max = 0;
-    auto mv = -DataTypeUtils::max<float>();
-    for (sd::LongType e = 0; e < this->lengthOf(); e++) {
-      auto val = this->e<float>(e);
-      if (mv < val) {
-        mv = val;
-        max = e;
-      }
+    bool NDArray::reshapei(const char order, const std::initializer_list<sd::LongType> &shape, const bool copyToNewBuff) {
+        std::vector<sd::LongType> vShape(shape);
+        return reshapei(order, vShape, copyToNewBuff);
     }
-    return max;
-  } else
-    throw std::runtime_error("Not implemented yet");
-}
+
+//////////////////////////////////////////////////////////////////////////
+    bool NDArray::reshapei(const std::initializer_list<sd::LongType> &shape, const bool copyToNewBuff) {
+        return reshapei(ordering(), shape, copyToNewBuff);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    bool NDArray::reshapei(const std::vector<sd::LongType> &shape, const bool copyToNewBuff) {
+        return reshapei(ordering(), shape, copyToNewBuff);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::enforce(const std::initializer_list<sd::LongType> &dimensions, char order) {
+        std::vector<sd::LongType> dims(dimensions);
+        enforce(dims, order);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::enforce(std::vector<sd::LongType> &dimensions, char o) {
+        sd::LongType prod = 1;
+        for (int e = 0; e < dimensions.size(); e++) prod *= dimensions[e];
+
+        if (prod != this->lengthOf()) {
+            std::string current = ShapeUtils::shapeAsString(this);
+            std::string enforced = ShapeUtils::shapeAsString(dimensions);
+            sd_printf("Can't enforce new shape, lengths mismatch. Original shape: %s; Requested shape: %s\n", current.c_str(),
+                      enforced.c_str());
+            throw std::runtime_error("Incompatible shape");
+        }
+
+        char order = o == 'a' ? this->ordering() : o;
+        auto desc = new ShapeDescriptor(dataType(), order, dimensions);
+        setShapeInfo(desc);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    sd::LongType NDArray::argMax(std::initializer_list<int> dimensions) {
+        if (isS()) throw std::runtime_error("NDArray::argMax: you can't use this method on String array!");
+
+        if (dimensions.size() == 0) {
+            sd::LongType max = 0;
+            auto mv = -DataTypeUtils::max<float>();
+            for (sd::LongType e = 0; e < this->lengthOf(); e++) {
+                auto val = this->e<float>(e);
+                if (mv < val) {
+                    mv = val;
+                    max = e;
+                }
+            }
+            return max;
+        } else
+            throw std::runtime_error("Not implemented yet");
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // create new array with corresponding order and shape, new array will point to the same _buffer as this array
-NDArray NDArray::reshape(const char order, const std::vector<sd::LongType> &shape, const bool copyToNewBuff) const & {
-  auto desc = new ShapeDescriptor(shapeInfo());
-  NDArray newArr(getDataBuffer(), desc, getContext(), bufferOffset());
-  newArr.reshapei(order, shape, copyToNewBuff);
+    NDArray NDArray::reshape(const char order, const std::vector<sd::LongType> &shape, const bool copyToNewBuff) const & {
+        auto desc = new ShapeDescriptor(shapeInfo());
+        NDArray newArr(getDataBuffer(), desc, getContext(), bufferOffset());
+        newArr.reshapei(order, shape, copyToNewBuff);
 
-  return newArr;
-}
+        return newArr;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::reshape(const char order, const std::vector<sd::LongType> &shape, const bool copyToNewBuff) && {
-  this->reshapei(order, shape, copyToNewBuff);
-  return std::move(*this);
-}
+    NDArray NDArray::reshape(const char order, const std::vector<sd::LongType> &shape, const bool copyToNewBuff) && {
+        this->reshapei(order, shape, copyToNewBuff);
+        return std::move(*this);
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // change an array by repeating it the number of times given by reps.
-void NDArray::tilei(const std::vector<sd::LongType> &reps) { *this = this->tile(reps); }
+    void NDArray::tilei(const std::vector<sd::LongType> &reps) { *this = this->tile(reps); }
 
 //////////////////////////////////////////////////////////////////////////
-sd::LongType NDArray::sizeAt(const int dim) const {
-  if (dim >= this->rankOf() || dim < -this->rankOf())
-    throw std::runtime_error("NDArray::sizeAt: bad size index requested");
+    sd::LongType NDArray::sizeAt(const int dim) const {
+        if (dim >= this->rankOf() || dim < -this->rankOf())
+            throw std::runtime_error("NDArray::sizeAt: bad size index requested");
 
-  if (dim >= 0)
-    return shape::shapeOf(_shapeInfo)[dim];
-  else
-    return shape::shapeOf(_shapeInfo)[this->rankOf() + dim];
-}
-
-//////////////////////////////////////////////////////////////////////////
-sd::LongType NDArray::strideAt(const int dim) const {
-  if (dim >= this->rankOf() || dim < -this->rankOf())
-    throw std::runtime_error("NDArray::strideAt: Bad size index requested");
-
-  if (dim >= 0)
-    return shape::stride(_shapeInfo)[dim];
-  else
-    return shape::stride(_shapeInfo)[this->rankOf() + dim];
-}
+        if (dim >= 0)
+            return shape::shapeOf(_shapeInfo)[dim];
+        else
+            return shape::shapeOf(_shapeInfo)[this->rankOf() + dim];
+    }
 
 //////////////////////////////////////////////////////////////////////////
-bool NDArray::permutei(const std::initializer_list<int> &dimensions) {
-  std::vector<int> vec(dimensions);
-  return permutei(vec);
-}
+    sd::LongType NDArray::strideAt(const int dim) const {
+        if (dim >= this->rankOf() || dim < -this->rankOf())
+            throw std::runtime_error("NDArray::strideAt: Bad size index requested");
+
+        if (dim >= 0)
+            return shape::stride(_shapeInfo)[dim];
+        else
+            return shape::stride(_shapeInfo)[this->rankOf() + dim];
+    }
 
 //////////////////////////////////////////////////////////////////////////
-bool NDArray::permutei(const std::vector<int> &dimensions) { return permutei(dimensions.data(), rankOf()); }
+    bool NDArray::permutei(const std::initializer_list<int> &dimensions) {
+        std::vector<int> vec(dimensions);
+        return permutei(vec);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-bool NDArray::permutei(const std::initializer_list<sd::LongType> &dimensions) {
-  std::vector<sd::LongType> vec(dimensions);
-  std::vector<int> ivec(dimensions.size());
-
-  for (int e = 0; e < vec.size(); e++) ivec[e] = static_cast<int>(vec[e]);
-
-  return permutei(ivec);
-}
+    bool NDArray::permutei(const std::vector<int> &dimensions) { return permutei(dimensions.data(), rankOf()); }
 
 //////////////////////////////////////////////////////////////////////////
-bool NDArray::permutei(const std::vector<sd::LongType> &dimensions) {
-  std::vector<int> ivec(dimensions.size());
+    bool NDArray::permutei(const std::initializer_list<sd::LongType> &dimensions) {
+        std::vector<sd::LongType> vec(dimensions);
+        std::vector<int> ivec(dimensions.size());
 
-  for (int e = 0; e < dimensions.size(); e++) ivec[e] = dimensions[e];
+        for (int e = 0; e < vec.size(); e++) ivec[e] = static_cast<int>(vec[e]);
 
-  return permutei(ivec.data(), rankOf());
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const int *dimensions, const int rank) const & {
-  // evaluate shapeInfo for output (permuted) array ret
-  auto shapeInfoPermuted = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, getContext()->getWorkspace());
-  auto buff =  ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfoPermuted);
-  NDArray ret(getDataBuffer(), const_cast<sd::LongType *>(buff->primary()), getContext(), bufferOffset());
-  ret._isView = true;
-  return ret;
-}
+        return permutei(ivec);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const int *dimensions, const int rank) && {
-  this->permutei(dimensions, rank);
-  return std::move(*this);
-}
+    bool NDArray::permutei(const std::vector<sd::LongType> &dimensions) {
+        std::vector<int> ivec(dimensions.size());
+
+        for (int e = 0; e < dimensions.size(); e++) ivec[e] = dimensions[e];
+
+        return permutei(ivec.data(), rankOf());
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::permute(const int *dimensions, const int rank) const & {
+        // evaluate shapeInfo for output (permuted) array ret
+        auto shapeInfoPermuted = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, getContext()->getWorkspace());
+        auto buff =  ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfoPermuted);
+        NDArray ret(getDataBuffer(), const_cast<sd::LongType *>(buff->primary()), getContext(), bufferOffset());
+        ret._isView = true;
+        return ret;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::permute(const int *dimensions, const int rank) && {
+        this->permutei(dimensions, rank);
+        return std::move(*this);
+    }
 
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const sd::LongType *dimensions, const int rank) const & {
-  int tempDims[SD_MAX_RANK];
-  shape::convertT<sd::LongType, int>(const_cast<sd::LongType *>(dimensions), tempDims, rank);
-  return permute(tempDims, rank);
-}
+    NDArray NDArray::permute(const sd::LongType *dimensions, const int rank) const & {
+        int tempDims[SD_MAX_RANK];
+        shape::convertT<sd::LongType, int>(const_cast<sd::LongType *>(dimensions), tempDims, rank);
+        return permute(tempDims, rank);
+    }
 
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const sd::LongType *dimensions, const int rank) && {
-  this->permutei(dimensions, rank);
-  return std::move(*this);
-}
+    NDArray NDArray::permute(const sd::LongType *dimensions, const int rank) && {
+        this->permutei(dimensions, rank);
+        return std::move(*this);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::vector<int> &dimensions) const & { return permute(dimensions.data(), rankOf()); }
+    NDArray NDArray::permute(const std::vector<int> &dimensions) const & { return permute(dimensions.data(), rankOf()); }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::vector<int> &dimensions) && {
-  this->permutei(dimensions);
-  return std::move(*this);
-}
+    NDArray NDArray::permute(const std::vector<int> &dimensions) && {
+        this->permutei(dimensions);
+        return std::move(*this);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::vector<sd::LongType> &dimensions) const & {
-  return permute(dimensions.data(), rankOf());
-}
+    NDArray NDArray::permute(const std::vector<sd::LongType> &dimensions) const & {
+        return permute(dimensions.data(), rankOf());
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::vector<sd::LongType> &dimensions) && {
-  this->permutei(dimensions);
-  return std::move(*this);
-}
+    NDArray NDArray::permute(const std::vector<sd::LongType> &dimensions) && {
+        this->permutei(dimensions);
+        return std::move(*this);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::initializer_list<int> &dimensions) const & {
-  std::vector<int> vec(dimensions);
-  return permute(vec);
-}
+    NDArray NDArray::permute(const std::initializer_list<int> &dimensions) const & {
+        std::vector<int> vec(dimensions);
+        return permute(vec);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::initializer_list<int> &dimensions) && {
-  this->permutei(dimensions);
-  return std::move(*this);
-}
+    NDArray NDArray::permute(const std::initializer_list<int> &dimensions) && {
+        this->permutei(dimensions);
+        return std::move(*this);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::initializer_list<sd::LongType> &dimensions) const & {
-  std::vector<sd::LongType> vec(dimensions);
-  return permute(vec);
-}
+    NDArray NDArray::permute(const std::initializer_list<sd::LongType> &dimensions) const & {
+        std::vector<sd::LongType> vec(dimensions);
+        return permute(vec);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::permute(const std::initializer_list<sd::LongType> &dimensions) && {
-  this->permutei(dimensions);
-  return std::move(*this);
-}
+    NDArray NDArray::permute(const std::initializer_list<sd::LongType> &dimensions) && {
+        this->permutei(dimensions);
+        return std::move(*this);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::permute(const int *dimensions, const int rank, NDArray &target) const {
-  if (!nonNull() || !target.nonNull() || rank != rankOf() || rank != target.rankOf())
-    throw std::runtime_error("NDArray<T>::permute method: either arrays are nullptr or ranks are not suitable!");
+    void NDArray::permute(const int *dimensions, const int rank, NDArray &target) const {
+        if (!nonNull() || !target.nonNull() || rank != rankOf() || rank != target.rankOf())
+            throw std::runtime_error("NDArray<T>::permute method: either arrays are nullptr or ranks are not suitable!");
 
-  auto shapeInfoNew = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, target.getContext()->getWorkspace());
+        auto shapeInfoNew = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, target.getContext()->getWorkspace());
 
-  target.setShapeInfo(shapeInfoNew);
-  target._buffer = _buffer;
-  target._offset = _offset;
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::permute(const sd::LongType *dimensions, const int rank, NDArray &target) const {
-  if (!nonNull() || !target.nonNull() || rank != rankOf() || rank != target.rankOf())
-    throw std::runtime_error("NDArray<T>::permute method: either arrays are nullptr or ranks are not suitable!");
-
-  auto shapeInfoNew = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, target.getContext()->getWorkspace());
-
-  target.setShapeInfo(shapeInfoNew);
-  target._buffer = _buffer;
-  target._offset = _offset;
-}
+        target.setShapeInfo(shapeInfoNew);
+        target._buffer = _buffer;
+        target._offset = _offset;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::permute(const std::vector<int> &dimensions, NDArray &target) const {
-  permute(dimensions.data(), rankOf(), target);
-}
+    void NDArray::permute(const sd::LongType *dimensions, const int rank, NDArray &target) const {
+        if (!nonNull() || !target.nonNull() || rank != rankOf() || rank != target.rankOf())
+            throw std::runtime_error("NDArray<T>::permute method: either arrays are nullptr or ranks are not suitable!");
+
+        auto shapeInfoNew = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, target.getContext()->getWorkspace());
+
+        target.setShapeInfo(shapeInfoNew);
+        target._buffer = _buffer;
+        target._offset = _offset;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::permute(const std::vector<sd::LongType> &dimensions, NDArray &target) const {
-  permute(dimensions.data(), rankOf(), target);
-}
+    void NDArray::permute(const std::vector<int> &dimensions, NDArray &target) const {
+        permute(dimensions.data(), rankOf(), target);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::permute(const std::vector<sd::LongType> &dimensions, NDArray &target) const {
+        permute(dimensions.data(), rankOf(), target);
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // check whether array is identity matrix
-bool NDArray::isIdentityMatrix() {
-  if (isS()) throw std::runtime_error("NDArray::isIdentityMatrix: you can't use this method on String array!");
-  if (rankOf() != 2 || rows() != columns())
-    throw std::runtime_error("isIdentityMatrix method: matrix must be square and have rank = 2 !");
+    bool NDArray::isIdentityMatrix() {
+        if (isS()) throw std::runtime_error("NDArray::isIdentityMatrix: you can't use this method on String array!");
+        if (rankOf() != 2 || rows() != columns())
+            throw std::runtime_error("isIdentityMatrix method: matrix must be square and have rank = 2 !");
 
-  const double eps = 1e-5f;
-  for (sd::LongType i = 0; i < rows(); ++i)
-    if (sd::math::sd_abs(e<double>(i, i) - 1.f) > eps) return false;
+        const double eps = 1e-5f;
+        for (sd::LongType i = 0; i < rows(); ++i)
+            if (sd::math::sd_abs(e<double>(i, i) - 1.f) > eps) return false;
 
-  for (sd::LongType i = 0; i < rows(); ++i) {
-    for (sd::LongType j = 0; j < columns(); ++j) {
-      if (i == j) continue;
-      if (sd::math::sd_abs(e<double>(i, j)) > eps) return false;
+        for (sd::LongType i = 0; i < rows(); ++i) {
+            for (sd::LongType j = 0; j < columns(); ++j) {
+                if (i == j) continue;
+                if (sd::math::sd_abs(e<double>(i, j)) > eps) return false;
+            }
+        }
+        return true;
     }
-  }
-  return true;
-}
 
 //////////////////////////////////////////////////////////////////////////
 // check whether array is unitary matrix
-bool NDArray::isUnitary() {
-  if (isS()) throw std::runtime_error("NDArray::isUnitary: you can't use this method on String array!");
-  if (rankOf() != 2 || rows() != columns())
-    throw std::runtime_error("isUnitary method: matrix must be square and have rank = 2 !");
+    bool NDArray::isUnitary() {
+        if (isS()) throw std::runtime_error("NDArray::isUnitary: you can't use this method on String array!");
+        if (rankOf() != 2 || rows() != columns())
+            throw std::runtime_error("isUnitary method: matrix must be square and have rank = 2 !");
 
-  auto tr = this->transpose();
-  auto trMul = MmulHelper::mmul(this, &tr, nullptr, 1.f, 0.f);
+        auto tr = this->transpose();
+        auto trMul = MmulHelper::mmul(this, &tr, nullptr, 1.f, 0.f);
 
-  bool result = trMul->isIdentityMatrix();
-  delete trMul;
+        bool result = trMul->isIdentityMatrix();
+        delete trMul;
 
-  return result;
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <>
-const std::string *SD_LIB_EXPORT NDArray::bufferAsT() const {
-  throw std::runtime_error("This method is NOT supposed to be used");
-}
+        return result;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-const T *NDArray::bufferAsT() const {
-  // FIXME: do we REALLY want sync here?
-  // syncToHost();
-
-  return reinterpret_cast<const T *>(buffer());
-}
-
-
-
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT const, *NDArray::bufferAsT() const, SD_COMMON_TYPES);
-
-template <typename T>
-T *NDArray::bufferAsT() {
-  if(buffer() == nullptr)
-    return nullptr;
-  syncToHost();
-  return reinterpret_cast<T *>(buffer());
-}
-
-
-
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, *NDArray::bufferAsT(), SD_COMMON_TYPES);
+    template <>
+    const std::string *SD_LIB_EXPORT NDArray::bufferAsT() const {
+        throw std::runtime_error("This method is NOT supposed to be used");
+    }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-T *NDArray::bufferasTWithOffset(sd::LongType offset) {
-  return reinterpret_cast<T *>(bufferWithOffset(offset));
+    template <typename T>
+    const T *NDArray::bufferAsT() const {
+        // FIXME: do we REALLY want sync here?
+        // syncToHost();
 
-}
-
-
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, *NDArray::bufferasTWithOffset(sd::LongType), SD_COMMON_TYPES_ALL);
-
-
-template <typename T>
-const T*  NDArray::bufferasTWithOffset(sd::LongType offset) const {
-  return static_cast<const T *>(bufferWithOffset(offset));
-}
+        return reinterpret_cast<const T *>(buffer());
+    }
 
 
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT const, *NDArray::bufferasTWithOffset(sd::LongType) const, SD_COMMON_TYPES_ALL);
+
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT const, *NDArray::bufferAsT() const, SD_COMMON_TYPES);
+
+    template <typename T>
+    T *NDArray::bufferAsT() {
+        if(buffer() == nullptr)
+            return nullptr;
+        syncToHost();
+        return reinterpret_cast<T *>(buffer());
+    }
+
+
+
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, *NDArray::bufferAsT(), SD_COMMON_TYPES);
+
+//////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    T *NDArray::bufferasTWithOffset(sd::LongType offset) {
+        return reinterpret_cast<T *>(bufferWithOffset(offset));
+
+    }
+
+
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, *NDArray::bufferasTWithOffset(sd::LongType), SD_COMMON_TYPES_ALL);
+
+
+    template <typename T>
+    const T*  NDArray::bufferasTWithOffset(sd::LongType offset) const {
+        return static_cast<const T *>(bufferWithOffset(offset));
+    }
+
+
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT const, *NDArray::bufferasTWithOffset(sd::LongType) const, SD_COMMON_TYPES_ALL);
 
 
 
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::subarray(IndicesList &idx) const {
-  const int idxSize = idx.size();
-  if (idxSize != this->rankOf()) throw std::runtime_error("NDArray::subarray: number of indices should match");
+    NDArray NDArray::subarray(IndicesList &idx) const {
+        const int idxSize = idx.size();
+        if (idxSize != this->rankOf()) throw std::runtime_error("NDArray::subarray: number of indices should match");
 
-  std::vector<sd::LongType> indexes(3 * idxSize);
+        std::vector<sd::LongType> indexes(3 * idxSize);
 
-  // convert IndicesList to vector
-  for (int d = 0; d < idxSize; ++d) {
-    if (idx.at(d)->isAll()) {
-      indexes[3 * d] = 0;      // first
-      indexes[3 * d + 1] = 0;  // last
-      indexes[3 * d + 2] = 1;  // stride
-    } else if (idx.at(d)->isPoint()) {
-      indexes[3 * d] = idx.at(d)->getIndices().at(0);  // first
-      indexes[3 * d + 1] = indexes[3 * d] + 1;         // last
-      indexes[3 * d + 2] = 1;                          // stride
-    } else if (idx.at(d)->isInterval()) {
-      indexes[3 * d] = idx.at(d)->getIndices().at(0);       // first
-      indexes[3 * d + 1] = idx.at(d)->getIndices().size();  // last
-      indexes[3 * d + 2] = idx.at(d)->stride();             // stride
-    } else {
-      indexes[3 * d] = idx.at(d)->getIndices().at(0);      // first
-      indexes[3 * d + 1] = idx.at(d)->getIndices().at(1);  // last
-      indexes[3 * d + 2] = idx.at(d)->getIndices().at(2);  // stride
-    }
-  }
-  return NDArray((*this)(indexes, true, true));
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::subarray(const std::initializer_list<NDIndex *> &idx) const {
-  const int idxSize = idx.size();
-  if (idxSize != this->rankOf())
-    throw std::runtime_error("NDArray::subarray: number of indices should match the array rank");
-
-  std::vector<sd::LongType> indexes(3 * idxSize);
-
-  // convert NDIndex to vector
-  int d = 0;
-  for (const auto &item : idx) {
-    if (item->isAll()) {
-      indexes[3 * d] = 0;      // first
-      indexes[3 * d + 1] = 0;  // last
-      indexes[3 * d + 2] = 1;  // stride
-    } else if (item->isPoint()) {
-      indexes[3 * d] = item->getIndices().at(0);  // first
-      indexes[3 * d + 1] = indexes[3 * d] + 1;    // last
-      indexes[3 * d + 2] = 1;                     // stride
-    } else if (item->isInterval()) {
-      indexes[3 * d] = item->getIndices().at(0);       // first
-      indexes[3 * d + 1] = item->getIndices().size();  // last
-      indexes[3 * d + 2] = item->stride();             // stride
-    } else {
-      indexes[3 * d] = item->getIndices().at(0);      // first
-      indexes[3 * d + 1] = item->getIndices().at(1);  // last
-      indexes[3 * d + 2] = item->getIndices().at(2);  // stride
-    }
-    ++d;
-  }
-
-  // release NDIndices
-  for (auto i : idx) delete i;
-
-  return NDArray((*this)(indexes, true, true));
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::subarray(const Intervals &idx) const {
-  const int idxSize = idx.size();
-  if (idxSize != this->rankOf())
-    throw std::runtime_error("NDArray::subarray: number of indices should match the rank of array!");
-
-  std::vector<sd::LongType> indexes(2 * idxSize);
-
-  // convert Intervals to vector
-  for (int d = 0; d < idxSize; ++d) {
-    if (idx[d].empty()) {
-      indexes[2 * d] = 0;      // first
-      indexes[2 * d + 1] = 0;  // last
-    } else {
-      indexes[2 * d] = idx[d][0];      // first
-      indexes[2 * d + 1] = idx[d][1];  // last
-    }
-  }
-
-  return NDArray((*this)(indexes, true));
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <typename T>
-NDArray NDArray::asT() const {
-  auto result = isScalar() ? NDArray('c', {}, std::vector<double>{0.}, DataTypeUtils::fromT<T>(), this->getContext())
-                           : NDArray(ordering(), getShapeAsVector(), DataTypeUtils::fromT<T>(), this->getContext());
-
-  prepareUse({&result}, {this});
-  NativeOpExecutioner::execTransformAny(getContext(), transform::AnyOps::Assign, buffer(), shapeInfo(), specialBuffer(),
-                                        specialShapeInfo(), result.buffer(), result.shapeInfo(), result.specialBuffer(),
-                                        result.specialShapeInfo(), nullptr, nullptr, nullptr);
-  registerUse({&result}, {this});
-
-  return result;
-}
-BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArray::asT, () const, SD_COMMON_TYPES);
-
-//////////////////////////////////////////////////////////////////////////
-template <typename T>
-NDArray NDArray::asS() const {
-  if (!isS()) throw std::runtime_error("NDArray::asS: you can use this method only for String array!");
-
-  auto dtype = DataTypeUtils::fromT<T>();
-
-  if (!(DataTypeUtils::isS(dtype))) throw std::invalid_argument("NDArray::asS: invalid DataType used");
-
-  if (dtype == dataType()) {
-    sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
-    const auto nInputoffsets = bufferAsT<sd::LongType>();
-    std::shared_ptr<DataBuffer> pBuffer = std::make_shared<DataBuffer>(offsetsLength + nInputoffsets[lengthOf()], dtype,
-                                                                       getContext()->getWorkspace(), true);
-
-    auto shapeDesc = new ShapeDescriptor(dtype, ordering(), getShapeAsVector());
-    auto buff = ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeDesc);
-    NDArray res(pBuffer,shapeDesc,getContext());
-    res.setAttached(getContext()->getWorkspace() != nullptr);
-
-    preparePrimaryUse({&res}, {this});
-    memcpy(res.bufferAsT<int8_t>(), nInputoffsets, offsetsLength);
-    auto data = res.bufferAsT<int8_t>() + offsetsLength;
-    const auto inData = bufferAsT<int8_t>() + offsetsLength;
-    memcpy(data, inData, nInputoffsets[lengthOf()]);
-
-    registerPrimaryUse({&res}, {this});
-    return res;
-  }
-
-  sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
-
-  std::vector<sd::LongType> offsets(lengthOf() + 1);
-
-  const auto nInputoffsets = bufferAsT<sd::LongType>();
-
-  sd::LongType start = 0, stop = 0;
-  sd::LongType dataLength = 0;
-
-  auto data = bufferAsT<int8_t>() + offsetsLength;
-  for (sd::LongType e = 0; e < lengthOf(); e++) {
-    offsets[e] = dataLength;
-    start = nInputoffsets[e];
-    stop = nInputoffsets[e + 1];
-    if (dataType() == DataType::UTF8) {
-      dataLength += (dtype == DataType::UTF16) ? unicode::offsetUtf8StringInUtf16(data + start, stop)
-                                               : unicode::offsetUtf8StringInUtf32(data + start, stop);
-    } else if (dataType() == DataType::UTF16) {
-      dataLength += (dtype == DataType::UTF32)
-                    ? unicode::offsetUtf16StringInUtf32(data + start, (stop / sizeof(char16_t)))
-                    : unicode::offsetUtf16StringInUtf8(data + start, (stop / sizeof(char16_t)));
-    } else {
-      dataLength += (dtype == DataType::UTF16)
-                    ? unicode::offsetUtf32StringInUtf16(data + start, (stop / sizeof(char32_t)))
-                    : unicode::offsetUtf32StringInUtf8(data + start, (stop / sizeof(char32_t)));
-    }
-  }
-  offsets[lengthOf()] = dataLength;
-
-  std::shared_ptr<DataBuffer> pBuffer =
-      std::make_shared<DataBuffer>(offsetsLength + dataLength, dtype, getContext()->getWorkspace(), true);
-
-  auto desc = new ShapeDescriptor(dtype, ordering(), getShapeAsVector());
-  NDArray res(pBuffer, desc, getContext());
-  res.setAttached(getContext()->getWorkspace() != nullptr);
-
-  preparePrimaryUse({&res}, {this});
-
-  memcpy(res.bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
-
-  auto outData = res.bufferAsT<int8_t>() + offsetsLength;
-  const auto inData = bufferAsT<int8_t>() + offsetsLength;
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (int e = start; e < stop; e++) {
-      auto cdata = outData + offsets[e];
-      auto end = nInputoffsets[e + 1];
-      auto idata = inData + nInputoffsets[e];
-      if (dtype == DataType::UTF16) {
-        if (dataType() == DataType::UTF8) {
-          unicode::utf8to16(idata, outData, end);
-        } else {
-          unicode::utf32to16(idata, outData, (end / sizeof(char32_t)));
+        // convert IndicesList to vector
+        for (int d = 0; d < idxSize; ++d) {
+            if (idx.at(d)->isAll()) {
+                indexes[3 * d] = 0;      // first
+                indexes[3 * d + 1] = 0;  // last
+                indexes[3 * d + 2] = 1;  // stride
+            } else if (idx.at(d)->isPoint()) {
+                indexes[3 * d] = idx.at(d)->getIndices().at(0);  // first
+                indexes[3 * d + 1] = indexes[3 * d] + 1;         // last
+                indexes[3 * d + 2] = 1;                          // stride
+            } else if (idx.at(d)->isInterval()) {
+                indexes[3 * d] = idx.at(d)->getIndices().at(0);       // first
+                indexes[3 * d + 1] = idx.at(d)->getIndices().size();  // last
+                indexes[3 * d + 2] = idx.at(d)->stride();             // stride
+            } else {
+                indexes[3 * d] = idx.at(d)->getIndices().at(0);      // first
+                indexes[3 * d + 1] = idx.at(d)->getIndices().at(1);  // last
+                indexes[3 * d + 2] = idx.at(d)->getIndices().at(2);  // stride
+            }
         }
-      } else if (dtype == DataType::UTF32) {
-        if (dataType() == DataType::UTF8) {
-          unicode::utf8to32(idata, cdata, end);
-        } else {
-          unicode::utf16to32(idata, outData, (end / sizeof(char16_t)));
+        return NDArray((*this)(indexes, true, true));
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::subarray(const std::initializer_list<NDIndex *> &idx) const {
+        const int idxSize = idx.size();
+        if (idxSize != this->rankOf())
+            throw std::runtime_error("NDArray::subarray: number of indices should match the array rank");
+
+        std::vector<sd::LongType> indexes(3 * idxSize);
+
+        // convert NDIndex to vector
+        int d = 0;
+        for (const auto &item : idx) {
+            if (item->isAll()) {
+                indexes[3 * d] = 0;      // first
+                indexes[3 * d + 1] = 0;  // last
+                indexes[3 * d + 2] = 1;  // stride
+            } else if (item->isPoint()) {
+                indexes[3 * d] = item->getIndices().at(0);  // first
+                indexes[3 * d + 1] = indexes[3 * d] + 1;    // last
+                indexes[3 * d + 2] = 1;                     // stride
+            } else if (item->isInterval()) {
+                indexes[3 * d] = item->getIndices().at(0);       // first
+                indexes[3 * d + 1] = item->getIndices().size();  // last
+                indexes[3 * d + 2] = item->stride();             // stride
+            } else {
+                indexes[3 * d] = item->getIndices().at(0);      // first
+                indexes[3 * d + 1] = item->getIndices().at(1);  // last
+                indexes[3 * d + 2] = item->getIndices().at(2);  // stride
+            }
+            ++d;
         }
-      } else {
-        if (dataType() == DataType::UTF16) {
-          unicode::utf16to8(idata, outData, (end / sizeof(char16_t)));
-        } else {
-          unicode::utf32to8(idata, outData, (end / sizeof(char32_t)));
+
+        // release NDIndices
+        for (auto i : idx) delete i;
+
+        return NDArray((*this)(indexes, true, true));
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::subarray(const Intervals &idx) const {
+        const int idxSize = idx.size();
+        if (idxSize != this->rankOf())
+            throw std::runtime_error("NDArray::subarray: number of indices should match the rank of array!");
+
+        std::vector<sd::LongType> indexes(2 * idxSize);
+
+        // convert Intervals to vector
+        for (int d = 0; d < idxSize; ++d) {
+            if (idx[d].empty()) {
+                indexes[2 * d] = 0;      // first
+                indexes[2 * d + 1] = 0;  // last
+            } else {
+                indexes[2 * d] = idx[d][0];      // first
+                indexes[2 * d + 1] = idx[d][1];  // last
+            }
         }
-      }
+
+        return NDArray((*this)(indexes, true));
     }
-  };
 
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+//////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    NDArray NDArray::asT() const {
+        auto result = isScalar() ? NDArray('c', {}, std::vector<double>{0.}, DataTypeUtils::fromT<T>(), this->getContext())
+                                 : NDArray(ordering(), getShapeAsVector(), DataTypeUtils::fromT<T>(), this->getContext());
 
-  registerPrimaryUse({&res}, {this});
+        prepareUse({&result}, {this});
+        NativeOpExecutioner::execTransformAny(getContext(), transform::AnyOps::Assign, buffer(), shapeInfo(), specialBuffer(),
+                                              specialShapeInfo(), result.buffer(), result.shapeInfo(), result.specialBuffer(),
+                                              result.specialShapeInfo(), nullptr, nullptr, nullptr);
+        registerUse({&result}, {this});
 
-  return res;
-}
-BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArray::asS, () const, SD_STRING_TYPES);
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::asT(DataType dtype) const {
-  if (isS() && !DataTypeUtils::isS(dtype))
-    throw std::runtime_error("NDArray::asT: you can't use this method on String array with not string DataType!");
-
-  if (!isS() && DataTypeUtils::isS(dtype))
-    throw std::runtime_error("NDArray::asT: you can't use this method on not String array with string DataType!");
-
-  if (isS()) {
-    BUILD_SINGLE_SELECTOR(dtype, return asS, (), SD_STRING_TYPES);
-  } else {
-    BUILD_SINGLE_SELECTOR(dtype, return asT, (), SD_COMMON_TYPES);
-  }
-
-  return NDArray();
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::cast(DataType dtype) const {
-  if (isS() && !DataTypeUtils::isS(dtype))
-    throw std::runtime_error("NDArray::cast: you can't use this method on String array with not string DataType!");
-
-  if (!isS() && DataTypeUtils::isS(dtype))
-    throw std::runtime_error("NDArray::cast: you can't use this method on not String array with string DataType!");
-
-  return this->asT(dtype);
-}
-
-////////////////////////////////////////////////////////////////////////
-void NDArray::cast(NDArray &target, DataType dtype) {
-  if (isS()) throw std::runtime_error("NDArray::cast: you can't use this method on String array!");
-  // TODO: to be implemented properly
-  target.assign(this);
-}
-
-////////////////////////////////////////////////////////////////////////
-void NDArray::operator+=(const NDArray &other) {
-  if (isS()) throw std::runtime_error("NDArray::operator+=: you can't use this method on String array!");
-  if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType() &&
-      (this->dataType() != DataType::BOOL || other.dataType() != BOOL))
-    throw sd::datatype_exception::build("NDArray operator+=: Cannot add different types", this->dataType(),
-                                        other.dataType());
-
-  if (this->lengthOf() != 1 && other.lengthOf() == 1) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execScalar(getContext(), sd::scalar::Add, buffer(), shapeInfo(), specialBuffer(),
-                                    specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                    other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                    nullptr);
-    registerUse({this}, {this, &other});
-  } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Add, buffer(), shapeInfo(), specialBuffer(),
-                                               specialShapeInfo(), other.buffer(), other.shapeInfo(),
-                                               other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
-                                               specialBuffer(), specialShapeInfo(), nullptr);
-    registerUse({this}, {this, &other});
-  } else {
-    const sd::LongType *bShape = nullptr;
-    if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
-      throw std::invalid_argument(
-          "NDArray::operator+=: the shapes of this and other arrays are not suitable for broadcast operation !");
-
-    if (shape::equalsTypesAndShapesSoft(shapeInfo(), bShape)) {
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Add(), other, *this, false);
-    } else {
-      NDArray result(bShape, true, getContext());
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Add(), other, result, false);
-      *this = std::move(result);  // move assignment operator, zero cost copy
+        return result;
     }
-  }
-}
+    BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArray::asT, () const, SD_COMMON_TYPES);
 
-////////////////////////////////////////////////////////////////////////
-void NDArray::operator-=(const NDArray &other) {
-  if (isS()) throw std::runtime_error("NDArray::operator-=: you can't use this method on String array!");
+//////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    NDArray NDArray::asS() const {
+        if (!isS()) throw std::runtime_error("NDArray::asS: you can use this method only for String array!");
 
-  if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType() &&
-      (this->dataType() != DataType::BOOL || other.dataType() != BOOL))
-    throw sd::datatype_exception::build("NDArray operator-=: Cannot subtract different types", this->dataType(),
-                                        other.dataType());
+        auto dtype = DataTypeUtils::fromT<T>();
 
-  if (lengthOf() != 1 && other.lengthOf() == 1) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execScalar(getContext(), sd::scalar::Subtract, buffer(), shapeInfo(), specialBuffer(),
-                                    specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                    other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                    nullptr);
-    registerUse({this}, {this, &other});
-  } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Subtract, buffer(), shapeInfo(),
-                                               specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
-                                               other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
-                                               specialBuffer(), specialShapeInfo(), nullptr);
-    registerUse({this}, {this, &other});
-  } else {
-    const sd::LongType *bShape = nullptr;
-    if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
-      throw std::invalid_argument(
-          "NDArray::operator-=: the shapes of this and other arrays are not suitable for broadcast operation !");
+        if (!(DataTypeUtils::isS(dtype))) throw std::invalid_argument("NDArray::asS: invalid DataType used");
 
-    if (shape::equalsTypesAndShapesSoft(shapeInfo(), bShape)) {
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), other, *this, false);
-    } else {
-      NDArray result(bShape, true, getContext());
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), other, result, false);
-      *this = std::move(result);  // move assignment operator, zero cost copy
+        if (dtype == dataType()) {
+            sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
+            const auto nInputoffsets = bufferAsT<sd::LongType>();
+            std::shared_ptr<DataBuffer> pBuffer = std::make_shared<DataBuffer>(offsetsLength + nInputoffsets[lengthOf()], dtype,
+                                                                               getContext()->getWorkspace(), true);
+
+            auto shapeDesc = new ShapeDescriptor(dtype, ordering(), getShapeAsVector());
+            auto buff = ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeDesc);
+            NDArray res(pBuffer,shapeDesc,getContext());
+            res.setAttached(getContext()->getWorkspace() != nullptr);
+
+            preparePrimaryUse({&res}, {this});
+            memcpy(res.bufferAsT<int8_t>(), nInputoffsets, offsetsLength);
+            auto data = res.bufferAsT<int8_t>() + offsetsLength;
+            const auto inData = bufferAsT<int8_t>() + offsetsLength;
+            memcpy(data, inData, nInputoffsets[lengthOf()]);
+
+            registerPrimaryUse({&res}, {this});
+            return res;
+        }
+
+        sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
+
+        std::vector<sd::LongType> offsets(lengthOf() + 1);
+
+        const auto nInputoffsets = bufferAsT<sd::LongType>();
+
+        sd::LongType start = 0, stop = 0;
+        sd::LongType dataLength = 0;
+
+        auto data = bufferAsT<int8_t>() + offsetsLength;
+        for (sd::LongType e = 0; e < lengthOf(); e++) {
+            offsets[e] = dataLength;
+            start = nInputoffsets[e];
+            stop = nInputoffsets[e + 1];
+            if (dataType() == DataType::UTF8) {
+                dataLength += (dtype == DataType::UTF16) ? unicode::offsetUtf8StringInUtf16(data + start, stop)
+                                                         : unicode::offsetUtf8StringInUtf32(data + start, stop);
+            } else if (dataType() == DataType::UTF16) {
+                dataLength += (dtype == DataType::UTF32)
+                              ? unicode::offsetUtf16StringInUtf32(data + start, (stop / sizeof(char16_t)))
+                              : unicode::offsetUtf16StringInUtf8(data + start, (stop / sizeof(char16_t)));
+            } else {
+                dataLength += (dtype == DataType::UTF16)
+                              ? unicode::offsetUtf32StringInUtf16(data + start, (stop / sizeof(char32_t)))
+                              : unicode::offsetUtf32StringInUtf8(data + start, (stop / sizeof(char32_t)));
+            }
+        }
+        offsets[lengthOf()] = dataLength;
+
+        std::shared_ptr<DataBuffer> pBuffer =
+                std::make_shared<DataBuffer>(offsetsLength + dataLength, dtype, getContext()->getWorkspace(), true);
+
+        auto desc = new ShapeDescriptor(dtype, ordering(), getShapeAsVector());
+        NDArray res(pBuffer, desc, getContext());
+        res.setAttached(getContext()->getWorkspace() != nullptr);
+
+        preparePrimaryUse({&res}, {this});
+
+        memcpy(res.bufferAsT<int8_t>(), offsets.data(), offsets.size() * sizeof(sd::LongType));
+
+        auto outData = res.bufferAsT<int8_t>() + offsetsLength;
+        const auto inData = bufferAsT<int8_t>() + offsetsLength;
+
+        auto func = PRAGMA_THREADS_FOR {
+            for (int e = start; e < stop; e++) {
+                auto cdata = outData + offsets[e];
+                auto end = nInputoffsets[e + 1];
+                auto idata = inData + nInputoffsets[e];
+                if (dtype == DataType::UTF16) {
+                    if (dataType() == DataType::UTF8) {
+                        unicode::utf8to16(idata, outData, end);
+                    } else {
+                        unicode::utf32to16(idata, outData, (end / sizeof(char32_t)));
+                    }
+                } else if (dtype == DataType::UTF32) {
+                    if (dataType() == DataType::UTF8) {
+                        unicode::utf8to32(idata, cdata, end);
+                    } else {
+                        unicode::utf16to32(idata, outData, (end / sizeof(char16_t)));
+                    }
+                } else {
+                    if (dataType() == DataType::UTF16) {
+                        unicode::utf16to8(idata, outData, (end / sizeof(char16_t)));
+                    } else {
+                        unicode::utf32to8(idata, outData, (end / sizeof(char32_t)));
+                    }
+                }
+            }
+        };
+
+        samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+        registerPrimaryUse({&res}, {this});
+
+        return res;
     }
-  }
-}
+    BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArray::asS, () const, SD_STRING_TYPES);
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::operator*=(const NDArray &other) {
-  if (isS()) throw std::runtime_error("NDArray::operator*=: you can't use this method on String array!");
-  if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType() &&
-      (this->dataType() != DataType::BOOL || other.dataType() != BOOL))
-    throw sd::datatype_exception::build("NDArray operator*=: Cannot multiply different types", this->dataType(),
-                                        other.dataType());
+    NDArray NDArray::asT(DataType dtype) const {
+        if (isS() && !DataTypeUtils::isS(dtype))
+            throw std::runtime_error("NDArray::asT: you can't use this method on String array with not string DataType!");
 
-  if (lengthOf() != 1 && other.lengthOf() == 1) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execScalar(getContext(), sd::scalar::Multiply, buffer(), shapeInfo(), specialBuffer(),
-                                    specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                    other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                    nullptr);
-    registerUse({this}, {this, &other});
-  } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Multiply, buffer(), shapeInfo(),
-                                               specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
-                                               other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
-                                               specialBuffer(), specialShapeInfo(), nullptr);
-    registerUse({this}, {this, &other});
-  } else {
-    const sd::LongType *bShape = nullptr;
-    if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
-      throw std::invalid_argument(
-          "NDArray::operator*=: the shapes of this and other arrays are not suitable for broadcast operation !");
+        if (!isS() && DataTypeUtils::isS(dtype))
+            throw std::runtime_error("NDArray::asT: you can't use this method on not String array with string DataType!");
 
-    if (shape::equalsTypesAndShapesSoft(_shapeInfo, bShape)) {
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), other, *this, false);
-    } else {
-      NDArray result(bShape, true, getContext());
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), other, result, false);
-      *this = std::move(result);  // move assignment operator, zero cost copy
+        if (isS()) {
+            BUILD_SINGLE_SELECTOR(dtype, return asS, (), SD_STRING_TYPES);
+        } else {
+            BUILD_SINGLE_SELECTOR(dtype, return asT, (), SD_COMMON_TYPES);
+        }
+
+        return NDArray();
     }
-  }
-}
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::operator/=(const NDArray &other) {
-  if (isS() || other.isS()) throw std::runtime_error("NDArray::operator/=: you can't use this method on String array!");
-  if (other.isB()) throw std::runtime_error("NDArray::operator/=: you can't divide by bool array!");
+    NDArray NDArray::cast(DataType dtype) const {
+        if (isS() && !DataTypeUtils::isS(dtype))
+            throw std::runtime_error("NDArray::cast: you can't use this method on String array with not string DataType!");
 
-  if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType()) {
-    throw sd::datatype_exception::build("NDArray operator/=: Cannot divide different types", this->dataType(),
-                                        other.dataType());
-  }
+        if (!isS() && DataTypeUtils::isS(dtype))
+            throw std::runtime_error("NDArray::cast: you can't use this method on not String array with string DataType!");
 
-  if (lengthOf() != 1 && other.lengthOf() == 1) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execScalar(getContext(), sd::scalar::Divide, buffer(), shapeInfo(), specialBuffer(),
-                                    specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                    other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                    nullptr);
-    registerUse({this}, {this, &other});
-  } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
-    prepareUse({this}, {this, &other});
-    NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Divide, buffer(), shapeInfo(),
-                                               specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
-                                               other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
-                                               specialBuffer(), specialShapeInfo(), nullptr);
-    registerUse({this}, {this, &other});
-  } else {
-    const sd::LongType *bShape = nullptr;
-    if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
-      throw std::invalid_argument(
-          "NDArray::operator/=: the shapes of this and other arrays are not suitable for broadcast operation !");
-
-    if (shape::equalsTypesAndShapesSoft(_shapeInfo, bShape)) {
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), other, *this, false);
-    } else {
-      NDArray result(bShape, true, getContext());
-      this->applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), other, result, false);
-      *this = std::move(result);  // move assignment operator, zero cost copy
+        return this->asT(dtype);
     }
-  }
-}
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::operator+=(const T value) {
-  if (isS()) throw std::runtime_error("NDArray::operator+=: you can't use this method on String array!");
-
-  auto other = NDArrayFactory::create(this->dataType(), value, getContext());
-
-  prepareUse({this}, {this, &other});
-  NativeOpExecutioner::execScalar(getContext(), sd::scalar::Add, buffer(), shapeInfo(), specialBuffer(),
-                                  specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                  other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                  nullptr);
-  registerUse({this}, {this, &other});
-}
-template SD_LIB_EXPORT void NDArray::operator+=(const double value);
-template SD_LIB_EXPORT void NDArray::operator+=(const float value);
-template SD_LIB_EXPORT void NDArray::operator+=(const float16 value);
-template SD_LIB_EXPORT void NDArray::operator+=(const bfloat16 value);
-template SD_LIB_EXPORT void NDArray::operator+=(const sd::LongType value);
-template SD_LIB_EXPORT void NDArray::operator+=(const int value);
-template SD_LIB_EXPORT void NDArray::operator+=(const bool value);
+    void NDArray::cast(NDArray &target, DataType dtype) {
+        if (isS()) throw std::runtime_error("NDArray::cast: you can't use this method on String array!");
+        // TODO: to be implemented properly
+        target.assign(this);
+    }
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::operator-=(const T value) {
-  if (isS()) throw std::runtime_error("NDArray::operator-=: you can't use this method on String array!");
+    void NDArray::operator+=(const NDArray &other) {
+        if (isS()) throw std::runtime_error("NDArray::operator+=: you can't use this method on String array!");
+        if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType() &&
+            (this->dataType() != DataType::BOOL || other.dataType() != BOOL))
+            throw sd::datatype_exception::build("NDArray operator+=: Cannot add different types", this->dataType(),
+                                                other.dataType());
 
-  auto other = NDArrayFactory::create(dataType(), value, getContext());
+        if (this->lengthOf() != 1 && other.lengthOf() == 1) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execScalar(getContext(), sd::scalar::Add, buffer(), shapeInfo(), specialBuffer(),
+                                            specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                            other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                            nullptr);
+            registerUse({this}, {this, &other});
+        } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Add, buffer(), shapeInfo(), specialBuffer(),
+                                                       specialShapeInfo(), other.buffer(), other.shapeInfo(),
+                                                       other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
+                                                       specialBuffer(), specialShapeInfo(), nullptr);
+            registerUse({this}, {this, &other});
+        } else {
+            const sd::LongType *bShape = nullptr;
+            if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
+                throw std::invalid_argument(
+                        "NDArray::operator+=: the shapes of this and other arrays are not suitable for broadcast operation !");
 
-  prepareUse({this}, {this, &other});
-  NativeOpExecutioner::execScalar(getContext(), sd::scalar::Subtract, buffer(), shapeInfo(), specialBuffer(),
-                                  specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                  other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                  nullptr);
-  registerUse({this}, {this, &other});
-}
-template SD_LIB_EXPORT void NDArray::operator-=(const double value);
-template SD_LIB_EXPORT void NDArray::operator-=(const float value);
-template SD_LIB_EXPORT void NDArray::operator-=(const float16 value);
-template SD_LIB_EXPORT void NDArray::operator-=(const bfloat16 value);
-template SD_LIB_EXPORT void NDArray::operator-=(const sd::LongType value);
-template SD_LIB_EXPORT void NDArray::operator-=(const int value);
-template SD_LIB_EXPORT void NDArray::operator-=(const bool value);
-
-////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::operator*=(const T scalar) {
-  if (isS()) throw std::runtime_error("NDArray::operator*=: you can't use this method on String array!");
-
-  auto other = NDArrayFactory::create(this->dataType(), scalar, getContext());
-  prepareUse({this}, {this, &other});
-  NativeOpExecutioner::execScalar(getContext(), sd::scalar::Multiply, buffer(), shapeInfo(), specialBuffer(),
-                                  specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                  other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                  nullptr);
-  registerUse({this}, {this, &other});
-}
-template SD_LIB_EXPORT void NDArray::operator*=(const double scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const float scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const float16 scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const bfloat16 scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const sd::LongType scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const int scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const int16_t scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const int8_t scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const uint8_t scalar);
-template SD_LIB_EXPORT void NDArray::operator*=(const bool scalar);
+            if (shape::equalsTypesAndShapesSoft(shapeInfo(), bShape)) {
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Add(), other, *this, false);
+            } else {
+                NDArray result(bShape, true, getContext());
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Add(), other, result, false);
+                *this = std::move(result);  // move assignment operator, zero cost copy
+            }
+        }
+    }
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::operator/=(const T scalar) {
-  if (isS()) throw std::runtime_error("NDArray::operator/=: you can't use this method on String array!");
+    void NDArray::operator-=(const NDArray &other) {
+        if (isS()) throw std::runtime_error("NDArray::operator-=: you can't use this method on String array!");
 
-  auto other = NDArrayFactory::create(this->dataType(), scalar, getContext());
-  prepareUse({this}, {this, &other});
-  NativeOpExecutioner::execScalar(getContext(), sd::scalar::Divide, buffer(), shapeInfo(), specialBuffer(),
-                                  specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                  other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                                  nullptr);
-  registerUse({this}, {this, &other});
-}
-template SD_LIB_EXPORT void NDArray::operator/=(const double scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const float scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const float16 scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const bfloat16 scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const sd::LongType scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const int scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const int16_t scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const int8_t scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const uint8_t scalar);
-template SD_LIB_EXPORT void NDArray::operator/=(const bool scalar);
+        if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType() &&
+            (this->dataType() != DataType::BOOL || other.dataType() != BOOL))
+            throw sd::datatype_exception::build("NDArray operator-=: Cannot subtract different types", this->dataType(),
+                                                other.dataType());
+
+        if (lengthOf() != 1 && other.lengthOf() == 1) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execScalar(getContext(), sd::scalar::Subtract, buffer(), shapeInfo(), specialBuffer(),
+                                            specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                            other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                            nullptr);
+            registerUse({this}, {this, &other});
+        } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Subtract, buffer(), shapeInfo(),
+                                                       specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
+                                                       other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
+                                                       specialBuffer(), specialShapeInfo(), nullptr);
+            registerUse({this}, {this, &other});
+        } else {
+            const sd::LongType *bShape = nullptr;
+            if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
+                throw std::invalid_argument(
+                        "NDArray::operator-=: the shapes of this and other arrays are not suitable for broadcast operation !");
+
+            if (shape::equalsTypesAndShapesSoft(shapeInfo(), bShape)) {
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), other, *this, false);
+            } else {
+                NDArray result(bShape, true, getContext());
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), other, result, false);
+                *this = std::move(result);  // move assignment operator, zero cost copy
+            }
+        }
+    }
+
+////////////////////////////////////////////////////////////////////////
+    void NDArray::operator*=(const NDArray &other) {
+        if (isS()) throw std::runtime_error("NDArray::operator*=: you can't use this method on String array!");
+        if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType() &&
+            (this->dataType() != DataType::BOOL || other.dataType() != BOOL))
+            throw sd::datatype_exception::build("NDArray operator*=: Cannot multiply different types", this->dataType(),
+                                                other.dataType());
+
+        if (lengthOf() != 1 && other.lengthOf() == 1) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execScalar(getContext(), sd::scalar::Multiply, buffer(), shapeInfo(), specialBuffer(),
+                                            specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                            other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                            nullptr);
+            registerUse({this}, {this, &other});
+        } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Multiply, buffer(), shapeInfo(),
+                                                       specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
+                                                       other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
+                                                       specialBuffer(), specialShapeInfo(), nullptr);
+            registerUse({this}, {this, &other});
+        } else {
+            const sd::LongType *bShape = nullptr;
+            if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
+                throw std::invalid_argument(
+                        "NDArray::operator*=: the shapes of this and other arrays are not suitable for broadcast operation !");
+
+            if (shape::equalsTypesAndShapesSoft(_shapeInfo, bShape)) {
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), other, *this, false);
+            } else {
+                NDArray result(bShape, true, getContext());
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), other, result, false);
+                *this = std::move(result);  // move assignment operator, zero cost copy
+            }
+        }
+    }
+
+////////////////////////////////////////////////////////////////////////
+    void NDArray::operator/=(const NDArray &other) {
+        if (isS() || other.isS()) throw std::runtime_error("NDArray::operator/=: you can't use this method on String array!");
+        if (other.isB()) throw std::runtime_error("NDArray::operator/=: you can't divide by bool array!");
+
+        if (!Environment::getInstance().isExperimentalBuild() && this->dataType() != other.dataType()) {
+            throw sd::datatype_exception::build("NDArray operator/=: Cannot divide different types", this->dataType(),
+                                                other.dataType());
+        }
+
+        if (lengthOf() != 1 && other.lengthOf() == 1) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execScalar(getContext(), sd::scalar::Divide, buffer(), shapeInfo(), specialBuffer(),
+                                            specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                            other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                            nullptr);
+            registerUse({this}, {this, &other});
+        } else if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
+            prepareUse({this}, {this, &other});
+            NativeOpExecutioner::execPairwiseTransform(getContext(), sd::pairwise::Divide, buffer(), shapeInfo(),
+                                                       specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
+                                                       other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
+                                                       specialBuffer(), specialShapeInfo(), nullptr);
+            registerUse({this}, {this, &other});
+        } else {
+            const sd::LongType *bShape = nullptr;
+            if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, bShape, getContext()->getWorkspace()))
+                throw std::invalid_argument(
+                        "NDArray::operator/=: the shapes of this and other arrays are not suitable for broadcast operation !");
+
+            if (shape::equalsTypesAndShapesSoft(_shapeInfo, bShape)) {
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), other, *this, false);
+            } else {
+                NDArray result(bShape, true, getContext());
+                this->applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), other, result, false);
+                *this = std::move(result);  // move assignment operator, zero cost copy
+            }
+        }
+    }
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void NDArray::operator+=(const T value) {
+        if (isS()) throw std::runtime_error("NDArray::operator+=: you can't use this method on String array!");
+
+        auto other = NDArrayFactory::create(this->dataType(), value, getContext());
+
+        prepareUse({this}, {this, &other});
+        NativeOpExecutioner::execScalar(getContext(), sd::scalar::Add, buffer(), shapeInfo(), specialBuffer(),
+                                        specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                        other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                        nullptr);
+        registerUse({this}, {this, &other});
+    }
+    template SD_LIB_EXPORT void NDArray::operator+=(const double value);
+    template SD_LIB_EXPORT void NDArray::operator+=(const float value);
+    template SD_LIB_EXPORT void NDArray::operator+=(const float16 value);
+    template SD_LIB_EXPORT void NDArray::operator+=(const bfloat16 value);
+    template SD_LIB_EXPORT void NDArray::operator+=(const sd::LongType value);
+    template SD_LIB_EXPORT void NDArray::operator+=(const int value);
+    template SD_LIB_EXPORT void NDArray::operator+=(const bool value);
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void NDArray::operator-=(const T value) {
+        if (isS()) throw std::runtime_error("NDArray::operator-=: you can't use this method on String array!");
+
+        auto other = NDArrayFactory::create(dataType(), value, getContext());
+
+        prepareUse({this}, {this, &other});
+        NativeOpExecutioner::execScalar(getContext(), sd::scalar::Subtract, buffer(), shapeInfo(), specialBuffer(),
+                                        specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                        other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                        nullptr);
+        registerUse({this}, {this, &other});
+    }
+    template SD_LIB_EXPORT void NDArray::operator-=(const double value);
+    template SD_LIB_EXPORT void NDArray::operator-=(const float value);
+    template SD_LIB_EXPORT void NDArray::operator-=(const float16 value);
+    template SD_LIB_EXPORT void NDArray::operator-=(const bfloat16 value);
+    template SD_LIB_EXPORT void NDArray::operator-=(const sd::LongType value);
+    template SD_LIB_EXPORT void NDArray::operator-=(const int value);
+    template SD_LIB_EXPORT void NDArray::operator-=(const bool value);
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void NDArray::operator*=(const T scalar) {
+        if (isS()) throw std::runtime_error("NDArray::operator*=: you can't use this method on String array!");
+
+        auto other = NDArrayFactory::create(this->dataType(), scalar, getContext());
+        prepareUse({this}, {this, &other});
+        NativeOpExecutioner::execScalar(getContext(), sd::scalar::Multiply, buffer(), shapeInfo(), specialBuffer(),
+                                        specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                        other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                        nullptr);
+        registerUse({this}, {this, &other});
+    }
+    template SD_LIB_EXPORT void NDArray::operator*=(const double scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const float scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const float16 scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const bfloat16 scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const sd::LongType scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const int scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const int16_t scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const int8_t scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const uint8_t scalar);
+    template SD_LIB_EXPORT void NDArray::operator*=(const bool scalar);
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void NDArray::operator/=(const T scalar) {
+        if (isS()) throw std::runtime_error("NDArray::operator/=: you can't use this method on String array!");
+
+        auto other = NDArrayFactory::create(this->dataType(), scalar, getContext());
+        prepareUse({this}, {this, &other});
+        NativeOpExecutioner::execScalar(getContext(), sd::scalar::Divide, buffer(), shapeInfo(), specialBuffer(),
+                                        specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                        other.buffer(), other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
+                                        nullptr);
+        registerUse({this}, {this, &other});
+    }
+    template SD_LIB_EXPORT void NDArray::operator/=(const double scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const float scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const float16 scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const bfloat16 scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const sd::LongType scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const int scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const int16_t scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const int8_t scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const uint8_t scalar);
+    template SD_LIB_EXPORT void NDArray::operator/=(const bool scalar);
 
 ////////////////////////////////////////////////////////////////////////
 // negative operator, it makes all array elements = -elements
-NDArray NDArray::operator-() const & {
-  if (isS()) throw std::runtime_error("NDArray::negative-: you can't use this method on String array!");
+    NDArray NDArray::operator-() const & {
+        if (isS()) throw std::runtime_error("NDArray::negative-: you can't use this method on String array!");
 
-  NDArray result(shapeInfo(), false, getContext());
+        NDArray result(shapeInfo(), false, getContext());
 
-  prepareUse({&result}, {this});
-  NativeOpExecutioner::execTransformSame(getContext(), sd::transform::Neg, buffer(), shapeInfo(), specialBuffer(),
-                                         specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                         result.specialBuffer(), result.specialShapeInfo(), nullptr, nullptr, nullptr);
-  registerUse({&result}, {this});
+        prepareUse({&result}, {this});
+        NativeOpExecutioner::execTransformSame(getContext(), sd::transform::Neg, buffer(), shapeInfo(), specialBuffer(),
+                                               specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                               result.specialBuffer(), result.specialShapeInfo(), nullptr, nullptr, nullptr);
+        registerUse({&result}, {this});
 
-  return result;
-}
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::operator-() && {
-  if (isS()) throw std::runtime_error("NDArray::negative-: you can't use this method on String array!");
+    NDArray NDArray::operator-() && {
+        if (isS()) throw std::runtime_error("NDArray::negative-: you can't use this method on String array!");
 
-  prepareUse({this}, {this});
-  NativeOpExecutioner::execTransformSame(getContext(), sd::transform::Neg, buffer(), shapeInfo(), specialBuffer(),
-                                         specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         nullptr, nullptr, nullptr);
-  registerUse({this}, {this});
+        prepareUse({this}, {this});
+        NativeOpExecutioner::execTransformSame(getContext(), sd::transform::Neg, buffer(), shapeInfo(), specialBuffer(),
+                                               specialShapeInfo(), buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                               nullptr, nullptr, nullptr);
+        registerUse({this}, {this});
 
-  return std::move(*this);
-}
+        return std::move(*this);
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // mathematical multiplication of two arrays
-NDArray mmul(const NDArray &left, const NDArray &right) {
-  if (left.isS() || right.isS())
-    throw std::runtime_error("mmul friend function: you can't use this function on String array!");
-  auto ptr = MmulHelper::mmul(const_cast<NDArray *>(&left), const_cast<NDArray *>(&right), nullptr, 1., 0.);
-  NDArray result(std::move(*ptr));
-  delete ptr;
-  return result;
-}
+    NDArray mmul(const NDArray &left, const NDArray &right) {
+        if (left.isS() || right.isS())
+            throw std::runtime_error("mmul friend function: you can't use this function on String array!");
+        auto ptr = MmulHelper::mmul(const_cast<NDArray *>(&left), const_cast<NDArray *>(&right), nullptr, 1., 0.);
+        NDArray result(std::move(*ptr));
+        delete ptr;
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::tileToShape(const std::vector<sd::LongType> &shape, NDArray &target) {
-  if (&target != this) {
-    this->tile(target);
-    return;
-  }
+    void NDArray::tileToShape(const std::vector<sd::LongType> &shape, NDArray &target) {
+        if (&target != this) {
+            this->tile(target);
+            return;
+        }
 
-  std::vector<sd::LongType> thisShape(rankOf());
-  for (int i = 0; i < rankOf(); ++i) thisShape[i] = sizeAt(i);
+        std::vector<sd::LongType> thisShape(rankOf());
+        for (int i = 0; i < rankOf(); ++i) thisShape[i] = sizeAt(i);
 
-  if (!ShapeUtils::areShapesBroadcastable(shape, thisShape))
-    throw std::runtime_error(
-        "NDArray::tileToShape method: the shape of this array and input shape are not suitable for broadcast operation "
-        "!");
+        if (!ShapeUtils::areShapesBroadcastable(shape, thisShape))
+            throw std::runtime_error(
+                    "NDArray::tileToShape method: the shape of this array and input shape are not suitable for broadcast operation "
+                    "!");
 
-  const int newRank = shape.size();
-  std::vector<sd::LongType> repeats(newRank);
+        const int newRank = shape.size();
+        std::vector<sd::LongType> repeats(newRank);
 
-  for (int i = 1; i <= newRank; ++i) {
-    if (i > rankOf())
-      repeats[newRank - i] = shape[newRank - i];
-    else
-      repeats[newRank - i] = shape[newRank - i] / thisShape[rankOf() - i];
-  }
+        for (int i = 1; i <= newRank; ++i) {
+            if (i > rankOf())
+                repeats[newRank - i] = shape[newRank - i];
+            else
+                repeats[newRank - i] = shape[newRank - i] / thisShape[rankOf() - i];
+        }
 
-  tilei(repeats);
-}
-
-////////////////////////////////////////////////////////////////////////
-void NDArray::tileToShape(const std::initializer_list<sd::LongType> &shape, NDArray &target) {
-  tileToShape(std::vector<sd::LongType>(shape), target);
-}
+        tilei(repeats);
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::tileToShape(const sd::LongType *shapeInfo) {
-  NDArray result(const_cast<sd::LongType *>(shapeInfo), false, getContext());
-  tile(result);
-  return result;
-}
+    void NDArray::tileToShape(const std::initializer_list<sd::LongType> &shape, NDArray &target) {
+        tileToShape(std::vector<sd::LongType>(shape), target);
+    }
 
 ////////////////////////////////////////////////////////////////////////
-double NDArray::getTrace() const {
-  if (isS()) throw std::runtime_error("NDArray::getTrace: you can't use this method on String array!");
-
-  int rank = rankOf();
-  auto shape = shapeOf();
-  int minDim = 100000000;
-
-  sd::LongType indices[SD_MAX_RANK];
-  for (int j = 0; j < rank; ++j) indices[j] = 1;
-
-  auto offset = shape::getOffset(shapeInfo(), indices);
-
-  for (int i = 0; i < rank; ++i)
-    if (minDim > shape[i]) minDim = shape[i];
-
-  double sum = 0.;
-
-  for (int i = 0; i < minDim; ++i) sum += e<double>(i * offset);
-
-  return sum;
-}
+    NDArray NDArray::tileToShape(const sd::LongType *shapeInfo) {
+        NDArray result(const_cast<sd::LongType *>(shapeInfo), false, getContext());
+        tile(result);
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::quantize(const NDArray &array) {
-  if (!array.isR()) throw std::invalid_argument("NDArray::quantize: type of array should be from real space!");
+    double NDArray::getTrace() const {
+        if (isS()) throw std::runtime_error("NDArray::getTrace: you can't use this method on String array!");
 
-  auto ws = array.getContext()->getWorkspace();
+        int rank = rankOf();
+        auto shape = shapeOf();
+        int minDim = 100000000;
 
-  sd::LongType *shapeInfo = ShapeBuilders::copyShapeInfo(array.shapeInfo(), true, ws);
-  ArrayOptions::setPropertyBit(shapeInfo, ARRAY_QUANTIZED);
+        sd::LongType indices[SD_MAX_RANK];
+        for (int j = 0; j < rank; ++j) indices[j] = 1;
 
-  std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(TypeCast::estimateQuantizedSize(array.lengthOf()),
-                                                                    ArrayOptions::dataType(shapeInfo), ws);
+        auto offset = shape::getOffset(shapeInfo(), indices);
 
-  auto desc = new ShapeDescriptor(shapeInfo);
-  NDArray result(buffer,desc , array.getContext());
+        for (int i = 0; i < rank; ++i)
+            if (minDim > shape[i]) minDim = shape[i];
 
-  return result;
-}
+        double sum = 0.;
 
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other, NDArray &target,
-                                 const bool checkTargetShape, ExtraArguments *extraArgs) const {
-  if (isS()) throw std::runtime_error("NDArray::applyTrueBroadcast: you can't use this method on String array!");
+        for (int i = 0; i < minDim; ++i) sum += e<double>(i * offset);
 
-  if (((op.s == scalar::Divide || op.s == scalar::FloorDiv || op.s == scalar::FloorMod) && other.isB()) ||
-      (op.s == scalar::ReverseDivide && this->isB()))
-    throw std::runtime_error("NDArray::applyTrueBroadcast method: you can't divide by bool array !");
-
-  if (isEmpty() || other.isEmpty()) return;
-
-  // if (lengthOf() == 1) {
-  //     target.assign(this);
-  //     target.applyPairwiseTransform(op.p, other, extraArgs);
-  //     return;
-  // }
-  // if (other.lengthOf() == 1) {
-  //     const_cast<NDArray*>(this)->applyScalarArr(op.s, other, target, extraArgs);
-  //     return;
-  // }
-
-  if (checkTargetShape) {
-    const sd::LongType *newShapeInfo = nullptr;
-    if (!ShapeUtils::evalBroadcastShapeInfo(
-        *this, other, true, newShapeInfo,
-        getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
-      throw std::runtime_error(
-          "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
-          "operation !");
-    if (!shape::equalsTypesAndShapesSoft(target.shapeInfo(), newShapeInfo))
-      throw std::runtime_error("NDArray::applyTrueBroadcast method: the shape or type of target array is wrong !");
-  }
-
-  sd::LongType const *xShapeInfoH = shapeInfo();
-  sd::LongType const *yShapeInfoH = other.shapeInfo();
-  sd::LongType const *xShapeInfoD = specialShapeInfo();
-  sd::LongType const *yShapeInfoD = other.specialShapeInfo();
-
-  if (!isSameShape(target)) {
-    auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
-    xShapeInfoH = xPack->primary();
-    xShapeInfoD = xPack->special();
-  }
-  if (!other.isSameShape(target)) {
-    auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
-    yShapeInfoH = yPack->primary();
-    yShapeInfoD = yPack->special();
-  }
-
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execBroadcast(getContext(), op.b, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
-                                     other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD, target.buffer(),
-                                     target.shapeInfo(), target.specialBuffer(), target.specialShapeInfo());
-  registerUse({&target}, {this, &other});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyTrueBroadcast(sd::BroadcastBoolOpsTuple op, const NDArray &other, NDArray &target,
-                                 const bool checkTargetShape, ExtraArguments *extraArgs) const {
-  if (isS()) throw std::runtime_error("NDArray::applyTrueBroadcast bool: you can't use this method on String array!");
-
-  if (isEmpty() || other.isEmpty()) return;
-
-
-
-  if (checkTargetShape) {
-    const sd::LongType *newShapeInfo = nullptr;
-    if (!ShapeUtils::evalBroadcastShapeInfo(
-        *this, other, true, newShapeInfo,
-        getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
-      throw std::runtime_error(
-          "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
-          "operation !");
-    if (!shape::equalsSoft(target._shapeInfo, newShapeInfo) || target.dataType() != DataType::BOOL)
-      throw std::runtime_error("NDArray::applyTrueBroadcast bool method: the shape or type of target array is wrong !");
-    if (dataType() != other.dataType())
-      throw std::invalid_argument(
-          "NDArray::applyTrueBroadcast bool method: this and other arrays must have the same type !");
-  }
-
-  sd::LongType const *xShapeInfoH = shapeInfo();
-  sd::LongType const *yShapeInfoH = other.shapeInfo();
-  sd::LongType const *xShapeInfoD = specialShapeInfo();
-  sd::LongType const *yShapeInfoD = other.specialShapeInfo();
-
-  if (!isSameShape(target)) {
-    auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
-    xShapeInfoH = xPack->primary();
-    xShapeInfoD = xPack->special();
-  }
-  if (!other.isSameShape(target)) {
-    auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
-    yShapeInfoH = yPack->primary();
-    yShapeInfoD = yPack->special();
-  }
-
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execBroadcastBool(getContext(), op.b, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
-                                         other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
-                                         target.buffer(), target.shapeInfo(), target.specialBuffer(),
-                                         target.specialShapeInfo(), nullptr);
-  registerUse({&target}, {this, &other});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyTrueBroadcast(sd::BroadcastIntOpsTuple op, const NDArray &other, NDArray &target,
-                                 const bool checkTargetShape, ExtraArguments *extraArgs) const {
-  if (isS()) throw std::runtime_error("NDArray::applyTrueBroadcast bool: you can't use this method on String array!");
-
-  if (isEmpty() || other.isEmpty()) return;
-
-  // if (lengthOf() == 1) {
-  //     NDArray temp(target._shapeInfo, dataType(), false, getContext());
-  //     temp.assign(this);
-  //     temp.applyPairwiseTransform(op.p, other, target,  extraArgs);
-  //     return;
-  // }
-  // if (other.lengthOf() == 1) {
-  //     this->applyScalarArr(op.s, other, target, extraArgs);
-  //     return;
-  // }
-
-  if (checkTargetShape) {
-    const sd::LongType *newShapeInfo = nullptr;
-    if (!ShapeUtils::evalBroadcastShapeInfo(
-        *this, other, false, newShapeInfo,
-        getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
-      throw std::runtime_error(
-          "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
-          "operation !");
-    if (!shape::equalsSoft(target._shapeInfo, newShapeInfo) || target.dataType() != this->dataType())
-      throw std::runtime_error("NDArray::applyTrueBroadcast int method: the shape or type of target array is wrong !");
-    if (dataType() != other.dataType())
-      throw std::invalid_argument(
-          "NDArray::applyTrueBroadcast int method: this and other arrays must have the same type !");
-  }
-
-  sd::LongType const *xShapeInfoH = shapeInfo();
-  sd::LongType const *yShapeInfoH = other.shapeInfo();
-  sd::LongType const *xShapeInfoD = specialShapeInfo();
-  sd::LongType const *yShapeInfoD = other.specialShapeInfo();
-
-  if (!isSameShape(target)) {
-    auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
-  }
-  if (!other.isSameShape(target)) {
-    auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
-  }
-
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execBroadcastInt(getContext(), op.b, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
-                                        other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
-                                        target.buffer(), target.shapeInfo(), target.specialBuffer(),
-                                        target.specialShapeInfo());
-  registerUse({&target}, {this, &other});
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other, ExtraArguments *extraArgs) const & {
-  if (isEmpty() || other.isEmpty()) {
-    if (isEmpty())
-      return NDArray(*this);
-    else
-      return NDArray(other);
-  }
-
-  const sd::LongType *newShapeInfo = nullptr;
-  if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
-                                          getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
-    throw std::runtime_error(
-        "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
-        "operation !");
-  NDArray result(newShapeInfo, true, getContext());
-
-  this->applyTrueBroadcast(op, other, result, false, extraArgs);
-
-  return result;
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, NDArray &&other, ExtraArguments *extraArgs) const & {
-  if (isEmpty() || other.isEmpty()) {
-    if (isEmpty())
-      return NDArray(*this);
-    else
-      return NDArray(other);
-  }
-
-  const sd::LongType *newShapeInfo = nullptr;
-  if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
-                                          getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
-    throw std::runtime_error(
-        "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
-        "operation !");
-
-  if (!shape::shapeEquals(newShapeInfo, other.shapeInfo())) {
-    NDArray result(newShapeInfo, true, getContext());
-    this->applyTrueBroadcast(op, other, result, false, extraArgs);
-    return std::move(result);
-  }
-
-  this->applyTrueBroadcast(op, other, other, false, extraArgs);
-  return std::move(other);
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other, ExtraArguments *extraArgs) && {
-  if (isEmpty() || other.isEmpty()) {
-    if (isEmpty())
-      return NDArray(*this);
-    else
-      return NDArray(other);
-  }
-
-  const sd::LongType *newShapeInfo = nullptr;
-  if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
-                                          getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
-    throw std::runtime_error(
-        "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
-        "operation !");
-
-  if (!shape::shapeEquals(newShapeInfo, shapeInfo())) {
-    NDArray result(newShapeInfo, true, getContext());
-    this->applyTrueBroadcast(op, other, result, false, extraArgs);
-    return std::move(result);
-  }
-
-  this->applyTrueBroadcast(op, other, *this, false, extraArgs);
-  return std::move(*this);
-}
-
-//////////////////////////////////////////////////////////////////////////
-NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, NDArray &&other, ExtraArguments *extraArgs) && {
-  if (isEmpty() || other.isEmpty()) {
-    if (isEmpty())
-      return NDArray(*this);
-    else
-      return NDArray(other);
-  }
-
-  const sd::LongType *newShapeInfo = nullptr;
-  if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
-                                          getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
-    throw std::runtime_error(
-        "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
-        "operation !");
-
-  const bool thisMove = shape::shapeEquals(newShapeInfo, shapeInfo());
-  const bool otherMove = shape::shapeEquals(newShapeInfo, other.shapeInfo());
-
-  if (!thisMove && !otherMove) {
-    NDArray result(newShapeInfo, true, getContext());
-    this->applyTrueBroadcast(op, other, result, false, extraArgs);
-    return std::move(result);
-  }
-
-  if (thisMove) {
-    this->applyTrueBroadcast(op, other, *this, false, extraArgs);
-    return std::move(*this);
-  }
-
-  // otherMove
-  this->applyTrueBroadcast(op, other, other, false, extraArgs);
-  return std::move(other);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyBroadcast(sd::broadcast::Ops op, const std::vector<int> &dimensions, const NDArray &other,
-                             NDArray &target, ExtraArguments *extraArgs) {
-  if (dimensions.size() == 0) return;
-
-  if (isS()) throw std::runtime_error("NDArray::applyBroadcast: you can't use this method on String array!");
-  if (((op == broadcast::Divide || op == broadcast::FloorDiv || op == broadcast::FloorMod) && other.isB()) ||
-      (op == broadcast::ReverseDivide && this->isB()))
-    throw std::runtime_error("NDArray::applyBroadcast: you can't divide by array!");
-  if (isEmpty() || other.isEmpty()) {
-    if (!target.isEmpty())
-      throw std::runtime_error(
-          "NDArray::applyBroadcast method: when some of input arrays (or both) is empty, target array must be empty as "
-          "well !");
-    return;
-  }
-
-
-  if (target.dataType() != DataTypeUtils::pickPairwiseResultType(shapeInfo(), other.shapeInfo()))
-    throw std::invalid_argument("NDArray::applyBroadcast method: wrong type of target array !");
-  if (!target.isSameShape(this) && !target.isSameShape(other))
-    throw std::invalid_argument(
-        "NDArray::applyBroadcast method: one of of two input arrays (this or other) should has the same shape as "
-        "target array!");
-
-  std::vector<int> copy(dimensions);
-
-  if (dimensions.size() > 1) std::sort(copy.begin(), copy.end());
-
-  sd::LongType const *xShapeInfoH = shapeInfo();
-  sd::LongType const *yShapeInfoH = other.shapeInfo();
-  sd::LongType const *xShapeInfoD = specialShapeInfo();
-  sd::LongType const *yShapeInfoD = other.specialShapeInfo();
-
-  if (!isSameShape(target)) {
-    auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
-  }
-  if (!other.isSameShape(target)) {
-    auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
-  }
-
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execBroadcast(getContext(), op, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
-                                     other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD, target.buffer(),
-                                     target.shapeInfo(), target.specialBuffer(), target.specialShapeInfo());
-  registerUse({&target}, {this, &other});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyBroadcast(sd::broadcast::BoolOps op, const std::vector<int> &dimensions, const NDArray &other,
-                             NDArray &target, ExtraArguments *extraArgs) {
-  if (dimensions.size() == 0) return;
-
-  if (isS()) throw std::runtime_error("NDArray::applyBroadcast BoolOps: you can't use this method on String array!");
-  if (isEmpty() || other.isEmpty()) {
-    if (!target.isEmpty())
-      throw std::runtime_error(
-          "NDArray::applyBroadcast BoolOps: when some of input arrays (or both) is empty, target array must be empty "
-          "as well !");
-    return;
-  }
-
-  // if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
-  //     prepareUse({&target}, {this, &other});
-  //     NativeOpExecutioner::execPairwiseBoolTransform(getContext(), fromBroadcastToPairwiseBool(op), buffer(),
-  //     shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(), other.specialBuffer(),
-  //     other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(), target.special(),
-  //     nullptr); registerUse({&target}, {this, &other}); return;
-  // }
-
-  if (target.dataType() != DataType::BOOL)
-    throw std::invalid_argument("NDArray::applyBroadcast bool method: type of target array must be BOOL!");
-  if (!target.isSameShape(this) && !target.isSameShape(other))
-    throw std::invalid_argument(
-        "NDArray::applyBroadcast bool method: one of of two input arrays (this or other) should has the same shape as "
-        "target array!");
-  if (_dataType != other._dataType)
-    throw std::invalid_argument("NDArray::applyBroadcast bool method: this and other arrays must have the same type !");
-
-  std::vector<int> copy(dimensions);
-
-  if (dimensions.size() > 1) std::sort(copy.begin(), copy.end());
-
-  sd::LongType const *xShapeInfoH = shapeInfo();
-  sd::LongType const *yShapeInfoH = other.shapeInfo();
-  sd::LongType const *xShapeInfoD = specialShapeInfo();
-  sd::LongType const *yShapeInfoD = other.specialShapeInfo();
-
-  if (!isSameShape(target)) {
-    auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
-  }
-  if (!other.isSameShape(target)) {
-    auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
-  }
-
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execBroadcastBool(getContext(), op, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
-                                         other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
-                                         target.buffer(), target.shapeInfo(), target.specialBuffer(),
-                                         target.specialShapeInfo(), nullptr);
-  registerUse({&target}, {this, &other});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyBroadcast(sd::broadcast::IntOps op, const std::vector<int> &dimensions, const NDArray &other,
-                             NDArray &target, ExtraArguments *extraArgs) {
-  if (dimensions.empty()) return;
-
-  if (!isZ())
-    throw std::runtime_error("NDArray::applyBroadcast IntOps: you can't use this method on non-Integer array!");
-  if (isEmpty() || other.isEmpty()) {
-    if (!target.isEmpty())
-      throw std::runtime_error(
-          "NDArray::applyBroadcast IntOps: when some of input arrays (or both) is empty, target array must be empty as "
-          "well !");
-    return;
-  }
-
-  // if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
-  //     prepareUse({&target}, {this, &other});
-  //     NativeOpExecutioner::execPairwiseIntTransform(getContext(), fromBroadcastToPairwiseInt(op), buffer(),
-  //     shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(), other.specialBuffer(),
-  //     other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(), target.special(),
-  //     nullptr); registerUse({&target}, {this, &other}); return;
-  // }
-
-  if (target.dataType() != dataType())
-    throw std::invalid_argument("NDArray::applyBroadcast int method: type of target array must be the same as input!");
-  if (!target.isSameShape(this) && !target.isSameShape(other))
-    throw std::invalid_argument(
-        "NDArray::applyBroadcast int method: one of of two input arrays (this or other) should has the same shape as "
-        "target array!");
-  if (_dataType != other._dataType)
-    throw std::invalid_argument("NDArray::applyBroadcast int method: this and other arrays must have the same type !");
-
-  std::vector<int> copy(dimensions);
-
-  if (dimensions.size() > 1) std::sort(copy.begin(), copy.end());
-
-  sd::LongType const *xShapeInfoH = shapeInfo();
-  sd::LongType const *yShapeInfoH = other.shapeInfo();
-  sd::LongType const *xShapeInfoD = specialShapeInfo();
-  sd::LongType const *yShapeInfoD = other.specialShapeInfo();
-
-  if (!isSameShape(target)) {
-    auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
-  }
-  if (!other.isSameShape(target)) {
-    auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
-        target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
-  }
-
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execBroadcastInt(getContext(), op, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
-                                        other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
-                                        target.buffer(), target.shapeInfo(), target.specialBuffer(),
-                                        target.specialShapeInfo());
-  registerUse({&target}, {this, &other});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyBroadcast(sd::broadcast::Ops op, const std::initializer_list<int> dimensions,
-                             const NDArray &tadArray, NDArray &target, ExtraArguments *extraArgs) {
-  std::vector<int> vec(dimensions);
-  applyBroadcast(op, vec, tadArray, target, extraArgs);
-}
+        return sum;
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void *NDArray::operator new(size_t i) {
-  if (sd::memory::MemoryRegistrator::getInstance().hasWorkspaceAttached()) {
-    sd::memory::Workspace *ws = sd::memory::MemoryRegistrator::getInstance().getWorkspace();
-    return ws->allocateBytes((sd::LongType)i);
-  } else {
-    auto p = malloc(i);
-    CHECK_ALLOC(p, "Failed to allocate new NDArray", i);
-    return p;
-  }
-}
+    NDArray NDArray::quantize(const NDArray &array) {
+        if (!array.isR()) throw std::invalid_argument("NDArray::quantize: type of array should be from real space!");
+
+        auto ws = array.getContext()->getWorkspace();
+
+        sd::LongType *shapeInfo = ShapeBuilders::copyShapeInfo(array.shapeInfo(), true, ws);
+        ArrayOptions::setPropertyBit(shapeInfo, ARRAY_QUANTIZED);
+
+        std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(TypeCast::estimateQuantizedSize(array.lengthOf()),
+                                                                          ArrayOptions::dataType(shapeInfo), ws);
+
+        auto desc = new ShapeDescriptor(shapeInfo);
+        NDArray result(buffer,desc , array.getContext());
+
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other, NDArray &target,
+                                     const bool checkTargetShape, ExtraArguments *extraArgs) const {
+        if (isS()) throw std::runtime_error("NDArray::applyTrueBroadcast: you can't use this method on String array!");
+
+        if (((op.s == scalar::Divide || op.s == scalar::FloorDiv || op.s == scalar::FloorMod) && other.isB()) ||
+            (op.s == scalar::ReverseDivide && this->isB()))
+            throw std::runtime_error("NDArray::applyTrueBroadcast method: you can't divide by bool array !");
+
+        if (isEmpty() || other.isEmpty()) return;
+
+        // if (lengthOf() == 1) {
+        //     target.assign(this);
+        //     target.applyPairwiseTransform(op.p, other, extraArgs);
+        //     return;
+        // }
+        // if (other.lengthOf() == 1) {
+        //     const_cast<NDArray*>(this)->applyScalarArr(op.s, other, target, extraArgs);
+        //     return;
+        // }
+
+        if (checkTargetShape) {
+            const sd::LongType *newShapeInfo = nullptr;
+            if (!ShapeUtils::evalBroadcastShapeInfo(
+                    *this, other, true, newShapeInfo,
+                    getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
+                throw std::runtime_error(
+                        "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
+                        "operation !");
+            if (!shape::equalsTypesAndShapesSoft(target.shapeInfo(), newShapeInfo))
+                throw std::runtime_error("NDArray::applyTrueBroadcast method: the shape or type of target array is wrong !");
+        }
+
+        sd::LongType const *xShapeInfoH = shapeInfo();
+        sd::LongType const *yShapeInfoH = other.shapeInfo();
+        sd::LongType const *xShapeInfoD = specialShapeInfo();
+        sd::LongType const *yShapeInfoD = other.specialShapeInfo();
+
+        if (!isSameShape(target)) {
+            auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
+            xShapeInfoH = xPack->primary();
+            xShapeInfoD = xPack->special();
+        }
+        if (!other.isSameShape(target)) {
+            auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
+            yShapeInfoH = yPack->primary();
+            yShapeInfoD = yPack->special();
+        }
+
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execBroadcast(getContext(), op.b, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
+                                           other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD, target.buffer(),
+                                           target.shapeInfo(), target.specialBuffer(), target.specialShapeInfo());
+        registerUse({&target}, {this, &other});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyTrueBroadcast(sd::BroadcastBoolOpsTuple op, const NDArray &other, NDArray &target,
+                                     const bool checkTargetShape, ExtraArguments *extraArgs) const {
+        if (isS()) throw std::runtime_error("NDArray::applyTrueBroadcast bool: you can't use this method on String array!");
+
+        if (isEmpty() || other.isEmpty()) return;
+
+
+
+        if (checkTargetShape) {
+            const sd::LongType *newShapeInfo = nullptr;
+            if (!ShapeUtils::evalBroadcastShapeInfo(
+                    *this, other, true, newShapeInfo,
+                    getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
+                throw std::runtime_error(
+                        "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
+                        "operation !");
+            if (!shape::equalsSoft(target._shapeInfo, newShapeInfo) || target.dataType() != DataType::BOOL)
+                throw std::runtime_error("NDArray::applyTrueBroadcast bool method: the shape or type of target array is wrong !");
+            if (dataType() != other.dataType())
+                throw std::invalid_argument(
+                        "NDArray::applyTrueBroadcast bool method: this and other arrays must have the same type !");
+        }
+
+        sd::LongType const *xShapeInfoH = shapeInfo();
+        sd::LongType const *yShapeInfoH = other.shapeInfo();
+        sd::LongType const *xShapeInfoD = specialShapeInfo();
+        sd::LongType const *yShapeInfoD = other.specialShapeInfo();
+
+        if (!isSameShape(target)) {
+            auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
+            xShapeInfoH = xPack->primary();
+            xShapeInfoD = xPack->special();
+        }
+        if (!other.isSameShape(target)) {
+            auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
+            yShapeInfoH = yPack->primary();
+            yShapeInfoD = yPack->special();
+        }
+
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execBroadcastBool(getContext(), op.b, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
+                                               other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
+                                               target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                                               target.specialShapeInfo(), nullptr);
+        registerUse({&target}, {this, &other});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyTrueBroadcast(sd::BroadcastIntOpsTuple op, const NDArray &other, NDArray &target,
+                                     const bool checkTargetShape, ExtraArguments *extraArgs) const {
+        if (isS()) throw std::runtime_error("NDArray::applyTrueBroadcast bool: you can't use this method on String array!");
+
+        if (isEmpty() || other.isEmpty()) return;
+
+        // if (lengthOf() == 1) {
+        //     NDArray temp(target._shapeInfo, dataType(), false, getContext());
+        //     temp.assign(this);
+        //     temp.applyPairwiseTransform(op.p, other, target,  extraArgs);
+        //     return;
+        // }
+        // if (other.lengthOf() == 1) {
+        //     this->applyScalarArr(op.s, other, target, extraArgs);
+        //     return;
+        // }
+
+        if (checkTargetShape) {
+            const sd::LongType *newShapeInfo = nullptr;
+            if (!ShapeUtils::evalBroadcastShapeInfo(
+                    *this, other, false, newShapeInfo,
+                    getContext()->getWorkspace()))  // the rank of target array must be equal to max->rankOf)()
+                throw std::runtime_error(
+                        "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
+                        "operation !");
+            if (!shape::equalsSoft(target._shapeInfo, newShapeInfo) || target.dataType() != this->dataType())
+                throw std::runtime_error("NDArray::applyTrueBroadcast int method: the shape or type of target array is wrong !");
+            if (dataType() != other.dataType())
+                throw std::invalid_argument(
+                        "NDArray::applyTrueBroadcast int method: this and other arrays must have the same type !");
+        }
+
+        sd::LongType const *xShapeInfoH = shapeInfo();
+        sd::LongType const *yShapeInfoH = other.shapeInfo();
+        sd::LongType const *xShapeInfoD = specialShapeInfo();
+        sd::LongType const *yShapeInfoD = other.specialShapeInfo();
+
+        if (!isSameShape(target)) {
+            auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
+            xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+            xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
+        }
+        if (!other.isSameShape(target)) {
+            auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
+            yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+            yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
+        }
+
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execBroadcastInt(getContext(), op.b, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
+                                              other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
+                                              target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                                              target.specialShapeInfo());
+        registerUse({&target}, {this, &other});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other, ExtraArguments *extraArgs) const & {
+        if (isEmpty() || other.isEmpty()) {
+            if (isEmpty())
+                return NDArray(*this);
+            else
+                return NDArray(other);
+        }
+
+        const sd::LongType *newShapeInfo = nullptr;
+        if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
+                                                getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
+            throw std::runtime_error(
+                    "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
+                    "operation !");
+        NDArray result(newShapeInfo, true, getContext());
+
+        this->applyTrueBroadcast(op, other, result, false, extraArgs);
+
+        return result;
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, NDArray &&other, ExtraArguments *extraArgs) const & {
+        if (isEmpty() || other.isEmpty()) {
+            if (isEmpty())
+                return NDArray(*this);
+            else
+                return NDArray(other);
+        }
+
+        const sd::LongType *newShapeInfo = nullptr;
+        if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
+                                                getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
+            throw std::runtime_error(
+                    "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
+                    "operation !");
+
+        if (!shape::shapeEquals(newShapeInfo, other.shapeInfo())) {
+            NDArray result(newShapeInfo, true, getContext());
+            this->applyTrueBroadcast(op, other, result, false, extraArgs);
+            return std::move(result);
+        }
+
+        this->applyTrueBroadcast(op, other, other, false, extraArgs);
+        return std::move(other);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other, ExtraArguments *extraArgs) && {
+        if (isEmpty() || other.isEmpty()) {
+            if (isEmpty())
+                return NDArray(*this);
+            else
+                return NDArray(other);
+        }
+
+        const sd::LongType *newShapeInfo = nullptr;
+        if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
+                                                getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
+            throw std::runtime_error(
+                    "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
+                    "operation !");
+
+        if (!shape::shapeEquals(newShapeInfo, shapeInfo())) {
+            NDArray result(newShapeInfo, true, getContext());
+            this->applyTrueBroadcast(op, other, result, false, extraArgs);
+            return std::move(result);
+        }
+
+        this->applyTrueBroadcast(op, other, *this, false, extraArgs);
+        return std::move(*this);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, NDArray &&other, ExtraArguments *extraArgs) && {
+        if (isEmpty() || other.isEmpty()) {
+            if (isEmpty())
+                return NDArray(*this);
+            else
+                return NDArray(other);
+        }
+
+        const sd::LongType *newShapeInfo = nullptr;
+        if (!ShapeUtils::evalBroadcastShapeInfo(*this, other, true, newShapeInfo,
+                                                getContext()->getWorkspace()))  // the rank of new array = max->rankOf)()
+            throw std::runtime_error(
+                    "NDArray::applyTrueBroadcast method: the shapes of this and other arrays are not suitable for broadcast "
+                    "operation !");
+
+        const bool thisMove = shape::shapeEquals(newShapeInfo, shapeInfo());
+        const bool otherMove = shape::shapeEquals(newShapeInfo, other.shapeInfo());
+
+        if (!thisMove && !otherMove) {
+            NDArray result(newShapeInfo, true, getContext());
+            this->applyTrueBroadcast(op, other, result, false, extraArgs);
+            return std::move(result);
+        }
+
+        if (thisMove) {
+            this->applyTrueBroadcast(op, other, *this, false, extraArgs);
+            return std::move(*this);
+        }
+
+        // otherMove
+        this->applyTrueBroadcast(op, other, other, false, extraArgs);
+        return std::move(other);
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyBroadcast(sd::broadcast::Ops op, const std::vector<int> &dimensions, const NDArray &other,
+                                 NDArray &target, ExtraArguments *extraArgs) {
+        if (dimensions.size() == 0) return;
+
+        if (isS()) throw std::runtime_error("NDArray::applyBroadcast: you can't use this method on String array!");
+        if (((op == broadcast::Divide || op == broadcast::FloorDiv || op == broadcast::FloorMod) && other.isB()) ||
+            (op == broadcast::ReverseDivide && this->isB()))
+            throw std::runtime_error("NDArray::applyBroadcast: you can't divide by array!");
+        if (isEmpty() || other.isEmpty()) {
+            if (!target.isEmpty())
+                throw std::runtime_error(
+                        "NDArray::applyBroadcast method: when some of input arrays (or both) is empty, target array must be empty as "
+                        "well !");
+            return;
+        }
+
+
+        if (target.dataType() != DataTypeUtils::pickPairwiseResultType(shapeInfo(), other.shapeInfo()))
+            throw std::invalid_argument("NDArray::applyBroadcast method: wrong type of target array !");
+        if (!target.isSameShape(this) && !target.isSameShape(other))
+            throw std::invalid_argument(
+                    "NDArray::applyBroadcast method: one of of two input arrays (this or other) should has the same shape as "
+                    "target array!");
+
+        std::vector<int> copy(dimensions);
+
+        if (dimensions.size() > 1) std::sort(copy.begin(), copy.end());
+
+        sd::LongType const *xShapeInfoH = shapeInfo();
+        sd::LongType const *yShapeInfoH = other.shapeInfo();
+        sd::LongType const *xShapeInfoD = specialShapeInfo();
+        sd::LongType const *yShapeInfoD = other.specialShapeInfo();
+
+        if (!isSameShape(target)) {
+            auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
+            xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+            xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
+        }
+        if (!other.isSameShape(target)) {
+            auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
+            yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+            yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
+        }
+
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execBroadcast(getContext(), op, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
+                                           other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD, target.buffer(),
+                                           target.shapeInfo(), target.specialBuffer(), target.specialShapeInfo());
+        registerUse({&target}, {this, &other});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyBroadcast(sd::broadcast::BoolOps op, const std::vector<int> &dimensions, const NDArray &other,
+                                 NDArray &target, ExtraArguments *extraArgs) {
+        if (dimensions.size() == 0) return;
+
+        if (isS()) throw std::runtime_error("NDArray::applyBroadcast BoolOps: you can't use this method on String array!");
+        if (isEmpty() || other.isEmpty()) {
+            if (!target.isEmpty())
+                throw std::runtime_error(
+                        "NDArray::applyBroadcast BoolOps: when some of input arrays (or both) is empty, target array must be empty "
+                        "as well !");
+            return;
+        }
+
+        // if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
+        //     prepareUse({&target}, {this, &other});
+        //     NativeOpExecutioner::execPairwiseBoolTransform(getContext(), fromBroadcastToPairwiseBool(op), buffer(),
+        //     shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(), other.specialBuffer(),
+        //     other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(), target.special(),
+        //     nullptr); registerUse({&target}, {this, &other}); return;
+        // }
+
+        if (target.dataType() != DataType::BOOL)
+            throw std::invalid_argument("NDArray::applyBroadcast bool method: type of target array must be BOOL!");
+        if (!target.isSameShape(this) && !target.isSameShape(other))
+            throw std::invalid_argument(
+                    "NDArray::applyBroadcast bool method: one of of two input arrays (this or other) should has the same shape as "
+                    "target array!");
+        if (_dataType != other._dataType)
+            throw std::invalid_argument("NDArray::applyBroadcast bool method: this and other arrays must have the same type !");
+
+        std::vector<int> copy(dimensions);
+
+        if (dimensions.size() > 1) std::sort(copy.begin(), copy.end());
+
+        sd::LongType const *xShapeInfoH = shapeInfo();
+        sd::LongType const *yShapeInfoH = other.shapeInfo();
+        sd::LongType const *xShapeInfoD = specialShapeInfo();
+        sd::LongType const *yShapeInfoD = other.specialShapeInfo();
+
+        if (!isSameShape(target)) {
+            auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
+            xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+            xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
+        }
+        if (!other.isSameShape(target)) {
+            auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
+            yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+            yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
+        }
+
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execBroadcastBool(getContext(), op, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
+                                               other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
+                                               target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                                               target.specialShapeInfo(), nullptr);
+        registerUse({&target}, {this, &other});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyBroadcast(sd::broadcast::IntOps op, const std::vector<int> &dimensions, const NDArray &other,
+                                 NDArray &target, ExtraArguments *extraArgs) {
+        if (dimensions.empty()) return;
+
+        if (!isZ())
+            throw std::runtime_error("NDArray::applyBroadcast IntOps: you can't use this method on non-Integer array!");
+        if (isEmpty() || other.isEmpty()) {
+            if (!target.isEmpty())
+                throw std::runtime_error(
+                        "NDArray::applyBroadcast IntOps: when some of input arrays (or both) is empty, target array must be empty as "
+                        "well !");
+            return;
+        }
+
+        // if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
+        //     prepareUse({&target}, {this, &other});
+        //     NativeOpExecutioner::execPairwiseIntTransform(getContext(), fromBroadcastToPairwiseInt(op), buffer(),
+        //     shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(), other.specialBuffer(),
+        //     other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(), target.special(),
+        //     nullptr); registerUse({&target}, {this, &other}); return;
+        // }
+
+        if (target.dataType() != dataType())
+            throw std::invalid_argument("NDArray::applyBroadcast int method: type of target array must be the same as input!");
+        if (!target.isSameShape(this) && !target.isSameShape(other))
+            throw std::invalid_argument(
+                    "NDArray::applyBroadcast int method: one of of two input arrays (this or other) should has the same shape as "
+                    "target array!");
+        if (_dataType != other._dataType)
+            throw std::invalid_argument("NDArray::applyBroadcast int method: this and other arrays must have the same type !");
+
+        std::vector<int> copy(dimensions);
+
+        if (dimensions.size() > 1) std::sort(copy.begin(), copy.end());
+
+        sd::LongType const *xShapeInfoH = shapeInfo();
+        sd::LongType const *yShapeInfoH = other.shapeInfo();
+        sd::LongType const *xShapeInfoD = specialShapeInfo();
+        sd::LongType const *yShapeInfoD = other.specialShapeInfo();
+
+        if (!isSameShape(target)) {
+            auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
+            xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+            xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
+        }
+        if (!other.isSameShape(target)) {
+            auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
+                    target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
+            yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+            yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
+        }
+
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execBroadcastInt(getContext(), op, buffer(), xShapeInfoH, specialBuffer(), xShapeInfoD,
+                                              other.buffer(), yShapeInfoH, other.specialBuffer(), yShapeInfoD,
+                                              target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                                              target.specialShapeInfo());
+        registerUse({&target}, {this, &other});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyBroadcast(sd::broadcast::Ops op, const std::initializer_list<int> dimensions,
+                                 const NDArray &tadArray, NDArray &target, ExtraArguments *extraArgs) {
+        std::vector<int> vec(dimensions);
+        applyBroadcast(op, vec, tadArray, target, extraArgs);
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::operator delete(void *p) {
-  if (!sd::memory::MemoryRegistrator::getInstance().hasWorkspaceAttached()) {
-    free(p);
-  }
-}
+    void *NDArray::operator new(size_t i) {
+        if (sd::memory::MemoryRegistrator::getInstance().hasWorkspaceAttached()) {
+            sd::memory::Workspace *ws = sd::memory::MemoryRegistrator::getInstance().getWorkspace();
+            return ws->allocateBytes((sd::LongType)i);
+        } else {
+            auto p = malloc(i);
+            CHECK_ALLOC(p, "Failed to allocate new NDArray", i);
+            return p;
+        }
+    }
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-std::vector<T> NDArray::asVectorT() {
-  std::vector<T> result(this->lengthOf());
+    void NDArray::operator delete(void *p) {
+        if (!sd::memory::MemoryRegistrator::getInstance().hasWorkspaceAttached()) {
+            free(p);
+        }
+    }
 
-  PRAGMA_OMP_SIMD
-  for (int e = 0; e < this->lengthOf(); e++) result[e] = this->e<T>(e);
+////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    std::vector<T> NDArray::asVectorT() {
+        std::vector<T> result(this->lengthOf());
 
-  return result;
-}
-BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT std::vector, NDArray::asVectorT(), SD_COMMON_TYPES_ALL);
+        PRAGMA_OMP_SIMD
+        for (int e = 0; e < this->lengthOf(); e++) result[e] = this->e<T>(e);
+
+        return result;
+    }
+    BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT std::vector, NDArray::asVectorT(), SD_COMMON_TYPES_ALL);
 
 //////////////////////////////////////////////////////////////////////////
 // set new order and shape in case of suitable array length
-bool NDArray::reshapei(const char order, const std::vector<sd::LongType> &cshape, const bool copyToNewBuff) {
-  // check firstly whether cshape is identical to shape of array, if yes then reshape is unnecessary
-  if (order == ordering() && shape::shapeEquals(rankOf(), shapeOf(), cshape.size(), cshape.data())) return true;
+    bool NDArray::reshapei(const char order, const std::vector<sd::LongType> &cshape, const bool copyToNewBuff) {
+        // check firstly whether cshape is identical to shape of array, if yes then reshape is unnecessary
+        if (order == ordering() && shape::shapeEquals(rankOf(), shapeOf(), cshape.size(), cshape.data())) return true;
 
-  const bool isOutShapeEmpty = std::find(cshape.begin(), cshape.end(), 0) != cshape.end();
+        const bool isOutShapeEmpty = std::find(cshape.begin(), cshape.end(), 0) != cshape.end();
 
-  if (isEmpty() && !isOutShapeEmpty)
-    throw std::invalid_argument("NDArray::reshapei: can't reshape empty array to non-empty !");
-  if (isEmpty() && isOutShapeEmpty) {
-    sd::LongType *shapeInfoNew = ShapeBuilders::emptyShapeInfo(dataType(), order, cshape, getContext()->getWorkspace());
-    setShapeInfo(shapeInfoNew);
-    RELEASE(shapeInfoNew, getContext()->getWorkspace());
-    return true;
-  }
+        if (isEmpty() && !isOutShapeEmpty)
+            throw std::invalid_argument("NDArray::reshapei: can't reshape empty array to non-empty !");
+        if (isEmpty() && isOutShapeEmpty) {
+            sd::LongType *shapeInfoNew = ShapeBuilders::emptyShapeInfo(dataType(), order, cshape, getContext()->getWorkspace());
+            setShapeInfo(shapeInfoNew);
+            RELEASE(shapeInfoNew, getContext()->getWorkspace());
+            return true;
+        }
 
-  std::vector<sd::LongType> shape(cshape);
-  int rank = shape.size();
+        std::vector<sd::LongType> shape(cshape);
+        int rank = shape.size();
 
-  // looking for negative in shape
+        // looking for negative in shape
 
-  int numberNegativesOnes = 0;
+        int numberNegativesOnes = 0;
 
-  sd::LongType *shape_ = shape.data();
-  for (int i = 0; i < (int)shape.size(); i++) {
-    if (shape[i] < 0) {
-      if (numberNegativesOnes >= 1)
-        throw std::runtime_error("NDArray::reshapei: only one dimension can be negative at once");
+        sd::LongType *shape_ = shape.data();
+        for (int i = 0; i < (int)shape.size(); i++) {
+            if (shape[i] < 0) {
+                if (numberNegativesOnes >= 1)
+                    throw std::runtime_error("NDArray::reshapei: only one dimension can be negative at once");
 
-      numberNegativesOnes++;
+                numberNegativesOnes++;
 
-      int shapeLength = 1;
-      for (int j = 0; j < (int)shape.size(); j++)
-        if (i != j) shapeLength *= shape_[j];
+                int shapeLength = 1;
+                for (int j = 0; j < (int)shape.size(); j++)
+                    if (i != j) shapeLength *= shape_[j];
 
-      sd::LongType realShape = sd::math::sd_abs<int>(lengthOf() / shapeLength);
-      auto thisNewShape = new sd::LongType[shape.size()];
+                sd::LongType realShape = sd::math::sd_abs<int>(lengthOf() / shapeLength);
+                auto thisNewShape = new sd::LongType[shape.size()];
 
-      for (int j = 0; j < (int)shape.size(); j++)
-        if (i != j)
-          thisNewShape[j] = shape_[j];
-        else
-          thisNewShape[j] = realShape;
+                for (int j = 0; j < (int)shape.size(); j++)
+                    if (i != j)
+                        thisNewShape[j] = shape_[j];
+                    else
+                        thisNewShape[j] = realShape;
 
-      shape_ = thisNewShape;
+                shape_ = thisNewShape;
+            }
+        }
+
+        for (int e = 0; e < (int)shape.size(); e++) shape[e] = shape_[e];
+
+        if (numberNegativesOnes > 0) delete[] shape_;
+
+        sd::LongType arrLength = 1;
+        for (const auto &item : shape) arrLength *= item;
+
+        if (platformBuffer() == nullptr || arrLength != this->lengthOf()) {
+            this->printShapeInfo("Mismatched shape");
+            sd::Logger::printv("Shape requested: ", shape);
+            sd_debug("Requested length in reshape: %i; Existing length: %i;\n", arrLength, this->lengthOf());
+            throw std::runtime_error("NDArray::reshapei: bad input shape!");
+        }
+
+        sd::LongType *shapeInfoNew;
+        ALLOCATE(shapeInfoNew, getContext()->getWorkspace(), shape::shapeInfoLength(rank), sd::LongType);
+
+        bool canReshape = shape::reshapeC(shapeInfo(), order, shape.size(), shape.data(), shapeInfoNew);
+
+        if (canReshape) {
+            setShapeInfo(shapeInfoNew);
+        } else {
+            NDArray temp(order, shape, dataType(), getContext());
+            if (copyToNewBuff) this->applyTransform(transform::Assign, temp, nullptr);
+            *this = std::move(temp);
+        }
+
+        RELEASE(shapeInfoNew, getContext()->getWorkspace());
+
+        return canReshape;
     }
-  }
-
-  for (int e = 0; e < (int)shape.size(); e++) shape[e] = shape_[e];
-
-  if (numberNegativesOnes > 0) delete[] shape_;
-
-  sd::LongType arrLength = 1;
-  for (const auto &item : shape) arrLength *= item;
-
-  if (platformBuffer() == nullptr || arrLength != this->lengthOf()) {
-    this->printShapeInfo("Mismatched shape");
-    sd::Logger::printv("Shape requested: ", shape);
-    sd_debug("Requested length in reshape: %i; Existing length: %i;\n", arrLength, this->lengthOf());
-    throw std::runtime_error("NDArray::reshapei: bad input shape!");
-  }
-
-  sd::LongType *shapeInfoNew;
-  ALLOCATE(shapeInfoNew, getContext()->getWorkspace(), shape::shapeInfoLength(rank), sd::LongType);
-
-  bool canReshape = shape::reshapeC(shapeInfo(), order, shape.size(), shape.data(), shapeInfoNew);
-
-  if (canReshape) {
-    setShapeInfo(shapeInfoNew);
-  } else {
-    NDArray temp(order, shape, dataType(), getContext());
-    if (copyToNewBuff) this->applyTransform(transform::Assign, temp, nullptr);
-    *this = std::move(temp);
-  }
-
-  RELEASE(shapeInfoNew, getContext()->getWorkspace());
-
-  return canReshape;
-}
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::nullify() {
-  if (isEmpty()) return;
+    void NDArray::nullify() {
+        if (isEmpty()) return;
 
-  if (isView() || ews() != 1)
-    assign(0);
-  else
-    _buffer->setToZeroBuffers();
-}
-
-////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::templatedSet(void *buffer, const sd::LongType xOfsset, sd::DataType dtype, const void *value) {
-  BUILD_SINGLE_PARTIAL_SELECTOR(dtype, templatedSet<, T>(buffer, xOfsset, value), SD_COMMON_TYPES);
-}
-BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedSet,
-                      (void *buffer, const sd::LongType xOfsset, sd::DataType dtype, const void *value),
-                      SD_COMMON_TYPES);
+        if (isView() || ews() != 1)
+            assign(0);
+        else
+            _buffer->setToZeroBuffers();
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::applyPairwiseTransform(sd::pairwise::Ops op, const NDArray &other, NDArray &target,
-                                     ExtraArguments *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::applyPairwiseTransform: you can't use this method on String array!");
-  if (target.dataType() != this->dataType() && target.dataType() != other.dataType())
-    throw std::invalid_argument(
-        "NDArray::applyPairwiseTransform method - type of target array must be the same as type of this or other array "
-        "!");
-
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execPairwiseTransform(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
-      other.specialBuffer(), other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(),
-      target.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
-  registerUse({&target}, {this, &other});
-
-  if (extraParams != nullptr) synchronize("NDArray::applyPairwiseTransform");
-}
+    template <typename T>
+    void NDArray::templatedSet(void *buffer, const sd::LongType xOfsset, sd::DataType dtype, const void *value) {
+        BUILD_SINGLE_PARTIAL_SELECTOR(dtype, templatedSet<, T>(buffer, xOfsset, value), SD_COMMON_TYPES);
+    }
+    BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedSet,
+                          (void *buffer, const sd::LongType xOfsset, sd::DataType dtype, const void *value),
+                          SD_COMMON_TYPES);
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::applyPairwiseTransform(sd::pairwise::BoolOps op, const NDArray &other, NDArray &target,
-                                     ExtraArguments *extraParams) const {
-  if (isS())
-    throw std::runtime_error("NDArray::applyPairwiseTransform BoolOps: you can't use this method on String array!");
-  if (other.lengthOf() != target.lengthOf())
-    throw std::invalid_argument("NDArray::applyPairwiseTransform BoolOps method - lengths of arrays are mismatched");
-  if (!target.isB())
-    throw std::invalid_argument("NDArray::applyPairwiseTransform BoolOps method - result must have bool type");
-  if (dataType() != other.dataType())
-    throw std::invalid_argument(
-        "NDArray::applyPairwiseTransform BoolOps method - this and other arrays must have the same type !");
+    void NDArray::applyPairwiseTransform(sd::pairwise::Ops op, const NDArray &other, NDArray &target,
+                                         ExtraArguments *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::applyPairwiseTransform: you can't use this method on String array!");
+        if (target.dataType() != this->dataType() && target.dataType() != other.dataType())
+            throw std::invalid_argument(
+                    "NDArray::applyPairwiseTransform method - type of target array must be the same as type of this or other array "
+                    "!");
 
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execPairwiseBoolTransform(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
-      other.specialBuffer(), other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(),
-      target.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
-  registerUse({&target}, {this, &other});
-}
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execPairwiseTransform(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
+                other.specialBuffer(), other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                target.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
+        registerUse({&target}, {this, &other});
+
+        if (extraParams != nullptr) synchronize("NDArray::applyPairwiseTransform");
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::applyPairwiseTransform(sd::pairwise::IntOps op, const NDArray &other, NDArray &target,
-                                     ExtraArguments *extraParams) const {
-  if (isS())
-    throw std::runtime_error("NDArray::applyPairwiseTransform IntOps: you can't use this method on String array!");
-  if (other.lengthOf() != target.lengthOf())
-    throw std::invalid_argument("NDArray::applyPairwiseTransform IntOps method - lengths of arrays are mismatched");
-  if (!target.isZ())
-    throw std::invalid_argument("NDArray::applyPairwiseTransform IntOps method - result must have bool type");
-  if (dataType() != other.dataType())
-    throw std::invalid_argument(
-        "NDArray::applyPairwiseTransform IntOps method - this and other arrays must have the same type !");
+    void NDArray::applyPairwiseTransform(sd::pairwise::BoolOps op, const NDArray &other, NDArray &target,
+                                         ExtraArguments *extraParams) const {
+        if (isS())
+            throw std::runtime_error("NDArray::applyPairwiseTransform BoolOps: you can't use this method on String array!");
+        if (other.lengthOf() != target.lengthOf())
+            throw std::invalid_argument("NDArray::applyPairwiseTransform BoolOps method - lengths of arrays are mismatched");
+        if (!target.isB())
+            throw std::invalid_argument("NDArray::applyPairwiseTransform BoolOps method - result must have bool type");
+        if (dataType() != other.dataType())
+            throw std::invalid_argument(
+                    "NDArray::applyPairwiseTransform BoolOps method - this and other arrays must have the same type !");
 
-  prepareUse({&target}, {this, &other});
-  NativeOpExecutioner::execPairwiseIntTransform(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
-      other.specialBuffer(), other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(),
-      target.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
-  registerUse({&target}, {this, &other});
-}
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execPairwiseBoolTransform(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
+                other.specialBuffer(), other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                target.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
+        registerUse({&target}, {this, &other});
+    }
+
+////////////////////////////////////////////////////////////////////////
+    void NDArray::applyPairwiseTransform(sd::pairwise::IntOps op, const NDArray &other, NDArray &target,
+                                         ExtraArguments *extraParams) const {
+        if (isS())
+            throw std::runtime_error("NDArray::applyPairwiseTransform IntOps: you can't use this method on String array!");
+        if (other.lengthOf() != target.lengthOf())
+            throw std::invalid_argument("NDArray::applyPairwiseTransform IntOps method - lengths of arrays are mismatched");
+        if (!target.isZ())
+            throw std::invalid_argument("NDArray::applyPairwiseTransform IntOps method - result must have bool type");
+        if (dataType() != other.dataType())
+            throw std::invalid_argument(
+                    "NDArray::applyPairwiseTransform IntOps method - this and other arrays must have the same type !");
+
+        prepareUse({&target}, {this, &other});
+        NativeOpExecutioner::execPairwiseIntTransform(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(),
+                other.specialBuffer(), other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                target.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
+        registerUse({&target}, {this, &other});
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::applyPairwiseTransform(sd::pairwise::Ops op, const NDArray &other, ExtraArguments *extraParams) {
-  applyPairwiseTransform(op, other, *this, extraParams);
-}
+    void NDArray::applyPairwiseTransform(sd::pairwise::Ops op, const NDArray &other, ExtraArguments *extraParams) {
+        applyPairwiseTransform(op, other, *this, extraParams);
+    }
 
 ////////////////////////////////////////////////////////////////////////
-template <typename X, typename Y>
-void NDArray::templatedDoubleAssign(void *xBuffer, const sd::LongType xOffset, const void *yBuffer,
-                                    const sd::LongType yOffset) const {
-  auto x = reinterpret_cast<X *>(xBuffer);
-  const auto y = reinterpret_cast<const Y *>(yBuffer);
-  x[xOffset] = static_cast<X>(y[yOffset]);
-}
-BUILD_DOUBLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedDoubleAssign,
-                      (void *xBuffer, const sd::LongType xOffset, const void *yBuffer, const sd::LongType yOffset)
-                          const,
-                      SD_COMMON_TYPES, SD_COMMON_TYPES);
+    template <typename X, typename Y>
+    void NDArray::templatedDoubleAssign(void *xBuffer, const sd::LongType xOffset, const void *yBuffer,
+                                        const sd::LongType yOffset) const {
+        auto x = reinterpret_cast<X *>(xBuffer);
+        const auto y = reinterpret_cast<const Y *>(yBuffer);
+        x[xOffset] = static_cast<X>(y[yOffset]);
+    }
+    BUILD_DOUBLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedDoubleAssign,
+                          (void *xBuffer, const sd::LongType xOffset, const void *yBuffer, const sd::LongType yOffset)
+                                  const,
+                          SD_COMMON_TYPES, SD_COMMON_TYPES);
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::varianceAlongDimension(sd::variance::Ops op, NDArray &target, const bool biasCorrected,
-                                     const std::vector<int> &dimensions) const {
-  if (isS()) throw std::runtime_error("NDArray::varianceAlongDimension: you can't use this method on String array!");
+    void NDArray::varianceAlongDimension(sd::variance::Ops op, NDArray &target, const bool biasCorrected,
+                                         const std::vector<int> &dimensions) const {
+        if (isS()) throw std::runtime_error("NDArray::varianceAlongDimension: you can't use this method on String array!");
 
-  if (!target.isR()) throw std::runtime_error("NDArray::varianceAlongDimension: target array must have FLOAT type");
+        if (!target.isR()) throw std::runtime_error("NDArray::varianceAlongDimension: target array must have FLOAT type");
 
-  prepareUse({&target}, {this});
+        prepareUse({&target}, {this});
 
-  if (rankOf() == dimensions.size() || dimensions.empty())
-    NativeOpExecutioner::execSummaryStatsScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                                specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
-                                                target.specialBuffer(), target.specialShapeInfo(), biasCorrected);
-  else {
-    std::vector<int> copy(dimensions);
-    auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
-    auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimensions);
-    NativeOpExecutioner::execSummaryStats(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                          nullptr, target.buffer(), target.shapeInfo(), target.specialBuffer(),
-                                          target.specialShapeInfo(), pDims, dimensions.size(),
-                                          packX.platformShapeInfo(), packX.platformOffsets(), biasCorrected);
-    synchronize("NDArray::varianceAlongDimension");
-  }
+        if (rankOf() == dimensions.size() || dimensions.empty())
+            NativeOpExecutioner::execSummaryStatsScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                        specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
+                                                        target.specialBuffer(), target.specialShapeInfo(), biasCorrected);
+        else {
+            std::vector<int> copy(dimensions);
+            auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
+            auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimensions);
+            NativeOpExecutioner::execSummaryStats(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                  nullptr, target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                                                  target.specialShapeInfo(), pDims, dimensions.size(),
+                                                  packX.platformShapeInfo(), packX.platformOffsets(), biasCorrected);
+            synchronize("NDArray::varianceAlongDimension");
+        }
 
-  registerUse({&target}, {this});
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCorrected,
-                                        const std::vector<int> &dimensions) const {
-  if (isS()) throw std::runtime_error("NDArray::varianceAlongDimension: you can't use this method on String array!");
-
-  std::vector<int> copy(dimensions);
-  if (copy.size() > 1) std::sort(copy.begin(), copy.end());
-
-  auto newShape = ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataTypeUtils::pickFloatingType(dataType()), false,
-                                                  false, getContext()->getWorkspace());
-  NDArray result(newShape, true, getContext());
-
-  this->varianceAlongDimension(op, result, biasCorrected, dimensions);
-
-  return result;
-}
+        registerUse({&target}, {this});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCorrected,
-                                        const std::initializer_list<int> &dimensions) const {
-  return varianceAlongDimension(op, biasCorrected, std::vector<int>(dimensions));
-}
+    NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCorrected,
+                                            const std::vector<int> &dimensions) const {
+        if (isS()) throw std::runtime_error("NDArray::varianceAlongDimension: you can't use this method on String array!");
+
+        std::vector<int> copy(dimensions);
+        if (copy.size() > 1) std::sort(copy.begin(), copy.end());
+
+        auto newShape = ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataTypeUtils::pickFloatingType(dataType()), false,
+                                                        false, getContext()->getWorkspace());
+        NDArray result(newShape, true, getContext());
+
+        this->varianceAlongDimension(op, result, biasCorrected, dimensions);
+
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::varianceAlongDimension(sd::variance::Ops op, NDArray &target, const bool biasCorrected,
-                                     const std::initializer_list<int> &dimensions) const {
-  varianceAlongDimension(op, target, biasCorrected, std::vector<int>(dimensions));
-}
+    NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCorrected,
+                                            const std::initializer_list<int> &dimensions) const {
+        return varianceAlongDimension(op, biasCorrected, std::vector<int>(dimensions));
+    }
+
+////////////////////////////////////////////////////////////////////////
+    void NDArray::varianceAlongDimension(sd::variance::Ops op, NDArray &target, const bool biasCorrected,
+                                         const std::initializer_list<int> &dimensions) const {
+        varianceAlongDimension(op, target, biasCorrected, std::vector<int>(dimensions));
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // This method returns new copy of this NDArray, optionally in different order
-NDArray NDArray::dup(const char newOrder) const {
-  if (isEmpty()) return NDArrayFactory::empty(dataType(), getContext());
+    NDArray NDArray::dup(const char newOrder) const {
+        if (isEmpty()) return NDArrayFactory::empty(dataType(), getContext());
 
-  char order = newOrder == 'a' ? ordering() : newOrder;
+        char order = newOrder == 'a' ? ordering() : newOrder;
 
-  // for now string arrays require special treatment
-  if (isS()) {
-    if (dataType() == DataType::UTF8) {
-      std::vector<std::string> strings(lengthOf());
+        // for now string arrays require special treatment
+        if (isS()) {
+            if (dataType() == DataType::UTF8) {
+                std::vector<std::string> strings(lengthOf());
 
-      auto func = PRAGMA_THREADS_FOR {
-        for (auto i = start; i < stop; i++) {
-          strings[i] = std::move(this->e<std::string>(i));
+                auto func = PRAGMA_THREADS_FOR {
+                    for (auto i = start; i < stop; i++) {
+                        strings[i] = std::move(this->e<std::string>(i));
+                    }
+                };
+
+                samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+                return NDArray(getShapeAsVector(), strings, dataType(), getContext());
+            }
+            if (dataType() == DataType::UTF16) {
+                std::vector<std::u16string> strings(lengthOf());
+
+                auto func = PRAGMA_THREADS_FOR {
+                    for (auto i = start; i < stop; i++) {
+                        strings[i] = std::move(this->e<std::u16string>(i));
+                    }
+                };
+
+                samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+                return NDArray(getShapeAsVector(), strings, dataType(), getContext());
+            }
+
+            std::vector<std::u32string> strings(lengthOf());
+            auto func = PRAGMA_THREADS_FOR {
+                for (auto i = start; i < stop; i++) {
+                    strings[i] = std::move(this->e<std::u32string>(i));
+                }
+            };
+
+            samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+
+            return NDArray(getShapeAsVector(), strings, dataType(), getContext());
         }
-      };
 
-      samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+        NDArray result(order, isScalar() ? std::vector<sd::LongType>({0}) : getShapeAsVector(), dataType(), getContext());
+        result.assign(*this);
 
-      return NDArray(getShapeAsVector(), strings, dataType(), getContext());
+        return result;
     }
-    if (dataType() == DataType::UTF16) {
-      std::vector<std::u16string> strings(lengthOf());
-
-      auto func = PRAGMA_THREADS_FOR {
-        for (auto i = start; i < stop; i++) {
-          strings[i] = std::move(this->e<std::u16string>(i));
-        }
-      };
-
-      samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-      return NDArray(getShapeAsVector(), strings, dataType(), getContext());
-    }
-
-    std::vector<std::u32string> strings(lengthOf());
-    auto func = PRAGMA_THREADS_FOR {
-      for (auto i = start; i < stop; i++) {
-        strings[i] = std::move(this->e<std::u32string>(i));
-      }
-    };
-
-    samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
-
-    return NDArray(getShapeAsVector(), strings, dataType(), getContext());
-  }
-
-  NDArray result(order, isScalar() ? std::vector<sd::LongType>({0}) : getShapeAsVector(), dataType(), getContext());
-  result.assign(*this);
-
-  return result;
-}
 
 ////////////////////////////////////////////////////////////////////////
 // This method returns true if two arrays are equal, with custom or default Eps value of 1e-5, false otherwise
-bool NDArray::equalsTo(const NDArray *other, double eps) const {
-  if (dataType() != other->dataType() || lengthOf() != other->lengthOf()) return false;
+    bool NDArray::equalsTo(const NDArray *other, double eps) const {
+        if (dataType() != other->dataType() || lengthOf() != other->lengthOf()) return false;
 
-  // we need to be able to compare [1, len] to [len]
-  if ((rankOf() == 1 && other->rankOf() == 2) || (rankOf() == 2 && other->rankOf() == 1)) {
-    // FIXME: do something here?
-  } else if (!shape::equalsSoft(shapeInfo(), other->shapeInfo()))
-    return false;
+        // we need to be able to compare [1, len] to [len]
+        if ((rankOf() == 1 && other->rankOf() == 2) || (rankOf() == 2 && other->rankOf() == 1)) {
+            // FIXME: do something here?
+        } else if (!shape::equalsSoft(shapeInfo(), other->shapeInfo()))
+            return false;
 
-  if (isS()) {
-    // string is special case, we'll compare them one by one, considering both arrays are guaranteed to have the same
-    // length
+        if (isS()) {
+            // string is special case, we'll compare them one by one, considering both arrays are guaranteed to have the same
+            // length
 
-    if (dataType() == DataType::UTF8) {
-      for (sd::LongType e = 0; e < this->lengthOf(); e++) {
-        auto s1 = this->e<std::string>(e);
-        auto s2 = other->e<std::string>(e);
+            if (dataType() == DataType::UTF8) {
+                for (sd::LongType e = 0; e < this->lengthOf(); e++) {
+                    auto s1 = this->e<std::string>(e);
+                    auto s2 = other->e<std::string>(e);
 
-        if (s1 != s2) return false;
-      }
-    } else if (dataType() == DataType::UTF16) {
-      for (sd::LongType e = 0; e < this->lengthOf(); e++) {
-        auto s1 = this->e<std::u16string>(e);
-        auto s2 = other->e<std::u16string>(e);
+                    if (s1 != s2) return false;
+                }
+            } else if (dataType() == DataType::UTF16) {
+                for (sd::LongType e = 0; e < this->lengthOf(); e++) {
+                    auto s1 = this->e<std::u16string>(e);
+                    auto s2 = other->e<std::u16string>(e);
 
-        if (s1 != s2) return false;
-      }
-    } else {
-      for (sd::LongType e = 0; e < this->lengthOf(); e++) {
-        auto s1 = this->e<std::u32string>(e);
-        auto s2 = other->e<std::u32string>(e);
+                    if (s1 != s2) return false;
+                }
+            } else {
+                for (sd::LongType e = 0; e < this->lengthOf(); e++) {
+                    auto s1 = this->e<std::u32string>(e);
+                    auto s2 = other->e<std::u32string>(e);
 
-        if (s1 != s2) return false;
-      }
+                    if (s1 != s2) return false;
+                }
+            }
+
+            return true;
+        } else {
+            // regular numeric types
+            NDArray tmp(sd::DataType::FLOAT32, getContext());  // scalar = 0
+
+            ExtraArguments extras({0.0, 0.0, eps});
+#if defined(__CUDABLAS__)
+            prepareUse({&tmp}, {this, other});
+#else
+            NDArray::preparePrimaryUse({&tmp}, {this, other});
+#endif
+            NativeOpExecutioner::execReduce3Scalar(getContext(), reduce3::EqualsWithEps, buffer(), shapeInfo(), specialBuffer(),
+                                                   specialShapeInfo(), extras.argumentsAsT(DataType::FLOAT32), other->buffer(),
+                                                   other->shapeInfo(), other->specialBuffer(), other->specialShapeInfo(),
+                                                   tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(), tmp.specialShapeInfo());
+#if defined(__CUDABLAS__)
+            NDArray::registerSpecialUse({&tmp}, {this, other});
+#else
+            NDArray::registerPrimaryUse({&tmp}, {this, other});
+#endif
+            synchronize("NDArray::equalsTo");
+
+            if (tmp.e<sd::LongType>(0) != 0) return false;
+
+            return true;
+        }
     }
 
-    return true;
-  } else {
-    // regular numeric types
-    NDArray tmp(sd::DataType::FLOAT32, getContext());  // scalar = 0
+//////////////////////////////////////////////////////////////////////////
+    template <>
+    std::string NDArray::e(const sd::LongType i) const {
+        if (!isS()) throw std::runtime_error("Can't get std::string out of non-string array");
 
-    ExtraArguments extras({0.0, 0.0, eps});
-#if defined(__CUDABLAS__)
-    prepareUse({&tmp}, {this, other});
-#else
-    NDArray::preparePrimaryUse({&tmp}, {this, other});
-#endif
-    NativeOpExecutioner::execReduce3Scalar(getContext(), reduce3::EqualsWithEps, buffer(), shapeInfo(), specialBuffer(),
-                                           specialShapeInfo(), extras.argumentsAsT(DataType::FLOAT32), other->buffer(),
-                                           other->shapeInfo(), other->specialBuffer(), other->specialShapeInfo(),
-                                           tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(), tmp.specialShapeInfo());
-#if defined(__CUDABLAS__)
-    NDArray::registerSpecialUse({&tmp}, {this, other});
-#else
-    NDArray::registerPrimaryUse({&tmp}, {this, other});
-#endif
-    synchronize("NDArray::equalsTo");
+        if (i == lengthOf()) throw std::runtime_error("Can't get std::string for index out of range");
 
-    if (tmp.e<sd::LongType>(0) != 0) return false;
+        if (this->dataType() == DataType::UTF16) {
+            auto u16 = this->e<std::u16string>(i);
+            std::string s;
+            StringUtils::u16StringToU8String(u16, s);
+            return s;
+        }
 
-    return true;
-  }
-}
+        if (this->dataType() == DataType::UTF32) {
+            auto u32 = this->e<std::u32string>(i);
+            std::string s;
+            StringUtils::u32StringToU8String(u32, s);
+            return s;
+        }
+
+        NDArray::preparePrimaryUse({}, {this});
+
+        auto offsets = bufferAsT<sd::LongType>();
+        auto offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
+        auto start = offsets[i];
+        auto end = offsets[i + 1];
+        auto data = bufferAsT<int8_t>() + offsetsLength + start;
+
+        std::string r(reinterpret_cast<const char *>(data), (end - start));
+
+        registerPrimaryUse({}, {this});
+
+        return r;
+    }
+
+    template <>
+    std::u16string NDArray::e(const sd::LongType i) const {
+        if (!isS()) throw std::runtime_error("Can't get std::u16string out of non-string array");
+
+        if (i == lengthOf()) throw std::runtime_error("Can't get std::u16string for index out of range");
+
+        if (this->dataType() == DataType::UTF8) {
+            auto u = this->e<std::string>(i);
+            std::u16string s;
+            StringUtils::u8StringToU16String(u, s);
+            return s;
+        }
+
+        if (this->dataType() == DataType::UTF32) {
+            auto u32 = this->e<std::u32string>(i);
+            std::u16string s;
+            StringUtils::u32StringToU16String(u32, s);
+            return s;
+        }
+
+        NDArray::preparePrimaryUse({}, {this});
+
+        auto offsets = bufferAsT<sd::LongType>();
+        sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
+        sd::LongType start = offsets[i];
+        sd::LongType end = offsets[i + 1];
+        auto data = bufferAsT<int8_t>() + offsetsLength + start;
+
+        std::u16string r(reinterpret_cast<const char16_t *>(data), (end - start) / sizeof(char16_t));
+
+        registerPrimaryUse({}, {this});
+
+        return r;
+    }
+
+    template <>
+    std::u32string NDArray::e(const sd::LongType i) const {
+        if (!isS()) throw std::runtime_error("Can't get std::u32string out of non-string array");
+
+        if (i == lengthOf()) throw std::runtime_error("Can't get std::u32string for index out of range");
+
+        if (this->dataType() == DataType::UTF8) {
+            auto u = this->e<std::string>(i);
+            std::u32string s;
+            StringUtils::u8StringToU32String(u, s);
+            return s;
+        }
+
+        if (this->dataType() == DataType::UTF16) {
+            auto u16 = this->e<std::u16string>(i);
+            std::u32string s;
+            StringUtils::u16StringToU32String(u16, s);
+            return s;
+        }
+
+        NDArray::preparePrimaryUse({}, {this});
+
+        auto offsets = bufferAsT<sd::LongType>();
+        sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
+        sd::LongType start = offsets[i];
+        sd::LongType end = offsets[i + 1];
+
+        auto data = bufferAsT<int8_t>() + offsetsLength + start;
+
+        std::u32string r(reinterpret_cast<const char32_t *>(data), (end - start) / sizeof(char32_t));
+
+        registerPrimaryUse({}, {this});
+
+        return r;
+    }
 
 //////////////////////////////////////////////////////////////////////////
-template <>
-std::string NDArray::e(const sd::LongType i) const {
-  if (!isS()) throw std::runtime_error("Can't get std::string out of non-string array");
+    template <>
+    utf8string NDArray::e(const sd::LongType i) const {
+        if (!isS()) throw std::runtime_error("This method is available for String arrays only");
 
-  if (i == lengthOf()) throw std::runtime_error("Can't get std::string for index out of range");
+        auto rp = getOffset(i);
 
-  if (this->dataType() == DataType::UTF16) {
-    auto u16 = this->e<std::u16string>(i);
-    std::string s;
-    StringUtils::u16StringToU8String(u16, s);
-    return s;
-  }
+        syncToHost();
+        tickReadHost();
 
-  if (this->dataType() == DataType::UTF32) {
-    auto u32 = this->e<std::u32string>(i);
-    std::string s;
-    StringUtils::u32StringToU8String(u32, s);
-    return s;
-  }
-
-  NDArray::preparePrimaryUse({}, {this});
-
-  auto offsets = bufferAsT<sd::LongType>();
-  auto offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
-  auto start = offsets[i];
-  auto end = offsets[i + 1];
-  auto data = bufferAsT<int8_t>() + offsetsLength + start;
-
-  std::string r(reinterpret_cast<const char *>(data), (end - start));
-
-  registerPrimaryUse({}, {this});
-
-  return r;
-}
-
-template <>
-std::u16string NDArray::e(const sd::LongType i) const {
-  if (!isS()) throw std::runtime_error("Can't get std::u16string out of non-string array");
-
-  if (i == lengthOf()) throw std::runtime_error("Can't get std::u16string for index out of range");
-
-  if (this->dataType() == DataType::UTF8) {
-    auto u = this->e<std::string>(i);
-    std::u16string s;
-    StringUtils::u8StringToU16String(u, s);
-    return s;
-  }
-
-  if (this->dataType() == DataType::UTF32) {
-    auto u32 = this->e<std::u32string>(i);
-    std::u16string s;
-    StringUtils::u32StringToU16String(u32, s);
-    return s;
-  }
-
-  NDArray::preparePrimaryUse({}, {this});
-
-  auto offsets = bufferAsT<sd::LongType>();
-  sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
-  sd::LongType start = offsets[i];
-  sd::LongType end = offsets[i + 1];
-  auto data = bufferAsT<int8_t>() + offsetsLength + start;
-
-  std::u16string r(reinterpret_cast<const char16_t *>(data), (end - start) / sizeof(char16_t));
-
-  registerPrimaryUse({}, {this});
-
-  return r;
-}
-
-template <>
-std::u32string NDArray::e(const sd::LongType i) const {
-  if (!isS()) throw std::runtime_error("Can't get std::u32string out of non-string array");
-
-  if (i == lengthOf()) throw std::runtime_error("Can't get std::u32string for index out of range");
-
-  if (this->dataType() == DataType::UTF8) {
-    auto u = this->e<std::string>(i);
-    std::u32string s;
-    StringUtils::u8StringToU32String(u, s);
-    return s;
-  }
-
-  if (this->dataType() == DataType::UTF16) {
-    auto u16 = this->e<std::u16string>(i);
-    std::u32string s;
-    StringUtils::u16StringToU32String(u16, s);
-    return s;
-  }
-
-  NDArray::preparePrimaryUse({}, {this});
-
-  auto offsets = bufferAsT<sd::LongType>();
-  sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
-  sd::LongType start = offsets[i];
-  sd::LongType end = offsets[i + 1];
-
-  auto data = bufferAsT<int8_t>() + offsetsLength + start;
-
-  std::u32string r(reinterpret_cast<const char32_t *>(data), (end - start) / sizeof(char32_t));
-
-  registerPrimaryUse({}, {this});
-
-  return r;
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <>
-utf8string NDArray::e(const sd::LongType i) const {
-  if (!isS()) throw std::runtime_error("This method is available for String arrays only");
-
-  auto rp = getOffset(i);
-
-  syncToHost();
-  tickReadHost();
-
-  return *(reinterpret_cast<utf8string *const *>(buffer())[rp]);
-}
+        return *(reinterpret_cast<utf8string *const *>(buffer())[rp]);
+    }
 
 /////////////////////////////////////////////////////////////////////////
-template <typename T>
-T NDArray::e(const sd::LongType i) const {
-  const auto rp = getOffset(i);
+    template <typename T>
+    T NDArray::e(const sd::LongType i) const {
+        const auto rp = getOffset(i);
 
-  NDArray::preparePrimaryUse({}, {this});
-  NDArray::registerPrimaryUse({}, {this});
-  BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), rp), SD_COMMON_TYPES_ALL);
-}
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, NDArray::e(const sd::LongType) const, SD_COMMON_TYPES_ALL);
+        NDArray::preparePrimaryUse({}, {this});
+        NDArray::registerPrimaryUse({}, {this});
+        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), rp), SD_COMMON_TYPES_ALL);
+    }
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, NDArray::e(const sd::LongType) const, SD_COMMON_TYPES_ALL);
 
 //////////////////////////////////////////////////////////////////////////
 // Returns value from 2D matrix by coordinates/indexes
-template <typename T>
-T NDArray::e(const sd::LongType i, const sd::LongType j) const {
-  if (rankOf() != 2 || i >= shapeOf()[0] || j >= shapeOf()[1])
-    throw std::invalid_argument("NDArray::e(i,j): one of input indexes is out of array length or rank!=2 !");
+    template <typename T>
+    T NDArray::e(const sd::LongType i, const sd::LongType j) const {
+        if (rankOf() != 2 || i >= shapeOf()[0] || j >= shapeOf()[1])
+            throw std::invalid_argument("NDArray::e(i,j): one of input indexes is out of array length or rank!=2 !");
 
-  const auto xOffset = i * strideAt(0) + j * strideAt(1);
+        const auto xOffset = i * strideAt(0) + j * strideAt(1);
 
-  NDArray::preparePrimaryUse({}, {this});
-  NDArray::registerPrimaryUse({}, {this});
+        NDArray::preparePrimaryUse({}, {this});
+        NDArray::registerPrimaryUse({}, {this});
 
-  BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), xOffset), SD_COMMON_TYPES_ALL);
+        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), xOffset), SD_COMMON_TYPES_ALL);
 
-  return static_cast<T>(119);
-}
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, NDArray::e(const sd::LongType, const sd::LongType) const,
-                                SD_COMMON_TYPES_ALL);
-
-//////////////////////////////////////////////////////////////////////////
-// returns value from 3D tensor by coordinates
-template <typename T>
-T NDArray::e(const sd::LongType i, const sd::LongType j, const sd::LongType k) const {
-  if (rankOf() != 3 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2])
-    throw std::invalid_argument("NDArray::e(i,j,k): one of input indexes is out of array length or rank!=3 !");
-
-  const auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2);
-
-  NDArray::preparePrimaryUse({}, {this});
-  NDArray::registerPrimaryUse({}, {this});
-
-  BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), xOffset), SD_COMMON_TYPES_ALL);
-
-  return static_cast<T>(119);
-}
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT,
-                                NDArray::e(const sd::LongType, const sd::LongType, const sd::LongType) const,
-                                SD_COMMON_TYPES_ALL);
+        return static_cast<T>(119);
+    }
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT, NDArray::e(const sd::LongType, const sd::LongType) const,
+                                    SD_COMMON_TYPES_ALL);
 
 //////////////////////////////////////////////////////////////////////////
 // returns value from 3D tensor by coordinates
-template <typename T>
-T NDArray::e(const sd::LongType i, const sd::LongType j, const sd::LongType k, const sd::LongType l) const {
-  if (rankOf() != 4 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2] || l >= shapeOf()[3])
-    throw std::invalid_argument("NDArray::e(i,j,k,l): one of input indexes is out of array length or rank!=4 !");
+    template <typename T>
+    T NDArray::e(const sd::LongType i, const sd::LongType j, const sd::LongType k) const {
+        if (rankOf() != 3 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2])
+            throw std::invalid_argument("NDArray::e(i,j,k): one of input indexes is out of array length or rank!=3 !");
 
-  const auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2) + l * strideAt(3);
+        const auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2);
 
-  NDArray::preparePrimaryUse({}, {this});
-  NDArray::registerPrimaryUse({}, {this});
+        NDArray::preparePrimaryUse({}, {this});
+        NDArray::registerPrimaryUse({}, {this});
 
-  BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), xOffset), SD_COMMON_TYPES_ALL);
+        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), xOffset), SD_COMMON_TYPES_ALL);
 
-  return static_cast<T>(119);
-}
-BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT,
-                                NDArray::e(const sd::LongType, const sd::LongType, const sd::LongType,
-                                    const sd::LongType) const,
-                                SD_COMMON_TYPES_ALL);
+        return static_cast<T>(119);
+    }
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT,
+                                    NDArray::e(const sd::LongType, const sd::LongType, const sd::LongType) const,
+                                    SD_COMMON_TYPES_ALL);
 
 //////////////////////////////////////////////////////////////////////////
-NDArray NDArray::e(const sd::LongType i) const {
-  const auto offset = getOffset(i);
+// returns value from 3D tensor by coordinates
+    template <typename T>
+    T NDArray::e(const sd::LongType i, const sd::LongType j, const sd::LongType k, const sd::LongType l) const {
+        if (rankOf() != 4 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2] || l >= shapeOf()[3])
+            throw std::invalid_argument("NDArray::e(i,j,k,l): one of input indexes is out of array length or rank!=4 !");
 
-  NDArray scalar(dataType(), getContext());
+        const auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2) + l * strideAt(3);
 
-  scalar.copyBuffersContinuouslyFrom(*this, sizeOfT(), 0, bufferOffset() + offset);
+        NDArray::preparePrimaryUse({}, {this});
+        NDArray::registerPrimaryUse({}, {this});
 
-  return scalar;
-}
+        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), return templatedGet<, T>(buffer(), xOffset), SD_COMMON_TYPES_ALL);
+
+        return static_cast<T>(119);
+    }
+    BUILD_SINGLE_UNCHAINED_TEMPLATE(template SD_LIB_EXPORT,
+                                    NDArray::e(const sd::LongType, const sd::LongType, const sd::LongType,
+                                            const sd::LongType) const,
+                                    SD_COMMON_TYPES_ALL);
+
+//////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::e(const sd::LongType i) const {
+        const auto offset = getOffset(i);
+
+        NDArray scalar(dataType(), getContext());
+
+        scalar.copyBuffersContinuouslyFrom(*this, sizeOfT(), 0, bufferOffset() + offset);
+
+        return scalar;
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // perform array transformation
-void NDArray::applyTransform(sd::transform::FloatOps op, NDArray &target, ExtraArguments *extraParams) {
-  if (isS()) throw std::runtime_error("NDArray::applyTransform FloatOps: you can't use this method on String array!");
+    void NDArray::applyTransform(sd::transform::FloatOps op, NDArray &target, ExtraArguments *extraParams) {
+        if (isS()) throw std::runtime_error("NDArray::applyTransform FloatOps: you can't use this method on String array!");
 
-  if (!target.isR())
-    throw std::runtime_error("NDArray::applyTransform FloatOps: target array must have one of FLOAT types");
+        if (!target.isR())
+            throw std::runtime_error("NDArray::applyTransform FloatOps: target array must have one of FLOAT types");
 
-  NDArray::prepareSpecialUse({&target}, {this});
-  NativeOpExecutioner::execTransformFloat(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(),
-      extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this});
-}
-
-////////////////////////////////////////////////////////////////////////
-void NDArray::applyTransform(sd::transform::AnyOps op, NDArray &target, ExtraArguments *extraParams) {
-  if (isS()) throw std::runtime_error("NDArray::applyTransform AnyOps: you can't use this method on String array!");
-
-  NDArray::prepareSpecialUse({&target}, {this});
-  NativeOpExecutioner::execTransformAny(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(),
-      extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this});
-}
+        NDArray::prepareSpecialUse({&target}, {this});
+        NativeOpExecutioner::execTransformFloat(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(),
+                extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::applyTransform(sd::transform::SameOps op, NDArray &target, ExtraArguments *extraParams) {
-  if (isS()) throw std::runtime_error("NDArray::applyTransform SameOps: you can't use this method on String array!");
+    void NDArray::applyTransform(sd::transform::AnyOps op, NDArray &target, ExtraArguments *extraParams) {
+        if (isS()) throw std::runtime_error("NDArray::applyTransform AnyOps: you can't use this method on String array!");
 
-  if (target.dataType() != dataType())
-    throw std::runtime_error(
-        "NDArray::applyTransform SameOps: target array must have the same data type as original array");
-
-  NDArray::prepareSpecialUse({&target}, {this});
-  NativeOpExecutioner::execTransformSame(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(),
-      extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this});
-}
+        NDArray::prepareSpecialUse({&target}, {this});
+        NativeOpExecutioner::execTransformAny(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(),
+                extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::applyTransform(sd::transform::StrictOps op, NDArray &target, ExtraArguments *extraParams) {
-  if (isS()) throw std::runtime_error("NDArray::applyTransform StrictOps: you can't use this method on String array!");
+    void NDArray::applyTransform(sd::transform::SameOps op, NDArray &target, ExtraArguments *extraParams) {
+        if (isS()) throw std::runtime_error("NDArray::applyTransform SameOps: you can't use this method on String array!");
 
-  if (!this->isR() || !target.isR() || (this->dataType() != target.dataType()))
-    throw std::runtime_error(
-        "NDArray::applyTransform StrictOps: both Source and Target array must have same FLOAT type !");
+        if (target.dataType() != dataType())
+            throw std::runtime_error(
+                    "NDArray::applyTransform SameOps: target array must have the same data type as original array");
 
-  NDArray::prepareSpecialUse({&target}, {this});
-  NativeOpExecutioner::execTransformStrict(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(),
-      extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this});
-}
-
-////////////////////////////////////////////////////////////////////////
-void NDArray::applyTransform(sd::transform::BoolOps op, NDArray &target, ExtraArguments *extraParams) {
-  if (isS()) throw std::runtime_error("NDArray::applyTransform BoolOps: you can't use this method on String array!");
-
-  if (!target.isB())
-    throw std::runtime_error("NDArray::applyTransform BoolOps: target array must have one of BOOL types");
-
-  NDArray::prepareSpecialUse({&target}, {this});
-  NativeOpExecutioner::execTransformBool(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(),
-      extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this});
-}
+        NDArray::prepareSpecialUse({&target}, {this});
+        NativeOpExecutioner::execTransformSame(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(),
+                extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::FloatOps op, void *extraParams) const & {
-  if (isS()) throw std::runtime_error("NDArray::transform FloatOps: you can't use this method on String array!");
+    void NDArray::applyTransform(sd::transform::StrictOps op, NDArray &target, ExtraArguments *extraParams) {
+        if (isS()) throw std::runtime_error("NDArray::applyTransform StrictOps: you can't use this method on String array!");
 
-  NDArray result(ordering(), getShapeAsVector(), DataTypeUtils::pickFloatingType(dataType()), getContext());
+        if (!this->isR() || !target.isR() || (this->dataType() != target.dataType()))
+            throw std::runtime_error(
+                    "NDArray::applyTransform StrictOps: both Source and Target array must have same FLOAT type !");
 
-  NDArray::prepareSpecialUse({&result}, {this});
-  NativeOpExecutioner::execTransformFloat(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                          result.buffer(), result.shapeInfo(), result.specialBuffer(),
-                                          result.specialShapeInfo(), extraParams, nullptr, nullptr);
-  NDArray::registerSpecialUse({&result}, {this});
-
-  return result;
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::FloatOps op, void *extraParams) && {
-  if (isS()) throw std::runtime_error("NDArray::transform SameOps: you can't use this method on String array!");
-
-  NDArray::prepareSpecialUse({this}, {this});
-  NativeOpExecutioner::execTransformFloat(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                          buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
-                                          nullptr, nullptr);
-  NDArray::registerSpecialUse({this}, {this});
-
-  return std::move(*this);
-}
+        NDArray::prepareSpecialUse({&target}, {this});
+        NativeOpExecutioner::execTransformStrict(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(),
+                extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::SameOps op, void *extraParams) const & {
-  if (isS()) throw std::runtime_error("NDArray::transform SameOps: you can't use this method on String array!");
+    void NDArray::applyTransform(sd::transform::BoolOps op, NDArray &target, ExtraArguments *extraParams) {
+        if (isS()) throw std::runtime_error("NDArray::applyTransform BoolOps: you can't use this method on String array!");
 
-  NDArray result(shapeInfo(), false, getContext());
+        if (!target.isB())
+            throw std::runtime_error("NDArray::applyTransform BoolOps: target array must have one of BOOL types");
 
-  NDArray::prepareSpecialUse({&result}, {this});
-  NativeOpExecutioner::execTransformSame(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         result.buffer(), result.shapeInfo(), result.specialBuffer(),
-                                         result.specialShapeInfo(), extraParams, nullptr, nullptr);
-  NDArray::registerSpecialUse({&result}, {this});
-
-  return result;
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::SameOps op, void *extraParams) && {
-  if (isS()) throw std::runtime_error("NDArray::transform SameOps: you can't use this method on String array!");
-
-  NDArray::prepareSpecialUse({this}, {this});
-  NativeOpExecutioner::execTransformSame(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
-                                         nullptr, nullptr);
-  NDArray::registerSpecialUse({this}, {this});
-
-  return std::move(*this);
-}
+        NDArray::prepareSpecialUse({&target}, {this});
+        NativeOpExecutioner::execTransformBool(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(),
+                extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr, nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::StrictOps op, void *extraParams) const & {
-  if (!this->isR()) throw std::runtime_error("Source array must have one of FLOAT types");
+    NDArray NDArray::transform(sd::transform::FloatOps op, void *extraParams) const & {
+        if (isS()) throw std::runtime_error("NDArray::transform FloatOps: you can't use this method on String array!");
 
-  NDArray result(shapeInfo(), false, getContext());
+        NDArray result(ordering(), getShapeAsVector(), DataTypeUtils::pickFloatingType(dataType()), getContext());
 
-  NDArray::prepareSpecialUse({&result}, {this});
-  NativeOpExecutioner::execTransformStrict(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                           result.buffer(), result.shapeInfo(), result.specialBuffer(),
-                                           result.specialShapeInfo(), extraParams, nullptr, nullptr);
-  NDArray::registerSpecialUse({&result}, {this});
+        NDArray::prepareSpecialUse({&result}, {this});
+        NativeOpExecutioner::execTransformFloat(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                result.buffer(), result.shapeInfo(), result.specialBuffer(),
+                                                result.specialShapeInfo(), extraParams, nullptr, nullptr);
+        NDArray::registerSpecialUse({&result}, {this});
 
-  return result;
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::StrictOps op, void *extraParams) && {
-  if (!this->isR()) throw std::runtime_error("Source array must have one of FLOAT types");
-
-  NDArray::prepareSpecialUse({this}, {this});
-  NativeOpExecutioner::execTransformStrict(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                           buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
-                                           nullptr, nullptr);
-  NDArray::registerSpecialUse({this}, {this});
-
-  return std::move(*this);
-}
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::BoolOps op, void *extraParams) const & {
-  if (isS()) throw std::runtime_error("NDArray::transform BoolOps: you can't use this method on String array!");
+    NDArray NDArray::transform(sd::transform::FloatOps op, void *extraParams) && {
+        if (isS()) throw std::runtime_error("NDArray::transform SameOps: you can't use this method on String array!");
 
-  NDArray result(ordering(), getShapeAsVector(), sd::DataType::BOOL, getContext());
+        NDArray::prepareSpecialUse({this}, {this});
+        NativeOpExecutioner::execTransformFloat(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
+                                                nullptr, nullptr);
+        NDArray::registerSpecialUse({this}, {this});
 
-  NDArray::prepareSpecialUse({&result}, {this});
-  NativeOpExecutioner::execTransformBool(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         result.buffer(), result.shapeInfo(), result.specialBuffer(),
-                                         result.specialShapeInfo(), extraParams, nullptr, nullptr);
-  NDArray::registerSpecialUse({&result}, {this});
-
-  return result;
-}
+        return std::move(*this);
+    }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::transform(sd::transform::BoolOps op, void *extraParams) && {
-  if (isS()) throw std::runtime_error("NDArray::transform BoolOps: you can't use this method on String array!");
+    NDArray NDArray::transform(sd::transform::SameOps op, void *extraParams) const & {
+        if (isS()) throw std::runtime_error("NDArray::transform SameOps: you can't use this method on String array!");
 
-  NDArray::prepareSpecialUse({this}, {this});
-  NativeOpExecutioner::execTransformBool(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
-                                         nullptr, nullptr);
-  NDArray::registerSpecialUse({this}, {this});
+        NDArray result(shapeInfo(), false, getContext());
 
-  return std::move(*this);
-}
+        NDArray::prepareSpecialUse({&result}, {this});
+        NativeOpExecutioner::execTransformSame(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                               result.buffer(), result.shapeInfo(), result.specialBuffer(),
+                                               result.specialShapeInfo(), extraParams, nullptr, nullptr);
+        NDArray::registerSpecialUse({&result}, {this});
+
+        return result;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::transform(sd::transform::SameOps op, void *extraParams) && {
+        if (isS()) throw std::runtime_error("NDArray::transform SameOps: you can't use this method on String array!");
+
+        NDArray::prepareSpecialUse({this}, {this});
+        NativeOpExecutioner::execTransformSame(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                               buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
+                                               nullptr, nullptr);
+        NDArray::registerSpecialUse({this}, {this});
+
+        return std::move(*this);
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::transform(sd::transform::StrictOps op, void *extraParams) const & {
+        if (!this->isR()) throw std::runtime_error("Source array must have one of FLOAT types");
+
+        NDArray result(shapeInfo(), false, getContext());
+
+        NDArray::prepareSpecialUse({&result}, {this});
+        NativeOpExecutioner::execTransformStrict(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                 result.buffer(), result.shapeInfo(), result.specialBuffer(),
+                                                 result.specialShapeInfo(), extraParams, nullptr, nullptr);
+        NDArray::registerSpecialUse({&result}, {this});
+
+        return result;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::transform(sd::transform::StrictOps op, void *extraParams) && {
+        if (!this->isR()) throw std::runtime_error("Source array must have one of FLOAT types");
+
+        NDArray::prepareSpecialUse({this}, {this});
+        NativeOpExecutioner::execTransformStrict(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                 buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
+                                                 nullptr, nullptr);
+        NDArray::registerSpecialUse({this}, {this});
+
+        return std::move(*this);
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::transform(sd::transform::BoolOps op, void *extraParams) const & {
+        if (isS()) throw std::runtime_error("NDArray::transform BoolOps: you can't use this method on String array!");
+
+        NDArray result(ordering(), getShapeAsVector(), sd::DataType::BOOL, getContext());
+
+        NDArray::prepareSpecialUse({&result}, {this});
+        NativeOpExecutioner::execTransformBool(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                               result.buffer(), result.shapeInfo(), result.specialBuffer(),
+                                               result.specialShapeInfo(), extraParams, nullptr, nullptr);
+        NDArray::registerSpecialUse({&result}, {this});
+
+        return result;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::transform(sd::transform::BoolOps op, void *extraParams) && {
+        if (isS()) throw std::runtime_error("NDArray::transform BoolOps: you can't use this method on String array!");
+
+        NDArray::prepareSpecialUse({this}, {this});
+        NativeOpExecutioner::execTransformBool(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                               buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), extraParams,
+                                               nullptr, nullptr);
+        NDArray::registerSpecialUse({this}, {this});
+
+        return std::move(*this);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::applyScalarArr(sd::scalar::Ops op, const NDArray &scalar, NDArray &target, ExtraArguments *extraParams) {
-  if (isS()) throw std::runtime_error("NDArray::applyScalarArr: you can't use this method on String array!");
-  if (scalar.lengthOf() != 1) throw std::invalid_argument("NDArray::applyScalarArr method: operand is not a scalar!");
+    void NDArray::applyScalarArr(sd::scalar::Ops op, const NDArray &scalar, NDArray &target, ExtraArguments *extraParams) {
+        if (isS()) throw std::runtime_error("NDArray::applyScalarArr: you can't use this method on String array!");
+        if (scalar.lengthOf() != 1) throw std::invalid_argument("NDArray::applyScalarArr method: operand is not a scalar!");
 
-  if (target.dataType() != DataTypeUtils::pickPairwiseResultType(shapeInfo(), scalar.shapeInfo()) &&
-      !(target.dataType() == dataType() || target.dataType() == scalar.dataType()))
-    throw std::invalid_argument("NDArray::applyScalarArr method: wrong type of target array!");
+        if (target.dataType() != DataTypeUtils::pickPairwiseResultType(shapeInfo(), scalar.shapeInfo()) &&
+            !(target.dataType() == dataType() || target.dataType() == scalar.dataType()))
+            throw std::invalid_argument("NDArray::applyScalarArr method: wrong type of target array!");
 
-  NDArray::prepareSpecialUse({&target}, {this, &scalar});
-  NativeOpExecutioner::execScalar(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(), scalar.buffer(), scalar.shapeInfo(), scalar.specialBuffer(),
-      scalar.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &scalar});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::applyScalarArr(sd::scalar::BoolOps op, const NDArray &scalar, NDArray &target,
-                             ExtraArguments *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::applyScalarArr BoolOps: you can't use this method on String array!");
-  if (!target.isB()) throw std::invalid_argument("NDArray::applyScalarArr bool method: target has not bool type!");
-  if (dataType() != scalar.dataType()) {
-    sd_printf("NDArray::applyScalarArr BoolOps: this dtype: [%i]; scalar dtype: [%i]\n", this->dataType(),
-              scalar.dataType());
-    throw std::invalid_argument("NDArray::applyScalarArr bool method: this and scalar arrays must have the same type!");
-  }
-
-  NDArray::prepareSpecialUse({&target}, {this, &scalar});
-  NativeOpExecutioner::execScalarBool(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(), scalar.buffer(), scalar.shapeInfo(), scalar.specialBuffer(),
-      scalar.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &scalar});
-}
+        NDArray::prepareSpecialUse({&target}, {this, &scalar});
+        NativeOpExecutioner::execScalar(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(), scalar.buffer(), scalar.shapeInfo(), scalar.specialBuffer(),
+                scalar.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &scalar});
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::applyScalarArr(sd::scalar::IntOps op, const NDArray &scalar, NDArray &target,
-                             ExtraArguments *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::applyScalarArr IntOps: you can't use this method on String array!");
+    void NDArray::applyScalarArr(sd::scalar::BoolOps op, const NDArray &scalar, NDArray &target,
+                                 ExtraArguments *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::applyScalarArr BoolOps: you can't use this method on String array!");
+        if (!target.isB()) throw std::invalid_argument("NDArray::applyScalarArr bool method: target has not bool type!");
+        if (dataType() != scalar.dataType()) {
+            sd_printf("NDArray::applyScalarArr BoolOps: this dtype: [%i]; scalar dtype: [%i]\n", this->dataType(),
+                      scalar.dataType());
+            throw std::invalid_argument("NDArray::applyScalarArr bool method: this and scalar arrays must have the same type!");
+        }
 
-  if (target.dataType() != this->dataType())
-    throw std::invalid_argument("NDArray::applyScalarArr int method: target has not bool type!");
-  if (dataType() != scalar.dataType()) {
-    sd_printf("NDArray::applyScalarArr IntOps: this dtype: [%i]; scalar dtype: [%i]\n", this->dataType(),
-              scalar.dataType());
-    throw std::invalid_argument("NDArray::applyScalarArr int method: this and scalar arrays must have the same type!");
-  }
+        NDArray::prepareSpecialUse({&target}, {this, &scalar});
+        NativeOpExecutioner::execScalarBool(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(), scalar.buffer(), scalar.shapeInfo(), scalar.specialBuffer(),
+                scalar.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &scalar});
+    }
 
-  NDArray::prepareSpecialUse({&target}, {this, &scalar});
-  NativeOpExecutioner::execScalarInt(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
-      target.specialBuffer(), target.specialShapeInfo(), scalar.buffer(), scalar.shapeInfo(), scalar.specialBuffer(),
-      scalar.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &scalar});
-}
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::applyScalarArr(sd::scalar::IntOps op, const NDArray &scalar, NDArray &target,
+                                 ExtraArguments *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::applyScalarArr IntOps: you can't use this method on String array!");
+
+        if (target.dataType() != this->dataType())
+            throw std::invalid_argument("NDArray::applyScalarArr int method: target has not bool type!");
+        if (dataType() != scalar.dataType()) {
+            sd_printf("NDArray::applyScalarArr IntOps: this dtype: [%i]; scalar dtype: [%i]\n", this->dataType(),
+                      scalar.dataType());
+            throw std::invalid_argument("NDArray::applyScalarArr int method: this and scalar arrays must have the same type!");
+        }
+
+        NDArray::prepareSpecialUse({&target}, {this, &scalar});
+        NativeOpExecutioner::execScalarInt(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                target.specialBuffer(), target.specialShapeInfo(), scalar.buffer(), scalar.shapeInfo(), scalar.specialBuffer(),
+                scalar.specialShapeInfo(), extraParams != nullptr ? extraParams->argumentsAsT(target.dataType()) : nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &scalar});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::applyScalar(sd::scalar::IntOps op, const T scalar, NDArray &target, ExtraArguments *extraParams) const {
-  NDArray scalarArr = NDArrayFactory::create(this->dataType(), scalar, getContext());
-  applyScalarArr(op, scalarArr, target, extraParams);
-}
+    template <typename T>
+    void NDArray::applyScalar(sd::scalar::IntOps op, const T scalar, NDArray &target, ExtraArguments *extraParams) const {
+        NDArray scalarArr = NDArrayFactory::create(this->dataType(), scalar, getContext());
+        applyScalarArr(op, scalarArr, target, extraParams);
+    }
 
-template <>
-SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::IntOps op, const NDArray &scalar, NDArray &target,
-                                        ExtraArguments *extraParams) const {
-  throw std::runtime_error("NDArray::applyScalar<NDArray*> method: do not use me!");
-}
-template SD_LIB_EXPORT void NDArray::applyScalar<double>(sd::scalar::IntOps op, const double scalar, NDArray &target,
-                                                         ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<float>(sd::scalar::IntOps op, const float scalar, NDArray &target,
-                                                        ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<float16>(sd::scalar::IntOps op, const float16 scalar, NDArray &target,
-                                                          ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<bfloat16>(sd::scalar::IntOps op, const bfloat16 scalar,
-                                                           NDArray &target, ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<sd::LongType>(sd::scalar::IntOps op, const sd::LongType scalar,
+    template <>
+    SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::IntOps op, const NDArray &scalar, NDArray &target,
+                                            ExtraArguments *extraParams) const {
+        throw std::runtime_error("NDArray::applyScalar<NDArray*> method: do not use me!");
+    }
+    template SD_LIB_EXPORT void NDArray::applyScalar<double>(sd::scalar::IntOps op, const double scalar, NDArray &target,
+                                                             ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<float>(sd::scalar::IntOps op, const float scalar, NDArray &target,
+                                                            ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<float16>(sd::scalar::IntOps op, const float16 scalar, NDArray &target,
+                                                              ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<bfloat16>(sd::scalar::IntOps op, const bfloat16 scalar,
                                                                NDArray &target, ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<int>(sd::scalar::IntOps op, const int scalar, NDArray &target,
-                                                      ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<int16_t>(sd::scalar::IntOps op, const int16_t scalar, NDArray &target,
+    template SD_LIB_EXPORT void NDArray::applyScalar<sd::LongType>(sd::scalar::IntOps op, const sd::LongType scalar,
+                                                                   NDArray &target, ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<int>(sd::scalar::IntOps op, const int scalar, NDArray &target,
                                                           ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<int8_t>(sd::scalar::IntOps op, const int8_t scalar, NDArray &target,
-                                                         ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<uint8_t>(sd::scalar::IntOps op, const uint8_t scalar, NDArray &target,
-                                                          ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<bool>(sd::scalar::IntOps op, const bool scalar, NDArray &target,
-                                                       ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<int16_t>(sd::scalar::IntOps op, const int16_t scalar, NDArray &target,
+                                                              ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<int8_t>(sd::scalar::IntOps op, const int8_t scalar, NDArray &target,
+                                                             ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<uint8_t>(sd::scalar::IntOps op, const uint8_t scalar, NDArray &target,
+                                                              ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<bool>(sd::scalar::IntOps op, const bool scalar, NDArray &target,
+                                                           ExtraArguments *extraParams) const;
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::applyScalar(sd::scalar::Ops op, const T scalar, NDArray &target, ExtraArguments *extraParams) {
-  auto scalarArr = NDArrayFactory::create<T>(dataType(), scalar, this->getContext());
-  applyScalarArr(op, scalarArr, target, extraParams);
-}
-template <>
-SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const NDArray &scalar, NDArray &target,
-                                        ExtraArguments *extraParams) {
-  throw std::runtime_error("NDArray::applyScalar<NDArray*> method: do not use me!");
-}
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const double scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const float scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const float16 scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const bfloat16 scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const sd::LongType scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const int scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const int16_t scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const int8_t scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const uint8_t scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
-template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const bool scalar, NDArray &target,
-                                                 ExtraArguments *extraParams);
+    template <typename T>
+    void NDArray::applyScalar(sd::scalar::Ops op, const T scalar, NDArray &target, ExtraArguments *extraParams) {
+        auto scalarArr = NDArrayFactory::create<T>(dataType(), scalar, this->getContext());
+        applyScalarArr(op, scalarArr, target, extraParams);
+    }
+    template <>
+    SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const NDArray &scalar, NDArray &target,
+                                            ExtraArguments *extraParams) {
+        throw std::runtime_error("NDArray::applyScalar<NDArray*> method: do not use me!");
+    }
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const double scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const float scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const float16 scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const bfloat16 scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const sd::LongType scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const int scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const int16_t scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const int8_t scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const uint8_t scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
+    template SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::Ops op, const bool scalar, NDArray &target,
+                                                     ExtraArguments *extraParams);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::applyScalar(sd::scalar::BoolOps op, const T scalar, NDArray &target, ExtraArguments *extraParams) const {
-  NDArray scalarArr = NDArrayFactory::create<T>(dataType(), scalar, getContext());
-  applyScalarArr(op, scalarArr, target, extraParams);
-}
+    template <typename T>
+    void NDArray::applyScalar(sd::scalar::BoolOps op, const T scalar, NDArray &target, ExtraArguments *extraParams) const {
+        NDArray scalarArr = NDArrayFactory::create<T>(dataType(), scalar, getContext());
+        applyScalarArr(op, scalarArr, target, extraParams);
+    }
 
-template <>
-SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::BoolOps op, const NDArray &scalar, NDArray &target,
-                                        ExtraArguments *extraParams) const {
-  throw std::runtime_error("NDArray::applyScalar<NDArray*> method: do not use me!");
-}
-template SD_LIB_EXPORT void NDArray::applyScalar<double>(sd::scalar::BoolOps op, const double scalar, NDArray &target,
-                                                         ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<float>(sd::scalar::BoolOps op, const float scalar, NDArray &target,
-                                                        ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<float16>(sd::scalar::BoolOps op, const float16 scalar, NDArray &target,
-                                                          ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<bfloat16>(sd::scalar::BoolOps op, const bfloat16 scalar,
-                                                           NDArray &target, ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<sd::LongType>(sd::scalar::BoolOps op, const sd::LongType scalar,
+    template <>
+    SD_LIB_EXPORT void NDArray::applyScalar(sd::scalar::BoolOps op, const NDArray &scalar, NDArray &target,
+                                            ExtraArguments *extraParams) const {
+        throw std::runtime_error("NDArray::applyScalar<NDArray*> method: do not use me!");
+    }
+    template SD_LIB_EXPORT void NDArray::applyScalar<double>(sd::scalar::BoolOps op, const double scalar, NDArray &target,
+                                                             ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<float>(sd::scalar::BoolOps op, const float scalar, NDArray &target,
+                                                            ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<float16>(sd::scalar::BoolOps op, const float16 scalar, NDArray &target,
+                                                              ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<bfloat16>(sd::scalar::BoolOps op, const bfloat16 scalar,
                                                                NDArray &target, ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<int>(sd::scalar::BoolOps op, const int scalar, NDArray &target,
-                                                      ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<int16_t>(sd::scalar::BoolOps op, const int16_t scalar, NDArray &target,
+    template SD_LIB_EXPORT void NDArray::applyScalar<sd::LongType>(sd::scalar::BoolOps op, const sd::LongType scalar,
+                                                                   NDArray &target, ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<int>(sd::scalar::BoolOps op, const int scalar, NDArray &target,
                                                           ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<int8_t>(sd::scalar::BoolOps op, const int8_t scalar, NDArray &target,
-                                                         ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<uint8_t>(sd::scalar::BoolOps op, const uint8_t scalar, NDArray &target,
-                                                          ExtraArguments *extraParams) const;
-template SD_LIB_EXPORT void NDArray::applyScalar<bool>(sd::scalar::BoolOps op, const bool scalar, NDArray &target,
-                                                       ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<int16_t>(sd::scalar::BoolOps op, const int16_t scalar, NDArray &target,
+                                                              ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<int8_t>(sd::scalar::BoolOps op, const int8_t scalar, NDArray &target,
+                                                             ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<uint8_t>(sd::scalar::BoolOps op, const uint8_t scalar, NDArray &target,
+                                                              ExtraArguments *extraParams) const;
+    template SD_LIB_EXPORT void NDArray::applyScalar<bool>(sd::scalar::BoolOps op, const bool scalar, NDArray &target,
+                                                           ExtraArguments *extraParams) const;
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::applyIndexReduce(sd::indexreduce::Ops op, NDArray &target, const std::vector<int> &dimensions,
-                               const ExtraArguments *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::applyIndexReduce: you can't use this method on String array!");
+    void NDArray::applyIndexReduce(sd::indexreduce::Ops op, NDArray &target, const std::vector<int> &dimensions,
+                                   const ExtraArguments *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::applyIndexReduce: you can't use this method on String array!");
 
-  if (target.dataType() != sd::DataType::INT64 && target.dataType() != sd::DataType::INT32)
-    throw std::runtime_error("NDArray::applyIndexReduce operations return INT32/INT64");
+        if (target.dataType() != sd::DataType::INT64 && target.dataType() != sd::DataType::INT32)
+            throw std::runtime_error("NDArray::applyIndexReduce operations return INT32/INT64");
 
-  void *params =
-      extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(this->dataType()) : nullptr;
+        void *params =
+                extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(this->dataType()) : nullptr;
 
-  NDArray::prepareSpecialUse({&target}, {this});
+        NDArray::prepareSpecialUse({&target}, {this});
 
-  if (target.lengthOf() == 1) {
-    NativeOpExecutioner::execIndexReduceScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                               specialShapeInfo(), params, target.buffer(), target.shapeInfo(),
-                                               target.specialBuffer(), target.specialShapeInfo());
-  } else {
-    std::vector<int> copy = dimensions;
-    shape::checkDimensions(rankOf(), copy);
-    auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
-    auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), copy);
-    NativeOpExecutioner::execIndexReduce(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         params, target.buffer(), target.shapeInfo(), target.specialBuffer(),
-                                         target.specialShapeInfo(), pDims, copy.size(), packX.platformShapeInfo(),
-                                         packX.platformOffsets());
-    synchronize("NDArray::applyIndexReduce");
-  }
+        if (target.lengthOf() == 1) {
+            NativeOpExecutioner::execIndexReduceScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                       specialShapeInfo(), params, target.buffer(), target.shapeInfo(),
+                                                       target.specialBuffer(), target.specialShapeInfo());
+        } else {
+            std::vector<int> copy = dimensions;
+            shape::checkDimensions(rankOf(), copy);
+            auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
+            auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), copy);
+            NativeOpExecutioner::execIndexReduce(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                 params, target.buffer(), target.shapeInfo(), target.specialBuffer(),
+                                                 target.specialShapeInfo(), pDims, copy.size(), packX.platformShapeInfo(),
+                                                 packX.platformOffsets());
+            synchronize("NDArray::applyIndexReduce");
+        }
 
-  registerSpecialUse({&target}, {this});
-}
+        registerSpecialUse({&target}, {this});
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // reduce dimensions in this array relying on index operations
-NDArray NDArray::applyIndexReduce(sd::indexreduce::Ops op, const std::vector<int> &dimensions,
-                                  const ExtraArguments *extraParams) const {
-  std::vector<int> copy = dimensions;
-  auto newShape =
-      ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataType::INT64, false, false, getContext()->getWorkspace());
-  NDArray result(newShape, true, getContext());
+    NDArray NDArray::applyIndexReduce(sd::indexreduce::Ops op, const std::vector<int> &dimensions,
+                                      const ExtraArguments *extraParams) const {
+        std::vector<int> copy = dimensions;
+        auto newShape =
+                ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataType::INT64, false, false, getContext()->getWorkspace());
+        NDArray result(newShape, true, getContext());
 
-  applyIndexReduce(op, result, copy, extraParams);
+        applyIndexReduce(op, result, copy, extraParams);
 
-  return result;
-}
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // apply reduce3 operations to this and other array, return result in new output array
-NDArray NDArray::applyReduce3(sd::reduce3::Ops op, const NDArray &other, const ExtraArguments *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::applyReduce3 method: you can't use this method on String array!");
-  if (dataType() != other.dataType())
-    throw std::runtime_error("NDArray::applyReduce3 method: the types of this and other arrays must be the same !");
-  // check shapes consistency
-  if (!isSameShape(other))
-    throw std::runtime_error("NDArray::applyReduce3 method: the shapes of this and other arrays must be the same !");
-  // create shapeInfo for scalar
-  auto newShape =
-      ShapeBuilders::createScalarShapeInfo(DataTypeUtils::pickFloatingType(dataType()), getContext()->getWorkspace());
-  // create output array (scalar)
-  NDArray result(newShape, true, getContext());
-  RELEASE(newShape, getContext()->getWorkspace());
-  // create dynamic array of extra parameters if array extraParams is empty (==nullptr)
-  void *params = extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(dataType()) : nullptr;
+    NDArray NDArray::applyReduce3(sd::reduce3::Ops op, const NDArray &other, const ExtraArguments *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::applyReduce3 method: you can't use this method on String array!");
+        if (dataType() != other.dataType())
+            throw std::runtime_error("NDArray::applyReduce3 method: the types of this and other arrays must be the same !");
+        // check shapes consistency
+        if (!isSameShape(other))
+            throw std::runtime_error("NDArray::applyReduce3 method: the shapes of this and other arrays must be the same !");
+        // create shapeInfo for scalar
+        auto newShape =
+                ShapeBuilders::createScalarShapeInfo(DataTypeUtils::pickFloatingType(dataType()), getContext()->getWorkspace());
+        // create output array (scalar)
+        NDArray result(newShape, true, getContext());
+        RELEASE(newShape, getContext()->getWorkspace());
+        // create dynamic array of extra parameters if array extraParams is empty (==nullptr)
+        void *params = extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(dataType()) : nullptr;
 
-  NDArray::prepareSpecialUse({&result}, {this, &other});
-  NativeOpExecutioner::execReduce3Scalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         params, other.buffer(), other.shapeInfo(), other.specialBuffer(),
-                                         other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                         result.specialBuffer(), result.specialShapeInfo());
-  NDArray::registerSpecialUse({&result}, {this, &other});
+        NDArray::prepareSpecialUse({&result}, {this, &other});
+        NativeOpExecutioner::execReduce3Scalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                               params, other.buffer(), other.shapeInfo(), other.specialBuffer(),
+                                               other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                               result.specialBuffer(), result.specialShapeInfo());
+        NDArray::registerSpecialUse({&result}, {this, &other});
 
-  return result;
-}
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // apply reduce3 (exec) operations to this and other array, return result in new output array
-NDArray NDArray::applyReduce3(sd::reduce3::Ops op, const NDArray &other, const std::vector<int> &dimensions,
-                              const ExtraArguments *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::applyReduce3: you can't use this method on String array!");
-  if (dataType() != other.dataType())
-    throw std::runtime_error("NDArray::applyReduce3 method: the types of this and other arrays must be the same !");
+    NDArray NDArray::applyReduce3(sd::reduce3::Ops op, const NDArray &other, const std::vector<int> &dimensions,
+                                  const ExtraArguments *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::applyReduce3: you can't use this method on String array!");
+        if (dataType() != other.dataType())
+            throw std::runtime_error("NDArray::applyReduce3 method: the types of this and other arrays must be the same !");
 
-  std::vector<int> copy(dimensions);
-  shape::checkDimensions(rankOf(), copy);
-  shape::checkDimensions(other.rankOf(), copy);
+        std::vector<int> copy(dimensions);
+        shape::checkDimensions(rankOf(), copy);
+        shape::checkDimensions(other.rankOf(), copy);
 
-  auto newShape = ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataTypeUtils::pickFloatingType(dataType()), false,
-                                                  false, getContext()->getWorkspace());
-  NDArray result(newShape, true, getContext());
-  // create temporary dynamic array of extra parameters if array extraParams is empty (==nullptr)
-  void *params = extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(dataType()) : nullptr;
+        auto newShape = ShapeUtils::evalReduceShapeInfo('c', copy, *this, DataTypeUtils::pickFloatingType(dataType()), false,
+                                                        false, getContext()->getWorkspace());
+        NDArray result(newShape, true, getContext());
+        // create temporary dynamic array of extra parameters if array extraParams is empty (==nullptr)
+        void *params = extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(dataType()) : nullptr;
 
-  NDArray::prepareSpecialUse({&result}, {this, &other});
+        NDArray::prepareSpecialUse({&result}, {this, &other});
 
-  // perform calculations
-  if (rankOf() == copy.size() && other.rankOf() == copy.size()) {
-    NativeOpExecutioner::execReduce3Scalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                           params, other.buffer(), other.shapeInfo(), other.specialBuffer(),
-                                           other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                           result.specialBuffer(), result.specialShapeInfo());
-  } else {
-    auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
+        // perform calculations
+        if (rankOf() == copy.size() && other.rankOf() == copy.size()) {
+            NativeOpExecutioner::execReduce3Scalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                   params, other.buffer(), other.shapeInfo(), other.specialBuffer(),
+                                                   other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                                   result.specialBuffer(), result.specialShapeInfo());
+        } else {
+            auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
 
-    auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), copy);
-    auto packY = sd::ConstantTadHelper::getInstance().tadForDimensions(other.shapeInfo(), copy);
+            auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), copy);
+            auto packY = sd::ConstantTadHelper::getInstance().tadForDimensions(other.shapeInfo(), copy);
 
-    if (!shape::equalsSoft(packX.primaryShapeInfo(), packY.primaryShapeInfo()) ||
-        (packX.numberOfTads() != packY.numberOfTads() && packX.numberOfTads() != 1 && packY.numberOfTads() != 1))
-      throw std::runtime_error("NDArray::applyReduce3 cuda method: arrays tads are inconsistent !");
+            if (!shape::equalsSoft(packX.primaryShapeInfo(), packY.primaryShapeInfo()) ||
+                (packX.numberOfTads() != packY.numberOfTads() && packX.numberOfTads() != 1 && packY.numberOfTads() != 1))
+                throw std::runtime_error("NDArray::applyReduce3 cuda method: arrays tads are inconsistent !");
 
-    NativeOpExecutioner::execReduce3(
-        getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), params, other.buffer(),
-        other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-        result.specialBuffer(), result.specialShapeInfo(), pDims, copy.size(), packX.platformShapeInfo(),
-        packX.platformOffsets(), packY.platformShapeInfo(), packY.platformOffsets());
-  }
+            NativeOpExecutioner::execReduce3(
+                    getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), params, other.buffer(),
+                    other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                    result.specialBuffer(), result.specialShapeInfo(), pDims, copy.size(), packX.platformShapeInfo(),
+                    packX.platformOffsets(), packY.platformShapeInfo(), packY.platformOffsets());
+        }
 
-  registerSpecialUse({&result}, {this, &other});
+        registerSpecialUse({&result}, {this, &other});
 
-  return result;
-}
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // apply reduce3 (execAll) operations to this and other array, return result in new output array
-NDArray NDArray::applyAllReduce3(sd::reduce3::Ops op, const NDArray &other, const std::vector<int> &dimensions,
-                                 const ExtraArguments *extraParams) const {
-  if (isS()) throw std::runtime_error("NDArray::applyAllReduce3: you can't use this method on String array!");
-  if (dataType() != other.dataType())
-    throw std::runtime_error("NDArray::applyAllReduce3 method: the types of this and other arrays must be the same !");
+    NDArray NDArray::applyAllReduce3(sd::reduce3::Ops op, const NDArray &other, const std::vector<int> &dimensions,
+                                     const ExtraArguments *extraParams) const {
+        if (isS()) throw std::runtime_error("NDArray::applyAllReduce3: you can't use this method on String array!");
+        if (dataType() != other.dataType())
+            throw std::runtime_error("NDArray::applyAllReduce3 method: the types of this and other arrays must be the same !");
 
-  // be careful, copy array may undergo changes (sort, transformation of negative dimensions to positive, duplicates
-  // removing )
-  std::vector<int> copy(dimensions);
-  shape::checkDimensions(rankOf(), copy);
-  shape::checkDimensions(other.rankOf(), copy);
+        // be careful, copy array may undergo changes (sort, transformation of negative dimensions to positive, duplicates
+        // removing )
+        std::vector<int> copy(dimensions);
+        shape::checkDimensions(rankOf(), copy);
+        shape::checkDimensions(other.rankOf(), copy);
 
-  auto packX = ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), copy);
-  auto packY = ConstantTadHelper::getInstance().tadForDimensions(other.shapeInfo(), copy);
+        auto packX = ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), copy);
+        auto packY = ConstantTadHelper::getInstance().tadForDimensions(other.shapeInfo(), copy);
 
-  // check tads shapes
-  if (!shape::equalsSoft(packX.primaryShapeInfo(), packY.primaryShapeInfo()))
-    throw std::runtime_error("NDArray::applyAllReduce3 method: the shapes of array tads are different !");
+        // check tads shapes
+        if (!shape::equalsSoft(packX.primaryShapeInfo(), packY.primaryShapeInfo()))
+            throw std::runtime_error("NDArray::applyAllReduce3 method: the shapes of array tads are different !");
 
-  // set newShape for output array
-  auto newShape = ConstantShapeHelper::getInstance().createShapeInfo(DataTypeUtils::pickFloatingType(dataType()), 'c',
-                                                                     {packX.numberOfTads(), packY.numberOfTads()});
+        // set newShape for output array
+        auto newShape = ConstantShapeHelper::getInstance().createShapeInfo(DataTypeUtils::pickFloatingType(dataType()), 'c',
+                                                                           {packX.numberOfTads(), packY.numberOfTads()});
 
-  // create output array
-  NDArray result(newShape, true, getContext());
+        // create output array
+        NDArray result(newShape, true, getContext());
 
-  // create dynamic array of extra parameters if array extraParams is empty (==nullptr)
-  void *params = extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(dataType()) : nullptr;
+        // create dynamic array of extra parameters if array extraParams is empty (==nullptr)
+        void *params = extraParams != nullptr ? const_cast<ExtraArguments *>(extraParams)->argumentsAsT(dataType()) : nullptr;
 
-  auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
+        auto pDims = sd::Environment::getInstance().isCPU() ? copy.data() : nullptr;
 
-  NDArray::prepareSpecialUse({&result}, {this, &other});
-  NativeOpExecutioner::execReduce3All(
-      getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), params, other.buffer(),
-      other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-      result.specialBuffer(), result.specialShapeInfo(), pDims, copy.size(), packX.platformShapeInfo(),
-      packX.platformOffsets(), packY.platformShapeInfo(), packY.platformOffsets());
-  NDArray::registerSpecialUse({&result}, {this, &other});
+        NDArray::prepareSpecialUse({&result}, {this, &other});
+        NativeOpExecutioner::execReduce3All(
+                getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(), params, other.buffer(),
+                other.shapeInfo(), other.specialBuffer(), other.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                result.specialBuffer(), result.specialShapeInfo(), pDims, copy.size(), packX.platformShapeInfo(),
+                packX.platformOffsets(), packY.platformShapeInfo(), packY.platformOffsets());
+        NDArray::registerSpecialUse({&result}, {this, &other});
 
-  return result;
-}
+        return result;
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // method reduces array by excluding its shapes along axes present in dimensions vector
-void NDArray::reduceAlongDimension(sd::reduce::FloatOps op, NDArray &target, const std::vector<int> &dimensions,
-                                   const bool keepDims, const bool checkTargetShape) const {
-  if (isS())
-    throw std::runtime_error("NDArray::reduceAlongDimension FloatOps: you can't use this method on String array!");
-  if (!target.isR())
-    throw std::invalid_argument(
-        "NDArray::reduceAlongDimension FloatOps: requires target array to be present and have type form real space!");
+    void NDArray::reduceAlongDimension(sd::reduce::FloatOps op, NDArray &target, const std::vector<int> &dimensions,
+                                       const bool keepDims, const bool checkTargetShape) const {
+        if (isS())
+            throw std::runtime_error("NDArray::reduceAlongDimension FloatOps: you can't use this method on String array!");
+        if (!target.isR())
+            throw std::invalid_argument(
+                    "NDArray::reduceAlongDimension FloatOps: requires target array to be present and have type form real space!");
 
-  std::vector<int> copy(dimensions);
+        std::vector<int> copy(dimensions);
 
-  if (checkTargetShape) {
-    auto newShape =
-        ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
-    if (!shape::shapeEquals(newShape, target.shapeInfo()))
-      throw std::runtime_error("NDArray::reduceAlongDimension FloatOps: wrong target shape!");
-  }
+        if (checkTargetShape) {
+            auto newShape =
+                    ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
+            if (!shape::shapeEquals(newShape, target.shapeInfo()))
+                throw std::runtime_error("NDArray::reduceAlongDimension FloatOps: wrong target shape!");
+        }
 
-  NDArray::prepareSpecialUse({&target}, {this});
+        NDArray::prepareSpecialUse({&target}, {this});
 
-  if (rankOf() == copy.size() || copy.empty()) {
-    NativeOpExecutioner::execReduceFloatScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                               specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
-                                               target.specialBuffer(), target.specialShapeInfo());
-  } else {
-    const sd::LongType *zShapeInfoH = target.shapeInfo();
-    const sd::LongType *zShapeInfoD = target.specialShapeInfo();
+        if (rankOf() == copy.size() || copy.empty()) {
+            NativeOpExecutioner::execReduceFloatScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                       specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
+                                                       target.specialBuffer(), target.specialShapeInfo());
+        } else {
+            const sd::LongType *zShapeInfoH = target.shapeInfo();
+            const sd::LongType *zShapeInfoD = target.specialShapeInfo();
 
-    if (rankOf() - dimensions.size() != target.rankOf()) {
-      auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
-          target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            if (rankOf() - dimensions.size() != target.rankOf()) {
+                auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
+                        target.shapeInfo(), copy, target.getContext()->getWorkspace());
+                zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+                zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            }
+
+            std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
+            NativeOpExecutioner::execReduceFloat(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                 nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
+                                                 dims.data(), dims.size());
+        }
+        synchronize("NDArray::reduceAlongDimension FloatOps");
+
+        NDArray::registerSpecialUse({&target}, {this});
     }
-
-    std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
-    NativeOpExecutioner::execReduceFloat(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                         nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
-                                         dims.data(), dims.size());
-  }
-  synchronize("NDArray::reduceAlongDimension FloatOps");
-
-  NDArray::registerSpecialUse({&target}, {this});
-}
 
 //////////////////////////////////////////////////////////////////////////
 // method reduces array by excluding its shapes along axes present in dimensions vector
-void NDArray::reduceAlongDimension(sd::reduce::SameOps op, NDArray &target, const std::vector<int> &dimensions,
-                                   const bool keepDims, const bool checkTargetShape) const {
-  if (isS())
-    throw std::runtime_error("NDArray::reduceAlongDimension SameOps: you can't use this method on String array!");
-  if (target.dataType() != dataType())
-    throw std::runtime_error(
-        "NDArray::reduceAlongDimension SameOps: requires target array to be present and have same dtype as input");
+    void NDArray::reduceAlongDimension(sd::reduce::SameOps op, NDArray &target, const std::vector<int> &dimensions,
+                                       const bool keepDims, const bool checkTargetShape) const {
+        if (isS())
+            throw std::runtime_error("NDArray::reduceAlongDimension SameOps: you can't use this method on String array!");
+        if (target.dataType() != dataType())
+            throw std::runtime_error(
+                    "NDArray::reduceAlongDimension SameOps: requires target array to be present and have same dtype as input");
 
-  std::vector<int> copy(dimensions);
+        std::vector<int> copy(dimensions);
 
-  if (checkTargetShape) {
-    auto newShape =
-        ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
-    if (!shape::shapeEquals(newShape, target.shapeInfo()))
-      throw std::runtime_error("NDArray::reduceAlongDimension SameOps: wrong target shape!");
-  }
+        if (checkTargetShape) {
+            auto newShape =
+                    ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
+            if (!shape::shapeEquals(newShape, target.shapeInfo()))
+                throw std::runtime_error("NDArray::reduceAlongDimension SameOps: wrong target shape!");
+        }
 
-  NDArray::prepareSpecialUse({&target}, {this});
+        NDArray::prepareSpecialUse({&target}, {this});
 
-  if (rankOf() == copy.size() || copy.empty()) {
-    NativeOpExecutioner::execReduceSameScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                              specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
-                                              target.specialBuffer(), target.specialShapeInfo());
-  } else {
-    const sd::LongType *zShapeInfoH = target.shapeInfo();
-    const sd::LongType *zShapeInfoD = target.specialShapeInfo();
+        if (rankOf() == copy.size() || copy.empty()) {
+            NativeOpExecutioner::execReduceSameScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                      specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
+                                                      target.specialBuffer(), target.specialShapeInfo());
+        } else {
+            const sd::LongType *zShapeInfoH = target.shapeInfo();
+            const sd::LongType *zShapeInfoD = target.specialShapeInfo();
 
-    if (rankOf() - dimensions.size() != target.rankOf()) {
-      auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
-          target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            if (rankOf() - dimensions.size() != target.rankOf()) {
+                auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
+                        target.shapeInfo(), copy, target.getContext()->getWorkspace());
+                zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+                zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            }
+
+            std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
+            NativeOpExecutioner::execReduceSame(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
+                                                dims.data(), dims.size());
+        }
+        synchronize("NDArray::reduceAlongDimension SameOps");
+
+        NDArray::registerSpecialUse({&target}, {this});
     }
-
-    std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
-    NativeOpExecutioner::execReduceSame(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                        nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
-                                        dims.data(), dims.size());
-  }
-  synchronize("NDArray::reduceAlongDimension SameOps");
-
-  NDArray::registerSpecialUse({&target}, {this});
-}
 
 //////////////////////////////////////////////////////////////////////////
 // method reduces array by excluding its shapes along axes present in dimensions vector
-void NDArray::reduceAlongDimension(sd::reduce::LongOps op, NDArray &target, const std::vector<int> &dimensions,
-                                   const bool keepDims, const bool checkTargetShape) const {
-  if (isS())
-    throw std::runtime_error("NDArray::reduceAlongDimension LongOps: you can't use this method on String array!");
-  if (target.dataType() != DataType::INT64)
-    throw std::runtime_error(
-        "NDArray::reduceAlongDimension LongOps: requires target array to be present and have type of INT64");
+    void NDArray::reduceAlongDimension(sd::reduce::LongOps op, NDArray &target, const std::vector<int> &dimensions,
+                                       const bool keepDims, const bool checkTargetShape) const {
+        if (isS())
+            throw std::runtime_error("NDArray::reduceAlongDimension LongOps: you can't use this method on String array!");
+        if (target.dataType() != DataType::INT64)
+            throw std::runtime_error(
+                    "NDArray::reduceAlongDimension LongOps: requires target array to be present and have type of INT64");
 
-  std::vector<int> copy(dimensions);
+        std::vector<int> copy(dimensions);
 
-  if (checkTargetShape) {
-    auto newShape =
-        ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
-    if (!shape::shapeEquals(newShape, target.shapeInfo()))
-      throw std::runtime_error("NDArray::reduceAlongDimension LongOps: wrong target shape!");
-  }
+        if (checkTargetShape) {
+            auto newShape =
+                    ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
+            if (!shape::shapeEquals(newShape, target.shapeInfo()))
+                throw std::runtime_error("NDArray::reduceAlongDimension LongOps: wrong target shape!");
+        }
 
-  NDArray::prepareSpecialUse({&target}, {this});
+        NDArray::prepareSpecialUse({&target}, {this});
 
-  if (rankOf() == copy.size() || copy.empty()) {
-    NativeOpExecutioner::execReduceLongScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                              specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
-                                              target.specialBuffer(), target.specialShapeInfo());
-  } else {
-    const sd::LongType *zShapeInfoH = target.shapeInfo();
-    const sd::LongType *zShapeInfoD = target.specialShapeInfo();
+        if (rankOf() == copy.size() || copy.empty()) {
+            NativeOpExecutioner::execReduceLongScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                      specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
+                                                      target.specialBuffer(), target.specialShapeInfo());
+        } else {
+            const sd::LongType *zShapeInfoH = target.shapeInfo();
+            const sd::LongType *zShapeInfoD = target.specialShapeInfo();
 
-    if (rankOf() - dimensions.size() != target.rankOf()) {
-      auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
-          target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            if (rankOf() - dimensions.size() != target.rankOf()) {
+                auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
+                        target.shapeInfo(), copy, target.getContext()->getWorkspace());
+                zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+                zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            }
+
+            std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
+            NativeOpExecutioner::execReduceLong(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
+                                                dims.data(), dims.size());
+        }
+        synchronize("NDArray::reduceAlongDimension LongOps");
+
+        NDArray::registerSpecialUse({&target}, {this});
     }
-
-    std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
-    NativeOpExecutioner::execReduceLong(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                        nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
-                                        dims.data(), dims.size());
-  }
-  synchronize("NDArray::reduceAlongDimension LongOps");
-
-  NDArray::registerSpecialUse({&target}, {this});
-}
 
 //////////////////////////////////////////////////////////////////////////
 // method reduces array by excluding its shapes along axes present in dimensions vector
-void NDArray::reduceAlongDimension(sd::reduce::BoolOps op, NDArray &target, const std::vector<int> &dimensions,
-                                   const bool keepDims, const bool checkTargetShape) const {
-  if (isS())
-    throw std::runtime_error("NDArray::reduceAlongDimension BoolOps cuda: you can't use this method on String array!");
-  if (!target.isB())
-    throw std::invalid_argument(
-        "NDArray::reduceAlongDimension BoolOps cuda: requires target array to be present and have BOOL type!");
+    void NDArray::reduceAlongDimension(sd::reduce::BoolOps op, NDArray &target, const std::vector<int> &dimensions,
+                                       const bool keepDims, const bool checkTargetShape) const {
+        if (isS())
+            throw std::runtime_error("NDArray::reduceAlongDimension BoolOps cuda: you can't use this method on String array!");
+        if (!target.isB())
+            throw std::invalid_argument(
+                    "NDArray::reduceAlongDimension BoolOps cuda: requires target array to be present and have BOOL type!");
 
-  std::vector<int> copy(dimensions);
+        std::vector<int> copy(dimensions);
 
-  if (checkTargetShape) {
-    auto newShape =
-        ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
-    if (!shape::shapeEquals(newShape, target.shapeInfo()))
-      throw std::runtime_error("NDArray::reduceAlongDimension BoolOps cuda: wrong target shape!");
-  }
+        if (checkTargetShape) {
+            auto newShape =
+                    ShapeUtils::evalReduceShapeInfo(target.ordering(), copy, *this, keepDims, false, getContext()->getWorkspace());
+            if (!shape::shapeEquals(newShape, target.shapeInfo()))
+                throw std::runtime_error("NDArray::reduceAlongDimension BoolOps cuda: wrong target shape!");
+        }
 
-  NDArray::prepareSpecialUse({&target}, {this});
+        NDArray::prepareSpecialUse({&target}, {this});
 
-  if (rankOf() == copy.size() || copy.empty()) {
-    NativeOpExecutioner::execReduceBoolScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
-                                              specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
-                                              target.specialBuffer(), target.specialShapeInfo());
-  } else {
-    const sd::LongType *zShapeInfoH = target.shapeInfo();
-    const sd::LongType *zShapeInfoD = target.specialShapeInfo();
+        if (rankOf() == copy.size() || copy.empty()) {
+            NativeOpExecutioner::execReduceBoolScalar(getContext(), op, buffer(), shapeInfo(), specialBuffer(),
+                                                      specialShapeInfo(), nullptr, target.buffer(), target.shapeInfo(),
+                                                      target.specialBuffer(), target.specialShapeInfo());
+        } else {
+            const sd::LongType *zShapeInfoH = target.shapeInfo();
+            const sd::LongType *zShapeInfoD = target.specialShapeInfo();
 
-    if (rankOf() - dimensions.size() != target.rankOf()) {
-      auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
-          target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            if (rankOf() - dimensions.size() != target.rankOf()) {
+                auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
+                        target.shapeInfo(), copy, target.getContext()->getWorkspace());
+                zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+                zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
+            }
+
+            std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
+            NativeOpExecutioner::execReduceBool(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
+                                                nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
+                                                dims.data(), dims.size());
+        }
+        synchronize("NDArray::reduceAlongDimension LongOps");
+
+        NDArray::registerSpecialUse({&target}, {this});
     }
-
-    std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
-    NativeOpExecutioner::execReduceBool(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
-                                        nullptr, target.buffer(), zShapeInfoH, target.specialBuffer(), zShapeInfoD,
-                                        dims.data(), dims.size());
-  }
-  synchronize("NDArray::reduceAlongDimension LongOps");
-
-  NDArray::registerSpecialUse({&target}, {this});
-}
 
 //////////////////////////////////////////////////////////////////////////
 // This method sets value in linear buffer to position i
-template <typename T>
-void NDArray::p(const sd::LongType i, const T value) {
-  if (i >= lengthOf()) throw std::invalid_argument("NDArray::p(i, value): input index is out of array length !");
+    template <typename T>
+    void NDArray::p(const sd::LongType i, const T value) {
+        if (i >= lengthOf()) throw std::invalid_argument("NDArray::p(i, value): input index is out of array length !");
 
-  auto rp = getOffset(i);
-  const void *pV = reinterpret_cast<const void *>(const_cast<T *>(&value));
+        auto rp = getOffset(i);
+        const void *pV = reinterpret_cast<const void *>(const_cast<T *>(&value));
 
-  NDArray::preparePrimaryUse({this}, {}, true);
-  BUILD_SINGLE_PARTIAL_SELECTOR(this->dataType(), templatedSet<, T>(this->buffer(), rp, pV), SD_COMMON_TYPES);
-  NDArray::registerPrimaryUse({this}, {});
-}
+        NDArray::preparePrimaryUse({this}, {}, true);
+        BUILD_SINGLE_PARTIAL_SELECTOR(this->dataType(), templatedSet<, T>(this->buffer(), rp, pV), SD_COMMON_TYPES);
+        NDArray::registerPrimaryUse({this}, {});
+    }
 
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const double value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const float value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const float16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const bfloat16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const int value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const int8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint32_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint64_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const int16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const bool value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const double value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const float value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const float16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const bfloat16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const int value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const int8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint32_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const uint64_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const int16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const bool value);
 
 //////////////////////////////////////////////////////////////////////////
 // This method sets value in 2D matrix to position i, j
-template <typename T>
-void NDArray::p(const sd::LongType i, const sd::LongType j, const T value) {
-  if (rankOf() != 2 || i >= shapeOf()[0] || j >= shapeOf()[1])
-    throw std::invalid_argument("NDArray:pe(i,j, value): one of input indexes is out of array length or rank!=2 !");
+    template <typename T>
+    void NDArray::p(const sd::LongType i, const sd::LongType j, const T value) {
+        if (rankOf() != 2 || i >= shapeOf()[0] || j >= shapeOf()[1])
+            throw std::invalid_argument("NDArray:pe(i,j, value): one of input indexes is out of array length or rank!=2 !");
 
-  void *p = reinterpret_cast<void *>(const_cast<T *>(&value));
-  auto xOffset = i * strideAt(0) + j * strideAt(1);
+        void *p = reinterpret_cast<void *>(const_cast<T *>(&value));
+        auto xOffset = i * strideAt(0) + j * strideAt(1);
 
-  NDArray::preparePrimaryUse({this}, {}, true);
-  BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
-  NDArray::registerPrimaryUse({this}, {});
-}
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const double value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const float value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const float16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const bfloat16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const int value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const int8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint32_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint64_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const int16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const bool value);
+        NDArray::preparePrimaryUse({this}, {}, true);
+        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
+        NDArray::registerPrimaryUse({this}, {});
+    }
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const double value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const float value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const float16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const bfloat16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const int value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const int8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint32_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const uint64_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const int16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const bool value);
 
 //////////////////////////////////////////////////////////////////////////
 // This method sets value in 3D matrix to position i,j,k
-template <typename T>
-void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k, const T value) {
-  //(*this)(i,j,k) = value;
-  if (rankOf() != 3 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2])
-    throw std::invalid_argument("NDArray:pe(i,j,k, value): one of input indexes is out of array length or rank!=3 !");
+    template <typename T>
+    void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k, const T value) {
+        //(*this)(i,j,k) = value;
+        if (rankOf() != 3 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2])
+            throw std::invalid_argument("NDArray:pe(i,j,k, value): one of input indexes is out of array length or rank!=3 !");
 
-  void *p = reinterpret_cast<void *>(const_cast<T *>(&value));
-  auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2);
+        void *p = reinterpret_cast<void *>(const_cast<T *>(&value));
+        auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2);
 
-  NDArray::preparePrimaryUse({this}, {}, true);
-  BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
-  NDArray::registerPrimaryUse({this}, {});
-}
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const double value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const float value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const float16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const bfloat16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const int value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const int8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const uint8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const uint16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const uint32_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const uint64_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const int16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const bool value);
+        NDArray::preparePrimaryUse({this}, {}, true);
+        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
+        NDArray::registerPrimaryUse({this}, {});
+    }
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const double value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const float value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const float16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const bfloat16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const int value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const int8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const uint8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const uint16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const uint32_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const uint64_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const int16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const bool value);
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k, const sd::LongType l, const T value) {
-  //(*this)(i,j,k) = value;
-  if (rankOf() != 4 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2] || l >= shapeOf()[3])
-    throw std::invalid_argument("NDArray::p(i,j,k,l, value): one of input indexes is out of array length or rank!=4 !");
+    template <typename T>
+    void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k, const sd::LongType l, const T value) {
+        //(*this)(i,j,k) = value;
+        if (rankOf() != 4 || i >= shapeOf()[0] || j >= shapeOf()[1] || k >= shapeOf()[2] || l >= shapeOf()[3])
+            throw std::invalid_argument("NDArray::p(i,j,k,l, value): one of input indexes is out of array length or rank!=4 !");
 
-  void *p = reinterpret_cast<void *>(const_cast<T *>(&value));
-  auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2) + l * strideAt(3);
+        void *p = reinterpret_cast<void *>(const_cast<T *>(&value));
+        auto xOffset = i * strideAt(0) + j * strideAt(1) + k * strideAt(2) + l * strideAt(3);
 
-  NDArray::preparePrimaryUse({this}, {}, true);
-  BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
-  NDArray::registerPrimaryUse({this}, {});
-}
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const double value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const float value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const float16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const bfloat16 value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const sd::LongType value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const int value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const int8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const uint8_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const uint16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const uint32_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const uint64_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const int16_t value);
-template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
-                                       const sd::LongType l, const bool value);
+        NDArray::preparePrimaryUse({this}, {}, true);
+        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
+        NDArray::registerPrimaryUse({this}, {});
+    }
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const double value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const float value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const float16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const bfloat16 value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const sd::LongType value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const int value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const int8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const uint8_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const uint16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const uint32_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const uint64_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const int16_t value);
+    template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k,
+                                           const sd::LongType l, const bool value);
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::p(const sd::LongType i, const NDArray &scalar) {
-  if (scalar.lengthOf() != 1) throw std::invalid_argument("NDArray::p method: input array must be scalar!");
-  if (i >= _length) throw std::invalid_argument("NDArray::p(i, NDArray_scalar): input index is out of array length !");
+    void NDArray::p(const sd::LongType i, const NDArray &scalar) {
+        if (scalar.lengthOf() != 1) throw std::invalid_argument("NDArray::p method: input array must be scalar!");
+        if (i >= _length) throw std::invalid_argument("NDArray::p(i, NDArray_scalar): input index is out of array length !");
 
-  NDArray::preparePrimaryUse({this}, {&scalar}, true);
-  auto rp = getOffset(i);
-  BUILD_SINGLE_SELECTOR(scalar.dataType(), templatedSet, (buffer(), rp, scalar.dataType(), scalar.buffer()),
-                        SD_COMMON_TYPES);
-  NDArray::registerPrimaryUse({this}, {&scalar});
-}
+        NDArray::preparePrimaryUse({this}, {&scalar}, true);
+        auto rp = getOffset(i);
+        BUILD_SINGLE_SELECTOR(scalar.dataType(), templatedSet, (buffer(), rp, scalar.dataType(), scalar.buffer()),
+                              SD_COMMON_TYPES);
+        NDArray::registerPrimaryUse({this}, {&scalar});
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k, const sd::LongType l,
-                const NDArray &scalar) {
-  if (scalar.lengthOf() != 1) throw std::invalid_argument("NDArray::p method: input array must be scalar!");
-  if (i >= _length) throw std::invalid_argument("NDArray::p(i, NDArray_scalar): input index is out of array length !");
+    void NDArray::p(const sd::LongType i, const sd::LongType j, const sd::LongType k, const sd::LongType l,
+                    const NDArray &scalar) {
+        if (scalar.lengthOf() != 1) throw std::invalid_argument("NDArray::p method: input array must be scalar!");
+        if (i >= _length) throw std::invalid_argument("NDArray::p(i, NDArray_scalar): input index is out of array length !");
 
-  //        void *p = reinterpret_cast<void *>(scalar.buffer());
-  sd::LongType coords[4] = {i, j, k, l};
-  auto xOffset = shape::getOffset(shapeInfo(), coords);
+        //        void *p = reinterpret_cast<void *>(scalar.buffer());
+        sd::LongType coords[4] = {i, j, k, l};
+        auto xOffset = shape::getOffset(shapeInfo(), coords);
 
-  NDArray::preparePrimaryUse({this}, {&scalar}, true);
-  //        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
-  BUILD_SINGLE_SELECTOR(scalar.dataType(), templatedSet, (this->buffer(), xOffset, scalar.dataType(), scalar.buffer()),
-                        SD_COMMON_TYPES);
-  NDArray::registerPrimaryUse({this}, {&scalar});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::addRowVector(const NDArray &row, NDArray &target) const {
-  if (isS()) throw std::runtime_error("NDArray::addRowVector: you can't use this method on String array!");
-  if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.lengthOf()) {
-    sd_printf("NDArray::addiRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
-    throw std::invalid_argument("NDArray::addRowVector: wrong arguments !");
-  }
-  if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()) &&
-      !(isR() && row.isR() && target.isR()))
-    throw std::invalid_argument("NDArray::addRowVector: wrong type of target array !");
-
-  int dimension = 1;
-
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
-
-  NDArray::prepareSpecialUse({&target}, {this, &row});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
-                                     row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
-                                     target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
-                                     packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &row});
-}
+        NDArray::preparePrimaryUse({this}, {&scalar}, true);
+        //        BUILD_SINGLE_PARTIAL_SELECTOR(dataType(), templatedSet<, T>(this->buffer(), xOffset, p), SD_COMMON_TYPES);
+        BUILD_SINGLE_SELECTOR(scalar.dataType(), templatedSet, (this->buffer(), xOffset, scalar.dataType(), scalar.buffer()),
+                              SD_COMMON_TYPES);
+        NDArray::registerPrimaryUse({this}, {&scalar});
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::subRowVector(const NDArray &row, NDArray &target) const {
-  if (isS()) throw std::runtime_error("NDArray::addRowVector: you can't use this method on String array!");
-  if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.lengthOf()) {
-    sd_printf("NDArray::addRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
-    throw std::invalid_argument("NDArray::addRowVector: wrong arguments !");
-  }
-  if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()) &&
-      !(isR() && row.isR() && target.isR()))
-    throw std::invalid_argument("NDArray::addRowVector: wrong type of target array !");
+    void NDArray::addRowVector(const NDArray &row, NDArray &target) const {
+        if (isS()) throw std::runtime_error("NDArray::addRowVector: you can't use this method on String array!");
+        if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
+            !row.isRowVector() || columns() != row.lengthOf()) {
+            sd_printf("NDArray::addiRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
+            throw std::invalid_argument("NDArray::addRowVector: wrong arguments !");
+        }
+        if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()) &&
+            !(isR() && row.isR() && target.isR()))
+            throw std::invalid_argument("NDArray::addRowVector: wrong type of target array !");
 
-  int dimension = 1;
+        int dimension = 1;
 
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
 
-  NDArray::prepareSpecialUse({&target}, {this, &row});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Subtract, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
-                                     row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
-                                     target.specialBuffer(), target.specialShapeInfo(), &dimension, 1,
-                                     packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &row});
-}
-
-//////////////////////////////////////////////////////////////////////////
-void NDArray::mulRowVector(const NDArray &row, NDArray &target) const {
-  if (isS()) throw std::runtime_error("NDArray::mulRowVector: you can't use this method on String array!");
-  if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.columns()) {
-    sd_printf("NDArray::mulRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
-    throw std::invalid_argument("NDArray::mulRowVector: wrong arguments !");
-  }
-  if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()))
-    throw std::invalid_argument("NDArray::mulRowVector: wrong type of target array !");
-
-  int dimension = 1;
-
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
-
-  NDArray::prepareSpecialUse({&target}, {this, &row});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Multiply, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
-                                     row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
-                                     target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
-                                     packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &row});
-}
+        NDArray::prepareSpecialUse({&target}, {this, &row});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
+                                           row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                                           target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
+                                           packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &row});
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::divRowVector(const NDArray &row, NDArray &target) const {
-  if (isS()) throw std::runtime_error("NDArray::divRowVector: you can't use this method on String array!");
-  if (row.isB()) throw std::runtime_error("NDArray::divRowVector: you can't divide by bool row!");
-  if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !row.isRowVector() || columns() != row.columns()) {
-    sd_printf("NDArray::divRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
-    throw std::invalid_argument("NDArray::divRowVector: wrong arguments !");
-  }
-  if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()))
-    throw std::invalid_argument("NDArray::divRowVector: wrong type of target array !");
+    void NDArray::subRowVector(const NDArray &row, NDArray &target) const {
+        if (isS()) throw std::runtime_error("NDArray::addRowVector: you can't use this method on String array!");
+        if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
+            !row.isRowVector() || columns() != row.lengthOf()) {
+            sd_printf("NDArray::addRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
+            throw std::invalid_argument("NDArray::addRowVector: wrong arguments !");
+        }
+        if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()) &&
+            !(isR() && row.isR() && target.isR()))
+            throw std::invalid_argument("NDArray::addRowVector: wrong type of target array !");
 
-  int dimension = 1;
+        int dimension = 1;
 
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
 
-  NDArray::prepareSpecialUse({&target}, {this, &row});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Divide, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
-                                     row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
-                                     target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
-                                     packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &row});
-}
+        NDArray::prepareSpecialUse({&target}, {this, &row});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Subtract, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
+                                           row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                                           target.specialBuffer(), target.specialShapeInfo(), &dimension, 1,
+                                           packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &row});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::mulRowVector(const NDArray &row, NDArray &target) const {
+        if (isS()) throw std::runtime_error("NDArray::mulRowVector: you can't use this method on String array!");
+        if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
+            !row.isRowVector() || columns() != row.columns()) {
+            sd_printf("NDArray::mulRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
+            throw std::invalid_argument("NDArray::mulRowVector: wrong arguments !");
+        }
+        if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()))
+            throw std::invalid_argument("NDArray::mulRowVector: wrong type of target array !");
+
+        int dimension = 1;
+
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+
+        NDArray::prepareSpecialUse({&target}, {this, &row});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Multiply, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
+                                           row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                                           target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
+                                           packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &row});
+    }
+
+//////////////////////////////////////////////////////////////////////////
+    void NDArray::divRowVector(const NDArray &row, NDArray &target) const {
+        if (isS()) throw std::runtime_error("NDArray::divRowVector: you can't use this method on String array!");
+        if (row.isB()) throw std::runtime_error("NDArray::divRowVector: you can't divide by bool row!");
+        if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
+            !row.isRowVector() || columns() != row.columns()) {
+            sd_printf("NDArray::divRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
+            throw std::invalid_argument("NDArray::divRowVector: wrong arguments !");
+        }
+        if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), row.dataType()))
+            throw std::invalid_argument("NDArray::divRowVector: wrong type of target array !");
+
+        int dimension = 1;
+
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+
+        NDArray::prepareSpecialUse({&target}, {this, &row});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Divide, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
+                                           row.specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                                           target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
+                                           packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &row});
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // This method adds given row to all rows in this NDArray, this array becomes affected
-void NDArray::addiRowVector(const NDArray &row) {
-  if (isS()) throw std::runtime_error("NDArray::addiRowVector: you can't use this method on String array!");
-  if (rankOf() != 2 || !row.isRowVector() || columns() != row.lengthOf()) {
-    sd_printf("NDArray::addiRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
-    throw std::invalid_argument("NDArray::addiRowVector: wrong arguments !");
-  }
-  int dimension = 1;
+    void NDArray::addiRowVector(const NDArray &row) {
+        if (isS()) throw std::runtime_error("NDArray::addiRowVector: you can't use this method on String array!");
+        if (rankOf() != 2 || !row.isRowVector() || columns() != row.lengthOf()) {
+            sd_printf("NDArray::addiRowVector Input rank %d, Row is row vector %d, Number of columns: %d Row length: %d\n",rankOf(),row.isRowVector(),columns(),row.lengthOf());
+            throw std::invalid_argument("NDArray::addiRowVector: wrong arguments !");
+        }
+        int dimension = 1;
 
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
 
-  NDArray::prepareSpecialUse({this}, {&row});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
-                                     row.specialShapeInfo(), this->buffer(), this->shapeInfo(), this->specialBuffer(),
-                                     this->specialShapeInfo(), nullptr, 1, packX.platformShapeInfo(),
-                                     packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({this}, {&row});
-}
+        NDArray::prepareSpecialUse({this}, {&row});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), row.buffer(), row.shapeInfo(), row.specialBuffer(),
+                                           row.specialShapeInfo(), this->buffer(), this->shapeInfo(), this->specialBuffer(),
+                                           this->specialShapeInfo(), nullptr, 1, packX.platformShapeInfo(),
+                                           packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({this}, {&row});
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::addColumnVector(const NDArray &column, NDArray &target) const {
-  if (isS()) throw std::runtime_error("NDArray::addColumnVector: you can't use this method on String array!");
-  if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
-      !column.isColumnVector() || rows() != column.lengthOf()) {
-    sd_printf("NDArray::addColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
-    throw std::invalid_argument("NDArray::addColumnVector: wrong arguments !");
-  }
-  if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), column.dataType()))
-    throw std::invalid_argument("NDArray::addColumnVector: wrong type of target array !");
+    void NDArray::addColumnVector(const NDArray &column, NDArray &target) const {
+        if (isS()) throw std::runtime_error("NDArray::addColumnVector: you can't use this method on String array!");
+        if (rankOf() != 2 || target.rankOf() != 2 || rows() != target.rows() || columns() != target.columns() ||
+            !column.isColumnVector() || rows() != column.lengthOf()) {
+            sd_printf("NDArray::addColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
+            throw std::invalid_argument("NDArray::addColumnVector: wrong arguments !");
+        }
+        if (target.dataType() != DataTypeUtils::pickPairwiseResultType(dataType(), column.dataType()))
+            throw std::invalid_argument("NDArray::addColumnVector: wrong type of target array !");
 
-  int dimension = 0;
+        int dimension = 0;
 
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
 
-  NDArray::prepareSpecialUse({&target}, {this, &column});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), column.buffer(), column.shapeInfo(), column.specialBuffer(),
-                                     column.specialShapeInfo(), target.buffer(), target.shapeInfo(),
-                                     target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
-                                     packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({&target}, {this, &column});
-}
+        NDArray::prepareSpecialUse({&target}, {this, &column});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), column.buffer(), column.shapeInfo(), column.specialBuffer(),
+                                           column.specialShapeInfo(), target.buffer(), target.shapeInfo(),
+                                           target.specialBuffer(), target.specialShapeInfo(), nullptr, 1,
+                                           packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({&target}, {this, &column});
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // This method adds given column to all columns in this NDArray, this array becomes affected
-void NDArray::addiColumnVector(const NDArray &column) {
-  if (isS()) throw std::runtime_error("NDArray::addiColumnVector: you can't use this method on String array!");
-  if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf()) {
-    sd_printf("NDArray::addiColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
-    throw std::invalid_argument("NDArray::addiColumnVector: wrong arguments !");
-  }
+    void NDArray::addiColumnVector(const NDArray &column) {
+        if (isS()) throw std::runtime_error("NDArray::addiColumnVector: you can't use this method on String array!");
+        if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf()) {
+            sd_printf("NDArray::addiColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
+            throw std::invalid_argument("NDArray::addiColumnVector: wrong arguments !");
+        }
 
-  int dimension = 0;
+        int dimension = 0;
 
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
 
-  NDArray::prepareSpecialUse({this}, {&column});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), column.buffer(), column.shapeInfo(), column.specialBuffer(),
-                                     column.specialShapeInfo(), this->buffer(), this->shapeInfo(),
-                                     this->specialBuffer(), this->specialShapeInfo(), nullptr, 1,
-                                     packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({this}, {&column});
-}
+        NDArray::prepareSpecialUse({this}, {&column});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Add, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), column.buffer(), column.shapeInfo(), column.specialBuffer(),
+                                           column.specialShapeInfo(), this->buffer(), this->shapeInfo(),
+                                           this->specialBuffer(), this->specialShapeInfo(), nullptr, 1,
+                                           packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({this}, {&column});
+    }
 
 //////////////////////////////////////////////////////////////////////////
 // This method multiplies each column of this array by given argument-column, this array becomes affected
-void NDArray::muliColumnVector(const NDArray &column) {
-  if (isS()) throw std::runtime_error("NDArray::muliColumnVector: you can't use this method on String array!");
-  if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf()) {
-    sd_printf("NDArray::muliColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
-    throw std::invalid_argument("NDArray::muliColumnVector: wrong arguments !");
-  }
-  int dimension = 0;
+    void NDArray::muliColumnVector(const NDArray &column) {
+        if (isS()) throw std::runtime_error("NDArray::muliColumnVector: you can't use this method on String array!");
+        if (rankOf() != 2 || !column.isColumnVector() || rows() != column.lengthOf()) {
+            sd_printf("NDArray::muliColumnVector Input rank %d, Vector is column vector %d, Number of columns: %d Row length: %d\n",rankOf(),column.isColumnVector(),rows(),column.lengthOf());
+            throw std::invalid_argument("NDArray::muliColumnVector: wrong arguments !");
+        }
+        int dimension = 0;
 
-  auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
+        auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(this->shapeInfo(), dimension);
 
-  NDArray::prepareSpecialUse({this}, {&column});
-  NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Multiply, buffer(), shapeInfo(), specialBuffer(),
-                                     specialShapeInfo(), column.buffer(), column.shapeInfo(), column.specialBuffer(),
-                                     column.specialShapeInfo(), this->buffer(), this->shapeInfo(),
-                                     this->specialBuffer(), this->specialShapeInfo(), nullptr, 1,
-                                     packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
-  NDArray::registerSpecialUse({this}, {&column});
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <typename T>
-void NDArray::templatedAssign(void *xBuffer, sd::LongType xOffset, const void *yBuffer,
-                              const sd::LongType yOffset) const {
-  if (xBuffer != nullptr && yBuffer != nullptr)
-    *(reinterpret_cast<T *>(xBuffer) + xOffset) = *(reinterpret_cast<const T *>(yBuffer) + yOffset);
-}
-BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedAssign,
-                      (void *xBuffer, const sd::LongType xOffset, const void *yBuffer, const sd::LongType yOffset)
-                          const,
-                      SD_COMMON_TYPES);
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::permutei(const int *dimensions, const int rank) {
-  auto shapeInfo = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, getContext()->getWorkspace());
-  setShapeInfo(shapeInfo);
-
-  return true;
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool NDArray::permutei(const sd::LongType *dimensions, const int rank) {
-  auto shapeInfo = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, getContext()->getWorkspace());
-  setShapeInfo(shapeInfo);
-
-  return true;
-}
-
-////////////////////////////////////////////////////////////////////////
-ResultSet NDArray::multipleTensorsAlongDimension(const std::vector<int> &indices,
-                                                 const std::vector<int> &dimensions) const {
-  ResultSet result;
-
-  if (indices.size() == 0) return result;
-
-  auto pack = ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), const_cast<int *>(dimensions.data()),
-                                                                dimensions.size());
-
-  auto tadLength = shape::length(pack.primaryShapeInfo());
-  auto numTads = lengthOf() / tadLength;
-
-  for (auto idx : indices) {
-    if (idx >= numTads) {
-      sd_printf("NDArray::multipleTensorsAlongDimension: index %i is higher then number of TADs: %i\n", idx, numTads);
-      throw std::runtime_error("Bad index");
+        NDArray::prepareSpecialUse({this}, {&column});
+        NativeOpExecutioner::execBroadcast(getContext(), sd::broadcast::Ops::Multiply, buffer(), shapeInfo(), specialBuffer(),
+                                           specialShapeInfo(), column.buffer(), column.shapeInfo(), column.specialBuffer(),
+                                           column.specialShapeInfo(), this->buffer(), this->shapeInfo(),
+                                           this->specialBuffer(), this->specialShapeInfo(), nullptr, 1,
+                                           packX.platformShapeInfo(), packX.platformOffsets(), nullptr, nullptr);
+        NDArray::registerSpecialUse({this}, {&column});
     }
 
-    auto newShapeInfoCast = const_cast<sd::LongType * const>(pack.primaryShapeInfo());
-    auto array = new NDArray(getDataBuffer(), newShapeInfoCast, getContext(),
-                             pack.primaryOffsets()[idx] + bufferOffset());
-    result.push_back(array);
-  }
+//////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void NDArray::templatedAssign(void *xBuffer, sd::LongType xOffset, const void *yBuffer,
+                                  const sd::LongType yOffset) const {
+        if (xBuffer != nullptr && yBuffer != nullptr)
+            *(reinterpret_cast<T *>(xBuffer) + xOffset) = *(reinterpret_cast<const T *>(yBuffer) + yOffset);
+    }
+    BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::templatedAssign,
+                          (void *xBuffer, const sd::LongType xOffset, const void *yBuffer, const sd::LongType yOffset)
+                                  const,
+                          SD_COMMON_TYPES);
 
-  return result;
-}
+//////////////////////////////////////////////////////////////////////////
+    bool NDArray::permutei(const int *dimensions, const int rank) {
+        auto shapeInfo = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, getContext()->getWorkspace());
+        setShapeInfo(shapeInfo);
 
-////////////////////////////////////////////////////////////////////////
-ResultSet NDArray::allTensorsAlongDimension(const std::initializer_list<int> &dimensions) const {
-  return allTensorsAlongDimension(std::vector<int>(dimensions));
-}
-
-////////////////////////////////////////////////////////////////////////
-ResultSet NDArray::allExamples() const {
-  std::vector<int> dimensions(rankOf() - 1);
-  for (int e = 1; e < rankOf(); e++) dimensions[e - 1] = e;
-
-  return allTensorsAlongDimension(dimensions);
-}
-
-////////////////////////////////////////////////////////////////////////
-sd::LongType NDArray::getOffset(const sd::LongType i) const {
-  if (i >= lengthOf()) {
-    sd_debug("NDArray::getOffset: input index %d array length %d\n", i, lengthOf());
-    throw std::invalid_argument("NDArray::getOffset: input index %d is out of array length %d!");
-  }
-
-  return shape::getIndexOffset(i, _shapeInfo);
-}
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::like() { return NDArray(shapeInfo(), this->dataType(), false, getContext()); }
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::ulike() const { return NDArray(this, false, getContext()); }
-
-////////////////////////////////////////////////////////////////////////
-NDArray NDArray::diagonal(const char type) const {
-  if (isS()) throw std::runtime_error("NDArray::diagonal: you can't use this method on String array!");
-
-  const char order = ordering();
-  const int rank = rankOf();
-  sd::LongType *outShapeInfo;
-  ALLOCATE(outShapeInfo, getContext()->getWorkspace(), 8, sd::LongType);
-  outShapeInfo[0] = 2;
-  outShapeInfo[5] = 0;
-
-  if (isVector() || isScalar()) {
-    outShapeInfo[1] = outShapeInfo[2] = outShapeInfo[3] = outShapeInfo[4] = 1;
-    outShapeInfo[6] = 1;
-    outShapeInfo[7] = (int)order;
-  } else {
-    int diagSize = 100000000;
-    sd::LongType indices[SD_MAX_RANK];
-
-    for (int i = 0; i < rank; ++i) {
-      if (diagSize > shapeOf()[i]) diagSize = shapeOf()[i];
-      indices[i] = 1;
+        return true;
     }
 
-    auto step = shape::getOffset(shapeInfo(), indices);
+//////////////////////////////////////////////////////////////////////////
+    bool NDArray::permutei(const sd::LongType *dimensions, const int rank) {
+        auto shapeInfo = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, getContext()->getWorkspace());
+        setShapeInfo(shapeInfo);
 
-    if (type == 'c') {
-      outShapeInfo[1] = diagSize;
-      outShapeInfo[2] = 1;
-    } else {
-      outShapeInfo[1] = 1;
-      outShapeInfo[2] = diagSize;
+        return true;
     }
-    shape::updateStrides(outShapeInfo, order);
-
-    outShapeInfo[3] *= step;
-    outShapeInfo[4] *= step;
-    outShapeInfo[6] = 0;
-  }
-
-  ArrayOptions::setDataType(outShapeInfo, this->dataType());
-  auto buff = ConstantShapeHelper::getInstance().bufferForShapeInfo(outShapeInfo);
-  NDArray result(_buffer, const_cast<sd::LongType  *>(buff->primary()), getContext(), bufferOffset());
-
-  RELEASE(outShapeInfo, getContext()->getWorkspace());
-
-  return result;
-}
 
 ////////////////////////////////////////////////////////////////////////
-ResultSet NDArray::allTensorsAlongDimension(const std::vector<int> &dimensions) const {
-  ResultSet result;
-  if (dimensions.size() == 0) {
-    return result;
-  }
-  if (dimensions.back() == rankOf() || isScalar() && dimensions.size() == 1 && dimensions[0] == 0) {
-    auto newShapeInfoCast = const_cast<sd::LongType * const>(this->shapeInfo());
-    auto array = new NDArray(_buffer, newShapeInfoCast, getContext(), bufferOffset());
-    array->_isView = true;
-    result.push_back(array);
-    sd_debug("NDArray::allTensorsAlongDimension: Dimensions were equal %d with this rank of %d\n", dimensions.back(),
-             rankOf());
-    return result;
-  }
+    ResultSet NDArray::multipleTensorsAlongDimension(const std::vector<int> &indices,
+                                                     const std::vector<int> &dimensions) const {
+        ResultSet result;
 
-  if (dimensions.back() >= rankOf()) {
-    sd_debug("Dimensions failure %d and rank %d\n", dimensions.back(), rankOf());
-    throw std::runtime_error(
-        "NDArray::allTensorsAlongDimension static function: all input dimensions must be smaller than rank of input "
-        "array !");
-  }
+        if (indices.size() == 0) return result;
 
-  auto pack = ConstantTadHelper::getInstance().tadForDimensions(_shapeInfo, const_cast<int *>(dimensions.data()),
-                                                                dimensions.size());
-  auto numTads = pack.numberOfTads();
-  auto newShapeInfoCast = const_cast<sd::LongType *>(pack.primaryShapeInfo());
+        auto pack = ConstantTadHelper::getInstance().tadForDimensions(shapeInfo(), const_cast<int *>(dimensions.data()),
+                                                                      dimensions.size());
 
-  for (sd::LongType idx = 0; idx < numTads; idx++) {
-    auto array = new NDArray(_buffer, newShapeInfoCast, getContext(),
-                             pack.primaryOffsets()[idx] + bufferOffset());
-    array->_isView = true;
-    result.push_back(array);
-  }
+        auto tadLength = shape::length(pack.primaryShapeInfo());
+        auto numTads = lengthOf() / tadLength;
 
-  return result;
-}
+        for (auto idx : indices) {
+            if (idx >= numTads) {
+                sd_printf("NDArray::multipleTensorsAlongDimension: index %i is higher then number of TADs: %i\n", idx, numTads);
+                throw std::runtime_error("Bad index");
+            }
+
+            auto newShapeInfoCast = const_cast<sd::LongType * const>(pack.primaryShapeInfo());
+            auto array = new NDArray(getDataBuffer(), newShapeInfoCast, getContext(),
+                                     pack.primaryOffsets()[idx] + bufferOffset());
+            result.push_back(array);
+        }
+
+        return result;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    ResultSet NDArray::allTensorsAlongDimension(const std::initializer_list<int> &dimensions) const {
+        return allTensorsAlongDimension(std::vector<int>(dimensions));
+    }
+
+////////////////////////////////////////////////////////////////////////
+    ResultSet NDArray::allExamples() const {
+        std::vector<int> dimensions(rankOf() - 1);
+        for (int e = 1; e < rankOf(); e++) dimensions[e - 1] = e;
+
+        return allTensorsAlongDimension(dimensions);
+    }
+
+////////////////////////////////////////////////////////////////////////
+    sd::LongType NDArray::getOffset(const sd::LongType i) const {
+        if (i >= lengthOf()) {
+            sd_debug("NDArray::getOffset: input index %d array length %d\n", i, lengthOf());
+            throw std::invalid_argument("NDArray::getOffset: input index %d is out of array length %d!");
+        }
+
+        return shape::getIndexOffset(i, _shapeInfo);
+    }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::like() { return NDArray(shapeInfo(), this->dataType(), false, getContext()); }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::ulike() const { return NDArray(this, false, getContext()); }
+
+////////////////////////////////////////////////////////////////////////
+    NDArray NDArray::diagonal(const char type) const {
+        if (isS()) throw std::runtime_error("NDArray::diagonal: you can't use this method on String array!");
+
+        const char order = ordering();
+        const int rank = rankOf();
+        sd::LongType *outShapeInfo;
+        ALLOCATE(outShapeInfo, getContext()->getWorkspace(), 8, sd::LongType);
+        outShapeInfo[0] = 2;
+        outShapeInfo[5] = 0;
+
+        if (isVector() || isScalar()) {
+            outShapeInfo[1] = outShapeInfo[2] = outShapeInfo[3] = outShapeInfo[4] = 1;
+            outShapeInfo[6] = 1;
+            outShapeInfo[7] = (int)order;
+        } else {
+            int diagSize = 100000000;
+            sd::LongType indices[SD_MAX_RANK];
+
+            for (int i = 0; i < rank; ++i) {
+                if (diagSize > shapeOf()[i]) diagSize = shapeOf()[i];
+                indices[i] = 1;
+            }
+
+            auto step = shape::getOffset(shapeInfo(), indices);
+
+            if (type == 'c') {
+                outShapeInfo[1] = diagSize;
+                outShapeInfo[2] = 1;
+            } else {
+                outShapeInfo[1] = 1;
+                outShapeInfo[2] = diagSize;
+            }
+            shape::updateStrides(outShapeInfo, order);
+
+            outShapeInfo[3] *= step;
+            outShapeInfo[4] *= step;
+            outShapeInfo[6] = 0;
+        }
+
+        ArrayOptions::setDataType(outShapeInfo, this->dataType());
+        auto buff = ConstantShapeHelper::getInstance().bufferForShapeInfo(outShapeInfo);
+        NDArray result(_buffer, const_cast<sd::LongType  *>(buff->primary()), getContext(), bufferOffset());
+
+        RELEASE(outShapeInfo, getContext()->getWorkspace());
+
+        return result;
+    }
+
+////////////////////////////////////////////////////////////////////////
+    ResultSet NDArray::allTensorsAlongDimension(const std::vector<int> &dimensions) const {
+        ResultSet result;
+        if (dimensions.size() == 0) {
+            return result;
+        }
+        if (dimensions.back() == rankOf() || isScalar() && dimensions.size() == 1 && dimensions[0] == 0) {
+            auto newShapeInfoCast = const_cast<sd::LongType * const>(this->shapeInfo());
+            auto array = new NDArray(_buffer, newShapeInfoCast, getContext(), bufferOffset());
+            array->_isView = true;
+            result.push_back(array);
+            sd_debug("NDArray::allTensorsAlongDimension: Dimensions were equal %d with this rank of %d\n", dimensions.back(),
+                     rankOf());
+            return result;
+        }
+
+        if (dimensions.back() >= rankOf()) {
+            sd_debug("Dimensions failure %d and rank %d\n", dimensions.back(), rankOf());
+            throw std::runtime_error(
+                    "NDArray::allTensorsAlongDimension static function: all input dimensions must be smaller than rank of input "
+                    "array !");
+        }
+
+        auto pack = ConstantTadHelper::getInstance().tadForDimensions(_shapeInfo, const_cast<int *>(dimensions.data()),
+                                                                      dimensions.size());
+        auto numTads = pack.numberOfTads();
+        auto newShapeInfoCast = const_cast<sd::LongType *>(pack.primaryShapeInfo());
+
+        for (sd::LongType idx = 0; idx < numTads; idx++) {
+            auto array = new NDArray(_buffer, newShapeInfoCast, getContext(),
+                                     pack.primaryOffsets()[idx] + bufferOffset());
+            array->_isView = true;
+            result.push_back(array);
+        }
+
+        return result;
+    }
 
 ////////////////////////////////////////////////////////////////////////
 // operator returns sub-array with buffer pointing at this->_buffer + certain offset
-NDArray NDArray::operator()(const std::vector<sd::LongType> &idx, const bool keepUnitiesInShape,
-                            const bool isStrided) const {
-  if (isEmpty()) throw std::invalid_argument("NDArray::operator(sub-arrays): array is empty !");
+    NDArray NDArray::operator()(const std::vector<sd::LongType> &idx, const bool keepUnitiesInShape,
+                                const bool isStrided) const {
+        if (isEmpty()) throw std::invalid_argument("NDArray::operator(sub-arrays): array is empty !");
 
 
-  int numOfUntiesInSubArrShape = 0;
+        int numOfUntiesInSubArrShape = 0;
 
-  sd::LongType *subArrShapeInfo = nullptr;
+        sd::LongType *subArrShapeInfo = nullptr;
 
-  if (!keepUnitiesInShape) {
-    int n(isStrided ? 3 : 2), first, last;
+        if (!keepUnitiesInShape) {
+            int n(isStrided ? 3 : 2), first, last;
 
-    // calculate the number of unities in shape
-    for (sd::Unsigned d = 0; d < rankOf(); ++d) {
-      if (idx[n * d] != idx[n * d + 1]) {
-        first = idx[n * d] >= 0 ? idx[n * d] : idx[n * d] + sizeAt(d) + 1;
-        last = idx[n * d + 1] >= 0 ? idx[n * d + 1] : idx[n * d + 1] + sizeAt(d) + 1;
-        if (last - first == 1) ++numOfUntiesInSubArrShape;
-      }
+            // calculate the number of unities in shape
+            for (sd::Unsigned d = 0; d < rankOf(); ++d) {
+                if (idx[n * d] != idx[n * d + 1]) {
+                    first = idx[n * d] >= 0 ? idx[n * d] : idx[n * d] + sizeAt(d) + 1;
+                    last = idx[n * d + 1] >= 0 ? idx[n * d + 1] : idx[n * d + 1] + sizeAt(d) + 1;
+                    if (last - first == 1) ++numOfUntiesInSubArrShape;
+                }
+            }
+        }
+
+        ALLOCATE(subArrShapeInfo, getContext()->getWorkspace(), shape::shapeInfoLength(rankOf() - numOfUntiesInSubArrShape),
+                 sd::LongType);
+
+        sd::LongType offset;
+
+        shape::calcSubArrShapeInfoAndOffset(idx.data(), shapeInfo(), subArrShapeInfo, offset, keepUnitiesInShape, isStrided,
+                                            numOfUntiesInSubArrShape);
+
+        NDArray result(_buffer, subArrShapeInfo, getContext(), offset + bufferOffset());
+        result._isView = true;
+
+        RELEASE(subArrShapeInfo, getContext()->getWorkspace());
+
+        return result;
     }
-  }
-
-  ALLOCATE(subArrShapeInfo, getContext()->getWorkspace(), shape::shapeInfoLength(rankOf() - numOfUntiesInSubArrShape),
-           sd::LongType);
-
-  sd::LongType offset;
-  sd_printf("() operator: About to Calculated sub arr shape info and offset\n",0);
-
-  shape::calcSubArrShapeInfoAndOffset(idx.data(), shapeInfo(), subArrShapeInfo, offset, keepUnitiesInShape, isStrided,
-                                      numOfUntiesInSubArrShape);
-
-  sd_printf("() operator: Calculated sub arr shape info and offset\n",0);
-  NDArray result(_buffer, subArrShapeInfo, getContext(), offset + bufferOffset());
-  result._isView = true;
-  sd_printf("() operator: Created result\n",0);
-
-  RELEASE(subArrShapeInfo, getContext()->getWorkspace());
-
-  return result;
-}
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArray::operator()(const sd::LongType subArrIdx, const std::vector<int> &dimsToExclude,
-                            bool keepUnitiesInShape) const {
-  std::vector<sd::LongType> idxRanges(2 * rankOf());
+    NDArray NDArray::operator()(const sd::LongType subArrIdx, const std::vector<int> &dimsToExclude,
+                                bool keepUnitiesInShape) const {
+        std::vector<sd::LongType> idxRanges(2 * rankOf());
 
-  const auto rank = rankOf();
-  const auto subArrRank = static_cast<int>(dimsToExclude.size());
+        const auto rank = rankOf();
+        const auto subArrRank = static_cast<int>(dimsToExclude.size());
 
-  if (subArrRank > rank)
-    throw std::invalid_argument(
-        "NDArray::operator(const sd::LongType subArrIdx, const std::vector<int>& dimsToExclude, bool "
-        "keepUnitiesInShape): static method: dimsToExclude is empty or has size > rank of array !");
+        if (subArrRank > rank)
+            throw std::invalid_argument(
+                    "NDArray::operator(const sd::LongType subArrIdx, const std::vector<int>& dimsToExclude, bool "
+                    "keepUnitiesInShape): static method: dimsToExclude is empty or has size > rank of array !");
 
-  memset(idxRanges.data(), 0, 2 * rank * sizeof(sd::LongType));
+        memset(idxRanges.data(), 0, 2 * rank * sizeof(sd::LongType));
 
-  // subArrRank == 0 means whole array, idxRanges should contain zeros only
+        // subArrRank == 0 means whole array, idxRanges should contain zeros only
 
-  if (subArrRank != 0) {
-    std::vector<sd::LongType> shapeOfSubArr(subArrRank), indexes(subArrRank);
-    for (int i = 0; i < subArrRank; ++i) shapeOfSubArr[i] = sizeAt(dimsToExclude[i]);
+        if (subArrRank != 0) {
+            std::vector<sd::LongType> shapeOfSubArr(subArrRank), indexes(subArrRank);
+            for (int i = 0; i < subArrRank; ++i) shapeOfSubArr[i] = sizeAt(dimsToExclude[i]);
 
-    shape::index2coords(subArrIdx, subArrRank, shapeOfSubArr.data(), indexes.data());
+            shape::index2coords(subArrIdx, subArrRank, shapeOfSubArr.data(), indexes.data());
 
-    for (int i = 0; i < subArrRank; ++i) {
-      int currIdx = 2 * dimsToExclude[i];
-      idxRanges[currIdx] = indexes[i];
-      idxRanges[currIdx + 1] = indexes[i] + 1;
+            for (int i = 0; i < subArrRank; ++i) {
+                int currIdx = 2 * dimsToExclude[i];
+                idxRanges[currIdx] = indexes[i];
+                idxRanges[currIdx + 1] = indexes[i] + 1;
+            }
+        }
+
+        return (*this)(idxRanges, keepUnitiesInShape);
     }
-  }
-
-  return (*this)(idxRanges, keepUnitiesInShape);
-}
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::getSubArrShapeAndOffsets(const std::vector<int> &dimsToExclude, sd::LongType *&subArrShapeInfo,
-                                       sd::LongType *&subArrOffsets, bool keepUnitiesInShape) const {
-  if (isEmpty()) throw std::invalid_argument("NDArray::getSubArrShapeAndOffsets: array is empty !");
+    void NDArray::getSubArrShapeAndOffsets(const std::vector<int> &dimsToExclude, sd::LongType *&subArrShapeInfo,
+                                           sd::LongType *&subArrOffsets, bool keepUnitiesInShape) const {
+        if (isEmpty()) throw std::invalid_argument("NDArray::getSubArrShapeAndOffsets: array is empty !");
 
-  const int rank = rankOf();
-  const int subArrRank = (rank == dimsToExclude.size() || keepUnitiesInShape) ? rank : rank - dimsToExclude.size();
-  const sd::LongType numOfSubArrs = ShapeUtils::getNumOfSubArrs(_shapeInfo, dimsToExclude);
+        const int rank = rankOf();
+        const int subArrRank = (rank == dimsToExclude.size() || keepUnitiesInShape) ? rank : rank - dimsToExclude.size();
+        const sd::LongType numOfSubArrs = ShapeUtils::getNumOfSubArrs(_shapeInfo, dimsToExclude);
 
-  // allocate memory
-  ALLOCATE(subArrShapeInfo, getContext()->getWorkspace(), shape::shapeInfoLength(subArrRank), sd::LongType);
-  ALLOCATE(subArrOffsets, getContext()->getWorkspace(), numOfSubArrs, sd::LongType);
+        // allocate memory
+        ALLOCATE(subArrShapeInfo, getContext()->getWorkspace(), shape::shapeInfoLength(subArrRank), sd::LongType);
+        ALLOCATE(subArrOffsets, getContext()->getWorkspace(), numOfSubArrs, sd::LongType);
 
-  shape::calcSubArrsShapeInfoAndOffsets(_shapeInfo, numOfSubArrs, dimsToExclude.size(), dimsToExclude.data(),
-                                        subArrShapeInfo, subArrOffsets, keepUnitiesInShape);
-}
+        shape::calcSubArrsShapeInfoAndOffsets(_shapeInfo, numOfSubArrs, dimsToExclude.size(), dimsToExclude.data(),
+                                              subArrShapeInfo, subArrOffsets, keepUnitiesInShape);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::setShapeInfo(const sd::LongType *shapeInfo) {
-  if (shapeInfo != nullptr) {
-    sd_printf("Setting shape info from shapeinfo 2\n",0);
-    ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfo);
-    auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor);
+    void NDArray::setShapeInfo(const sd::LongType *shapeInfo) {
+        if (shapeInfo != nullptr) {
+            ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfo);
+            auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor);
 
-    _shapeInfo = shapeBuffer->primary();
+            _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-    _shapeInfoD = shapeBuffer.special();
+            _shapeInfoD = shapeBuffer.special();
 #endif
 
-    if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
-      _length = 0;
-    else
-      _length = shape::length(_shapeInfo);
+            if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
+                _length = 0;
+            else
+                _length = shape::length(_shapeInfo);
 
-    _dataType = ArrayOptions::dataType(_shapeInfo);
-  } else {
-    _dataType = sd::DataType::INHERIT;
-    _shapeInfoD = _shapeInfo = nullptr;
-  }
-}
+            _dataType = ArrayOptions::dataType(_shapeInfo);
+        } else {
+            _dataType = sd::DataType::INHERIT;
+            _shapeInfoD = _shapeInfo = nullptr;
+        }
+    }
 
 ////////////////////////////////////////////////////////////////////////
-void NDArray::setShapeInfo(const sd::LongType *shapeInfo, const sd::DataType dtype) {
-  sd_printf("Called set shape info from shape info buffer + data type\n",0);
-  if (shapeInfo != nullptr) {
-    sd_printf("NDrray: Setting shape info from shape info buffer\n",0);
-    sd::LongType *shapeInfoTemp =
-        ShapeBuilders::copyShapeInfoAndType(shapeInfo, dtype, true, getContext()->getWorkspace());
-    ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfoTemp);
-    auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor);
+    void NDArray::setShapeInfo(const sd::LongType *shapeInfo, const sd::DataType dtype) {
+        if (shapeInfo != nullptr) {
+            sd::LongType *shapeInfoTemp =
+                    ShapeBuilders::copyShapeInfoAndType(shapeInfo, dtype, true, getContext()->getWorkspace());
+            ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfoTemp);
+            auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor);
 
-    _shapeInfo = shapeBuffer->primary();
+            _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-    _shapeInfoD = shapeBuffer.special();
+            _shapeInfoD = shapeBuffer.special();
 #endif
 
-    if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
-      _length = 0;
-    else
-      _length = shape::length(_shapeInfo);
+            if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
+                _length = 0;
+            else
+                _length = shape::length(_shapeInfo);
 
-    _dataType = dtype;
-  } else {
-    _dataType = sd::DataType::INHERIT;
-    _shapeInfoD = _shapeInfo = nullptr;
-  }
-}
+            _dataType = dtype;
+        } else {
+            _dataType = sd::DataType::INHERIT;
+            _shapeInfoD = _shapeInfo = nullptr;
+        }
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::setShapeInfo(ShapeDescriptor *descriptor) {
-  sd_printf("Before set shape info descriptor call null check\n",0);
-  if(descriptor == nullptr) {
-    throw std::runtime_error("NDArray:setShapeInfo Passed in descriptor can't be null!");
-  }
+    void NDArray::setShapeInfo(ShapeDescriptor *descriptor) {
+        if(descriptor == nullptr) {
+            throw std::runtime_error("NDArray:setShapeInfo Passed in descriptor can't be null!");
+        }
 
-  sd_printf("Before printing shape descriptor information\n",0);
-  sd_printf("Before obtaining constant shape info for descriptor\n",0);
-
-  auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(const_cast<ShapeDescriptor *>(descriptor));
-  sd_printf("After obtaining constant shape info for descriptor\n",0);
-  _shapeInfo = shapeBuffer->primary();
+        auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(const_cast<ShapeDescriptor *>(descriptor));
+        _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-  _shapeInfoD = shapeBuffer.special();
+        _shapeInfoD = shapeBuffer.special();
 #endif
 
-  if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
-    _length = 0;
-  else
-    _length = shape::length(_shapeInfo);
+        if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
+            _length = 0;
+        else
+            _length = shape::length(_shapeInfo);
 
-  _dataType = ArrayOptions::dataType(_shapeInfo);
-}
+        _dataType = ArrayOptions::dataType(_shapeInfo);
+    }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::setShapeInfo(const ConstantShapeBuffer *shapeBuffer) {
-  _shapeInfo = shapeBuffer->primary();
+    void NDArray::setShapeInfo(const ConstantShapeBuffer *shapeBuffer) {
+        _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-  _shapeInfoD = shapeBuffer->special();
+        _shapeInfoD = shapeBuffer->special();
 #endif
 
-  if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
-    _length = 0;
-  else
-    _length = shape::length(_shapeInfo);
+        if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)
+            _length = 0;
+        else
+            _length = shape::length(_shapeInfo);
 
-  _dataType = ArrayOptions::dataType(_shapeInfo);
-}
+        _dataType = ArrayOptions::dataType(_shapeInfo);
+    }
 
 ///////////////////////////////////////////////////////////////////////
 // addition operator array + scalar
-template <typename T, typename>
-NDArray operator+(NDArray &&arr, const T &scalar) {
-  if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
-    return std::move(arr + scalar);  // arr is lvalue inside function body
+    template <typename T, typename>
+    NDArray operator+(NDArray &&arr, const T &scalar) {
+        if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
+            return std::move(arr + scalar);  // arr is lvalue inside function body
 
-  if (arr.isS())
-    throw std::runtime_error("operator+(NDArray&& arr, const T& scalar): you can't use this method on String array!");
-  if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
-    throw std::runtime_error("operator+(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.isS())
+            throw std::runtime_error("operator+(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
+            throw std::runtime_error("operator+(NDArray&& arr, const T& scalar): you can't use this method on String array!");
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
 
-  NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Add, arr.buffer(), arr.shapeInfo(), arr.specialBuffer(),
-                                  arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(), arr.specialBuffer(),
-                                  arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(),
-                                  tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
+        NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Add, arr.buffer(), arr.shapeInfo(), arr.specialBuffer(),
+                                        arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(), arr.specialBuffer(),
+                                        arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(),
+                                        tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
 
-  return std::move(arr);
-}
-template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const float &scalar);
-template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const float16 &scalar);
-template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const bfloat16 &scalar);
-template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const int &scalar);
-
-////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator+(const NDArray &arr, const T &scalar) {
-  if (arr.isS())
-    throw std::runtime_error(
-        "operator+(const NDArray& arr, const T& scalar): you can't use this method on String array!");
-
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
-  NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
-                 false, arr.getContext());
-
-  NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Add, arr.buffer(), arr.shapeInfo(), arr.specialBuffer(),
-                                  arr.specialShapeInfo(), result.buffer(), result.shapeInfo(), result.specialBuffer(),
-                                  result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(),
-                                  tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&result}, {&arr, &tmp});
-
-  return result;
-}
-template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const float &scalar);
-template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const float16 &scalar);
-template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const bfloat16 &scalar);
-template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const int &scalar);
+        return std::move(arr);
+    }
+    template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const float &scalar);
+    template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const float16 &scalar);
+    template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const bfloat16 &scalar);
+    template SD_LIB_EXPORT NDArray operator+(NDArray &&arr, const int &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator+(const T &scalar, NDArray &&arr) {
-  return std::move(arr) + scalar;
-}
-template SD_LIB_EXPORT NDArray operator+(const double &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator+(const float &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator+(const float16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator+(const bfloat16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator+(const int &scalar, NDArray &&arr);
+    template <typename T, typename>
+    NDArray operator+(const NDArray &arr, const T &scalar) {
+        if (arr.isS())
+            throw std::runtime_error(
+                    "operator+(const NDArray& arr, const T& scalar): you can't use this method on String array!");
+
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
+                       false, arr.getContext());
+
+        NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Add, arr.buffer(), arr.shapeInfo(), arr.specialBuffer(),
+                                        arr.specialShapeInfo(), result.buffer(), result.shapeInfo(), result.specialBuffer(),
+                                        result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(), tmp.specialBuffer(),
+                                        tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&result}, {&arr, &tmp});
+
+        return result;
+    }
+    template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const float &scalar);
+    template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const float16 &scalar);
+    template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const bfloat16 &scalar);
+    template SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const int &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator+(const T &scalar, const NDArray &arr) {
-  return arr + scalar;
-}
-template SD_LIB_EXPORT NDArray operator+(const double &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator+(const float &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator+(const int &scalar, const NDArray &arr);
+    template <typename T, typename>
+    NDArray operator+(const T &scalar, NDArray &&arr) {
+        return std::move(arr) + scalar;
+    }
+    template SD_LIB_EXPORT NDArray operator+(const double &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator+(const float &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator+(const float16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator+(const bfloat16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator+(const int &scalar, NDArray &&arr);
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T, typename>
+    NDArray operator+(const T &scalar, const NDArray &arr) {
+        return arr + scalar;
+    }
+    template SD_LIB_EXPORT NDArray operator+(const double &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator+(const float &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator+(const int &scalar, const NDArray &arr);
 
 ///////////////////////////////////////////////////////////////////////
 // addition operator array - scalar
-template <typename T, typename>
-NDArray operator-(NDArray &&arr, const T &scalar) {
-  if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
-    return std::move(arr - scalar);  // arr is lvalue inside function body
+    template <typename T, typename>
+    NDArray operator-(NDArray &&arr, const T &scalar) {
+        if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
+            return std::move(arr - scalar);  // arr is lvalue inside function body
 
-  if (arr.isS())
-    throw std::runtime_error("operator-(NDArray&& arr, const T& scalar): you can't use this method on String array!");
-  if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
-    throw std::runtime_error("operator-(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.isS())
+            throw std::runtime_error("operator-(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
+            throw std::runtime_error("operator-(NDArray&& arr, const T& scalar): you can't use this method on String array!");
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
 
-  NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Subtract, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
+        NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Subtract, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
 
-  return std::move(arr);
-}
-template SD_LIB_EXPORT NDArray operator-(NDArray &&arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator-(NDArray &&arr, const float &scalar);
-
-////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator-(const NDArray &arr, const T &scalar) {
-  if (arr.isS())
-    throw std::runtime_error(
-        "operator-(const NDArray& arr, const T& scalar): you can't use this method on String array!");
-
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
-  NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
-                 false, arr.getContext());
-
-  NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Subtract, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                  result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&result}, {&arr, &tmp});
-
-  return result;
-}
-template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const float &scalar);
-template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const float16 &scalar);
-template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const bfloat16 &scalar);
-template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const int &scalar);
+        return std::move(arr);
+    }
+    template SD_LIB_EXPORT NDArray operator-(NDArray &&arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator-(NDArray &&arr, const float &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator-(const T &scalar, NDArray &&arr) {
-  if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
-    return std::move(scalar - arr);  // arr is lvalue inside function body
+    template <typename T, typename>
+    NDArray operator-(const NDArray &arr, const T &scalar) {
+        if (arr.isS())
+            throw std::runtime_error(
+                    "operator-(const NDArray& arr, const T& scalar): you can't use this method on String array!");
 
-  if (arr.isS())
-    throw std::runtime_error("operator-(const T& scalar, NDArray&& arr): you can't use this method on String array!");
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
+                       false, arr.getContext());
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Subtract, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                        result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&result}, {&arr, &tmp});
 
-  NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseSubtract, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
-
-  return std::move(arr);
-}
-template SD_LIB_EXPORT NDArray operator-(const double &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator-(const float &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator-(const float16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator-(const bfloat16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator-(const int &scalar, NDArray &&arr);
+        return result;
+    }
+    template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const float &scalar);
+    template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const float16 &scalar);
+    template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const bfloat16 &scalar);
+    template SD_LIB_EXPORT NDArray operator-(const NDArray &arr, const int &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator-(const T &scalar, const NDArray &arr) {
-  if (arr.isS())
-    throw std::runtime_error(
-        "operator-(const T& scalar, const NDArray& arr): you can't use this method on String array!");
+    template <typename T, typename>
+    NDArray operator-(const T &scalar, NDArray &&arr) {
+        if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
+            return std::move(scalar - arr);  // arr is lvalue inside function body
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
-  NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
-                 false, arr.getContext());
+        if (arr.isS())
+            throw std::runtime_error("operator-(const T& scalar, NDArray&& arr): you can't use this method on String array!");
 
-  NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseSubtract, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                  result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&result}, {&arr, &tmp});
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
 
-  return result;
-}
-template SD_LIB_EXPORT NDArray operator-(const double &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator-(const float &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator-(const int &scalar, const NDArray &arr);
+        NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseSubtract, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
+
+        return std::move(arr);
+    }
+    template SD_LIB_EXPORT NDArray operator-(const double &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator-(const float &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator-(const float16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator-(const bfloat16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator-(const int &scalar, NDArray &&arr);
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T, typename>
+    NDArray operator-(const T &scalar, const NDArray &arr) {
+        if (arr.isS())
+            throw std::runtime_error(
+                    "operator-(const T& scalar, const NDArray& arr): you can't use this method on String array!");
+
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
+                       false, arr.getContext());
+
+        NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseSubtract, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                        result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&result}, {&arr, &tmp});
+
+        return result;
+    }
+    template SD_LIB_EXPORT NDArray operator-(const double &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator-(const float &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator-(const int &scalar, const NDArray &arr);
 
 ///////////////////////////////////////////////////////////////////////
 // addition operator array + scalar
-template <typename T, typename>
-NDArray operator*(NDArray &&arr, const T &scalar) {
-  if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
-    return std::move(arr * scalar);  // arr is lvalue inside function body
+    template <typename T, typename>
+    NDArray operator*(NDArray &&arr, const T &scalar) {
+        if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
+            return std::move(arr * scalar);  // arr is lvalue inside function body
 
-  if (arr.isS())
-    throw std::runtime_error("operator*(NDArray&& arr, const T& scalar): you can't use this method on String array!");
-  if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
-    throw std::runtime_error("operator*(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.isS())
+            throw std::runtime_error("operator*(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
+            throw std::runtime_error("operator*(NDArray&& arr, const T& scalar): you can't use this method on String array!");
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
 
-  NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Multiply, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
+        NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Multiply, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
 
-  return std::move(arr);
-}
-template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const float &scalar);
-template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const float16 &scalar);
-template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const bfloat16 &scalar);
-template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const int &scalar);
-template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const long long &scalar);
-
-////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator*(const NDArray &arr, const T &scalar) {
-  if (arr.isS())
-    throw std::runtime_error(
-        "operator*(const NDArray& arr, const T& scalar): you can't use this method on String array!");
-
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
-  NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
-                 false, arr.getContext());
-
-  NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Multiply, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                  result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&result}, {&arr, &tmp});
-
-  return result;
-}
-
-template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const float &scalar);
-template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const float16 &scalar);
-template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const bfloat16 &scalar);
-template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const int &scalar);
-template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const long long &scalar);
+        return std::move(arr);
+    }
+    template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const float &scalar);
+    template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const float16 &scalar);
+    template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const bfloat16 &scalar);
+    template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const int &scalar);
+    template SD_LIB_EXPORT NDArray operator*(NDArray &&arr, const long long &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator*(const T &scalar, NDArray &&arr) {
-  return std::move(arr) * scalar;
-}
-template SD_LIB_EXPORT NDArray operator*(const double &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator*(const float &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator*(const float16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator*(const bfloat16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator*(const int &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator*(const long long &scalar, NDArray &&arr);
+    template <typename T, typename>
+    NDArray operator*(const NDArray &arr, const T &scalar) {
+        if (arr.isS())
+            throw std::runtime_error(
+                    "operator*(const NDArray& arr, const T& scalar): you can't use this method on String array!");
+
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
+                       false, arr.getContext());
+
+        NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Multiply, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                        result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&result}, {&arr, &tmp});
+
+        return result;
+    }
+
+    template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const float &scalar);
+    template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const float16 &scalar);
+    template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const bfloat16 &scalar);
+    template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const int &scalar);
+    template SD_LIB_EXPORT NDArray operator*(const NDArray &arr, const long long &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator*(const T &scalar, const NDArray &arr) {
-  return arr * scalar;
-}
-template SD_LIB_EXPORT NDArray operator*(const double &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator*(const float &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator*(const float16 &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator*(const bfloat16 &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator*(const int &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator*(const long long &scalar, const NDArray &arr);
+    template <typename T, typename>
+    NDArray operator*(const T &scalar, NDArray &&arr) {
+        return std::move(arr) * scalar;
+    }
+    template SD_LIB_EXPORT NDArray operator*(const double &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator*(const float &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator*(const float16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator*(const bfloat16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator*(const int &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator*(const long long &scalar, NDArray &&arr);
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T, typename>
+    NDArray operator*(const T &scalar, const NDArray &arr) {
+        return arr * scalar;
+    }
+    template SD_LIB_EXPORT NDArray operator*(const double &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator*(const float &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator*(const float16 &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator*(const bfloat16 &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator*(const int &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator*(const long long &scalar, const NDArray &arr);
 
 ///////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator/(NDArray &&arr, const T &scalar) {
-  if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
-    return std::move(arr / scalar);  // arr is lvalue inside function body
+    template <typename T, typename>
+    NDArray operator/(NDArray &&arr, const T &scalar) {
+        if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
+            return std::move(arr / scalar);  // arr is lvalue inside function body
 
-  if (arr.isS())
-    throw std::runtime_error("operator/(NDArray&& arr, const T& scalar): you can't use this method on String array!");
-  if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
-    throw std::runtime_error("operator/(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.isS())
+            throw std::runtime_error("operator/(NDArray&& arr, const T& scalar): you can't use this method on String array!");
+        if (arr.dataType() != DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()))
+            throw std::runtime_error("operator/(NDArray&& arr, const T& scalar): you can't use this method on String array!");
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
 
-  NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Divide, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
+        NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Divide, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
 
-  return std::move(arr);
-}
-template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const float &scalar);
-template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const float16 &scalar);
-template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const bfloat16 &scalar);
-template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const long long &scalar);
-
-////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator/(const NDArray &arr, const T &scalar) {
-  if (arr.isS())
-    throw std::runtime_error(
-        "operator/(const NDArray& arr, const T& scalar): you can't use this method on String array!");
-
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
-  NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
-                 false, arr.getContext());
-
-  NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Divide, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                  result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&result}, {&arr, &tmp});
-
-  return result;
-}
-template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const double &scalar);
-template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const float &scalar);
-template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const float16 &scalar);
-template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const bfloat16 &scalar);
-template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const int &scalar);
-template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const long long &scalar);
+        return std::move(arr);
+    }
+    template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const float &scalar);
+    template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const float16 &scalar);
+    template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const bfloat16 &scalar);
+    template SD_LIB_EXPORT NDArray operator/(NDArray &&arr, const long long &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator/(const T &scalar, NDArray &&arr) {
-  if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
-    return std::move(scalar / arr);  // arr is lvalue inside function body
+    template <typename T, typename>
+    NDArray operator/(const NDArray &arr, const T &scalar) {
+        if (arr.isS())
+            throw std::runtime_error(
+                    "operator/(const NDArray& arr, const T& scalar): you can't use this method on String array!");
 
-  if (arr.isS())
-    throw std::runtime_error("operator/(const T& scalar, NDArray&& arr): you can't use this method on String array!");
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
+                       false, arr.getContext());
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::Divide, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                        result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&result}, {&arr, &tmp});
 
-  NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseDivide, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
-
-  return std::move(arr);
-}
-template SD_LIB_EXPORT NDArray operator/(const double &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator/(const float &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator/(const float16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator/(const bfloat16 &scalar, NDArray &&arr);
-template SD_LIB_EXPORT NDArray operator/(const int &scalar, NDArray &&arr);
+        return result;
+    }
+    template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const double &scalar);
+    template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const float &scalar);
+    template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const float16 &scalar);
+    template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const bfloat16 &scalar);
+    template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const int &scalar);
+    template SD_LIB_EXPORT NDArray operator/(const NDArray &arr, const long long &scalar);
 
 ////////////////////////////////////////////////////////////////////////
-template <typename T, typename>
-NDArray operator/(const T &scalar, const NDArray &arr) {
-  if (arr.isS())
-    throw std::runtime_error(
-        "operator/(const T& scalar, const NDArray& arr): you can't use this method on String array!");
+    template <typename T, typename>
+    NDArray operator/(const T &scalar, NDArray &&arr) {
+        if (arr.isView())                  // do not use resources of arrays which use buffers of other original arrays
+            return std::move(scalar / arr);  // arr is lvalue inside function body
 
-  auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
-  NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
-                 false, arr.getContext());
+        if (arr.isS())
+            throw std::runtime_error("operator/(const T& scalar, NDArray&& arr): you can't use this method on String array!");
 
-  NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
-  NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseDivide, arr.buffer(), arr.shapeInfo(),
-                                  arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
-                                  result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
-                                  tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
-  NDArray::registerSpecialUse({&result}, {&arr, &tmp});
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
 
-  return result;
-}
-template SD_LIB_EXPORT NDArray operator/(const double &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator/(const float &scalar, const NDArray &arr);
-template SD_LIB_EXPORT NDArray operator/(const int &scalar, const NDArray &arr);
+        NDArray::prepareSpecialUse({&arr}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseDivide, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&arr}, {&arr, &tmp});
+
+        return std::move(arr);
+    }
+    template SD_LIB_EXPORT NDArray operator/(const double &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator/(const float &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator/(const float16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator/(const bfloat16 &scalar, NDArray &&arr);
+    template SD_LIB_EXPORT NDArray operator/(const int &scalar, NDArray &&arr);
+
+////////////////////////////////////////////////////////////////////////
+    template <typename T, typename>
+    NDArray operator/(const T &scalar, const NDArray &arr) {
+        if (arr.isS())
+            throw std::runtime_error(
+                    "operator/(const T& scalar, const NDArray& arr): you can't use this method on String array!");
+
+        auto tmp = NDArrayFactory::create(arr.dataType(), scalar, arr.getContext());
+        NDArray result(arr.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr.dataType(), DataTypeUtils::fromT<T>()),
+                       false, arr.getContext());
+
+        NDArray::prepareSpecialUse({&result}, {&arr, &tmp});
+        NativeOpExecutioner::execScalar(arr.getContext(), sd::scalar::ReverseDivide, arr.buffer(), arr.shapeInfo(),
+                                        arr.specialBuffer(), arr.specialShapeInfo(), result.buffer(), result.shapeInfo(),
+                                        result.specialBuffer(), result.specialShapeInfo(), tmp.buffer(), tmp.shapeInfo(),
+                                        tmp.specialBuffer(), tmp.specialShapeInfo(), nullptr);
+        NDArray::registerSpecialUse({&result}, {&arr, &tmp});
+
+        return result;
+    }
+    template SD_LIB_EXPORT NDArray operator/(const double &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator/(const float &scalar, const NDArray &arr);
+    template SD_LIB_EXPORT NDArray operator/(const int &scalar, const NDArray &arr);
 
 ////////////////////////////////////////////////////////////////////////
 // addition operator array + array
-template <typename T1, typename T2, typename>
-NDArray operator+(T1 &&arr1, T2 &&arr2) {
-  if (arr1.isS() || arr2.isS())
-    throw std::runtime_error("operator+(T&& arr1, T&& arr2): you can't use this method on String arrays!");
-  if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
-      (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
-    throw sd::datatype_exception::build("operator+(T&& arr1, T&& arr2): Cannot multiply different types",
-                                        arr1.dataType(), arr2.dataType());
+    template <typename T1, typename T2, typename>
+    NDArray operator+(T1 &&arr1, T2 &&arr2) {
+        if (arr1.isS() || arr2.isS())
+            throw std::runtime_error("operator+(T&& arr1, T&& arr2): you can't use this method on String arrays!");
+        if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
+            (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
+            throw sd::datatype_exception::build("operator+(T&& arr1, T&& arr2): Cannot multiply different types",
+                                                arr1.dataType(), arr2.dataType());
 
-  PointersManager pointersManager(arr1.getContext(), "operator+(T&& arr1, T&& arr2)");
+        PointersManager pointersManager(arr1.getContext(), "operator+(T&& arr1, T&& arr2)");
 
-  if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
-    const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
-    const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
+        if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
+            const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
+            const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
 
-    NDArray *result = nullptr;
-    if (isArr1Rvalue)
-      result = const_cast<NDArray *>(&arr1);
-    else if (isArr2Rvalue)
-      result = const_cast<NDArray *>(&arr2);
-    else
-      result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
-                           false, arr1.getContext());
+            NDArray *result = nullptr;
+            if (isArr1Rvalue)
+                result = const_cast<NDArray *>(&arr1);
+            else if (isArr2Rvalue)
+                result = const_cast<NDArray *>(&arr2);
+            else
+                result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
+                                     false, arr1.getContext());
 
-    NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
-    NativeOpExecutioner::execPairwiseTransform(
-        arr1.getContext(), sd::pairwise::Add, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
-        arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
-        result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
-    NDArray::registerSpecialUse({result}, {&arr1, &arr2});
+            NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
+            NativeOpExecutioner::execPairwiseTransform(
+                    arr1.getContext(), sd::pairwise::Add, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
+                    arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
+                    result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
+            NDArray::registerSpecialUse({result}, {&arr1, &arr2});
 
-    if (!isArr1Rvalue && !isArr2Rvalue) {
-      NDArray res = std::move(*result);
-      delete result;
-      return std::move(res);
+            if (!isArr1Rvalue && !isArr2Rvalue) {
+                NDArray res = std::move(*result);
+                delete result;
+                return std::move(res);
+            }
+
+            return std::move(*result);
+        }
+
+        return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Add(), std::forward<T2>(arr2));
     }
-
-    return std::move(*result);
-  }
-
-  return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Add(), std::forward<T2>(arr2));
-}
-template SD_LIB_EXPORT NDArray operator+<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator+<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator+<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator+<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator+<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator+<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator+
-    <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator+<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator+<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator+<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator+<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator+<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator+<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator+<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator+<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator+
+            <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator+<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator+<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
 
 ////////////////////////////////////////////////////////////////////////
 // addition operator array - array
-template <typename T1, typename T2, typename>
-NDArray operator-(T1 &&arr1, T2 &&arr2) {
-  if (arr1.isS() || arr2.isS())
-    throw std::runtime_error("operator-(T&& arr1, T&& arr2): you can't use this method on String arrays!");
-  if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
-      (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
-    throw sd::datatype_exception::build("operator-(T&& arr1, T&& arr2): Cannot multiply different types",
-                                        arr1.dataType(), arr2.dataType());
+    template <typename T1, typename T2, typename>
+    NDArray operator-(T1 &&arr1, T2 &&arr2) {
+        if (arr1.isS() || arr2.isS())
+            throw std::runtime_error("operator-(T&& arr1, T&& arr2): you can't use this method on String arrays!");
+        if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
+            (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
+            throw sd::datatype_exception::build("operator-(T&& arr1, T&& arr2): Cannot multiply different types",
+                                                arr1.dataType(), arr2.dataType());
 
-  PointersManager pointersManager(arr1.getContext(), "operator-(T&& arr1, T&& arr2)");
+        PointersManager pointersManager(arr1.getContext(), "operator-(T&& arr1, T&& arr2)");
 
-  if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
-    const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
-    const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
+        if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
+            const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
+            const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
 
-    NDArray *result = nullptr;
-    if (isArr1Rvalue)
-      result = const_cast<NDArray *>(&arr1);
-    else if (isArr2Rvalue)
-      result = const_cast<NDArray *>(&arr2);
-    else
-      result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
-                           false, arr1.getContext());
+            NDArray *result = nullptr;
+            if (isArr1Rvalue)
+                result = const_cast<NDArray *>(&arr1);
+            else if (isArr2Rvalue)
+                result = const_cast<NDArray *>(&arr2);
+            else
+                result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
+                                     false, arr1.getContext());
 
-    NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
-    NativeOpExecutioner::execPairwiseTransform(
-        arr1.getContext(), sd::pairwise::Subtract, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
-        arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
-        result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
-    NDArray::registerSpecialUse({result}, {&arr1, &arr2});
+            NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
+            NativeOpExecutioner::execPairwiseTransform(
+                    arr1.getContext(), sd::pairwise::Subtract, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
+                    arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
+                    result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
+            NDArray::registerSpecialUse({result}, {&arr1, &arr2});
 
-    if (!isArr1Rvalue && !isArr2Rvalue) {
-      NDArray res = std::move(*result);
-      delete result;
-      return std::move(res);
+            if (!isArr1Rvalue && !isArr2Rvalue) {
+                NDArray res = std::move(*result);
+                delete result;
+                return std::move(res);
+            }
+
+            return std::move(*result);
+        }
+
+        return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), std::forward<T2>(arr2));
     }
-
-    return std::move(*result);
-  }
-
-  return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Subtract(), std::forward<T2>(arr2));
-}
-template SD_LIB_EXPORT NDArray operator-<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator-<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator-<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator-<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator-<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator-<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator-
-    <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator-<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator-<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator-<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator-<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator-<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator-<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator-<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator-<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator-
+            <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator-<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator-<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
 
 ////////////////////////////////////////////////////////////////////////
 // multiplication operator array*array
-template <typename T1, typename T2, typename>
-NDArray operator*(T1 &&arr1, T2 &&arr2) {
-  if (arr1.isS() || arr2.isS())
-    throw std::runtime_error("operator*(T&& arr1, T&& arr2): you can't use this method on String arrays!");
-  if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
-      (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
-    throw sd::datatype_exception::build("operator*(T&& arr1, T&& arr2): Cannot multiply different types",
-                                        arr1.dataType(), arr2.dataType());
+    template <typename T1, typename T2, typename>
+    NDArray operator*(T1 &&arr1, T2 &&arr2) {
+        if (arr1.isS() || arr2.isS())
+            throw std::runtime_error("operator*(T&& arr1, T&& arr2): you can't use this method on String arrays!");
+        if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
+            (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
+            throw sd::datatype_exception::build("operator*(T&& arr1, T&& arr2): Cannot multiply different types",
+                                                arr1.dataType(), arr2.dataType());
 
-  PointersManager pointersManager(arr1.getContext(), "operator*(T&& arr1, T&& arr2)");
+        PointersManager pointersManager(arr1.getContext(), "operator*(T&& arr1, T&& arr2)");
 
-  if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
-    const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
-    const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
+        if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
+            const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
+            const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
 
-    NDArray *result = nullptr;
-    if (isArr1Rvalue)
-      result = const_cast<NDArray *>(&arr1);
-    else if (isArr2Rvalue)
-      result = const_cast<NDArray *>(&arr2);
-    else
-      result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
-                           false, arr1.getContext());
+            NDArray *result = nullptr;
+            if (isArr1Rvalue)
+                result = const_cast<NDArray *>(&arr1);
+            else if (isArr2Rvalue)
+                result = const_cast<NDArray *>(&arr2);
+            else
+                result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
+                                     false, arr1.getContext());
 
-    NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
-    NativeOpExecutioner::execPairwiseTransform(
-        arr1.getContext(), sd::pairwise::Multiply, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
-        arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
-        result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
-    NDArray::registerSpecialUse({result}, {&arr1, &arr2});
+            NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
+            NativeOpExecutioner::execPairwiseTransform(
+                    arr1.getContext(), sd::pairwise::Multiply, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
+                    arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
+                    result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
+            NDArray::registerSpecialUse({result}, {&arr1, &arr2});
 
-    if (!isArr1Rvalue && !isArr2Rvalue) {
-      NDArray res = std::move(*result);
-      delete result;
-      return std::move(res);
+            if (!isArr1Rvalue && !isArr2Rvalue) {
+                NDArray res = std::move(*result);
+                delete result;
+                return std::move(res);
+            }
+
+            return std::move(*result);
+        }
+
+        return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), std::forward<T2>(arr2));
     }
-
-    return std::move(*result);
-  }
-
-  return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), std::forward<T2>(arr2));
-}
-template SD_LIB_EXPORT NDArray operator*<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator*<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator*<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator*<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator*<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator*<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator*
-    <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator*<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator*<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator*<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator*<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator*<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator*<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator*<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator*<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator*
+            <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator*<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator*<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
 
 ////////////////////////////////////////////////////////////////////////
 // multiplication operator array*array
-template <typename T1, typename T2, typename>
-NDArray operator/(T1 &&arr1, T2 &&arr2) {
-  if (arr1.isS() || arr2.isS())
-    throw std::runtime_error("operator/(T&& arr1, T&& arr2): you can't use this method on String arrays!");
-  if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
-      (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
-    throw sd::datatype_exception::build("operator/(T&& arr1, T&& arr2): Cannot multiply different types",
-                                        arr1.dataType(), arr2.dataType());
+    template <typename T1, typename T2, typename>
+    NDArray operator/(T1 &&arr1, T2 &&arr2) {
+        if (arr1.isS() || arr2.isS())
+            throw std::runtime_error("operator/(T&& arr1, T&& arr2): you can't use this method on String arrays!");
+        if (!Environment::getInstance().isExperimentalBuild() && arr1.dataType() != arr2.dataType() &&
+            (arr1.dataType() != DataType::BOOL || arr2.dataType() != BOOL))
+            throw sd::datatype_exception::build("operator/(T&& arr1, T&& arr2): Cannot multiply different types",
+                                                arr1.dataType(), arr2.dataType());
 
-  PointersManager pointersManager(arr1.getContext(), "operator/(T&& arr1, T&& arr2)");
+        PointersManager pointersManager(arr1.getContext(), "operator/(T&& arr1, T&& arr2)");
 
-  if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
-    const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
-    const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
+        if (arr1.lengthOf() == arr2.lengthOf() && arr1.rankOf() == arr2.rankOf()) {
+            const bool isArr1Rvalue = !std::is_reference<T1>::value && !arr1.isView();
+            const bool isArr2Rvalue = !std::is_reference<T2>::value && !arr2.isView();
 
-    NDArray *result = nullptr;
-    if (isArr1Rvalue)
-      result = const_cast<NDArray *>(&arr1);
-    else if (isArr2Rvalue)
-      result = const_cast<NDArray *>(&arr2);
-    else
-      result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
-                           false, arr1.getContext());
+            NDArray *result = nullptr;
+            if (isArr1Rvalue)
+                result = const_cast<NDArray *>(&arr1);
+            else if (isArr2Rvalue)
+                result = const_cast<NDArray *>(&arr2);
+            else
+                result = new NDArray(arr1.shapeInfo(), DataTypeUtils::pickPairwiseResultType(arr1.shapeInfo(), arr2.shapeInfo()),
+                                     false, arr1.getContext());
 
-    NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
-    NativeOpExecutioner::execPairwiseTransform(
-        arr1.getContext(), sd::pairwise::Divide, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
-        arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
-        result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
-    NDArray::registerSpecialUse({result}, {&arr1, &arr2});
+            NDArray::prepareSpecialUse({result}, {&arr1, &arr2});
+            NativeOpExecutioner::execPairwiseTransform(
+                    arr1.getContext(), sd::pairwise::Divide, arr1.buffer(), arr1.shapeInfo(), arr1.specialBuffer(),
+                    arr1.specialShapeInfo(), arr2.buffer(), arr2.shapeInfo(), arr2.specialBuffer(), arr2.specialShapeInfo(),
+                    result->buffer(), result->shapeInfo(), result->specialBuffer(), result->specialShapeInfo(), nullptr);
+            NDArray::registerSpecialUse({result}, {&arr1, &arr2});
 
-    if (!isArr1Rvalue && !isArr2Rvalue) {
-      NDArray res = std::move(*result);
-      delete result;
-      return std::move(res);
+            if (!isArr1Rvalue && !isArr2Rvalue) {
+                NDArray res = std::move(*result);
+                delete result;
+                return std::move(res);
+            }
+
+            return std::move(*result);
+        }
+
+        return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), std::forward<T2>(arr2));
     }
-
-    return std::move(*result);
-  }
-
-  return std::forward<T1>(arr1).applyTrueBroadcast(sd::BroadcastOpsTuple::Divide(), std::forward<T2>(arr2));
-}
-template SD_LIB_EXPORT NDArray operator/<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator/<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator/<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator/<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator/<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator/<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
-template SD_LIB_EXPORT NDArray operator/
-    <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator/<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
-template SD_LIB_EXPORT NDArray operator/<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator/<NDArray &, NDArray &, void>(NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator/<NDArray &, NDArray, void>(NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator/<NDArray, NDArray &, void>(NDArray &&arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator/<NDArray &, const NDArray &, void>(NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator/<const NDArray &, NDArray &, void>(const NDArray &arr1, NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator/<const NDArray &, NDArray, void>(const NDArray &arr1, NDArray &&arr2);
+    template SD_LIB_EXPORT NDArray operator/
+            <const NDArray &, const NDArray &, void>(const NDArray &arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator/<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
+    template SD_LIB_EXPORT NDArray operator/<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
 
 /*
 #ifndef __CLION_IDE__

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -82,11 +82,22 @@ NDArray::NDArray(const char order, const std::vector<sd::LongType> &shape, sd::D
   _isAttached = _context->getWorkspace() != nullptr;
   _offset = 0;
 
+  sd_printf("In NDArray constructor: const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,\n"
+            "                 sd::LaunchContext *context\n",0);
   if (shape.empty())
     setShapeInfo(ShapeDescriptor::emptyDescriptor(dtype));
-  else
-    setShapeInfo(ShapeDescriptor(dtype, order, shape));
+  else {
+    sd_printf("In NDArray constructor: creating non empty shape descriptor\n",0);
+    auto desc = new ShapeDescriptor(dtype, order, shape);
+    sd_printf("Created shape descriptor in NDArray constructor\n",0);
+    auto desc2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+    sd_printf("About to set shape buffer in NDArray constructor\n",0);
+    setShapeInfo(desc2);
+    sd_printf("Set shape info in ndarray constructor\n",0);
 
+  }
+  sd_printf("After NDArray constructor: const char order, const std::vector<sd::LongType> &shape, sd::DataType dtype,\n"
+            "                 sd::LaunchContext *context\n",0);
   _buffer =
       std::make_shared<DataBuffer>(lengthOf() * DataTypeUtils::sizeOf(dtype), dtype, getContext()->getWorkspace());
   _buffer->setToZeroBuffers();
@@ -101,12 +112,14 @@ NDArray::NDArray(const char order, const std::vector<sd::LongType> &shape, const
   _offset = 0;
 
   if (shape.size() == 0) {
-    if (data.size() == 0)
-      setShapeInfo(ShapeDescriptor::emptyDescriptor(dtype));
-    else
-      setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
+    if (data.size() == 0) {
+      setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::emptyDescriptor(dtype)));
+    } else {
+      setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(ShapeDescriptor::scalarDescriptor(dtype)));
+    }
   } else {
-    setShapeInfo(ShapeDescriptor(dtype, order, shape));
+    auto desc = new ShapeDescriptor(dtype, order, shape);
+    setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
   }
 
   if (lengthOf() != data.size()) {
@@ -132,11 +145,16 @@ NDArray::NDArray(const NDArray *other, const bool copyStrides, sd::LaunchContext
   _offset = 0;
   _isAttached = getContext()->getWorkspace() != nullptr;
 
-  if (copyStrides)
-    setShapeInfo(ShapeDescriptor(other->_shapeInfo));
-  else
-    setShapeInfo(ShapeDescriptor(other->dataType(), other->ordering(), other->shapeOf(), other->rankOf()));
-
+  if (copyStrides) {
+    auto desc = new ShapeDescriptor(other->_shapeInfo);
+    sd_printf("Created shape descriptor in NDArray constructor\n",0);
+    auto desc2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+    setShapeInfo(desc2);
+  } else {
+    auto newDesc = new ShapeDescriptor(other->dataType(), other->ordering(), other->shapeOf(), other->rankOf());
+    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(newDesc);
+    setShapeInfo(constDesc);
+  }
   if (!isEmpty())
     _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dataType(), getContext()->getWorkspace());
 }
@@ -149,8 +167,9 @@ NDArray::NDArray(void *buffer, const char order, const std::vector<sd::LongType>
   _context = context;
   _offset = 0;
   _isAttached = getContext()->getWorkspace() != nullptr;
-
-  setShapeInfo(ShapeDescriptor(dtype, order, shape));
+  auto desc = new ShapeDescriptor(dtype, order, shape);
+  auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+  setShapeInfo(constDesc);
 
   _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
                                          getContext()->getWorkspace());
@@ -164,7 +183,9 @@ NDArray::NDArray(void *buffer, const char order, const std::vector<sd::LongType>
   _offset = offset;
   _isAttached = getContext()->getWorkspace() != nullptr;
   _isView = isView;
-  setShapeInfo(ShapeDescriptor(dtype, order, shape));
+  auto desc = new ShapeDescriptor(dtype, order, shape);
+  auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+  setShapeInfo(constDesc);
 
   _buffer = std::make_shared<DataBuffer>(buffer, lengthOf() * sizeOfT(), dataType(), isBuffAlloc,
                                          getContext()->getWorkspace());
@@ -181,11 +202,15 @@ NDArray::NDArray(const sd::LongType *shapeInfo, const sd::DataType dtype, const 
   _context = context;
   _offset = 0;
 
-  if (copyStrides)
-    setShapeInfo(ShapeDescriptor(shapeInfo, dtype));
-  else
-    setShapeInfo(ShapeDescriptor(dtype, shape::order(shapeInfo), shape::shapeOf(shapeInfo), shape::rank(shapeInfo)));
-
+  if (copyStrides) {
+    auto desc = new ShapeDescriptor(shapeInfo, dtype);
+    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( desc);
+    setShapeInfo(constDesc);
+  }else {
+    auto desc = new ShapeDescriptor(dtype, shape::order(shapeInfo), shape::shapeOf(shapeInfo), shape::rank(shapeInfo));
+    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+    setShapeInfo(constDesc);
+  }
   if (!isEmpty()) {
     _buffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dtype, getContext()->getWorkspace());
 
@@ -201,7 +226,8 @@ NDArray::NDArray(sd::DataType dtype, sd::LaunchContext *context, const bool isSc
   _isAttached = getContext()->getWorkspace() != nullptr;
 
   if (isScalar) {
-    setShapeInfo(ShapeDescriptor::scalarDescriptor(dtype));
+    auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( ShapeDescriptor::scalarDescriptor(dtype));
+    setShapeInfo(constDesc);
     _buffer = std::make_shared<DataBuffer>(sizeOfT(), dtype, getContext()->getWorkspace());
     _buffer->setToZeroBuffers();
   } else
@@ -253,20 +279,37 @@ NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const char order, const std
   _offset = offset;
   _isAttached = getContext()->getWorkspace() != nullptr;
   _isView = isView;
-  setShapeInfo(ShapeDescriptor(dtype, order, shape));
+  auto desc = new ShapeDescriptor(dtype, order, shape);
+  setShapeInfo(desc);
 
   _buffer = buffer;
 }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const ShapeDescriptor &descriptor, sd::LaunchContext *context,
+
+
+NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, sd::LongType *shapeInfo, sd::LaunchContext *context,
                  const sd::LongType offset) {
   _context = context;
   _offset = offset;
-  setShapeInfo(descriptor);
+  sd_printf("Setting shape info in long shape info constructor\n",0);
+  setShapeInfo(shapeInfo);
   _buffer = buffer;
 
   _isView = offset > 0 || _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
+  sd_printf("Created ndarray shape info in long shape info constructor\n",0);
+}
+
+NDArray::NDArray(std::shared_ptr<DataBuffer> buffer,  ShapeDescriptor *descriptor, sd::LaunchContext *context,
+                 const sd::LongType offset) {
+  _context = context;
+  _offset = offset;
+  sd_printf("Setting shape info in descriptor to shape info constructor\n",0);
+  setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor));
+  _buffer = buffer;
+
+  _isView = offset > 0 || _length * DataTypeUtils::sizeOf(_dataType) < buffer->getLenInBytes();
+  sd_printf("Created ndarray setting shape info in descriptor to shape info constructor\n",0);
 }
 
 #endif
@@ -291,7 +334,7 @@ NDArray::NDArray(void *buffer, const sd::LongType *shapeInfo, sd::LaunchContext 
   _isAttached = getContext()->getWorkspace() != nullptr;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(shapeInfo));
+  setShapeInfo( ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
 
   if (this->isEmpty()) {
     tickReadDevice();
@@ -321,6 +364,7 @@ NDArray::NDArray(void *buffer, void *bufferD, const sd::LongType *shapeInfo, sd:
 
     }
 
+    sd_printf("Assembling buffer for shape info error\n",0);
     ShapeDescriptor shapeDescriptor(shapeInfo);
     errorMessage += std::string("]");
     errorMessage += std::string(" wasEmpty: " + std::to_string(shapeDescriptor.isEmpty()));
@@ -335,7 +379,9 @@ NDArray::NDArray(void *buffer, void *bufferD, const sd::LongType *shapeInfo, sd:
   _context = context;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(shapeInfo));
+  sd_printf("Before creating descriptor with shape info\n",0);
+  auto descriptor = ShapeDescriptor(shapeInfo);
+  setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfo));
 
   if (!isEmpty() && buffer != nullptr)
     _buffer = std::make_shared<DataBuffer>(buffer != nullptr ? buffer : buffer,
@@ -355,7 +401,8 @@ NDArray::NDArray(std::shared_ptr<DataBuffer> buffer, const char order, const std
   _context = context;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(buffer->getDataType(), order, shape));
+  auto desc = new ShapeDescriptor(buffer->getDataType(), order, shape);
+  setShapeInfo(ConstantShapeHelper::getInstance().bufferForShapeInfo(desc));
 
   _buffer = buffer;
 
@@ -544,7 +591,8 @@ NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const
   _context = context;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(dataType, 'c', shape));
+  auto desc = new ShapeDescriptor(dataType, 'c', shape);
+  setShapeInfo(desc);
 
   _isView = false;
 
@@ -607,7 +655,8 @@ NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::
   _context = context;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(dataType, 'c', shape));
+  auto desc = new ShapeDescriptor(dataType, 'c', shape);
+  setShapeInfo(desc);
 
   _isView = false;
 
@@ -669,7 +718,8 @@ NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::
   _context = context;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(dtype, 'c', shape));
+  auto desc = new ShapeDescriptor(dtype, 'c', shape);
+  setShapeInfo(desc);
 
   _isView = false;
 
@@ -732,7 +782,8 @@ NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const
   _context = context;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(dtype, 'c', shape));
+  auto desc = new ShapeDescriptor(dtype, 'c', shape);
+  setShapeInfo(desc);
 
   _isView = false;
 
@@ -793,8 +844,8 @@ NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<std::
 
   _context = context;
   _offset = 0;
-
-  setShapeInfo(ShapeDescriptor(dtype, 'c', shape));
+  auto desc = new ShapeDescriptor(dtype, 'c', shape);
+  setShapeInfo(desc);
 
   _isView = false;
 
@@ -857,7 +908,8 @@ NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const
   _context = context;
   _offset = 0;
 
-  setShapeInfo(ShapeDescriptor(dtype, 'c', shape));
+  auto desc = new ShapeDescriptor(dtype, 'c', shape);
+  setShapeInfo(desc);
 
   _isView = _length * DataTypeUtils::sizeOf(_dataType) < _buffer->getLenInBytes();
 
@@ -895,7 +947,8 @@ NDArray &NDArray::operator=(const NDArray &other) {
   } else {
     _context = other._context;
     _offset = 0;
-    setShapeInfo(ShapeDescriptor(other.dataType(), other.ordering(), other.shapeOf(), other.rankOf()));
+    auto desc = new ShapeDescriptor(other.dataType(), other.ordering(), other.shapeOf(), other.rankOf());
+    setShapeInfo(desc);
 
     if (!other.isEmpty()) {
       _buffer = std::make_shared<DataBuffer>(other.lengthOf() * other.sizeOfT(), other.dataType(),
@@ -1094,8 +1147,8 @@ void NDArray::streamline(char o) {
       std::make_shared<DataBuffer>(this->lengthOf() * sizeOfT(), dataType(), getContext()->getWorkspace());
   auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(dataType(), order, rankOf(), shapeOf());
   NativeOpExecutioner::execTransformSame(getContext(), transform::Copy, buffer(), shapeInfo(), specialBuffer(),
-                                         specialShapeInfo(), newBuffer->primary(), shapeBuffer.primary(),
-                                         newBuffer->special(), shapeBuffer.special(), nullptr, nullptr, nullptr);
+                                         specialShapeInfo(), newBuffer->primary(), shapeBuffer->primary(),
+                                         newBuffer->special(), shapeBuffer->special(), nullptr, nullptr, nullptr);
   setShapeInfo(shapeBuffer);
   _buffer = newBuffer;
   _offset = 0;
@@ -1203,10 +1256,16 @@ void NDArray::assign(const NDArray &other, bool allowParallelism) {
     }
 
     prepareUse({this}, {&other});
+
+    printShapeInfo("Assigning array");
+    other.printShapeInfo("Other array being assigned to");
     NativeOpExecutioner::execTransformAny(getContext(), transform::Assign, other.buffer(), other.shapeInfo(),
                                           other.specialBuffer(), other.specialShapeInfo(), buffer(), shapeInfo(),
                                           specialBuffer(), specialShapeInfo(), nullptr, nullptr, nullptr,
                                           allowParallelism);
+
+    printShapeInfo("Assigning array after assign");
+    other.printShapeInfo("Other array being assigned to after assign");
     registerUse({this}, {&other});
   }
 }
@@ -1247,8 +1306,10 @@ NDArray *NDArray::detach() {
   if (!isAttached()) return this;
 
   std::shared_ptr<DataBuffer> newBuffer = std::make_shared<DataBuffer>(lengthOf() * sizeOfT(), dataType());
-
-  auto result = new NDArray(newBuffer, ShapeDescriptor(dataType(), ordering(), shapeOf(), rankOf()));
+  auto desc = new ShapeDescriptor(dataType(), ordering(), shapeOf(), rankOf());
+  auto constantBuff = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+  auto recastShapeInfo = const_cast<sd::LongType *>(constantBuff->primary());
+  auto result = new NDArray(newBuffer,recastShapeInfo,getContext());
 
   result->assign(*this);
 
@@ -1477,6 +1538,7 @@ NDArray NDArray::reduceNumber(sd::reduce::FloatOps op, void *extraParams) const 
 NDArray NDArray::reduceNumber(sd::reduce::SameOps op, void *extraParams) const {
   if (isS()) throw std::runtime_error("NDArray::reduceNumber SameOps: you can't use this method on String array!");
 
+  sd_printf("reduceNumber: before result creation\n",0);
   NDArray result(dataType(), getContext());
 
   prepareUse({&result}, {this});
@@ -1801,7 +1863,8 @@ BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void *NDArray::templatedPointerShif
 //////////////////////////////////////////////////////////////////////////
 // method makes copy of this array and applies to the copy transpose operation, this array remains unaffected
 NDArray NDArray::transpose() const & {
-  NDArray newArr(getDataBuffer(), ShapeDescriptor(shapeInfo()), getContext(), bufferOffset());
+  auto desc = new ShapeDescriptor(shapeInfo());
+  NDArray newArr(getDataBuffer(),desc, getContext(), bufferOffset());
   newArr.transposei();
 
   return newArr;
@@ -1882,7 +1945,8 @@ void NDArray::enforce(std::vector<sd::LongType> &dimensions, char o) {
   }
 
   char order = o == 'a' ? this->ordering() : o;
-  setShapeInfo(ShapeDescriptor(dataType(), order, dimensions));
+  auto desc = new ShapeDescriptor(dataType(), order, dimensions);
+  setShapeInfo(desc);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1907,7 +1971,8 @@ sd::LongType NDArray::argMax(std::initializer_list<int> dimensions) {
 //////////////////////////////////////////////////////////////////////////
 // create new array with corresponding order and shape, new array will point to the same _buffer as this array
 NDArray NDArray::reshape(const char order, const std::vector<sd::LongType> &shape, const bool copyToNewBuff) const & {
-  NDArray newArr(getDataBuffer(), ShapeDescriptor(shapeInfo()), getContext(), bufferOffset());
+  auto desc = new ShapeDescriptor(shapeInfo());
+  NDArray newArr(getDataBuffer(), desc, getContext(), bufferOffset());
   newArr.reshapei(order, shape, copyToNewBuff);
 
   return newArr;
@@ -1977,7 +2042,8 @@ bool NDArray::permutei(const std::vector<sd::LongType> &dimensions) {
 NDArray NDArray::permute(const int *dimensions, const int rank) const & {
   // evaluate shapeInfo for output (permuted) array ret
   auto shapeInfoPermuted = ShapeUtils::evalPermShapeInfo(dimensions, rank, *this, getContext()->getWorkspace());
-  NDArray ret(getDataBuffer(), ShapeDescriptor(shapeInfoPermuted), getContext(), bufferOffset());
+  auto buff =  ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfoPermuted);
+  NDArray ret(getDataBuffer(), const_cast<sd::LongType *>(buff->primary()), getContext(), bufferOffset());
   ret._isView = true;
   return ret;
 }
@@ -2288,7 +2354,9 @@ NDArray NDArray::asS() const {
     std::shared_ptr<DataBuffer> pBuffer = std::make_shared<DataBuffer>(offsetsLength + nInputoffsets[lengthOf()], dtype,
                                                                        getContext()->getWorkspace(), true);
 
-    NDArray res(pBuffer, ShapeDescriptor(dtype, ordering(), getShapeAsVector()), getContext());
+    auto shapeDesc = new ShapeDescriptor(dtype, ordering(), getShapeAsVector());
+    auto buff = ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeDesc);
+    NDArray res(pBuffer,shapeDesc,getContext());
     res.setAttached(getContext()->getWorkspace() != nullptr);
 
     preparePrimaryUse({&res}, {this});
@@ -2333,7 +2401,8 @@ NDArray NDArray::asS() const {
   std::shared_ptr<DataBuffer> pBuffer =
       std::make_shared<DataBuffer>(offsetsLength + dataLength, dtype, getContext()->getWorkspace(), true);
 
-  NDArray res(pBuffer, ShapeDescriptor(dtype, ordering(), getShapeAsVector()), getContext());
+  auto desc = new ShapeDescriptor(dtype, ordering(), getShapeAsVector());
+  NDArray res(pBuffer, desc, getContext());
   res.setAttached(getContext()->getWorkspace() != nullptr);
 
   preparePrimaryUse({&res}, {this});
@@ -2775,7 +2844,8 @@ NDArray NDArray::quantize(const NDArray &array) {
   std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(TypeCast::estimateQuantizedSize(array.lengthOf()),
                                                                     ArrayOptions::dataType(shapeInfo), ws);
 
-  NDArray result(buffer, ShapeDescriptor(shapeInfo), array.getContext());
+  auto desc = new ShapeDescriptor(shapeInfo);
+  NDArray result(buffer,desc , array.getContext());
 
   return result;
 }
@@ -2821,14 +2891,14 @@ void NDArray::applyTrueBroadcast(sd::BroadcastOpsTuple op, const NDArray &other,
   if (!isSameShape(target)) {
     auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
-    xShapeInfoH = xPack.primary();
-    xShapeInfoD = xPack.special();
+    xShapeInfoH = xPack->primary();
+    xShapeInfoD = xPack->special();
   }
   if (!other.isSameShape(target)) {
     auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
-    yShapeInfoH = yPack.primary();
-    yShapeInfoD = yPack.special();
+    yShapeInfoH = yPack->primary();
+    yShapeInfoD = yPack->special();
   }
 
   prepareUse({&target}, {this, &other});
@@ -2845,16 +2915,7 @@ void NDArray::applyTrueBroadcast(sd::BroadcastBoolOpsTuple op, const NDArray &ot
 
   if (isEmpty() || other.isEmpty()) return;
 
-  // if (lengthOf() == 1) {
-  //     NDArray temp(target._shapeInfo, dataType(), false, getContext());
-  //     temp.assign(this);
-  //     temp.applyPairwiseTransform(op.p, other, target,  extraArgs);
-  //     return;
-  // }
-  // if (other.lengthOf() == 1) {
-  //     this->applyScalarArr(op.s, other, target, extraArgs);
-  //     return;
-  // }
+
 
   if (checkTargetShape) {
     const sd::LongType *newShapeInfo = nullptr;
@@ -2879,14 +2940,14 @@ void NDArray::applyTrueBroadcast(sd::BroadcastBoolOpsTuple op, const NDArray &ot
   if (!isSameShape(target)) {
     auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
-    xShapeInfoH = xPack.primary();
-    xShapeInfoD = xPack.special();
+    xShapeInfoH = xPack->primary();
+    xShapeInfoD = xPack->special();
   }
   if (!other.isSameShape(target)) {
     auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
-    yShapeInfoH = yPack.primary();
-    yShapeInfoD = yPack.special();
+    yShapeInfoH = yPack->primary();
+    yShapeInfoD = yPack->special();
   }
 
   prepareUse({&target}, {this, &other});
@@ -2938,14 +2999,14 @@ void NDArray::applyTrueBroadcast(sd::BroadcastIntOpsTuple op, const NDArray &oth
   if (!isSameShape(target)) {
     auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), shapeInfo(), getContext()->getWorkspace());
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack.primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack.special());
+    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
   }
   if (!other.isSameShape(target)) {
     auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace());
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack.primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack.special());
+    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
   }
 
   prepareUse({&target}, {this, &other});
@@ -3082,13 +3143,6 @@ void NDArray::applyBroadcast(sd::broadcast::Ops op, const std::vector<int> &dime
     return;
   }
 
-  // if (other.lengthOf() == lengthOf() && this->rankOf() == other.rankOf()) {
-  //     prepareUse({&target}, {this, &other});
-  //     NativeOpExecutioner::execPairwiseTransform(getContext(), fromBroadcastToPairwise(op), buffer(), shapeInfo(),
-  //     specialBuffer(), specialShapeInfo(), other.buffer(), other.shapeInfo(), other.specialBuffer(),
-  //     other.specialShapeInfo(), target.buffer(), target.shapeInfo(), target.specialBuffer(), target.special(),
-  //     nullptr); registerUse({&target}, {this, &other}); return;
-  // }
 
   if (target.dataType() != DataTypeUtils::pickPairwiseResultType(shapeInfo(), other.shapeInfo()))
     throw std::invalid_argument("NDArray::applyBroadcast method: wrong type of target array !");
@@ -3109,14 +3163,14 @@ void NDArray::applyBroadcast(sd::broadcast::Ops op, const std::vector<int> &dime
   if (!isSameShape(target)) {
     auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack.primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack.special());
+    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
   }
   if (!other.isSameShape(target)) {
     auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack.primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack.special());
+    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
   }
 
   prepareUse({&target}, {this, &other});
@@ -3169,14 +3223,14 @@ void NDArray::applyBroadcast(sd::broadcast::BoolOps op, const std::vector<int> &
   if (!isSameShape(target)) {
     auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack.primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack.special());
+    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
   }
   if (!other.isSameShape(target)) {
     auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack.primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack.special());
+    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
   }
 
   prepareUse({&target}, {this, &other});
@@ -3231,14 +3285,14 @@ void NDArray::applyBroadcast(sd::broadcast::IntOps op, const std::vector<int> &d
   if (!isSameShape(target)) {
     auto xPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), shapeInfo(), getContext()->getWorkspace(), copy);
-    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack.primary());
-    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack.special());
+    xShapeInfoH = reinterpret_cast<sd::LongType const *>(xPack->primary());
+    xShapeInfoD = reinterpret_cast<sd::LongType const *>(xPack->special());
   }
   if (!other.isSameShape(target)) {
     auto yPack = ConstantShapeHelper::getInstance().createShapeInfoWithUnitiesForBroadcast(
         target.shapeInfo(), other.shapeInfo(), other.getContext()->getWorkspace(), copy);
-    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack.primary());
-    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack.special());
+    yShapeInfoH = reinterpret_cast<sd::LongType const *>(yPack->primary());
+    yShapeInfoD = reinterpret_cast<sd::LongType const *>(yPack->special());
   }
 
   prepareUse({&target}, {this, &other});
@@ -4384,8 +4438,8 @@ void NDArray::reduceAlongDimension(sd::reduce::FloatOps op, NDArray &target, con
     if (rankOf() - dimensions.size() != target.rankOf()) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
           target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
@@ -4430,8 +4484,8 @@ void NDArray::reduceAlongDimension(sd::reduce::SameOps op, NDArray &target, cons
     if (rankOf() - dimensions.size() != target.rankOf()) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
           target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
@@ -4476,8 +4530,8 @@ void NDArray::reduceAlongDimension(sd::reduce::LongOps op, NDArray &target, cons
     if (rankOf() - dimensions.size() != target.rankOf()) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
           target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
@@ -4522,8 +4576,8 @@ void NDArray::reduceAlongDimension(sd::reduce::BoolOps op, NDArray &target, cons
     if (rankOf() - dimensions.size() != target.rankOf()) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
           target.shapeInfo(), copy, target.getContext()->getWorkspace());
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims = ShapeUtils::evalDimsForReduceOp(rankOf(), copy);
@@ -4938,7 +4992,8 @@ ResultSet NDArray::multipleTensorsAlongDimension(const std::vector<int> &indices
       throw std::runtime_error("Bad index");
     }
 
-    auto array = new NDArray(getDataBuffer(), ShapeDescriptor(pack.primaryShapeInfo()), getContext(),
+    auto newShapeInfoCast = const_cast<sd::LongType * const>(pack.primaryShapeInfo());
+    auto array = new NDArray(getDataBuffer(), newShapeInfoCast, getContext(),
                              pack.primaryOffsets()[idx] + bufferOffset());
     result.push_back(array);
   }
@@ -5016,8 +5071,8 @@ NDArray NDArray::diagonal(const char type) const {
   }
 
   ArrayOptions::setDataType(outShapeInfo, this->dataType());
-
-  NDArray result(_buffer, ShapeDescriptor(outShapeInfo), getContext(), bufferOffset());
+  auto buff = ConstantShapeHelper::getInstance().bufferForShapeInfo(outShapeInfo);
+  NDArray result(_buffer, const_cast<sd::LongType  *>(buff->primary()), getContext(), bufferOffset());
 
   RELEASE(outShapeInfo, getContext()->getWorkspace());
 
@@ -5031,7 +5086,8 @@ ResultSet NDArray::allTensorsAlongDimension(const std::vector<int> &dimensions) 
     return result;
   }
   if (dimensions.back() == rankOf() || isScalar() && dimensions.size() == 1 && dimensions[0] == 0) {
-    auto array = new NDArray(_buffer, this->shapeInfo(), getContext(), bufferOffset());
+    auto newShapeInfoCast = const_cast<sd::LongType * const>(this->shapeInfo());
+    auto array = new NDArray(_buffer, newShapeInfoCast, getContext(), bufferOffset());
     array->_isView = true;
     result.push_back(array);
     sd_debug("NDArray::allTensorsAlongDimension: Dimensions were equal %d with this rank of %d\n", dimensions.back(),
@@ -5049,9 +5105,10 @@ ResultSet NDArray::allTensorsAlongDimension(const std::vector<int> &dimensions) 
   auto pack = ConstantTadHelper::getInstance().tadForDimensions(_shapeInfo, const_cast<int *>(dimensions.data()),
                                                                 dimensions.size());
   auto numTads = pack.numberOfTads();
+  auto newShapeInfoCast = const_cast<sd::LongType *>(pack.primaryShapeInfo());
 
   for (sd::LongType idx = 0; idx < numTads; idx++) {
-    auto array = new NDArray(_buffer, ShapeDescriptor(pack.primaryShapeInfo()), getContext(),
+    auto array = new NDArray(_buffer, newShapeInfoCast, getContext(),
                              pack.primaryOffsets()[idx] + bufferOffset());
     array->_isView = true;
     result.push_back(array);
@@ -5066,8 +5123,6 @@ NDArray NDArray::operator()(const std::vector<sd::LongType> &idx, const bool kee
                             const bool isStrided) const {
   if (isEmpty()) throw std::invalid_argument("NDArray::operator(sub-arrays): array is empty !");
 
-  // sd::LongType *outShapeInfo = nullptr;
-  //     ALLOCATE(outShapeInfo, workspace, shape::shapeInfoLength(inShapeInfo), sd::LongType);
 
   int numOfUntiesInSubArrShape = 0;
 
@@ -5090,12 +5145,15 @@ NDArray NDArray::operator()(const std::vector<sd::LongType> &idx, const bool kee
            sd::LongType);
 
   sd::LongType offset;
+  sd_printf("() operator: About to Calculated sub arr shape info and offset\n",0);
 
   shape::calcSubArrShapeInfoAndOffset(idx.data(), shapeInfo(), subArrShapeInfo, offset, keepUnitiesInShape, isStrided,
                                       numOfUntiesInSubArrShape);
 
-  NDArray result(_buffer, ShapeDescriptor(subArrShapeInfo), getContext(), offset + bufferOffset());
+  sd_printf("() operator: Calculated sub arr shape info and offset\n",0);
+  NDArray result(_buffer, subArrShapeInfo, getContext(), offset + bufferOffset());
   result._isView = true;
+  sd_printf("() operator: Created result\n",0);
 
   RELEASE(subArrShapeInfo, getContext()->getWorkspace());
 
@@ -5155,10 +5213,11 @@ void NDArray::getSubArrShapeAndOffsets(const std::vector<int> &dimsToExclude, sd
 //////////////////////////////////////////////////////////////////////////
 void NDArray::setShapeInfo(const sd::LongType *shapeInfo) {
   if (shapeInfo != nullptr) {
-    ShapeDescriptor descriptor(shapeInfo);
+    sd_printf("Setting shape info from shapeinfo 2\n",0);
+    ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfo);
     auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor);
 
-    _shapeInfo = shapeBuffer.primary();
+    _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
     _shapeInfoD = shapeBuffer.special();
 #endif
@@ -5177,13 +5236,15 @@ void NDArray::setShapeInfo(const sd::LongType *shapeInfo) {
 
 ////////////////////////////////////////////////////////////////////////
 void NDArray::setShapeInfo(const sd::LongType *shapeInfo, const sd::DataType dtype) {
+  sd_printf("Called set shape info from shape info buffer + data type\n",0);
   if (shapeInfo != nullptr) {
+    sd_printf("NDrray: Setting shape info from shape info buffer\n",0);
     sd::LongType *shapeInfoTemp =
         ShapeBuilders::copyShapeInfoAndType(shapeInfo, dtype, true, getContext()->getWorkspace());
-    ShapeDescriptor descriptor(shapeInfoTemp);
+    ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfoTemp);
     auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor);
 
-    _shapeInfo = shapeBuffer.primary();
+    _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
     _shapeInfoD = shapeBuffer.special();
 #endif
@@ -5201,18 +5262,18 @@ void NDArray::setShapeInfo(const sd::LongType *shapeInfo, const sd::DataType dty
 }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::setShapeInfo(const ShapeDescriptor &descriptor) {
+void NDArray::setShapeInfo(ShapeDescriptor *descriptor) {
+  sd_printf("Before set shape info descriptor call null check\n",0);
   if(descriptor == nullptr) {
-    throw std::runtime_error("Passed in descriptor can't be null!");
+    throw std::runtime_error("NDArray:setShapeInfo Passed in descriptor can't be null!");
   }
 
-
-  sd_printf("Descriptor about to set: rank %d data type %d is empty %d\n" ,descriptor.rank(),descriptor.dataType(),descriptor.isEmpty());
+  sd_printf("Before printing shape descriptor information\n",0);
   sd_printf("Before obtaining constant shape info for descriptor\n",0);
 
-  auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(const_cast<ShapeDescriptor &>(descriptor));
+  auto shapeBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(const_cast<ShapeDescriptor *>(descriptor));
   sd_printf("After obtaining constant shape info for descriptor\n",0);
-  _shapeInfo = shapeBuffer.primary();
+  _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
   _shapeInfoD = shapeBuffer.special();
 #endif
@@ -5226,10 +5287,10 @@ void NDArray::setShapeInfo(const ShapeDescriptor &descriptor) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-void NDArray::setShapeInfo(const ConstantShapeBuffer &shapeBuffer) {
-  _shapeInfo = shapeBuffer.primary();
+void NDArray::setShapeInfo(const ConstantShapeBuffer *shapeBuffer) {
+  _shapeInfo = shapeBuffer->primary();
 #ifdef __CUDABLAS__
-  _shapeInfoD = shapeBuffer.special();
+  _shapeInfoD = shapeBuffer->special();
 #endif
 
   if (ArrayOptions::arrayType(_shapeInfo) == ArrayType::EMPTY)

--- a/libnd4j/include/array/NDArrayFactory.h
+++ b/libnd4j/include/array/NDArrayFactory.h
@@ -65,7 +65,7 @@ class SD_LIB_EXPORT NDArrayFactory {
   template <typename T>
   static NDArray *linspace(T from, T to, sd::LongType numElements);
 
-  static NDArray create(const ShapeDescriptor &shapeDescriptor,
+  static NDArray create(ShapeDescriptor *shapeDescriptor,
                         sd::LaunchContext *context = sd::LaunchContext ::defaultContext());
 
   static NDArray create(const char order, const std::vector<sd::LongType> &shape, sd::DataType dataType,

--- a/libnd4j/include/array/ShapeDescriptor.h
+++ b/libnd4j/include/array/ShapeDescriptor.h
@@ -123,12 +123,12 @@ class SD_LIB_EXPORT ShapeDescriptor {
 
   sd::LongType *toShapeInfo() const;
 
-  static ShapeDescriptor emptyDescriptor(const DataType type);
-  static ShapeDescriptor scalarDescriptor(const DataType type);
-  static ShapeDescriptor vectorDescriptor(const sd::LongType length, const DataType type);
+  static ShapeDescriptor * emptyDescriptor(const DataType type);
+  static ShapeDescriptor  * scalarDescriptor(const DataType type);
+  static ShapeDescriptor * vectorDescriptor(const sd::LongType length, const DataType type);
 
   // create Descriptor with padded buffer.
-  static ShapeDescriptor paddedBufferDescriptor(const DataType type, const char order,
+  static ShapeDescriptor * paddedBufferDescriptor(const DataType type, const char order,
                                                 const std::vector<sd::LongType> &shape,
                                                 const std::vector<sd::LongType> &paddings);
 };

--- a/libnd4j/include/array/ShapeList.h
+++ b/libnd4j/include/array/ShapeList.h
@@ -44,11 +44,9 @@ class SD_LIB_EXPORT ShapeList {
   ShapeList(const sd::LongType *shape = nullptr);
   ShapeList(const std::vector<const sd::LongType *> &shapes, bool isWorkspace);
   ShapeList(const std::vector<const sd::LongType *> &shapes);
-  // ShapeList(bool autoRemovable);
 
   ~ShapeList();
 
-  // std::vector<const sd::LongType *> *asVector();
   void destroy();
   int size() const;
   const sd::LongType *at(int idx);

--- a/libnd4j/include/array/cpu/NDArray.cpp
+++ b/libnd4j/include/array/cpu/NDArray.cpp
@@ -378,7 +378,7 @@ NDArray NDArray::tile(const std::vector<sd::LongType>& reps) const {
   auto desc = new ShapeDescriptor(newShapeInfo);
   // assign new shape and new buffer to resulting array
   NDArray result(newBuff,desc , getContext());
-
+delete desc;
   // fill newBuff, loop through all elements of newBuff
   // looping through _buffer goes automatically by means of getSubArrayIndex applying
   const auto resultLen = result.lengthOf();

--- a/libnd4j/include/array/cpu/NDArray.cpp
+++ b/libnd4j/include/array/cpu/NDArray.cpp
@@ -375,8 +375,9 @@ NDArray NDArray::tile(const std::vector<sd::LongType>& reps) const {
   // create new buffer, in any case the memory amount new buffer points to is bigger then those for old _buffer
   std::shared_ptr<DataBuffer> newBuff =
       std::make_shared<DataBuffer>(shape::length(newShapeInfo) * sizeOfT(), dataType(), getContext()->getWorkspace());
+  auto desc = new ShapeDescriptor(newShapeInfo);
   // assign new shape and new buffer to resulting array
-  NDArray result(newBuff, ShapeDescriptor(newShapeInfo), getContext());
+  NDArray result(newBuff,desc , getContext());
 
   // fill newBuff, loop through all elements of newBuff
   // looping through _buffer goes automatically by means of getSubArrayIndex applying

--- a/libnd4j/include/array/cuda/NDArray.cu
+++ b/libnd4j/include/array/cuda/NDArray.cu
@@ -156,7 +156,7 @@ void NDArray::fillAsTriangular(const float val, int lower, int upper, NDArray& t
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void NDArray::fillAsTriangular,
                       (const float val, int lower, int upper, NDArray& target, const char direction,
-                       const bool includeEdges),
+                          const bool includeEdges),
                       SD_COMMON_TYPES);
 
 ////////////////////////////////////////////////////////////////////////
@@ -200,7 +200,7 @@ static void identityMatrixCudaLauncher(const int blocksPerGrid, const int thread
 }
 BUILD_SINGLE_TEMPLATE(template void identityMatrixCudaLauncher,
                       (const int blocksPerGrid, const int threadsPerBlock, const int sharedMem,
-                       const cudaStream_t* stream, void* vx, const sd::LongType* xShapeInfo, const float val),
+                          const cudaStream_t* stream, void* vx, const sd::LongType* xShapeInfo, const float val),
                       SD_COMMON_TYPES);
 
 ////////////////////////////////////////////////////////////////////////
@@ -220,7 +220,7 @@ void NDArray::setIdentity() {
   syncToDevice();
   BUILD_SINGLE_SELECTOR(dataType(), identityMatrixCudaLauncher,
                         (blocksPerGrid, threadsPerBlock, sharedMem, getContext()->getCudaStream(), platformBuffer(),
-                         platformShapeInfo(), 1.f),
+                            platformShapeInfo(), 1.f),
                         SD_COMMON_TYPES);
   tickWriteDevice();
 
@@ -245,7 +245,7 @@ void NDArray::swapUnsafe(NDArray& other) {
   prepareSpecialUse({&other, this}, {&other, this});
   BUILD_SINGLE_SELECTOR(xType, templatedSwapUnsafe,
                         (specialBuffer(), specialShapeInfo(), other.specialBuffer(), other.specialShapeInfo(),
-                         getContext()->getCudaStream()),
+                            getContext()->getCudaStream()),
                         SD_COMMON_TYPES);
   registerSpecialUse({&other, this}, {&other, this});
 
@@ -349,8 +349,9 @@ NDArray NDArray::tile(const std::vector<sd::LongType>& reps) const {
   std::shared_ptr<DataBuffer> newBuff = std::make_shared<DataBuffer>(shape::length(newShapeInfo) * sizeOfT(),
                                                                      dataType(), getContext()->getWorkspace(), true);
   // assign new shape and new buffer to resulting array
-  NDArray result(newBuff, ShapeDescriptor(newShapeInfo), getContext());
-
+  ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo);
+  NDArray result(newBuff,descriptor , getContext());
+  delete descriptor;
   // fill newBuff, loop through all elements of newBuff
   // looping through buffer() goes automatically by means of getSubArrayIndex applying
   const auto resultLen = result.lengthOf();
@@ -360,7 +361,7 @@ NDArray NDArray::tile(const std::vector<sd::LongType>& reps) const {
   prepareSpecialUse({&result}, {this});
   BUILD_SINGLE_SELECTOR(xType, tileKernelH,
                         (this->specialBuffer(), this->specialShapeInfo(), result.specialBuffer(),
-                         result.specialShapeInfo(), resultLen, stream),
+                            result.specialShapeInfo(), resultLen, stream),
                         SD_COMMON_TYPES);
   registerSpecialUse({&result}, {this});
 
@@ -469,12 +470,12 @@ static void repeatCudaLauncher(const int blocksPerGrid, const int threadsPerBloc
                                const cudaStream_t* stream, const void* vx, const sd::LongType* xShapeInfo, void* vz,
                                const sd::LongType* zShapeInfo, const int* repeats, const int repSize, const int axis) {
   repeatCuda<X, Z>
-      <<<blocksPerGrid, threadsPerBlock, sharedMem, *stream>>>(vx, xShapeInfo, vz, zShapeInfo, repeats, repSize, axis);
+  <<<blocksPerGrid, threadsPerBlock, sharedMem, *stream>>>(vx, xShapeInfo, vz, zShapeInfo, repeats, repSize, axis);
 }
 BUILD_DOUBLE_TEMPLATE(template void repeatCudaLauncher,
                       (const int blocksPerGrid, const int threadsPerBlock, const int sharedMem,
-                       const cudaStream_t* stream, const void* vx, const sd::LongType* xShapeInfo, void* vz,
-                       const sd::LongType* zShapeInfo, const int* repeats, const int repSize, const int axis),
+                          const cudaStream_t* stream, const void* vx, const sd::LongType* xShapeInfo, void* vz,
+                          const sd::LongType* zShapeInfo, const int* repeats, const int repSize, const int axis),
                       SD_COMMON_TYPES, SD_COMMON_TYPES);
 
 //////////////////////////////////////////////////////////////////////////
@@ -494,7 +495,7 @@ NDArray NDArray::repeat(const int axis, const std::vector<int>& repeats) const {
   BUILD_SINGLE_SELECTOR_TWICE(
       dataType(), repeatCudaLauncher,
       (blocksPerGrid, threadsPerBlock, sharedMem, getContext()->getCudaStream(), specialBuffer(), specialShapeInfo(),
-       output.specialBuffer(), output.specialShapeInfo(), reps, repeats.size(), axis),
+          output.specialBuffer(), output.specialShapeInfo(), reps, repeats.size(), axis),
       SD_COMMON_TYPES);
   prepareSpecialUse({&output}, {this});
 
@@ -523,7 +524,7 @@ void NDArray::repeat(const int axis, const std::vector<int>& repeats, NDArray& t
   BUILD_DOUBLE_SELECTOR(
       dataType(), target.dataType(), repeatCudaLauncher,
       (blocksPerGrid, threadsPerBlock, sharedMem, getContext()->getCudaStream(), specialBuffer(), specialShapeInfo(),
-       target.specialBuffer(), target.specialShapeInfo(), reps, repeats.size(), axis),
+          target.specialBuffer(), target.specialShapeInfo(), reps, repeats.size(), axis),
       SD_COMMON_TYPES, SD_COMMON_TYPES);
   prepareSpecialUse({&target}, {this});
 

--- a/libnd4j/include/array/impl/NDArrayFactory.cpp
+++ b/libnd4j/include/array/impl/NDArrayFactory.cpp
@@ -107,7 +107,7 @@ SD_LIB_EXPORT NDArray NDArrayFactory::create<bool>(const char order, const std::
                                                                     sd::DataType::BOOL, true, context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
-
+  delete descriptor;
   return result;
 }
 
@@ -130,7 +130,7 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
       data.data(), DataTypeUtils::fromT<T>(), descriptor->arrLength() * sizeof(T), context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
-
+  delete descriptor;
   return result;
 }
 

--- a/libnd4j/include/array/impl/NDArrayFactory.cpp
+++ b/libnd4j/include/array/impl/NDArrayFactory.cpp
@@ -117,7 +117,6 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
                                sd::LaunchContext* context) {
   if ((int)shape.size() > SD_MAX_RANK)
     throw std::invalid_argument("NDArrayFactory::create: rank of NDArray can't exceed 32 !");
-
   ShapeDescriptor *descriptor = new ShapeDescriptor(DataTypeUtils::fromT<T>(), order, shape);
 
   if (descriptor->arrLength() != data.size()) {
@@ -321,8 +320,9 @@ NDArray NDArrayFactory::create(const T scalar, sd::LaunchContext* context) {
   std::shared_ptr<DataBuffer> buffer =
       std::make_shared<DataBuffer>(1 * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
 
-  NDArray res(buffer, ShapeDescriptor::scalarDescriptor(DataTypeUtils::fromT<T>()), context);
-
+  auto desc = ShapeDescriptor::scalarDescriptor(DataTypeUtils::fromT<T>());
+  NDArray res(buffer,desc , context);
+  delete desc;
   res.bufferAsT<T>()[0] = scalar;
 
   res.tickWriteHost();
@@ -510,6 +510,8 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
                                sd::LaunchContext* context) {
   if ((int)shape.size() > SD_MAX_RANK)
     throw std::invalid_argument("NDArrayFactory::create: rank of NDArray can't exceed 32");
+  sd_printf("In arrLength usage aDArrayFactory::create(const char order, const std::vector<sd::LongType>& shape, sd::DataType dtype,\n"
+            "                               sd::LaunchContext* context)\n",0);
 
   ShapeDescriptor *descriptor = new ShapeDescriptor(dtype, order, shape);
 
@@ -639,6 +641,8 @@ NDArray* NDArrayFactory::create_(const char order, const std::vector<sd::LongTyp
 template <typename T>
 NDArray NDArrayFactory::create(T* buffer, const char order, const std::initializer_list<sd::LongType>& shape,
                                sd::LaunchContext* context) {
+  sd_printf("In arrLength usage at  NDArrayFactory::create(T* buffer, const char order, const std::initializer_list<sd::LongType>& shape,\n"
+            "                               sd::LaunchContext* context\n",0);
   if ((int)shape.size() > SD_MAX_RANK)
     throw std::invalid_argument("NDArrayFactory::create: Rank of NDArray can't exceed 32");
 
@@ -649,7 +653,7 @@ NDArray NDArrayFactory::create(T* buffer, const char order, const std::initializ
       buffer, descriptor->arrLength() * sizeof(T), descriptor->dataType(), false, context->getWorkspace());
 
   NDArray result(pBuffer, descriptor, context);
-
+  delete descriptor;
   return result;
 }
 

--- a/libnd4j/include/array/impl/NDArrayFactory.cpp
+++ b/libnd4j/include/array/impl/NDArrayFactory.cpp
@@ -36,15 +36,15 @@
 
 namespace sd {
 
-SD_LIB_EXPORT NDArray NDArrayFactory::create(const ShapeDescriptor& shapeDescriptor, sd::LaunchContext* context) {
-  auto status = shapeDescriptor.validate();
+SD_LIB_EXPORT NDArray NDArrayFactory::create(ShapeDescriptor *shapeDescriptor, sd::LaunchContext* context) {
+  auto status = shapeDescriptor->validate();
   if (status != SHAPE_DESC_OK) {
     sd_printf("NDArrayFactory::create: ShapeDescriptor status code [%d]\n", status);
     throw std::invalid_argument("NDArrayFactory::create: invalid ShapeDescriptor ");
   }
-  sd::LongType allocSize = shapeDescriptor.allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor.dataType());
+  sd::LongType allocSize = shapeDescriptor->allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor->dataType());
   std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(allocSize, shapeDescriptor.dataType(), context->getWorkspace());
+      std::make_shared<DataBuffer>(allocSize, shapeDescriptor->dataType(), context->getWorkspace());
   NDArray result(buffer, shapeDescriptor, context);
   result.nullify();
   return result;
@@ -63,9 +63,9 @@ SD_LIB_EXPORT NDArray NDArrayFactory::create(const char order, const std::vector
 
   auto shapeDescriptor = ShapeDescriptor::paddedBufferDescriptor(dataType, order, shape, paddings);
 
-  sd::LongType allocSize = shapeDescriptor.allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor.dataType());
+  sd::LongType allocSize = shapeDescriptor->allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor->dataType());
   std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(allocSize, shapeDescriptor.dataType(), context->getWorkspace());
+      std::make_shared<DataBuffer>(allocSize, shapeDescriptor->dataType(), context->getWorkspace());
 
   // lets check offsets
   int check_size = paddingOffsets.size() < rank ? paddingOffsets.size() : rank;
@@ -77,7 +77,7 @@ SD_LIB_EXPORT NDArray NDArrayFactory::create(const char order, const std::vector
     }
   }
 
-  sd::LongType offset = offset_from_coords(shapeDescriptor.stridesPtr(), paddingOffsets.data(), check_size);
+  sd::LongType offset = offset_from_coords(shapeDescriptor->stridesPtr(), paddingOffsets.data(), check_size);
 
   NDArray result(buffer, shapeDescriptor, context, offset);
   result.nullify();
@@ -91,11 +91,11 @@ SD_LIB_EXPORT NDArray NDArrayFactory::create<bool>(const char order, const std::
   if ((int)shape.size() > SD_MAX_RANK)
     throw std::invalid_argument("NDArrayFactory::create: rank of NDArray can't exceed 32 !");
 
-  ShapeDescriptor descriptor(sd::DataType::BOOL, order, shape);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(sd::DataType::BOOL, order, shape);
 
-  if (descriptor.arrLength() != data.size()) {
+  if (descriptor->arrLength() != data.size()) {
     sd_printf("NDArrayFactory::create: data size [%i] doesn't match shape length [%lld]\n", data.size(),
-              descriptor.arrLength());
+              descriptor->arrLength());
     throw std::runtime_error("NDArrayFactory::create: data size doesn't match shape");
   }
 
@@ -118,16 +118,16 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
   if ((int)shape.size() > SD_MAX_RANK)
     throw std::invalid_argument("NDArrayFactory::create: rank of NDArray can't exceed 32 !");
 
-  ShapeDescriptor descriptor(DataTypeUtils::fromT<T>(), order, shape);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(DataTypeUtils::fromT<T>(), order, shape);
 
-  if (descriptor.arrLength() != data.size()) {
+  if (descriptor->arrLength() != data.size()) {
     sd_printf("NDArrayFactory::create: data size [%i] doesn't match shape length [%lld]\n", data.size(),
-              descriptor.arrLength());
+              descriptor->arrLength());
     throw std::runtime_error("NDArrayFactory::create: data size doesn't match shape");
   }
 
   std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(
-      data.data(), DataTypeUtils::fromT<T>(), descriptor.arrLength() * sizeof(T), context->getWorkspace());
+      data.data(), DataTypeUtils::fromT<T>(), descriptor->arrLength() * sizeof(T), context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
 
@@ -254,7 +254,10 @@ NDArray* NDArrayFactory::create_(const T scalar, sd::LaunchContext* context) {
   std::shared_ptr<DataBuffer> buffer =
       std::make_shared<DataBuffer>(1 * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
 
-  NDArray* res = new NDArray(buffer, ShapeDescriptor::scalarDescriptor(DataTypeUtils::fromT<T>()), context);
+  auto desc = ShapeDescriptor::scalarDescriptor(DataTypeUtils::fromT<T>());
+  auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+  auto recast = const_cast<sd::LongType *>(constDesc->primary());
+  NDArray* res = new NDArray(buffer, recast, context);
 
   res->bufferAsT<T>()[0] = scalar;
 
@@ -453,8 +456,9 @@ template <typename T>
 NDArray* NDArrayFactory::vector(sd::LongType length, const T value, sd::LaunchContext* context) {
   std::shared_ptr<DataBuffer> buffer =
       std::make_shared<DataBuffer>(length * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
-
-  auto res = new NDArray(buffer, ShapeDescriptor::vectorDescriptor(length, DataTypeUtils::fromT<T>()), context);
+  auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo( ShapeDescriptor::vectorDescriptor(length, DataTypeUtils::fromT<T>()));
+  auto recast = const_cast<sd::LongType *>(constDesc->primary());
+  auto res = new NDArray(buffer, recast, context);
 
   if (value == (T)0.0f)
     res->nullify();
@@ -507,10 +511,10 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
   if ((int)shape.size() > SD_MAX_RANK)
     throw std::invalid_argument("NDArrayFactory::create: rank of NDArray can't exceed 32");
 
-  ShapeDescriptor descriptor(dtype, order, shape);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(dtype, order, shape);
 
   std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(
-      descriptor.arrLength() * DataTypeUtils::sizeOfElement(dtype), dtype, context->getWorkspace());
+      descriptor->arrLength() * DataTypeUtils::sizeOfElement(dtype), dtype, context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
 
@@ -639,10 +643,10 @@ NDArray NDArrayFactory::create(T* buffer, const char order, const std::initializ
     throw std::invalid_argument("NDArrayFactory::create: Rank of NDArray can't exceed 32");
 
   std::vector<sd::LongType> shp(shape);
-  ShapeDescriptor descriptor(DataTypeUtils::fromT<T>(), order, shp);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(DataTypeUtils::fromT<T>(), order, shp);
 
   std::shared_ptr<DataBuffer> pBuffer = std::make_shared<DataBuffer>(
-      buffer, descriptor.arrLength() * sizeof(T), descriptor.dataType(), false, context->getWorkspace());
+      buffer, descriptor->arrLength() * sizeof(T), descriptor->dataType(), false, context->getWorkspace());
 
   NDArray result(pBuffer, descriptor, context);
 

--- a/libnd4j/include/array/impl/NDArrayFactory.cpp
+++ b/libnd4j/include/array/impl/NDArrayFactory.cpp
@@ -644,8 +644,6 @@ NDArray* NDArrayFactory::create_(const char order, const std::vector<sd::LongTyp
 template <typename T>
 NDArray NDArrayFactory::create(T* buffer, const char order, const std::initializer_list<sd::LongType>& shape,
                                sd::LaunchContext* context) {
-  sd_printf("In arrLength usage at  NDArrayFactory::create(T* buffer, const char order, const std::initializer_list<sd::LongType>& shape,\n"
-            "                               sd::LaunchContext* context\n",0);
   if ((int)shape.size() > SD_MAX_RANK)
     throw std::invalid_argument("NDArrayFactory::create: Rank of NDArray can't exceed 32");
 

--- a/libnd4j/include/array/impl/NDArrayFactory.cpp
+++ b/libnd4j/include/array/impl/NDArrayFactory.cpp
@@ -258,7 +258,7 @@ NDArray* NDArrayFactory::create_(const T scalar, sd::LaunchContext* context) {
   auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
   auto recast = const_cast<sd::LongType *>(constDesc->primary());
   NDArray* res = new NDArray(buffer, recast, context);
- delete desc;
+  delete desc;
   res->bufferAsT<T>()[0] = scalar;
 
   res->tickWriteHost();
@@ -461,7 +461,7 @@ NDArray* NDArrayFactory::vector(sd::LongType length, const T value, sd::LaunchCo
   auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
   auto recast = const_cast<sd::LongType *>(constDesc->primary());
   auto res = new NDArray(buffer, recast, context);
-delete desc;
+  delete desc;
   if (value == (T)0.0f)
     res->nullify();
   else
@@ -521,7 +521,7 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
       descriptor->arrLength() * DataTypeUtils::sizeOfElement(dtype), dtype, context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
-
+  delete descriptor;
   result.nullify();
 
   return result;
@@ -531,9 +531,9 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
 NDArray NDArrayFactory::create(sd::DataType dtype, sd::LaunchContext* context) {
   std::shared_ptr<DataBuffer> buffer =
       std::make_shared<DataBuffer>(DataTypeUtils::sizeOfElement(dtype), dtype, context->getWorkspace(), true);
-auto desc = ShapeDescriptor::scalarDescriptor(dtype);
+  auto desc = ShapeDescriptor::scalarDescriptor(dtype);
   NDArray res(buffer, desc, context);
-delete desc;
+  delete desc;
   res.nullify();
 
   return res;
@@ -553,7 +553,7 @@ NDArray NDArrayFactory::create(const std::vector<T>& values, sd::LaunchContext* 
 
   auto desc = ShapeDescriptor::vectorDescriptor(values.size(), DataTypeUtils::fromT<T>());
   NDArray res(buffer, desc, context);
-delete desc;
+  delete desc;
   memcpyFromVector<T>(res.buffer(), values);
 
   res.tickWriteHost();

--- a/libnd4j/include/array/impl/ShapeDescriptor.cpp
+++ b/libnd4j/include/array/impl/ShapeDescriptor.cpp
@@ -153,11 +153,24 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const sd::LongType length)
 }
 
 ShapeDescriptor::ShapeDescriptor(const sd::LongType *shapeInfo, bool inheritDtype) {
+  if(shapeInfo == nullptr) {
+    throw std::runtime_error("Shape info can not be null!");
+  }
+
+  if(shape::rank(shapeInfo) < 0 || shape::rank(shapeInfo) > SD_MAX_RANK) {
+    throw std::runtime_error("ShapeDescriptor constructor: Corrupt shape buffer found. Likely was deallocated. Please ensure proper usage of the buffer\n");
+  }
+
   _order = shape::order(shapeInfo);
+  sd_printf("ShapeDescriptor constructor: Determined order\n",0);
   _ews = shape::elementWiseStride(shapeInfo);
+  sd_printf("ShapeDescriptor constructor: Determined ews\n",0);
   _rank = shape::rank(shapeInfo);
+  sd_printf("ShapeDescriptor constructor: Determined rank\n",0);
   _extraProperties = ArrayOptions::propertyWithoutDataType(shapeInfo);
+  sd_printf("ShapeDescriptor constructor: Determined extra properties\n",0);
   if (inheritDtype) _dataType = ArrayOptions::dataType(shapeInfo);
+  sd_printf("ShapeDescriptor constructor: Determined dtype\n",0);
 
   _shape_strides.resize(2 * _rank);
 

--- a/libnd4j/include/array/impl/ShapeDescriptor.cpp
+++ b/libnd4j/include/array/impl/ShapeDescriptor.cpp
@@ -162,15 +162,10 @@ ShapeDescriptor::ShapeDescriptor(const sd::LongType *shapeInfo, bool inheritDtyp
   }
 
   _order = shape::order(shapeInfo);
-  sd_printf("ShapeDescriptor constructor: Determined order\n",0);
   _ews = shape::elementWiseStride(shapeInfo);
-  sd_printf("ShapeDescriptor constructor: Determined ews\n",0);
   _rank = shape::rank(shapeInfo);
-  sd_printf("ShapeDescriptor constructor: Determined rank\n",0);
   _extraProperties = ArrayOptions::propertyWithoutDataType(shapeInfo);
-  sd_printf("ShapeDescriptor constructor: Determined extra properties\n",0);
   if (inheritDtype) _dataType = ArrayOptions::dataType(shapeInfo);
-  sd_printf("ShapeDescriptor constructor: Determined dtype\n",0);
 
   _shape_strides.resize(2 * _rank);
 
@@ -190,19 +185,16 @@ ShapeDescriptor::ShapeDescriptor(const sd::LongType *shapeInfo, bool inheritDtyp
 ShapeDescriptor::ShapeDescriptor(const sd::LongType *shapeInfo, const sd::DataType dtypeOverride)
     : ShapeDescriptor::ShapeDescriptor(shapeInfo, false) {
   _dataType = dtypeOverride;
-  sd_printf("Invoking with data type override 2\n",0);
 }
 
 ShapeDescriptor::ShapeDescriptor(const sd::LongType *shapeInfo, const sd::LongType *dtypeOverride)
     : ShapeDescriptor::ShapeDescriptor(shapeInfo, ArrayOptions::dataType(dtypeOverride)) {
-          sd_printf("Invoking with data type override\n",0);
 }
 
 ShapeDescriptor::ShapeDescriptor(const sd::LongType *shapeInfo, const sd::LongType *dtypeOverride,
                                  const sd::LongType *orderOverride)
     : ShapeDescriptor::ShapeDescriptor(shapeInfo, ArrayOptions::dataType(dtypeOverride)) {
   _order = shape::order(orderOverride);
-  sd_printf("Invoking with order override 2\n",0);
 }
 
 int ShapeDescriptor::rank() const { return _rank; }

--- a/libnd4j/include/graph/impl/Context.cpp
+++ b/libnd4j/include/graph/impl/Context.cpp
@@ -24,427 +24,428 @@
 #include <helpers/ShapeUtils.h>
 
 namespace sd {
-    namespace graph {
-        Context::Context(ContextPrototype *prototype, VariableSpace *variableSpace) {
-            _variableSpace = variableSpace;
-            _dataType = prototype->dataType();
+namespace graph {
+Context::Context(ContextPrototype *prototype, VariableSpace *variableSpace) {
+  _variableSpace = variableSpace;
+  _dataType = prototype->dataType();
 
-            if (prototype != nullptr) {
-                for (const auto &v : *(prototype->inputs())) {
-                    this->_inputs.push_back(v);
-                }
+  if (prototype != nullptr) {
+    for (const auto &v : *(prototype->inputs())) {
+      this->_inputs.push_back(v);
+    }
 
-                for (const auto &v : *(prototype->getTArguments())) {
-                    this->_tArgs.push_back(v);
-                }
+    for (const auto &v : *(prototype->getTArguments())) {
+      this->_tArgs.push_back(v);
+    }
 
-                for (const auto &v : *(prototype->getIArguments())) {
-                    this->_iArgs.push_back(v);
-                }
+    for (const auto &v : *(prototype->getIArguments())) {
+      this->_iArgs.push_back(v);
+    }
 
-                for (const auto &v : *(prototype->getBArguments())) {
-                    this->_bArgs.push_back(v);
-                }
+    for (const auto &v : *(prototype->getBArguments())) {
+      this->_bArgs.push_back(v);
+    }
 
-                for (const auto &v : *(prototype->getAxis())) {
-                    this->_axis.push_back(v);
-                }
+    for (const auto &v : *(prototype->getAxis())) {
+      this->_axis.push_back(v);
+    }
 
-                this->_opNum = prototype->opNum();
-                this->_isInplace = prototype->isInplace();
-                this->_nodeId = prototype->nodeId();
-                this->_useONEDNN = prototype->isUseONEDNN();
-            }
+    this->_opNum = prototype->opNum();
+    this->_isInplace = prototype->isInplace();
+    this->_nodeId = prototype->nodeId();
+    this->_useONEDNN = prototype->isUseONEDNN();
+  }
 
-            if (variableSpace != nullptr && variableSpace->launchContext()->getWorkspace() != nullptr)
-                this->_workspace = variableSpace->launchContext()->getWorkspace();
+  if (variableSpace != nullptr && variableSpace->launchContext()->getWorkspace() != nullptr)
+    this->_workspace = variableSpace->launchContext()->getWorkspace();
+}
+sd::DataType Context::dataType(int index) { return _dataType; }
+
+sd::DataType Context::dataType() { return dataType(0); }
+
+void Context::setDataType(int index, sd::DataType type) {
+  if (this->_dataTypes.size() > (size_t)index) _dataTypes[index] = type;
+  _dataType = type;
+}
+
+Context::Context(int nodeId, VariableSpace *variableSpace) {
+  this->_nodeId = nodeId;
+  this->_variableSpace = variableSpace;
+  this->_isInplace = false;
+  this->_workspace = nullptr;
+
+  this->_executionTime.first = 0;
+  this->_executionTime.second = 0;
+
+  if (variableSpace != nullptr && variableSpace->launchContext()->getWorkspace() != nullptr)
+    this->_workspace = variableSpace->launchContext()->getWorkspace();
+}
+
+Context::Context(int nodeId, VariableSpace *variableSpace, bool isInplace) : Context(nodeId, variableSpace) {
+  this->_isInplace = isInplace;
+}
+
+Context::~Context() {
+  this->_iArgs.clear();
+  this->_tArgs.clear();
+  this->_inputs.clear();
+  this->_fastpath_in.clear();
+  this->_fastpath_out.clear();
+
+  for (auto v : _handles) delete v;
+
+  if (_context != nullptr) delete _context;
+}
+
+void Context::setTargetEngine(samediff::Engine engine) { _engine = engine; }
+
+bool Context::hasWorkspaceProvided() { return this->_workspace != nullptr; }
+
+void Context::attachWorkspace(sd::memory::Workspace *workspace) { this->_workspace = workspace; }
+
+void Context::setVariableSpace(VariableSpace *variableSpace) { this->_variableSpace = variableSpace; }
+
+void Context::forgetWorkspace() { _workspace = nullptr; }
+
+std::vector<NDArray *> &Context::fastpath_in() { return _fastpath_in; }
+
+std::vector<NDArray *> &Context::fastpath_out() { return _fastpath_out; }
+
+bool Context::isFastPath() {
+  auto ie = _fastpath_in.empty();
+  auto io = _fastpath_out.empty();
+  // two options here.
+  // either both IN/OUT are filled
+  auto b1 = (!ie && !io) || (!ie && _isInplace);
+
+  // or at least something is filled, and FastPath is NOT forbidden
+  auto b2 = (!ie || !io) && !_forbidFastPath;
+  return b1 || b2;
+}
+
+void Context::forbidFastPath(bool reallyForbid) { _forbidFastPath = reallyForbid; }
+
+VariableSpace *Context::getVariableSpace() { return _variableSpace; }
+
+sd::memory::Workspace *Context::getWorkspace() { return _workspace; }
+
+sd::memory::Workspace *Context::workspace() { return _workspace; }
+
+sd::random::RandomBuffer *Context::getRNG() { return _rng; }
+
+void Context::setRNG(sd::random::RandomBuffer *rng) { _rng = rng; }
+
+
+Stash *Context::getStash() { return _variableSpace->getStash(); }
+
+void Context::trackList(NDArrayList *list) { _variableSpace->trackList(list); }
+
+int Context::getBranch() { return _variableSpace->flowPath()->branch(this->nodeId()); }
+
+void Context::setBranch(int branch) {
+  //_branch = branch;
+  if (_variableSpace->flowPath() != nullptr) _variableSpace->flowPath()->markBranch(this->nodeId(), branch);
+}
+
+sd::LongType sd::graph::Context::getOuterTime() { return this->_executionTime.first; }
+
+sd::LongType sd::graph::Context::getInnerTime() { return this->_executionTime.second; }
+
+void sd::graph::Context::setOuterTime(sd::LongType time) { this->_executionTime.first = time; }
+
+void sd::graph::Context::setInnerTime(sd::LongType time) { this->_executionTime.second = time; }
+
+Variable *Context::getVariable(int idx) {
+  if (idx >= this->_inputs.size()) {
+    sd_printf("Node %i; Variable [%i] requested, but only %i inputs available\n", this->_nodeId, idx,
+              this->_inputs.size());
+    throw std::runtime_error("Context: bad Variable index");
+  }
+
+  auto p = this->_inputs[idx];
+
+  auto v = variable(p);
+  // preconditioned with v->variableType()==VariableType::NDARRAY as for other cases getNDArray() can throw exception
+  if (Environment::getInstance().isDebugAndVerbose() && v != nullptr && v->variableType() == VariableType::NDARRAY &&
+      v->getNDArray() != nullptr) {
+    auto array = v->getNDArray();
+    std::string shape_ = ShapeUtils::shapeAsString(array);
+    auto type = DataTypeUtils::asString(array->dataType());
+    float m = std::numeric_limits<float>::quiet_NaN();
+    if (!array->isEmpty()) {
+      auto values = array->asIndexedString(16);
+
+      sd_printf("Debug info for node_%i input[%i]; shape: %s; ews: [%i]; order: [%c]; dtype: [%s]; first values: %s\n",
+                this->_nodeId, idx, shape_.c_str(), (int)array->ews(), array->ordering(), type.c_str(), values.c_str());
+    } else {
+      sd_printf("Debug info for node_%i input[%i]; shape: %s; ews: [%i]; order: [%c]; dtype: [%s]; mean value: [%f]\n",
+                this->_nodeId, idx, shape_.c_str(), (int)array->ews(), array->ordering(), type.c_str(), m);
+    }
+  }
+
+  return v;
+}
+
+Variable *Context::variable(int idx) { return getVariable(idx); }
+
+Variable *Context::variable(std::initializer_list<int> p) {
+  if (p.size() != 2) throw std::runtime_error("Variable address should have size of 2");
+
+  std::vector<int> vec(p);
+  std::pair<int, int> pair(vec[0], vec[1]);
+  return variable(pair);
+}
+
+Variable *Context::variable(int node, int idx) {
+  std::pair<int, int> pair(node, idx);
+  return variable(pair);
+}
+
+Variable *Context::variable(std::pair<int, int> &p) {
+  try {
+    return _variableSpace->getVariable(p);
+  } catch (std::exception &e) {
+    sd_printf("Node %i; Non-existent variable requested: [%i:%i]\n", this->_nodeId, p.first, p.second);
+    throw std::runtime_error("Bad variable");
+  }
+}
+
+void Context::pushNDArrayToVariableSpace(int nodeId, int index, NDArray *array, bool removable) {
+  std::pair<int, int> pair(nodeId, index);
+  pushNDArrayToVariableSpace(pair, array, removable);
+}
+
+void Context::pushNDArrayToVariableSpace(std::pair<int, int> &pair, NDArray *array, bool removable) {
+  if (_variableSpace != nullptr) {
+    if (!_variableSpace->hasVariable(pair)) {
+      auto var = new Variable(array, nullptr, pair.first, pair.second);
+      _variableSpace->putVariable(pair, var);
+      var->markRemovable(removable);
+    } else {
+      sd_debug("Context: Getting variable in push ndarray",0);
+      auto var = _variableSpace->getVariable(pair);
+      sd_debug("Context: After getting variable in push ndarray to variable space",0);
+      if (var->hasNDArray()) {
+        if (var->getNDArray() != array) {
+          if (var->isRemovable() && var->hasNDArray() && !var->getNDArray()->isView()) {
+            delete var->getNDArray();
+          }
+          var->setNDArray(array);
+          var->markRemovable(removable);
         }
-        sd::DataType Context::dataType(int index) { return _dataType; }
-
-        sd::DataType Context::dataType() { return dataType(0); }
-
-        void Context::setDataType(int index, sd::DataType type) {
-            if (this->_dataTypes.size() > (size_t)index) _dataTypes[index] = type;
-            _dataType = type;
-        }
-
-        Context::Context(int nodeId, VariableSpace *variableSpace) {
-            this->_nodeId = nodeId;
-            this->_variableSpace = variableSpace;
-            this->_isInplace = false;
-            this->_workspace = nullptr;
-
-            this->_executionTime.first = 0;
-            this->_executionTime.second = 0;
-
-            if (variableSpace != nullptr && variableSpace->launchContext()->getWorkspace() != nullptr)
-                this->_workspace = variableSpace->launchContext()->getWorkspace();
-        }
-
-        Context::Context(int nodeId, VariableSpace *variableSpace, bool isInplace) : Context(nodeId, variableSpace) {
-            this->_isInplace = isInplace;
-        }
-
-        Context::~Context() {
-            this->_iArgs.clear();
-            this->_tArgs.clear();
-            this->_inputs.clear();
-            this->_fastpath_in.clear();
-            this->_fastpath_out.clear();
-
-            for (auto v : _handles) delete v;
-
-            if (_context != nullptr) delete _context;
-        }
-
-        void Context::setTargetEngine(samediff::Engine engine) { _engine = engine; }
-
-        bool Context::hasWorkspaceProvided() { return this->_workspace != nullptr; }
-
-        void Context::attachWorkspace(sd::memory::Workspace *workspace) { this->_workspace = workspace; }
-
-        void Context::setVariableSpace(VariableSpace *variableSpace) { this->_variableSpace = variableSpace; }
-
-        void Context::forgetWorkspace() { _workspace = nullptr; }
-
-        std::vector<NDArray *> &Context::fastpath_in() { return _fastpath_in; }
-
-        std::vector<NDArray *> &Context::fastpath_out() { return _fastpath_out; }
-
-        bool Context::isFastPath() {
-            auto ie = _fastpath_in.empty();
-            auto io = _fastpath_out.empty();
-            // two options here.
-            // either both IN/OUT are filled
-            auto b1 = (!ie && !io) || (!ie && _isInplace);
-
-            // or at least something is filled, and FastPath is NOT forbidden
-            auto b2 = (!ie || !io) && !_forbidFastPath;
-            return b1 || b2;
-        }
-
-        void Context::forbidFastPath(bool reallyForbid) { _forbidFastPath = reallyForbid; }
-
-        VariableSpace *Context::getVariableSpace() { return _variableSpace; }
-
-        sd::memory::Workspace *Context::getWorkspace() { return _workspace; }
-
-        sd::memory::Workspace *Context::workspace() { return _workspace; }
-
-        sd::random::RandomBuffer *Context::getRNG() { return _rng; }
-
-        void Context::setRNG(sd::random::RandomBuffer *rng) { _rng = rng; }
-
-
-        Stash *Context::getStash() { return _variableSpace->getStash(); }
-
-        void Context::trackList(NDArrayList *list) { _variableSpace->trackList(list); }
-
-        int Context::getBranch() { return _variableSpace->flowPath()->branch(this->nodeId()); }
-
-        void Context::setBranch(int branch) {
-            //_branch = branch;
-            if (_variableSpace->flowPath() != nullptr) _variableSpace->flowPath()->markBranch(this->nodeId(), branch);
-        }
-
-        sd::LongType sd::graph::Context::getOuterTime() { return this->_executionTime.first; }
-
-        sd::LongType sd::graph::Context::getInnerTime() { return this->_executionTime.second; }
-
-        void sd::graph::Context::setOuterTime(sd::LongType time) { this->_executionTime.first = time; }
-
-        void sd::graph::Context::setInnerTime(sd::LongType time) { this->_executionTime.second = time; }
-
-        Variable *Context::getVariable(int idx) {
-            if (idx >= this->_inputs.size()) {
-                sd_printf("Node %i; Variable [%i] requested, but only %i inputs available\n", this->_nodeId, idx,
-                          this->_inputs.size());
-                throw std::runtime_error("Context: bad Variable index");
-            }
-
-            auto p = this->_inputs[idx];
-
-            auto v = variable(p);
-            // preconditioned with v->variableType()==VariableType::NDARRAY as for other cases getNDArray() can throw exception
-            if (Environment::getInstance().isDebugAndVerbose() && v != nullptr && v->variableType() == VariableType::NDARRAY &&
-                v->getNDArray() != nullptr) {
-                auto array = v->getNDArray();
-                std::string shape_ = ShapeUtils::shapeAsString(array);
-                auto type = DataTypeUtils::asString(array->dataType());
-                float m = std::numeric_limits<float>::quiet_NaN();
-                if (!array->isEmpty()) {
-                    auto values = array->asIndexedString(16);
-
-                    sd_printf("Debug info for node_%i input[%i]; shape: %s; ews: [%i]; order: [%c]; dtype: [%s]; first values: %s\n",
-                              this->_nodeId, idx, shape_.c_str(), (int)array->ews(), array->ordering(), type.c_str(), values.c_str());
-                } else {
-                    sd_printf("Debug info for node_%i input[%i]; shape: %s; ews: [%i]; order: [%c]; dtype: [%s]; mean value: [%f]\n",
-                              this->_nodeId, idx, shape_.c_str(), (int)array->ews(), array->ordering(), type.c_str(), m);
-                }
-            }
-
-            return v;
-        }
-
-        Variable *Context::variable(int idx) { return getVariable(idx); }
-
-        Variable *Context::variable(std::initializer_list<int> p) {
-            if (p.size() != 2) throw std::runtime_error("Variable address should have size of 2");
-
-            std::vector<int> vec(p);
-            std::pair<int, int> pair(vec[0], vec[1]);
-            return variable(pair);
-        }
-
-        Variable *Context::variable(int node, int idx) {
-            std::pair<int, int> pair(node, idx);
-            return variable(pair);
-        }
-
-        Variable *Context::variable(std::pair<int, int> &p) {
-            try {
-                return _variableSpace->getVariable(p);
-            } catch (std::exception &e) {
-                sd_printf("Node %i; Non-existent variable requested: [%i:%i]\n", this->_nodeId, p.first, p.second);
-                throw std::runtime_error("Bad variable");
-            }
-        }
-
-        void Context::pushNDArrayToVariableSpace(int nodeId, int index, NDArray *array, bool removable) {
-            std::pair<int, int> pair(nodeId, index);
-            pushNDArrayToVariableSpace(pair, array, removable);
-        }
-
-        void Context::pushNDArrayToVariableSpace(std::pair<int, int> &pair, NDArray *array, bool removable) {
-            if (_variableSpace != nullptr) {
-                if (!_variableSpace->hasVariable(pair)) {
-                    auto var = new Variable(array, nullptr, pair.first, pair.second);
-                    _variableSpace->putVariable(pair, var);
-                    var->markRemovable(removable);
-                } else {
-                    sd_debug("Context: Getting variable in push ndarray",0);
-                    auto var = _variableSpace->getVariable(pair);
-                    sd_debug("Context: After getting variable in push ndarray to variable space",0);
-                    if (var->hasNDArray()) {
-                        if (var->getNDArray() != array) {
-                            if (var->isRemovable() && var->hasNDArray() && !var->getNDArray()->isView()) {
-                                delete var->getNDArray();
-                            }
-                            var->setNDArray(array);
-                            var->markRemovable(removable);
-                        }
-                    } else {
-                        var->setNDArray(array);
-                        var->markRemovable(removable);
-                    }
-                }
-            }
-        }
-
-        void Context::pushNDArrayListToVariableSpace(int nodeId, int index, NDArrayList *list, bool track) {
-            std::pair<int, int> pair(nodeId, index);
-            pushNDArrayListToVariableSpace(pair, list, track);
-        }
-
-        void Context::pushNDArrayListToVariableSpace(std::pair<int, int> &pair, NDArrayList *list, bool track) {
-            sd_debug("Pre push variable list\n",0);
-            if (!_variableSpace->hasVariable(pair)) {
-                sd_debug("Context::pushNDArrayListToVariableSpace: Pre create variable when none exists\n",0);
-                auto var = new Variable(nullptr, nullptr, pair.first, pair.second);
-                sd_debug("Context::pushNDArrayListToVariableSpace: Created when none exists\n",0);
-                var->setNDArrayList(list);
-                _variableSpace->putVariable(pair, var);
-                sd_debug("Context::pushNDArrayListToVariableSpace: Put variable\n",0);
-            } else {
-                sd_debug("Context::pushNDArrayListToVariableSpace: In else: Getting variable\n",0);
-                auto var = _variableSpace->getVariable(pair);
-                sd_debug("Context::pushNDArrayListToVariableSpace: Got variable setting list\n",0);
-                var->setNDArrayList(list);
-            }
-
-            sd_debug("Context::pushNDArrayListToVariableSpace: pre tracking\n",0);
-
-            if (track) _variableSpace->trackList(list);
-        }
-
-        Variable *Context::ensureVariable(int idx) {
-            std::pair<int, int> pair(this->nodeId(), idx);
-
-            if (_variableSpace == nullptr) throw std::runtime_error("Context::ensureVariable VariableSpace is NULL!");
-
-            if (!_variableSpace->hasVariable(pair)) {
-                auto var = new Variable(nullptr, nullptr, this->nodeId(), idx);
-                _variableSpace->putVariable(pair, var);
-                return var;
-            } else {
-                sd_debug("Before ensure variable",0);
-                return _variableSpace->getVariable(pair);
-            }
-        }
-
-        bool Context::isValueAvailable(int idx) {
-            auto var = ensureVariable(idx);
-
-            if (var->variableType() == VariableType::NDARRAY) {
-                return var->hasNDArray();
-            } else if (var->variableType() == VariableType::ARRAY_LIST) {
-                return var->hasNDArrayList();
-            }
-
-            return false;
-        }
-
-        NDArray *Context::getNDArray(int idx) { return array(idx); }
-
-        NDArray *Context::array(int idx) {
-            // we check for fastpath first
-            if (!_fastpath_in.empty() && _fastpath_in.size() > idx) {
-                return _fastpath_in[idx];
-            }
-            // if no luck for fastpath - return whatever is available
-            return getVariable(idx)->getNDArray();
-        }
-
-        sd::memory::Workspace *Context::fWorkspace() { return workspace(); }
-
-        sd::memory::Workspace *Context::tWorkspace() { return nullptr; }
-
-        sd::memory::Workspace *Context::oWorkspace() { return nullptr; }
-
-        LaunchContext *Context::launchContext() {
-            // FIXME: we need proper context to be shared here
-            if (_context == nullptr) {
-                return LaunchContext::defaultContext();
-            } else {
-                return _context;
-            }
-        }
-
-        unsigned long Context::width() {
-            if (!_fastpath_in.empty())
-                return _fastpath_in.size();
-            else
-                return _inputs.size();
-        }
-
-        void Context::setInputArray(int index, NDArray *array, bool removable) {
-            if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
-
-            _fastpath_in[index] = array;
-            if (removable) _handles.emplace_back(array);
-        }
-
-        void Context::setInputArray(int index, void *buffer, void *shapeInfo, void *specialBuffer, void *specialShapeInfo) {
-            this->setInputArray(index, buffer, const_cast<const void *>(shapeInfo), specialBuffer,
-                                const_cast<const void *>(specialShapeInfo));
-        }
-
-        void Context::setInputArray(int index, void *buffer, void const *shapeInfo, void *specialBuffer,
-                                    void const *specialShapeInfo) {
-            auto array = new NDArray(buffer, specialBuffer, reinterpret_cast<sd::LongType const *>(shapeInfo));
-            if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
-
-            _fastpath_in[index] = array;
-            _handles.emplace_back(array);
-
-            if (_context != nullptr) array->setContext(_context);
-        }
-
-
-
-
-        void Context::setOutputArray(int index, NDArray *array, bool removable) {
-            if (_fastpath_out.size() < index + 1) _fastpath_out.resize(index + 1);
-
-            _fastpath_out[index] = array;
-
-            if (removable) _handles.emplace_back(array);
-        }
-
-        void Context::setOutputArray(int index, void *buffer, void *shapeInfo, void *specialBuffer, void *specialShapeInfo) {
-            this->setOutputArray(index, buffer, const_cast<const void *>(shapeInfo), specialBuffer,
-                                 const_cast<const void *>(specialShapeInfo));
-        }
-
-        void Context::setOutputArray(int index, void *buffer, const void *shapeInfo, void *specialBuffer,
-                                     const void *specialShapeInfo) {
-            if (_fastpath_out.size() < index + 1) _fastpath_out.resize(index + 1);
-
-            auto array =  new NDArray(buffer, specialBuffer, reinterpret_cast<sd::LongType const *>(shapeInfo));
-
-            _fastpath_out[index] = array;
-            _handles.emplace_back(array);
-
-            if (_context != nullptr) array->setContext(_context);
-        }
-
-        void Context::setInputArray(int index, void *vdatabuffer, void const *shapeInfo, void const *specialShapeInfo) {
-            auto dataBuffer = reinterpret_cast<InteropDataBuffer *>(vdatabuffer);
-            auto shapeInfoCast = reinterpret_cast<sd::LongType const *>(shapeInfo);
-            if(shape::rank(shapeInfoCast) > SD_MAX_RANK || shape::rank(shapeInfoCast) < 0) {
-              std::string error;
-              error += std::string("Shape Buffer at index ");
-              error += std::string(" " + index);
-              error += std::string(" was corrupt! This is likely due to deallocation. Please double check the passed in shape  buffer.");
-              throw std::runtime_error(error.c_str());
-            }
-            if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
-            NDArray *array;
-            if (dataBuffer != nullptr && !shape::isEmpty(shapeInfoCast)) {
-                array = new NDArray(dataBuffer->dataBuffer(), shapeInfoCast,
-                                    sd::LaunchContext::defaultContext(),
-                                    dataBuffer->offset() / DataTypeUtils::sizeOf(ArrayOptions::dataType(
-                                                             shapeInfoCast)));
-            } else {
-                array = new NDArray(nullptr, nullptr, shapeInfoCast);
-            }
-            _fastpath_in[index] = array;
-            _handles.emplace_back(array);
-
-            if (_context != nullptr) array->setContext(_context);
-        }
-
-        void Context::setOutputArray(int index, void *vdatabuffer, void const *shapeInfo, void const *specialShapeInfo) {
-            auto dataBuffer = reinterpret_cast<InteropDataBuffer *>(vdatabuffer);
-
-            if (_fastpath_out.size() < index + 1) _fastpath_out.resize(index + 1);
-
-            NDArray *array;
-            if (dataBuffer != nullptr && !shape::isEmpty(reinterpret_cast<sd::LongType const *>(shapeInfo)))
-                array = new NDArray(dataBuffer->dataBuffer(), reinterpret_cast<sd::LongType const *>(shapeInfo),
-                                    sd::LaunchContext::defaultContext(),
-                                    dataBuffer->offset() / DataTypeUtils::sizeOf(ArrayOptions::dataType(
-                                            reinterpret_cast<sd::LongType const *>(shapeInfo))));
-            else {
-                array = new NDArray(nullptr, nullptr, reinterpret_cast<sd::LongType const *>(shapeInfo));
-            }
-            _fastpath_out[index] = array;
-            _handles.emplace_back(array);
-
-            if (_context != nullptr) array->setContext(_context);
-        }
-
-        void Context::setTArguments(double *arguments, int numberOfArguments) {
-            _tArgs.clear();
-            _tArgs.reserve(numberOfArguments);
-            for (int e = 0; e < numberOfArguments; e++) _tArgs.push_back(arguments[e]);
-        }
-
-        void Context::setIArguments(sd::LongType *arguments, int numberOfArguments) {
-            _iArgs.clear();
-            _iArgs.reserve(numberOfArguments);
-            for (int e = 0; e < numberOfArguments; e++) _iArgs.push_back(arguments[e]);
-        }
-
-        void Context::setBArguments(bool *arguments, int numberOfArguments) {
-            _bArgs.clear();
-            _bArgs.reserve(numberOfArguments);
-            for (int e = 0; e < numberOfArguments; e++) _bArgs.push_back(arguments[e]);
-        }
-
-        void Context::setCudaContext(sd::Pointer cudaStream, sd::Pointer reductionPointer, sd::Pointer allocationPointer) {
+      } else {
+        var->setNDArray(array);
+        var->markRemovable(removable);
+      }
+    }
+  }
+}
+
+void Context::pushNDArrayListToVariableSpace(int nodeId, int index, NDArrayList *list, bool track) {
+  std::pair<int, int> pair(nodeId, index);
+  pushNDArrayListToVariableSpace(pair, list, track);
+}
+
+void Context::pushNDArrayListToVariableSpace(std::pair<int, int> &pair, NDArrayList *list, bool track) {
+  sd_debug("Pre push variable list\n",0);
+  if (!_variableSpace->hasVariable(pair)) {
+    sd_debug("Context::pushNDArrayListToVariableSpace: Pre create variable when none exists\n",0);
+    auto var = new Variable(nullptr, nullptr, pair.first, pair.second);
+    sd_debug("Context::pushNDArrayListToVariableSpace: Created when none exists\n",0);
+    var->setNDArrayList(list);
+    _variableSpace->putVariable(pair, var);
+    sd_debug("Context::pushNDArrayListToVariableSpace: Put variable\n",0);
+  } else {
+    sd_debug("Context::pushNDArrayListToVariableSpace: In else: Getting variable\n",0);
+    auto var = _variableSpace->getVariable(pair);
+    sd_debug("Context::pushNDArrayListToVariableSpace: Got variable setting list\n",0);
+    var->setNDArrayList(list);
+  }
+
+  sd_debug("Context::pushNDArrayListToVariableSpace: pre tracking\n",0);
+
+  if (track) _variableSpace->trackList(list);
+}
+
+Variable *Context::ensureVariable(int idx) {
+  std::pair<int, int> pair(this->nodeId(), idx);
+
+  if (_variableSpace == nullptr) throw std::runtime_error("Context::ensureVariable VariableSpace is NULL!");
+
+  if (!_variableSpace->hasVariable(pair)) {
+    auto var = new Variable(nullptr, nullptr, this->nodeId(), idx);
+    _variableSpace->putVariable(pair, var);
+    return var;
+  } else {
+    sd_debug("Before ensure variable",0);
+    return _variableSpace->getVariable(pair);
+  }
+}
+
+bool Context::isValueAvailable(int idx) {
+  auto var = ensureVariable(idx);
+
+  if (var->variableType() == VariableType::NDARRAY) {
+    return var->hasNDArray();
+  } else if (var->variableType() == VariableType::ARRAY_LIST) {
+    return var->hasNDArrayList();
+  }
+
+  return false;
+}
+
+NDArray *Context::getNDArray(int idx) { return array(idx); }
+
+NDArray *Context::array(int idx) {
+  // we check for fastpath first
+  if (!_fastpath_in.empty() && _fastpath_in.size() > idx) {
+    return _fastpath_in[idx];
+  }
+  // if no luck for fastpath - return whatever is available
+  return getVariable(idx)->getNDArray();
+}
+
+sd::memory::Workspace *Context::fWorkspace() { return workspace(); }
+
+sd::memory::Workspace *Context::tWorkspace() { return nullptr; }
+
+sd::memory::Workspace *Context::oWorkspace() { return nullptr; }
+
+LaunchContext *Context::launchContext() {
+  // FIXME: we need proper context to be shared here
+  if (_context == nullptr) {
+    return LaunchContext::defaultContext();
+  } else {
+    return _context;
+  }
+}
+
+unsigned long Context::width() {
+  if (!_fastpath_in.empty())
+    return _fastpath_in.size();
+  else
+    return _inputs.size();
+}
+
+void Context::setInputArray(int index, NDArray *array, bool removable) {
+  if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
+
+  _fastpath_in[index] = array;
+  if (removable) _handles.emplace_back(array);
+}
+
+void Context::setInputArray(int index, void *buffer, void *shapeInfo, void *specialBuffer, void *specialShapeInfo) {
+  this->setInputArray(index, buffer, const_cast<const void *>(shapeInfo), specialBuffer,
+                      const_cast<const void *>(specialShapeInfo));
+}
+
+void Context::setInputArray(int index, void *buffer, void const *shapeInfo, void *specialBuffer,
+                            void const *specialShapeInfo) {
+  auto array = new NDArray(buffer, specialBuffer, reinterpret_cast<sd::LongType const *>(shapeInfo));
+  if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
+
+  _fastpath_in[index] = array;
+  _handles.emplace_back(array);
+
+  if (_context != nullptr) array->setContext(_context);
+}
+
+
+
+
+void Context::setOutputArray(int index, NDArray *array, bool removable) {
+  if (_fastpath_out.size() < index + 1) _fastpath_out.resize(index + 1);
+
+  _fastpath_out[index] = array;
+
+  if (removable) _handles.emplace_back(array);
+}
+
+void Context::setOutputArray(int index, void *buffer, void *shapeInfo, void *specialBuffer, void *specialShapeInfo) {
+  this->setOutputArray(index, buffer, const_cast<const void *>(shapeInfo), specialBuffer,
+                       const_cast<const void *>(specialShapeInfo));
+}
+
+void Context::setOutputArray(int index, void *buffer, const void *shapeInfo, void *specialBuffer,
+                             const void *specialShapeInfo) {
+  if (_fastpath_out.size() < index + 1) _fastpath_out.resize(index + 1);
+
+  auto array =  new NDArray(buffer, specialBuffer, reinterpret_cast<sd::LongType const *>(shapeInfo));
+
+  _fastpath_out[index] = array;
+  _handles.emplace_back(array);
+
+  if (_context != nullptr) array->setContext(_context);
+}
+
+void Context::setInputArray(int index, void *vdatabuffer, void const *shapeInfo, void const *specialShapeInfo) {
+  auto dataBuffer = reinterpret_cast<InteropDataBuffer *>(vdatabuffer);
+  auto shapeInfoCast = reinterpret_cast<sd::LongType const *>(shapeInfo);
+  auto newShapeInfoCast = const_cast<sd::LongType *>(shapeInfoCast);
+  if(shape::rank(shapeInfoCast) > SD_MAX_RANK || shape::rank(shapeInfoCast) < 0) {
+    std::string error;
+    error += std::string("Shape Buffer at index ");
+    error += std::string(" " + index);
+    error += std::string(" was corrupt! This is likely due to deallocation. Please double check the passed in shape  buffer.");
+    throw std::runtime_error(error.c_str());
+  }
+  if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
+  NDArray *array;
+  if (dataBuffer != nullptr && !shape::isEmpty(shapeInfoCast)) {
+    sd_printf("Before creating non empty ndarray using shape info cast\n",0);
+    array = new NDArray(dataBuffer->dataBuffer(),newShapeInfoCast);
+
+  } else {
+    sd_printf("Creating shape descriptor from shape info cast with empty data buffer\n",0);
+    array = new NDArray(nullptr, nullptr, shapeInfoCast);
+  }
+  _fastpath_in[index] = array;
+  _handles.emplace_back(array);
+
+  if (_context != nullptr) array->setContext(_context);
+}
+
+void Context::setOutputArray(int index, void *vdatabuffer, void const *shapeInfo, void const *specialShapeInfo) {
+  auto dataBuffer = reinterpret_cast<InteropDataBuffer *>(vdatabuffer);
+
+  if (_fastpath_out.size() < index + 1) _fastpath_out.resize(index + 1);
+
+  auto shapeInfoCast = reinterpret_cast<sd::LongType const *>(shapeInfo);
+  auto newShapeInfoCast = const_cast<sd::LongType *>(shapeInfoCast);
+  NDArray *array;
+  if (dataBuffer != nullptr && !shape::isEmpty(shapeInfoCast))
+    array = new NDArray(dataBuffer->dataBuffer(),newShapeInfoCast);
+
+  else {
+    array = new NDArray(nullptr, nullptr, shapeInfoCast);
+  }
+  _fastpath_out[index] = array;
+  _handles.emplace_back(array);
+
+  if (_context != nullptr) array->setContext(_context);
+}
+
+void Context::setTArguments(double *arguments, int numberOfArguments) {
+  _tArgs.clear();
+  _tArgs.reserve(numberOfArguments);
+  for (int e = 0; e < numberOfArguments; e++) _tArgs.push_back(arguments[e]);
+}
+
+void Context::setIArguments(sd::LongType *arguments, int numberOfArguments) {
+  _iArgs.clear();
+  _iArgs.reserve(numberOfArguments);
+  for (int e = 0; e < numberOfArguments; e++) _iArgs.push_back(arguments[e]);
+}
+
+void Context::setBArguments(bool *arguments, int numberOfArguments) {
+  _bArgs.clear();
+  _bArgs.reserve(numberOfArguments);
+  for (int e = 0; e < numberOfArguments; e++) _bArgs.push_back(arguments[e]);
+}
+
+void Context::setCudaContext(sd::Pointer cudaStream, sd::Pointer reductionPointer, sd::Pointer allocationPointer) {
 #ifdef __CUDABLAS__
-            _context = new LaunchContext(cudaStream, reductionPointer, allocationPointer);
+  _context = new LaunchContext(cudaStream, reductionPointer, allocationPointer);
 
   // FIXME: either pass handle from outside, or make sure outside we use the same handle
   _context->setCublasHandle(LaunchContext::defaultContext()->getCublasHandle());
@@ -453,100 +454,100 @@ namespace sd {
 
   for (auto v : _fastpath_in) v->setContext(_context);
 #endif
-        }
+}
 
-        void Context::allowHelpers(bool reallyAllow) { _helpersAllowed = reallyAllow; }
+void Context::allowHelpers(bool reallyAllow) { _helpersAllowed = reallyAllow; }
 
-        bool Context::helpersAllowed() { return _helpersAllowed; }
+bool Context::helpersAllowed() { return _helpersAllowed; }
 
-        void Context::setTArguments(const std::vector<double> &tArgs) {
-            for (auto t : tArgs) _tArgs.emplace_back(t);
-        }
+void Context::setTArguments(const std::vector<double> &tArgs) {
+  for (auto t : tArgs) _tArgs.emplace_back(t);
+}
 
-        void Context::setIArguments(const std::vector<sd::LongType> &iArgs) {
-            for (auto i : iArgs) _iArgs.emplace_back(i);
-        }
+void Context::setIArguments(const std::vector<sd::LongType> &iArgs) {
+  for (auto i : iArgs) _iArgs.emplace_back(i);
+}
 
-        void Context::setBArguments(const std::vector<bool> &bArgs) {
-            for (auto b : bArgs) _bArgs.push_back(b);
-        }
+void Context::setBArguments(const std::vector<bool> &bArgs) {
+  for (auto b : bArgs) _bArgs.push_back(b);
+}
 
-        void Context::setShapeFunctionOverride(bool reallyOverride) { _shapeFunctionOverride = reallyOverride; }
+void Context::setShapeFunctionOverride(bool reallyOverride) { _shapeFunctionOverride = reallyOverride; }
 
-        bool Context::shapeFunctionOverride() { return _shapeFunctionOverride; }
+bool Context::shapeFunctionOverride() { return _shapeFunctionOverride; }
 
-        samediff::ExecutionMode Context::executionMode() { return _execMode; }
+samediff::ExecutionMode Context::executionMode() { return _execMode; }
 
-        void Context::setExecutionMode(samediff::ExecutionMode executionMode) { _execMode = executionMode; }
+void Context::setExecutionMode(samediff::ExecutionMode executionMode) { _execMode = executionMode; }
 
-        bool Context::isTraining() { return _execMode == samediff::ExecutionMode::MODE_TRAINING; }
+bool Context::isTraining() { return _execMode == samediff::ExecutionMode::MODE_TRAINING; }
 
-        bool Context::isInference() { return _execMode == samediff::ExecutionMode::MODE_INFERENCE; }
+bool Context::isInference() { return _execMode == samediff::ExecutionMode::MODE_INFERENCE; }
 
-        void Context::setDArguments(sd::DataType *arguments, int numberOfArguments) {
-            _dArgs.clear();
-            for (int e = 0; e < numberOfArguments; e++) _dArgs.emplace_back(arguments[e]);
-        }
+void Context::setDArguments(sd::DataType *arguments, int numberOfArguments) {
+  _dArgs.clear();
+  for (int e = 0; e < numberOfArguments; e++) _dArgs.emplace_back(arguments[e]);
+}
 
-        void Context::setDArguments(const std::vector<sd::DataType> &dArgs) {
-            _dArgs.clear();
-            for (auto d : dArgs) _dArgs.emplace_back(d);
-        }
+void Context::setDArguments(const std::vector<sd::DataType> &dArgs) {
+  _dArgs.clear();
+  for (auto d : dArgs) _dArgs.emplace_back(d);
+}
 
-        void Context::clearFastPath() {
-            _fastpath_in.clear();
-            _fastpath_out.clear();
+void Context::clearFastPath() {
+  _fastpath_in.clear();
+  _fastpath_out.clear();
 
-            for (auto v : _handles) delete v;
+  for (auto v : _handles) delete v;
 
-            _handles.clear();
-        }
+  _handles.clear();
+}
 
-        void Context::setInputArrays(int numArrays,NDArray** array, bool removable) {
-            for(int i = 0; i < numArrays; i++) {
-                setInputArray(i,array[i],removable);
-            }
-        }
-        void Context::setInputArrays(int numArrays,void** buffer, void const** shapeInfo, void** specialBuffer, void const** specialShapeInfo) {
-            for(int i = 0; i < numArrays; i++) {
-                setInputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialShapeInfo[i]);
-            }
-        }
-        void Context::setInputArrays(int numArrays,void** buffer, void** shapeInfo, void** specialBuffer, void** specialShapeInfo) {
-            for(int i = 0; i < numArrays; i++) {
-                setInputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialBuffer[i]);
-            }
+void Context::setInputArrays(int numArrays,NDArray** array, bool removable) {
+  for(int i = 0; i < numArrays; i++) {
+    setInputArray(i,array[i],removable);
+  }
+}
+void Context::setInputArrays(int numArrays,void** buffer, void const** shapeInfo, void** specialBuffer, void const** specialShapeInfo) {
+  for(int i = 0; i < numArrays; i++) {
+    setInputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialShapeInfo[i]);
+  }
+}
+void Context::setInputArrays(int numArrays,void** buffer, void** shapeInfo, void** specialBuffer, void** specialShapeInfo) {
+  for(int i = 0; i < numArrays; i++) {
+    setInputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialBuffer[i]);
+  }
 
-        }
-        void Context::setInputArrays(int numArrays,void** databuffer, void const** shapeInfo, void const** specialShapeInfo) {
-            for(int i = 0; i < numArrays; i++) {
-                setInputArray(i,databuffer[i],shapeInfo[i],specialShapeInfo[i]);
-            }
-        }
+}
+void Context::setInputArrays(int numArrays,void** databuffer, void const** shapeInfo, void const** specialShapeInfo) {
+  for(int i = 0; i < numArrays; i++) {
+    setInputArray(i,databuffer[i],shapeInfo[i],specialShapeInfo[i]);
+  }
+}
 
-        void Context::setOutputArrays(int numArrays,NDArray** array, bool removable) {
-            for(int i = 0; i < numArrays; i++) {
-                setOutputArray(i,array[i],removable);
-            }
-        }
-        void Context::setOutputArrays(int numArrays,void** buffer, const void** shapeInfo, void** specialBuffer,
-                                      const void** specialShapeInfo) {
-            for(int i = 0; i < numArrays; i++) {
-                setOutputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialShapeInfo[i]);
-            }
+void Context::setOutputArrays(int numArrays,NDArray** array, bool removable) {
+  for(int i = 0; i < numArrays; i++) {
+    setOutputArray(i,array[i],removable);
+  }
+}
+void Context::setOutputArrays(int numArrays,void** buffer, const void** shapeInfo, void** specialBuffer,
+                              const void** specialShapeInfo) {
+  for(int i = 0; i < numArrays; i++) {
+    setOutputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialShapeInfo[i]);
+  }
 
-        }
-        void Context::setOutputArrays(int numArrays,void** buffer, void** shapeInfo, void** specialBuffer, void** specialShapeInfo) {
-            for(int i = 0; i < numArrays; i++) {
-                setOutputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialShapeInfo[i]);
-            }
-        }
+}
+void Context::setOutputArrays(int numArrays,void** buffer, void** shapeInfo, void** specialBuffer, void** specialShapeInfo) {
+  for(int i = 0; i < numArrays; i++) {
+    setOutputArray(i,buffer[i],shapeInfo[i],specialBuffer[i],specialShapeInfo[i]);
+  }
+}
 
-        void Context::setOutputArrays(int numArrays,void** databuffer, void const** shapeInfo, void const** specialShapeInfo) {
-            for(int i = 0; i < numArrays; i++) {
-                setOutputArray(i,databuffer[i],shapeInfo[i],specialShapeInfo[i]);
-            }
-        }
+void Context::setOutputArrays(int numArrays,void** databuffer, void const** shapeInfo, void const** specialShapeInfo) {
+  for(int i = 0; i < numArrays; i++) {
+    setOutputArray(i,databuffer[i],shapeInfo[i],specialShapeInfo[i]);
+  }
+}
 
-    }  // namespace graph
+}  // namespace graph
 }  // namespace sd

--- a/libnd4j/include/graph/impl/Context.cpp
+++ b/libnd4j/include/graph/impl/Context.cpp
@@ -392,11 +392,9 @@ void Context::setInputArray(int index, void *vdatabuffer, void const *shapeInfo,
   if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
   NDArray *array;
   if (dataBuffer != nullptr && !shape::isEmpty(shapeInfoCast)) {
-    sd_printf("Before creating non empty ndarray using shape info cast\n",0);
     array = new NDArray(dataBuffer->dataBuffer(),newShapeInfoCast);
 
   } else {
-    sd_printf("Creating shape descriptor from shape info cast with empty data buffer\n",0);
     array = new NDArray(nullptr, nullptr, shapeInfoCast);
   }
   _fastpath_in[index] = array;

--- a/libnd4j/include/graph/impl/Context.cpp
+++ b/libnd4j/include/graph/impl/Context.cpp
@@ -392,7 +392,9 @@ void Context::setInputArray(int index, void *vdatabuffer, void const *shapeInfo,
   if (_fastpath_in.size() < index + 1) _fastpath_in.resize(index + 1);
   NDArray *array;
   if (dataBuffer != nullptr && !shape::isEmpty(shapeInfoCast)) {
-    array = new NDArray(dataBuffer->dataBuffer(),newShapeInfoCast);
+    array = new NDArray(dataBuffer->dataBuffer(),newShapeInfoCast, sd::LaunchContext::defaultContext(),
+                        dataBuffer->offset() / DataTypeUtils::sizeOf(ArrayOptions::dataType(
+                            shapeInfoCast)));
 
   } else {
     array = new NDArray(nullptr, nullptr, shapeInfoCast);
@@ -412,7 +414,10 @@ void Context::setOutputArray(int index, void *vdatabuffer, void const *shapeInfo
   auto newShapeInfoCast = const_cast<sd::LongType *>(shapeInfoCast);
   NDArray *array;
   if (dataBuffer != nullptr && !shape::isEmpty(shapeInfoCast))
-    array = new NDArray(dataBuffer->dataBuffer(),newShapeInfoCast);
+    array = new NDArray(dataBuffer->dataBuffer(),newShapeInfoCast,
+                        sd::LaunchContext::defaultContext(),
+                        dataBuffer->offset() / DataTypeUtils::sizeOf(ArrayOptions::dataType(
+                            shapeInfoCast)));
 
   else {
     array = new NDArray(nullptr, nullptr, shapeInfoCast);

--- a/libnd4j/include/graph/impl/GraphExecutioner.cpp
+++ b/libnd4j/include/graph/impl/GraphExecutioner.cpp
@@ -166,7 +166,6 @@ sd::Status GraphExecutioner::executeFlatNode(Graph *graph, Node *node, VariableS
 
       auto var = variableSpace->getVariable(pair);
 
-      // sd_printf("HasArray: [%i]; Removable: [%i]\n", var->hasNDArray(), var->isRemovable());
       var->setNDArray(array);
       var->markRemovable(true);
     }

--- a/libnd4j/include/helpers/ConstantShapeHelper.h
+++ b/libnd4j/include/helpers/ConstantShapeHelper.h
@@ -37,7 +37,7 @@ namespace sd {
 class SD_LIB_EXPORT ConstantShapeHelper {
  private:
   std::mutex _mutex;
-  std::vector<SD_MAP_IMPL<ShapeDescriptor, ConstantShapeBuffer>> _cache;
+  std::vector<SD_MAP_IMPL<ShapeDescriptor *, ConstantShapeBuffer *>> _cache;
 #if defined(__NEC__)
   bool _cache_existing_pointers = true;
 #endif
@@ -59,24 +59,24 @@ class SD_LIB_EXPORT ConstantShapeHelper {
 
   static ConstantShapeHelper& getInstance();
 
-  ConstantShapeBuffer& bufferForShapeInfo(sd::DataType dataType, char order, const std::vector<sd::LongType>& shape);
-  ConstantShapeBuffer& bufferForShapeInfo(const ShapeDescriptor& descriptor);
-  ConstantShapeBuffer& bufferForShapeInfo(const sd::LongType* shapeInfo);
-  ConstantShapeBuffer& bufferForShapeInfo(sd::DataType dataType, char order, int rank, const sd::LongType* shape);
-  ConstantShapeBuffer& createShapeInfoWithUnitiesForBroadcast(const sd::LongType* maxShapeInfo,
+  ConstantShapeBuffer* bufferForShapeInfo(sd::DataType dataType, char order, const std::vector<sd::LongType>& shape);
+  ConstantShapeBuffer* bufferForShapeInfo(ShapeDescriptor *descriptor);
+  ConstantShapeBuffer* bufferForShapeInfo(const sd::LongType* shapeInfo);
+  ConstantShapeBuffer* bufferForShapeInfo(sd::DataType dataType, char order, int rank, const sd::LongType* shape);
+  ConstantShapeBuffer* createShapeInfoWithUnitiesForBroadcast(const sd::LongType* maxShapeInfo,
                                                               const sd::LongType* minShapeInfo,
                                                               sd::memory::Workspace* workspace = nullptr,
                                                               const std::vector<int>& dimensions = {});
-  ConstantShapeBuffer& createShapeInfoWithNoUnitiesForReduce(const sd::LongType* maxShapeInfo,
+  ConstantShapeBuffer* createShapeInfoWithNoUnitiesForReduce(const sd::LongType* maxShapeInfo,
                                                              const std::vector<int>& dimsWithUnities,
                                                              sd::memory::Workspace* workspace = nullptr);
-  ConstantShapeBuffer& createSubArrShapeInfo(const sd::LongType* inShapeInfo, const int* dims, const int dimsSize,
+  ConstantShapeBuffer* createSubArrShapeInfo(const sd::LongType* inShapeInfo, const int* dims, const int dimsSize,
                                              sd::memory::Workspace* workspace = nullptr);
 
   const sd::LongType* emptyShapeInfo(sd::DataType dataType);
   const sd::LongType* scalarShapeInfo(sd::DataType dataType);
   const sd::LongType* vectorShapeInfo(sd::LongType length, sd::DataType dataType);
-  const sd::LongType* createShapeInfo(const ShapeDescriptor& descriptor);
+  const sd::LongType* createShapeInfo(ShapeDescriptor *descriptor);
   const sd::LongType* createShapeInfo(sd::DataType dataType, char order, const std::vector<sd::LongType>& shape);
   const sd::LongType* createShapeInfo(sd::DataType dataType, char order, int rank, const sd::LongType* shape);
   const sd::LongType* createShapeInfo(sd::DataType dataType, const sd::LongType* shapeInfo);
@@ -84,7 +84,7 @@ class SD_LIB_EXPORT ConstantShapeHelper {
   const sd::LongType* createFromExisting(sd::LongType* shapeInfo, sd::memory::Workspace* workspace);
   const sd::LongType* createFromExisting(sd::LongType* shapeInfo, bool destroyOriginal = true);
 
-  bool checkBufferExistenceForShapeInfo(ShapeDescriptor& descriptor);
+  bool checkBufferExistenceForShapeInfo(ShapeDescriptor *descriptor);
 
   /**
    * This method returns number of cached TAD shapes/offsets on specific device

--- a/libnd4j/include/helpers/ConstantShapeHelper.h
+++ b/libnd4j/include/helpers/ConstantShapeHelper.h
@@ -37,7 +37,7 @@ namespace sd {
 class SD_LIB_EXPORT ConstantShapeHelper {
  private:
   std::mutex _mutex;
-  std::vector<SD_MAP_IMPL<ShapeDescriptor *, ConstantShapeBuffer *>> _cache;
+  std::vector<SD_MAP_IMPL<ShapeDescriptor , ConstantShapeBuffer *>> _cache;
 #if defined(__NEC__)
   bool _cache_existing_pointers = true;
 #endif

--- a/libnd4j/include/helpers/Loops.h
+++ b/libnd4j/include/helpers/Loops.h
@@ -743,26 +743,49 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
                                                               const sd::LongType* zShapeInfo, E* extraParams,
                                                               uint64_t threadId, uint64_t numThreads) {
   const LoopKind::Kind kindOfLoop = LoopKind::deduceKindOfLoopXZ(xShapeInfo, zShapeInfo);
+  if(xShapeInfo == nullptr) {
+    throw std::runtime_error("Input x shape info was null!");
+  }
+
+  if(xShapeInfo[0] > SD_MAX_RANK || xShapeInfo[0] < 0) {
+    throw std::runtime_error("x shape info appears to be corrupt. This is likely due to deallocation.");
+  }
+
+  if(zShapeInfo[0] > SD_MAX_RANK || zShapeInfo[0] < 0) {
+    throw std::runtime_error("z shape info appears to be corrupt. This is likely due to deallocation.");
+  }
+
+  if(zShapeInfo == nullptr) {
+    throw std::runtime_error("Input z shape info was null!");
+  }
+
+
+
+  sd_printf("TransformAny loopTransform: before casted pointers\n",0);
 
   const sd::LongType* xShape = shape::shapeOf(const_cast<sd::LongType*>(xShapeInfo));
   const sd::LongType* xStride = shape::stride(const_cast<sd::LongType*>(xShapeInfo));
   const sd::LongType* zStride = shape::stride(const_cast<sd::LongType*>(zShapeInfo));
-
+  sd_printf("TransformAny loopTransform: after casted pointers\n",0);
   const sd::LongType len = shape::length(xShapeInfo);
 
   if (len == 0) return;
 
   switch (kindOfLoop) {
-      //*********************************************//
+    //*********************************************//
     case LoopKind::EWS1: {
+      sd_printf("TransformAny EWS1: after casted pointers\n",0);
       auto span = samediff::Span::build(threadId, numThreads, 0, len, 1);
       int64_t start = span.startX(), stop = span.stopX();
 
       for (auto i = start; i < stop; i++) z[i] = OpType::op(x[i], extraParams);
+      sd_printf("After TransformAny EWS1: after casted pointers\n",0);
+
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::EWSNONZERO: {
+      sd_printf("TransformAny EWSNONZERO: after casted pointers\n",0);
       const sd::Unsigned xEws = shape::elementWiseStride(xShapeInfo);
       const sd::Unsigned zEws = shape::elementWiseStride(zShapeInfo);
 
@@ -770,10 +793,14 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
       int64_t start = span.startX(), stop = span.stopX();
 
       for (auto i = start; i < stop; i++) z[i * zEws] = OpType::op(x[i * xEws], extraParams);
+      sd_printf("After TransformAny EWS1: after casted pointers\n",0);
+
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::Z_EWSNONZERO: {
+      sd_printf("TransformAny Z_EWSNONZERO: before exec\n",0);
+
       const sd::Unsigned zEws = shape::elementWiseStride(zShapeInfo);
       sd::Unsigned castXShapeInfo[SD_MAX_RANK];
       const bool canCastX = sd::DataTypeUtils::castShapeInfo<sd::Unsigned>(xShapeInfo, castXShapeInfo);
@@ -792,35 +819,56 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
           z[i] = OpType::op(x[xOffset], extraParams);
         }
       }
+
+      sd_printf("TransformAny Z_EWSNONZERO: after exec\n",0);
+
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK1: {
+      sd_printf("TransformAny RANK1: before exec\n",0);
       auto span = samediff::Span::build(threadId, numThreads, 0, len, 1);
 
-      for (auto i0 = span.startX(); i0 < span.stopX(); i0++)
+      for (auto i0 = span.startX(); i0 < span.stopX(); i0++) {
+        sd_printf("zStride[0] is %d xStride[0] is %d io is %d\n",zStride[0],xStride[0],i0);
         z[i0 * zStride[0]] = OpType::op(x[i0 * xStride[0]], extraParams);
+      }
+      sd_printf("TransformAny RANK1: after exec\n",0);
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK2: {
+      sd_printf("TransformAny RANK2: before exec\n",0);
       auto uXShape0 = static_cast<sd::Unsigned>(xShape[0]);
       auto uXShape1 = static_cast<sd::Unsigned>(xShape[1]);
+      sd_printf("TransoformANy: loopTransform: shape %d %d\n",uXShape0,uXShape1);
 
+      sd_printf("TransformAny RANK2: After casting\n",0);
       auto loop = samediff::ThreadsHelper::pickLoop2d(numThreads, uXShape0, uXShape1);
+      sd_printf("TransformAny RANK2: After pick loop\n",0);
+
       auto span = samediff::Span2::build(loop, threadId, numThreads, 0, uXShape0, 1, 0, uXShape1, 1);
+      sd_printf("TransformAny RANK2: After span\n",0);
 
       for (auto i0 = span.startX(); i0 < span.stopX(); i0++) {
+        sd_printf("TransformAny RANK2: loop element %d\n",i0);
         auto z0 = i0 * zStride[0];
         auto x0 = i0 * xStride[0];
 
-        for (auto i1 = span.startY(); i1 < span.stopY(); ++i1)
+        for (auto i1 = span.startY(); i1 < span.stopY(); ++i1) {
+          sd_printf("zStride[0] is %d xStride[0] is %d io is %d zStride[1] is %d xStride[1] is %d\n",zStride[0],xStride[0],i0,zStride[1],xStride[1]);
           z[z0 + i1 * zStride[1]] = OpType::op(x[x0 + i1 * xStride[1]], extraParams);
+
+        }
       }
+
+      sd_printf("TransformAny RANK2: after exec\n",0);
+
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK3: {
+      sd_printf("TransformAny RANK3: before exec\n",0);
       auto uXShape0 = xShape[0];
       auto uXShape1 = xShape[1];
       auto uXShape2 = xShape[2];
@@ -836,10 +884,15 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
           for (sd::LongType i2 = 0; i2 < uXShape2; ++i2)
             z[z0 + i2 * zStride[2]] = OpType::op(x[x0 + i2 * xStride[2]], extraParams);
         }
+
+      sd_printf("TransformAny RANK3: after exec\n",0);
+
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK4: {
+      sd_printf("TransformAny RANK4: before exec\n",0);
+
       auto uXShape0 = xShape[0];
       auto uXShape1 = xShape[1];
       auto uXShape2 = xShape[2];
@@ -857,10 +910,14 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
             for (sd::LongType i3 = 0; i3 < uXShape3; ++i3)
               z[z0 + i3 * zStride[3]] = OpType::op(x[x0 + i3 * xStride[3]], extraParams);
           }
+
+      sd_printf("TransformAny RANK3: after exec\n",0);
+
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK5: {
+      sd_printf("TransformAny RANK5: before exec\n",0);
       auto uXShape0 = xShape[0];
       auto uXShape1 = xShape[1];
       auto uXShape2 = xShape[2];
@@ -885,10 +942,14 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
             }
           }
 
+      sd_printf("TransformAny RANK4: after exec\n",0);
+
     } break;
 
-    //*********************************************//
+      //*********************************************//
     default: {
+      sd_printf("TransformAny default: before exec\n",0);
+
       sd::Unsigned xShapeInfoCast[SD_MAX_RANK];
       sd::Unsigned zShapeInfoCast[SD_MAX_RANK];
 
@@ -902,6 +963,9 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
         auto zOffset = shape::indexOffset(i, zShapeInfo, zShapeInfoCast, canCastZ);
         z[zOffset] = OpType::op(x[xOffset], extraParams);
       }
+
+      sd_printf("TransformAny default: after exec\n",0);
+
     }
   }
 }
@@ -978,7 +1042,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3(const X* x, const sd::LongType* xSha
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::EWSNONZERO: {
       Z extraParams[3];
       for (auto i = start; i < stop; i++) {
@@ -997,7 +1061,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3(const X* x, const sd::LongType* xSha
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK1: {
       Z extraParams[3];
       for (auto i = start; i < stop; i++) {
@@ -1019,7 +1083,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3(const X* x, const sd::LongType* xSha
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK2: {
       Z extraParams[3];
       for (auto i = start; i < stop; i++) {
@@ -1042,7 +1106,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3(const X* x, const sd::LongType* xSha
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK3: {
       Z extraParams[3];
       for (auto i = start; i < stop; i++) {
@@ -1067,7 +1131,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3(const X* x, const sd::LongType* xSha
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK4: {
       Z extraParams[3];
       for (auto i = start; i < stop; i++) {
@@ -1096,7 +1160,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3(const X* x, const sd::LongType* xSha
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK5: {
       Z extraParams[3];
       for (auto i = start; i < stop; i++) {
@@ -1127,7 +1191,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3(const X* x, const sd::LongType* xSha
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     default: {
       sd::Unsigned castXTadShapeInfo[SD_MAX_RANK];
       const bool canCastXTad = sd::DataTypeUtils::castShapeInfo<sd::Unsigned>(xTadShapeInfo, castXTadShapeInfo);
@@ -1232,7 +1296,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3All(const X* x, const sd::LongType* x
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::EWSNONZERO: {
       Z extraParams[3];
       for (sd::LongType ix = 0; ix < numXTads; ix++) {
@@ -1254,7 +1318,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3All(const X* x, const sd::LongType* x
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK1: {
       Z extraParams[3];
       for (sd::LongType ix = 0; ix < numXTads; ix++) {
@@ -1278,7 +1342,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3All(const X* x, const sd::LongType* x
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK2: {
       Z extraParams[3];
       for (sd::LongType ix = 0; ix < numXTads; ix++) {
@@ -1304,7 +1368,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3All(const X* x, const sd::LongType* x
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK3: {
       Z extraParams[3];
       for (sd::LongType ix = 0; ix < numXTads; ix++) {
@@ -1332,7 +1396,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3All(const X* x, const sd::LongType* x
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK4: {
       Z extraParams[3];
       for (sd::LongType ix = 0; ix < numXTads; ix++) {
@@ -1364,7 +1428,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3All(const X* x, const sd::LongType* x
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     case LoopKind::RANK5: {
       Z extraParams[3];
       for (sd::LongType ix = 0; ix < numXTads; ix++) {
@@ -1398,7 +1462,7 @@ void sd::Reduction3Loops<X, Z>::loopReduce3All(const X* x, const sd::LongType* x
       };
     } break;
 
-    //*********************************************//
+      //*********************************************//
     default: {
       sd::Unsigned castXTadShapeInfo[SD_MAX_RANK];
       const bool canCastXTad = sd::DataTypeUtils::castShapeInfo<sd::Unsigned>(xTadShapeInfo, castXTadShapeInfo);

--- a/libnd4j/include/helpers/Loops.h
+++ b/libnd4j/include/helpers/Loops.h
@@ -761,12 +761,10 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
 
 
 
-  sd_printf("TransformAny loopTransform: before casted pointers\n",0);
 
   const sd::LongType* xShape = shape::shapeOf(const_cast<sd::LongType*>(xShapeInfo));
   const sd::LongType* xStride = shape::stride(const_cast<sd::LongType*>(xShapeInfo));
   const sd::LongType* zStride = shape::stride(const_cast<sd::LongType*>(zShapeInfo));
-  sd_printf("TransformAny loopTransform: after casted pointers\n",0);
   const sd::LongType len = shape::length(xShapeInfo);
 
   if (len == 0) return;
@@ -774,18 +772,15 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
   switch (kindOfLoop) {
     //*********************************************//
     case LoopKind::EWS1: {
-      sd_printf("TransformAny EWS1: after casted pointers\n",0);
       auto span = samediff::Span::build(threadId, numThreads, 0, len, 1);
       int64_t start = span.startX(), stop = span.stopX();
 
       for (auto i = start; i < stop; i++) z[i] = OpType::op(x[i], extraParams);
-      sd_printf("After TransformAny EWS1: after casted pointers\n",0);
 
     } break;
 
       //*********************************************//
     case LoopKind::EWSNONZERO: {
-      sd_printf("TransformAny EWSNONZERO: after casted pointers\n",0);
       const sd::Unsigned xEws = shape::elementWiseStride(xShapeInfo);
       const sd::Unsigned zEws = shape::elementWiseStride(zShapeInfo);
 
@@ -793,13 +788,11 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
       int64_t start = span.startX(), stop = span.stopX();
 
       for (auto i = start; i < stop; i++) z[i * zEws] = OpType::op(x[i * xEws], extraParams);
-      sd_printf("After TransformAny EWS1: after casted pointers\n",0);
 
     } break;
 
       //*********************************************//
     case LoopKind::Z_EWSNONZERO: {
-      sd_printf("TransformAny Z_EWSNONZERO: before exec\n",0);
 
       const sd::Unsigned zEws = shape::elementWiseStride(zShapeInfo);
       sd::Unsigned castXShapeInfo[SD_MAX_RANK];
@@ -820,55 +813,40 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
         }
       }
 
-      sd_printf("TransformAny Z_EWSNONZERO: after exec\n",0);
-
     } break;
 
       //*********************************************//
     case LoopKind::RANK1: {
-      sd_printf("TransformAny RANK1: before exec\n",0);
       auto span = samediff::Span::build(threadId, numThreads, 0, len, 1);
 
       for (auto i0 = span.startX(); i0 < span.stopX(); i0++) {
-        sd_printf("zStride[0] is %d xStride[0] is %d io is %d\n",zStride[0],xStride[0],i0);
         z[i0 * zStride[0]] = OpType::op(x[i0 * xStride[0]], extraParams);
       }
-      sd_printf("TransformAny RANK1: after exec\n",0);
     } break;
 
       //*********************************************//
     case LoopKind::RANK2: {
-      sd_printf("TransformAny RANK2: before exec\n",0);
       auto uXShape0 = static_cast<sd::Unsigned>(xShape[0]);
       auto uXShape1 = static_cast<sd::Unsigned>(xShape[1]);
-      sd_printf("TransoformANy: loopTransform: shape %d %d\n",uXShape0,uXShape1);
 
-      sd_printf("TransformAny RANK2: After casting\n",0);
       auto loop = samediff::ThreadsHelper::pickLoop2d(numThreads, uXShape0, uXShape1);
-      sd_printf("TransformAny RANK2: After pick loop\n",0);
 
       auto span = samediff::Span2::build(loop, threadId, numThreads, 0, uXShape0, 1, 0, uXShape1, 1);
-      sd_printf("TransformAny RANK2: After span\n",0);
 
       for (auto i0 = span.startX(); i0 < span.stopX(); i0++) {
-        sd_printf("TransformAny RANK2: loop element %d\n",i0);
         auto z0 = i0 * zStride[0];
         auto x0 = i0 * xStride[0];
 
         for (auto i1 = span.startY(); i1 < span.stopY(); ++i1) {
-          sd_printf("zStride[0] is %d xStride[0] is %d io is %d zStride[1] is %d xStride[1] is %d\n",zStride[0],xStride[0],i0,zStride[1],xStride[1]);
           z[z0 + i1 * zStride[1]] = OpType::op(x[x0 + i1 * xStride[1]], extraParams);
 
         }
       }
 
-      sd_printf("TransformAny RANK2: after exec\n",0);
-
     } break;
 
       //*********************************************//
     case LoopKind::RANK3: {
-      sd_printf("TransformAny RANK3: before exec\n",0);
       auto uXShape0 = xShape[0];
       auto uXShape1 = xShape[1];
       auto uXShape2 = xShape[2];
@@ -885,13 +863,10 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
             z[z0 + i2 * zStride[2]] = OpType::op(x[x0 + i2 * xStride[2]], extraParams);
         }
 
-      sd_printf("TransformAny RANK3: after exec\n",0);
-
     } break;
 
       //*********************************************//
     case LoopKind::RANK4: {
-      sd_printf("TransformAny RANK4: before exec\n",0);
 
       auto uXShape0 = xShape[0];
       auto uXShape1 = xShape[1];
@@ -911,13 +886,10 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
               z[z0 + i3 * zStride[3]] = OpType::op(x[x0 + i3 * xStride[3]], extraParams);
           }
 
-      sd_printf("TransformAny RANK3: after exec\n",0);
-
     } break;
 
       //*********************************************//
     case LoopKind::RANK5: {
-      sd_printf("TransformAny RANK5: before exec\n",0);
       auto uXShape0 = xShape[0];
       auto uXShape1 = xShape[1];
       auto uXShape2 = xShape[2];
@@ -942,13 +914,10 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
             }
           }
 
-      sd_printf("TransformAny RANK4: after exec\n",0);
-
     } break;
 
       //*********************************************//
     default: {
-      sd_printf("TransformAny default: before exec\n",0);
 
       sd::Unsigned xShapeInfoCast[SD_MAX_RANK];
       sd::Unsigned zShapeInfoCast[SD_MAX_RANK];
@@ -964,7 +933,6 @@ SD_LIB_HIDDEN void sd::TransformLoops<X, Z, E>::loopTransform(const X* x, const 
         z[zOffset] = OpType::op(x[xOffset], extraParams);
       }
 
-      sd_printf("TransformAny default: after exec\n",0);
 
     }
   }

--- a/libnd4j/include/helpers/cpu/ConstantShapeHelper.cpp
+++ b/libnd4j/include/helpers/cpu/ConstantShapeHelper.cpp
@@ -31,7 +31,7 @@ namespace sd {
 ConstantShapeHelper::ConstantShapeHelper() {
   _cache.resize(1);
   for (int e = 0; e < 1; e++) {
-    SD_MAP_IMPL<ShapeDescriptor, ConstantShapeBuffer> cache;
+    SD_MAP_IMPL<ShapeDescriptor *, ConstantShapeBuffer *> cache;
     _cache[e] = cache;
   }
 }
@@ -41,40 +41,60 @@ ConstantShapeHelper& ConstantShapeHelper::getInstance() {
   return instance;
 }
 
-ConstantShapeBuffer& ConstantShapeHelper::bufferForShapeInfo(sd::DataType dataType, char order,
+ConstantShapeBuffer* ConstantShapeHelper::bufferForShapeInfo(sd::DataType dataType, char order,
                                                              const std::vector<sd::LongType>& shape) {
-  ShapeDescriptor descriptor(dataType, order, shape);
+  auto descriptor = new ShapeDescriptor(dataType, order, shape);
   return bufferForShapeInfo(descriptor);
 }
 
-ConstantShapeBuffer& ConstantShapeHelper::bufferForShapeInfo(const sd::DataType dataType, const char order,
+ConstantShapeBuffer* ConstantShapeHelper::bufferForShapeInfo(const sd::DataType dataType, const char order,
                                                              const int rank, const sd::LongType* shape) {
-  ShapeDescriptor descriptor(dataType, order, shape, rank);
+  auto descriptor = new ShapeDescriptor(dataType, order, shape, rank);
   return bufferForShapeInfo(descriptor);
 }
 
-ConstantShapeBuffer& ConstantShapeHelper::bufferForShapeInfo(const ShapeDescriptor& descriptor) {
+ConstantShapeBuffer * ConstantShapeHelper::bufferForShapeInfo(ShapeDescriptor *descriptor) {
   int deviceId = 0;
-
   std::lock_guard<std::mutex> lock(_mutex);
-
-  if (_cache[deviceId].count(descriptor) == 0) {
-    auto hPtr =
-        std::make_shared<PointerWrapper>(descriptor.toShapeInfo(), std::make_shared<PrimaryPointerDeallocator>());
-    ConstantShapeBuffer buffer(hPtr);
-    _cache[deviceId][descriptor] = buffer;
-    return _cache[deviceId][descriptor];
-  } else {
-    return _cache[deviceId].at(descriptor);
+  sd_printf("Before cache access\n",0);
+  if(_cache.empty()) {
+    throw std::runtime_error("Cache is empty!");
   }
+
+  sd_printf("Access cache based on descriptor with rank: %d order: %d is empty: %d data type: %d\n",
+            descriptor->rank(),descriptor->order(),descriptor->isEmpty(),descriptor->dataType());
+  sd_printf("Accessing cache with device id %d\n",deviceId);
+  auto cacheForDevice = _cache[deviceId];
+  sd_printf("Obtained cache\n",0);
+  auto hPtr =
+      std::make_shared<PointerWrapper>(descriptor->toShapeInfo(), std::make_shared<PrimaryPointerDeallocator>());
+  ConstantShapeBuffer *constantShapeBuffer2 = new ConstantShapeBuffer(hPtr, hPtr);
+  return constantShapeBuffer2;
+ /* if (cacheForDevice.count(descriptor) == 0) {
+    sd_printf("About to create deallocator\n",0);
+
+    sd_printf("After setting up deallocator\n",0);
+    ConstantShapeBuffer *constantShapeBuffer2 = new ConstantShapeBuffer(hPtr);
+    sd_printf("After constant shape buffer construction\n",0);
+    sd_printf("Shape info being set is: order: %d rank %d\n",descriptor->order(),descriptor->rank());
+    _cache[deviceId][descriptor] = constantShapeBuffer2;
+    sd_printf("Setting cache for descriptor\n",0);
+    return constantShapeBuffer2;
+  } else {
+    sd_printf("Hitting cache access\n",0);
+    return _cache[deviceId].at(descriptor);
+  }*/
 }
 
-ConstantShapeBuffer& ConstantShapeHelper::bufferForShapeInfo(const sd::LongType* shapeInfo) {
-  ShapeDescriptor descriptor(shapeInfo);
-  return bufferForShapeInfo(descriptor);
+ConstantShapeBuffer* ConstantShapeHelper::bufferForShapeInfo(const sd::LongType* shapeInfo) {
+  sd_printf("Before creating buffer for shape info with descriptor\n",0);
+  auto descriptor = new ShapeDescriptor(shapeInfo);
+  sd_printf("After creating buffer for shape info with descriptor\n",0);
+  auto ret =  bufferForShapeInfo(descriptor);
+  return ret;
 }
 
-bool ConstantShapeHelper::checkBufferExistenceForShapeInfo(ShapeDescriptor& descriptor) {
+bool ConstantShapeHelper::checkBufferExistenceForShapeInfo(ShapeDescriptor *descriptor) {
   int deviceId = 0;
   std::lock_guard<std::mutex> lock(_mutex);
 
@@ -83,8 +103,8 @@ bool ConstantShapeHelper::checkBufferExistenceForShapeInfo(ShapeDescriptor& desc
 
 const sd::LongType* ConstantShapeHelper::createShapeInfo(const sd::DataType dataType, const char order, const int rank,
                                                          const sd::LongType* shape) {
-  ShapeDescriptor descriptor(dataType, order, shape, rank);
-  return bufferForShapeInfo(descriptor).primary();
+  auto descriptor = new ShapeDescriptor(dataType, order, shape, rank);
+  return bufferForShapeInfo(descriptor)->primary();
 }
 
 const sd::LongType* ConstantShapeHelper::createShapeInfo(const sd::DataType dataType, const sd::LongType* shapeInfo) {
@@ -94,32 +114,34 @@ const sd::LongType* ConstantShapeHelper::createShapeInfo(const sd::DataType data
 
 const sd::LongType* ConstantShapeHelper::emptyShapeInfo(const sd::DataType dataType) {
   auto descriptor = ShapeDescriptor::emptyDescriptor(dataType);
-  return bufferForShapeInfo(descriptor).primary();
+  return bufferForShapeInfo(descriptor)->primary();
 }
 
 const sd::LongType* ConstantShapeHelper::scalarShapeInfo(const sd::DataType dataType) {
   auto descriptor = ShapeDescriptor::scalarDescriptor(dataType);
-  return bufferForShapeInfo(descriptor).primary();
+  return bufferForShapeInfo(descriptor)->primary();
 }
 
 const sd::LongType* ConstantShapeHelper::vectorShapeInfo(const sd::LongType length, const sd::DataType dataType) {
   auto descriptor = ShapeDescriptor::vectorDescriptor(length, dataType);
-  return bufferForShapeInfo(descriptor).primary();
+  return bufferForShapeInfo(descriptor)->primary();
 }
 
 const sd::LongType* ConstantShapeHelper::createShapeInfo(const sd::DataType dataType, const char order,
                                                          const std::vector<sd::LongType>& shape) {
-  ShapeDescriptor descriptor(dataType, order, shape);
-  return bufferForShapeInfo(descriptor).primary();
+  ShapeDescriptor * descriptor = new ShapeDescriptor(dataType, order, shape);
+  return bufferForShapeInfo(descriptor)->primary();
 }
 
-const sd::LongType* ConstantShapeHelper::createShapeInfo(const ShapeDescriptor& descriptor) {
-  return bufferForShapeInfo(descriptor).primary();
+const sd::LongType* ConstantShapeHelper::createShapeInfo(ShapeDescriptor* descriptor) {
+  return bufferForShapeInfo(descriptor)->primary();
 }
 
 const sd::LongType* ConstantShapeHelper::createFromExisting(sd::LongType* shapeInfo, bool destroyOriginal) {
-  ShapeDescriptor descriptor(shapeInfo);
+  sd_printf("Before creating from exsting with boolean destroyOriginal\n",0);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfo);
   auto result = createShapeInfo(descriptor);
+  sd_printf("After creating from exsting with boolean destroyOriginal\n",0);
 
   if (destroyOriginal) RELEASE(shapeInfo, nullptr)
 
@@ -127,7 +149,9 @@ const sd::LongType* ConstantShapeHelper::createFromExisting(sd::LongType* shapeI
 }
 
 const sd::LongType* ConstantShapeHelper::createFromExisting(sd::LongType* shapeInfo, sd::memory::Workspace* workspace) {
-  ShapeDescriptor descriptor(shapeInfo);
+  sd_printf("Creating from existing\n",0);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfo);
+  sd_printf("After creating from existing\n",0);
   auto result = createShapeInfo(descriptor);
 
   RELEASE(shapeInfo, workspace);
@@ -136,7 +160,7 @@ const sd::LongType* ConstantShapeHelper::createFromExisting(sd::LongType* shapeI
 }
 
 ////////////////////////////////////////////////////////////////////////
-ConstantShapeBuffer& ConstantShapeHelper::createShapeInfoWithUnitiesForBroadcast(const sd::LongType* maxShapeInfo,
+ConstantShapeBuffer* ConstantShapeHelper::createShapeInfoWithUnitiesForBroadcast(const sd::LongType* maxShapeInfo,
                                                                                  const sd::LongType* minShapeInfo,
                                                                                  sd::memory::Workspace* workspace,
                                                                                  const std::vector<int>& dimensions) {
@@ -174,7 +198,7 @@ ConstantShapeBuffer& ConstantShapeHelper::createShapeInfoWithUnitiesForBroadcast
     }
   }
 
-  ShapeDescriptor descriptor(newShapeInfo);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo);
 
   RELEASE(newShapeInfo, workspace);
 
@@ -182,7 +206,7 @@ ConstantShapeBuffer& ConstantShapeHelper::createShapeInfoWithUnitiesForBroadcast
 }
 
 ////////////////////////////////////////////////////////////////////////
-ConstantShapeBuffer& ConstantShapeHelper::createShapeInfoWithNoUnitiesForReduce(const sd::LongType* inShapeInfo,
+ConstantShapeBuffer* ConstantShapeHelper::createShapeInfoWithNoUnitiesForReduce(const sd::LongType* inShapeInfo,
                                                                                 const std::vector<int>& dimsWithUnities,
                                                                                 sd::memory::Workspace* workspace) {
   sd::LongType* newShapeInfo = nullptr;
@@ -197,7 +221,7 @@ ConstantShapeBuffer& ConstantShapeHelper::createShapeInfoWithNoUnitiesForReduce(
     shape::excludeUnitiesFromShapeInfo(inShapeInfo, dimsWithUnities.data(), dimsWithUnities.size(), newShapeInfo);
   }
 
-  ShapeDescriptor descriptor(newShapeInfo);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo);
 
   RELEASE(newShapeInfo, workspace);
 
@@ -205,11 +229,11 @@ ConstantShapeBuffer& ConstantShapeHelper::createShapeInfoWithNoUnitiesForReduce(
 }
 
 ////////////////////////////////////////////////////////////////////////
-ConstantShapeBuffer& ConstantShapeHelper::createSubArrShapeInfo(const sd::LongType* inShapeInfo, const int* dims,
+ConstantShapeBuffer* ConstantShapeHelper::createSubArrShapeInfo(const sd::LongType* inShapeInfo, const int* dims,
                                                                 const int dimsSize, sd::memory::Workspace* workspace) {
   sd::LongType* newShapeInfo = ShapeBuilders::createSubArrShapeInfo(inShapeInfo, dims, dimsSize, workspace);
 
-  ShapeDescriptor descriptor(newShapeInfo);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo);
 
   RELEASE(newShapeInfo, workspace);
 

--- a/libnd4j/include/helpers/cpu/svd.cpp
+++ b/libnd4j/include/helpers/cpu/svd.cpp
@@ -432,8 +432,6 @@ void SVD<T>::calcSingVals(const NDArray& col0, const NDArray& diag, const NDArra
 
       T fLeft = secularEq(leftShifted, col0, diag, permut, diagShifted, shift);
       T fRight = secularEq(rightShifted, col0, diag, permut, diagShifted, shift);
-      // if(fLeft * fRight >= (T)0.)
-      // throw "ops::helpers::SVD::calcSingVals method: fLeft * fRight >= (T)0. !";
 
       while (rightShifted - leftShifted >
              (T)2.f * DataTypeUtils::eps<T>() *

--- a/libnd4j/include/helpers/impl/ShapeUtils.cpp
+++ b/libnd4j/include/helpers/impl/ShapeUtils.cpp
@@ -130,9 +130,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfoEmpty(const char order, std::
                                                          const bool keepDims, sd::memory::Workspace* workspace) {
   if (dimsToExclude.size() == 0) {  // return copy of input shape
     sd::LongType* outShapeInfo = ShapeBuilders::copyShapeInfoAndType(shapeInfo, dataType, true, workspace);
-    ShapeDescriptor descriptor(outShapeInfo, dataType);
+    ShapeDescriptor *descriptor = new ShapeDescriptor(outShapeInfo, dataType);
     RELEASE(outShapeInfo, workspace);
-    return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+    return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
   }
 
   const int rank = shape::rank(shapeInfo);
@@ -164,9 +164,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfoEmpty(const char order, std::
     outShapeInfo = ShapeBuilders::createShapeInfo(dataType, order, outShape, workspace);
   }
 
-  ShapeDescriptor descriptor(outShapeInfo, dataType);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(outShapeInfo, dataType);
   RELEASE(outShapeInfo, workspace);
-  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
 }
 
 const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<int>& dimsToExclude,
@@ -212,20 +212,20 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
       ShapeUtils::updateStridesAndType(newShapeInfo, shapeInfo, order);
       ArrayOptions::setDataType(newShapeInfo, dataType);
 
-      ShapeDescriptor descriptor(newShapeInfo, dataType);
+      ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
     } else if (supportOldShapes) {
       ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
       shape::shapeOldScalar(dataType, newShapeInfo, 'c');
-      ShapeDescriptor descriptor(newShapeInfo, dataType);
+      ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
     } else {
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, workspace);
-      ShapeDescriptor descriptor(newShapeInfo, dataType);
+      ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
     }
   }
 
@@ -244,9 +244,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
         newShapeInfo[i + 1] = shapeInfo[i + 1];
 
     ShapeUtils::updateStridesAndType(newShapeInfo, shapeInfo, order);
-    ShapeDescriptor descriptor(newShapeInfo, dataType);
+    ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
     RELEASE(newShapeInfo, workspace);
-    return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+    return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
   }
 
   int newRank = rank - dimSize;
@@ -257,14 +257,14 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
     if (supportOldShapes) {
       ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
       shape::shapeOldScalar(ArrayOptions::dataType(shapeInfo), newShapeInfo, 'c');
-      ShapeDescriptor descriptor(newShapeInfo, dataType);
+      ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
     } else {
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(ArrayOptions::dataType(shapeInfo), workspace);
-      ShapeDescriptor descriptor(newShapeInfo, dataType);
+      ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
     }
   }
 
@@ -293,9 +293,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
 
   ShapeUtils::updateStridesAndType(newShapeInfo, shapeInfo, order);
 
-  ShapeDescriptor descriptor(newShapeInfo, dataType);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
   RELEASE(newShapeInfo, workspace);
-  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -341,11 +341,11 @@ const sd::LongType* ShapeUtils::evalPermShapeInfo(const int* dimensions, const i
 
   if (setContigStrides) shape::updateStrides(shapeInfoNew, arr.ordering());
 
-  ShapeDescriptor descriptor(shapeInfoNew);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfoNew);
 
   RELEASE(shapeInfoNew, workspace);
 
-  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -484,9 +484,9 @@ bool ShapeUtils::evalBroadcastShapeInfo(const sd::LongType* max, const sd::LongT
     memset(shape::stride(tmpShapeInfo), 0, shape::rank(tmpShapeInfo) * sizeof(sd::LongType));
   }
 
-  ShapeDescriptor descriptor(tmpShapeInfo);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(tmpShapeInfo);
   RELEASE(tmpShapeInfo, workspace);
-  resultShapeInfo = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+  resultShapeInfo = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
 
   return true;
 }
@@ -521,9 +521,10 @@ bool ShapeUtils::evalCommonBroadcastShapeInfo(const std::vector<const NDArray*>&
   shape::updateStrides(tmpShapeInfo, arrays[0]->ordering());
   ArrayOptions::setDataType(tmpShapeInfo, arrays[0]->dataType());
 
-  ShapeDescriptor descriptor(tmpShapeInfo);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(tmpShapeInfo);
   RELEASE(tmpShapeInfo, workspace);
-  resultShapeInfo = const_cast<sd::LongType*>(ConstantShapeHelper::getInstance().createShapeInfo(descriptor));
+  auto bufferForSHape = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor);
+  resultShapeInfo = const_cast<sd::LongType*>(ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary());
 
   return true;
 }
@@ -588,9 +589,9 @@ const sd::LongType* ShapeUtils::evalTileShapeInfo(const NDArray& arr, const std:
   shape::updateStrides(newShapeInfo, arr.ordering());
   ArrayOptions::setDataType(newShapeInfo, arr.dataType());
 
-  ShapeDescriptor descriptor(newShapeInfo);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo);
   RELEASE(newShapeInfo, workspace);
-  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor).primary();
+  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
 }
 
 std::vector<sd::LongType> ShapeUtils::pullShapeFromShapeInfo(const sd::LongType* shapeInfo) {
@@ -723,10 +724,10 @@ const sd::LongType* ShapeUtils::evalDiagShapeInfo(const sd::LongType* shapeInfoC
   }
 
   ShapeUtils::updateStridesAndType(outputShapeInfo, shapeInfo, shape::order(shapeInfo));
-
-  auto result = ConstantShapeHelper::getInstance().createShapeInfo(outputShapeInfo);
+  auto nonConstShape = const_cast<sd::LongType *>(outputShapeInfo);
+  auto result = ConstantShapeHelper::getInstance().bufferForShapeInfo(nonConstShape);
   RELEASE(outputShapeInfo, workspace);
-  return result;
+  return result->primary();
 }
 
 std::vector<int> ShapeUtils::evalBroadcastBackwardAxis(const sd::LongType* operandShapeInfo,

--- a/libnd4j/include/helpers/impl/ShapeUtils.cpp
+++ b/libnd4j/include/helpers/impl/ShapeUtils.cpp
@@ -132,7 +132,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfoEmpty(const char order, std::
     sd::LongType* outShapeInfo = ShapeBuilders::copyShapeInfoAndType(shapeInfo, dataType, true, workspace);
     ShapeDescriptor *descriptor = new ShapeDescriptor(outShapeInfo, dataType);
     RELEASE(outShapeInfo, workspace);
-    return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+    auto ret =  ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+    delete descriptor;
+    return ret;
   }
 
   const int rank = shape::rank(shapeInfo);
@@ -166,7 +168,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfoEmpty(const char order, std::
 
   ShapeDescriptor *descriptor = new ShapeDescriptor(outShapeInfo, dataType);
   RELEASE(outShapeInfo, workspace);
-  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+  auto ret =  ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+  delete descriptor;
+  return ret;
 }
 
 const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<int>& dimsToExclude,

--- a/libnd4j/include/helpers/impl/ShapeUtils.cpp
+++ b/libnd4j/include/helpers/impl/ShapeUtils.cpp
@@ -218,18 +218,24 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
 
       ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      auto ret =  ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      delete descriptor;
+      return ret;
     } else if (supportOldShapes) {
       ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
       shape::shapeOldScalar(dataType, newShapeInfo, 'c');
       ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      auto ret =  ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      delete descriptor;
+      return ret;
     } else {
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, workspace);
       ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      auto ret =  ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      delete descriptor;
+      return ret;
     }
   }
 
@@ -250,7 +256,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
     ShapeUtils::updateStridesAndType(newShapeInfo, shapeInfo, order);
     ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
     RELEASE(newShapeInfo, workspace);
-    return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+    auto ret =  ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+    delete descriptor;
+    return ret;
   }
 
   int newRank = rank - dimSize;
@@ -262,13 +270,17 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
       ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
       shape::shapeOldScalar(ArrayOptions::dataType(shapeInfo), newShapeInfo, 'c');
       ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
+      auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      delete descriptor;
+      return ret;
     } else {
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(ArrayOptions::dataType(shapeInfo), workspace);
       ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
+      auto ret =  ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
       RELEASE(newShapeInfo, workspace);
-      return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+      delete descriptor;
+      return ret;
     }
   }
 
@@ -299,7 +311,9 @@ const sd::LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vecto
 
   ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo, dataType);
   RELEASE(newShapeInfo, workspace);
-  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+  auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+  delete descriptor;
+  return ret;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -347,9 +361,11 @@ const sd::LongType* ShapeUtils::evalPermShapeInfo(const int* dimensions, const i
 
   ShapeDescriptor *descriptor = new ShapeDescriptor(shapeInfoNew);
 
-  RELEASE(shapeInfoNew, workspace);
 
-  return ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+  auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(descriptor)->primary();
+  RELEASE(shapeInfoNew, workspace);
+  delete descriptor;
+  return ret;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/helpers/impl/jacobiSVD.cpp
+++ b/libnd4j/include/helpers/impl/jacobiSVD.cpp
@@ -24,367 +24,404 @@
 #include <helpers/jacobiSVD.h>
 #if NOT_EXCLUDED(svd)
 namespace sd {
-namespace ops {
-namespace helpers {
+    namespace ops {
+        namespace helpers {
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-JacobiSVD<T>::JacobiSVD(const NDArray& matrix, const bool calcU, const bool calcV, const bool fullUV) {
-  if (matrix.rankOf() != 2 || matrix.isScalar())
-    throw std::runtime_error("ops::helpers::JacobiSVD constructor: input array must be 2D matrix !");
+            template <typename T>
+            JacobiSVD<T>::JacobiSVD(const NDArray& matrix, const bool calcU, const bool calcV, const bool fullUV) {
+                if (matrix.rankOf() != 2 || matrix.isScalar())
+                    throw std::runtime_error("ops::helpers::JacobiSVD constructor: input array must be 2D matrix !");
 
-  _rows = static_cast<int>(matrix.sizeAt(0));
-  _cols = static_cast<int>(matrix.sizeAt(1));
-  _diagSize = math::sd_min<int>(_rows, _cols);
+                sd_printf("Before rows and cols\n",0);
+                _rows = static_cast<int>(matrix.sizeAt(0));
+                _cols = static_cast<int>(matrix.sizeAt(1));
+                _diagSize = math::sd_min<int>(_rows, _cols);
+                sd_printf("After rows and cols\n",0);
 
-  _calcU = calcU;
-  _calcV = calcV;
-  _fullUV = fullUV;
+                _calcU = calcU;
+                _calcV = calcV;
+                _fullUV = fullUV;
+                sd_printf("Before _s\n",0);
 
-  _s = NDArray(matrix.ordering(), {_diagSize, 1}, matrix.dataType(), matrix.getContext());
+                _s = NDArray(matrix.ordering(), {_diagSize, 1}, matrix.dataType(), matrix.getContext());
+                sd_printf("After _s\n",0);
 
-  if (_calcU) {
-    if (_fullUV)
-      _u = NDArray(matrix.ordering(), {_rows, _rows}, matrix.dataType(), matrix.getContext());
-    else
-      _u = NDArray(matrix.ordering(), {_rows, _diagSize}, matrix.dataType(), matrix.getContext());
-  } else
-    _u = NDArray(matrix.ordering(), {_rows, 1}, matrix.dataType(), matrix.getContext());
+                if (_calcU) {
+                    if (_fullUV)
+                        _u = NDArray(matrix.ordering(), {_rows, _rows}, matrix.dataType(), matrix.getContext());
+                    else
+                        _u = NDArray(matrix.ordering(), {_rows, _diagSize}, matrix.dataType(), matrix.getContext());
+                } else
+                    _u = NDArray(matrix.ordering(), {_rows, 1}, matrix.dataType(), matrix.getContext());
 
-  if (_calcV) {
-    if (_fullUV)
-      _v = NDArray(matrix.ordering(), {_cols, _cols}, matrix.dataType(), matrix.getContext());
-    else
-      _v = NDArray(matrix.ordering(), {_cols, _diagSize}, matrix.dataType(), matrix.getContext());
-  } else
-    _v = NDArray(matrix.ordering(), {_cols, 1}, matrix.dataType(), matrix.getContext());
+                if (_calcV) {
+                    if (_fullUV)
+                        _v = NDArray(matrix.ordering(), {_cols, _cols}, matrix.dataType(), matrix.getContext());
+                    else
+                        _v = NDArray(matrix.ordering(), {_cols, _diagSize}, matrix.dataType(), matrix.getContext());
+                } else
+                    _v = NDArray(matrix.ordering(), {_cols, 1}, matrix.dataType(), matrix.getContext());
 
-  _m = NDArray(matrix.ordering(), {_diagSize, _diagSize}, matrix.dataType(), matrix.getContext());
+                _m = NDArray(matrix.ordering(), {_diagSize, _diagSize}, matrix.dataType(), matrix.getContext());
 
-  evalData(matrix);
-}
+                sd_printf("Before jacobi evalData\n",0);
 
-//////////////////////////////////////////////////////////////////////////
-template <typename T>
-void JacobiSVD<T>::mulRotationOnLeft(const int i, const int j, NDArray& block, const NDArray& rotation) {
-  if (i < j) {
-    if (j + 1 > block.sizeAt(0))
-      throw std::runtime_error(
-          "ops::helpers::JacobiSVD mulRotationOnLeft: second arguments is out of array row range !");
-
-    auto temp = block({i, j + 1, j - i, 0, 0, 0}, true, true);
-    temp.assign(mmul(rotation, temp));
-
-    // auto pTemp = block({i,j+1,j-i,  0,0,0}, true, true);
-    // auto temp = pTemp.dup();
-    // pTemp.assign(mmul(rotation, temp));
-  } else {
-    if (j + 1 > block.sizeAt(0) || i + 1 > block.sizeAt(0))
-      throw std::runtime_error(
-          "ops::helpers::JacobiSVD mulRotationOnLeft: some or both integer arguments are out of array row range !");
-
-    NDArray temp(block.ordering(), {2, block.sizeAt(1)}, block.dataType(), block.getContext());
-    auto row1 = block({i, i + 1, 0, 0}, true);
-    auto row2 = block({j, j + 1, 0, 0}, true);
-    auto rowTemp1 = temp({0, 1, 0, 0}, true);
-    auto rowTemp2 = temp({1, 2, 0, 0}, true);
-    rowTemp1.assign(row1);
-    rowTemp2.assign(row2);
-    temp.assign(mmul(rotation, temp));
-    row1.assign(rowTemp1);
-    row2.assign(rowTemp2);
-  }
-}
+                evalData(matrix);
+            }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-void JacobiSVD<T>::mulRotationOnRight(const int i, const int j, NDArray& block, const NDArray& rotation) {
-  if (i < j) {
-    if (j + 1 > block.sizeAt(1))
-      throw std::runtime_error(
-          "ops::helpers::JacobiSVD mulRotationOnRight: second argument is out of array column range !");
+            template <typename T>
+            void JacobiSVD<T>::mulRotationOnLeft(const int i, const int j, NDArray& block, const NDArray& rotation) {
+                if (i < j) {
+                    if (j + 1 > block.sizeAt(0))
+                        throw std::runtime_error(
+                                "ops::helpers::JacobiSVD mulRotationOnLeft: second arguments is out of array row range !");
 
-    auto temp = block({0, 0, 0, i, j + 1, j - i}, true, true);
-    temp.assign(mmul(temp, rotation));
+                    auto temp = block({i, j + 1, j - i, 0, 0, 0}, true, true);
+                    temp.assign(mmul(rotation, temp));
 
-    // auto pTemp = block({0,0,0,  i,j+1,j-i}, true, true);
-    // auto temp = pTemp.dup();
-    // pTemp.assign(mmul(temp, rotation));
-  } else {
-    if (j + 1 > block.sizeAt(1) || i + 1 > block.sizeAt(1))
-      throw std::runtime_error(
-          "ops::helpers::JacobiSVD mulRotationOnRight: some or both integer arguments are out of array column range !");
+                    // auto pTemp = block({i,j+1,j-i,  0,0,0}, true, true);
+                    // auto temp = pTemp.dup();
+                    // pTemp.assign(mmul(rotation, temp));
+                } else {
+                    if (j + 1 > block.sizeAt(0) || i + 1 > block.sizeAt(0))
+                        throw std::runtime_error(
+                                "ops::helpers::JacobiSVD mulRotationOnLeft: some or both integer arguments are out of array row range !");
 
-    NDArray temp(block.ordering(), {block.sizeAt(0), 2}, block.dataType(), block.getContext());
-    auto col1 = block({0, 0, i, i + 1}, true);
-    auto col2 = block({0, 0, j, j + 1}, true);
-    auto colTemp1 = temp({0, 0, 0, 1}, true);
-    auto colTemp2 = temp({0, 0, 1, 2}, true);
-    colTemp1.assign(col1);
-    colTemp2.assign(col2);
-    temp.assign(mmul(temp, rotation));
-    col1.assign(colTemp1);
-    col2.assign(colTemp2);
-  }
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <typename T>
-bool JacobiSVD<T>::isBlock2x2NotDiag(NDArray& block, int p, int q, T& maxElem) {
-  NDArray rotation(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
-
-  T n = math::sd_sqrt<T, T>(block.t<T>(p, p) * block.t<T>(p, p) + block.t<T>(q, p) * block.t<T>(q, p));
-
-  const T almostZero = DataTypeUtils::min_positive<T>();
-  const T precision = DataTypeUtils::eps<T>();
-
-  if (n == (T)0.f) {
-    block.r<T>(p, p) = (T)0;
-    block.r<T>(q, p) = (T)0;
-  } else {
-    T v = block.t<T>(p, p) / n;
-
-    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = v;
-
-    v = block.t<T>(q, p) / n;
-    rotation.r<T>(0, 1) = v;
-
-    rotation.r<T>(1, 0) = -rotation.template t<T>(0, 1);
-    mulRotationOnLeft(p, q, block, rotation);
-
-    if (_calcU) mulRotationOnRight(p, q, _u, rotation.transpose());
-  }
-
-  maxElem =
-      math::sd_max<T>(maxElem, math::sd_max<T>(math::sd_abs<T>(block.t<T>(p, p)), math::sd_abs<T>(block.t<T>(q, q))));
-  T threshold = math::sd_max<T>(almostZero, precision * maxElem);
-
-  return math::sd_abs<T>(block.t<T>(p, q)) > threshold || math::sd_abs<T>(block.t<T>(q, p)) > threshold;
-}
+                    NDArray temp(block.ordering(), {2, block.sizeAt(1)}, block.dataType(), block.getContext());
+                    auto row1 = block({i, i + 1, 0, 0}, true);
+                    auto row2 = block({j, j + 1, 0, 0}, true);
+                    auto rowTemp1 = temp({0, 1, 0, 0}, true);
+                    auto rowTemp2 = temp({1, 2, 0, 0}, true);
+                    rowTemp1.assign(row1);
+                    rowTemp2.assign(row2);
+                    temp.assign(mmul(rotation, temp));
+                    row1.assign(rowTemp1);
+                    row2.assign(rowTemp2);
+                }
+            }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-bool JacobiSVD<T>::createJacobiRotation(const T& x, const T& y, const T& z, NDArray& rotation) {
-  T denom = (T)(2.f) * math::sd_abs<T>(y);
+            template <typename T>
+            void JacobiSVD<T>::mulRotationOnRight(const int i, const int j, NDArray& block, const NDArray& rotation) {
+                if (i < j) {
+                    if (j + 1 > block.sizeAt(1))
+                        throw std::runtime_error(
+                                "ops::helpers::JacobiSVD mulRotationOnRight: second argument is out of array column range !");
 
-  if (denom < DataTypeUtils::min_positive<T>()) {
-    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = (T)1.f;
-    rotation.r<T>(0, 1) = rotation.r<T>(1, 0) = (T)0.f;
+                    auto temp = block({0, 0, 0, i, j + 1, j - i}, true, true);
+                    temp.assign(mmul(temp, rotation));
 
-    return false;
-  } else {
-    T tau = (x - z) / denom;
-    T w = math::sd_sqrt<T, T>(tau * tau + (T)1.f);
-    T t;
+                    // auto pTemp = block({0,0,0,  i,j+1,j-i}, true, true);
+                    // auto temp = pTemp.dup();
+                    // pTemp.assign(mmul(temp, rotation));
+                } else {
+                    if (j + 1 > block.sizeAt(1) || i + 1 > block.sizeAt(1))
+                        throw std::runtime_error(
+                                "ops::helpers::JacobiSVD mulRotationOnRight: some or both integer arguments are out of array column range !");
 
-    if (tau > (T)0.)
-      t = (T)1.f / (tau + w);
-    else
-      t = (T)1.f / (tau - w);
-
-    T sign = t > (T)0. ? (T)1.f : (T)-1.f;
-
-    T cos = (T)1.f / math::sd_sqrt<T, T>(t * t + (T)1.f);
-    T sin = -sign * (y / math::sd_abs<T>(y)) * math::sd_abs<T>(t) * cos;
-
-    rotation.r<T>(0, 1) = sin;
-    rotation.r<T>(1, 0) = -sin;
-    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = cos;
-
-    return true;
-  }
-}
-
-//////////////////////////////////////////////////////////////////////////
-template <typename T>
-void JacobiSVD<T>::createJacobiRotationGivens(const T& p, const T& q, NDArray& rotation) {
-  T cos, sin;
-
-  if (q == (T)0) {
-    cos = p < (T)0 ? (T)-1 : (T)1;
-    sin = (T)0;
-  } else if (p == (T)0) {
-    cos = (T)0;
-    sin = q < (T)0 ? (T)1 : (T)-1;
-  } else if (math::sd_abs<T>(p) > math::sd_abs<T>(q)) {
-    T t = q / p;
-    T u = math::sd_sqrt<T, T>((T)1 + t * t);
-    if (p < (T)0) u = -u;
-    cos = (T)1 / u;
-    sin = -t * cos;
-  } else {
-    T t = p / q;
-    T u = math::sd_sqrt<T, T>((T)1 + t * t);
-    if (q < (T)0) u = -u;
-    sin = -(T)1 / u;
-    cos = -t * sin;
-  }
-
-  rotation.r<T>(0, 1) = sin;
-  rotation.r<T>(1, 0) = -sin;
-  rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = cos;
-}
+                    NDArray temp(block.ordering(), {block.sizeAt(0), 2}, block.dataType(), block.getContext());
+                    auto col1 = block({0, 0, i, i + 1}, true);
+                    auto col2 = block({0, 0, j, j + 1}, true);
+                    auto colTemp1 = temp({0, 0, 0, 1}, true);
+                    auto colTemp2 = temp({0, 0, 1, 2}, true);
+                    colTemp1.assign(col1);
+                    colTemp2.assign(col2);
+                    temp.assign(mmul(temp, rotation));
+                    col1.assign(colTemp1);
+                    col2.assign(colTemp2);
+                }
+            }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-void JacobiSVD<T>::svd2x2(const NDArray& block, int p, int q, NDArray& left, NDArray& right) {
-  NDArray m(block.ordering(), {2, 2}, block.dataType(), block.getContext());
-  m.r<T>(0, 0) = block.t<T>(p, p);
-  m.r<T>(0, 1) = block.t<T>(p, q);
-  m.r<T>(1, 0) = block.t<T>(q, p);
-  m.r<T>(1, 1) = block.t<T>(q, q);
+            template <typename T>
+            bool JacobiSVD<T>::isBlock2x2NotDiag(NDArray& block, int p, int q, T& maxElem) {
+                NDArray rotation(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
 
-  NDArray rotation(block.ordering(), {2, 2}, block.dataType(), block.getContext());
-  T t = m.t<T>(0, 0) + m.t<T>(1, 1);
-  T d = m.t<T>(1, 0) - m.t<T>(0, 1);
+                T n = math::sd_sqrt<T, T>(block.t<T>(p, p) * block.t<T>(p, p) + block.t<T>(q, p) * block.t<T>(q, p));
 
-  if (math::sd_abs<T>(d) < DataTypeUtils::min<T>()) {
-    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = (T)1;
-    rotation.r<T>(0, 1) = rotation.r<T>(1, 0) = (T)0;
-  } else {
-    T u = t / d;
-    T tmp = math::sd_sqrt<T, T>((T)1.f + u * u);
-    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = u / tmp;
-    rotation.r<T>(0, 1) = (T)1.f / tmp;
-    rotation.r<T>(1, 0) = -rotation.t<T>(0, 1);
-  }
+                const T almostZero = DataTypeUtils::min_positive<T>();
+                const T precision = DataTypeUtils::eps<T>();
 
-  m.assign(mmul(rotation, m));
+                if (n == (T)0.f) {
+                    block.r<T>(p, p) = (T)0;
+                    block.r<T>(q, p) = (T)0;
+                } else {
+                    T v = block.t<T>(p, p) / n;
 
-  createJacobiRotation(m.t<T>(0, 0), m.t<T>(0, 1), m.t<T>(1, 1), right);
+                    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = v;
 
-  left.assign(mmul(rotation, right.transpose()));
-}
+                    v = block.t<T>(q, p) / n;
+                    rotation.r<T>(0, 1) = v;
+
+                    rotation.r<T>(1, 0) = -rotation.template t<T>(0, 1);
+                    mulRotationOnLeft(p, q, block, rotation);
+
+                    if (_calcU) mulRotationOnRight(p, q, _u, rotation.transpose());
+                }
+
+                maxElem =
+                        math::sd_max<T>(maxElem, math::sd_max<T>(math::sd_abs<T>(block.t<T>(p, p)), math::sd_abs<T>(block.t<T>(q, q))));
+                T threshold = math::sd_max<T>(almostZero, precision * maxElem);
+
+                return math::sd_abs<T>(block.t<T>(p, q)) > threshold || math::sd_abs<T>(block.t<T>(q, p)) > threshold;
+            }
 
 //////////////////////////////////////////////////////////////////////////
-template <typename T>
-void JacobiSVD<T>::evalData(const NDArray& matrix) {
-  const T precision = (T)2.f * DataTypeUtils::eps<T>();
-  const T almostZero = DataTypeUtils::min_positive<T>();
+            template <typename T>
+            bool JacobiSVD<T>::createJacobiRotation(const T& x, const T& y, const T& z, NDArray& rotation) {
+                T denom = (T)(2.f) * math::sd_abs<T>(y);
 
-  T scale = matrix.reduceNumber(reduce::AMax).template t<T>(0);
-  if (scale <   (T)1.f) scale = (T)1.f;
+                if (denom < DataTypeUtils::min_positive<T>()) {
+                    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = (T)1.f;
+                    rotation.r<T>(0, 1) = rotation.r<T>(1, 0) = (T)0.f;
 
-  if (_rows > _cols) {
-    HHcolPivQR qr(matrix / scale);
-    _m.assign(qr._qr({0, _cols, 0, _cols}));
-    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l',false);
+                    return false;
+                } else {
+                    T tau = (x - z) / denom;
+                    T w = math::sd_sqrt<T, T>(tau * tau + (T)1.f);
+                    T t;
 
-    HHsequence hhSeg(qr._qr, qr._coeffs, 'u');
+                    if (tau > (T)0.)
+                        t = (T)1.f / (tau + w);
+                    else
+                        t = (T)1.f / (tau - w);
 
-    if (_fullUV)
-      hhSeg.applyTo(_u);
-    else if (_calcU) {
-      _u.setIdentity();
-      hhSeg.mulLeft(_u);
-    }
+                    T sign = t > (T)0. ? (T)1.f : (T)-1.f;
 
-    if (_calcV) _v.assign(qr._permut);
-  } else if (_rows < _cols) {
-    HHcolPivQR qr(matrix.transpose() / scale);
-    _m.assign(qr._qr({0, _rows, 0, _rows}));
-    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l',false);
-    _m.transposei();
+                    T cos = (T)1.f / math::sd_sqrt<T, T>(t * t + (T)1.f);
+                    T sin = -sign * (y / math::sd_abs<T>(y)) * math::sd_abs<T>(t) * cos;
 
-    HHsequence hhSeg(qr._qr, qr._coeffs, 'u');  // type = 'u' is not mistake here !
+                    rotation.r<T>(0, 1) = sin;
+                    rotation.r<T>(1, 0) = -sin;
+                    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = cos;
 
-    if (_fullUV)
-      hhSeg.applyTo(_v);
-    else if (_calcV) {
-      _v.setIdentity();
-      hhSeg.mulLeft(_v);
-    }
+                    return true;
+                }
+            }
 
-    if (_calcU) _u.assign(qr._permut);
-  } else {
-    _m.assign(matrix({0, _diagSize, 0, _diagSize}) / scale);
+//////////////////////////////////////////////////////////////////////////
+            template <typename T>
+            void JacobiSVD<T>::createJacobiRotationGivens(const T& p, const T& q, NDArray& rotation) {
+                T cos, sin;
 
-    if (_calcU) _u.setIdentity();
+                if (q == (T)0) {
+                    cos = p < (T)0 ? (T)-1 : (T)1;
+                    sin = (T)0;
+                } else if (p == (T)0) {
+                    cos = (T)0;
+                    sin = q < (T)0 ? (T)1 : (T)-1;
+                } else if (math::sd_abs<T>(p) > math::sd_abs<T>(q)) {
+                    T t = q / p;
+                    T u = math::sd_sqrt<T, T>((T)1 + t * t);
+                    if (p < (T)0) u = -u;
+                    cos = (T)1 / u;
+                    sin = -t * cos;
+                } else {
+                    T t = p / q;
+                    T u = math::sd_sqrt<T, T>((T)1 + t * t);
+                    if (q < (T)0) u = -u;
+                    sin = -(T)1 / u;
+                    cos = -t * sin;
+                }
 
-    if (_calcV) _v.setIdentity();
-  }
+                rotation.r<T>(0, 1) = sin;
+                rotation.r<T>(1, 0) = -sin;
+                rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = cos;
+            }
 
-  T maxDiagElem = 0.;
-  for (int i = 0; i < _diagSize; ++i) {
-    T current = math::sd_abs<T>(_m.t<T>(i, i));
-    if (maxDiagElem < current) maxDiagElem = current;
-  }
+//////////////////////////////////////////////////////////////////////////
+            template <typename T>
+            void JacobiSVD<T>::svd2x2(const NDArray& block, int p, int q, NDArray& left, NDArray& right) {
+                NDArray m(block.ordering(), {2, 2}, block.dataType(), block.getContext());
+                m.r<T>(0, 0) = block.t<T>(p, p);
+                m.r<T>(0, 1) = block.t<T>(p, q);
+                m.r<T>(1, 0) = block.t<T>(q, p);
+                m.r<T>(1, 1) = block.t<T>(q, q);
 
-  bool stop = false;
+                NDArray rotation(block.ordering(), {2, 2}, block.dataType(), block.getContext());
+                T t = m.t<T>(0, 0) + m.t<T>(1, 1);
+                T d = m.t<T>(1, 0) - m.t<T>(0, 1);
 
-  while (!stop) {
-    stop = true;
+                if (math::sd_abs<T>(d) < DataTypeUtils::min<T>()) {
+                    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = (T)1;
+                    rotation.r<T>(0, 1) = rotation.r<T>(1, 0) = (T)0;
+                } else {
+                    T u = t / d;
+                    T tmp = math::sd_sqrt<T, T>((T)1.f + u * u);
+                    rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = u / tmp;
+                    rotation.r<T>(0, 1) = (T)1.f / tmp;
+                    rotation.r<T>(1, 0) = -rotation.t<T>(0, 1);
+                }
 
-    for (int p = 1; p < _diagSize; ++p) {
-      for (int q = 0; q < p; ++q) {
-        T threshold = math::sd_max<T>(almostZero, precision * maxDiagElem);
+                m.assign(mmul(rotation, m));
 
-        if (math::sd_abs<T>(_m.t<T>(p, q)) > threshold || math::sd_abs<T>(_m.t<T>(q, p)) > threshold) {
-          stop = false;
+                createJacobiRotation(m.t<T>(0, 0), m.t<T>(0, 1), m.t<T>(1, 1), right);
 
-          // if(isBlock2x2NotDiag(_m, p, q, maxDiagElem))
-          {
-            NDArray rotLeft(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
-            NDArray rotRight(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
-            svd2x2(_m, p, q, rotLeft, rotRight);
+                left.assign(mmul(rotation, right.transpose()));
+            }
 
-            mulRotationOnLeft(p, q, _m, rotLeft);
+//////////////////////////////////////////////////////////////////////////
+            template <typename T>
+            void JacobiSVD<T>::evalData(const NDArray& matrix) {
+                const T precision = (T)2.f * DataTypeUtils::eps<T>();
+                const T almostZero = DataTypeUtils::min_positive<T>();
+                sd_printf("In jacobi jacobi evalData\n",0);
 
-            if (_calcU) mulRotationOnRight(p, q, _u, rotLeft.transpose());
+                T scale = matrix.reduceNumber(reduce::AMax).template t<T>(0);
+                if (scale <   (T)1.f) scale = (T)1.f;
 
-            mulRotationOnRight(p, q, _m, rotRight);
+                if (_rows > _cols) {
+                    sd_printf("In jacobi evalData rows > cols\n",0);
 
-            if (_calcV) mulRotationOnRight(p, q, _v, rotRight);
+                    HHcolPivQR qr(matrix / scale);
+                    sd_printf("After qr \n",0);
 
-            maxDiagElem = math::sd_max<T>(
-                maxDiagElem, math::sd_max<T>(math::sd_abs<T>(_m.t<T>(p, p)), math::sd_abs<T>(_m.t<T>(q, q))));
-          }
-        }
-      }
-    }
-  }
+                    _m.assign(qr._qr({0, _cols, 0, _cols}));
+                    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l',false);
+                    sd_printf("After fillAsTriangular \n",0);
 
-  for (int i = 0; i < _diagSize; ++i) {
-    _s.r<T>(i) = math::sd_abs<T>(_m.t<T>(i, i));
+                    HHsequence hhSeg(qr._qr, qr._coeffs, 'u');
+                    sd_printf("After hhSeg \n",0);
 
-    if (_calcU && _m.t<T>(i, i) < (T)0.) {
-      auto temp = _u({0, 0, i, i + 1}, true);
-      temp.applyTransform(transform::Neg, temp, nullptr);
-    }
-  }
+                    if (_fullUV)
+                        hhSeg.applyTo(_u);
+                    else if (_calcU) {
+                        _u.setIdentity();
+                        hhSeg.mulLeft(_u);
+                    }
 
-  _s *= scale;
+                    sd_printf("After hhSeg apply \n",0);
 
-  for (int i = 0; i < _diagSize; i++) {
-    int pos = (_s({i, -1, 0, 0}).indexReduceNumber(indexreduce::IndexMax, nullptr)).template e<int>(0);
-    T maxSingVal = _s({i, -1, 0, 0}).reduceNumber(reduce::Max).template t<T>(0);
+                    if (_calcV) _v.assign(qr._permut);
+                } else if (_rows < _cols) {
+                    sd_printf("In rows < columns\n",0);
 
-    if (maxSingVal == (T)0.) break;
+                    HHcolPivQR qr(matrix.transpose() / scale);
+                    _m.assign(qr._qr({0, _rows, 0, _rows}));
+                    _m.fillAsTriangular<T>(0., 0, 0, _m, 'l',false);
+                    _m.transposei();
+                    sd_printf("After in place transpose\n",0);
 
-    if (pos) {
-      pos += i;
+                    HHsequence hhSeg(qr._qr, qr._coeffs, 'u');  // type = 'u' is not mistake here !
 
-      math::sd_swap<T>(_s.r<T>(i), _s.r<T>(pos));
+                    if (_fullUV)
+                        hhSeg.applyTo(_v);
+                    else if (_calcV) {
+                        _v.setIdentity();
+                        hhSeg.mulLeft(_v);
+                    }
 
-      if (_calcU) {
-        auto temp1 = _u({0, 0, pos, pos + 1}, true);
-        auto temp2 = _u({0, 0, i, i + 1}, true);
-        temp1.swapUnsafe(temp2);
-      }
+                    sd_printf("After fullUV appy\n",0);
 
-      if (_calcV) {
-        auto temp1 = _v({0, 0, pos, pos + 1}, true);
-        auto temp2 = _v({0, 0, i, i + 1}, true);
-        temp1.swapUnsafe(temp2);
-      }
-    }
-  }
-}
+                    if (_calcU) _u.assign(qr._permut);
+                } else {
+                    _m.assign(matrix({0, _diagSize, 0, _diagSize}) / scale);
 
-BUILD_SINGLE_TEMPLATE(template class JacobiSVD, , SD_FLOAT_TYPES);
+                    if (_calcU) _u.setIdentity();
 
-}  // namespace helpers
-}  // namespace ops
+                    if (_calcV) _v.setIdentity();
+                }
+
+                sd_printf("Before maxDiagElemn",0);
+
+                T maxDiagElem = 0.;
+                for (int i = 0; i < _diagSize; ++i) {
+                    T current = math::sd_abs<T>(_m.t<T>(i, i));
+                    if (maxDiagElem < current) maxDiagElem = current;
+                }
+
+                bool stop = false;
+                sd_printf("AFter maxDiagElemn\n",0);
+
+                while (!stop) {
+                    stop = true;
+                    sd_printf("In diagSize not stopping\n",0);
+
+                    for (int p = 1; p < _diagSize; ++p) {
+                        for (int q = 0; q < p; ++q) {
+                            T threshold = math::sd_max<T>(almostZero, precision * maxDiagElem);
+
+                            if (math::sd_abs<T>(_m.t<T>(p, q)) > threshold || math::sd_abs<T>(_m.t<T>(q, p)) > threshold) {
+                                stop = false;
+
+                                NDArray rotLeft(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
+                                NDArray rotRight(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
+                                svd2x2(_m, p, q, rotLeft, rotRight);
+
+                                mulRotationOnLeft(p, q, _m, rotLeft);
+
+                                if (_calcU) mulRotationOnRight(p, q, _u, rotLeft.transpose());
+
+                                mulRotationOnRight(p, q, _m, rotRight);
+
+                                if (_calcV) mulRotationOnRight(p, q, _v, rotRight);
+
+                                maxDiagElem = math::sd_max<T>(
+                                        maxDiagElem, math::sd_max<T>(math::sd_abs<T>(_m.t<T>(p, p)), math::sd_abs<T>(_m.t<T>(q, q))));
+
+                            }
+                        }
+                    }
+                }
+
+
+                sd_printf("After diagSize not stopping\n",0);
+
+                for (int i = 0; i < _diagSize; ++i) {
+                    _s.r<T>(i) = math::sd_abs<T>(_m.t<T>(i, i));
+
+                    if (_calcU && _m.t<T>(i, i) < (T)0.) {
+                        auto temp = _u({0, 0, i, i + 1}, true);
+                        temp.applyTransform(transform::Neg, temp, nullptr);
+                    }
+                }
+
+
+                sd_printf("Before muli scale\n",0);
+
+                _s *= scale;
+                sd_printf("After muli scale\n",0);
+                for (int i = 0; i < _diagSize; i++) {
+                  sd_printf("Determining position\n",0);
+                  int pos = (_s({i, -1, 0, 0}).indexReduceNumber(indexreduce::IndexMax, nullptr)).template e<int>(0);
+                  sd_printf("After Determining position\n",0);
+                    T maxSingVal = _s({i, -1, 0, 0}).reduceNumber(reduce::Max).template t<T>(0);
+                    sd_printf("After maxSingVal\n",0);
+
+                    if (maxSingVal == (T)0.) break;
+
+                    if (pos) {
+                        pos += i;
+
+                        math::sd_swap<T>(_s.r<T>(i), _s.r<T>(pos));
+
+                        if (_calcU) {
+                          sd_printf("Before temp1 temp2 swapUnsafe\n",0);
+                            auto temp1 = _u({0, 0, pos, pos + 1}, true);
+                            auto temp2 = _u({0, 0, i, i + 1}, true);
+                            temp1.swapUnsafe(temp2);
+                            sd_printf("After temp1 temp2 swapUnsafe\n",0);
+
+                        }
+
+                        if (_calcV) {
+                            auto temp1 = _v({0, 0, pos, pos + 1}, true);
+                            auto temp2 = _v({0, 0, i, i + 1}, true);
+                            temp1.swapUnsafe(temp2);
+                        }
+                    }
+                }
+
+                sd_printf("AFter muli scale loop\n",0);
+
+            }
+
+            BUILD_SINGLE_TEMPLATE(template class JacobiSVD, , SD_FLOAT_TYPES);
+
+        }  // namespace helpers
+    }  // namespace ops
 }  // namespace sd
 
 #endif

--- a/libnd4j/include/legacy/NativeOps.h
+++ b/libnd4j/include/legacy/NativeOps.h
@@ -1074,7 +1074,7 @@ static long _numpyHeaderLength(OpaqueDataBuffer *opaqueDataBuffer,sd::Pointer sh
 }
 
 template<typename  T>
-SD_LIB_EXPORT static long _numpyHeaderLengthWordSize(sd::Pointer shapeBuffer,long wordSize) {
+ static long _numpyHeaderLengthWordSize(sd::Pointer shapeBuffer,long wordSize) {
   sd::LongType* shapeBufferCast = reinterpret_cast<sd::LongType*>(shapeBuffer);
   int rank = shape::rank(shapeBufferCast);
   sd::LongType* shape = shape::shapeOf(shapeBufferCast);

--- a/libnd4j/include/legacy/NativeOps.h
+++ b/libnd4j/include/legacy/NativeOps.h
@@ -1092,14 +1092,14 @@ template<typename  T>
 
 extern "C" {
 
-SD_LIB_EXPORT static long numpyHeaderLengthWordSize(sd::Pointer shapeBuffer,long wordSize) {
+ static long numpyHeaderLengthWordSize(sd::Pointer shapeBuffer,long wordSize) {
   auto shapeBufferCast = reinterpret_cast<sd::LongType*>(shapeBuffer);
   auto type = sd::ArrayOptions::dataType(shapeBufferCast);
   BUILD_SINGLE_SELECTOR(type, return _numpyHeaderLengthWordSize, (shapeBuffer, wordSize), SD_COMMON_TYPES);
 
 }
 
-SD_LIB_EXPORT static long numpyHeaderLength(OpaqueDataBuffer *opaqueDataBuffer,sd::Pointer shapeBuffer) {
+ static long numpyHeaderLength(OpaqueDataBuffer *opaqueDataBuffer,sd::Pointer shapeBuffer) {
   auto shapeBufferCast = reinterpret_cast<sd::LongType*>(shapeBuffer);
   auto type = sd::ArrayOptions::dataType(shapeBufferCast);
 
@@ -1109,7 +1109,7 @@ SD_LIB_EXPORT static long numpyHeaderLength(OpaqueDataBuffer *opaqueDataBuffer,s
 
 
 
-SD_LIB_EXPORT static sd::Pointer numpyFromNd4j(sd::Pointer data, sd::Pointer shapeBuffer, sd::LongType wordSize) {
+ static sd::Pointer numpyFromNd4j(sd::Pointer data, sd::Pointer shapeBuffer, sd::LongType wordSize) {
   auto shapeBufferCast = reinterpret_cast<sd::LongType*>(shapeBuffer);
   auto type = sd::ArrayOptions::dataType(shapeBufferCast);
 

--- a/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
@@ -68,9 +68,11 @@ void NativeOpExecutioner::execIndexReduceScalar(sd::LaunchContext *lc, int opNum
                                                 const sd::LongType *dXShapeInfo, void *extraParams, void *hZ,
                                                 const sd::LongType *hZShapeInfo, void *dZ,
                                                 const sd::LongType *dZShapeInfo) {
+  sd_printf("execIndexReduceScalar determining data types\n",0);
   auto xType = sd::ArrayOptions::dataType(hXShapeInfo);
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
   auto hz = reinterpret_cast<sd::LongType *>(hZ);
+  sd_printf("After execIndexReduceScalar determining data types\n",0);
 
   BUILD_DOUBLE_SELECTOR(xType, zType, hz[0] = functions::indexreduce::IndexReduce,
                         ::execScalar(opNum, hX, hXShapeInfo, extraParams), SD_COMMON_TYPES, SD_INDEXING_TYPES);

--- a/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
@@ -852,9 +852,9 @@ void NativeOpExecutioner::execScalar(sd::LaunchContext *lc, int opNum, const voi
   samediff::Threads::parallel_for(
       func, 0, zLen, 1,
       !allowParallelism
-          ? 1
-          : sd::math::sd_max<int>(
-                1, sd::math::sd_min<int>(zLen / 1024, sd::Environment::getInstance().maxMasterThreads())));
+      ? 1
+      : sd::math::sd_max<int>(
+          1, sd::math::sd_min<int>(zLen / 1024, sd::Environment::getInstance().maxMasterThreads())));
 
 
 #endif
@@ -927,9 +927,9 @@ void NativeOpExecutioner::execScalarBool(sd::LaunchContext *lc, int opNum, const
   samediff::Threads::parallel_for(
       func, 0, zLen, 1,
       !allowParallelism
-          ? 1
-          : sd::math::sd_max<int>(
-                1, sd::math::sd_min<int>(zLen / 1024, sd::Environment::getInstance().maxMasterThreads())));
+      ? 1
+      : sd::math::sd_max<int>(
+          1, sd::math::sd_min<int>(zLen / 1024, sd::Environment::getInstance().maxMasterThreads())));
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -993,9 +993,9 @@ void NativeOpExecutioner::execScalarInt(sd::LaunchContext *lc, int opNum, const 
   samediff::Threads::parallel_for(
       func, 0, zLen, 1,
       !allowParallelism
-          ? 1
-          : sd::math::sd_max<int>(
-                1, sd::math::sd_min<int>(zLen / 1024, sd::Environment::getInstance().maxMasterThreads())));
+      ? 1
+      : sd::math::sd_max<int>(
+          1, sd::math::sd_min<int>(zLen / 1024, sd::Environment::getInstance().maxMasterThreads())));
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1164,16 +1164,23 @@ void NativeOpExecutioner::execTransformAny(sd::LaunchContext *lc, int opNum, con
                                            void *dZ, const sd::LongType *dZShapeInfo, void *extraParams,
                                            const sd::LongType *tadShapeInfo, const sd::LongType *tadOffsets,
                                            bool allowParallelism) {
+  sd_printf("execTransformAny: before data types\n",0);
   auto xType = sd::ArrayOptions::dataType(hXShapeInfo);
+
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
+  sd_printf("execTransformAny: after data types\n",0);
 
   if (shape::isEmpty(hXShapeInfo)) return;
 
   if (opNum == sd::transform::Assign && shape::order(hXShapeInfo) == shape::order(hZShapeInfo) &&
       shape::order(hXShapeInfo) == 'c' && xType == zType && shape::elementWiseStride(hXShapeInfo) == 1 &&
       shape::elementWiseStride(hZShapeInfo) == 1) {
+    sd_printf("execTransformAny: memcpy\n",0);
     memcpy(hZ, hX, shape::length(hXShapeInfo) * sd::DataTypeUtils::sizeOfElement(xType));
+    sd_printf("execTransformAny: after memcpy\n",0);
+
   } else {
+    sd_printf("execTransformAny: Before other exec\n",0);
     auto func = PRAGMA_THREADS_DO {
       BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformAny,
                             ::exec(opNum, hX, hXShapeInfo, hZ, hZShapeInfo, extraParams, thread_id, numThreads),

--- a/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
@@ -68,11 +68,9 @@ void NativeOpExecutioner::execIndexReduceScalar(sd::LaunchContext *lc, int opNum
                                                 const sd::LongType *dXShapeInfo, void *extraParams, void *hZ,
                                                 const sd::LongType *hZShapeInfo, void *dZ,
                                                 const sd::LongType *dZShapeInfo) {
-  sd_printf("execIndexReduceScalar determining data types\n",0);
   auto xType = sd::ArrayOptions::dataType(hXShapeInfo);
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
   auto hz = reinterpret_cast<sd::LongType *>(hZ);
-  sd_printf("After execIndexReduceScalar determining data types\n",0);
 
   BUILD_DOUBLE_SELECTOR(xType, zType, hz[0] = functions::indexreduce::IndexReduce,
                         ::execScalar(opNum, hX, hXShapeInfo, extraParams), SD_COMMON_TYPES, SD_INDEXING_TYPES);
@@ -1164,23 +1162,18 @@ void NativeOpExecutioner::execTransformAny(sd::LaunchContext *lc, int opNum, con
                                            void *dZ, const sd::LongType *dZShapeInfo, void *extraParams,
                                            const sd::LongType *tadShapeInfo, const sd::LongType *tadOffsets,
                                            bool allowParallelism) {
-  sd_printf("execTransformAny: before data types\n",0);
   auto xType = sd::ArrayOptions::dataType(hXShapeInfo);
 
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
-  sd_printf("execTransformAny: after data types\n",0);
 
   if (shape::isEmpty(hXShapeInfo)) return;
 
   if (opNum == sd::transform::Assign && shape::order(hXShapeInfo) == shape::order(hZShapeInfo) &&
       shape::order(hXShapeInfo) == 'c' && xType == zType && shape::elementWiseStride(hXShapeInfo) == 1 &&
       shape::elementWiseStride(hZShapeInfo) == 1) {
-    sd_printf("execTransformAny: memcpy\n",0);
     memcpy(hZ, hX, shape::length(hXShapeInfo) * sd::DataTypeUtils::sizeOfElement(xType));
-    sd_printf("execTransformAny: after memcpy\n",0);
 
   } else {
-    sd_printf("execTransformAny: Before other exec\n",0);
     auto func = PRAGMA_THREADS_DO {
       BUILD_DOUBLE_SELECTOR(xType, zType, functions::transform::TransformAny,
                             ::exec(opNum, hX, hXShapeInfo, hZ, hZShapeInfo, extraParams, thread_id, numThreads),

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -298,11 +298,9 @@ void  setGraphContextInputBuffers(OpaqueContext* ptr, int numArrays, OpaqueDataB
   if(shapeInfo == nullptr)
     throw std::runtime_error("Input shape info was null!");
   for(int i = 0; i < numArrays; i++) {
-    sd_printf("Setting buffer %d\n",i);
     if(inputShapeBuffers[i] == nullptr)
       throw std::runtime_error("Input shape at index was null!");
     if(buffer != nullptr && buffer[i] != nullptr) {
-      sd_printf("Setting graph context input buffer with neither buffer  or buffer[i] == nullptr\n",0);
       setGraphContextInputBuffer(ptr,i,buffer[i],inputShapeBuffers[i],specialShapeInfo != nullptr ? specialShapeInfo[i] : nullptr);
     }
     else {
@@ -2683,7 +2681,6 @@ void setGraphContextInputBuffer(OpaqueContext *ptr, int index, OpaqueDataBuffer 
     throw std::runtime_error(error.c_str());
   }
 
-  sd_printf("Setting input array at index %d\n",index);
   ptr->setInputArray(index, buffer, shapeInfo, specialShapeInfo);
 }
 

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -298,10 +298,13 @@ void  setGraphContextInputBuffers(OpaqueContext* ptr, int numArrays, OpaqueDataB
   if(shapeInfo == nullptr)
     throw std::runtime_error("Input shape info was null!");
   for(int i = 0; i < numArrays; i++) {
+    sd_printf("Setting buffer %d\n",i);
     if(inputShapeBuffers[i] == nullptr)
       throw std::runtime_error("Input shape at index was null!");
-    if(buffer != nullptr && buffer[i] != nullptr)
+    if(buffer != nullptr && buffer[i] != nullptr) {
+      sd_printf("Setting graph context input buffer with neither buffer  or buffer[i] == nullptr\n",0);
       setGraphContextInputBuffer(ptr,i,buffer[i],inputShapeBuffers[i],specialShapeInfo != nullptr ? specialShapeInfo[i] : nullptr);
+    }
     else {
       setGraphContextInputBuffer(ptr,i, nullptr,inputShapeBuffers[i],specialShapeInfo);
     }
@@ -459,8 +462,8 @@ void execReduceFloat2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *d
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo) && zLen != 1) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims =
@@ -494,8 +497,8 @@ void execReduceBool2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo)) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims =
@@ -529,8 +532,8 @@ void execReduceSame2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo) && zLen != 1) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims =
@@ -564,8 +567,8 @@ void execReduceLong2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo) && zLen != 1) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
-      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack.special());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
+      zShapeInfoD = reinterpret_cast<sd::LongType const *>(zPack->special());
     }
 
     std::vector<int> dims =
@@ -2592,9 +2595,9 @@ OpaqueConstantShapeBuffer *shapeBuffer(int rank, sd::LongType *shape, sd::LongTy
 OpaqueConstantShapeBuffer *shapeBufferEx(int rank, sd::LongType *shape, sd::LongType *strides, sd::DataType dtype,
                                          char order, sd::LongType ews, sd::LongType extras) {
   try {
-    auto buffer = new ConstantShapeBuffer();
-    *buffer = sd::ConstantShapeHelper::getInstance().bufferForShapeInfo(
-        ShapeDescriptor(dtype, order, shape, strides, rank, ews, extras));
+    auto desc = new  ShapeDescriptor(dtype, order, shape, strides, rank, ews, extras);
+    auto buffer = sd::ConstantShapeHelper::getInstance().bufferForShapeInfo(
+        desc);
     return buffer;
   } catch (std::exception &e) {
     sd::LaunchContext::defaultContext()->errorReference()->setErrorCode(1);
@@ -2603,9 +2606,13 @@ OpaqueConstantShapeBuffer *shapeBufferEx(int rank, sd::LongType *shape, sd::Long
   }
 }
 
-void deleteConstantShapeBuffer(OpaqueConstantShapeBuffer *ptr) { delete ptr; }
+void deleteConstantShapeBuffer(OpaqueConstantShapeBuffer *ptr) {
+  //delete ptr;
+   }
 
-void deleteConstantDataBuffer(sd::ConstantDataBuffer *ptr) { delete ptr; }
+void deleteConstantDataBuffer(sd::ConstantDataBuffer *ptr) {
+//  delete ptr;
+}
 
 void deleteTadPack(sd::TadPack *ptr) { delete ptr; }
 
@@ -2676,6 +2683,7 @@ void setGraphContextInputBuffer(OpaqueContext *ptr, int index, OpaqueDataBuffer 
     throw std::runtime_error(error.c_str());
   }
 
+  sd_printf("Setting input array at index %d\n",index);
   ptr->setInputArray(index, buffer, shapeInfo, specialShapeInfo);
 }
 

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -276,9 +276,9 @@ void execPairwiseTransform(sd::Pointer *extraPointers, int opNum, OpaqueDataBuff
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execPairwiseTransform(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbY->primary(), hYShapeInfo,
-        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(), dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbY->primary(), hYShapeInfo,
+        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(), dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         extraParams);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
@@ -299,9 +299,9 @@ void execPairwiseTransformBool(sd::Pointer *extraPointers, int opNum, OpaqueData
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execPairwiseBoolTransform(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbY->primary(), hYShapeInfo,
-        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(), dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbY->primary(), hYShapeInfo,
+        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(), dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         extraParams);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
@@ -322,8 +322,8 @@ void execSummaryStatsScalar(sd::Pointer *extraPointers, int opNum, OpaqueDataBuf
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execSummaryStatsScalar(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         biasCorrected);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -355,9 +355,9 @@ void execBroadcastBool(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execBroadcastBool(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbY->primary(), hYShapeInfo,
-        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(), dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbY->primary(), hYShapeInfo,
+        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(), dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         extraParams, dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ, tadOffsetsZ);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
@@ -406,9 +406,9 @@ void execBroadcast(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX,
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execBroadcast(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbY->primary(), hYShapeInfo,
-        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(), dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbY->primary(), hYShapeInfo,
+        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(), dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         dimension, dimensionLength, tadOnlyShapeInfo, tadOffsets, tadOnlyShapeInfoZ, tadOffsetsZ);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
@@ -437,8 +437,8 @@ void execReduceFloat(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduceFloatScalar(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special());
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
   } catch (std::exception &e) {
@@ -457,8 +457,8 @@ void execReduceSame(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduceSameScalar(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special());
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
   } catch (std::exception &e) {
@@ -487,16 +487,16 @@ void execReduceSame2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo) && zLen != 1) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
     }
 
     std::vector<int> dims =
         (zLen != 1) ? ShapeUtils::evalDimsForReduceOp(shape::rank(hXShapeInfo), dimensions) : std::vector<int>();
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduceSame(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                         extraParams, dbZ->primary(), zShapeInfoH, dbZ->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH)->special(),
                                         dims.data(), dims.size());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -526,7 +526,7 @@ void execReduceLong2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo) && zLen != 1) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
     }
 
     std::vector<int> dims =
@@ -534,9 +534,9 @@ void execReduceLong2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduceLong(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                         extraParams, dbZ->primary(), zShapeInfoH, dbZ->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH)->special(),
                                         dims.data(), dims.size());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -573,9 +573,9 @@ void execReduceLong(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX
     BUILD_DOUBLE_SELECTOR(
         xType, zType, functions::reduce::ReduceLongFunction,
         ::execReduceScalar(launchDims, stream, opNum, dbX->special(),
-                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), hXShapeInfo,
+                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), hXShapeInfo,
                            extraParams, dbZ->special(),
-                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), hXShapeInfo,
+                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), hXShapeInfo,
                            nullptr, 0, reductionPointer, dTADShapeInfo),
         SD_COMMON_TYPES, SD_LONG_TYPES);
 
@@ -608,7 +608,7 @@ void execReduceBool2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo) && zLen != 1) {
       auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
     }
 
     std::vector<int> dims =
@@ -616,9 +616,9 @@ void execReduceBool2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduceBool(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                         extraParams, dbZ->primary(), zShapeInfoH, dbZ->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH)->special(),
                                         dims.data(), dims.size());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -654,9 +654,9 @@ void execReduceBool(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX
     BUILD_DOUBLE_SELECTOR(
         xType, zType, functions::reduce::ReduceBoolFunction,
         ::execReduceScalar(launchDims, stream, opNum, dbX->special(),
-                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), hXShapeInfo,
+                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), hXShapeInfo,
                            extraParams, dbZ->special(),
-                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), hZShapeInfo,
+                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), hZShapeInfo,
                            nullptr, 0, reductionPointer, dTADShapeInfo),
         SD_COMMON_TYPES, SD_BOOL_TYPES);
 
@@ -698,8 +698,8 @@ void execIndexReduce(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *db
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execIndexReduce(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         (int *)dbDimension->special(), dimensionLength, tadPack.specialShapeInfo(), tadPack.specialOffsets());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -737,8 +737,9 @@ void execReduceFloat2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *d
     const sd::LongType *zShapeInfoH = hZShapeInfo;
 
     if (shape::rank(hXShapeInfo) - dimensionLength != shape::rank(hZShapeInfo) && zLen != 1) {
-      auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, dimensions);
-      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack.primary());
+      auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(hZShapeInfo, 
+                                                                                            dimensions);
+      zShapeInfoH = reinterpret_cast<sd::LongType const *>(zPack->primary());
     }
 
     std::vector<int> dims =
@@ -746,9 +747,9 @@ void execReduceFloat2(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *d
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduceFloat(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                         ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                         ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                          extraParams, dbZ->primary(), zShapeInfoH, dbZ->special(),
-                                         ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH).special(),
+                                         ConstantShapeHelper::getInstance().bufferForShapeInfo(zShapeInfoH)->special(),
                                          dims.data(), dims.size());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -775,8 +776,8 @@ void execIndexReduceScalar(sd::Pointer *extraPointers, int opNum, OpaqueDataBuff
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execIndexReduceScalar(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special());
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
   } catch (std::exception &e) {
@@ -797,9 +798,9 @@ void execTransformSame(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execTransformSame(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                            dbZ->primary(), hZShapeInfo, dbZ->special(),
-                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
                                            extraParams, tadShapeInfo, tadOffsets);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -821,9 +822,9 @@ void execTransformBool(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execTransformBool(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                            dbZ->primary(), hZShapeInfo, dbZ->special(),
-                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+                                           ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
                                            extraParams, tadShapeInfo, tadOffsets);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -846,9 +847,9 @@ void execTransformAny(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *d
                      reinterpret_cast<int *>(extraPointers[6]));
 
     NativeOpExecutioner::execTransformAny(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                           dbZ->primary(), hZShapeInfo, dbZ->special(),
-                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
                                           extraParams, nullptr, nullptr);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -871,8 +872,8 @@ void execTransformStrict(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execTransformStrict(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbZ->primary(), hZShapeInfo,
-        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), extraParams,
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbZ->primary(), hZShapeInfo,
+        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), extraParams,
         tadShapeInfo, tadOffsets);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -895,8 +896,8 @@ void execTransformFloat(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execTransformFloat(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbZ->primary(), hZShapeInfo,
-        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), extraParams,
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbZ->primary(), hZShapeInfo,
+        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), extraParams,
         tadShapeInfo, tadOffsets);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -1571,9 +1572,9 @@ void execSummaryStats(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *d
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execSummaryStats(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                           extraParams, dbZ->primary(), hZShapeInfo, dbZ->special(),
-                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+                                          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
                                           biasCorrected);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
@@ -1600,8 +1601,8 @@ void execSummaryStatsTad(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execSummaryStats(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         reinterpret_cast<int *>(dbDimension->special()), dimensionLength, tadShapeInfo, tadOffsets, biasCorrected);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbDimension});
@@ -1621,11 +1622,11 @@ void execReduce3(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX, s
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduce3(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                     ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                     ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                      extraParams, dbY->primary(), hYShapeInfo, dbY->special(),
-                                     ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(),
+                                     ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(),
                                      dbZ->primary(), hZShapeInfo, dbZ->special(),
-                                     ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special());
+                                     ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
   } catch (std::exception &e) {
@@ -1660,18 +1661,18 @@ void execReduce3Tad(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX
     if (tadLength == yLength || tadLength == xLength) {
       NativeOpExecutioner::execReduce3(
           &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbY->primary(),
-          hYShapeInfo, dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(),
+          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbY->primary(),
+          hYShapeInfo, dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(),
           dbZ->primary(), hZShapeInfo, dbZ->special(),
-          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), dimension, dimensionLength,
+          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), dimension, dimensionLength,
           tadOnlyShapeInfo, tadOffsets, yTadOnlyShapeInfo, yTadOffsets);
     } else
       NativeOpExecutioner::execReduce3TAD(
           &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbY->primary(),
-          hYShapeInfo, dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(),
+          ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbY->primary(),
+          hYShapeInfo, dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(),
           dbZ->primary(), hZShapeInfo, dbZ->special(),
-          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), dimension, dimensionLength,
+          ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), dimension, dimensionLength,
           tadOnlyShapeInfo, yTadOffsets, yTadOnlyShapeInfo, yTadOffsets);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
@@ -1692,10 +1693,10 @@ void execReduce3Scalar(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduce3Scalar(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbY->primary(),
-        hYShapeInfo, dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbY->primary(),
+        hYShapeInfo, dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(),
         dbZ->primary(), hZShapeInfo, dbZ->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special());
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special());
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
   } catch (std::exception &e) {
@@ -1715,10 +1716,10 @@ void execScalarBool(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execScalarBool(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbZ->primary(), hZShapeInfo,
-        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbZ->primary(), hZShapeInfo,
+        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         dbScalar->primary(), hScalarShapeInfo, dbScalar->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hScalarShapeInfo).special(), extraParams);
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hScalarShapeInfo)->special(), extraParams);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbScalar});
   } catch (std::exception &e) {
@@ -1746,10 +1747,10 @@ void execScalarBoolTad(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execScalarBool(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), extraParams, dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), extraParams, dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         dbScalars->primary(), hScalarShapeInfo, dbScalars->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hScalarShapeInfo).special(), dimension, dimensionLength,
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hScalarShapeInfo)->special(), dimension, dimensionLength,
         tadShapeInfo, tadOffsets, tadShapeInfoZ, tadOffsetsZ);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbScalars});
@@ -1770,10 +1771,10 @@ void execScalar(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX, sd
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execScalar(
         &lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbZ->primary(), hZShapeInfo,
-        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbZ->primary(), hZShapeInfo,
+        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         dbScalar->primary(), hScalarShapeInfo, dbScalar->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hScalarShapeInfo).special(), extraParams);
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hScalarShapeInfo)->special(), extraParams);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbScalar});
   } catch (std::exception &e) {
@@ -1819,8 +1820,8 @@ void execScalarTad(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX,
         xType, functions::scalar::ScalarTransform,
         ::executeCudaAlongDimension(
             launchDims, stream, opNum, dbX->special(),
-            ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbZ->special(),
-            ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), dbScalars->special(),
+            ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbZ->special(),
+            ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), dbScalars->special(),
             extraParams, dimension, dimensionLength, tadShapeInfo, tadOffsets, tadShapeInfoZ, tadOffsetsZ),
         SD_COMMON_TYPES);
 #endif
@@ -1854,7 +1855,7 @@ void execRandom(sd::Pointer *extraPointers, int opNum, sd::Pointer stateHost, Op
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execRandom(&lc, opNum, stateHost, dbZ->primary(), hZShapeInfo, dbZ->special(),
-                                    ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+                                    ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
                                     extraArguments);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {});
@@ -1874,8 +1875,8 @@ void execRandom2(sd::Pointer *extraPointers, int opNum, sd::Pointer stateHost, O
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execRandom(
         &lc, opNum, stateHost, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbZ->primary(), hZShapeInfo,
-        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(), extraArguments);
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbZ->primary(), hZShapeInfo,
+        dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(), extraArguments);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX});
   } catch (std::exception &e) {
@@ -1895,9 +1896,9 @@ void execRandom3(sd::Pointer *extraPointers, int opNum, sd::Pointer stateHost, O
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execRandom(
         &lc, opNum, stateHost, dbX->primary(), hXShapeInfo, dbX->special(),
-        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(), dbY->primary(), hYShapeInfo,
-        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(), dbZ->primary(),
-        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(), dbY->primary(), hYShapeInfo,
+        dbY->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(), dbZ->primary(),
+        hZShapeInfo, dbZ->special(), ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
         extraArguments);
 
     InteropDataBuffer::registerSpecialUse({dbZ}, {dbX, dbY});
@@ -2056,7 +2057,7 @@ void prescanArrayRecursive(sd::Pointer *extras, int *dZ, int *dX, int numElement
 
   // setup execution parameters
   // if NP2, we process the last block separately
-  dim3 grid(max(1, numBlocks - np2LastBlock), 1, 1);
+  dim3 grid(sd::math::sd_max<int>(1, numBlocks - np2LastBlock), 1, 1);
   dim3 threads(numThreads, 1, 1);
   dim3 gridOnes(1, 1, 1);
   dim3 threadsOnes(numThreadsLastBlock, 1, 1);
@@ -2088,7 +2089,8 @@ void prescanArrayRecursive(sd::Pointer *extras, int *dZ, int *dX, int numElement
           numBlocks - 1, numElements - numEltsLastBlock);
     }
   } else if (isPowerOfTwo(numElements)) {
-    sd::prescanLauncher<false, false>(grid, threads, sharedMemSize, stream, dZ, dX, 0, numThreads * 2, 0, 0);
+    sd::prescanLauncher<false, false>(grid, threads, sharedMemSize, stream, dZ,
+                                      dX, 0, numThreads * 2, 0, 0);
   } else {
     sd::prescanLauncher<false, true>(grid, threads, sharedMemSize, stream, dZ, dX, 0, numElements, 0, 0);
   }
@@ -2113,11 +2115,11 @@ void execReduce3All(sd::Pointer *extraPointers, int opNum, OpaqueDataBuffer *dbX
 
     LaunchContext lc(extraPointers[1], extraPointers[4], extraPointers[5], extraPointers[3]);
     NativeOpExecutioner::execReduce3All(&lc, opNum, dbX->primary(), hXShapeInfo, dbX->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hXShapeInfo)->special(),
                                         extraParamsVals, dbY->primary(), hYShapeInfo, dbY->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hYShapeInfo)->special(),
                                         dbZ->primary(), hZShapeInfo, dbZ->special(),
-                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo).special(),
+                                        ConstantShapeHelper::getInstance().bufferForShapeInfo(hZShapeInfo)->special(),
                                         reinterpret_cast<int *>(dbDimension->special()), dimensionLength, xTadShapeInfo,
                                         xOffsets, yTadShapeInfo, yOffsets);
 
@@ -3198,9 +3200,9 @@ OpaqueConstantShapeBuffer *shapeBuffer(int rank, sd::LongType *shape, sd::LongTy
 OpaqueConstantShapeBuffer *shapeBufferEx(int rank, sd::LongType *shape, sd::LongType *strides, sd::DataType dtype,
                                          char order, sd::LongType ews, sd::LongType extras) {
   try {
-    auto buffer = new ConstantShapeBuffer();
-    *buffer = sd::ConstantShapeHelper::getInstance().bufferForShapeInfo(
-        ShapeDescriptor(dtype, order, shape, strides, rank, ews, extras));
+    auto desc = new ShapeDescriptor(dtype, order, shape, strides, rank, ews, extras);
+    auto buffer = sd::ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
+    delete desc;
     return buffer;
   } catch (std::exception &e) {
     sd::LaunchContext::defaultContext()->errorReference()->setErrorCode(1);

--- a/libnd4j/include/loops/cpu/transform/transform_any.cpp
+++ b/libnd4j/include/loops/cpu/transform/transform_any.cpp
@@ -44,9 +44,12 @@ template <typename OpType>
 void SD_HOST TransformAny<X, Z>::exec(const void *vx, const sd::LongType *xShapeInfo, void *vz,
                                       const sd::LongType *zShapeInfo, void *vextraParams, uint64_t threadId,
                                       uint64_t numThreads) {
+  sd_printf("TransformAny kernel: before casted pointers\n",0);
   auto x = reinterpret_cast<const X *>(vx);
   auto z = reinterpret_cast<Z *>(vz);
+  sd_printf("TransformAny kernel: affter casted pointers\n",0);
   auto extraParams = reinterpret_cast<X *>(vextraParams);
+  sd_printf("TransformAny kernel: after extra params pointers\n",0);
 
   sd::TransformLoops<X, Z, X>::template loopTransform<OpType>(x, xShapeInfo, z, zShapeInfo, extraParams, threadId,
                                                               numThreads);

--- a/libnd4j/include/loops/cpu/transform/transform_any.cpp
+++ b/libnd4j/include/loops/cpu/transform/transform_any.cpp
@@ -44,12 +44,9 @@ template <typename OpType>
 void SD_HOST TransformAny<X, Z>::exec(const void *vx, const sd::LongType *xShapeInfo, void *vz,
                                       const sd::LongType *zShapeInfo, void *vextraParams, uint64_t threadId,
                                       uint64_t numThreads) {
-  sd_printf("TransformAny kernel: before casted pointers\n",0);
   auto x = reinterpret_cast<const X *>(vx);
   auto z = reinterpret_cast<Z *>(vz);
-  sd_printf("TransformAny kernel: affter casted pointers\n",0);
   auto extraParams = reinterpret_cast<X *>(vextraParams);
-  sd_printf("TransformAny kernel: after extra params pointers\n",0);
 
   sd::TransformLoops<X, Z, X>::template loopTransform<OpType>(x, xShapeInfo, z, zShapeInfo, extraParams, threadId,
                                                               numThreads);

--- a/libnd4j/include/loops/cuda/reduce/reduce_bool.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_bool.cu
@@ -245,8 +245,8 @@ SD_HOST void ReduceBoolFunction<X, Z>::intermediateXD(dim3 launchDims, cudaStrea
     auto innerPack = sd::ConstantShapeHelper::getInstance().createSubArrShapeInfo(hXShapeInfo, dims + zRank, tadRank);
 
     simpleReduce<X, Z, OpType><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(
-        x, reinterpret_cast<sd::LongType const *>(outerPack.special()),
-        reinterpret_cast<sd::LongType const *>(innerPack.special()), extraParams, vreductionBuffer, z, dZShapeInfo);
+        x, reinterpret_cast<sd::LongType const *>(outerPack->special()),
+        reinterpret_cast<sd::LongType const *>(innerPack->special()), extraParams, vreductionBuffer, z, dZShapeInfo);
     sd::DebugHelper::checkErrorCode(stream, "reduceBoolDim(...) failed");
   }
 }

--- a/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
+++ b/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
@@ -254,7 +254,10 @@ SD_HOST void ReduceFloatFunction<X,Z>::intermediateXD(dim3 launchDims, cudaStrea
         auto outerPack = sd::ConstantShapeHelper::getInstance().createSubArrShapeInfo(hXShapeInfo, dims, zRank);
         auto innerPack = sd::ConstantShapeHelper::getInstance().createSubArrShapeInfo(hXShapeInfo, dims+zRank, tadRank);
 
-        simpleReduce<X, Z, OpType><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(x, reinterpret_cast<sd::LongType const*>(outerPack.special()), reinterpret_cast<sd::LongType const*>(innerPack.special()), extraParams, vreductionBuffer, z, dZShapeInfo);
+        simpleReduce<X, Z, OpType><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(x,
+                                                                                          reinterpret_cast<sd::LongType const*>(outerPack->special()),
+                                                                                          reinterpret_cast<sd::LongType const*>(innerPack->special()),
+                                                                                          extraParams, vreductionBuffer, z, dZShapeInfo);
     }
 }
 

--- a/libnd4j/include/loops/cuda/reduce/reduce_long.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_long.cu
@@ -252,8 +252,8 @@ SD_HOST void ReduceLongFunction<X, Z>::intermediateXD(dim3 launchDims, cudaStrea
     auto innerPack = sd::ConstantShapeHelper::getInstance().createSubArrShapeInfo(hXShapeInfo, dims + zRank, tadRank);
 
     simpleReduce<X, Z, OpType><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(
-        x, reinterpret_cast<sd::LongType const *>(outerPack.special()),
-        reinterpret_cast<sd::LongType const *>(innerPack.special()), extraParams, vreductionBuffer, z, dZShapeInfo);
+        x, reinterpret_cast<sd::LongType const *>(outerPack->special()),
+        reinterpret_cast<sd::LongType const *>(innerPack->special()), extraParams, vreductionBuffer, z, dZShapeInfo);
   }
 }
 

--- a/libnd4j/include/loops/cuda/reduce/reduce_same.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_same.cu
@@ -256,10 +256,12 @@ SD_HOST void ReduceSameFunction<X>::intermediateXD(dim3 launchDims, cudaStream_t
     const int tadRank = shape::rank(hXShapeInfo) - zRank;
 
     auto outerPack = sd::ConstantShapeHelper::getInstance().createSubArrShapeInfo(hXShapeInfo, dims, zRank);
-    auto innerPack = sd::ConstantShapeHelper::getInstance().createSubArrShapeInfo(hXShapeInfo, dims + zRank, tadRank);
+    auto innerPack = sd::ConstantShapeHelper::getInstance().createSubArrShapeInfo(hXShapeInfo,
+                                                                                  dims + zRank,
+                                                                                  tadRank);
     simpleReduce<X, OpType><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(
-        x, reinterpret_cast<sd::LongType const *>(outerPack.special()),
-        reinterpret_cast<sd::LongType const *>(innerPack.special()), extraParams, vreductionBuffer, z, dZShapeInfo);
+        x, reinterpret_cast<sd::LongType const *>(outerPack->special()),
+        reinterpret_cast<sd::LongType const *>(innerPack->special()), extraParams, vreductionBuffer, z, dZShapeInfo);
   }
 }
 

--- a/libnd4j/include/ops/declarable/generic/blas/tensormmul.cpp
+++ b/libnd4j/include/ops/declarable/generic/blas/tensormmul.cpp
@@ -78,8 +78,9 @@ DECLARE_SHAPE_FN(tensormmul) {
   auto outShape = sd::ShapeUtils::evalShapeForTensorDot(aShapeInfo, bShapeInfo, axes_0, axes_1, permutAt, permutBt,
                                                         shapeAt, shapeBt);
 
+  auto desc = new  ShapeDescriptor(ArrayOptions::dataType(aShapeInfo), 'c', outShape);
   return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(aShapeInfo), 'c', outShape)));
+     desc));
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/ops/declarable/generic/broadcastable/atan2.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/atan2.cpp
@@ -36,14 +36,8 @@ BROADCASTABLE_OP_IMPL(tf_atan2, 0, 0) {
 
   BROADCAST_CHECK_EMPTY(x, y, z);
 
-  // auto tZ = BroadcastHelper<T>::template broadcastApply<simdOps::Atan2<T>>(y, x, z);
   x->applyTrueBroadcast(sd::BroadcastOpsTuple::custom(scalar::Atan2, pairwise::Atan2, broadcast::Atan2), *y, *z, true);
 
-  // if (tZ == nullptr)
-  //     return sd::Status::KERNEL_FAILURE;
-  // else if (tZ != z) {
-  //     OVERWRITE_RESULT(tZ);
-  // }
 
   return sd::Status::OK;
 }

--- a/libnd4j/include/ops/declarable/generic/broadcastable/divide.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/divide.cpp
@@ -66,20 +66,13 @@ CUSTOM_OP_IMPL(divide_bp, 3, 2, false, 0, 0) {
   auto gradX = OUTPUT_VARIABLE(0);
   auto gradY = OUTPUT_VARIABLE(1);
 
-  /*
-              auto lambdaY = LAMBDA_TTT(_e, _x, _y) {
-                  return _e * -_x / (_y * _y);
-              };
-  */
 
   if (x->isSameShape(y)) {
     // PWT case case
 
     // X gradient
-    // epsNext->applyPairwiseLambda(y, lambdaX, gradX);
     gradX->assign((*epsNext) / (*y));
     // Y gradient
-    // epsNext->applyTriplewiseLambda(x, y, lambdaY, gradY);
     gradY->assign((*epsNext) * (*x) / ((*y) * (*y)));
     gradY->applyTransform(transform::Neg, *gradY);
 
@@ -88,12 +81,9 @@ CUSTOM_OP_IMPL(divide_bp, 3, 2, false, 0, 0) {
 
     auto tmp = epsNext->reduceNumber(reduce::Sum);
     auto tmpX = x->reduceNumber(reduce::Sum);
-    // tmpX.printBuffer("SumX");
-    // tmp.printBuffer("Sum Eps");
     gradY->assign(tmp * tmpX / ((*y) * (*y)));
     gradY->applyTransform(transform::Neg, *gradY);
 
-    // epsNext->applyLambda(lambdaS, *gradX);
     epsNext->applyScalarArr(scalar::Divide, *y, *gradX);
   } else {
     // broadcast case

--- a/libnd4j/include/ops/declarable/generic/broadcastable/igamma.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/igamma.cpp
@@ -35,10 +35,6 @@ BROADCASTABLE_OP_IMPL(igamma, 0, 0) {
 
   BROADCAST_CHECK_EMPTY(x, y, z);
 
-  // REQUIRE_TRUE(!y->isB(), 0, "Pairwise OP: you can't divide by bool array!");
-
-  //            auto tZ = BroadcastHelper::broadcastApply({scalar::IGamma, pairwise::IGamma, broadcast::IGamma}, x, y,
-  //            z);
   auto tZ = BroadcastHelper::broadcastApply(BroadcastOpsTuple::IGamma(), x, y, z);
 
   if (tZ == nullptr)

--- a/libnd4j/include/ops/declarable/generic/broadcastable/igammac.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/igammac.cpp
@@ -35,10 +35,6 @@ BROADCASTABLE_OP_IMPL(igammac, 0, 0) {
 
   BROADCAST_CHECK_EMPTY(x, y, z);
 
-  // REQUIRE_TRUE(!y->isB(), 0, "Pairwise OP: you can't divide by bool array!");
-
-  //            auto tZ = BroadcastHelper::broadcastApply({scalar::IGammac, pairwise::IGammac, broadcast::IGammac}, x,
-  //            y, z);
   auto tZ = BroadcastHelper::broadcastApply(BroadcastOpsTuple::IGammac(), x, y, z);
   if (tZ == nullptr)
     return sd::Status::KERNEL_FAILURE;

--- a/libnd4j/include/ops/declarable/generic/broadcastable/realdiv.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/realdiv.cpp
@@ -70,11 +70,9 @@ CUSTOM_OP_IMPL(realdiv_bp, 3, 2, false, 0, 0) {
     // PWT case case
 
     // X gradient
-    // epsNext->applyPairwiseLambda(y, lambdaX, gradX);
     epsNext->applyPairwiseTransform(pairwise::Divide, *y, *gradX);
 
     // Y gradient
-    // epsNext->applyTriplewiseLambda(x, y, lambdaY, gradY);
 
     gradY->assign((*epsNext) * -(*x) / ((*y) * (*y)));
 
@@ -85,7 +83,6 @@ CUSTOM_OP_IMPL(realdiv_bp, 3, 2, false, 0, 0) {
     auto tmpX = x->reduceNumber(reduce::Sum);
     gradY->assign(tmp * -tmpX / ((*y) * (*y)));
 
-    // epsNext->applyLambda(lambdaS, gradX);
     epsNext->applyScalarArr(scalar::Divide, *y, *gradX);
   } else {
     // broadcast case

--- a/libnd4j/include/ops/declarable/generic/broadcastable/reverse_divide.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/reverse_divide.cpp
@@ -65,11 +65,9 @@ CUSTOM_OP_IMPL(reversedivide_bp, 3, 2, false, 0, 0) {
     // PWT case case
 
     // X gradient
-    // epsNext->applyTriplewiseLambda(x, y, lambdaX, gradX);
     gradX->assign((*epsNext) * (*y) / ((*x) * (*x)));
     gradX->applyTransform(transform::Neg, *gradX);
     // Y gradient
-    // epsNext->applyPairwiseLambda(x, lambdaY, gradY);
     gradY->assign((*epsNext) / (*x));
   } else if (y->isScalar()) {
     // scalar case

--- a/libnd4j/include/ops/declarable/generic/broadcastable/squared_subtract.cpp
+++ b/libnd4j/include/ops/declarable/generic/broadcastable/squared_subtract.cpp
@@ -61,15 +61,6 @@ CUSTOM_OP_IMPL(squaredsubtract_bp, 3, 2, false, 0, 0) {
   auto gradX = OUTPUT_VARIABLE(0);
   auto gradY = OUTPUT_VARIABLE(1);
 
-  /*
-  auto lambdaX = LAMBDA_TTT(_e, _x, _y) {
-      return _e * (T) 2.0 * (_x - _y) ;
-  };
-
-  auto lambdaY = LAMBDA_TTT(_e, _x, _y) {
-      return _e * (T) 2.0 * (_y - _x);
-  };
-  */
 
   auto ts = NDArrayFactory::create(x->dataType(), 2, block.launchContext());
 
@@ -77,19 +68,15 @@ CUSTOM_OP_IMPL(squaredsubtract_bp, 3, 2, false, 0, 0) {
     // PWT case case
 
     // X gradient
-    // epsNext->applyTriplewiseLambda(x, y, lambdaX, gradX);
     gradX->assign((*epsNext) * ts * ((*x) - (*y)));
 
     // Y gradient
-    // epsNext->applyTriplewiseLambda(x, y, lambdaY, gradY);
     gradY->assign((*epsNext) * ts * ((*y) - (*x)));
 
   } else if (y->isScalar()) {
     // scalar case
     auto tmpX = x->reduceNumber(reduce::Sum);
     gradY->assign(tmpX);
-
-    // epsNext->applyPairwiseLambda(x, lambdaS, gradX);
     gradX->assign((*epsNext) * ts * ((*x) - (*y)));
   } else {
     // broadcast case
@@ -102,8 +89,6 @@ CUSTOM_OP_IMPL(squaredsubtract_bp, 3, 2, false, 0, 0) {
     preX.tileToShape(targetShape, preX);
     preY.tileToShape(targetShape, preY);
 
-    // epsNext->applyTriplewiseLambda(x, y, lambdaX, preX);
-    // epsNext->applyTriplewiseLambda(x, y, lambdaY, preY);
     auto resX = (*epsNext) * ts * ((*x) - (*y));
     preX.assign(resX);
     auto resY = (*epsNext) * ts * ((*y) - (*x));

--- a/libnd4j/include/ops/declarable/generic/datatypes/bitcast.cpp
+++ b/libnd4j/include/ops/declarable/generic/datatypes/bitcast.cpp
@@ -65,12 +65,14 @@ DECLARE_SHAPE_FN(bitcast) {
   auto inputSize = DataTypeUtils::sizeOf(oldType);
   auto outputSize = DataTypeUtils::sizeOf(newType);
 
-  if (shape::length(inShape) == 0)
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape, newType)));
-
+  if (shape::length(inShape) == 0) {
+    auto desc = new ShapeDescriptor(inShape, newType);
+    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  }
   if (inputSize == outputSize) {
     // only type should be changed
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape, newType)));
+    auto desc = new ShapeDescriptor(inShape, newType);
+    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (inputSize > outputSize) {
     // range of output increased by 1 with inputSize / outputSize as last dimension
     std::vector<sd::LongType> shapeOf(inputRank + 1);

--- a/libnd4j/include/ops/declarable/generic/datatypes/bitcast.cpp
+++ b/libnd4j/include/ops/declarable/generic/datatypes/bitcast.cpp
@@ -67,12 +67,16 @@ DECLARE_SHAPE_FN(bitcast) {
 
   if (shape::length(inShape) == 0) {
     auto desc = new ShapeDescriptor(inShape, newType);
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
+    return ret;
   }
   if (inputSize == outputSize) {
     // only type should be changed
     auto desc = new ShapeDescriptor(inShape, newType);
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
+    return ret;
   } else if (inputSize > outputSize) {
     // range of output increased by 1 with inputSize / outputSize as last dimension
     std::vector<sd::LongType> shapeOf(inputRank + 1);

--- a/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
+++ b/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
@@ -48,12 +48,14 @@ DECLARE_SHAPE_FN(cast) {
   auto inShape = inputShape->at(0);
   if(!block.getDArguments()->empty()) {
     DataType newType = block.dataType(0);
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape, newType)));
+    auto desc = new ShapeDescriptor(inShape, newType);
+    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 
   } else {
     auto it = INT_ARG(0);
     DataType newType = DataTypeUtils::fromInt(it);
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape, newType)));
+    auto desc = new ShapeDescriptor(inShape, newType);
+    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 
   }
  }

--- a/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
+++ b/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
@@ -55,10 +55,11 @@ DECLARE_SHAPE_FN(cast) {
     auto it = INT_ARG(0);
     DataType newType = DataTypeUtils::fromInt(it);
     auto desc = new ShapeDescriptor(inShape, newType);
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
-
+    auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
+    return ret;
   }
- }
+}
 
 DECLARE_TYPES(cast) {
   getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setAllowedOutputTypes(sd::DataType::ANY);

--- a/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
+++ b/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
@@ -49,7 +49,9 @@ DECLARE_SHAPE_FN(cast) {
   if(!block.getDArguments()->empty()) {
     DataType newType = block.dataType(0);
     auto desc = new ShapeDescriptor(inShape, newType);
-    return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
+    return ret;
 
   } else {
     auto it = INT_ARG(0);

--- a/libnd4j/include/ops/declarable/generic/decoder/ctc_beam_op.cpp
+++ b/libnd4j/include/ops/declarable/generic/decoder/ctc_beam_op.cpp
@@ -129,13 +129,13 @@ DECLARE_SHAPE_FN(ctc_beam) {
 
   auto dtype_float = ArrayOptions::dataType(logitShapeInfo);
   auto dtype_index = ArrayOptions::dataType(sequenceShapeInfo);
-
-  auto output0 = ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(dtype_index, 'c', {batch_size, nbest_len, max_t}));
+  auto desc = new  ShapeDescriptor(dtype_index, 'c', {batch_size, nbest_len, max_t});
+  auto output0 = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  auto desc2 = new ShapeDescriptor(dtype_float, 'c', {batch_size, nbest_len});
   auto output1 =
-      ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(dtype_float, 'c', {batch_size, nbest_len}));
-  auto output2 =
-      ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(dtype_index, 'c', {batch_size, nbest_len}));
+      ConstantShapeHelper::getInstance().createShapeInfo(desc2);
+  auto desc3 = new ShapeDescriptor(dtype_index, 'c', {batch_size, nbest_len});
+  auto output2 = ConstantShapeHelper::getInstance().createShapeInfo(desc3);
   return SHAPELIST(output0, output1, output2);
 }
 

--- a/libnd4j/include/ops/declarable/generic/decoder/ctc_beam_op.cpp
+++ b/libnd4j/include/ops/declarable/generic/decoder/ctc_beam_op.cpp
@@ -136,6 +136,9 @@ DECLARE_SHAPE_FN(ctc_beam) {
       ConstantShapeHelper::getInstance().createShapeInfo(desc2);
   auto desc3 = new ShapeDescriptor(dtype_index, 'c', {batch_size, nbest_len});
   auto output2 = ConstantShapeHelper::getInstance().createShapeInfo(desc3);
+  delete desc;
+  delete desc2;
+  delete desc3;
   return SHAPELIST(output0, output1, output2);
 }
 

--- a/libnd4j/include/ops/declarable/generic/images/crop_and_resize.cpp
+++ b/libnd4j/include/ops/declarable/generic/images/crop_and_resize.cpp
@@ -80,20 +80,19 @@ DECLARE_SHAPE_FN(crop_and_resize) {
   outputShape[1] = width;
   outputShape[2] = height;
   outputShape[3] = in[4];
-
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(in), shape::order(in), outputShape, 4)));
+  auto desc = new  ShapeDescriptor(ArrayOptions::dataType(in), shape::order(in), outputShape, 4);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(crop_and_resize) {
   getOpDescriptor()
       ->setAllowedInputTypes(0, {ALL_INTS, ALL_FLOATS})
-      //                    ->setAllowedInputTypes(1, {ALL_FLOATS})
+          //                    ->setAllowedInputTypes(1, {ALL_FLOATS})
       ->setAllowedInputTypes(1, {ALL_INTS, ALL_FLOATS})
       ->setAllowedInputTypes(2, {ALL_INTS})
       ->setAllowedInputTypes(3, {ALL_INTS})
       ->setAllowedOutputTypes({ALL_INTS, ALL_FLOATS});  // as TF
-                                                        //                    ->setAllowedOutputTypes({ALL_FLOATS});
+  //                    ->setAllowedOutputTypes({ALL_FLOATS});
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/generic/linalg/eig.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/eig.cpp
@@ -70,6 +70,8 @@ DECLARE_SHAPE_FN(eig) {
   auto output0 = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   auto desc2 = new ShapeDescriptor(dtype_float, ordering, {n1, n1, 2});
   auto output1 =ConstantShapeHelper::getInstance().createShapeInfo(desc2);
+  delete desc;
+  delete desc2;
   return SHAPELIST(output0, output1);
 }
 

--- a/libnd4j/include/ops/declarable/generic/linalg/eig.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/eig.cpp
@@ -43,7 +43,7 @@ CUSTOM_OP_IMPL(eig, 1, 2, false, 0, 0) {
   REQUIRE_TRUE(eig_vals->rankOf() == 2 && eig_vals->sizeAt(0) == n1 && eig_vals->sizeAt(1) == 2, 0,
                "Eig: the shape of the eigenvalue results should be {%i, 2}", n1);
   REQUIRE_TRUE(eig_vectors->rankOf() == 3 && eig_vectors->sizeAt(0) == n1 && eig_vectors->sizeAt(1) == n1 &&
-                   eig_vectors->sizeAt(2) == 2,
+               eig_vectors->sizeAt(2) == 2,
                0, "Eig: the shape of the eigenvector results should be {%i, %i, 2}", n1);
 
   sd::ops::helpers::eig(*input, *eig_vals, *eig_vectors);
@@ -66,9 +66,10 @@ DECLARE_SHAPE_FN(eig) {
   auto dtype_float = ArrayOptions::dataType(inputShapeInfo);
   auto ordering = shape::order(inputShapeInfo);
 
-  auto output0 = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(dtype_float, ordering, {n1, 2}));
-  auto output1 =
-      ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(dtype_float, ordering, {n1, n1, 2}));
+  auto desc = new ShapeDescriptor(dtype_float, ordering, {n1, 2});
+  auto output0 = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  auto desc2 = new ShapeDescriptor(dtype_float, ordering, {n1, n1, 2});
+  auto output1 =ConstantShapeHelper::getInstance().createShapeInfo(desc2);
   return SHAPELIST(output0, output1);
 }
 

--- a/libnd4j/include/ops/declarable/generic/linalg/eye.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/eye.cpp
@@ -96,7 +96,9 @@ DECLARE_SHAPE_FN(eye) {
   auto desc = new ShapeDescriptor(outShapeInfo, dtype);
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outShapeInfo, block.getWorkspace());
-  return SHAPELIST(result);
+  auto ret =  SHAPELIST(result);
+  delete desc;
+  return ret;
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/linalg/eye.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/eye.cpp
@@ -93,7 +93,8 @@ DECLARE_SHAPE_FN(eye) {
   }
 
   shape::updateStrides(outShapeInfo, static_cast<char>(-params[0]));
-  auto result = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(outShapeInfo, dtype));
+  auto desc = new ShapeDescriptor(outShapeInfo, dtype);
+  auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outShapeInfo, block.getWorkspace());
   return SHAPELIST(result);
 }

--- a/libnd4j/include/ops/declarable/generic/linalg/svd.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/svd.cpp
@@ -96,10 +96,12 @@ DECLARE_SHAPE_FN(svd) {
 
     shape::updateStrides(uShapeInfo, shape::order(inShapeInfo));
     shape::updateStrides(vShapeInfo, shape::order(inShapeInfo));
-
-    auto result = SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(sShapeInfo)),
-                            ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(uShapeInfo)),
-                            ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(vShapeInfo)));
+    auto desc1 = new ShapeDescriptor(sShapeInfo);
+    auto desc2 = new ShapeDescriptor(uShapeInfo);
+    auto desc3 = new ShapeDescriptor(vShapeInfo);
+    auto result = SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc1),
+                            ConstantShapeHelper::getInstance().createShapeInfo(desc2),
+                            ConstantShapeHelper::getInstance().createShapeInfo(desc3));
     RELEASE(sShapeInfo, block.workspace());
     RELEASE(uShapeInfo, block.workspace());
     RELEASE(vShapeInfo, block.workspace());

--- a/libnd4j/include/ops/declarable/generic/linalg/svd.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/svd.cpp
@@ -105,6 +105,9 @@ DECLARE_SHAPE_FN(svd) {
     RELEASE(sShapeInfo, block.workspace());
     RELEASE(uShapeInfo, block.workspace());
     RELEASE(vShapeInfo, block.workspace());
+    delete desc1;
+    delete desc2;
+    delete desc3;
     return result;
   }
 

--- a/libnd4j/include/ops/declarable/generic/linalg/trace.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/trace.cpp
@@ -62,6 +62,7 @@ DECLARE_SHAPE_FN(trace) {
   auto desc = new ShapeDescriptor(outShapeInfo, ArrayOptions::dataType(inShapeInfo));
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outShapeInfo, block.getWorkspace());
+  delete desc;
   return SHAPELIST(result);
 }
 

--- a/libnd4j/include/ops/declarable/generic/linalg/trace.cpp
+++ b/libnd4j/include/ops/declarable/generic/linalg/trace.cpp
@@ -59,8 +59,8 @@ DECLARE_SHAPE_FN(trace) {
   for (int i = 1; i <= rank; ++i) outShapeInfo[i] = inShapeInfo[i];
 
   shape::updateStrides(outShapeInfo, shape::order(inShapeInfo));
-  auto result = ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(outShapeInfo, ArrayOptions::dataType(inShapeInfo)));
+  auto desc = new ShapeDescriptor(outShapeInfo, ArrayOptions::dataType(inShapeInfo));
+  auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outShapeInfo, block.getWorkspace());
   return SHAPELIST(result);
 }

--- a/libnd4j/include/ops/declarable/generic/loss/absoluteDifference.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/absoluteDifference.cpp
@@ -144,10 +144,11 @@ DECLARE_SHAPE_FN(absolute_difference_loss) {
 
   if (INT_ARG(0) != 0)  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else  // in this case output has the same shape as labels and predictions
-    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
-
+  else {  // in this case output has the same shape as labels and predictions
+    auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
+                                    shape::rank(labelsShapeInfo));
+    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  }
   return SHAPELIST(outShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/absoluteDifference.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/absoluteDifference.cpp
@@ -121,6 +121,8 @@ DECLARE_SHAPE_FN(absolute_difference_loss) {
   auto weightsShapeInfo = inputShape->at(1);
   auto labelsShapeInfo = inputShape->at(2);
 
+
+
   // labels and predictions must have the same shapes
   REQUIRE_TRUE(shape::shapeEquals(labelsShapeInfo, predictionsShapeInfo), 0,
                "ABSOLUTE_DIFFERENCE_LOSS OP: labels and predictions arrays must have the same shapes, but got %s and "
@@ -139,19 +141,20 @@ DECLARE_SHAPE_FN(absolute_difference_loss) {
       "and labels = %s instead!",
       ShapeUtils::shapeAsString(weightsShapeInfo).c_str(), ShapeUtils::shapeAsString(labelsShapeInfo).c_str());
 
+
   DataType outType = DataTypeUtils::pickFloatingType(ArrayOptions::dataType(predictionsShapeInfo));
   sd::LongType const* outShapeInfo = nullptr;
 
-  if (INT_ARG(0) != 0)  // in this case output is scalar
+  if (INT_ARG(0) != 0) {  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else {  // in this case output has the same shape as labels and predictions
+  } else {  // in this case output has the same shape as labels and predictions
     auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
                                     shape::rank(labelsShapeInfo));
     outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
     delete desc;
   }
 
-  SHAPELIST(outShapeInfo);
+  return SHAPELIST(outShapeInfo);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/ops/declarable/generic/loss/absoluteDifference.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/absoluteDifference.cpp
@@ -77,7 +77,7 @@ CUSTOM_OP_IMPL(absolute_difference_loss, 3, 1, false, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       if (weights->isScalar())
         sum = (*weights) * E.lengthOf();
@@ -91,7 +91,7 @@ CUSTOM_OP_IMPL(absolute_difference_loss, 3, 1, false, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -148,8 +148,10 @@ DECLARE_SHAPE_FN(absolute_difference_loss) {
     auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
                                     shape::rank(labelsShapeInfo));
     outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    delete desc;
   }
-  return SHAPELIST(outShapeInfo);
+
+  SHAPELIST(outShapeInfo);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -217,7 +219,7 @@ CUSTOM_OP_IMPL(absolute_difference_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
 
       NDArray sum;
       if (weights->isScalar())
@@ -244,7 +246,7 @@ CUSTOM_OP_IMPL(absolute_difference_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
 
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {

--- a/libnd4j/include/ops/declarable/generic/loss/ctcLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/ctcLoss.cpp
@@ -87,7 +87,8 @@ DECLARE_SHAPE_FN(ctc_loss) {
   auto zShapeInfo = inputShape->at(2);
 
   auto dtype = ArrayOptions::dataType(yShapeInfo);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(zShapeInfo, dtype)));
+  auto desc = new ShapeDescriptor(zShapeInfo, dtype);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -147,7 +148,8 @@ DECLARE_TYPES(ctc_loss_grad) {
 DECLARE_SHAPE_FN(ctc_loss_grad) {
   auto yShapeInfo = inputShape->at(1);
   auto dtype = ArrayOptions::dataType(yShapeInfo);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(yShapeInfo, dtype)));
+  auto desc = new ShapeDescriptor(yShapeInfo, dtype);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/loss/ctcLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/ctcLoss.cpp
@@ -88,7 +88,9 @@ DECLARE_SHAPE_FN(ctc_loss) {
 
   auto dtype = ArrayOptions::dataType(yShapeInfo);
   auto desc = new ShapeDescriptor(zShapeInfo, dtype);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -149,7 +151,9 @@ DECLARE_SHAPE_FN(ctc_loss_grad) {
   auto yShapeInfo = inputShape->at(1);
   auto dtype = ArrayOptions::dataType(yShapeInfo);
   auto desc = new ShapeDescriptor(yShapeInfo, dtype);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/loss/hingeLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/hingeLoss.cpp
@@ -81,7 +81,7 @@ CUSTOM_OP_IMPL(hinge_loss, 3, 1, false, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       sum.setContext(block.launchContext());
       if (weights->isScalar())
@@ -96,7 +96,7 @@ CUSTOM_OP_IMPL(hinge_loss, 3, 1, false, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -150,10 +150,11 @@ DECLARE_SHAPE_FN(hinge_loss) {
 
   if (INT_ARG(0) != 0)  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else  // in this case output has the same shape as labels and predictions
-    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
-
+  else {  // in this case output has the same shape as labels and predictions
+    auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
+                                    shape::rank(labelsShapeInfo));
+                                    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  }
   return SHAPELIST(outShapeInfo);
 }
 
@@ -228,7 +229,7 @@ CUSTOM_OP_IMPL(hinge_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
 
       NDArray sum;
       sum.setContext(block.launchContext());
@@ -258,7 +259,7 @@ CUSTOM_OP_IMPL(hinge_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
 
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {

--- a/libnd4j/include/ops/declarable/generic/loss/hingeLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/hingeLoss.cpp
@@ -153,7 +153,8 @@ DECLARE_SHAPE_FN(hinge_loss) {
   else {  // in this case output has the same shape as labels and predictions
     auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
                                     shape::rank(labelsShapeInfo));
-                                    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    delete desc;
   }
   return SHAPELIST(outShapeInfo);
 }

--- a/libnd4j/include/ops/declarable/generic/loss/huberLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/huberLoss.cpp
@@ -86,7 +86,7 @@ CUSTOM_OP_IMPL(huber_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       sum.setContext(block.launchContext());
       if (weights->isScalar())
@@ -101,7 +101,7 @@ CUSTOM_OP_IMPL(huber_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -159,6 +159,7 @@ DECLARE_SHAPE_FN(huber_loss) {
     auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
                                     shape::rank(labelsShapeInfo));
     outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    delete desc;
   }
   return SHAPELIST(outShapeInfo);
 }
@@ -246,7 +247,7 @@ CUSTOM_OP_IMPL(huber_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
 
       NDArray sum;
       sum.setContext(block.launchContext());
@@ -276,7 +277,7 @@ CUSTOM_OP_IMPL(huber_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
 
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {

--- a/libnd4j/include/ops/declarable/generic/loss/huberLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/huberLoss.cpp
@@ -155,10 +155,11 @@ DECLARE_SHAPE_FN(huber_loss) {
 
   if (INT_ARG(0) != 0)  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else  // in this case output has the same shape as labels and predictions
-    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
-
+  else {  // in this case output has the same shape as labels and predictions
+    auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
+                                    shape::rank(labelsShapeInfo));
+    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  }
   return SHAPELIST(outShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/logLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/logLoss.cpp
@@ -152,10 +152,11 @@ DECLARE_SHAPE_FN(log_loss) {
 
   if (INT_ARG(0) != 0)  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else  // in this case output has the same shape as labels and predictions
-    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
-
+  else {  // in this case output has the same shape as labels and predictions
+    auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
+                                    shape::rank(labelsShapeInfo));
+    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  }
   return SHAPELIST(outShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/logLoss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/logLoss.cpp
@@ -83,7 +83,7 @@ CUSTOM_OP_IMPL(log_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       sum.setContext(block.launchContext());
       if (weights->isScalar())
@@ -98,7 +98,7 @@ CUSTOM_OP_IMPL(log_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -156,6 +156,7 @@ DECLARE_SHAPE_FN(log_loss) {
     auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
                                     shape::rank(labelsShapeInfo));
     outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    delete desc;
   }
   return SHAPELIST(outShapeInfo);
 }
@@ -235,7 +236,7 @@ CUSTOM_OP_IMPL(log_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
 
       NDArray sum;
       sum.setContext(block.launchContext());
@@ -266,7 +267,7 @@ CUSTOM_OP_IMPL(log_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
 
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {

--- a/libnd4j/include/ops/declarable/generic/loss/log_poisson_loss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/log_poisson_loss.cpp
@@ -155,9 +155,10 @@ DECLARE_SHAPE_FN(log_poisson_loss) {
 
   if (INT_ARG(0) != 0)  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else  // in this case output has the same shape as labels and predictions
-    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(labelsShapeInfo, outType));
-
+  else {  // in this case output has the same shape as labels and predictions
+    auto desc = new ShapeDescriptor(labelsShapeInfo, outType);
+    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  }
   return SHAPELIST(outShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/log_poisson_loss.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/log_poisson_loss.cpp
@@ -85,7 +85,7 @@ CUSTOM_OP_IMPL(log_poisson_loss, 3, 1, true, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       sum.setContext(block.launchContext());
       if (weights->isScalar())
@@ -100,7 +100,7 @@ CUSTOM_OP_IMPL(log_poisson_loss, 3, 1, true, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -158,6 +158,7 @@ DECLARE_SHAPE_FN(log_poisson_loss) {
   else {  // in this case output has the same shape as labels and predictions
     auto desc = new ShapeDescriptor(labelsShapeInfo, outType);
     outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    delete desc;
   }
   return SHAPELIST(outShapeInfo);
 }
@@ -238,7 +239,7 @@ CUSTOM_OP_IMPL(log_poisson_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
 
       NDArray sum;
       sum.setContext(block.launchContext());
@@ -268,7 +269,7 @@ CUSTOM_OP_IMPL(log_poisson_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
 
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {

--- a/libnd4j/include/ops/declarable/generic/loss/meanSqErr.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/meanSqErr.cpp
@@ -150,10 +150,11 @@ DECLARE_SHAPE_FN(mean_sqerr_loss) {
 
   if (INT_ARG(0) != 0)  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else  // in this case output has the same shape as labels and predictions
-    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
-
+  else {  // in this case output has the same shape as labels and predictions
+    auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
+                                    shape::rank(labelsShapeInfo));
+    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  }
   return SHAPELIST(outShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/meanSqErr.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/meanSqErr.cpp
@@ -80,7 +80,7 @@ CUSTOM_OP_IMPL(mean_sqerr_loss, 3, 1, false, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       sum.setContext(block.launchContext());
       if (weights->isScalar())
@@ -95,7 +95,7 @@ CUSTOM_OP_IMPL(mean_sqerr_loss, 3, 1, false, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -154,6 +154,7 @@ DECLARE_SHAPE_FN(mean_sqerr_loss) {
     auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
                                     shape::rank(labelsShapeInfo));
     outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    delete desc;
   }
   return SHAPELIST(outShapeInfo);
 }
@@ -224,7 +225,7 @@ CUSTOM_OP_IMPL(mean_sqerr_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
 
       NDArray sum;
       sum.setContext(block.launchContext());
@@ -252,7 +253,7 @@ CUSTOM_OP_IMPL(mean_sqerr_loss_grad, 3, 3, false, 0, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
 
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {

--- a/libnd4j/include/ops/declarable/generic/loss/sigmCrossEntropy.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/sigmCrossEntropy.cpp
@@ -161,10 +161,11 @@ DECLARE_SHAPE_FN(sigm_cross_entropy_loss) {
 
   if (INT_ARG(0) != 0)  // in this case output is scalar
     outShapeInfo = ConstantShapeHelper::getInstance().scalarShapeInfo(outType);
-  else  // in this case output has the same shape as labels and logits
-    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
-
+  else {  // in this case output has the same shape as labels and logits
+    auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
+                                    shape::rank(labelsShapeInfo));
+    outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  }
   return SHAPELIST(outShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/sigmCrossEntropy.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/sigmCrossEntropy.cpp
@@ -91,7 +91,7 @@ CUSTOM_OP_IMPL(sigm_cross_entropy_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       sum.setContext(block.launchContext());
       if (weights->isScalar())
@@ -106,7 +106,7 @@ CUSTOM_OP_IMPL(sigm_cross_entropy_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -165,6 +165,7 @@ DECLARE_SHAPE_FN(sigm_cross_entropy_loss) {
     auto desc = new ShapeDescriptor(outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo),
                                     shape::rank(labelsShapeInfo));
     outShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+    delete desc;
   }
   return SHAPELIST(outShapeInfo);
 }
@@ -248,7 +249,7 @@ CUSTOM_OP_IMPL(sigm_cross_entropy_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       sum.setContext(block.launchContext());
       if (weights->isScalar())
@@ -278,7 +279,7 @@ CUSTOM_OP_IMPL(sigm_cross_entropy_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();

--- a/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropy.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropy.cpp
@@ -415,12 +415,15 @@ DECLARE_SHAPE_FN(softmax_cross_entropy_loss_grad) {
 
   auto outType = DataTypeUtils::pickFloatingType(ArrayOptions::dataType(logitsShapeInfo));
 
-  auto dLdpShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-      outType, shape::order(logitsShapeInfo), shape::shapeOf(logitsShapeInfo), shape::rank(logitsShapeInfo)));
-  auto dLdwShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-      outType, shape::order(weightsShapeInfo), shape::shapeOf(weightsShapeInfo), shape::rank(weightsShapeInfo)));
-  auto dLdlShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-      outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
+  auto desc1 = new ShapeDescriptor(
+      outType, shape::order(logitsShapeInfo), shape::shapeOf(logitsShapeInfo), shape::rank(logitsShapeInfo));
+ auto desc2 = new ShapeDescriptor(
+      outType, shape::order(weightsShapeInfo), shape::shapeOf(weightsShapeInfo), shape::rank(weightsShapeInfo));
+ auto desc3 = new ShapeDescriptor(
+     outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo));
+  auto dLdpShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc1);
+  auto dLdwShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc2);
+  auto dLdlShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc3);
 
   return SHAPELIST(dLdpShapeInfo, dLdwShapeInfo, dLdlShapeInfo);
 }

--- a/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropy.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropy.cpp
@@ -85,8 +85,8 @@ CUSTOM_OP_IMPL(softmax_cross_entropy_loss, 3, 1, false, 1, 1) {
   std::vector<int> dimensions = {-1};
   NDArray shiftedLogits = *logits - logits->reduceAlongDimension(reduce::Max, dimensions, true);
   NDArray logSumExp = shiftedLogits.transform(transform::Exp)
-                          .reduceAlongDimension(reduce::Sum, dimensions, true)
-                          .transform(transform::Log);
+      .reduceAlongDimension(reduce::Sum, dimensions, true)
+      .transform(transform::Log);
   NDArray E = (*newLabels * (logSumExp - shiftedLogits)).reduceAlongDimension(reduce::Sum, dimensions);
 
   // perform weights broadcasting/tile to E if it is necessary
@@ -111,7 +111,7 @@ CUSTOM_OP_IMPL(softmax_cross_entropy_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       double sum;
       if (weights->isScalar())
         sum = weights->e<double>(0) * E.lengthOf();
@@ -125,7 +125,7 @@ CUSTOM_OP_IMPL(softmax_cross_entropy_loss, 3, 1, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -263,8 +263,8 @@ CUSTOM_OP_IMPL(softmax_cross_entropy_loss_grad, 3, 3, false, 1, 1) {
 
   NDArray shiftedLogits = *logits - logits->reduceAlongDimension(reduce::Max, dimensions, true);
   NDArray logSumExp = shiftedLogits.transform(transform::Exp)
-                          .reduceAlongDimension(reduce::Sum, dimensions, true)
-                          .transform(transform::Log);
+      .reduceAlongDimension(reduce::Sum, dimensions, true)
+      .transform(transform::Log);
   NDArray E = (*newLabels * (logSumExp - shiftedLogits)).reduceAlongDimension(reduce::Sum, dimensions);
 
   // perform weights broadcasting/tile to E if it is necessary
@@ -296,7 +296,7 @@ CUSTOM_OP_IMPL(softmax_cross_entropy_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 2: {  // 2 - "weighted_mean", output is scalar and equal to sum of all elements of E array divided by sum of
-               // all elements of weightsBroad array
+      // all elements of weightsBroad array
       NDArray sum;
       if (weights->isScalar())
         sum = (*weights) * E.lengthOf();
@@ -330,7 +330,7 @@ CUSTOM_OP_IMPL(softmax_cross_entropy_loss_grad, 3, 3, false, 1, 1) {
       break;
     }
     case 3: {  // 3 - "weighted_sum_by_nonzero_weights", output is scalar and equal to scalar sum of all elements of E
-               // array divided by number of non-zero weights
+      // array divided by number of non-zero weights
       sd::LongType numOfNonZeroWeights = 0;
       if (weights->isScalar()) {
         if (weights->e<double>(0) != 0.) numOfNonZeroWeights = E.lengthOf();
@@ -417,14 +417,16 @@ DECLARE_SHAPE_FN(softmax_cross_entropy_loss_grad) {
 
   auto desc1 = new ShapeDescriptor(
       outType, shape::order(logitsShapeInfo), shape::shapeOf(logitsShapeInfo), shape::rank(logitsShapeInfo));
- auto desc2 = new ShapeDescriptor(
+  auto desc2 = new ShapeDescriptor(
       outType, shape::order(weightsShapeInfo), shape::shapeOf(weightsShapeInfo), shape::rank(weightsShapeInfo));
- auto desc3 = new ShapeDescriptor(
-     outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo));
+  auto desc3 = new ShapeDescriptor(
+      outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo));
   auto dLdpShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc1);
   auto dLdwShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc2);
   auto dLdlShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc3);
-
+  delete desc1;
+  delete desc2;
+  delete desc3;
   return SHAPELIST(dLdpShapeInfo, dLdwShapeInfo, dLdlShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropyWithLogits.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropyWithLogits.cpp
@@ -111,18 +111,18 @@ CUSTOM_OP_IMPL(softmax_cross_entropy_loss_with_logits_grad, 2, 2, false, 0, 0) {
   softmax /= softmax.reduceAlongDimension(reduce::Sum, dimension, true);
 
 
-    // dEdp = softmax * sum_i(labels_i) - labels
-    //note the eps is to account for exact 0s in the log calculation being nan
-    auto labelsPlusEps = *labels + 1e-6;
-    labelsPlusEps.printBuffer("Labels plus eps");
-    dLdp->assign(((softmax * labelsPlusEps.reduceAlongDimension(reduce::Sum, dimension, true) - labelsPlusEps)));
-    auto negSoftmax = softmax;
+  // dEdp = softmax * sum_i(labels_i) - labels
+  //note the eps is to account for exact 0s in the log calculation being nan
+  auto labelsPlusEps = *labels + 1e-6;
+  labelsPlusEps.printBuffer("Labels plus eps");
+  dLdp->assign(((softmax * labelsPlusEps.reduceAlongDimension(reduce::Sum, dimension, true) - labelsPlusEps)));
+  auto negSoftmax = softmax;
 
 
-    // dEdl = -log(softmax)
-    softmax.applyTransform(transform::Log, *dLdl);
-    dLdl->applyTransform(transform::Neg,*dLdl);
-    return Status::OK;
+  // dEdl = -log(softmax)
+  softmax.applyTransform(transform::Log, *dLdl);
+  dLdl->applyTransform(transform::Neg,*dLdl);
+  return Status::OK;
 
 }
 
@@ -150,7 +150,8 @@ DECLARE_SHAPE_FN(softmax_cross_entropy_loss_with_logits_grad) {
       outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo));
   auto dLdpShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc1);
   auto dLdlShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc2);
-
+  delete desc1;
+  delete desc2;
   return SHAPELIST(dLdpShapeInfo, dLdlShapeInfo);
 }
 

--- a/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropyWithLogits.cpp
+++ b/libnd4j/include/ops/declarable/generic/loss/softmaxCrossEntropyWithLogits.cpp
@@ -144,10 +144,12 @@ DECLARE_SHAPE_FN(softmax_cross_entropy_loss_with_logits_grad) {
 
   DataType outType = DataTypeUtils::pickFloatingType(ArrayOptions::dataType(logitsShapeInfo));
 
-  auto dLdpShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-      outType, shape::order(logitsShapeInfo), shape::shapeOf(logitsShapeInfo), shape::rank(logitsShapeInfo)));
-  auto dLdlShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-      outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo)));
+  auto desc1 = new ShapeDescriptor(
+      outType, shape::order(logitsShapeInfo), shape::shapeOf(logitsShapeInfo), shape::rank(logitsShapeInfo));
+  auto desc2 = new ShapeDescriptor(
+      outType, shape::order(labelsShapeInfo), shape::shapeOf(labelsShapeInfo), shape::rank(labelsShapeInfo));
+  auto dLdpShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc1);
+  auto dLdlShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc2);
 
   return SHAPELIST(dLdpShapeInfo, dLdlShapeInfo);
 }

--- a/libnd4j/include/ops/declarable/generic/nlp/cbow.cpp
+++ b/libnd4j/include/ops/declarable/generic/nlp/cbow.cpp
@@ -46,6 +46,7 @@ CONFIGURABLE_OP_IMPL(cbow_inference, 6, 6, true, -2, -2) {
   std::vector<sd::LongType> *context = new std::vector<sd::LongType>();
   std::vector<sd::LongType> *lockedWords = new std::vector<sd::LongType>();
 
+
   int currIdx = 4;
   for(int i = 0; i < numCodes; i++) {
     codes->push_back(I_ARG(currIdx));
@@ -92,22 +93,26 @@ CONFIGURABLE_OP_IMPL(cbow_inference, 6, 6, true, -2, -2) {
   lockedWordsSize->push_back(lockedWords->size());
   const std::vector<sd::LongType> *lockedWordsShape = lockedWordsSize;
 
-
-  auto indicesArrOne = indicesVec->size() > 0 ? NDArrayFactory::create('c',*indicesShape,*indicesVec) : NDArrayFactory::empty<sd::LongType>();
+  sd_printf("Before array creation indices vec size %d\n",indicesVec->size());
+  auto indicesArrOne = indicesVec->size() > 0 ? NDArrayFactory::create<sd::LongType>('c',*indicesShape,*indicesVec) : NDArrayFactory::empty<sd::LongType>();
+  sd_printf("After indices array factory creation\n",0);
   auto indicesArr = new NDArray(indicesArrOne);
-
-  auto codesArrOne = codesVec->size() > 0 ?  NDArrayFactory::create('c',*codesShape,*codesVec) :  NDArrayFactory::empty<sd::LongType>();
+  sd_printf("After indices array creation\n",0);
+  auto codesArrOne = codesVec->size() > 0 ?  NDArrayFactory::create<sd::LongType>('c',*codesShape,*codesVec) :  NDArrayFactory::empty<sd::LongType>();
   auto codesArr = new NDArray(codesArrOne);
 
 
 
-  auto contextArrOne = context->size() > 0 ? NDArrayFactory::create('c',*contextShape,*contextVec) : NDArrayFactory::empty<sd::LongType>();
+  auto contextArrOne = context->size() > 0 ? NDArrayFactory::create<sd::LongType>('c',*contextShape,*contextVec) : NDArrayFactory::empty<sd::LongType>();
   auto contextArr = new NDArray(contextArrOne);
+  sd_printf("After context array creation\n",0);
 
 
-  auto lockedWordsOne = lockedWordsVec->size() > 0 ?  NDArrayFactory::create('c',*lockedWordsShape,*lockedWordsVec) : NDArrayFactory::empty<sd::LongType>();
+  auto lockedWordsOne = lockedWordsVec->size() > 0 ?  NDArrayFactory::create<sd::LongType>('c',*lockedWordsShape,*lockedWordsVec) : NDArrayFactory::empty<sd::LongType>();
   auto lockedWordsArr = new NDArray(lockedWordsOne);
+  sd_printf("After words array creation\n",0);
 
+  sd_printf("After array creation\n",0);
   auto target = I_ARG(currIdx++);
   auto ngStarter = I_ARG(currIdx++);
   auto numLabels = I_ARG(currIdx++);
@@ -145,24 +150,24 @@ CONFIGURABLE_OP_IMPL(cbow_inference, 6, 6, true, -2, -2) {
 
 
   sd::ops::helpers::cbowInference(
-                                 *syn0,
-                                  *syn1,
-                                *syn1neg,
-                                   *expTable,
-                                    *negTable,
-                                    target,
-                                  ngStarter,
-                                   nsRounds,
-                                 *contextArr,
-                                *lockedWordsArr,
-                              *indicesArr,
-                              *codesArr,
-                                 alpha,
-                              randomValue,
-                              numLabels,
-                           *inferenceVector,
-                              trainWords,
-                                 numWorkers,iterations,minLearningRate);
+      *syn0,
+      *syn1,
+      *syn1neg,
+      *expTable,
+      *negTable,
+      target,
+      ngStarter,
+      nsRounds,
+      *contextArr,
+      *lockedWordsArr,
+      *indicesArr,
+      *codesArr,
+      alpha,
+      randomValue,
+      numLabels,
+      *inferenceVector,
+      trainWords,
+      numWorkers,iterations,minLearningRate);
 
   return sd::Status::OK;
 }

--- a/libnd4j/include/ops/declarable/generic/nlp/cbow.cpp
+++ b/libnd4j/include/ops/declarable/generic/nlp/cbow.cpp
@@ -93,11 +93,8 @@ CONFIGURABLE_OP_IMPL(cbow_inference, 6, 6, true, -2, -2) {
   lockedWordsSize->push_back(lockedWords->size());
   const std::vector<sd::LongType> *lockedWordsShape = lockedWordsSize;
 
-  sd_printf("Before array creation indices vec size %d\n",indicesVec->size());
   auto indicesArrOne = indicesVec->size() > 0 ? NDArrayFactory::create<sd::LongType>('c',*indicesShape,*indicesVec) : NDArrayFactory::empty<sd::LongType>();
-  sd_printf("After indices array factory creation\n",0);
   auto indicesArr = new NDArray(indicesArrOne);
-  sd_printf("After indices array creation\n",0);
   auto codesArrOne = codesVec->size() > 0 ?  NDArrayFactory::create<sd::LongType>('c',*codesShape,*codesVec) :  NDArrayFactory::empty<sd::LongType>();
   auto codesArr = new NDArray(codesArrOne);
 
@@ -105,14 +102,11 @@ CONFIGURABLE_OP_IMPL(cbow_inference, 6, 6, true, -2, -2) {
 
   auto contextArrOne = context->size() > 0 ? NDArrayFactory::create<sd::LongType>('c',*contextShape,*contextVec) : NDArrayFactory::empty<sd::LongType>();
   auto contextArr = new NDArray(contextArrOne);
-  sd_printf("After context array creation\n",0);
 
 
   auto lockedWordsOne = lockedWordsVec->size() > 0 ?  NDArrayFactory::create<sd::LongType>('c',*lockedWordsShape,*lockedWordsVec) : NDArrayFactory::empty<sd::LongType>();
   auto lockedWordsArr = new NDArray(lockedWordsOne);
-  sd_printf("After words array creation\n",0);
 
-  sd_printf("After array creation\n",0);
   auto target = I_ARG(currIdx++);
   auto ngStarter = I_ARG(currIdx++);
   auto numLabels = I_ARG(currIdx++);

--- a/libnd4j/include/ops/declarable/generic/nn/activations/crelu.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/activations/crelu.cpp
@@ -102,7 +102,8 @@ DECLARE_TYPES(crelu_bp) {
 
 DECLARE_SHAPE_FN(crelu_bp) {
   auto inShape = inputShape->at(0);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape)));
+  auto desc = new ShapeDescriptor(inShape);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/generic/nn/activations/crelu.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/activations/crelu.cpp
@@ -103,7 +103,9 @@ DECLARE_TYPES(crelu_bp) {
 DECLARE_SHAPE_FN(crelu_bp) {
   auto inShape = inputShape->at(0);
   auto desc = new ShapeDescriptor(inShape);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/generic/nn/bias_add.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/bias_add.cpp
@@ -66,7 +66,9 @@ DECLARE_SHAPE_FN(biasadd) {
 
   auto dtype = ArrayOptions::dataType(yShape);
   auto desc = new ShapeDescriptor(xShape, dtype);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 DECLARE_TYPES(biasadd) {

--- a/libnd4j/include/ops/declarable/generic/nn/bias_add.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/bias_add.cpp
@@ -65,7 +65,8 @@ DECLARE_SHAPE_FN(biasadd) {
   auto yShape = inputShape->at(1);
 
   auto dtype = ArrayOptions::dataType(yShape);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(xShape, dtype)));
+  auto desc = new ShapeDescriptor(xShape, dtype);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(biasadd) {

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool2d.cpp
@@ -134,9 +134,8 @@ DECLARE_SHAPE_FN(avgpool2d) {
     newShape[2] = oW;
     newShape[3] = iD;
   }
-
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(inShape), shape::order(inShape), newShape, 4)));
+  auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShape), shape::order(inShape), newShape, 4);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(avgpool2d_bp) {
@@ -225,8 +224,8 @@ DECLARE_SHAPE_FN(avgpool2d_bp) {
                "AVGPOOL2D_BP op: output's gradient array (next epsilon) must be 4D, but got %i instead!",
                inputShape->at(1)[0]);
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)))));
+  auto desc = new  ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)));
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool2d.cpp
@@ -135,7 +135,9 @@ DECLARE_SHAPE_FN(avgpool2d) {
     newShape[3] = iD;
   }
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShape), shape::order(inShape), newShape, 4);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 DECLARE_TYPES(avgpool2d_bp) {

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool3d.cpp
@@ -146,8 +146,8 @@ DECLARE_SHAPE_FN(avgpool3dnew) {
     outputShape[4] = iC;
   }
   // TF DOC: A Tensor. Has the same type as input.
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5)));
+  auto desc = new ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(avgpool3dnew_bp) {
@@ -224,8 +224,8 @@ CUSTOM_OP_IMPL(avgpool3dnew_bp, 2, 1, false, 0, 14) {
 }
 
 DECLARE_SHAPE_FN(avgpool3dnew_bp) {
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)))));
+  auto desc = new ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)));
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool3d.cpp
@@ -147,7 +147,9 @@ DECLARE_SHAPE_FN(avgpool3dnew) {
   }
   // TF DOC: A Tensor. Has the same type as input.
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 DECLARE_TYPES(avgpool3dnew_bp) {
@@ -225,7 +227,9 @@ CUSTOM_OP_IMPL(avgpool3dnew_bp, 2, 1, false, 0, 14) {
 
 DECLARE_SHAPE_FN(avgpool3dnew_bp) {
   auto desc = new ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)));
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool2d.cpp
@@ -133,8 +133,8 @@ DECLARE_SHAPE_FN(maxpool2d) {
     newShape[3] = iC;
   }
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(inShape), order, newShape, 4)));
+  auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, newShape, 4);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(maxpool2d_bp) {
@@ -226,8 +226,8 @@ DECLARE_SHAPE_FN(maxpool2d_bp) {
                "MAXPOOL2D_BP op: output's gradient array (next epsilon) must be 4D, but got %i instead!",
                inputShape->at(1)[0]);
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)))));
+  auto desc = new   ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)));
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool2d.cpp
@@ -134,7 +134,9 @@ DECLARE_SHAPE_FN(maxpool2d) {
   }
 
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, newShape, 4);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 DECLARE_TYPES(maxpool2d_bp) {

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool3d.cpp
@@ -149,7 +149,9 @@ DECLARE_SHAPE_FN(maxpool3dnew) {
   }
 
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret = SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 DECLARE_TYPES(maxpool3dnew_bp) {

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool3d.cpp
@@ -148,8 +148,8 @@ DECLARE_SHAPE_FN(maxpool3dnew) {
     outputShape[4] = iC;
   }
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5)));
+  auto desc = new ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(maxpool3dnew_bp) {
@@ -241,8 +241,8 @@ CUSTOM_OP_IMPL(maxpool3dnew_bp, 2, 1, false, 0, 14) {
 }
 
 DECLARE_SHAPE_FN(maxpool3dnew_bp) {
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)))));
+  auto desc = new  ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)));
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool_with_argmax.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool_with_argmax.cpp
@@ -54,8 +54,10 @@ DECLARE_TYPES(max_pool_with_argmax) {
 DECLARE_SHAPE_FN(max_pool_with_argmax) {
   auto in = inputShape->at(0);
   auto dtype = block.numD() ? D_ARG(0) : sd::DataType::INT64;
-  auto valuesShape = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(in));
-  auto indicesShape = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(in, dtype));
+  auto desc = new ShapeDescriptor(in);
+  auto desc2 = new ShapeDescriptor(in, dtype);
+  auto valuesShape = ConstantShapeHelper::getInstance().createShapeInfo(desc);
+  auto indicesShape = ConstantShapeHelper::getInstance().createShapeInfo(desc2);
 
   return SHAPELIST(valuesShape, indicesShape);
 }

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool_with_argmax.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool_with_argmax.cpp
@@ -58,7 +58,8 @@ DECLARE_SHAPE_FN(max_pool_with_argmax) {
   auto desc2 = new ShapeDescriptor(in, dtype);
   auto valuesShape = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   auto indicesShape = ConstantShapeHelper::getInstance().createShapeInfo(desc2);
-
+  delete desc;
+  delete desc2;
   return SHAPELIST(valuesShape, indicesShape);
 }
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/pnormpool2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/pnormpool2d.cpp
@@ -131,8 +131,8 @@ DECLARE_SHAPE_FN(pnormpool2d) {
     newShape[3] = iC;
   }
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(inShape), order, newShape, 4)));
+  auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, newShape, 4);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(pnormpool2d_bp) {
@@ -238,8 +238,8 @@ DECLARE_SHAPE_FN(pnormpool2d_bp) {
                "PNORMPOOL2D_BP op: output's gradient array (next epsilon) must be 4D, but got %i instead!",
                inputShape->at(1)[0]);
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)))));
+  auto desc = new  ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)));
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/pnormpool2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/pnormpool2d.cpp
@@ -132,7 +132,9 @@ DECLARE_SHAPE_FN(pnormpool2d) {
   }
 
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, newShape, 4);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 DECLARE_TYPES(pnormpool2d_bp) {

--- a/libnd4j/include/ops/declarable/generic/nn/recurrent/lstmCell.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/recurrent/lstmCell.cpp
@@ -171,8 +171,10 @@ DECLARE_SHAPE_FN(lstmCell) {
   ShapeUtils::updateStridesAndType(hShapeInfo, xtShapeInfo, shape::order(ht_1ShapeInfo));
   ShapeUtils::updateStridesAndType(cShapeInfo, xtShapeInfo, shape::order(ct_1ShapeInfo));
 
-  auto result = SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(hShapeInfo),
-                          ConstantShapeHelper::getInstance().createShapeInfo(cShapeInfo));
+  auto desc = new ShapeDescriptor(hShapeInfo);
+  auto desc2 = new ShapeDescriptor(cShapeInfo);
+  auto result = SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc),
+                          ConstantShapeHelper::getInstance().createShapeInfo(desc2));
   RELEASE(hShapeInfo, block.workspace());
   RELEASE(cShapeInfo, block.workspace());
   return result;

--- a/libnd4j/include/ops/declarable/generic/nn/recurrent/lstmCell.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/recurrent/lstmCell.cpp
@@ -177,6 +177,8 @@ DECLARE_SHAPE_FN(lstmCell) {
                           ConstantShapeHelper::getInstance().createShapeInfo(desc2));
   RELEASE(hShapeInfo, block.workspace());
   RELEASE(cShapeInfo, block.workspace());
+  delete desc;
+  delete desc2;
   return result;
 }
 

--- a/libnd4j/include/ops/declarable/generic/nn/recurrent/sru.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/recurrent/sru.cpp
@@ -157,6 +157,7 @@ DECLARE_SHAPE_FN(sru) {
   ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo1);
   RELEASE(newShapeInfo1, block.getWorkspace());
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(descriptor);
+  delete descriptor;
   return SHAPELIST(result, result);
 }
 
@@ -345,10 +346,15 @@ DECLARE_SHAPE_FN(sru_bp) {
   ShapeDescriptor *descriptor3 = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, {1, 2 * inSize});
   ShapeDescriptor *descriptor4 = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, {bS, inSize});
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor1),
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor1),
                    ConstantShapeHelper::getInstance().createShapeInfo(descriptor2),
                    ConstantShapeHelper::getInstance().createShapeInfo(descriptor3),
                    ConstantShapeHelper::getInstance().createShapeInfo(descriptor4));
+  delete descriptor1;
+  delete descriptor2;
+  delete descriptor3;
+  delete descriptor4;
+  return ret;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/ops/declarable/generic/nn/recurrent/sru.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/recurrent/sru.cpp
@@ -154,7 +154,7 @@ DECLARE_SHAPE_FN(sru) {
   newShapeInfo1[3] = time;
 
   ShapeUtils::updateStridesAndType(newShapeInfo1, xShapeInfo, shape::order(xShapeInfo));
-  ShapeDescriptor descriptor(newShapeInfo1);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(newShapeInfo1);
   RELEASE(newShapeInfo1, block.getWorkspace());
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(descriptor);
   return SHAPELIST(result, result);
@@ -340,10 +340,10 @@ DECLARE_SHAPE_FN(sru_bp) {
   auto time = inShape[3];
   char order = (char)(inShape[9]);
 
-  ShapeDescriptor descriptor1(ArrayOptions::dataType(inShape), order, {bS, inSize, time});
-  ShapeDescriptor descriptor2(ArrayOptions::dataType(inShape), order, {bS, 3 * inSize, inSize});
-  ShapeDescriptor descriptor3(ArrayOptions::dataType(inShape), order, {1, 2 * inSize});
-  ShapeDescriptor descriptor4(ArrayOptions::dataType(inShape), order, {bS, inSize});
+  ShapeDescriptor *descriptor1 = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, {bS, inSize, time});
+  ShapeDescriptor *descriptor2 = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, {bS, 3 * inSize, inSize});
+  ShapeDescriptor *descriptor3 = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, {1, 2 * inSize});
+  ShapeDescriptor *descriptor4 = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, {bS, inSize});
 
   return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor1),
                    ConstantShapeHelper::getInstance().createShapeInfo(descriptor2),
@@ -458,7 +458,7 @@ DECLARE_SHAPE_FN(sru_bi) {
 
   char order = shape::order(xShapeInfo);
 
-  ShapeDescriptor descriptor(ArrayOptions::dataType(xShapeInfo), order, {time, bS, 2 * inSize});
+  ShapeDescriptor *descriptor = new ShapeDescriptor(ArrayOptions::dataType(xShapeInfo), order, {time, bS, 2 * inSize});
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(descriptor);
   return SHAPELIST(result, result);
 }
@@ -613,10 +613,10 @@ DECLARE_SHAPE_FN(sru_bi_bp) {
 
   const char order = shape::order(xShapeInfo);
 
-  ShapeDescriptor descriptor1(ArrayOptions::dataType(xShapeInfo), order, {time, bS, 2 * inSize});
-  ShapeDescriptor descriptor2(ArrayOptions::dataType(xShapeInfo), order, {time, 2 * inSize, 6 * inSize});
-  ShapeDescriptor descriptor3(ArrayOptions::dataType(xShapeInfo), order, {4 * inSize});
-  ShapeDescriptor descriptor4(ArrayOptions::dataType(xShapeInfo), order, {bS, 2 * inSize});
+  ShapeDescriptor *descriptor1 = new ShapeDescriptor(ArrayOptions::dataType(xShapeInfo), order, {time, bS, 2 * inSize});
+  ShapeDescriptor *descriptor2 = new ShapeDescriptor(ArrayOptions::dataType(xShapeInfo), order, {time, 2 * inSize, 6 * inSize});
+  ShapeDescriptor *descriptor3 = new ShapeDescriptor(ArrayOptions::dataType(xShapeInfo), order, {4 * inSize});
+  ShapeDescriptor *descriptor4 = new ShapeDescriptor(ArrayOptions::dataType(xShapeInfo), order, {bS, 2 * inSize});
 
   return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor1),
                    ConstantShapeHelper::getInstance().createShapeInfo(descriptor2),

--- a/libnd4j/include/ops/declarable/generic/parity_ops/check_numerics.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/check_numerics.cpp
@@ -43,7 +43,9 @@ CUSTOM_OP_IMPL(check_numerics, 2, 1, true, 0, 0) {
 
 DECLARE_SHAPE_FN(check_numerics) {
   auto desc = new ShapeDescriptor(inputShape->at(0));
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 DECLARE_TYPES(check_numerics) {

--- a/libnd4j/include/ops/declarable/generic/parity_ops/check_numerics.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/check_numerics.cpp
@@ -42,7 +42,8 @@ CUSTOM_OP_IMPL(check_numerics, 2, 1, true, 0, 0) {
 }
 
 DECLARE_SHAPE_FN(check_numerics) {
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inputShape->at(0))));
+  auto desc = new ShapeDescriptor(inputShape->at(0));
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 DECLARE_TYPES(check_numerics) {

--- a/libnd4j/include/ops/declarable/generic/parity_ops/expose.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/expose.cpp
@@ -65,7 +65,8 @@ DECLARE_SHAPE_FN(expose) {
     auto var = block.getVariable(e);
     if (var->variableType() == VariableType::NDARRAY) {
       auto inShape = inputShape->at(e);
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape)));
+      auto desc = new ShapeDescriptor(inShape);
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
     }
   }
 

--- a/libnd4j/include/ops/declarable/generic/parity_ops/expose.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/expose.cpp
@@ -26,7 +26,7 @@ namespace sd {
 namespace ops {
 CUSTOM_OP_IMPL(expose, -2, -2, true, 0, 0) {
   for (int e = 0; e < block.width(); e++) {
-   //omit for eager computation, normally array size should be equal to block size
+    //omit for eager computation, normally array size should be equal to block size
     if(block.getVariableSpace() == nullptr || block.getVariableSpace()->getVariables().size() != block.width()) {
       auto in = INPUT_VARIABLE(e);
       auto out = OUTPUT_VARIABLE(e);
@@ -67,6 +67,7 @@ DECLARE_SHAPE_FN(expose) {
       auto inShape = inputShape->at(e);
       auto desc = new ShapeDescriptor(inShape);
       shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+      delete desc;
     }
   }
 

--- a/libnd4j/include/ops/declarable/generic/parity_ops/top_k.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/top_k.cpp
@@ -78,8 +78,8 @@ DECLARE_SHAPE_FN(top_k) {
     aShape[shapeRank] = k;
 
     shape::updateStrides(aShape, shape::order(in));
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(
-        ShapeDescriptor(aShape, (e == 0 ? ArrayOptions::dataType(in) : sd::DataType::INT64))));
+    auto desc = new  ShapeDescriptor(aShape, (e == 0 ? ArrayOptions::dataType(in) : sd::DataType::INT64));
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 
     RELEASE(aShape, block.getWorkspace());
   }

--- a/libnd4j/include/ops/declarable/generic/parity_ops/zero_fraction.cpp
+++ b/libnd4j/include/ops/declarable/generic/parity_ops/zero_fraction.cpp
@@ -38,13 +38,8 @@ CUSTOM_OP_IMPL(zero_fraction, 1, 1, false, 0, 0) {
     return sd::Status::OK;
   }
 
-  int numZeros = 0;
-  //            for (int e = 0; e < input->lengthOf(); e++)
-  //                if ((*input)(e) == T(0))
-  //                    numZeros++;
+
   auto countZero = input->reduceNumber(reduce::CountZero);
-  // sd_printf("Zero count is %f for %i elements.", countZero.e<double>(0), input->lengthOf());
-  // countZero /= double(input->lengthOf());
   output->p<double>(0, countZero.e<sd::LongType>(0) / double(input->lengthOf()));  // printIndexedBuffer("Zero count");
 
   return sd::Status::OK;

--- a/libnd4j/include/ops/declarable/generic/tensor/ones_as.cpp
+++ b/libnd4j/include/ops/declarable/generic/tensor/ones_as.cpp
@@ -39,9 +39,6 @@ DECLARE_SHAPE_FN(ones_as) {
   auto in = inputShape->at(0);
   auto dtype = block.numD() ? D_ARG(0) : ArrayOptions::dataType(in);
   auto shape = sd::ConstantShapeHelper::getInstance().createShapeInfo(dtype, in);
-
-  // sd_printf("numD: %i; dtype: %s\n", block.numD(), DataTypeUtils::asString(dtype).c_str());
-
   return SHAPELIST(shape);
 }
 

--- a/libnd4j/include/ops/declarable/generic/tensor/range.cpp
+++ b/libnd4j/include/ops/declarable/generic/tensor/range.cpp
@@ -172,8 +172,6 @@ DECLARE_SHAPE_FN(range) {
         delta = INPUT_VARIABLE(2)->e<sd::LongType>(0);
       }
 
-      // sd_printf("Start: [%lld]; Limit: [%lld]; Delta: [%lld];\n", start, limit, delta)
-
       if (limit == start) {
         // Return [0] to match TF
         return SHAPELIST(ConstantShapeHelper::getInstance().vectorShapeInfo(0, dtype));

--- a/libnd4j/include/ops/declarable/generic/tensor/strided_slice.cpp
+++ b/libnd4j/include/ops/declarable/generic/tensor/strided_slice.cpp
@@ -167,7 +167,6 @@ bool _preprocess_strided_slice(std::vector<sd::LongType>* indicesList, std::vect
     bool shrink_i = (dense_spec.shrink_axis_mask & (1 << e));
 
     if (stride_idx == 0) {
-      sd_printf("Stride is 0 at index %i\n", e);
       return false;
     }
     if (size_idx == -1) {

--- a/libnd4j/include/ops/declarable/generic/tensor/strided_slice.cpp
+++ b/libnd4j/include/ops/declarable/generic/tensor/strided_slice.cpp
@@ -157,7 +157,6 @@ bool _preprocess_strided_slice(std::vector<sd::LongType>* indicesList, std::vect
   StridedSliceDenseSpec dense_spec = {(int)input_shape.size(), 0, 0, false, false, begin, end, strides};
   if (!dense_spec.buildDenseSpec(sparse_spec)) return false;
 
-  // sd_printv("Input shape: ", input_shape);
 
   for (int e = 0; e < (int)input_shape.size(); e++) {
     int begin_idx = begin[e];
@@ -248,16 +247,10 @@ bool _preprocess_strided_slice(std::vector<sd::LongType>* indicesList, std::vect
           indicesList->push_back(begin_idx);
           indicesList->push_back(end_idx);
           indicesList->push_back(stride_idx);
-          // (*indicesList)[3*e]   = begin_idx;
-          // (*indicesList)[3*e+1] = end_idx;
-          // (*indicesList)[3*e+2] = stride_idx;
         } else if (interval_length == 1) {
           indicesList->push_back(begin_idx);
           indicesList->push_back(begin_idx + 1);
           indicesList->push_back(1);
-          // (*indicesList)[3*e]   = begin_idx;
-          // (*indicesList)[3*e+1] = begin_idx + 1;
-          // (*indicesList)[3*e+2] = 1;
         }
       }
 
@@ -424,8 +417,8 @@ CUSTOM_OP_IMPL(strided_slice, 1, 1, false, 0, 5) {
     NDArray::prepareSpecialUse({z}, {x});
 
     NativeOpExecutioner::execTransformAny(block.launchContext(), sd::transform::Assign, x->bufferWithOffset(offset),
-                                          subArrShapeInfoPack.primary(), x->specialBufferWithOffset(offset),
-                                          subArrShapeInfoPack.special(), z->buffer(), z->shapeInfo(),
+                                          subArrShapeInfoPack->primary(), x->specialBufferWithOffset(offset),
+                                          subArrShapeInfoPack->special(), z->buffer(), z->shapeInfo(),
                                           z->specialBuffer(), z->specialShapeInfo(), nullptr, nullptr, nullptr, true);
 
     NDArray::registerSpecialUse({z}, {x});

--- a/libnd4j/include/ops/declarable/generic/tests/test_scalar.cpp
+++ b/libnd4j/include/ops/declarable/generic/tests/test_scalar.cpp
@@ -54,6 +54,7 @@ DECLARE_SHAPE_FN(test_scalar) {
   auto desc = new ShapeDescriptor(newShape);
   auto shape = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(newShape, block.getWorkspace());
+  delete desc;
   return SHAPELIST(shape);
 }
 

--- a/libnd4j/include/ops/declarable/generic/tests/test_scalar.cpp
+++ b/libnd4j/include/ops/declarable/generic/tests/test_scalar.cpp
@@ -51,8 +51,8 @@ DECLARE_SHAPE_FN(test_scalar) {
   newShape[7] = 99;
 
   ArrayOptions::setDataType(newShape, ArrayOptions::dataType(inputShape->at(0)));
-
-  auto shape = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(newShape));
+  auto desc = new ShapeDescriptor(newShape);
+  auto shape = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(newShape, block.getWorkspace());
   return SHAPELIST(shape);
 }

--- a/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
@@ -222,6 +222,7 @@ DECLARE_SHAPE_FN(concat) {
   auto desc = new ShapeDescriptor(outShapeInfo);
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outShapeInfo, block.getWorkspace());
+  delete desc;
   return SHAPELIST(result);
 }
 
@@ -277,8 +278,9 @@ DECLARE_SHAPE_FN(concat_bp) {
   for (int e = 0; e < numOfInArrs - 1; e++) {
     auto inShape = inputShape->at(e);
     auto desc = new ShapeDescriptor(
-                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/concat.cpp
@@ -219,7 +219,8 @@ DECLARE_SHAPE_FN(concat) {
   ShapeUtils::updateStridesAndType(outShapeInfo, arrShapes.at(0), shape::order(arrShapes.at(0)));
 
 
-  auto result = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(outShapeInfo));
+  auto desc = new ShapeDescriptor(outShapeInfo);
+  auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outShapeInfo, block.getWorkspace());
   return SHAPELIST(result);
 }
@@ -275,8 +276,9 @@ DECLARE_SHAPE_FN(concat_bp) {
 
   for (int e = 0; e < numOfInArrs - 1; e++) {
     auto inShape = inputShape->at(e);
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape))));
+    auto desc = new ShapeDescriptor(
+                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/dynamic_stitch.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/dynamic_stitch.cpp
@@ -79,8 +79,8 @@ DECLARE_SHAPE_FN(dynamic_stitch) {
   outShape[0] = maxValue + 1;
   for (int i = 1; i < outRank; ++i) outShape[i] = shape::sizeAt(restShape, i);
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(restShape), shape::order(firstShape), outShape)));
+  auto desc = new ShapeDescriptor(ArrayOptions::dataType(restShape), shape::order(firstShape), outShape);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/generic/transforms/dynamic_stitch.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/dynamic_stitch.cpp
@@ -80,7 +80,9 @@ DECLARE_SHAPE_FN(dynamic_stitch) {
   for (int i = 1; i < outRank; ++i) outShape[i] = shape::sizeAt(restShape, i);
 
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(restShape), shape::order(firstShape), outShape);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/generic/transforms/gather.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/gather.cpp
@@ -157,6 +157,7 @@ DECLARE_SHAPE_FN(gather) {
 
   auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outputShapeInfo, block.getWorkspace());
+  delete desc;
   return SHAPELIST(result);
 }
 

--- a/libnd4j/include/ops/declarable/generic/transforms/gather.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/gather.cpp
@@ -153,7 +153,9 @@ DECLARE_SHAPE_FN(gather) {
     ArrayOptions::setPropertyBit(outputShapeInfo, ARRAY_EMPTY);
   }
 
-  auto result = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(outputShapeInfo));
+  auto desc = new ShapeDescriptor(outputShapeInfo);
+
+  auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   RELEASE(outputShapeInfo, block.getWorkspace());
   return SHAPELIST(result);
 }

--- a/libnd4j/include/ops/declarable/generic/transforms/merge_add.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/merge_add.cpp
@@ -83,8 +83,9 @@ DECLARE_SHAPE_FN(mergeadd_bp) {
   for (int e = 0; e < numOfInArrs; e++) {
     auto inShape = inputShape->at(e);
     auto desc = new ShapeDescriptor(
-                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/merge_add.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/merge_add.cpp
@@ -82,8 +82,9 @@ DECLARE_SHAPE_FN(mergeadd_bp) {
 
   for (int e = 0; e < numOfInArrs; e++) {
     auto inShape = inputShape->at(e);
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape))));
+    auto desc = new ShapeDescriptor(
+                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/merge_avg.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/merge_avg.cpp
@@ -72,8 +72,9 @@ DECLARE_SHAPE_FN(mergeavg_bp) {
   for (int e = 0; e < numOfInArrs; e++) {
     auto inShape = inputShape->at(e);
     auto desc = new ShapeDescriptor(
-                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/merge_avg.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/merge_avg.cpp
@@ -71,8 +71,9 @@ DECLARE_SHAPE_FN(mergeavg_bp) {
 
   for (int e = 0; e < numOfInArrs; e++) {
     auto inShape = inputShape->at(e);
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape))));
+    auto desc = new ShapeDescriptor(
+                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/merge_max.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/merge_max.cpp
@@ -77,8 +77,9 @@ DECLARE_SHAPE_FN(mergemax_bp) {
 
   for (int e = 0; e < numOfInArrs; e++) {
     auto inShape = inputShape->at(e);
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(
-        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape))));
+    auto desc = new ShapeDescriptor(
+                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/merge_max.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/merge_max.cpp
@@ -78,8 +78,9 @@ DECLARE_SHAPE_FN(mergemax_bp) {
   for (int e = 0; e < numOfInArrs; e++) {
     auto inShape = inputShape->at(e);
     auto desc = new ShapeDescriptor(
-                    ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
+        ArrayOptions::dataType(inShape), shape::order(inShape), shape::shapeOf(inShape), shape::rank(inShape));
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/generic/transforms/pad.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/pad.cpp
@@ -117,7 +117,7 @@ DECLARE_SHAPE_FN(pad) {
     outShapeInfo[i] = inputShapeInfo[i] + paddings->e<sd::LongType>(i - 1, 0) + paddings->e<sd::LongType>(i - 1, 1);
 
   ShapeUtils::updateStridesAndType(outShapeInfo, inputShapeInfo, shape::order(inputShapeInfo));
-  ShapeDescriptor descriptor(outShapeInfo);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(outShapeInfo);
   RELEASE(outShapeInfo, block.getWorkspace());
   return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor));
 }

--- a/libnd4j/include/ops/declarable/generic/transforms/pad.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/pad.cpp
@@ -119,6 +119,7 @@ DECLARE_SHAPE_FN(pad) {
   ShapeUtils::updateStridesAndType(outShapeInfo, inputShapeInfo, shape::order(inputShapeInfo));
   ShapeDescriptor *descriptor = new ShapeDescriptor(outShapeInfo);
   RELEASE(outShapeInfo, block.getWorkspace());
+  delete descriptor;
   return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor));
 }
 

--- a/libnd4j/include/ops/declarable/generic/transforms/pad.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/pad.cpp
@@ -101,7 +101,9 @@ DECLARE_SHAPE_FN(pad) {
   auto inputShapeInfo = inputShape->at(0);
   auto paddings = INPUT_VARIABLE(1);
   const int rank = inputShapeInfo[0];
-
+  if(rank < 0 || rank > SD_MAX_RANK) {
+    throw std::runtime_error("PAD op: Bad shape buffer. Likely corrupt. Please ensure buffer was not deallocated.");
+  }
   // paddings validation
   const std::vector<sd::LongType> expectedPaddingsShape = {rank, 2};
   const std::vector<sd::LongType> currentPaddingsShape = paddings->getShapeAsVector();
@@ -119,8 +121,9 @@ DECLARE_SHAPE_FN(pad) {
   ShapeUtils::updateStridesAndType(outShapeInfo, inputShapeInfo, shape::order(inputShapeInfo));
   ShapeDescriptor *descriptor = new ShapeDescriptor(outShapeInfo);
   RELEASE(outShapeInfo, block.getWorkspace());
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor));
   delete descriptor;
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(descriptor));
+  return ret;
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/transforms/repeat.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/repeat.cpp
@@ -68,7 +68,9 @@ DECLARE_SHAPE_FN(repeat) {
   auto outShape = ShapeUtils::evalRepeatShape(axis, repeats, *input);
 
   auto desc = new ShapeDescriptor(input->dataType(), input->ordering(), outShape);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/generic/transforms/repeat.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/repeat.cpp
@@ -67,8 +67,8 @@ DECLARE_SHAPE_FN(repeat) {
 
   auto outShape = ShapeUtils::evalRepeatShape(axis, repeats, *input);
 
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(input->dataType(), input->ordering(), outShape)));
+  auto desc = new ShapeDescriptor(input->dataType(), input->ordering(), outShape);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/generic/transforms/slice.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/slice.cpp
@@ -98,8 +98,8 @@ CUSTOM_OP_IMPL(slice, 1, 1, false, 0, -2) {
   NDArray::prepareSpecialUse({output}, {input});
 
   NativeOpExecutioner::execTransformAny(
-      block.launchContext(), sd::transform::Assign, input->bufferWithOffset(offset), subArrShapeInfoPack.primary(),
-      input->specialBufferWithOffset(offset), subArrShapeInfoPack.special(), output->buffer(), output->shapeInfo(),
+      block.launchContext(), sd::transform::Assign, input->bufferWithOffset(offset), subArrShapeInfoPack->primary(),
+      input->specialBufferWithOffset(offset), subArrShapeInfoPack->special(), output->buffer(), output->shapeInfo(),
       output->specialBuffer(), output->specialShapeInfo(), nullptr, nullptr, nullptr, true);
 
   NDArray::registerSpecialUse({output}, {input});

--- a/libnd4j/include/ops/declarable/generic/transforms/slice.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/slice.cpp
@@ -106,8 +106,6 @@ CUSTOM_OP_IMPL(slice, 1, 1, false, 0, -2) {
 
   RELEASE(subArrShapeInfo, block.getWorkspace());
 
-  // auto sub = (*input)(indices, true);
-  // output->assign(sub);
 
   STORE_RESULT(output);
 

--- a/libnd4j/include/ops/declarable/generic/transforms/stack.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/stack.cpp
@@ -101,8 +101,8 @@ DECLARE_SHAPE_FN(stack) {
 
   // insert (int) block.width() at dim position of input shape to get output shape
   outShape.insert(outShape.begin() + sd::LongType(dim), (sd::LongType)block.width());
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(
-      ShapeDescriptor(ArrayOptions::dataType(inShapeInfo), shape::order(inShapeInfo), outShape)));
+  auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShapeInfo), shape::order(inShapeInfo), outShape);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/transforms/stack.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/stack.cpp
@@ -102,7 +102,9 @@ DECLARE_SHAPE_FN(stack) {
   // insert (int) block.width() at dim position of input shape to get output shape
   outShape.insert(outShape.begin() + sd::LongType(dim), (sd::LongType)block.width());
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShapeInfo), shape::order(inShapeInfo), outShape);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret = SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/helpers/cpu/compare_and_bitpack.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/compare_and_bitpack.cpp
@@ -104,7 +104,6 @@ void compareAndBitpack_(const NDArray& input, const NDArray& thresholdScalar, ND
   if (input.ordering() == 'c' && output.ordering() == 'c' && input.ews() == 1 && output.ews() == 1) {
     FUNC_1D func = [buff, outBuff, threshold](uint64_t thread_id, int64_t start, int64_t stop,
                                               int64_t increment) -> void {
-      // sd_printf("s: %i e: %i \n", (int)start,(int)stop);
       auto outBuffPart = outBuff + start;
       auto buffPart = buff + start * 8;
       auto len = stop - start;
@@ -154,7 +153,6 @@ void compareAndBitpack_(const NDArray& input, const NDArray& thresholdScalar, ND
                          uint64_t thread_id, int64_t start, int64_t stop, int64_t increment) -> void {
         sd::LongType coords[SD_MAX_RANK] = {};
         sd::LongType* ptr_coords = (sd::LongType*)&coords;
-        // sd_printf("generic s: %i e: %i \n", (int)start,(int)stop);
         auto len = (stop - start);
         // its extended as {rank+1} so extendedStrides[rank] is valid
         auto innermostStride = extendedStrides[rank];

--- a/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
@@ -176,7 +176,6 @@ static NDArray lup_(LaunchContext* context, NDArray* input, NDArray* compound, N
   }
 
   for (int e = 0; e < rowNum; e++) {
-    // sd_printf("Compound matrix diag %i %f.\n", e, (*compoundMatrix)(e, e));
     determinant *= compoundMatrix.e<T>(e, e);
   }
   if (swapCount % 2) determinant = -determinant;

--- a/libnd4j/include/ops/declarable/helpers/cpu/pad.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/pad.cpp
@@ -41,7 +41,6 @@ static void copy_core_rank(const T* x, T* coreZ, const sd::LongType* xShapes, co
   auto lastStrideX = xStrides[constRank - 1];
   auto lastStrideZ = zStrides[constRank - 1];
   auto inputLastSize = xShapes[constRank - 1];
-  // sd_printf("%d %d %d %d %d\n",start, stop,(int)offset.second, (int)lastStrideX, (int)lastStrideZ);
   if (lastStrideZ == 1 && lastStrideX == 1) {
     for (auto k = 0; k < (stop - start); k++) {
       auto xPtr = &(x[offset.first]);

--- a/libnd4j/include/ops/declarable/helpers/cpu/random_crop.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/random_crop.cpp
@@ -46,7 +46,6 @@ static sd::Status _randomCropFunctor(graph::Context& context, NDArray* input, ND
   sd::LongType maxIndex = output->argMax();
   sd::LongType startPos = output->e<sd::LongType>(maxIndex);
   sd::LongType lastDim = input->sizeAt(-1);
-  // sd_printf("Before processing: %i %i. Output length %i\n", maxIndex, startPos, output->lengthOf());
   sd::LongType pos = 0;
   sd::LongType width = startPos + shape->e<sd::LongType>(last);
   if (width >= lastDim) {

--- a/libnd4j/include/ops/declarable/helpers/cpu/svd.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/svd.cpp
@@ -33,38 +33,28 @@ namespace helpers {
 template <typename T>
 static void svd_(const NDArray* x, const std::vector<NDArray*>& outArrs, const bool fullUV, const bool calcUV,
                  const int switchNum) {
-  sd_printf("In svd helper\n",0);
   auto s = outArrs[0];
   auto u = outArrs[1];
   auto v = outArrs[2];
-  sd_printf("After s,u,v\n",0);
   const int rank = x->rankOf();
   const int sRank = rank - 1;
 
-  sd_printf("before listX\n",0);
   auto listX = x->allTensorsAlongDimension({rank - 2, rank - 1});
-  sd_printf("before listS\n",0);
   auto listS = s->allTensorsAlongDimension({sRank - 1});
   ResultSet *listU(nullptr), *listV(nullptr);
 
   if (calcUV) {
-    sd_printf("in calcUV\n",0);
     listU = new ResultSet(u->allTensorsAlongDimension({rank - 2, rank - 1}));
     listV = new ResultSet(v->allTensorsAlongDimension({rank - 2, rank - 1}));
-    sd_printf("after calcUV\n",0);
   }
 
   for (int i = 0; i < listX.size(); ++i) {
-    sd_printf("calculating svd at %d\n",i);
     helpers::SVD<T> svdObj(*(listX.at(i)), switchNum, calcUV, calcUV, fullUV);
-    sd_printf("Before assign in calculating svd\n",0);
     listS.at(i)->assign(svdObj._s);
 
     if (calcUV) {
-      sd_printf("before assign in calcUV %d\n",i);
       listU->at(i)->assign(svdObj._u);
       listV->at(i)->assign(svdObj._v);
-      sd_printf("after assign in calcUV %d\n",i);
     }
   }
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/svd.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/svd.cpp
@@ -33,31 +33,38 @@ namespace helpers {
 template <typename T>
 static void svd_(const NDArray* x, const std::vector<NDArray*>& outArrs, const bool fullUV, const bool calcUV,
                  const int switchNum) {
+  sd_printf("In svd helper\n",0);
   auto s = outArrs[0];
   auto u = outArrs[1];
   auto v = outArrs[2];
-
+  sd_printf("After s,u,v\n",0);
   const int rank = x->rankOf();
   const int sRank = rank - 1;
 
+  sd_printf("before listX\n",0);
   auto listX = x->allTensorsAlongDimension({rank - 2, rank - 1});
+  sd_printf("before listS\n",0);
   auto listS = s->allTensorsAlongDimension({sRank - 1});
   ResultSet *listU(nullptr), *listV(nullptr);
 
   if (calcUV) {
+    sd_printf("in calcUV\n",0);
     listU = new ResultSet(u->allTensorsAlongDimension({rank - 2, rank - 1}));
     listV = new ResultSet(v->allTensorsAlongDimension({rank - 2, rank - 1}));
+    sd_printf("after calcUV\n",0);
   }
 
   for (int i = 0; i < listX.size(); ++i) {
-    // NDArray<T> matrix(x->ordering(), {listX.at(i)->sizeAt(0), listX.at(i)->sizeAt(1)}, block.getContext());
-    // matrix.assign(listX.at(i));
+    sd_printf("calculating svd at %d\n",i);
     helpers::SVD<T> svdObj(*(listX.at(i)), switchNum, calcUV, calcUV, fullUV);
+    sd_printf("Before assign in calculating svd\n",0);
     listS.at(i)->assign(svdObj._s);
 
     if (calcUV) {
+      sd_printf("before assign in calcUV %d\n",i);
       listU->at(i)->assign(svdObj._u);
       listV->at(i)->assign(svdObj._v);
+      sd_printf("after assign in calcUV %d\n",i);
     }
   }
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdam.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdam.cpp
@@ -66,7 +66,6 @@ static void adamUpdater_(const NDArray& gradient, const NDArray& initStateU, con
       for (auto i = start; i < stop; i++) {
         stM[i] = beta1 * initM[i] + grad[i] * (1 - beta1);
         stU[i] = beta2 * initU[i] + grad[i] * grad[i] * (1 - beta2);
-
         up[i] = (stM[i] * epsilonT) / (sd::math::sd_sqrt<T, T>(stU[i]) + epsilon);
       }
     };
@@ -94,7 +93,6 @@ static void adamUpdater_(const NDArray& gradient, const NDArray& initStateU, con
 
       stM[stMOffset] = beta1 * initM[initMOffset] + grad[xOffset] * (1 - beta1);
       stU[stUOffset] = beta2 * initU[initUOffset] + grad[xOffset] * grad[xOffset] * (1 - beta2);
-
       up[zOffset] = (stM[stMOffset] * epsilonT) / (sd::math::sd_sqrt<T, T>(stU[stUOffset]) + epsilon);
     }
   };

--- a/libnd4j/include/ops/declarable/helpers/cuda/compare_and_bitpack.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/compare_and_bitpack.cu
@@ -149,7 +149,6 @@ static SD_HOST void cmpBitpackCudaLauncher(sd::graph::Context& block, const NDAr
   // grid size
   const int blocksPerGrid = (output.lengthOf() + threadsPerBlock - 1) / threadsPerBlock;
   auto stream = block.launchContext()->getCudaStream();
-  // sd_printf("n %i g %i th %i \n", output.lengthOf(), blocksPerGrid, threadsPerBlock);
   PointersManager manager(block.launchContext(), "compare_and_bitpack");
   NDArray::prepareSpecialUse({&output}, {&input});
   if (input.ews() > 0 && output.ews() > 0 && input.ordering() == 'c' && output.ordering() == 'c') {

--- a/libnd4j/include/ops/declarable/helpers/impl/listdiff.cpp
+++ b/libnd4j/include/ops/declarable/helpers/impl/listdiff.cpp
@@ -74,8 +74,6 @@ static sd::Status listDiffFunctor_(NDArray* values, NDArray* keep, NDArray* outp
   }
 
   if (saved.size() == 0) {
-    //            if (sd::ops::conditionHelper(__FILE__, __LINE__, false, 0, "ListDiff: search returned no results") !=
-    //            0)
     sd_printf("ListDiff: search returned no results", "");
     throw std::invalid_argument("Op validation failed");
   } else {

--- a/libnd4j/include/ops/declarable/impl/BroadcastableBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/BroadcastableBoolOp.cpp
@@ -45,26 +45,34 @@ ShapeList *BroadcastableBoolOp::calculateOutputShape(ShapeList *inputShape, sd::
 
     const sd::LongType *newshape = nullptr;
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(newshape, dtype)));
+    auto desc = new ShapeDescriptor(newshape, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (shape::isScalar(x) && shape::isScalar(y)) {
     if (shape::rank(x) >= shape::rank(y)) {
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+      auto desc = new ShapeDescriptor(x, dtype);
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
     } else {
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(y, dtype)));
+      auto desc = new ShapeDescriptor(y, dtype);
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
     }
   } else if (shape::equalsSoft(x, y)) {
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+    auto desc = new ShapeDescriptor(x, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (shape::isScalar(x) && !shape::isScalar(y)) {
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(y, dtype)));
+    auto desc = new ShapeDescriptor(y, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (!shape::isScalar(x) && shape::isScalar(y)) {
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+    auto desc = new ShapeDescriptor(x, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (ShapeUtils::areShapesBroadcastable(x, y)) {
     const sd::LongType *newshape = nullptr;
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(newshape, dtype)));
+    auto desc = new ShapeDescriptor(newshape, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else {
     // in this case we'll throw exception later
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+    auto desc = new ShapeDescriptor(x, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/impl/BroadcastableBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/BroadcastableBoolOp.cpp
@@ -47,32 +47,41 @@ ShapeList *BroadcastableBoolOp::calculateOutputShape(ShapeList *inputShape, sd::
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
     auto desc = new ShapeDescriptor(newshape, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (shape::isScalar(x) && shape::isScalar(y)) {
     if (shape::rank(x) >= shape::rank(y)) {
       auto desc = new ShapeDescriptor(x, dtype);
       shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+      delete desc;
     } else {
       auto desc = new ShapeDescriptor(y, dtype);
       shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+      delete desc;
     }
   } else if (shape::equalsSoft(x, y)) {
     auto desc = new ShapeDescriptor(x, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (shape::isScalar(x) && !shape::isScalar(y)) {
     auto desc = new ShapeDescriptor(y, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (!shape::isScalar(x) && shape::isScalar(y)) {
     auto desc = new ShapeDescriptor(x, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (ShapeUtils::areShapesBroadcastable(x, y)) {
     const sd::LongType *newshape = nullptr;
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
     auto desc = new ShapeDescriptor(newshape, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else {
     // in this case we'll throw exception later
     auto desc = new ShapeDescriptor(x, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
+
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/impl/BroadcastableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/BroadcastableOp.cpp
@@ -58,26 +58,34 @@ ShapeList *BroadcastableOp::calculateOutputShape(ShapeList *inputShape, sd::grap
 
     const sd::LongType *newshape = nullptr;
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(newshape, dtype)));
+    auto desc = new ShapeDescriptor(newshape, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (shape::isScalar(x) && shape::isScalar(y)) {
     if (shape::rank(x) >= shape::rank(y)) {
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+      auto desc = new ShapeDescriptor(x, dtype);
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
     } else {
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(y, dtype)));
+      auto desc = new ShapeDescriptor(y, dtype);
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
     }
   } else if (shape::equalsSoft(x, y)) {
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+    auto desc = new ShapeDescriptor(x, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (shape::isScalar(x) && !shape::isScalar(y)) {
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(y, dtype)));
+    auto desc = new ShapeDescriptor(y, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (!shape::isScalar(x) && shape::isScalar(y)) {
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+    auto desc = new ShapeDescriptor(x, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else if (ShapeUtils::areShapesBroadcastable(x, y)) {
     const sd::LongType *newshape = nullptr;
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(newshape, dtype)));
+    auto desc = new ShapeDescriptor(newshape, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   } else {
     // in this case we'll throw exception later
-    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(x, dtype)));
+    auto desc = new ShapeDescriptor(x, dtype);
+    shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/impl/BroadcastableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/BroadcastableOp.cpp
@@ -60,32 +60,40 @@ ShapeList *BroadcastableOp::calculateOutputShape(ShapeList *inputShape, sd::grap
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
     auto desc = new ShapeDescriptor(newshape, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (shape::isScalar(x) && shape::isScalar(y)) {
     if (shape::rank(x) >= shape::rank(y)) {
       auto desc = new ShapeDescriptor(x, dtype);
       shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+      delete desc;
     } else {
       auto desc = new ShapeDescriptor(y, dtype);
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));    delete desc;
+      delete desc;
     }
   } else if (shape::equalsSoft(x, y)) {
     auto desc = new ShapeDescriptor(x, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (shape::isScalar(x) && !shape::isScalar(y)) {
     auto desc = new ShapeDescriptor(y, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (!shape::isScalar(x) && shape::isScalar(y)) {
     auto desc = new ShapeDescriptor(x, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else if (ShapeUtils::areShapesBroadcastable(x, y)) {
     const sd::LongType *newshape = nullptr;
     ShapeUtils::evalBroadcastShapeInfo(x, y, true, newshape, block.workspace());
     auto desc = new ShapeDescriptor(newshape, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   } else {
     // in this case we'll throw exception later
     auto desc = new ShapeDescriptor(x, dtype);
     shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+    delete desc;
   }
 
   return shapeList;

--- a/libnd4j/include/ops/declarable/impl/BroadcastableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/BroadcastableOp.cpp
@@ -52,7 +52,9 @@ ShapeList *BroadcastableOp::calculateOutputShape(ShapeList *inputShape, sd::grap
   if (shape::isEmpty(x) || shape::isEmpty(y)) {
     // this is edge case, [3, 4] + [] = []
     if ((shape::isEmpty(x) && shape::rank(x) == 0) || (shape::isEmpty(y) && shape::rank(y) == 0)) {
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor::emptyDescriptor(dtype)));
+      auto desc = ShapeDescriptor::emptyDescriptor(dtype);
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+      delete desc;
       return shapeList;
     }
 
@@ -68,7 +70,7 @@ ShapeList *BroadcastableOp::calculateOutputShape(ShapeList *inputShape, sd::grap
       delete desc;
     } else {
       auto desc = new ShapeDescriptor(y, dtype);
-      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));    delete desc;
+      shapeList->push_back(ConstantShapeHelper::getInstance().createShapeInfo(desc));
       delete desc;
     }
   } else if (shape::equalsSoft(x, y)) {

--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -136,8 +136,7 @@ sd::NDArray *sd::ops::DeclarableOp::getZ(Context &ctx, int inputId) {
         sd_printf("Can't get Z variable for node_%i!\n", ctx.nodeId());
       }
     } else {
-      sd_printf("BOOM!\n", "");
-      throw std::runtime_error("Boom!");
+      throw std::runtime_error("getZ: Unable to return z variable!");
     }
   }
 
@@ -423,7 +422,6 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, std::initializer_list
   auto workspace = block.getWorkspace();
 
   sd::LongType len = shape::length(shape);
-  sd_printf("Allocating result 1\n",0);
   // if that's first run - we probably have nothing here
   if (var->getNDArray() == nullptr) {
     var->setNDArray(new NDArray(order, shape, block.dataType(), block.launchContext()));

--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -406,13 +406,13 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, sd::LongType *shape) 
   if (var->getNDArray() == nullptr) {
     std::shared_ptr<DataBuffer> buffer =
         std::make_shared<DataBuffer>(len * sizeof(int8_t), ArrayOptions::dataType(__shape), workspace);
-    var->setNDArray(new NDArray(buffer, ShapeDescriptor(__shape), block.launchContext()));
+    var->setNDArray(new NDArray(buffer, __shape, block.launchContext()));
   } else if (var->getNDArray()->lengthOf() != len) {
     // if length not match - lets reallocate array
     delete var->getNDArray();
     std::shared_ptr<DataBuffer> buffer =
         std::make_shared<DataBuffer>(len * sizeof(int8_t), ArrayOptions::dataType(__shape), workspace);
-    var->setNDArray(new NDArray(buffer, ShapeDescriptor(__shape), block.launchContext()));
+    var->setNDArray(new NDArray(buffer, __shape, block.launchContext()));
   }
 
   return true;
@@ -423,6 +423,7 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, std::initializer_list
   auto workspace = block.getWorkspace();
 
   sd::LongType len = shape::length(shape);
+  sd_printf("Allocating result 1\n",0);
   // if that's first run - we probably have nothing here
   if (var->getNDArray() == nullptr) {
     var->setNDArray(new NDArray(order, shape, block.dataType(), block.launchContext()));

--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -403,15 +403,19 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, sd::LongType *shape) 
 
   // if that's first run - we probably have nothing here
   if (var->getNDArray() == nullptr) {
+    auto desc = new ShapeDescriptor(__shape);
     std::shared_ptr<DataBuffer> buffer =
-        std::make_shared<DataBuffer>(len * sizeof(int8_t), ArrayOptions::dataType(__shape), workspace);
-    var->setNDArray(new NDArray(buffer, __shape, block.launchContext()));
+        std::make_shared<DataBuffer>(len * sizeof(int8_t),desc->dataType(), workspace);
+    var->setNDArray(new NDArray(buffer, desc, block.launchContext()));
+    delete desc;
   } else if (var->getNDArray()->lengthOf() != len) {
     // if length not match - lets reallocate array
     delete var->getNDArray();
+    auto desc = new ShapeDescriptor(__shape);
     std::shared_ptr<DataBuffer> buffer =
-        std::make_shared<DataBuffer>(len * sizeof(int8_t), ArrayOptions::dataType(__shape), workspace);
-    var->setNDArray(new NDArray(buffer, __shape, block.launchContext()));
+        std::make_shared<DataBuffer>(len * sizeof(int8_t), desc->dataType(), workspace);
+    var->setNDArray(new NDArray(buffer, desc, block.launchContext()));
+    delete desc;
   }
 
   return true;

--- a/libnd4j/include/ops/declarable/impl/LegacyBroadcastBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyBroadcastBoolOp.cpp
@@ -105,7 +105,9 @@ LegacyOp *LegacyBroadcastBoolOp::clone() { return new LegacyBroadcastBoolOp(this
 ShapeList *LegacyBroadcastBoolOp::calculateOutputShape(ShapeList *inputShape, sd::graph::Context &block) {
   auto inShape = inputShape->at(0);
   auto desc = new ShapeDescriptor(inShape, DataType::BOOL);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/impl/LegacyBroadcastBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyBroadcastBoolOp.cpp
@@ -104,7 +104,8 @@ LegacyOp *LegacyBroadcastBoolOp::clone() { return new LegacyBroadcastBoolOp(this
  */
 ShapeList *LegacyBroadcastBoolOp::calculateOutputShape(ShapeList *inputShape, sd::graph::Context &block) {
   auto inShape = inputShape->at(0);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape, DataType::BOOL)));
+  auto desc = new ShapeDescriptor(inShape, DataType::BOOL);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
@@ -94,7 +94,7 @@ ShapeList *LegacyIndexReduceOp::calculateOutputShape(ShapeList *inputShape, sd::
       return SHAPELIST(result);
     } else {
       // in this case we're building proper shape for reduction
-      auto array = INPUT_VARIABLE(0);  // new NDArray(nullptr, inShape, block.getWorkspace());
+      auto array = INPUT_VARIABLE(0);
       return SHAPELIST(
           ShapeUtils::evalReduceShapeInfo('c', axis, *array, DataType::INT64, false, true, block.workspace()));
     }

--- a/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
@@ -54,6 +54,7 @@ ShapeList *LegacyIndexReduceOp::calculateOutputShape(ShapeList *inputShape, sd::
     auto desc = new ShapeDescriptor(newShape, DataType::INT64);
     auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
     RELEASE(newShape, block.getWorkspace());
+    delete desc;
     return SHAPELIST(result);
   } else if (block.getAxis()->size()) {
     // in this case we're building proper shape for reduction
@@ -89,6 +90,7 @@ ShapeList *LegacyIndexReduceOp::calculateOutputShape(ShapeList *inputShape, sd::
       auto desc = new ShapeDescriptor(newShape, DataType::INT64);
       auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
       RELEASE(newShape, block.getWorkspace());
+      delete desc;
       return SHAPELIST(result);
     } else {
       // in this case we're building proper shape for reduction

--- a/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
@@ -51,7 +51,8 @@ ShapeList *LegacyIndexReduceOp::calculateOutputShape(ShapeList *inputShape, sd::
     newShape[6] = 1;
     newShape[7] = 99;
 
-    auto result = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(newShape, DataType::INT64));
+    auto desc = new ShapeDescriptor(newShape, DataType::INT64);
+    auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
     RELEASE(newShape, block.getWorkspace());
     return SHAPELIST(result);
   } else if (block.getAxis()->size()) {
@@ -85,7 +86,8 @@ ShapeList *LegacyIndexReduceOp::calculateOutputShape(ShapeList *inputShape, sd::
       newShape[6] = 1;
       newShape[7] = 99;
 
-      auto result = ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(newShape, DataType::INT64));
+      auto desc = new ShapeDescriptor(newShape, DataType::INT64);
+      auto result = ConstantShapeHelper::getInstance().createShapeInfo(desc);
       RELEASE(newShape, block.getWorkspace());
       return SHAPELIST(result);
     } else {

--- a/libnd4j/include/ops/declarable/impl/LegacyPairwiseTransformBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyPairwiseTransformBoolOp.cpp
@@ -67,7 +67,8 @@ sd::Status LegacyPairwiseTransformBoolOp::validateAndExecute(Context &block) {
  */
 ShapeList *LegacyPairwiseTransformBoolOp::calculateOutputShape(ShapeList *inputShape, sd::graph::Context &block) {
   auto inShape = inputShape->at(0);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape, DataType::BOOL)));
+  auto desc = new ShapeDescriptor(inShape, DataType::BOOL);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/impl/LegacyPairwiseTransformBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyPairwiseTransformBoolOp.cpp
@@ -68,7 +68,9 @@ sd::Status LegacyPairwiseTransformBoolOp::validateAndExecute(Context &block) {
 ShapeList *LegacyPairwiseTransformBoolOp::calculateOutputShape(ShapeList *inputShape, sd::graph::Context &block) {
   auto inShape = inputShape->at(0);
   auto desc = new ShapeDescriptor(inShape, DataType::BOOL);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/impl/LegacyReduce3Op.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduce3Op.cpp
@@ -60,21 +60,17 @@ sd::Status LegacyReduce3Op::validateAndExecute(Context &block) {
 
     auto xTadShape = Environment::getInstance().isCPU()
                          ? packX.primaryShapeInfo()
-                         : packX.specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tadX.tadOnlyShapeInfo,
-                                                      //shape::shapeInfoByteLength(tadX.tadOnlyShapeInfo));
+                         : packX.specialShapeInfo();
     auto xTadOffsets = Environment::getInstance().isCPU()
                            ? packX.primaryOffsets()
-                           : packX.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tadX.tadOffsets,
-                                                      //tadX.numTads * sizeof(sd::LongType));
+                           : packX.specialOffsets();
 
     auto yTadShape = Environment::getInstance().isCPU()
                          ? packZ.primaryShapeInfo()
-                         : packZ.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tadY.tadOnlyShapeInfo,
-                                                    //shape::shapeInfoByteLength(tadY.tadOnlyShapeInfo));
+                         : packZ.specialOffsets();
     auto yTadOffsets = Environment::getInstance().isCPU()
                            ? packZ.primaryOffsets()
-                           : packZ.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tadY.tadOffsets,
-                                                      //tadY.numTads * sizeof(sd::LongType));
+                           : packZ.specialOffsets();
 
     NativeOpExecutioner::execReduce3(block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(),
                                      x->specialShapeInfo(), extras.argumentsAsT(z->dataType()), y->buffer(),

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceBoolOp.cpp
@@ -77,8 +77,8 @@ sd::Status LegacyReduceBoolOp::validateAndExecute(Context& block) {
       if (x->rankOf() - dims.size() != z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);
@@ -86,19 +86,6 @@ sd::Status LegacyReduceBoolOp::validateAndExecute(Context& block) {
                                           x->specialShapeInfo(), nullptr, z->buffer(), zShapeInfoH, z->specialBuffer(),
                                           zShapeInfoD, dims2.data(), dims2.size());
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //manager.replicatePointer(tad.tadOnlyShapeInfo, shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto
-      // pTadOffsets = Environment::getInstance().isCPU() ? packX.primaryOffsets() : packX.specialOffsets();
-      // //manager.replicatePointer(tad.tadOffsets, tad.numTads * sizeof(sd::LongType));
-
-      // NativeOpExecutioner::execReduceBool(block.launchContext(), opNum, x->buffer(), x->shapeInfo(),
-      // x->specialBuffer(), x->specialShapeInfo(),
-      //         extras.argumentsAsT(x->dataType()),
-      //         z->buffer(), z->shapeInfo(), z->specialBuffer(), z->specialShapeInfo(),
-      //         dims.data(), (int) dims.size(), reinterpret_cast<sd::LongType const*>(pTadShape),
-      //         reinterpret_cast<sd::LongType const*>(pTadOffsets));
     }
 
     STORE_RESULT(*z);
@@ -131,8 +118,8 @@ sd::Status LegacyReduceBoolOp::validateAndExecute(Context& block) {
       if (x->rankOf() - dims.size() != z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);
@@ -140,18 +127,6 @@ sd::Status LegacyReduceBoolOp::validateAndExecute(Context& block) {
                                           x->specialShapeInfo(), nullptr, z->buffer(), zShapeInfoH, z->specialBuffer(),
                                           zShapeInfoD, dims2.data(), dims2.size());
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
-      // shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto pTadOffsets = Environment::getInstance().isCPU() ?
-      // packX.primaryOffsets() : packX.specialOffsets(); //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
-      // tad.numTads * sizeof(sd::LongType));
-
-      // NativeOpExecutioner::execReduceBool(block.launchContext(), opNum, x->buffer(), x->shapeInfo(),
-      // x->specialBuffer(), x->specialShapeInfo(), extras.argumentsAsT(x->dataType()),
-      //         z->buffer(), z->shapeInfo(), z->specialBuffer(), z->specialShapeInfo(), dims.data(), (int) dims.size(),
-      //         pTadShape, pTadOffsets);
     }
   }
 

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceFloatOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceFloatOp.cpp
@@ -56,8 +56,6 @@ sd::Status LegacyReduceFloatOp::validateAndExecute(Context& block) {
   if (block.width() == 1) {
     if (axis.size() == x->rankOf()) allAxes = true;
 
-    // _axis.(block.getIArguments()->size() == 0) ||
-    //                    (block.getIArguments()->size() == 1 && INT_ARG(0) == sd::DataTypeUtils::max<int>())
     if (block.getAxis()->empty() || allAxes) {
       // scalar
       NativeOpExecutioner::execReduceFloatScalar(
@@ -72,12 +70,6 @@ sd::Status LegacyReduceFloatOp::validateAndExecute(Context& block) {
 
       REQUIRE_TRUE(dims.size() > 0, 0, "Some dimensions required for reduction!");
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //manager.replicatePointer(tad.tadOnlyShapeInfo, shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto
-      // pTadOffsets = Environment::getInstance().isCPU() ? packX.primaryOffsets() : packX.specialOffsets();
-      // //manager.replicatePointer(tad.tadOffsets, tad.numTads * sizeof(sd::LongType));
 
       const sd::LongType* zShapeInfoH = z->shapeInfo();
       const sd::LongType* zShapeInfoD = z->specialShapeInfo();
@@ -85,8 +77,8 @@ sd::Status LegacyReduceFloatOp::validateAndExecute(Context& block) {
       if (x->rankOf() == z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);
@@ -119,13 +111,6 @@ sd::Status LegacyReduceFloatOp::validateAndExecute(Context& block) {
       // TAD
       REQUIRE_TRUE(dims.size() > 0, 0, "Some dimensions required for reduction!");
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
-      // shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto pTadOffsets = Environment::getInstance().isCPU() ?
-      // packX.primaryOffsets() : packX.specialOffsets(); //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
-      // tad.numTads * sizeof(sd::LongType));
 
       const sd::LongType* zShapeInfoH = z->shapeInfo();
       const sd::LongType* zShapeInfoD = z->specialShapeInfo();
@@ -133,8 +118,8 @@ sd::Status LegacyReduceFloatOp::validateAndExecute(Context& block) {
       if (x->rankOf() == z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceLongOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceLongOp.cpp
@@ -78,8 +78,8 @@ sd::Status LegacyReduceLongOp::validateAndExecute(Context& block) {
       if (x->rankOf() - dims.size() != z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);
@@ -87,19 +87,6 @@ sd::Status LegacyReduceLongOp::validateAndExecute(Context& block) {
                                           x->specialShapeInfo(), nullptr, z->buffer(), zShapeInfoH, z->specialBuffer(),
                                           zShapeInfoD, dims2.data(), dims2.size());
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
-      // shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto pTadOffsets = Environment::getInstance().isCPU() ?
-      // packX.primaryOffsets() : packX.specialOffsets(); //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
-      // tad.numTads * sizeof(sd::LongType));
-
-      // NativeOpExecutioner::execReduceLong(block.launchContext(), opNum, x->buffer(), x->shapeInfo(),
-      // x->specialBuffer(), x->specialShapeInfo(),
-      //         extras.argumentsAsT(x->dataType()),
-      //         z->buffer(), z->shapeInfo(), z->specialBuffer(), z->specialShapeInfo(),
-      //         dims.data(), (int) dims.size(), pTadShape, pTadOffsets);
     }
 
     STORE_RESULT(*z);
@@ -130,8 +117,8 @@ sd::Status LegacyReduceLongOp::validateAndExecute(Context& block) {
       if (x->rankOf() - dims.size() != z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);
@@ -139,18 +126,6 @@ sd::Status LegacyReduceLongOp::validateAndExecute(Context& block) {
                                           x->specialShapeInfo(), nullptr, z->buffer(), zShapeInfoH, z->specialBuffer(),
                                           zShapeInfoD, dims2.data(), dims2.size());
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
-      // shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto pTadOffsets = Environment::getInstance().isCPU() ?
-      // packX.primaryOffsets() : packX.specialOffsets(); //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
-      // tad.numTads * sizeof(sd::LongType));
-
-      // NativeOpExecutioner::execReduceLong(block.launchContext(), opNum, x->buffer(), x->shapeInfo(),
-      // x->specialBuffer(), x->specialShapeInfo(), extras.argumentsAsT(x->dataType()),
-      //         z->buffer(), z->shapeInfo(), z->specialBuffer(), z->specialShapeInfo(), dims.data(), (int) dims.size(),
-      //         pTadShape, pTadOffsets);
     }
   }
 

--- a/libnd4j/include/ops/declarable/impl/LegacyReduceSameOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduceSameOp.cpp
@@ -76,8 +76,8 @@ sd::Status LegacyReduceSameOp::validateAndExecute(Context& block) {
       if (x->rankOf() - dims.size() != z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);
@@ -85,19 +85,6 @@ sd::Status LegacyReduceSameOp::validateAndExecute(Context& block) {
                                           x->specialShapeInfo(), nullptr, z->buffer(), zShapeInfoH, z->specialBuffer(),
                                           zShapeInfoD, dims2.data(), dims2.size());
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
-      // shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto pTadOffsets = Environment::getInstance().isCPU() ?
-      // packX.primaryOffsets() : packX.specialOffsets(); //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
-      // tad.numTads * sizeof(sd::LongType));
-
-      // NativeOpExecutioner::execReduceSame(block.launchContext(), opNum, x->buffer(), x->shapeInfo(),
-      // x->specialBuffer(), x->specialShapeInfo(),
-      //         extras.argumentsAsT(z->dataType()),
-      //         z->buffer(), z->shapeInfo(), x->specialBuffer(), x->specialShapeInfo(),
-      //         dims.data(), (int) dims.size(), pTadShape, pTadOffsets);
     }
 
     STORE_RESULT(*z);
@@ -128,8 +115,8 @@ sd::Status LegacyReduceSameOp::validateAndExecute(Context& block) {
       if (x->rankOf() - dims.size() != z->rankOf()) {
         auto zPack = ConstantShapeHelper::getInstance().createShapeInfoWithNoUnitiesForReduce(
             z->shapeInfo(), dims, z->getContext()->getWorkspace());
-        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack.primary());
-        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack.special());
+        zShapeInfoH = reinterpret_cast<sd::LongType const*>(zPack->primary());
+        zShapeInfoD = reinterpret_cast<sd::LongType const*>(zPack->special());
       }
 
       std::vector<int> dims2 = ShapeUtils::evalDimsForReduceOp(x->rankOf(), dims);
@@ -137,18 +124,6 @@ sd::Status LegacyReduceSameOp::validateAndExecute(Context& block) {
                                           x->specialShapeInfo(), nullptr, z->buffer(), zShapeInfoH, z->specialBuffer(),
                                           zShapeInfoD, dims2.data(), dims2.size());
 
-      // auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
-
-      // auto pTadShape = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-      // //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
-      // shape::shapeInfoByteLength(tad.tadOnlyShapeInfo)); auto pTadOffsets = Environment::getInstance().isCPU() ?
-      // packX.primaryOffsets() : packX.specialOffsets(); //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
-      // tad.numTads * sizeof(sd::LongType));
-
-      // NativeOpExecutioner::execReduceSame(block.launchContext(), opNum, x->buffer(), x->shapeInfo(),
-      // x->specialBuffer(), x->specialShapeInfo(),
-      //         extras.argumentsAsT(z->dataType()), z->buffer(), z->shapeInfo(), z->specialBuffer(),
-      //         z->specialShapeInfo(), dims.data(), (int) dims.size(), pTadShape, pTadOffsets);
     }
   }
 

--- a/libnd4j/include/ops/declarable/impl/LegacyTransformBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyTransformBoolOp.cpp
@@ -64,7 +64,9 @@ sd::Status LegacyTransformBoolOp::validateAndExecute(Context &block) {
 ShapeList *LegacyTransformBoolOp::calculateOutputShape(ShapeList *inputShape, sd::graph::Context &block) {
   auto inShape = inputShape->at(0);
   auto desc = new ShapeDescriptor(inShape, DataType::BOOL);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
+  delete desc;
+  return ret;
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/impl/LegacyTransformBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyTransformBoolOp.cpp
@@ -63,7 +63,8 @@ sd::Status LegacyTransformBoolOp::validateAndExecute(Context &block) {
  */
 ShapeList *LegacyTransformBoolOp::calculateOutputShape(ShapeList *inputShape, sd::graph::Context &block) {
   auto inShape = inputShape->at(0);
-  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(ShapeDescriptor(inShape, DataType::BOOL)));
+  auto desc = new ShapeDescriptor(inShape, DataType::BOOL);
+  return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
 }
 }  // namespace ops
 }  // namespace sd

--- a/libnd4j/include/ops/declarable/platform/vednn/add_mult.cpp
+++ b/libnd4j/include/ops/declarable/platform/vednn/add_mult.cpp
@@ -97,7 +97,6 @@ PLATFORM_IMPL(add, ENGINE_CPU) {
 
   auto length0 = input0->lengthOf();
   auto length1 = input1->lengthOf();
-  // sd_printf("%s %d:  %d %d\n",__FILE__, __LINE__, (int)length0, (int)length1);
   auto func = handle.getFunctionByConstPtrName("vedaAdd_A");
   VEDA_CALL_THROW(vedaLaunchKernel(func, 0, (uint64_t)length0, vIn0, (uint64_t)length1, vIn1, vO));
 
@@ -150,7 +149,6 @@ PLATFORM_IMPL(multiply, ENGINE_CPU) {
 
   auto length0 = input0->lengthOf();
   auto length1 = input1->lengthOf();
-  // sd_printf("mult %s %d:  %d %d\n",__FILE__, __LINE__, (int)length0, (int)length1);
   auto func = handle.getFunctionByConstPtrName("vedaMult_A");
   VEDA_CALL_THROW(vedaLaunchKernel(func, 0, (uint64_t)length0, vIn0, (uint64_t)length1, vIn1, vO));
 

--- a/libnd4j/include/ops/ops.h
+++ b/libnd4j/include/ops/ops.h
@@ -2013,7 +2013,6 @@ class MatchCondition {
   SD_OP_DEF static Z update(Z old, Z opOutput, X *extraParams) { return old + opOutput; }
 
   SD_OP_DEF static Z op(X d1, X compare, X eps, int mode) {
-    sd_debug("MatchCondition: value: %f; comp: %f; eps: %f; mode: %i;\n", d1, compare, eps, mode);
     switch (mode) {
       case 0:  // equals
         return sd::math::sd_abs<X>(d1 - compare) <= eps ? 1 : 0;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
@@ -22,6 +22,7 @@ package org.nd4j.linalg.api.buffer;
 
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.indexer.Indexer;
+import org.nd4j.linalg.api.memory.Deallocatable;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.nativeblas.OpaqueDataBuffer;
 
@@ -29,7 +30,7 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
-public interface DataBuffer extends Serializable, AutoCloseable {
+public interface DataBuffer extends Serializable, AutoCloseable, Deallocatable {
     enum TypeEx {
 
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/ReferenceMetaData.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/ReferenceMetaData.java
@@ -17,31 +17,24 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *  *****************************************************************************
  */
-
 package org.nd4j.linalg.api.memory;
 
-import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public interface Deallocator {
-    /**
-     * This method does actual deallocation
-     */
-    void deallocate();
+/**
+ * Track reference metadata relevant
+ * to allocation/deallocation.
+ *
+ * @author Adam Gibson
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReferenceMetaData {
+    private boolean isConstant;
 
-    /**
-     * Log event for a deallocation.
-     * Only used when {@link org.nd4j.linalg.profiler.data.eventlogger.EventLogger#enabled}
-     * is true. We store events on deallocators to retain metadata
-     * about a be to be deleted buffer without the need to retain a reference
-     * to the deallocatable object. This is to avoid conflict with {@link java.lang.ref.WeakReference}
-     *
-     * @return
-     */
-    LogEvent logEvent();
-
-    /**
-     * Reference metadata for determining whether to deallocate a reference.
-     * @return
-     */
-    ReferenceMetaData referenceMetaData();
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/abstracts/DummyWorkspace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/abstracts/DummyWorkspace.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.api.memory.abstracts;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.Deallocator;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
+import org.nd4j.linalg.api.memory.ReferenceMetaData;
 import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
 import org.nd4j.linalg.api.memory.enums.MemoryKind;
 import org.nd4j.linalg.api.memory.pointers.PagedPointer;
@@ -274,6 +275,11 @@ public class DummyWorkspace implements MemoryWorkspace {
 
             @Override
             public LogEvent logEvent() {
+                return null;
+            }
+
+            @Override
+            public ReferenceMetaData referenceMetaData() {
                 return null;
             }
         };

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/abstracts/Nd4jWorkspace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/abstracts/Nd4jWorkspace.java
@@ -428,6 +428,7 @@ public abstract class Nd4jWorkspace implements MemoryWorkspace {
                     if (!trimmer) {
                         externalCount.incrementAndGet();
                         AllocationsTracker.getInstance().getTracker(id).allocateSpilled(type,kind,numElements,requiredMemory);
+                        AllocationsTracker.getInstance().getTracker(id).allocateExternal(type,kind,numElements,requiredMemory);
                         spilledAllocationsSize.addAndGet(requiredMemory);
                         PagedPointer pointer = new PagedPointer(
                                 memoryManager.allocate(requiredMemory, MemoryKind.HOST, initialize),

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatableReference.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatableReference.java
@@ -38,4 +38,13 @@ public class DeallocatableReference extends WeakReference<Deallocatable> {
         this.id = referent.getUniqueId();
         this.deallocator = referent.deallocator();
     }
+
+    public void deallocate() {
+        if(get() != null && !get().shouldDeAllocate() || deallocator.referenceMetaData().isConstant()) {
+            throw new IllegalStateException("Unable to deallocate reference. Not ready yet.");
+        }
+
+        deallocator.deallocate();
+    }
+
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
@@ -48,7 +48,7 @@ public class DeallocatorService {
     public DeallocatorService() {
         // we need to have at least 2 threads, but for CUDA we'd need at least numDevices threads, due to thread->device affinity
         int numDevices = Nd4j.getAffinityManager().getNumberOfDevices();
-        int numThreads = 1;
+        int numThreads = Math.max(2, numDevices * 2);
 
         for (int e = 0; e < numDevices; e++)
             deviceMap.add(new ArrayList<>());

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
@@ -48,7 +48,7 @@ public class DeallocatorService {
     public DeallocatorService() {
         // we need to have at least 2 threads, but for CUDA we'd need at least numDevices threads, due to thread->device affinity
         int numDevices = Nd4j.getAffinityManager().getNumberOfDevices();
-        int numThreads = Math.max(2, numDevices * 2);
+        int numThreads = 1;
 
         for (int e = 0; e < numDevices; e++)
             deviceMap.add(new ArrayList<>());
@@ -123,7 +123,7 @@ public class DeallocatorService {
                 // if periodicGc is enabled, only first thread will call for it
                 if (Nd4j.getMemoryManager().isPeriodicGcActive() && threadIdx == 0 && Nd4j.getMemoryManager().getAutoGcWindow() > 0) {
                     val reference = (DeallocatableReference) queue.poll();
-                    if (reference == null || (reference != null && reference.get() != null &&  !reference.get().shouldDeAllocate())) {
+                    if (reference == null || (reference != null && reference.get() != null &&  !reference.get().shouldDeAllocate()) || !reference.getDeallocator().referenceMetaData().isConstant()) {
                         val timeout = Nd4j.getMemoryManager().getAutoGcWindow();
                         try {
                             Thread.sleep(Nd4j.getMemoryManager().getAutoGcWindow());
@@ -133,9 +133,10 @@ public class DeallocatorService {
                         }
                     } else {
                         // invoking deallocator
-                        if (reference != null && (reference.get() != null &&  reference.get().shouldDeAllocate()))
-                            reference.getDeallocator().deallocate();
-                        referenceMap.remove(reference.getId());
+                        if (reference != null && (reference.get().shouldDeAllocate()) || reference.getDeallocator().referenceMetaData().isConstant()) {
+                            reference.deallocate();
+                            referenceMap.remove(reference.getId());
+                        }
                     }
                 } else {
                     try {
@@ -143,12 +144,12 @@ public class DeallocatorService {
                         if (reference == null)
                             continue;
 
-                        if( (reference.get() != null && !reference.get().shouldDeAllocate()))
+                        if( (reference.get() != null && !reference.get().shouldDeAllocate()) || reference.getDeallocator().referenceMetaData().isConstant())
                             continue;
 
 
                         // invoking deallocator
-                        reference.getDeallocator().deallocate();
+                        reference.deallocate();
                         referenceMap.remove(reference.getId());
                     } catch (InterruptedException e) {
                         canRun = false;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/custom/Svd.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/custom/Svd.java
@@ -108,7 +108,7 @@ public class Svd extends DynamicCustomOp {
     }
 
     @Override
-    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes){
+    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes) {
         if(computeUv){
             DataType d = dataTypes.get(0);
             return Arrays.asList(d, d, d);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/rng/distribution/impl/OrthogonalDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/rng/distribution/impl/OrthogonalDistribution.java
@@ -55,13 +55,7 @@ public class OrthogonalDistribution extends BaseDistribution {
         this.gain = gain;
         this.random = Nd4j.getRandom();
     }
-/*
-    max doesn't want this distripution
-    public OrthogonalDistribution(@NonNull INDArray gains) {
-        this.gains = gains;
-        this.random = Nd4j.getRandom();
-    }
-*/
+
     /**
      * Access the mean.
      *
@@ -219,7 +213,7 @@ public class OrthogonalDistribution extends BaseDistribution {
     }
 
     @Override
-    public INDArray sample(long[] shape){
+    public INDArray sample(long[] shape) {
         long numRows = 1;
         for (int i = 0; i < shape.length - 1; i++)
             numRows *= shape[i];
@@ -251,7 +245,8 @@ public class OrthogonalDistribution extends BaseDistribution {
     }
 
     @Override
-    public INDArray sample(INDArray target){
-        return target.assign(sample(target.shape()));
+    public INDArray sample(INDArray target) {
+        INDArray retSample = sample(target.shape());
+        return target.assign(retSample);
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/compression/CompressedDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/compression/CompressedDataBuffer.java
@@ -66,24 +66,29 @@ public class CompressedDataBuffer extends BaseDataBuffer {
 
     @Override
     public void write(DataOutputStream out) throws IOException {
-        //        logger.info("Writing out CompressedDataBuffer");
         // here we should mimic to usual DataBuffer array
         out.writeUTF(allocationMode.name());
         out.writeLong(compressionDescriptor.getCompressedLength());
         out.writeUTF(DataType.COMPRESSED.name());
         // at this moment we don't care about mimics anymore
-        //ByteIndexer indexer = ByteIndexer.create((BytePointer) pointer);
         out.writeUTF(compressionDescriptor.getCompressionAlgorithm());
         out.writeLong(compressionDescriptor.getCompressedLength());
         out.writeLong(compressionDescriptor.getOriginalLength());
         out.writeLong(compressionDescriptor.getNumberOfElements());
         out.writeInt(compressionDescriptor.getOriginalDataType().ordinal());
-        //        out.write(((BytePointer) pointer).getStringBytes());
         for (int x = 0; x < pointer.capacity() * pointer.sizeof(); x++) {
             byte b = pointer.asByteBuffer().get(x);
             out.writeByte(b);
         }
     }
+
+    @Override
+    public String getUniqueId() {
+        //this is actually a no op since compressed pointers don't get deallocated
+        return "CMDB_" ;
+    }
+
+
 
     @Override
     protected void setIndexer(Indexer indexer) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogger.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/profiler/data/eventlogger/EventLogger.java
@@ -30,7 +30,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * EventLogger is used for profiling allocations, deallocations and other events

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/DirectShapeInfoProvider.java
@@ -61,6 +61,7 @@ public class DirectShapeInfoProvider extends BaseShapeInfoProvider {
                     if (!longCache.containsKey(descriptor)) {
                         counter.incrementAndGet();
                         Pair<DataBuffer, long[]> buffer = super.createShapeInformation(shape, stride, elementWiseStride, order, extras);
+                        buffer.getFirst().setConstant(true);
                         longCache.put(descriptor, buffer);
 
                         bytes.addAndGet(buffer.getFirst().length() * 8 * 2);

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
@@ -41,17 +41,12 @@ import static org.nd4j.linalg.api.buffer.DataType.INT8;
 public abstract class BaseCpuDataBuffer extends BaseDataBuffer implements Deallocatable {
 
     protected transient Pointer addressPointer;
-
     private transient final long instanceId = Nd4j.getDeallocatorService().nextValue();
 
     protected BaseCpuDataBuffer() {
 
     }
 
-    @Override
-    public boolean shouldDeAllocate() {
-        return !released && !constant;
-    }
 
     @Override
     public String getUniqueId() {
@@ -60,7 +55,11 @@ public abstract class BaseCpuDataBuffer extends BaseDataBuffer implements Deallo
 
     @Override
     public Deallocator deallocator() {
-        return new CpuDeallocator(this);
+        if(deallocator != null)
+            return deallocator;
+
+        deallocator = new CpuDeallocator(this);
+        return deallocator;
     }
 
     public OpaqueDataBuffer getOpaqueDataBuffer() {

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/CpuDeallocator.java
@@ -22,6 +22,7 @@ package org.nd4j.linalg.cpu.nativecpu.buffer;
 
 import lombok.extern.slf4j.Slf4j;
 import org.nd4j.linalg.api.memory.Deallocator;
+import org.nd4j.linalg.api.memory.ReferenceMetaData;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
 import org.nd4j.linalg.profiler.data.eventlogger.EventType;
@@ -34,9 +35,15 @@ import org.nd4j.nativeblas.OpaqueDataBuffer;
 public class CpuDeallocator implements Deallocator {
     private final transient OpaqueDataBuffer opaqueDataBuffer;
     private LogEvent logEvent;
+    private ReferenceMetaData referenceMetaData;
 
     public CpuDeallocator(BaseCpuDataBuffer buffer) {
         opaqueDataBuffer = buffer.getOpaqueDataBuffer();
+        referenceMetaData = ReferenceMetaData.
+                builder()
+                .isConstant(buffer.isConstant())
+                .build();
+
         if(EventLogger.getInstance().isEnabled()) {
             logEvent = LogEvent.builder()
                     .attached(buffer.isAttached())
@@ -64,11 +71,17 @@ public class CpuDeallocator implements Deallocator {
             logEvent.setThreadName(Thread.currentThread().getName());
             EventLogger.getInstance().log(logEvent);
         }
+
         NativeOpsHolder.getInstance().getDeviceNativeOps().deleteDataBuffer(opaqueDataBuffer);
     }
 
     @Override
     public LogEvent logEvent() {
         return logEvent;
+    }
+
+    @Override
+    public ReferenceMetaData referenceMetaData() {
+        return referenceMetaData;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
@@ -36,6 +36,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.common.primitives.Pair;
 import org.nd4j.nativeblas.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CpuOpContext extends BaseOpContext implements OpContext, Deallocatable {
@@ -187,10 +188,12 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
     public void setInputArrays(@NonNull List<INDArray> arrays) {
         PointerPointer<OpaqueDataBuffer> buffers = new PointerPointer<>(arrays.size());
         PointerPointer<LongPointer> shapeInfoBuffer = new PointerPointer<>(arrays.size());
+        List<DataBuffer> shapeInfoReferences = new ArrayList<>();
         for(int i = 0; i < arrays.size(); i++) {
             INDArray array = arrays.get(i);
             buffers.put(i,array.isEmpty() ? null : ((BaseCpuDataBuffer) array.data()).getOpaqueDataBuffer());
             DataBuffer dataBuffer = array.shapeInfoDataBuffer();
+            shapeInfoReferences.add(dataBuffer);
             Pointer addressPointer = dataBuffer.pointer();
             addressPointer.retainReference();
             shapeInfoBuffer.put(i,addressPointer);
@@ -199,6 +202,7 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
 
         buffers.retainReference();
         shapeInfoBuffer.retainReference();
+        //TODO: something here is forcing the context input buffers to be null
         nativeOps.setGraphContextInputBuffers(context,arrays.size(),buffers,shapeInfoBuffer,null);
 
     }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContextDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContextDeallocator.java
@@ -21,6 +21,7 @@
 package org.nd4j.linalg.cpu.nativecpu.ops;
 
 import org.nd4j.linalg.api.memory.Deallocator;
+import org.nd4j.linalg.api.memory.ReferenceMetaData;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
 import org.nd4j.linalg.profiler.data.eventlogger.EventType;
@@ -32,10 +33,11 @@ import org.nd4j.nativeblas.OpaqueContext;
 public class CpuOpContextDeallocator implements Deallocator {
     private transient final OpaqueContext context;
     private LogEvent logEvent;
+    private ReferenceMetaData referenceMetaData;
 
     public CpuOpContextDeallocator(CpuOpContext ctx) {
         context = (OpaqueContext) ctx.contextPointer();
-
+        referenceMetaData = ReferenceMetaData.builder().build();
         if(EventLogger.getInstance().isEnabled()) {
             logEvent = LogEvent.builder()
                     .eventType(EventType.DEALLOCATION)
@@ -62,5 +64,10 @@ public class CpuOpContextDeallocator implements Deallocator {
     @Override
     public LogEvent logEvent() {
         return logEvent;
+    }
+
+    @Override
+    public ReferenceMetaData referenceMetaData() {
+        return referenceMetaData;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/workspace/CpuWorkspaceDeallocator.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.LongPointer;
 import org.nd4j.common.primitives.Pair;
 import org.nd4j.linalg.api.memory.Deallocator;
+import org.nd4j.linalg.api.memory.ReferenceMetaData;
 import org.nd4j.linalg.api.memory.enums.LocationPolicy;
 import org.nd4j.linalg.api.memory.enums.MemoryKind;
 import org.nd4j.linalg.api.memory.pointers.PointersPair;
@@ -35,6 +36,7 @@ import org.nd4j.linalg.profiler.data.eventlogger.LogEvent;
 import org.nd4j.linalg.profiler.data.eventlogger.ObjectAllocationType;
 import org.nd4j.nativeblas.NativeOpsHolder;
 
+import java.sql.Ref;
 import java.util.List;
 import java.util.Queue;
 
@@ -46,12 +48,14 @@ public class CpuWorkspaceDeallocator implements Deallocator {
     private LocationPolicy location;
     private Pair<LongPointer, Long> mmapInfo;
     private LogEvent logEvent;
+    private ReferenceMetaData referenceMetaData;
 
     public CpuWorkspaceDeallocator(@NonNull CpuWorkspace workspace) {
         this.pointersPair = workspace.workspace();
         this.pinnedPointers = workspace.pinnedPointers();
         this.externalPointers = workspace.externalPointers();
         this.location = workspace.getWorkspaceConfiguration().getPolicyLocation();
+        referenceMetaData = ReferenceMetaData.builder().build();
         if(EventLogger.getInstance().isEnabled()) {
             logEvent = LogEvent.builder()
                     .eventType(EventType.DEALLOCATION)
@@ -129,5 +133,10 @@ public class CpuWorkspaceDeallocator implements Deallocator {
     @Override
     public LogEvent logEvent() {
         return logEvent;
+    }
+
+    @Override
+    public ReferenceMetaData referenceMetaData() {
+        return referenceMetaData;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/impl/CudaDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/impl/CudaDeallocator.java
@@ -20,6 +20,7 @@ package org.nd4j.jita.allocator.impl;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.nd4j.linalg.api.memory.ReferenceMetaData;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.jcublas.buffer.BaseCudaDataBuffer;
 import org.nd4j.linalg.api.memory.Deallocator;
@@ -35,12 +36,13 @@ public class CudaDeallocator implements Deallocator {
 
     private OpaqueDataBuffer opaqueDataBuffer;
     private LogEvent logEvent;
+    private ReferenceMetaData referenceMetaData;
 
     public CudaDeallocator(@NonNull BaseCudaDataBuffer buffer) {
         opaqueDataBuffer = buffer.getOpaqueDataBuffer();
         if(EventLogger.getInstance().isEnabled()) {
             logEvent = LogEvent.builder()
-                    .isAttached(buffer.isAttached())
+                    .attached(buffer.isAttached())
                     .isConstant(buffer.isConstant())
                     .eventType(EventType.DEALLOCATION)
                     .objectAllocationType(ObjectAllocationType.DATA_BUFFER)
@@ -48,6 +50,8 @@ public class CudaDeallocator implements Deallocator {
                     .build();
 
         }
+
+        referenceMetaData = ReferenceMetaData.builder().build();
     }
 
     @Override
@@ -64,6 +68,11 @@ public class CudaDeallocator implements Deallocator {
 
     @Override
     public LogEvent logEvent() {
-        return null;
+        return logEvent;
+    }
+
+    @Override
+    public ReferenceMetaData referenceMetaData() {
+        return referenceMetaData;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -300,6 +300,11 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         allocationPoint.tickDeviceWrite();
     }
 
+    @Override
+    public boolean shouldDeAllocate() {
+        return !released && !isConstant();
+    }
+
     protected void initHostPointerAndIndexer() {
         if (length() == 0)
             return;
@@ -1696,33 +1701,6 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         super.release();
     }
 
-    /*
-    protected short fromFloat( float fval ) {
-        int fbits = Float.floatToIntBits( fval );
-        int sign = fbits >>> 16 & 0x8000;          // sign only
-        int val = ( fbits & 0x7fffffff ) + 0x1000; // rounded value
-
-        if( val >= 0x47800000 )               // might be or become NaN/Inf
-        {                                     // avoid Inf due to rounding
-            if( ( fbits & 0x7fffffff ) >= 0x47800000 )
-            {                                 // is or must become NaN/Inf
-                if( val < 0x7f800000 )        // was value but too large
-                    return (short) (sign | 0x7c00);     // make it +/-Inf
-                return (short) (sign | 0x7c00 |        // remains +/-Inf or NaN
-                        ( fbits & 0x007fffff ) >>> 13); // keep NaN (and Inf) bits
-            }
-            return (short) (sign | 0x7bff);             // unrounded not quite Inf
-        }
-        if( val >= 0x38800000 )               // remains normalized value
-            return (short) (sign | val - 0x38000000 >>> 13); // exp - 127 + 15
-        if( val < 0x33000000 )                // too small for subnormal
-            return (short) sign;                      // becomes +/-0
-        val = ( fbits & 0x7fffffff ) >>> 23;  // tmp exp for subnormal calc
-        return (short) (sign | ( ( fbits & 0x7fffff | 0x800000 ) // add subnormal bit
-                + ( 0x800000 >>> val - 102 )     // round depending on cut off
-                >>> 126 - val ));   // div by 2^(1-(exp-127+15)) and >> 13 | exp=0
-    }
-    */
 
     @Override
     public String getUniqueId() {
@@ -1735,7 +1713,12 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
      */
     @Override
     public Deallocator deallocator() {
-        return new CudaDeallocator(this);
+        if(deallocator != null)
+            return deallocator;
+
+        deallocator = new CudaDeallocator(this);
+        return deallocator;
+
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContext.java
@@ -110,7 +110,6 @@ public class CudaOpContext extends BaseOpContext implements OpContext, Deallocat
 
     @Override
     public void setInputArray(int index, @NonNull INDArray array) {
-        //val ctx = AtomicAllocator.getInstance().getFlowController().prepareAction(null, array);
         nativeOps.setGraphContextInputBuffer(context, index, array.isEmpty() ? null : ((BaseCudaDataBuffer) array.data()).getOpaqueDataBuffer(), array.shapeInfoDataBuffer().addressPointer(), AtomicAllocator.getInstance().getPointer(array.shapeInfoDataBuffer()));
 
         super.setInputArray(index, array);
@@ -118,7 +117,6 @@ public class CudaOpContext extends BaseOpContext implements OpContext, Deallocat
 
     @Override
     public void setOutputArray(int index, @NonNull INDArray array) {
-        //val ctx = AtomicAllocator.getInstance().getFlowController().prepareAction(array, null);
         nativeOps.setGraphContextOutputBuffer(context, index, array.isEmpty() ? null : ((BaseCudaDataBuffer) array.data()).getOpaqueDataBuffer(), array.shapeInfoDataBuffer().addressPointer(), AtomicAllocator.getInstance().getPointer(array.shapeInfoDataBuffer()));
 
         super.setOutputArray(index, array);

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContextDeallocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContextDeallocator.java
@@ -19,6 +19,7 @@
 package org.nd4j.linalg.jcublas.ops.executioner;
 
 import org.nd4j.linalg.api.memory.Deallocator;
+import org.nd4j.linalg.api.memory.ReferenceMetaData;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
 import org.nd4j.linalg.profiler.data.eventlogger.EventType;
@@ -30,6 +31,7 @@ import org.nd4j.nativeblas.OpaqueContext;
 public class CudaOpContextDeallocator implements Deallocator {
     private transient final OpaqueContext context;
     private transient LogEvent logEvent;
+    private transient  ReferenceMetaData referenceMetaData;
 
     public CudaOpContextDeallocator(CudaOpContext ctx) {
         context = (OpaqueContext) ctx.contextPointer();
@@ -41,6 +43,8 @@ public class CudaOpContextDeallocator implements Deallocator {
                     .build();
 
         }
+
+        referenceMetaData = ReferenceMetaData.builder().build();
     }
 
     @Override
@@ -51,5 +55,10 @@ public class CudaOpContextDeallocator implements Deallocator {
     @Override
     public LogEvent logEvent() {
         return logEvent;
+    }
+
+    @Override
+    public ReferenceMetaData referenceMetaData() {
+        return referenceMetaData;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java9/module-info.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java9/module-info.java
@@ -32,6 +32,7 @@ open module nd4j.cuda {
     exports org.nd4j.jita.handler.impl;
     exports org.nd4j.jita.memory;
     exports org.nd4j.jita.workspace;
+    exports org.nd4j.jita.allocator;
     exports org.nd4j.linalg.jcublas;
     exports org.nd4j.linalg.jcublas.bindings;
     exports org.nd4j.linalg.jcublas.blas;

--- a/nd4j/samediff-import/samediff-import-api/pom.xml
+++ b/nd4j/samediff-import/samediff-import-api/pom.xml
@@ -152,6 +152,11 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
 
   </dependencies>
 

--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -79,9 +79,7 @@
         <surefire.threads>8</surefire.threads>
         <tests>samediff,rng,java-only,dl4j-old-api,ndarray-indexing,compression,loss-functions,keras,python,tensorflow,onnx</tests>
         <excludedTests>large-resources,downloads,long-running-test</excludedTests>
-<!--
-        <preload>/usr/lib64/libjemalloc.so.2</preload>
--->
+     <!--   <preload>/usr/local/lib/libjemalloc.so.2</preload>-->
     </properties>
 
     <dependencyManagement>

--- a/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -388,6 +388,8 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
         if(backend.getNDArrayClass().toString().toLowerCase().contains("cu"))
             return;
 
+        Nd4j.getExecutioner().enableDebugMode(true);
+        Nd4j.getExecutioner().enableVerboseMode(true);
         File file = Resources.asFile("/big/raw_sentences.txt");
         SentenceIterator iter = new BasicLineIterator(file);
 
@@ -809,7 +811,7 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
         // we're building classifier now, with pre-built w2v model passed in
         ParagraphVectors paragraphVectors = new ParagraphVectors.Builder().seed(119).iterate(labelAwareIterator)
                 .learningRate(0.025).minLearningRate(0.001).iterations(10).epochs(1).layerSize(150)
-                .tokenizerFactory(t).sequenceLearningAlgorithm(new DBOW<VocabWord>()).useHierarchicSoftmax(true)
+                .tokenizerFactory(t).sequenceLearningAlgorithm(new DBOW<>()).useHierarchicSoftmax(true)
                 .allowParallelTokenization(true)
                 .workers(1)
                 .trainWordVectors(false).useExistingWordVectors(wordVectors).build();

--- a/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -973,7 +973,7 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
         }
 
         int count = 0;
-        int till = 100000000;
+        int till = 10;
         while(count < till) {
             for(int i = 0; i < numThreads; i++) {
                 File write = new File("pv_" + i + ".zip");

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/dl4jcore/nn/layers/recurrent/TestTimeDistributed.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/dl4jcore/nn/layers/recurrent/TestTimeDistributed.java
@@ -52,6 +52,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.learning.config.Adam;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.linalg.profiler.ProfilerConfig;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -76,8 +77,13 @@ public class TestTimeDistributed extends BaseDL4JTest {
     @ParameterizedTest
     @MethodSource("org.eclipse.deeplearning4j.dl4jcore.nn.layers.recurrent.TestTimeDistributed#params")
     public void testTimeDistributed(RNNFormat rnnDataFormat,Nd4jBackend backend){
+        Nd4j.getExecutioner().enableVerboseMode(true);
+        Nd4j.getExecutioner().enableDebugMode(true);
         for(WorkspaceMode wsm : new WorkspaceMode[]{WorkspaceMode.ENABLED, WorkspaceMode.NONE}) {
-
+            Nd4j.getExecutioner().setProfilingConfig(ProfilerConfig.builder()
+                    .checkForNAN(true)
+                    .checkForINF(true)
+                    .build());
             MultiLayerConfiguration conf1 = new NeuralNetConfiguration.Builder()
                     .trainingWorkspaceMode(wsm)
                     .inferenceWorkspaceMode(wsm)

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/keras/configurations/Keras2ModelConfigurationTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/keras/configurations/Keras2ModelConfigurationTest.java
@@ -280,6 +280,9 @@ class Keras2ModelConfigurationTest extends BaseDL4JTest {
     @Test
     @DisplayName("Test 5982")
     void test5982() throws Exception {
+        Nd4j.getExecutioner().enableDebugMode(true);
+        Nd4j.getExecutioner().enableVerboseMode(true);
+        Nd4j.getProfiler().start();
         File jsonFile = Resources.asFile("modelimport/keras/configs/bidirectional_last_timeStep.json");
         val modelGraphConf = KerasModelImport.importKerasSequentialConfiguration(jsonFile.getAbsolutePath());
         MultiLayerNetwork model = new MultiLayerNetwork(modelGraphConf);
@@ -307,7 +310,7 @@ class Keras2ModelConfigurationTest extends BaseDL4JTest {
 
     @Test
     @DisplayName("Reshape Embedding Concat Test")
-    // @Disabled("AB 2019/11/23 - known issue - see https://github.com/eclipse/deeplearning4j/issues/8373 and https://github.com/eclipse/deeplearning4j/issues/8441")
+        // @Disabled("AB 2019/11/23 - known issue - see https://github.com/eclipse/deeplearning4j/issues/8373 and https://github.com/eclipse/deeplearning4j/issues/8441")
     void ReshapeEmbeddingConcatTest() throws Exception {
         try (InputStream is = Resources.asStream("/modelimport/keras/configs/keras2/reshape_embedding_concat.json")) {
             ComputationGraphConfiguration config = new KerasModel().modelBuilder().modelJsonInputStream(is).enforceTrainingConfig(false).buildModel().getComputationGraphConfiguration();

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/keras/configurations/Keras2ModelConfigurationTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/keras/configurations/Keras2ModelConfigurationTest.java
@@ -280,8 +280,6 @@ class Keras2ModelConfigurationTest extends BaseDL4JTest {
     @Test
     @DisplayName("Test 5982")
     void test5982() throws Exception {
-        Nd4j.getExecutioner().enableDebugMode(true);
-        Nd4j.getExecutioner().enableVerboseMode(true);
         Nd4j.getProfiler().start();
         File jsonFile = Resources.asFile("modelimport/keras/configs/bidirectional_last_timeStep.json");
         val modelGraphConf = KerasModelImport.importKerasSequentialConfiguration(jsonFile.getAbsolutePath());


### PR DESCRIPTION
## What changes were proposed in this pull request?
ReferenceMetadata is added to deallocators .
This is to prevent deallocation of constant buffers.
This is also expandable to other metadata later
as needed to control allocation behavior.
Minor build updates (release version windows fixes)
Fixes windows  build issue
Rewrite shape descriptor allocation to use pointers.
Add kotlin-reflect to model import to ensure the new op annotation scanning works out of the box.

(Please fill in changes proposed in this fix)

## How was this patch tested?

Ran most recent tests to determine further source of crashes

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
