### PR TITLE
Fixes 9931

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/PCA.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dimensionalityreduction/PCA.java
@@ -196,6 +196,11 @@ public class PCA {
             factor.putColumn(i, V.getColumn(i));
         }
 
+        //difference from cuda vs cpu backends
+        //see: https://github.com/deeplearning4j/deeplearning4j/issues/9931
+        if(Nd4j.getEnvironment().isCPU())
+            return factor.transpose();
+
         return factor;
     }
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/blas/BlasTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/blas/BlasTests.java
@@ -32,6 +32,7 @@ import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.linalg.BaseNd4jTestWithBackends;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dimensionalityreduction.PCA;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 
@@ -43,6 +44,30 @@ import static org.junit.jupiter.api.Assertions.*;
 @Slf4j
 @NativeTag
 public class BlasTests extends BaseNd4jTestWithBackends {
+
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void pcaTest(Nd4jBackend backend) {
+        double[][] inputArray = { { 1.0, 2.0, 3.0 }, { 11.0, 12.0, 13.0 }, { 21.0, 22.0, 23.0 }, { 31.0, 32.0, 33.0 } };
+        INDArray inputMatrix = Nd4j.create( inputArray );
+        int nColumns = inputMatrix.columns();
+        System.out.println();
+        System.out.println( "Test results for backend: " + Nd4j.backend.toString() );
+        System.out.println();
+        System.out.println( "inputMatrix before PCA.pca_factor call:" );
+        System.out.println( inputMatrix.toString() );
+        System.out.println();
+        INDArray factor = PCA.pca_factor( inputMatrix, nColumns, false );
+        System.out.println( "inputMatrix after PCA.pca_factor call:" );
+        System.out.println( inputMatrix.toString() );
+        System.out.println();
+        System.out.println( "factor matrix as returned by PCA.pca_factor call:" );
+        System.out.println( factor.toString() );
+        System.out.println();
+        System.out.println( "Current Backend: " + Nd4j.backend.toString() );
+
+    }
 
 
     @ParameterizedTest

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/blas/BlasTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/blas/BlasTests.java
@@ -50,6 +50,12 @@ public class BlasTests extends BaseNd4jTestWithBackends {
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void pcaTest(Nd4jBackend backend) {
         double[][] inputArray = { { 1.0, 2.0, 3.0 }, { 11.0, 12.0, 13.0 }, { 21.0, 22.0, 23.0 }, { 31.0, 32.0, 33.0 } };
+        double[][] assertion = new double[][]{
+                {-0.55332, -0.72606, 0.40825},
+                {      -0.57703 ,-0.01936 ,-0.81650},
+                {-0.60073, 0.68735, 0.40825 }
+        };
+        INDArray assertArr = Nd4j.create(assertion);
         INDArray inputMatrix = Nd4j.create( inputArray );
         int nColumns = inputMatrix.columns();
         System.out.println();
@@ -59,6 +65,7 @@ public class BlasTests extends BaseNd4jTestWithBackends {
         System.out.println( inputMatrix.toString() );
         System.out.println();
         INDArray factor = PCA.pca_factor( inputMatrix, nColumns, false );
+        assertEquals(assertArr,factor);
         System.out.println( "inputMatrix after PCA.pca_factor call:" );
         System.out.println( inputMatrix.toString() );
         System.out.println();

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/blas/BlasTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/blas/BlasTests.java
@@ -58,21 +58,9 @@ public class BlasTests extends BaseNd4jTestWithBackends {
         INDArray assertArr = Nd4j.create(assertion);
         INDArray inputMatrix = Nd4j.create( inputArray );
         int nColumns = inputMatrix.columns();
-        System.out.println();
-        System.out.println( "Test results for backend: " + Nd4j.backend.toString() );
-        System.out.println();
-        System.out.println( "inputMatrix before PCA.pca_factor call:" );
-        System.out.println( inputMatrix.toString() );
-        System.out.println();
         INDArray factor = PCA.pca_factor( inputMatrix, nColumns, false );
         assertEquals(assertArr,factor);
-        System.out.println( "inputMatrix after PCA.pca_factor call:" );
-        System.out.println( inputMatrix.toString() );
-        System.out.println();
-        System.out.println( "factor matrix as returned by PCA.pca_factor call:" );
-        System.out.println( factor.toString() );
-        System.out.println();
-        System.out.println( "Current Backend: " + Nd4j.backend.toString() );
+
 
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixes #9931 

Transposes output result to handle difference between cpu and gpu lapack implementations.


(Please fill in changes proposed in this fix)

## How was this patch tested?

Add new test case from issue
## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
