### PR TITLE
Fix memory management for large documents in paragraph vectors

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/CBOW.java
@@ -22,6 +22,7 @@ package org.deeplearning4j.models.embeddings.learning.impl.elements;
 
 import lombok.*;
 import org.apache.commons.lang3.RandomUtils;
+import org.deeplearning4j.config.DL4JSystemProperties;
 import org.deeplearning4j.models.embeddings.WeightLookupTable;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
 import org.deeplearning4j.models.embeddings.learning.ElementsLearningAlgorithm;
@@ -39,6 +40,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.DeviceLocalNDArray;
 import org.nd4j.shade.guava.cache.Cache;
 import org.nd4j.shade.guava.cache.CacheBuilder;
+import org.nd4j.shade.guava.cache.Weigher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +64,13 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
     protected double sampling;
     protected int[] variableWindows;
     protected int workers = Runtime.getRuntime().availableProcessors();
-    private Cache<IterationArraysKey, Queue<IterationArrays>> iterationArrays = CacheBuilder.newBuilder().build();
+    private Cache<IterationArraysKey, Queue<IterationArrays>> iterationArrays = CacheBuilder.newBuilder()
+            .maximumSize(Integer.parseInt(System.getProperty(DL4JSystemProperties.NLP_CACHE_SIZE,"10000")))
+            .build();
+
+    protected int maxQueueSize = Integer.parseInt(System.getProperty(DL4JSystemProperties.NLP_QUEUE_SIZE,"1000"));
+
+
 
     public int getWorkers() {
         return workers;
@@ -347,7 +355,8 @@ public class CBOW<T extends SequenceElement> implements ElementsLearningAlgorith
 
 
                 Nd4j.close(currentWindowIndexes,inputWindowWords,alphas,randoms,codes,numLabelsArray,indices);
-                iterationArraysQueue.add(iterationArrays1);
+                if(iterationArraysQueue.size() < maxQueueSize)
+                    iterationArraysQueue.add(iterationArrays1);
 
                 batches.get().clear();
                 return 0.0;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
@@ -418,9 +418,8 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
                 items.clear();
 
                 Nd4j.close(targetArray,codes,indices,alphasArray,ngStarterArray,randomValuesArr);
-/*
                 if(iterationArraysQueue.size() < maxQueueSize)
-                    iterationArraysQueue.add(iterationArrays1);*/
+                    iterationArraysQueue.add(iterationArrays1);
 
             } else {
                 int cnt = 0;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/embeddings/learning/impl/elements/SkipGram.java
@@ -23,6 +23,7 @@ package org.deeplearning4j.models.embeddings.learning.impl.elements;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
+import org.deeplearning4j.config.DL4JSystemProperties;
 import org.deeplearning4j.models.embeddings.WeightLookupTable;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
 import org.deeplearning4j.models.embeddings.learning.ElementsLearningAlgorithm;
@@ -40,6 +41,7 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.util.DeviceLocalNDArray;
 import org.nd4j.shade.guava.cache.Cache;
 import org.nd4j.shade.guava.cache.CacheBuilder;
+import org.nd4j.shade.guava.cache.Weigher;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,8 +60,11 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
     protected double sampling;
     protected int[] variableWindows;
     protected int vectorLength;
+    protected int maxQueueSize = Integer.parseInt(System.getProperty(DL4JSystemProperties.NLP_QUEUE_SIZE,"1000"));
 
-    private Cache<IterationArraysKey, Queue<IterationArrays>> iterationArrays = CacheBuilder.newBuilder().build();
+    private Cache<IterationArraysKey, Queue<IterationArrays>> iterationArrays = CacheBuilder.newBuilder()
+            .maximumSize(Integer.parseInt(System.getProperty(DL4JSystemProperties.NLP_CACHE_SIZE,"10000")))
+            .build();
     protected int workers = Runtime.getRuntime().availableProcessors();
 
 
@@ -413,8 +418,9 @@ public class SkipGram<T extends SequenceElement> implements ElementsLearningAlgo
                 items.clear();
 
                 Nd4j.close(targetArray,codes,indices,alphasArray,ngStarterArray,randomValuesArr);
-
-                iterationArraysQueue.add(iterationArrays1);
+/*
+                if(iterationArraysQueue.size() < maxQueueSize)
+                    iterationArraysQueue.add(iterationArrays1);*/
 
             } else {
                 int cnt = 0;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
@@ -1130,6 +1130,7 @@ public class ParagraphVectors extends Word2Vec {
 
             if (labelAwareIterator != null) {
                 SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(labelAwareIterator)
+                        .vocabCache(vocabCache)
                         .tokenizerFactory(tokenizerFactory).allowMultithreading(allowParallelTokenization)
                         .build();
                 this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectors.java
@@ -1136,6 +1136,7 @@ public class ParagraphVectors extends Word2Vec {
                 this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
             }
 
+            ret.vectorCalcThreads = this.vectorCalcThreads;
             ret.numEpochs = this.numEpochs;
             ret.numIterations = this.iterations;
             ret.vocab = this.vocabCache;
@@ -1192,6 +1193,7 @@ public class ParagraphVectors extends Word2Vec {
                 this.configuration.setUseHierarchicSoftmax(this.useHierarchicSoftmax);
                 this.configuration.setTrainElementsVectors(this.trainElementsVectors);
                 this.configuration.setPreciseWeightInit(this.preciseWeightInit);
+                this.configuration.setVectorCalcThreads(this.vectorCalcThreads);
                 if(this.sequenceLearningAlgorithm != null)
                     this.configuration
                             .setSequenceLearningAlgorithm(this.sequenceLearningAlgorithm.getClass().getCanonicalName());

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
@@ -69,6 +69,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
 
         if (sentenceIter != null) {
             SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(sentenceIter)
+                    .vocabCache(vocab)
                     .tokenizerFactory(this.tokenizerFactory).build();
             this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
         }
@@ -80,11 +81,11 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
      * @param iterator SentenceIterator instance
      */
     public void setSentenceIterator(@NonNull SentenceIterator iterator) {
-        //if (tokenizerFactory == null) throw new IllegalStateException("Please call setTokenizerFactory() prior to setSentenceIter() call.");
 
         if (tokenizerFactory != null) {
             SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(iterator)
                     .tokenizerFactory(tokenizerFactory)
+                    .vocabCache(vocab)
                     .allowMultithreading(configuration == null || configuration.isAllowParallelTokenization())
                     .build();
             this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
@@ -687,6 +688,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
                     tokenizerFactory = new DefaultTokenizerFactory();
 
                 SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(sentenceIterator)
+                        .vocabCache(vocabCache)
                         .tokenizerFactory(tokenizerFactory).allowMultithreading(allowParallelTokenization)
                         .build();
                 this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
@@ -698,6 +700,7 @@ public class Word2Vec extends SequenceVectors<VocabWord> {
 
                 SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(labelAwareIterator)
                         .tokenizerFactory(tokenizerFactory).allowMultithreading(allowParallelTokenization)
+                        .vocabCache(vocabCache)
                         .build();
                 this.iterator = new AbstractSequenceIterator.Builder<>(transformer).build();
             }

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelledDocument.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/LabelledDocument.java
@@ -24,12 +24,13 @@ import lombok.Data;
 import lombok.ToString;
 import org.deeplearning4j.models.word2vec.VocabWord;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
 @ToString(exclude = "referencedContent")
-public class LabelledDocument {
+public class LabelledDocument implements Serializable  {
 
     // optional field
     private String id;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/ShardedLabelAwareIterator.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/documentiterator/ShardedLabelAwareIterator.java
@@ -1,0 +1,165 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.deeplearning4j.text.documentiterator;
+
+import org.deeplearning4j.text.tokenization.tokenizer.Tokenizer;
+import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
+import org.nd4j.shade.guava.collect.Lists;
+
+import java.util.List;
+
+/**
+ * The ShardedLabelAwareIterator class is an implementation of the LabelAwareIterator interface.
+ * It wraps a given LabelAwareIterator (subIterator) and splits its documents into smaller documents (shards)
+ * to help manage memory usage. This is particularly useful when dealing with large text documents.
+ * The documentSizeLimit field determines the maximum number of tokens per shard.
+ * The tokenizerFactory field is used to tokenize the documents before sharding them.
+ * The docBatches field stores the shards, and the currentBatch field keeps track of the current shard index.
+ *
+ * @author Adam Gibson
+ */
+public class ShardedLabelAwareIterator implements LabelAwareIterator {
+    // Instance variables
+    private LabelAwareIterator subIterator;
+    private int documentSizeLimit;
+    private TokenizerFactory tokenizerFactory;
+    private List<List<String>> docBatches;
+    private int currentBatch = 0;
+
+    // Constructor
+    public ShardedLabelAwareIterator(LabelAwareIterator subIterator, TokenizerFactory tokenizerFactory, int documentSizeLimit) {
+        this.subIterator = subIterator;
+        this.documentSizeLimit = documentSizeLimit;
+        this.tokenizerFactory = tokenizerFactory;
+    }
+
+    // Splits a document into smaller documents (shards) based on the documentSizeLimit
+    private void shardDocument(LabelledDocument document) {
+        Tokenizer tokenizer = tokenizerFactory.create(document.getContent());
+        this.docBatches = Lists.partition(tokenizer.getTokens(), documentSizeLimit);
+        currentBatch = 0;
+    }
+
+    // Checks if there are more documents available
+    @Override
+    public boolean hasNextDocument() {
+        LabelledDocument nextDoc = nextDocument();
+        if (nextDoc != null) {
+            currentBatch--; // Revert the currentBatch increment in the nextDocument() method
+        }
+        return nextDoc != null;
+    }
+
+    // Retrieves the next document from the iterator
+    @Override
+    public LabelledDocument nextDocument() {
+        while (docBatches == null || currentBatch >= docBatches.size() || (docBatches != null && docBatches.isEmpty())) {
+            if (!subIterator.hasNextDocument()) {
+                return null; // Return null if no more documents are available
+            }
+
+            LabelledDocument document = subIterator.nextDocument();
+            shardDocument(document);
+        }
+
+
+        if (currentBatch < docBatches.size()) {
+            LabelledDocument document = new LabelledDocument();
+            document.setLabels(subIterator.getLabelsSource().getLabels());
+            document.setContent(String.join(" ", docBatches.get(currentBatch)));
+            currentBatch++;
+            return document;
+        } else {
+            throw new IllegalStateException("No more documents");
+        }
+    }
+
+    // Resets the iterator
+    @Override
+    public void reset() {
+        subIterator.reset();
+        this.docBatches = null;
+        currentBatch = 0;
+    }
+
+    // Returns the LabelsSource from the wrapped iterator
+    @Override
+    public LabelsSource getLabelsSource() {
+        return subIterator.getLabelsSource();
+    }
+
+    // Empty method for shutting down the iterator (not needed in this case)
+    @Override
+    public void shutdown() {
+    }
+
+    // Alias for hasNextDocument(), checks if there are more documents available
+    @Override
+    public boolean hasNext() {
+        return hasNextDocument();
+    }
+
+    // Alias for nextDocument(), retrieves the next document from the iterator
+    @Override
+    public LabelledDocument next() {
+        return nextDocument();
+    }
+
+    public LabelAwareIterator getSubIterator() {
+        return subIterator;
+    }
+
+    public void setSubIterator(LabelAwareIterator subIterator) {
+        this.subIterator = subIterator;
+    }
+
+    public int getDocumentSizeLimit() {
+        return documentSizeLimit;
+    }
+
+    public void setDocumentSizeLimit(int documentSizeLimit) {
+        this.documentSizeLimit = documentSizeLimit;
+    }
+
+    public TokenizerFactory getTokenizerFactory() {
+        return tokenizerFactory;
+    }
+
+    public void setTokenizerFactory(TokenizerFactory tokenizerFactory) {
+        this.tokenizerFactory = tokenizerFactory;
+    }
+
+    public List<List<String>> getDocBatches() {
+        return docBatches;
+    }
+
+    public void setDocBatches(List<List<String>> docBatches) {
+        this.docBatches = docBatches;
+    }
+
+    public int getCurrentBatch() {
+        return currentBatch;
+    }
+
+    public void setCurrentBatch(int currentBatch) {
+        this.currentBatch = currentBatch;
+    }
+}

--- a/platform-tests/src/test/java/org/deeplearning4j/models/embeddings/inmemory/InMemoryLookupTableTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/embeddings/inmemory/InMemoryLookupTableTest.java
@@ -69,7 +69,9 @@ public class InMemoryLookupTableTest extends BaseDL4JTest {
 
 
         SentenceTransformer transformer =
-                        new SentenceTransformer.Builder().iterator(underlyingIterator).tokenizerFactory(t).build();
+                        new SentenceTransformer.Builder().iterator(underlyingIterator)
+                                .vocabCache(cacheSource)
+                                .tokenizerFactory(t).build();
 
         AbstractSequenceIterator<VocabWord> sequenceIterator =
                         new AbstractSequenceIterator.Builder<>(transformer).build();
@@ -148,7 +150,9 @@ public class InMemoryLookupTableTest extends BaseDL4JTest {
         FileLabelAwareIterator labelAwareIterator = new FileLabelAwareIterator.Builder()
                         .addSourceFolder(dir).build();
 
-        transformer = new SentenceTransformer.Builder().iterator(labelAwareIterator).tokenizerFactory(t).build();
+        transformer = new SentenceTransformer.Builder().iterator(labelAwareIterator)
+                .vocabCache(mem1.getVocabCache())
+                .tokenizerFactory(t).build();
 
         sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer).build();
 

--- a/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/paragraphvectors/ParagraphVectorsTest.java
@@ -688,8 +688,11 @@ public class ParagraphVectorsTest extends BaseDL4JTest {
     public void testParallelIterator() throws IOException {
         TokenizerFactory factory = new DefaultTokenizerFactory();
         SentenceIterator iterator = new BasicLineIterator(Resources.asFile("big/raw_sentences.txt"));
+        AbstractCache<VocabWord> cacheTarget = new AbstractCache.Builder<VocabWord>().build();
 
-        SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(iterator).allowMultithreading(true)
+        SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(iterator)
+                .vocabCache(cacheTarget)
+                .allowMultithreading(true)
                 .tokenizerFactory(factory).build();
 
         BasicTransformerIterator iter = (BasicTransformerIterator)transformer.iterator();

--- a/platform-tests/src/test/java/org/deeplearning4j/models/sequencevectors/SequenceVectorsTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/sequencevectors/SequenceVectorsTest.java
@@ -112,7 +112,9 @@ public class SequenceVectorsTest extends BaseDL4JTest {
         t.setTokenPreProcessor(new CommonPreprocessor());
 
         SentenceTransformer transformer =
-                        new SentenceTransformer.Builder().iterator(underlyingIterator).tokenizerFactory(t).build();
+                        new SentenceTransformer.Builder()
+                                .vocabCache(vocabCache)
+                                .iterator(underlyingIterator).tokenizerFactory(t).build();
 
 
         /*
@@ -233,9 +235,12 @@ public class SequenceVectorsTest extends BaseDL4JTest {
 
         TokenizerFactory t = new DefaultTokenizerFactory();
         t.setTokenPreProcessor(new CommonPreprocessor());
+        AbstractCache<VocabWord> vocabCache = new AbstractCache.Builder<VocabWord>().build();
 
         SentenceTransformer transformer =
-                        new SentenceTransformer.Builder().iterator(underlyingIterator).tokenizerFactory(t).build();
+                        new SentenceTransformer.Builder()
+                                .vocabCache(vocabCache)
+                                .iterator(underlyingIterator).tokenizerFactory(t).build();
 
         AbstractSequenceIterator<VocabWord> sequenceIterator =
                         new AbstractSequenceIterator.Builder<>(transformer).build();

--- a/platform-tests/src/test/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructorTest.java
+++ b/platform-tests/src/test/java/org/deeplearning4j/models/word2vec/wordstore/VocabConstructorTest.java
@@ -135,7 +135,9 @@ public class VocabConstructorTest extends BaseDL4JTest {
 
         VocabCache<VocabWord> cache = new AbstractCache.Builder<VocabWord>().build();
 
-        SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(iter).tokenizerFactory(t).build();
+        SentenceTransformer transformer = new SentenceTransformer.Builder()
+                .vocabCache(cache)
+                .iterator(iter).tokenizerFactory(t).build();
 
 
         AbstractSequenceIterator<VocabWord> sequenceIterator =
@@ -146,7 +148,6 @@ public class VocabConstructorTest extends BaseDL4JTest {
 
         constructor.buildJointVocabulary(false, true);
 
-        //        assertFalse(cache.hasToken("including"));
 
         assertEquals(242, cache.numWords());
 
@@ -271,7 +272,9 @@ public class VocabConstructorTest extends BaseDL4JTest {
 
 
         SentenceTransformer transformer =
-                        new SentenceTransformer.Builder().iterator(underlyingIterator).tokenizerFactory(t).build();
+                        new SentenceTransformer.Builder()
+                                .vocabCache(cacheSource)
+                                .iterator(underlyingIterator).tokenizerFactory(t).build();
 
         AbstractSequenceIterator<VocabWord> sequenceIterator =
                         new AbstractSequenceIterator.Builder<>(transformer).build();
@@ -325,7 +328,9 @@ public class VocabConstructorTest extends BaseDL4JTest {
         FileLabelAwareIterator labelAwareIterator = new FileLabelAwareIterator.Builder()
                         .addSourceFolder(dir).build();
 
-        transformer = new SentenceTransformer.Builder().iterator(labelAwareIterator).tokenizerFactory(t).build();
+        transformer = new SentenceTransformer.Builder()
+                .vocabCache(cacheSource)
+                .iterator(labelAwareIterator).tokenizerFactory(t).build();
 
         sequenceIterator = new AbstractSequenceIterator.Builder<>(transformer).build();
 
@@ -444,8 +449,11 @@ public class VocabConstructorTest extends BaseDL4JTest {
     public void testParallelTokenizationDisabled_Completes() throws Exception {
         File inputFile = Resources.asFile("big/raw_sentences.txt");
         SentenceIterator iter = new BasicLineIterator(inputFile);
+        AbstractCache<VocabWord> vocabCache = new AbstractCache.Builder<VocabWord>().build();
 
-        SentenceTransformer transformer = new SentenceTransformer.Builder().iterator(iter).tokenizerFactory(t).build();
+        SentenceTransformer transformer = new SentenceTransformer.Builder()
+                .vocabCache(vocabCache)
+                .iterator(iter).tokenizerFactory(t).build();
 
         AbstractSequenceIterator<VocabWord> sequenceIterator =
                 new AbstractSequenceIterator.Builder<>(transformer).build();

--- a/resources/src/main/java/org/deeplearning4j/config/DL4JSystemProperties.java
+++ b/resources/src/main/java/org/deeplearning4j/config/DL4JSystemProperties.java
@@ -113,4 +113,18 @@ public class DL4JSystemProperties {
      */
     public static final String DISABLE_HELPER_PROPERTY = "org.eclipse.deeplearning4j.helpers.disable";
     public final static String HELPER_DISABLE_DEFAULT_VALUE = "true";
+
+    /**
+     * Applicability: NLP SkipGram and CBOW
+     * modules controlling the max cache size
+     * for on heap parameters such as learning rates and random values.
+     */
+    public static final String NLP_CACHE_SIZE = "org.eclipse.deeplearning4j.nlp.cachesize";
+
+    /**
+     * Applicability: NLP SkipGram and CBOW
+     * modules controlling the max queue size
+     * for each cache value.
+     */
+    public static final String NLP_QUEUE_SIZE = "org.eclipse.deeplearning4j.nlp.queuesize";
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds new sharded label aware document iterator that breaks up documents
in to a configurable n words per string.

Adds queue and cache size for skipgram/cbow to control memory management
of the cached skipgram/cbow parameters.
## How was this patch tested?

Benchmarked manually. Simple test for regressions.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
