### PR TITLE
Fix LLVM template build errors

### DIFF
--- a/libnd4j/include/helpers/cpu/svd.cpp
+++ b/libnd4j/include/helpers/cpu/svd.cpp
@@ -121,22 +121,22 @@ void SVD<T>::deflation1(int col1, int shift, int ind, int size) {
   T denom = math::sd_sqrt<T, T>(cos * cos + sin * sin);
 
   if (denom == (T)0.) {
-    _m.r<T>(first + ind, first + ind) = (T)0;
+    _m.template r<T>(first + ind, first + ind) = (T)0;
     return;
   }
 
   cos /= denom;
   sin /= denom;
 
-  _m.r<T>(first, first) = denom;
-  _m.r<T>(first + ind, first) = (T)0;
-  _m.r<T>(first + ind, first + ind) = (T)0;
+  _m.template r<T>(first, first) = denom;
+  _m.template r<T>(first + ind, first) = (T)0;
+  _m.template r<T>(first + ind, first + ind) = (T)0;
 
   NDArray rotation(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
 
-  rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = cos;
-  rotation.r<T>(0, 1) = -sin;
-  rotation.r<T>(1, 0) = sin;
+  rotation.template r<T>(0, 0) = rotation.template r<T>(1, 1) = cos;
+  rotation.template r<T>(0, 1) = -sin;
+  rotation.template r<T>(1, 0) = sin;
 
   if (_calcU) {
     auto temp = _u({col1, col1 + size + 1, 0, 0}, true);
@@ -159,21 +159,21 @@ void SVD<T>::deflation2(int col1U, int col1M, int row1W, int col1W, int ind1, in
   T denom = math::sd_sqrt<T, T>(cos * cos + sin * sin);
 
   if (denom == (T)0.) {
-    _m.r<T>(col1M + ind1, col1M + ind1) = _m.t<T>(col1M + ind2, col1M + ind2);
+    _m.template r<T>(col1M + ind1, col1M + ind1) = _m.t<T>(col1M + ind2, col1M + ind2);
     return;
   }
 
   cos /= denom;
   sin /= denom;
-  _m.r<T>(col1M + ind1, col1M) = denom;
-  _m.r<T>(col1M + ind2, col1M + ind2) = _m.t<T>(col1M + ind1, col1M + ind1);
-  _m.r<T>(col1M + ind2, col1M) = (T)0;
+  _m.template r<T>(col1M + ind1, col1M) = denom;
+  _m.template r<T>(col1M + ind2, col1M + ind2) = _m.t<T>(col1M + ind1, col1M + ind1);
+  _m.template r<T>(col1M + ind2, col1M) = (T)0;
 
   NDArray rotation(_m.ordering(), {2, 2}, _m.dataType(), _m.getContext());
 
-  rotation.r<T>(0, 0) = rotation.r<T>(1, 1) = cos;
-  rotation.r<T>(0, 1) = -sin;
-  rotation.r<T>(1, 0) = sin;
+  rotation.template r<T>(0, 0) = rotation.template r<T>(1, 1) = cos;
+  rotation.template r<T>(0, 1) = -sin;
+  rotation.template r<T>(1, 0) = sin;
 
   if (_calcU) {
     auto temp = _u({col1U, col1U + size + 1, 0, 0}, true);
@@ -208,15 +208,15 @@ void SVD<T>::deflation(int col1, int col2, int ind, int row1W, int col1W, int sh
   T eps = math::sd_max<T>(almostZero, DataTypeUtils::eps<T>() * maxElem);
   T epsBig = (T)8. * DataTypeUtils::eps<T>() * math::sd_max<T>(maxElem0, maxElem);
 
-  if (diagInterval.template t<T>(0) < epsBig) diagInterval.r<T>(0) = epsBig;
+  if (diagInterval.template t<T>(0) < epsBig) diagInterval.template r<T>(0) = epsBig;
 
   for (int i = 1; i < len; ++i)
-    if (math::sd_abs<T>(colVec0.template t<T>(i)) < eps) colVec0.r<T>(i) = (T)0;
+    if (math::sd_abs<T>(colVec0.template t<T>(i)) < eps) colVec0.template r<T>(i) = (T)0;
 
   for (int i = 1; i < len; i++)
     if (diagInterval.template t<T>(i) < epsBig) {
       deflation1(col1, shift, i, len);
-      for (int i = 0; i < len; ++i) diagInterval.r<T>(i) = _m.t<T>(col1 + shift + i, col1 + shift + i);
+      for (int i = 0; i < len; ++i) diagInterval.template r<T>(i) = _m.t<T>(col1 + shift + i, col1 + shift + i);
     }
 
   {
@@ -275,9 +275,9 @@ void SVD<T>::deflation(int col1, int col2, int ind, int row1W, int col1W, int sh
       const int ki = permut[len - (totDefl ? i + 1 : i)];
       const int jac = tCol[ki];
 
-      math::sd_swap<T>(diagInterval.r<T>(i), diagInterval.r<T>(jac));
+      math::sd_swap<T>(diagInterval.template r<T>(i), diagInterval.template r<T>(jac));
 
-      if (i != 0 && jac != 0) math::sd_swap<T>(colVec0.r<T>(i), colVec0.r<T>(jac));
+      if (i != 0 && jac != 0) math::sd_swap<T>(colVec0.template r<T>(i), colVec0.template r<T>(jac));
 
       if (_calcU) {
         auto temp1 = _u({col1, col1 + len + 1, col1 + i, col1 + i + 1});
@@ -349,9 +349,9 @@ void SVD<T>::calcSingVals(const NDArray& col0, const NDArray& diag, const NDArra
 
   for (sd::LongType k = 0; k < len; ++k) {
     if (col0.t<T>(k) == (T)0.f || curLen == 1) {
-      singVals.r<T>(k) = k == 0 ? col0.t<T>(0) : diag.t<T>(k);
-      mus.r<T>(k) = (T)0;
-      shifts.r<T>(k) = k == 0 ? col0.t<T>(0) : diag.t<T>(k);
+      singVals.template r<T>(k) = k == 0 ? col0.t<T>(0) : diag.t<T>(k);
+      mus.template r<T>(k) = (T)0;
+      shifts.template r<T>(k) = k == 0 ? col0.t<T>(0) : diag.t<T>(k);
       continue;
     }
 
@@ -447,9 +447,9 @@ void SVD<T>::calcSingVals(const NDArray& col0, const NDArray& diag, const NDArra
       }
       muCur = (leftShifted + rightShifted) / (T)2.;
     }
-    singVals.r<T>(k) = shift + muCur;
-    shifts.r<T>(k) = shift;
-    mus.r<T>(k) = muCur;
+    singVals.template r<T>(k) = shift + muCur;
+    shifts.template r<T>(k) = shift;
+    mus.template r<T>(k) = muCur;
   }
 }
 
@@ -468,7 +468,7 @@ void SVD<T>::perturb(const NDArray& col0, const NDArray& diag, const NDArray& pe
 
   for (int k = 0; k < n; ++k) {
     if (col0.t<T>(k) == (T)0.f)
-      zhat.r<T>(k) = (T)0;
+      zhat.template r<T>(k) = (T)0;
     else {
       T dk = diag.t<T>(k);
       T prod = (singVals.t<T>(last) + dk) * (mus.t<T>(last) + (shifts.t<T>(last) - dk));
@@ -482,7 +482,7 @@ void SVD<T>::perturb(const NDArray& col0, const NDArray& diag, const NDArray& pe
         }
       }
       T tmp = math::sd_sqrt<T, T>(prod);
-      zhat.r<T>(k) = col0.t<T>(k) > (T)0 ? tmp : -tmp;
+      zhat.template r<T>(k) = col0.t<T>(k) > (T)0 ? tmp : -tmp;
     }
   }
 }
@@ -506,25 +506,25 @@ void SVD<T>::calcSingVecs(const NDArray& zhat, const NDArray& diag, const NDArra
     }
 
     if (zhat.t<T>(k) == (T)0.f) {
-      colU.r<T>(k) = (T)1;
+      colU.template r<T>(k) = (T)1;
 
-      if (_calcV) colV.r<T>(k) = (T)1;
+      if (_calcV) colV.template r<T>(k) = (T)1;
     } else {
       for (int l = 0; l < m; ++l) {
         int i = (int)perm.t<T>(l);
-        U.r<T>(i, k) =
+        U.template r<T>(i, k) =
             zhat.t<T>(i) / (((diag.t<T>(i) - shifts.t<T>(k)) - mus.t<T>(k))) / ((diag.t<T>(i) + singVals.t<T>(k)));
       }
-      U.r<T>(n, k) = (T)0;
+      U.template r<T>(n, k) = (T)0;
       colU /= colU.reduceNumber(reduce::Norm2);
 
       if (_calcV) {
         for (int l = 1; l < m; ++l) {
           int i = perm.t<T>(l);
-          V.r<T>(i, k) = diag.t<T>(i) * zhat.t<T>(i) / (((diag.t<T>(i) - shifts.t<T>(k)) - mus.t<T>(k))) /
+          V.template r<T>(i, k) = diag.t<T>(i) * zhat.t<T>(i) / (((diag.t<T>(i) - shifts.t<T>(k)) - mus.t<T>(k))) /
                          ((diag.t<T>(i) + singVals.t<T>(k)));
         }
-        V.r<T>(0, k) = (T)-1;
+        V.template r<T>(0, k) = (T)-1;
         colV /= colV.reduceNumber(reduce::Norm2);
       }
     }
@@ -532,7 +532,7 @@ void SVD<T>::calcSingVecs(const NDArray& zhat, const NDArray& diag, const NDArra
 
   NDArray colU = U({0, 0, n, n + 1});
   colU.nullify();
-  colU.r<T>(n) = (T)1;
+  colU.template r<T>(n) = (T)1;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -544,7 +544,7 @@ void SVD<T>::calcBlockSVD(int col1, int size, NDArray& U, NDArray& singVals, NDA
   auto col0 = _m({col1, end, col1, col1 + 1}, true);
   auto view = _m({col1, end, col1, end}, true);
   auto diag = view.diagonal('c');
-  diag.r<T>(0) = (T)0;
+  diag.template r<T>(0) = (T)0;
   singVals = NDArray(_m.ordering(), {size, 1}, _m.dataType(), _m.getContext());
   U = NDArray(_u.ordering(), {size + 1, size + 1}, _u.dataType(), _u.getContext());
   if (_calcV) V = NDArray(_v.ordering(), {size, size}, _v.dataType(), _v.getContext());
@@ -558,7 +558,7 @@ void SVD<T>::calcBlockSVD(int col1, int size, NDArray& U, NDArray& singVals, NDA
     if (math::sd_abs<T>(col0.template t<T>(k)) > almostZero) indices.push_back(k);
 
   NDArray permut(_m.ordering(), {(int)indices.size()}, _m.dataType(), _m.getContext());
-  for (int k = 0; k < indices.size(); ++k) permut.r<T>(k) = (T)indices[k];
+  for (int k = 0; k < indices.size(); ++k) permut.template r<T>(k) = (T)indices[k];
 
   NDArray shifts(_m.ordering(), {size, 1}, _m.dataType(), _m.getContext());
   NDArray mus(_m.ordering(), {size, 1}, _m.dataType(), _m.getContext());
@@ -570,7 +570,7 @@ void SVD<T>::calcBlockSVD(int col1, int size, NDArray& U, NDArray& singVals, NDA
 
   for (int i = 0; i < curSize - 1; ++i) {
     if (singVals.t<T>(i) > singVals.t<T>(i + 1)) {
-      math::sd_swap<T>(singVals.r<T>(i), singVals.r<T>(i + 1));
+      math::sd_swap<T>(singVals.template r<T>(i), singVals.template r<T>(i + 1));
 
       auto temp1 = U({0, 0, i, i + 1});
       auto temp2 = U({0, 0, i + 1, i + 2});
@@ -585,7 +585,7 @@ void SVD<T>::calcBlockSVD(int col1, int size, NDArray& U, NDArray& singVals, NDA
   }
 
   auto temp1 = singVals({0, curSize, 0, 0});
-  for (int e = 0; e < curSize / 2; ++e) math::sd_swap<T>(temp1.r<T>(e), temp1.r<T>(curSize - 1 - e));
+  for (int e = 0; e < curSize / 2; ++e) math::sd_swap<T>(temp1.template r<T>(e), temp1.template r<T>(curSize - 1 - e));
 
   auto temp2 = U({0, 0, 0, curSize}, true);
   for (int i = 0; i < curSize / 2; ++i) {
@@ -664,7 +664,7 @@ void SVD<T>::DivideAndConquer(int col1, int col2, int row1W, int col1W, int shif
   }
 
 
-  if (_calcV) _v.r<T>(row1W + k, col1W) = (T)1;
+  if (_calcV) _v.template r<T>(row1W + k, col1W) = (T)1;
 
   if (r0 < almostZero) {
     c0 = 1.;
@@ -691,18 +691,18 @@ void SVD<T>::DivideAndConquer(int col1, int col2, int row1W, int col1W, int shif
   } else {
     T q1 = _u.t<T>(0, col1 + k);
 
-    for (int i = col1 + k - 1; i >= col1; --i) _u.r<T>(0, i + 1) = _u.r<T>(0, i);
+    for (int i = col1 + k - 1; i >= col1; --i) _u.template r<T>(0, i + 1) = _u.template r<T>(0, i);
 
-    _u.r<T>(0, col1) = q1 * c0;
-    _u.r<T>(0, col2 + 1) = -q1 * s0;
-    _u.r<T>(1, col1) = _u.t<T>(1, col2 + 1) * s0;
-    _u.r<T>(1, col2 + 1) = _u.t<T>(1, col2 + 1) * c0;
+    _u.template r<T>(0, col1) = q1 * c0;
+    _u.template r<T>(0, col2 + 1) = -q1 * s0;
+    _u.template r<T>(1, col1) = _u.t<T>(1, col2 + 1) * s0;
+    _u.template r<T>(1, col2 + 1) = _u.t<T>(1, col2 + 1) * c0;
     _u({1, 2, col1 + 1, col1 + k + 1}).nullify();
     _u({0, 1, col1 + k + 1, col1 + n}).nullify();
   }
 
 
-  _m.r<T>(col1 + shift, col1 + shift) = r0;
+  _m.template r<T>(col1 + shift, col1 + shift) = r0;
 
   _m({col1 + shift + 1, col1 + shift + k + 1, col1 + shift, col1 + shift + 1}, true).assign(l * alphaK);
   _m({col1 + shift + k + 1, col1 + shift + n, col1 + shift, col1 + shift + 1}, true).assign(f * betaK);
@@ -788,7 +788,7 @@ void SVD<T>::evalData(const NDArray& matrix) {
 
   for (int i = 0; i < _diagSize; ++i) {
     T a = math::sd_abs<T>(_m.t<T>(i, i));
-    _s.r<T>(i) = a * scale;
+    _s.template r<T>(i) = a * scale;
     if (a < almostZero) {
       _s({i + 1, _diagSize, 0, 0}).nullify();
       break;

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -1723,7 +1723,7 @@ sd::ShapeList *_calculateOutputShapes(sd::Pointer *extraPointers, sd::ops::Decla
       throw std::runtime_error("Input shape was null!");
     }
 
-    if(shape_ != nullptr && shape_[0] > SD_MAX_RANK || shape_[0] < 0) {
+    if((shape_ != nullptr && shape_[0] > SD_MAX_RANK) || shape_[0] < 0) {
       throw std::runtime_error("Input shape rank is invalid. Either > 32 or < 0. Likely corrupt. Please check your input shapes.");
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes LLVM related build errors. A template prefix is needed in order to use the  field declarations + <T>.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
