### PR TITLE
Fix misc op context memory leaks

### DIFF
--- a/libnd4j/include/ops/declarable/LegacyReduce3Op.h
+++ b/libnd4j/include/ops/declarable/LegacyReduce3Op.h
@@ -39,7 +39,6 @@ class SD_LIB_EXPORT LegacyReduce3Op : public LegacyOp {
 
   ShapeList* calculateOutputShape(ShapeList* inputShape, sd::graph::Context& block) override;
   LegacyOp* clone() override;
-  void traceExecIfNeeded(Context& block);
 };
 }  // namespace ops
 }  // namespace sd

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
@@ -64,6 +64,8 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
     @Override
     public void close() {
         // no-op
+        nativeOps.ctxPurge(context);
+        context.deallocate();
     }
 
     @Override
@@ -203,7 +205,7 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
         List<DataBuffer> shapeInfoReferences = new ArrayList<>();
         for(int i = 0; i < arrays.size(); i++) {
             INDArray array = arrays.get(i);
-            buffers.put(i,array.isEmpty() ? null : ((BaseCpuDataBuffer) array.data()).getOpaqueDataBuffer());
+            buffers.put(i,Carray.isEmpty() ? null : ((BaseCpuDataBuffer) array.data()).getOpaqueDataBuffer());
             DataBuffer dataBuffer = array.shapeInfoDataBuffer();
             shapeInfoReferences.add(dataBuffer);
             Pointer addressPointer = dataBuffer.pointer();

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/CpuOpContext.java
@@ -205,7 +205,7 @@ public class CpuOpContext extends BaseOpContext implements OpContext, Deallocata
         List<DataBuffer> shapeInfoReferences = new ArrayList<>();
         for(int i = 0; i < arrays.size(); i++) {
             INDArray array = arrays.get(i);
-            buffers.put(i,Carray.isEmpty() ? null : ((BaseCpuDataBuffer) array.data()).getOpaqueDataBuffer());
+            buffers.put(i,array.isEmpty() ? null : ((BaseCpuDataBuffer) array.data()).getOpaqueDataBuffer());
             DataBuffer dataBuffer = array.shapeInfoDataBuffer();
             shapeInfoReferences.add(dataBuffer);
             Pointer addressPointer = dataBuffer.pointer();

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContext.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaOpContext.java
@@ -62,6 +62,8 @@ public class CudaOpContext extends BaseOpContext implements OpContext, Deallocat
 
     @Override
     public void close() {
+        nativeOps.ctxPurge(context);
+        context.deallocate();
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Apply optimizations for op context allocation
Adds databuffer removal from reference map when closed


## How was this patch tested?

Profiling locally with benchmarks

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
