### PR TITLE
Remove tests that used old filter from ffmpeg

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2140,7 +2140,7 @@ public class Nd4j {
     public static INDArray linspace(@NonNull DataType dataType, double lower, double step, long num) {
         if (num == 1)
             return Nd4j.scalar(dataType, lower);
-        return Nd4j.getExecutioner().exec(new Linspace(lower, num, step, dataType));
+        return Nd4j.getExecutioner().exec(new org.nd4j.linalg.api.ops.impl.shape.Linspace(lower, step,num, dataType))[0];
     }
 
     /**
@@ -2155,7 +2155,7 @@ public class Nd4j {
         Preconditions.checkState(dataType.isFPType(), "Datatype must be a floating point type for linspace, got %s", dataType);
         if (num == 1)
             return Nd4j.scalar(dataType, lower);
-        return Nd4j.getExecutioner().exec(new Linspace(lower, upper, num, dataType));
+        return Nd4j.getExecutioner().exec(new org.nd4j.linalg.api.ops.impl.shape.Linspace(lower, upper, num, dataType))[0];
     }
 
     private static INDArray linspaceWithCustomOp(long lower, long upper, int num, DataType dataType) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -2050,14 +2050,11 @@ public class Nd4j {
         ArrayList<Integer> list = new ArrayList<>(nCols);
         for (int i = 0; i < nCols; i++)
             list.add(i);
-        Collections.sort(list, new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-                if (ascending)
-                    return Double.compare(in.getDouble(rowIdx, o1), in.getDouble(rowIdx, o2));
-                else
-                    return -Double.compare(in.getDouble(rowIdx, o1), in.getDouble(rowIdx, o2));
-            }
+        Collections.sort(list, (o1, o2) -> {
+            if (ascending)
+                return Double.compare(in.getDouble(rowIdx, o1), in.getDouble(rowIdx, o2));
+            else
+                return -Double.compare(in.getDouble(rowIdx, o1), in.getDouble(rowIdx, o2));
         });
         for (int i = 0; i < nCols; i++) {
             out.putColumn(i, in.getColumn(list.get(i)));
@@ -2101,7 +2098,7 @@ public class Nd4j {
             long upper = lower + num * step;
             return linspaceWithCustomOpByRange( lower, upper, num, step, dtype);
         } else if (dtype.isFPType()) {
-            return Nd4j.getExecutioner().exec(new Linspace((double) lower, num, (double)step, dtype));
+            return Nd4j.getExecutioner().exec(new org.nd4j.linalg.api.ops.impl.shape.Linspace((double)step, (double) lower, (long) num, dtype))[0];
         }
         else {
             throw new IllegalStateException("Illegal data type for linspace: " + dtype.toString());

--- a/platform-tests/src/test/java/org/datavec/image/transform/JsonYamlTest.java
+++ b/platform-tests/src/test/java/org/datavec/image/transform/JsonYamlTest.java
@@ -75,13 +75,6 @@ class JsonYamlTest {
                 assertTrue(img.getFrame().imageWidth == imgJson.getFrame().imageWidth);
                 assertTrue(img.getFrame().imageHeight == imgYaml.getFrame().imageHeight);
                 assertTrue(img.getFrame().imageWidth == imgYaml.getFrame().imageWidth);
-            } else if (it instanceof FilterImageTransform) {
-                assertEquals(img.getFrame().imageHeight, imgJson.getFrame().imageHeight);
-                assertEquals(img.getFrame().imageWidth, imgJson.getFrame().imageWidth);
-                assertEquals(img.getFrame().imageChannels, imgJson.getFrame().imageChannels);
-                assertEquals(img.getFrame().imageHeight, imgYaml.getFrame().imageHeight);
-                assertEquals(img.getFrame().imageWidth, imgYaml.getFrame().imageWidth);
-                assertEquals(img.getFrame().imageChannels, imgYaml.getFrame().imageChannels);
             } else {
                 assertEquals(img, imgJson);
                 assertEquals(img, imgYaml);

--- a/platform-tests/src/test/java/org/datavec/image/transform/TestImageTransform.java
+++ b/platform-tests/src/test/java/org/datavec/image/transform/TestImageTransform.java
@@ -260,22 +260,6 @@ public class TestImageTransform {
         assertEquals(22, transformed[1], 0);
     }
 
-    @Test
-    public void testFilterImageTransform() throws Exception {
-        ImageWritable writable = makeRandomImage(0, 0, 4);
-        Frame frame = writable.getFrame();
-        ImageTransform transform = new FilterImageTransform("noise=alls=20:allf=t+u,format=rgba", frame.imageWidth,
-                        frame.imageHeight, frame.imageChannels);
-
-        for (int i = 0; i < 100; i++) {
-            ImageWritable w = transform.transform(writable);
-            Frame f = w.getFrame();
-            assertEquals(f.imageHeight, frame.imageHeight);
-            assertEquals(f.imageWidth, frame.imageWidth);
-            assertEquals(f.imageChannels, frame.imageChannels);
-        }
-        assertEquals(null, transform.transform(null));
-    }
 
     @Test
     public void testShowImageTransform() throws Exception {


### PR DESCRIPTION


## What changes were proposed in this pull request?
Fix linspace delegation to use new op instead of old random one
Remove old tests referencing non existant filter transform.

## How was this patch tested?

Manually

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
