### PR TITLE
More memory pressure  deallocation changes

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/ElementsLearningAlgorithm.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/ElementsLearningAlgorithm.java
@@ -28,10 +28,7 @@ import org.deeplearning4j.models.sequencevectors.sequence.Sequence;
 import org.deeplearning4j.models.sequencevectors.sequence.SequenceElement;
 import org.deeplearning4j.models.word2vec.wordstore.VocabCache;
 import org.nd4j.linalg.api.memory.conf.WorkspaceConfiguration;
-import org.nd4j.linalg.api.memory.enums.AllocationPolicy;
-import org.nd4j.linalg.api.memory.enums.LearningPolicy;
-import org.nd4j.linalg.api.memory.enums.ResetPolicy;
-import org.nd4j.linalg.api.memory.enums.SpillPolicy;
+import org.nd4j.linalg.api.memory.enums.*;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -39,14 +36,13 @@ import java.util.concurrent.atomic.AtomicLong;
 public interface ElementsLearningAlgorithm<T extends SequenceElement> {
     default WorkspaceConfiguration workspaceConfig() {
        return  WorkspaceConfiguration.builder()
-                .initialSize(0)
-                .overallocationLimit(0.02)
-                .policyLearning(LearningPolicy.OVER_TIME)
-                .cyclesBeforeInitialization(2)
-                .policyReset(ResetPolicy.BLOCK_LEFT)
-                .policySpill(SpillPolicy.REALLOCATE)
-                .policyAllocation(AllocationPolicy.OVERALLOCATE)
-                .build();
+               .policyAllocation(AllocationPolicy.STRICT)
+               .maxSize(3000)
+               .minSize(1000)
+               .policyReset(ResetPolicy.BLOCK_LEFT)
+               .policySpill(SpillPolicy.EXTERNAL)
+               .initialSize(1000)
+               .build();
     }
 
     String getCodeName();

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
@@ -293,6 +293,10 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
 
 
                 Nd4j.getExecutioner().exec(cbow);
+
+
+                Nd4j.close(currentWindowIndexes,inputWindowWords,alphas,randoms,codes,numLabelsArray,indices);
+
                 batches.get().clear();
                 return 0.0;
             } else {

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
@@ -385,6 +385,7 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
                 Nd4j.getExecutioner().exec(sg);
                 items.clear();
 
+                Nd4j.close(targetArray,codes,indices,alphasArray,ngStarterArray,randomValuesArr);
 
             } else {
                 int cnt = 0;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/sequence/DBOW.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/sequence/DBOW.java
@@ -217,6 +217,7 @@ public class DBOW<T extends SequenceElement> implements SequenceLearningAlgorith
         if(configuration.getWorkers() > 1) {
             Nd4j.getEnvironment().setMaxThreads(1);
         }
+
         Random random = Nd4j.getRandomFactory().getNewRandomInstance(configuration.getSeed() * sequence.hashCode(),
                 lookupTable.layerSize() + 1);
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -1814,8 +1814,6 @@ public abstract class BaseDataBuffer implements DataBuffer {
         deallocator().setConstant(reallyConstant);
         if(EventLogger.getInstance().isEnabled())
             deallocator().logEvent().setConstant(reallyConstant);
-        if(reallyConstant)
-            Nd4j.getDeallocatorService().getReferenceMap().remove(getUniqueId());
 
         this.constant = reallyConstant;
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatableReference.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatableReference.java
@@ -24,11 +24,12 @@ import lombok.Data;
 import org.nd4j.linalg.api.memory.Deallocatable;
 import org.nd4j.linalg.api.memory.Deallocator;
 
+import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 
 @Data
-public class DeallocatableReference extends WeakReference<Deallocatable> {
+public class DeallocatableReference extends PhantomReference<Deallocatable> {
     private long id;
     private Deallocator deallocator;
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/memory/deallocation/DeallocatorService.java
@@ -31,10 +31,7 @@ import org.nd4j.linalg.api.memory.Deallocatable;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.lang.ref.ReferenceQueue;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -83,7 +80,7 @@ public class DeallocatorService {
     //for the amount of memory overhead it has. String compression
     //with a large number of objects is more important over throughput.
     @Getter
-    private Map<Long,DeallocatableReference> referenceMap = new ConcurrentSkipListMap<>();
+    private Map<Deallocatable,DeallocatableReference> referenceMap = Collections.synchronizedMap(new WeakHashMap<>());
 
     private static AtomicBoolean blockDeallocator = new AtomicBoolean(false);
 
@@ -148,7 +145,7 @@ public class DeallocatorService {
             val reference = new DeallocatableReference(deallocatable, map.get(RandomUtils.nextInt(0, map.size())));
             if(referenceMap.containsKey(deallocatable.getUniqueId()))
                 throw new IllegalArgumentException("Duplicate deallocatable key found!");
-            referenceMap.put(deallocatable.getUniqueId(), reference);
+            referenceMap.put(deallocatable, reference);
             return deallocatable.getUniqueId();
         }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -5642,7 +5642,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         if (!closeable())
             throw new ND4JIllegalStateException("Can't release this INDArray");
 
-        data.close();
+        //data.close();
 
         released = true;
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2367,6 +2367,22 @@ public class Nd4j {
         stream.close();
     }
 
+
+    /**
+     * Close the passed in ndarrays.
+     * @param close
+     */
+    public static void close(INDArray...close) {
+        for(INDArray arr : close) {
+            if(arr == null)
+                continue;
+
+            if(arr.closeable() && !arr.data().wasClosed()) {
+                arr.close();
+            }
+        }
+    }
+
     /**
      * Convert an ndarray to a byte array
      * @param arr the array to convert

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/buffer/BaseCpuDataBuffer.java
@@ -874,8 +874,6 @@ public abstract class BaseCpuDataBuffer extends BaseDataBuffer implements Deallo
     @Override
     protected void release() {
         ptrDataBuffer.closeBuffer();
-        Nd4j.getDeallocatorService().getReferenceMap().remove(getUniqueId());
-        deallocator().deallocate();
         super.release();
     }
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
@@ -63,8 +63,6 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
     @Override
     public void close() {
         // no-op
-        Nd4j.getDeallocatorService().getReferenceMap().remove(deallocationId);
-        deallocator().deallocate();
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
@@ -64,6 +64,7 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
     public void close() {
         // no-op
         Nd4j.getDeallocatorService().getReferenceMap().remove(deallocationId);
+        deallocator().deallocate();
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContext.java
@@ -62,7 +62,6 @@ public class CudaOpContext extends BaseOpContext implements OpContext, Deallocat
 
     @Override
     public void close() {
-        Nd4j.getDeallocatorService().getReferenceMap().remove(this.deallocationId);
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Substantially increases performance for deallocation of arrays.
Before this, deallocator service was too slow to deallocate
references. This was due to the JVM holding references to 
out of scope objects longer than it needed to.

Adds Nd4j.close(...) method to allow closing ndarrays easier.
Adds Nd4j.close(..) to skipgram
Migrate reference map to be  a weak hashmap
Migrate deallocatable reference to be a phantom reference than a weak refere
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ ]X Relevant tests for your changes are passing.
