### PR TITLE
Fix training performance with skipgram/dbow by introducing cache for commonly allocated arrays

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
@@ -222,15 +222,6 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
                         maxWinWordsCols = curr;
                 }
 
-            /*    INDArray inputWindowWords = Nd4j.createUninitializedDetached(DataType.INT32, items.size(), maxWinWordsCols);
-                INDArray inputWordsStatuses = Nd4j.createUninitializedDetached(DataType.INT32, items.size(), maxWinWordsCols);
-                INDArray randoms = Nd4j.createUninitializedDetached(DataType.INT64, items.size());
-                INDArray alphas = Nd4j.createUninitializedDetached(DataType.DOUBLE, items.size());
-                INDArray currentWindowIndexes = Nd4j.createUninitializedDetached(DataType.INT32, items.size());
-                INDArray codes = Nd4j.createUninitializedDetached(DataType.INT8, items.size(), maxCols);
-                INDArray indices = Nd4j.createUninitializedDetached(DataType.INT32, items.size(), maxCols);
-                INDArray numLabelsArray = Nd4j.createUninitializedDetached(DataType.INT32, items.size());
-*/
 
 
 

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
@@ -20,9 +20,7 @@
 
 package org.deeplearning4j.models.embeddings.learning.impl.elements;
 
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
+import lombok.*;
 import org.apache.commons.lang3.RandomUtils;
 import org.deeplearning4j.models.embeddings.WeightLookupTable;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
@@ -39,11 +37,15 @@ import org.nd4j.linalg.api.ops.impl.nlp.CbowInference;
 import org.nd4j.linalg.api.ops.impl.nlp.CbowRound;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.DeviceLocalNDArray;
+import org.nd4j.shade.guava.cache.Cache;
+import org.nd4j.shade.guava.cache.CacheBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorithm<T> {
@@ -60,6 +62,7 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
     protected double sampling;
     protected int[] variableWindows;
     protected int workers = Runtime.getRuntime().availableProcessors();
+    private Cache<IterationArraysKey, Queue<IterationArrays>> iterationArrays = CacheBuilder.newBuilder().build();
 
     public int getWorkers() {
         return workers;
@@ -186,7 +189,14 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
         return false;
     }
 
-
+    @Data
+    @AllArgsConstructor
+    @Builder
+    @NoArgsConstructor
+    public static class IterationArraysKey {
+        private int itemSize;
+        private int maxCols;
+    }
 
 
     public double doExec(List<BatchItem<T>> items, INDArray inferenceVector) {
@@ -212,7 +222,7 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
                         maxWinWordsCols = curr;
                 }
 
-                INDArray inputWindowWords = Nd4j.createUninitializedDetached(DataType.INT32, items.size(), maxWinWordsCols);
+            /*    INDArray inputWindowWords = Nd4j.createUninitializedDetached(DataType.INT32, items.size(), maxWinWordsCols);
                 INDArray inputWordsStatuses = Nd4j.createUninitializedDetached(DataType.INT32, items.size(), maxWinWordsCols);
                 INDArray randoms = Nd4j.createUninitializedDetached(DataType.INT64, items.size());
                 INDArray alphas = Nd4j.createUninitializedDetached(DataType.DOUBLE, items.size());
@@ -220,30 +230,73 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
                 INDArray codes = Nd4j.createUninitializedDetached(DataType.INT8, items.size(), maxCols);
                 INDArray indices = Nd4j.createUninitializedDetached(DataType.INT32, items.size(), maxCols);
                 INDArray numLabelsArray = Nd4j.createUninitializedDetached(DataType.INT32, items.size());
+*/
+
+
+
+
+                INDArray inputWindowWords;
+                INDArray inputWordsStatuses;
+                INDArray randoms;
+                INDArray alphas;
+                INDArray currentWindowIndexes;
+                INDArray codes;
+                INDArray indices;
+                INDArray numLabelsArray;
+
+
+                IterationArraysKey key = IterationArraysKey.builder()
+                        .itemSize(items.size())
+                        .maxCols(maxCols).build();
+                Queue<IterationArrays> iterationArraysQueue = iterationArrays.getIfPresent(key);
+                IterationArrays iterationArrays1;
+                if(iterationArraysQueue == null) {
+                    iterationArraysQueue = new ConcurrentLinkedQueue<>();
+                    iterationArrays.put(key,iterationArraysQueue);
+                    iterationArrays1 = new IterationArrays(items.size(),maxCols);
+                } else {
+                    if(iterationArraysQueue.isEmpty()) {
+                        iterationArrays1 = new IterationArrays(items.size(),maxCols);
+
+                    }else {
+                        iterationArrays1 = iterationArraysQueue.remove();
+                        iterationArrays1.initCodes();
+                    }
+                }
+
+                int[][] inputWindowWordsArr = iterationArrays1.inputWindowWordsArr;
+                int[][] inputWindowWordStatuses = iterationArrays1.inputWindowWordStatuses;
+                int[]  currentWindowIndexesArr = iterationArrays1.currentWindowIndexes;
+                double[] alphasArr = iterationArrays1.alphas;
+                int[][] indicesArr = iterationArrays1.indicesArr;
+                int[][]  codesArr = iterationArrays1.codesArr;
+                long[] randomValues = iterationArrays1.randomValues;
+                int[] numLabelsArr = iterationArrays1.numLabels;
+                currentWindowIndexes = Nd4j.createFromArray(currentWindowIndexesArr);
 
                 for (int cnt = 0; cnt < items.size(); cnt++) {
                     T currentWord = items.get(cnt).getWord();
                     currentWindowIndexes.putScalar(0, currentWord.getIndex());
-
+                    currentWindowIndexesArr[0] = currentWord.getIndex();
                     int[] windowWords = items.get(cnt).getWindowWords().clone();
                     boolean[] windowStatuses = items.get(cnt).getWordStatuses().clone();
 
                     for (int i = 0; i < maxWinWordsCols; i++) {
                         if (i < windowWords.length) {
-                            inputWindowWords.putScalar(cnt, i, windowWords[i]);
-                            inputWordsStatuses.putScalar(cnt, i, windowStatuses[i] ? 1 : 0);
+                            inputWindowWordsArr[cnt][i] = windowWords[i];
+                            inputWindowWordStatuses[cnt][i] = windowStatuses[i] ? 1 : 0;
+
                         } else {
-                            inputWindowWords.putScalar(cnt, i, -1);
-                            inputWordsStatuses.putScalar(cnt, i, -1);
+                            inputWindowWordsArr[cnt][i] = -1;
+                            inputWindowWordStatuses[cnt][i] = -1;
                         }
                     }
 
                     long randomValue = items.get(cnt).getRandomValue();
                     double alpha = items.get(cnt).getAlpha();
-                    alphas.putScalar(cnt, alpha);
-
-                    randoms.putScalar(cnt, randomValue);
-                    numLabelsArray.putScalar(cnt, items.get(cnt).getNumLabel());
+                    alphasArr[cnt] = alpha;
+                    randomValues[cnt] = randomValue;
+                    numLabelsArr[cnt] = items.get(cnt).getNumLabel();
                     if (items.get(cnt).getNumLabel() > 0)
                         hasNumLabels = true;
 
@@ -253,8 +306,8 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
                                 continue;
 
 
-                            codes.putScalar(cnt, p, currentWord.getCodes().get(p));
-                            indices.putScalar(cnt, p, currentWord.getPoints().get(p));
+                            codesArr[cnt][p] = currentWord.getCodes().get(p);
+                            indicesArr[cnt][p] =  currentWord.getPoints().get(p);
                         }
 
                     }
@@ -269,6 +322,13 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
                 }
 
 
+                inputWindowWords = Nd4j.createFromArray(inputWindowWordsArr);
+                inputWordsStatuses = Nd4j.createFromArray(inputWindowWordStatuses);
+                numLabelsArray = Nd4j.createFromArray(numLabelsArr);
+                indices = Nd4j.createFromArray(indicesArr);
+                codes = Nd4j.createFromArray(codesArr);
+                alphas = Nd4j.createFromArray(alphasArr);
+                randoms = Nd4j.createFromArray(randomValues);
                 CbowRound cbow = CbowRound.builder()
                         .target(currentWindowIndexes)
                         .context(inputWindowWords)
@@ -296,6 +356,7 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
 
 
                 Nd4j.close(currentWindowIndexes,inputWindowWords,alphas,randoms,codes,numLabelsArray,indices);
+                iterationArraysQueue.add(iterationArrays1);
 
                 batches.get().clear();
                 return 0.0;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/IterationArrays.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/IterationArrays.java
@@ -1,0 +1,73 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.deeplearning4j.models.embeddings.learning.impl.elements;
+
+import lombok.Data;
+
+@Data
+public class IterationArrays {
+    private int itemSize;
+    private int maxCols;
+    private int maxWinWordsCols;
+    int[][] indicesArr;
+    int[][] codesArr;
+    long[] randomValues;
+    int[] ngStarters;
+    double[] alphas;
+    int[] targets;
+    int[][] inputWindowWordsArr;
+    int[][] inputWindowWordStatuses;
+    int[] currentWindowIndexes;
+    int[] numLabels;
+
+    public IterationArrays(int itemSize, int maxCols,int maxWinWordsCols) {
+        this.maxWinWordsCols = maxWinWordsCols;
+        this.itemSize = itemSize;
+        this.maxCols = maxCols;
+        indicesArr = new int[itemSize][maxCols];
+        codesArr = new int[itemSize][maxCols];
+        currentWindowIndexes = new int[itemSize];
+        inputWindowWordsArr = new int[itemSize][maxWinWordsCols];
+        inputWindowWordStatuses = new int[itemSize][maxWinWordsCols];
+        randomValues = new long[itemSize];
+        ngStarters = new int[itemSize];
+        alphas = new double[itemSize];
+        targets = new int[itemSize];
+        numLabels = new int[itemSize];
+        initCodes();
+    }
+
+    public IterationArrays(int itemSize, int maxCols) {
+        this(itemSize,maxCols,0);
+    }
+
+    /**
+     * USed to initialize codes to the -1 default value.
+     * This method should be called when reusing an iteration arrays object.
+     */
+    public void initCodes() {
+        for (int i = 0; i < codesArr.length; i++) {
+            for (int j = 0; j < codesArr[0].length; j++) {
+                codesArr[i][j] = -1;
+            }
+        }
+    }
+
+}

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/IterationArraysKey.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/IterationArraysKey.java
@@ -1,0 +1,34 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+package org.deeplearning4j.models.embeddings.learning.impl.elements;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class IterationArraysKey {
+    private int itemSize;
+    private int maxCols;
+}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/BaseDataBuffer.java
@@ -33,7 +33,6 @@ import org.nd4j.common.primitives.Triple;
 import org.nd4j.common.util.ArrayUtil;
 import org.nd4j.linalg.api.memory.Deallocator;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
-import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.profiler.data.eventlogger.EventLogger;
 import org.nd4j.nativeblas.NativeOpsHolder;
 import org.nd4j.nativeblas.OpaqueDataBuffer;
@@ -353,51 +352,38 @@ public abstract class BaseDataBuffer implements DataBuffer {
 
     @Override
     public void setData(int[] data) {
-        for (int i = 0; i < data.length; i++) {
-            put(i, data[i]);
-        }
+        put(data);
     }
 
     @Override
     public void setData(float[] data) {
-        for (int i = 0; i < data.length; i++) {
-            put(i, data[i]);
-        }
+        put(data);
     }
 
     @Override
     public void setData(double[] data) {
-        for (int i = 0; i < data.length; i++) {
-            put(i, data[i]);
-        }
+        put(data);
     }
 
     @Override
     public void setData(long[] data) {
-        for (int i = 0; i < data.length; i++) {
-            put(i, data[i]);
-        }
+        put(data);
     }
 
     @Override
     public void setData(byte[] data) {
-        for (int i = 0; i < data.length; i++) {
-            put(i, data[i]);
-        }
+        put(data);
     }
 
     @Override
     public void setData(short[] data) {
-        for (int i = 0; i < data.length; i++) {
-            put(i, data[i]);
-        }
+        put(data);
     }
+
 
     @Override
     public void setData(boolean[] data) {
-        for (int i = 0; i < data.length; i++) {
-            put(i, data[i]);
-        }
+        put(data);
     }
 
     @Override
@@ -1199,7 +1185,7 @@ public abstract class BaseDataBuffer implements DataBuffer {
     }
 
     @Override
-    public void put(long i, long element) {
+    public void put(long i,long element) {
         if (released)
             throw new IllegalStateException("You can't use DataBuffer once it was released");
 
@@ -1247,6 +1233,352 @@ public abstract class BaseDataBuffer implements DataBuffer {
                 throw new UnsupportedOperationException("Unsupported data type: " + dataType());
         }
     }
+
+    @Override
+    public void put(float[] element) {
+        if (released)
+            throw new IllegalStateException("You can't use DataBuffer once it was released");
+
+        switch (dataType()) {
+            case BOOL:
+
+                ((BooleanIndexer) indexer).put(0,ArrayUtil.fromFloat(element));
+                break;
+            case BYTE:
+                ((ByteIndexer) indexer).put(0,ArrayUtil.toBytes(element));
+                break;
+            case UBYTE:
+                ((UByteIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT16:
+                ((UShortIndexer) indexer).put(0,ArrayUtil.toInts(element));
+                break;
+            case SHORT:
+                ((ShortIndexer) indexer).put(0,ArrayUtil.toShorts(element));
+                break;
+            case UINT32:
+                ((UIntIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case INT:
+                ((IntIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT64:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongs(element));
+                break;
+            case LONG:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongs(element));
+                break;
+            case BFLOAT16:
+                ((Bfloat16Indexer) indexer).put(0,element);
+                break;
+            case HALF:
+                ((HalfIndexer) indexer).put(0,element);
+                break;
+            case FLOAT:
+                ((FloatIndexer) indexer).put(0,element);
+                break;
+            case DOUBLE:
+                ((DoubleIndexer) indexer).put(0,ArrayUtil.toDoubleArray(element));
+                break;
+            default:
+                throw new IllegalStateException("Unsupported type: " + dataType());
+        }
+    }
+
+    @Override
+    public void put(double[] element) {
+        if (released)
+            throw new IllegalStateException("You can't use DataBuffer once it was released");
+
+        switch (dataType()) {
+            case BOOL:
+                ((BooleanIndexer) indexer).put(0,ArrayUtil.toBooleanArray(element));
+                break;
+            case BYTE:
+                ((ByteIndexer) indexer).put(0,ArrayUtil.toBytes(element));
+                break;
+            case UBYTE:
+                ((UByteIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT16:
+                ((UShortIndexer) indexer).put(0,ArrayUtil.toInts(element));
+                break;
+            case SHORT:
+                ((ShortIndexer) indexer).put(0,ArrayUtil.toShorts(element));
+                break;
+            case UINT32:
+                ((UIntIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case INT:
+                ((IntIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT64:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case LONG:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case BFLOAT16:
+                ((Bfloat16Indexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case HALF:
+                ((HalfIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case FLOAT:
+                ((FloatIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case DOUBLE:
+                ((DoubleIndexer) indexer).put(0,ArrayUtil.toDoubleArray(element));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + dataType());
+        }
+    }
+
+    @Override
+    public void put(int[] element) {
+        if (released)
+            throw new IllegalStateException("You can't use DataBuffer once it was released");
+
+        switch (dataType()) {
+            case BOOL:
+                ((BooleanIndexer) indexer).put(0,ArrayUtil.toBooleanArray(element));
+                break;
+            case BYTE:
+                ((ByteIndexer) indexer).put(0,ArrayUtil.toBytes(element));
+                break;
+            case UBYTE:
+                ((UByteIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT16:
+                ((UShortIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case SHORT:
+                ((ShortIndexer) indexer).put(0,ArrayUtil.toShorts(element));
+                break;
+            case UINT32:
+                ((UIntIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case INT:
+                ((IntIndexer) indexer).put(0, element);
+                break;
+            case UINT64: //Fall through
+            case LONG:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case BFLOAT16:
+                ((Bfloat16Indexer) indexer).put(0, ArrayUtil.toFloatArray(element));
+                break;
+            case HALF:
+                ((HalfIndexer) indexer).put(0, ArrayUtil.toFloatArray(element));
+                break;
+            case FLOAT:
+                ((FloatIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case DOUBLE:
+                ((DoubleIndexer) indexer).put(0,ArrayUtil.toDouble(element));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + dataType());
+        }
+    }
+
+    @Override
+    public void put(boolean[] element) {
+        if (released)
+            throw new IllegalStateException("You can't use DataBuffer once it was released");
+
+        switch (dataType()) {
+            case BOOL:
+                ((BooleanIndexer) indexer).put(0, element);
+                break;
+            case BYTE:
+                ((ByteIndexer) indexer).put(0,ArrayUtil.toBytes(element));
+                break;
+            case UBYTE:
+                ((UByteIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT16:
+                ((UShortIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case SHORT:
+                ((ShortIndexer) indexer).put(0,ArrayUtil.toShorts(element));
+                break;
+            case UINT32:
+                ((UIntIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case INT:
+                ((IntIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT64:
+            case LONG:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case BFLOAT16:
+                ((Bfloat16Indexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case HALF:
+                ((HalfIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case FLOAT:
+                ((FloatIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case DOUBLE:
+                ((DoubleIndexer) indexer).put(0,ArrayUtil.toDoubleArray(element));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + dataType());
+        }
+    }
+
+
+    @Override
+    public void put(short[] element) {
+        if (released)
+            throw new IllegalStateException("You can't use DataBuffer once it was released");
+
+        switch (dataType()) {
+            case BOOL:
+                ((BooleanIndexer) indexer).put(0, ArrayUtil.toBooleanArray(element));
+                break;
+            case BYTE:
+                ((ByteIndexer) indexer).put(0,ArrayUtil.toBytes(element));
+                break;
+            case UBYTE:
+                ((UByteIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT16:
+                ((UShortIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case SHORT:
+                ((ShortIndexer) indexer).put(0,element);
+                break;
+            case UINT32:
+                ((UIntIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case INT:
+                ((IntIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT64:
+            case LONG:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case BFLOAT16:
+                ((Bfloat16Indexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case HALF:
+                ((HalfIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case FLOAT:
+                ((FloatIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case DOUBLE:
+                ((DoubleIndexer) indexer).put(0,ArrayUtil.toDoubleArray(element));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + dataType());
+        }
+    }
+
+
+    @Override
+    public void put(byte[] element) {
+        if (released)
+            throw new IllegalStateException("You can't use DataBuffer once it was released");
+
+        switch (dataType()) {
+            case BOOL:
+                ((BooleanIndexer) indexer).put(0, ArrayUtil.toBooleanArray(element));
+                break;
+            case BYTE:
+                ((ByteIndexer) indexer).put(0,element);
+                break;
+            case UBYTE:
+                ((UByteIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT16:
+                ((UShortIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case SHORT:
+                ((ShortIndexer) indexer).put(0,ArrayUtil.toShorts(element));
+                break;
+            case UINT32:
+                ((UIntIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case INT:
+                ((IntIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT64:
+            case LONG:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case BFLOAT16:
+                ((Bfloat16Indexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case HALF:
+                ((HalfIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case FLOAT:
+                ((FloatIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case DOUBLE:
+                ((DoubleIndexer) indexer).put(0,ArrayUtil.toDoubleArray(element));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + dataType());
+        }
+    }
+
+    @Override
+    public void put(long[] element) {
+        if (released)
+            throw new IllegalStateException("You can't use DataBuffer once it was released");
+
+        switch (dataType()) {
+            case BOOL:
+                ((BooleanIndexer) indexer).put(0,ArrayUtil.toBooleanArray(element));
+                break;
+            case BYTE:
+                ((ByteIndexer) indexer).put(0,ArrayUtil.toByteArray(element));
+                break;
+            case UBYTE:
+                ((UByteIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT16:
+                ((UShortIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case SHORT:
+                ((ShortIndexer) indexer).put(0,ArrayUtil.toShorts(element));
+                break;
+            case UINT32:
+                ((UIntIndexer) indexer).put(0,element);
+                break;
+            case INT:
+                ((IntIndexer) indexer).put(0,ArrayUtil.toIntArray(element));
+                break;
+            case UINT64:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case LONG:
+                ((LongIndexer) indexer).put(0,ArrayUtil.toLongArray(element));
+                break;
+            case BFLOAT16:
+                ((Bfloat16Indexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case HALF:
+                ((HalfIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case FLOAT:
+                ((FloatIndexer) indexer).put(0,ArrayUtil.toFloatArray(element));
+                break;
+            case DOUBLE:
+                ((DoubleIndexer) indexer).put(0,ArrayUtil.toDoubles(element));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported data type: " + dataType());
+        }
+    }
+
 
     @Override
     @Deprecated

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/buffer/DataBuffer.java
@@ -146,6 +146,20 @@ public interface DataBuffer extends Serializable, AutoCloseable, Deallocatable {
      */
     ByteBuffer asNio();
 
+    void put(float[] element);
+
+    void put(double[] element);
+
+    void put(int[] element);
+
+    void put(boolean[] element);
+
+    void put(short[] element);
+
+    void put(byte[] element);
+
+    void put(long[] element);
+
     /**
      * Whether the buffer is dirty:
      * aka has been updated

--- a/nd4j/nd4j-common/src/main/java/org/nd4j/common/util/ArrayUtil.java
+++ b/nd4j/nd4j-common/src/main/java/org/nd4j/common/util/ArrayUtil.java
@@ -43,6 +43,494 @@ public class ArrayUtil {
 
 
     /**
+     * Converts a byte array to a boolean array.
+     * @param input the input byte array
+     * @return a boolean array with true values for nonzero bytes and false values for zero bytes
+     */
+    public static boolean[] toBooleanArray(byte[] input) {
+        boolean[] output = new boolean[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] != 0;
+        }
+        return output;
+    }
+
+    /**
+     * Converts a short array to a boolean array.
+     * @param input the input short array
+     * @return a boolean array with true values for nonzero shorts and false values for zero shorts
+     */
+    public static boolean[] toBooleanArray(short[] input) {
+        boolean[] output = new boolean[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] != 0;
+        }
+        return output;
+    }
+
+    /**
+     * Converts an int array to a boolean array.
+     * @param input the input int array
+     * @return a boolean array with true values for nonzero integers and false values for zero integers
+     */
+    public static boolean[] toBooleanArray(int[] input) {
+        boolean[] output = new boolean[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] != 0;
+        }
+        return output;
+    }
+
+    /**
+     * Converts a long array to a boolean array.
+     * @param input the input long array
+     * @return a boolean array with true values for nonzero longs and false values for zero longs
+     */
+    public static boolean[] toBooleanArray(long[] input) {
+        boolean[] output = new boolean[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] != 0L;
+        }
+        return output;
+    }
+
+    /**
+     * Converts a float array to a boolean array.
+     * @param input the input float array
+     * @return a boolean array with true values for nonzero floats and false values for zero floats
+     */
+    public static boolean[] toBooleanArray(float[] input) {
+        boolean[] output = new boolean[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] != 0.0f;
+        }
+        return output;
+    }
+
+    /**
+     * Converts a double array to a boolean array.
+     * @param input the input double array
+     * @return a boolean array with true values for nonzero doubles and false values for zero doubles
+     */
+    public static boolean[] toBooleanArray(double[] input) {
+        boolean[] output = new boolean[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] != 0.0;
+        }
+        return output;
+    }
+
+
+    /**
+     * Create a boolean array from a float array.
+     * @param elements the elements to create
+     * @return the returned float array
+     */
+    public static boolean[] fromFloat(float[] elements) {
+        boolean[] ret = new boolean[elements.length];
+        for(int i = 0; i < elements.length; i++) {
+            ret[i] = elements[i] == 0.0f ? false : true;
+        }
+
+        return ret;
+    }
+
+    /**
+     * Generate an array with n elements of the same specified value.
+     * @param element the element to create n copies of
+     * @param n the number of elements
+     * @return the created array
+     */
+    public static boolean[] nTimes(boolean element,int n) {
+        boolean[] ret = new boolean[n];
+        //boolean values  default to false. Only need to iterate when true.
+        if(element) {
+            for (int i = 0; i < n; i++) {
+                ret[i] = element;
+            }
+        }
+        return ret;
+    }
+
+
+
+
+    /**
+     * Converts a short array to an int array.
+     * @param input the input short array
+     * @return an int array with each element equal to the corresponding short value
+     */
+    public static int[] toIntArray(short[] input) {
+        int[] output = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a short array to an int array.
+     * @param input the input short array
+     * @return an int array with each element equal to the corresponding int value
+     */
+    public static int[] toIntArray(boolean[] input) {
+        int[] output = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] ? 1 : 0;
+        }
+        return output;
+    }
+
+
+
+    /**
+     * Converts a char array to an int array.
+     * @param input the input char array
+     * @return an int array with each element equal to the corresponding char value
+     */
+    public static int[] toIntArray(char[] input) {
+        int[] output = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts an int array to an int array (i.e., returns a copy of the input array).
+     * @param input the input int array
+     * @return a new int array with the same values as the input array
+     */
+    public static int[] toIntArray(int[] input) {
+        int[] output = new int[input.length];
+        System.arraycopy(input, 0, output, 0, input.length);
+        return output;
+    }
+
+    /**
+     * Converts a long array to an int array.
+     * @param input the input long array
+     * @return an int array with each element equal to the corresponding long value cast to an int
+     */
+    public static int[] toIntArray(long[] input) {
+        int[] output = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = (int) input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a float array to an int array.
+     * @param input the input float array
+     * @return an int array with each element equal to the corresponding float value cast to an int
+     */
+    public static int[] toIntArray(float[] input) {
+        int[] output = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = (int) input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a double array to an int array.
+     * @param input the input double array
+     * @return an int array with each element equal to the corresponding double value cast to an int
+     */
+    public static int[] toIntArray(double[] input) {
+        int[] output = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = (int) input[i];
+        }
+        return output;
+    }
+
+
+
+    /**
+     * Converts a short array to a double array.
+     * @param input the input short array
+     * @return a double array with each element equal to the corresponding short value
+     */
+    public static double[] toDoubleArray(short[] input) {
+        double[] output = new double[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a char array to a double array.
+     * @param input the input char array
+     * @return a double array with each element equal to the corresponding char value
+     */
+    public static double[] toDoubleArray(char[] input) {
+        double[] output = new double[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a boolean array to a double array.
+     * @param input the input boolean array
+     * @return a double array with each element equal to the corresponding double value
+     */
+    public static double[] toDoubleArray(boolean[] input) {
+        double[] output = new double[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] ? 1.0 : 0.0;
+        }
+        return output;
+    }
+
+
+    /**
+     * Converts an int array to a double array.
+     * @param input the input int array
+     * @return a double array with each element equal to the corresponding int value
+     */
+    public static double[] toDoubleArray(int[] input) {
+        double[] output = new double[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a long array to a double array.
+     * @param input the input long array
+     * @return a double array with each element equal to the corresponding long value
+     */
+    public static double[] toDoubleArray(long[] input) {
+        double[] output = new double[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a float array to a double array.
+     * @param input the input float array
+     * @return a double array with each element equal to the corresponding float value
+     */
+    public static double[] toDoubleArray(float[] input) {
+        double[] output = new double[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a double array to a double array (i.e., returns a copy of the input array).
+     * @param input the input double array
+     * @return a new double array with the same values as the input array
+     */
+    public static double[] toDoubleArray(double[] input) {
+        double[] output = new double[input.length];
+        System.arraycopy(input, 0, output, 0, input.length);
+        return output;
+    }
+
+    /**
+     * Converts a byte array to a long array.
+     * @param input the input byte array
+     * @return a long array with each element equal to the corresponding byte value
+     */
+    public static long[] toLongArray(byte[] input) {
+        long[] output = new long[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a byte array to a long array.
+     * @param input the input boolean array
+     * @return a long array with each element equal to the corresponding long value
+     */
+    public static long[] toLongArray(boolean[] input) {
+        long[] output = new long[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] ? 1 : 0;
+        }
+        return output;
+    }
+
+    /**
+     * Converts a short array to a long array.
+     * @param input the input short array
+     * @return a long array with each element equal to the corresponding short value
+     */
+    public static long[] toLongArray(short[] input) {
+        long[] output = new long[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a char array to a long array.
+     * @param input the input char array
+     * @return a long array with each element equal to the corresponding char value
+     */
+    public static long[] toLongArray(char[] input) {
+        long[] output = new long[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts an int array to a long array.
+     * @param input the input int array
+     * @return a long array with each element equal to the corresponding int value
+     */
+    public static long[] toLongArrayInt(int[] input) {
+        long[] output = new long[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a float array to a long array.
+     * @param input the input float array
+     * @return a long array with each element equal to the corresponding float value
+     */
+    public static long[] toLongArrayFloat(float[] input) {
+        long[] output = new long[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = (long) input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a double array to a long array.
+     * @param input the input double array
+     * @return a long array with each element equal to the corresponding double value
+     */
+    public static long[] toLongArray(double[] input) {
+        long[] output = new long[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = (long) input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a long array to a long array (i.e., returns a copy of the input array).
+     * @param input the input long array
+     * @return a new long array with the same values as the input array
+     */
+    public static long[] toLongArray(long[] input) {
+        long[] output = new long[input.length];
+        System.arraycopy(input, 0, output, 0, input.length);
+        return output;
+    }
+
+
+    /**
+     * Converts a short array to a float array.
+     * @param input the input short array
+     * @return a float array with each element equal to the corresponding short value
+     */
+    public static float[] toFloatArray(short[] input) {
+        float[] output = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a boolean array to a float array.
+     * @param input the input boolean array
+     * @return a float array with each element equal to the corresponding boolean value
+     */
+    public static float[] toFloatArray(boolean[] input) {
+        float[] output = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i] ? 1.0f : 0.0f;
+        }
+        return output;
+    }
+
+    /**
+     * Converts a char array to a float array.
+     * @param input the input char array
+     * @return a float array with each element equal to the corresponding char value
+     */
+    public static float[] toFloatArray(char[] input) {
+        float[] output = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts an int array to a float array.
+     * @param input the input int array
+     * @return a float array with each element equal to the corresponding int value
+     */
+    public static float[] toFloatArray(int[] input) {
+        float[] output = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a long array to a float array.
+     * @param input the input long array
+     * @return a float array with each element equal to the corresponding long value
+     */
+    public static float[] toFloatArray(long[] input) {
+        float[] output = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a double array to a float array.
+     * @param input the input double array
+     * @return a float array with each element equal to the corresponding double value
+     */
+    public static float[] toFloatArray(double[] input) {
+        float[] output = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = (float) input[i];
+        }
+        return output;
+    }
+
+    /**
+     * Converts a float array to a float array (i.e., returns a copy of the input array).
+     * @param input the input float array
+     * @return a new float array with the same values as the input array
+     */
+    public static float[] toFloatArray(float[] input) {
+        float[] output = new float[input.length];
+        System.arraycopy(input, 0, output, 0, input.length);
+        return output;
+    }
+
+    /**
      * Concat all the elements
      * @param arrs the input arrays
      * @return
@@ -392,7 +880,7 @@ public class ArrayUtil {
         final int f = Float.floatToIntBits(v);
 
         return (short) (((f >> 16) & 0x8000) | ((((f & 0x7f800000) - 0x38000000) >> 13) & 0x7c00)
-                        | ((f >> 13) & 0x03ff));
+                | ((f >> 13) & 0x03ff));
     }
 
     public static int[] toInts(float[] data) {
@@ -413,6 +901,22 @@ public class ArrayUtil {
         val retVal = new byte[array.length];
         for (int i = 0; i < array.length; i++) {
             retVal[i] = (byte) array[i];
+        }
+        return retVal;
+    }
+
+    public static byte[] toBytes(short[] array) {
+        val retVal = new byte[array.length];
+        for (int i = 0; i < array.length; i++) {
+            retVal[i] = (byte) array[i];
+        }
+        return retVal;
+    }
+
+    public static byte[] toBytes(boolean[] array) {
+        val retVal = new byte[array.length];
+        for (int i = 0; i < array.length; i++) {
+            retVal[i] = (byte)  (array[i] ? 1 : 0);
         }
         return retVal;
     }
@@ -1152,10 +1656,26 @@ public class ArrayUtil {
         return toDoubles(Ints.concat(ints));
     }
 
+
     public static short[] toShorts(long[] ints) {
         val ret = new short[ints.length];
         for (int i = 0; i < ints.length; i++)
             ret[i] = (short) ints[i];
+        return ret;
+    }
+
+    public static short[] toShorts(byte[] ints) {
+        val ret = new short[ints.length];
+        for (int i = 0; i < ints.length; i++)
+            ret[i] = (short) ints[i];
+        return ret;
+    }
+
+
+    public static short[] toShorts(boolean[] ints) {
+        val ret = new short[ints.length];
+        for (int i = 0; i < ints.length; i++)
+            ret[i] = (short) (ints[i] ? 1 : 0);
         return ret;
     }
 
@@ -1373,7 +1893,7 @@ public class ArrayUtil {
         for (int i = 0; i < validationLength; i++) {
             if (aShape[axes[0][i]] != bShape[axes[1][i]])
                 throw new IllegalArgumentException(
-                                "Size of the given axes a" + " t each dimension must be the same size.");
+                        "Size of the given axes a" + " t each dimension must be the same size.");
             if (axes[0][i] < 0)
                 axes[0][i] += aShape.length;
             if (axes[1][i] < 0)
@@ -1550,6 +2070,21 @@ public class ArrayUtil {
         return bytes;
     }
 
+
+    /**
+     *
+     * @param longArray
+     * @return
+     */
+    public static byte[] toByteArray(long[] longArray) {
+        int times = Long.SIZE / Byte.SIZE;
+        byte[] bytes = new byte[longArray.length * times];
+        for (int i = 0; i < longArray.length; i++) {
+            ByteBuffer.wrap(bytes, i * times, times).putLong(longArray[i]);
+        }
+        return bytes;
+    }
+
     /**
      *
      * @param byteArray
@@ -1636,6 +2171,8 @@ public class ArrayUtil {
         }
         return ints;
     }
+
+
 
 
     /**


### PR DESCRIPTION
Fix training performance with skipgram/dbow by introducing cache for commonly allocated arrays
We cache the values on heap to avoid risks of JVM crashes and for fast mutation of arrays.
We allocate and close ndarrays manually to maintain performance.

Sequences per second immediately shoot back up to 10-11k sequences per second relative to 3k per second.
## What changes were proposed in this pull request?

Manually in external  benchmark

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
