### PR TITLE
Migrate cached TADPacks to heap pointers rather than stack

### DIFF
--- a/libnd4j/include/array/TadPack.h
+++ b/libnd4j/include/array/TadPack.h
@@ -38,7 +38,7 @@ class SD_LIB_EXPORT TadPack {
  public:
   explicit TadPack(const ConstantShapeBuffer& shapes, const ConstantOffsetsBuffer& offets, sd::LongType numTads);
   TadPack() = default;
-  ~TadPack() = default;
+  ~TadPack() {};
 
   const sd::LongType* primaryShapeInfo() const;
   const sd::LongType* primaryOffsets() const;

--- a/libnd4j/include/array/impl/ShapeDescriptor.cpp
+++ b/libnd4j/include/array/impl/ShapeDescriptor.cpp
@@ -121,6 +121,7 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const st
   for (int i = 0; i < _rank; i++) {
     _shape[i] = shape[i];
   }
+  _order = order;
   fillStrides();
 }
 
@@ -131,6 +132,8 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order,
   _rank = shape.size();
   _ews = 1;
   _shape_strides.resize(2 * _rank);
+  _order = order;
+
   auto _shape = _shape_strides.data();
   int i = 0;
   for (auto x : shape) {

--- a/libnd4j/include/array/impl/TadPack.cpp
+++ b/libnd4j/include/array/impl/TadPack.cpp
@@ -30,9 +30,15 @@ TadPack::TadPack(const ConstantShapeBuffer& shapes, const ConstantOffsetsBuffer&
   _numTads = numTads;
 }
 
-const sd::LongType* TadPack::primaryShapeInfo() const { return _tadShape.primary(); }
+const sd::LongType* TadPack::primaryShapeInfo() const {
+  if(_tadShape.primary() == nullptr)
+    throw std::runtime_error("TadPack::primaryShapeInfo: primary shape info is nullptr!");
+  return _tadShape.primary();
+}
 
-const sd::LongType* TadPack::primaryOffsets() const { return _tadOffsets.primary(); }
+const sd::LongType* TadPack::primaryOffsets() const {
+  return _tadOffsets.primary();
+}
 
 const sd::LongType* TadPack::specialShapeInfo() const { return _tadShape.special(); }
 

--- a/libnd4j/include/helpers/ConstantTadHelper.h
+++ b/libnd4j/include/helpers/ConstantTadHelper.h
@@ -37,7 +37,7 @@ namespace sd {
 class SD_LIB_EXPORT ConstantTadHelper {
  private:
   std::mutex _mutex;
-  std::vector<SD_MAP_IMPL<TadDescriptor, TadPack>> _cache;
+  std::vector<SD_MAP_IMPL<TadDescriptor *, TadPack *>> _cache;
 
   ConstantTadHelper();
 
@@ -54,14 +54,14 @@ class SD_LIB_EXPORT ConstantTadHelper {
    * @param keepUnitiesInShape
    * @return
    */
-  TadPack tadForDimensions(const sd::LongType *originalShape, const std::vector<LongType> &dimensions,
+  TadPack *tadForDimensions(const sd::LongType *originalShape, const std::vector<LongType> &dimensions,
                            const bool keepUnitiesInShape = false);
-  TadPack tadForDimensions(const sd::LongType *originalShape, LongType *dimensions, LongType dimLength,
+  TadPack *tadForDimensions(const sd::LongType *originalShape, LongType *dimensions, LongType dimLength,
                            const bool keepUnitiesInShape = false);
-  TadPack tadForDimensions(const sd::LongType *originalShape, LongType dimension, const bool keepUnitiesInShape = false);
-  TadPack tadForDimensions(ShapeDescriptor &descriptor, std::vector<LongType> &dimensions,
+  TadPack *tadForDimensions(const sd::LongType *originalShape, LongType dimension, const bool keepUnitiesInShape = false);
+  TadPack *tadForDimensions(ShapeDescriptor &descriptor, std::vector<LongType> &dimensions,
                            const bool keepUnitiesInShape = false);
-  TadPack tadForDimensions(TadDescriptor &descriptor);
+  TadPack *tadForDimensions(TadDescriptor *descriptor);
 
   /**
    * This method returns number of cached TAD shapes/offsets on specific device

--- a/libnd4j/include/helpers/TAD.h
+++ b/libnd4j/include/helpers/TAD.h
@@ -52,7 +52,7 @@ namespace shape {
 class TAD {
  public:
   sd::LongType tadIndex = 0;
-  int dimensionLength;
+  sd::LongType dimensionLength;
   sd::LongType *dimension = nullptr;
   sd::LongType const *shapeInfo = nullptr;
   sd::LongType *tadOnlyShapeInfo = nullptr;
@@ -92,12 +92,13 @@ class TAD {
    * This method is for GPU mostly, it allows to initialize TAD instance with precalculated tadOnlyShapeInfo
    */
   SD_INLINE SD_HOST_DEVICE void initWithExternalTAD(sd::LongType *existingTAD, sd::LongType *originalShape,
-                                                    long long int *dimension, int dimensionLength);
+                                                    sd::LongType *dimension, sd::LongType dimensionLength);
 
-  SD_INLINE SD_HOST_DEVICE void init(sd::LongType const *shapeInfo, const long long int *dimension, int dimensionLength);
+  SD_INLINE SD_HOST_DEVICE void init(sd::LongType const *shapeInfo, const sd::LongType *dimension,
+                                     sd::LongType dimensionLength);
 
-  SD_INLINE SD_HOST_DEVICE void init(int tadIndex, sd::LongType const *shapeInfo, const long long int *dimension,
-                                     int dimensionLength);
+  SD_INLINE SD_HOST_DEVICE void init(int tadIndex, sd::LongType const *shapeInfo, const sd::LongType *dimension,
+                                     sd::LongType dimensionLength);
 
   template <typename T>
   SD_INLINE SD_HOST_DEVICE void printTADsND(T *x);
@@ -174,7 +175,7 @@ class TAD {
    * the shape information
    */
   SD_INLINE SD_HOST_DEVICE sd::LongType tadLength(sd::LongType const *shapeInfo, const long long int *dimension,
-                                                  int dimensionLength);
+                                                  long long int dimensionLength);
 
   /**
    * Computes the number
@@ -183,7 +184,7 @@ class TAD {
    */
   SD_INLINE SD_HOST_DEVICE sd::LongType tensorsAlongDimension(sd::LongType const *shapeInfo,
                                                               const long long int *dimension,
-                                                              int dimensionLength);
+                                                              long long int dimensionLength);
 
 #ifdef __CUDACC__
   SD_INLINE SD_HOST_DEVICE void createOffsetForBlock(int blockIdx) {
@@ -199,8 +200,7 @@ SD_INLINE void TAD::setExternalBuffers(void *ptrManager) { this->ptrManager = pt
 SD_INLINE void TAD::setOutputBuffer(int *ptrOutput) { this->ptrOutput = ptrOutput; }
 
 SD_INLINE void TAD::initWithExternalTAD(sd::LongType *existingTAD, sd::LongType *originalShape,
-                                        long long int *dimension,
-                                        int dimensionLength) {
+                                        sd::LongType *dimension, sd::LongType dimensionLength) {
   this->tadOnlyShapeInfo = existingTAD;
   this->rank = shape::rank(originalShape);
 
@@ -227,12 +227,13 @@ SD_INLINE void TAD::initWithExternalTAD(sd::LongType *existingTAD, sd::LongType 
       ((this->dimensionLength == this->rank || this->numTads == shape::length(this->shapeInfo)) && ews == 1);
 }
 
-SD_INLINE void TAD::init(int tadIndex, sd::LongType const *shapeInfo, const long long int *dimension, int dimensionLength) {
+SD_INLINE void TAD::init(int tadIndex, sd::LongType const *shapeInfo, const long long int *dimension,
+                         long long int dimensionLength) {
   this->tadIndex = tadIndex;
   this->init(shapeInfo, dimension, dimensionLength);
 }
 
-SD_INLINE void TAD::init(sd::LongType const *shapeInfo, const long long int *dimension, int dimensionLength) {
+SD_INLINE void TAD::init(sd::LongType const *shapeInfo, const long long int *dimension, long long int dimensionLength) {
   this->originalShapeInfo = shapeInfo;
   this->originalDimension = dimension;
   this->originalDimensionLength = dimensionLength;
@@ -735,7 +736,8 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
   return ret2;
 }
 
-SD_INLINE sd::LongType TAD::tadLength(sd::LongType const *shapeInfo, const long long int *dimension, int dimensionLength) {
+SD_INLINE sd::LongType TAD::tadLength(sd::LongType const *shapeInfo, const long long int *dimension,
+                                      long long int dimensionLength) {
   if (dimensionLength == 1) {
     return shape::shapeOf(shapeInfo)[dimension[0]];
   } else {
@@ -750,7 +752,7 @@ SD_INLINE sd::LongType TAD::tadLength(sd::LongType const *shapeInfo, const long 
 }
 
 SD_INLINE sd::LongType TAD::tensorsAlongDimension(sd::LongType const *shapeInfo, const long long int *dimension,
-                                                  int dimensionLength) {
+                                                  long long int dimensionLength) {
   return shape::length(shapeInfo) / this->tadLength(shapeInfo, dimension, dimensionLength);
 }
 

--- a/libnd4j/include/helpers/benchmark/BroadcastBenchmark.h
+++ b/libnd4j/include/helpers/benchmark/BroadcastBenchmark.h
@@ -22,6 +22,8 @@
 
 #include <helpers/OpBenchmark.h>
 
+#include <utility>
+
 #ifndef DEV_TESTS_BROADCASTBENCHMARK_H
 #define DEV_TESTS_BROADCASTBENCHMARK_H
 
@@ -33,7 +35,7 @@ class SD_LIB_EXPORT BroadcastBenchmark : public OpBenchmark {
   }
 
   BroadcastBenchmark(broadcast::Ops op, std::string testName, NDArray *x, NDArray *y, NDArray *z, std::vector<sd::LongType> axis)
-      : OpBenchmark(testName, x, y, z, axis) {
+      : OpBenchmark(std::move(testName), x, y, z, axis) {
     _opNum = (int)op;
   }
 
@@ -77,11 +79,11 @@ class SD_LIB_EXPORT BroadcastBenchmark : public OpBenchmark {
     auto packX = ConstantTadHelper::getInstance().tadForDimensions(_x->shapeInfo(), _axis);
     auto packZ = ConstantTadHelper::getInstance().tadForDimensions(_z->shapeInfo(), _axis);
 
-    auto tadOnlyShapeInfo = Environment::getInstance().isCPU() ? packX.primaryShapeInfo() : packX.specialShapeInfo();
-    auto tadOffsets = Environment::getInstance().isCPU() ? packX.primaryOffsets() : packX.specialOffsets();
+    auto tadOnlyShapeInfo = Environment::getInstance().isCPU() ? packX->primaryShapeInfo() : packX->specialShapeInfo();
+    auto tadOffsets = Environment::getInstance().isCPU() ? packX->primaryOffsets() : packX->specialOffsets();
 
-    auto tadOnlyShapeInfoZ = Environment::getInstance().isCPU() ? packZ.primaryShapeInfo() : packZ.specialShapeInfo();
-    auto tadOffsetsZ = Environment::getInstance().isCPU() ? packZ.primaryOffsets() : packZ.specialOffsets();
+    auto tadOnlyShapeInfoZ = Environment::getInstance().isCPU() ? packZ->primaryShapeInfo() : packZ->specialShapeInfo();
+    auto tadOffsetsZ = Environment::getInstance().isCPU() ? packZ->primaryOffsets() : packZ->specialOffsets();
 
     NativeOpExecutioner::execBroadcast(LaunchContext::defaultContext(), _opNum, _x->buffer(), _x->shapeInfo(),
                                        _x->specialBuffer(), _x->specialShapeInfo(), _y->buffer(), _y->shapeInfo(),

--- a/libnd4j/include/helpers/benchmark/ReductionBenchmark.h
+++ b/libnd4j/include/helpers/benchmark/ReductionBenchmark.h
@@ -101,8 +101,8 @@ class SD_LIB_EXPORT ReductionBenchmark : public OpBenchmark {
     else {
       auto pack = ConstantTadHelper::getInstance().tadForDimensions(_x->shapeInfo(), _axis);
 
-      auto tadOnlyShapeInfo = Environment::getInstance().isCPU() ? pack.primaryShapeInfo() : pack.specialShapeInfo();
-      auto tadOffsets = Environment::getInstance().isCPU() ? pack.primaryOffsets() : pack.specialOffsets();
+      auto tadOnlyShapeInfo = Environment::getInstance().isCPU() ? pack->primaryShapeInfo() : pack->specialShapeInfo();
+      auto tadOffsets = Environment::getInstance().isCPU() ? pack->primaryOffsets() : pack->specialOffsets();
 
       if (_opType == 0)
         NativeOpExecutioner::execReduceFloat(LaunchContext::defaultContext(), _opNum, _x->buffer(), _x->shapeInfo(),

--- a/libnd4j/include/helpers/cpu/ConstantTadHelper.cpp
+++ b/libnd4j/include/helpers/cpu/ConstantTadHelper.cpp
@@ -31,7 +31,7 @@
 namespace sd {
 
 ConstantTadHelper::ConstantTadHelper() {
-  SD_MAP_IMPL<TadDescriptor, TadPack> pack;
+  SD_MAP_IMPL<TadDescriptor *, TadPack *> pack;
   _cache.emplace_back(pack);
 }
 
@@ -40,40 +40,41 @@ ConstantTadHelper &ConstantTadHelper::getInstance() {
   return instance;
 }
 
-TadPack ConstantTadHelper::tadForDimensions(const sd::LongType *originalShape, LongType dimension,
-                                            const bool keepUnitiesInShape) {
+TadPack *ConstantTadHelper::tadForDimensions(const sd::LongType *originalShape, LongType dimension,
+                                             const bool keepUnitiesInShape) {
   return tadForDimensions(originalShape, &dimension, 1, keepUnitiesInShape);
 }
 
-TadPack ConstantTadHelper::tadForDimensions(const sd::LongType *originalShape, const std::vector<LongType> &dimensions,
-                                            const bool keepUnitiesInShape) {
+TadPack *ConstantTadHelper::tadForDimensions(const sd::LongType *originalShape, const std::vector<LongType> &dimensions,
+                                             const bool keepUnitiesInShape) {
   return tadForDimensions(originalShape, const_cast<sd::LongType *>(dimensions.data()), dimensions.size(), keepUnitiesInShape);
 }
 
-TadPack ConstantTadHelper::tadForDimensions(const sd::LongType *originalShape, LongType *dimensions, LongType dimLength,
-                                            const bool keepUnitiesInShape) {
-  TadDescriptor tadDescriptor(originalShape, dimensions, dimLength, keepUnitiesInShape);
+TadPack *ConstantTadHelper::tadForDimensions(const sd::LongType *originalShape, LongType *dimensions, LongType dimLength,
+                                             const bool keepUnitiesInShape) {
+  TadDescriptor *tadDescriptor = new TadDescriptor(originalShape, dimensions, dimLength, keepUnitiesInShape);
   return tadForDimensions(tadDescriptor);
 }
 
-TadPack ConstantTadHelper::tadForDimensions(ShapeDescriptor &descriptor, std::vector<LongType> &dimensions,
-                                            const bool keepUnitiesInShape) {
-  TadDescriptor tadDescriptor(descriptor, dimensions, keepUnitiesInShape);
+TadPack *ConstantTadHelper::tadForDimensions(ShapeDescriptor &descriptor, std::vector<LongType> &dimensions,
+                                             const bool keepUnitiesInShape) {
+  TadDescriptor *tadDescriptor = new TadDescriptor(descriptor, dimensions, keepUnitiesInShape);
   return tadForDimensions(tadDescriptor);
 }
 
-TadPack ConstantTadHelper::tadForDimensions(TadDescriptor &descriptor) {
+TadPack *ConstantTadHelper::tadForDimensions(TadDescriptor *descriptor) {
   const int deviceId = 0;
-
+  if(descriptor == nullptr)
+    throw std::runtime_error("ConstantTadHelper::tadForDimensions: descriptor is nullptr!");
   std::lock_guard<std::mutex> lock(_mutex);
   if (_cache[deviceId].count(descriptor) == 0) {
     // if there's no TadPack matching this descriptor - create one
-    const auto shapeInfo = descriptor.originalShape().toShapeInfo();
+    const auto shapeInfo = descriptor->originalShape().toShapeInfo();
     const int rank = shape::rank(shapeInfo);
-    const std::vector<sd::LongType> dimsToExclude = ShapeUtils::evalDimsToExclude(rank, descriptor.axis());
+    const std::vector<sd::LongType> dimsToExclude = ShapeUtils::evalDimsToExclude(rank, descriptor->axis());
     const sd::LongType numOfSubArrs = ShapeUtils::getNumOfSubArrs(shapeInfo, dimsToExclude);
     const int subArrRank =
-        (rank == dimsToExclude.size() || descriptor.areUnitiesinShape()) ? rank : rank - dimsToExclude.size();
+        (rank == dimsToExclude.size() || descriptor->areUnitiesinShape()) ? rank : rank - dimsToExclude.size();
 
     auto sPtr = std::make_shared<PointerWrapper>(
         new sd::LongType[shape::shapeInfoLength(subArrRank)],
@@ -84,17 +85,19 @@ TadPack ConstantTadHelper::tadForDimensions(TadDescriptor &descriptor) {
     if (numOfSubArrs > 0)
       shape::calcSubArrsShapeInfoAndOffsets(shapeInfo, numOfSubArrs, dimsToExclude.size(), dimsToExclude.data(),
                                             sPtr->pointerAsT<sd::LongType>(), oPtr->pointerAsT<sd::LongType>(),
-                                            descriptor.areUnitiesinShape());
+                                            descriptor->areUnitiesinShape());
 
     ConstantShapeBuffer shapeBuffer(sPtr);
     ConstantOffsetsBuffer offsetsBuffer(oPtr);
-    TadPack t(shapeBuffer, offsetsBuffer, numOfSubArrs);
+    TadPack *t = new TadPack(shapeBuffer, offsetsBuffer, numOfSubArrs);
+
     _cache[deviceId][descriptor] = t;
 
-    delete[] shapeInfo;
   }
-
   return _cache[deviceId][descriptor];
+
+// if there's no TadPack matching this descriptor - create one
+
 }
 }  // namespace sd
 

--- a/libnd4j/include/helpers/impl/shape.cpp
+++ b/libnd4j/include/helpers/impl/shape.cpp
@@ -26,130 +26,132 @@ namespace shape {
 
 
 
-SD_HOST sd::LongType *computeResultShape(sd::LongType const *originalShapeBuffer, int *dimension,
-                                         int dimensionLength) {
-  sd::LongType *retShape;
-  int retShapeLength;
-  if (dimensionLength == 1 && dimension[0] == 2147483647) {
-    retShape = new sd::LongType[2];
-    retShape[0] = 1;
-    retShape[1] = 1;
-    retShapeLength = 2;
-  } else {
-    retShape = shape::removeIndex<sd::LongType, int>(shape::shapeOf(originalShapeBuffer), dimension,
-                                                     shape::shapeInfoLength(shape::rank(originalShapeBuffer)),
-                                                     dimensionLength);
-    retShapeLength = shape::rank(originalShapeBuffer) - dimensionLength;
-  }
-  // ensure vector is proper shape
-  if (retShapeLength == 1) {
-    if (dimension[0] == 0) {
-      auto newRetShape = new sd::LongType[2]{1, retShape[0]};
-      delete[] retShape;
-      retShape = newRetShape;
-      retShapeLength = 2;
-    } else {
-      auto newRetShape = new sd::LongType[2]{retShape[0], 1};
-      delete[] retShape;
-      retShape = newRetShape;
-      retShapeLength = 2;
-    }
-  } else if (retShapeLength == 0) {
-    auto newRetShape = new sd::LongType[2]{1, 1};
-    delete[] retShape;
-    retShape = newRetShape;
-    retShapeLength = 2;
-  }
+    SD_HOST sd::LongType *computeResultShape(sd::LongType const *originalShapeBuffer, long long int *dimension,
+                                             long long int dimensionLength) {
+        sd::LongType *retShape;
+        int retShapeLength;
+        if (dimensionLength == 1 && dimension[0] == 2147483647) {
+            retShape = new sd::LongType[2];
+            retShape[0] = 1;
+            retShape[1] = 1;
+            retShapeLength = 2;
+        } else {
+            retShape = shape::removeIndex<sd::LongType, sd::LongType>(shape::shapeOf(originalShapeBuffer), dimension,
+                                                                      shape::shapeInfoLength(shape::rank(originalShapeBuffer)),
+                                                                      dimensionLength);
+            retShapeLength = shape::rank(originalShapeBuffer) - dimensionLength;
+        }
+        // ensure vector is proper shape
+        if (retShapeLength == 1) {
+            if (dimension[0] == 0) {
+                auto newRetShape = new sd::LongType[2]{1, retShape[0]};
+                delete[] retShape;
+                retShape = newRetShape;
+                retShapeLength = 2;
+            } else {
+                auto newRetShape = new sd::LongType[2]{retShape[0], 1};
+                delete[] retShape;
+                retShape = newRetShape;
+                retShapeLength = 2;
+            }
+        } else if (retShapeLength == 0) {
+            auto newRetShape = new sd::LongType[2]{1, 1};
+            delete[] retShape;
+            retShape = newRetShape;
+            retShapeLength = 2;
+        }
 
-  auto ret = shape::shapeBuffer(retShapeLength, sd::ArrayOptions::dataType(originalShapeBuffer), retShape);
-  delete[] retShape;
+        auto ret = shape::shapeBuffer(retShapeLength, sd::ArrayOptions::dataType(originalShapeBuffer), retShape);
+        delete[] retShape;
 
-  return ret;
-}
-
-SD_HOST sd::LongType *shapeInfoOnlyShapeAndStride(const sd::LongType *shapeInfo,
-                                                  sd::LongType *dimension, int dimensionLength,
-                                                  bool reverseCopyStride, sd::LongType *buffer) {
-  sd::LongType *theShape = shape::shapeOf(shapeInfo);
-  sd::LongType *theStride = shape::stride(shapeInfo);
-  int rank = dimensionLength == 1 ? 2 : dimensionLength;
-  sd::LongType *ret = buffer;
-  // set the rank
-  ret[0] = rank;
-  sd::LongType *retShape = shape::shapeOf(ret);
-  sd::LongType *retStride = shape::stride(ret);
-  int len = rank;
-
-  if (dimensionLength == 1) {
-    if (shape::isMatrix(theShape, shape::rank(shapeInfo))) {
-      if (dimension[0] == 0) {
-        sd::LongType newStride[2] = {theStride[dimension[0]], 1};
-        sd::LongType newShape[2] = {theShape[dimension[0]], 1};
-        retShape[0] = newShape[0];
-        retShape[1] = newShape[1];
-        retStride[0] = newStride[0];
-        retStride[1] = newStride[1];
-      } else {
-        sd::LongType newStride[2] = {theStride[dimension[0]], 1};
-        sd::LongType newShape[2] = {theShape[dimension[0]], 1};
-        retShape[0] = newShape[0];
-        retShape[1] = newShape[1];
-        retStride[0] = newStride[0];
-        retStride[1] = newStride[1];
-      }
-    } else {
-      sd::LongType newStride[2] = {1, theStride[dimension[0]]};
-      sd::LongType newShape[2] = {1, theShape[dimension[0]]};
-      retShape[0] = newShape[0];
-      retShape[1] = newShape[1];
-      retStride[0] = newStride[0];
-      retStride[1] = newStride[1];
+        return ret;
     }
 
-  } else {
-    sd::LongType *newIndexes = dimension;
-    if (reverseCopyStride)
-      shape::reverseCopyTo(theStride, retStride, newIndexes, len);
-    else
-      shape::copyTo(len, theStride, retStride, newIndexes);
-    shape::copyTo(len, theShape, retShape, newIndexes);
-  }
+    SD_HOST sd::LongType *shapeInfoOnlyShapeAndStride(const sd::LongType *shapeInfo,
+                                                      sd::LongType *dimension,
+                                                      long long int dimensionLength,
+                                                      bool reverseCopyStride, sd::LongType *buffer) {
+        sd::LongType *theShape = shape::shapeOf(shapeInfo);
+        sd::LongType *theStride = shape::stride(shapeInfo);
+        int rank = dimensionLength == 1 ? 2 : dimensionLength;
+        sd::LongType *ret = buffer;
+        // set the rank
+        ret[0] = rank;
+        sd::LongType *retShape = shape::shapeOf(ret);
+        sd::LongType *retStride = shape::stride(ret);
+        int len = rank;
 
-  ret[shape::shapeInfoLength(rank) - 1] = shape::order(shapeInfo);
-  return ret;
-}
+        if (dimensionLength == 1) {
+            if (shape::isMatrix(theShape, shape::rank(shapeInfo))) {
+                if (dimension[0] == 0) {
+                    sd::LongType newStride[2] = {theStride[dimension[0]], 1};
+                    sd::LongType newShape[2] = {theShape[dimension[0]], 1};
+                    retShape[0] = newShape[0];
+                    retShape[1] = newShape[1];
+                    retStride[0] = newStride[0];
+                    retStride[1] = newStride[1];
+                } else {
+                    sd::LongType newStride[2] = {theStride[dimension[0]], 1};
+                    sd::LongType newShape[2] = {theShape[dimension[0]], 1};
+                    retShape[0] = newShape[0];
+                    retShape[1] = newShape[1];
+                    retStride[0] = newStride[0];
+                    retStride[1] = newStride[1];
+                }
+            } else {
+                sd::LongType newStride[2] = {1, theStride[dimension[0]]};
+                sd::LongType newShape[2] = {1, theShape[dimension[0]]};
+                retShape[0] = newShape[0];
+                retShape[1] = newShape[1];
+                retStride[0] = newStride[0];
+                retStride[1] = newStride[1];
+            }
 
-SD_HOST sd::LongType *shapeInfoOnlyShapeAndStride(const sd::LongType *shapeInfo,
-                                                  sd::LongType *dimension, int dimensionLength,
-                                                  bool reverseCopyStride) {
-  int rank = dimensionLength == 1 ? 2 : dimensionLength;
+        } else {
+            sd::LongType *newIndexes = dimension;
+            if (reverseCopyStride)
+                shape::reverseCopyTo(theStride, retStride, newIndexes, len);
+            else
+                shape::copyTo(len, theStride, retStride, newIndexes);
+            shape::copyTo(len, theShape, retShape, newIndexes);
+        }
 
-  traceNew(4);
+        ret[shape::shapeInfoLength(rank) - 1] = shape::order(shapeInfo);
+        return ret;
+    }
 
-  sd::LongType *ret = new sd::LongType[shape::shapeInfoLength(rank)];
-  return shapeInfoOnlyShapeAndStride(shapeInfo, dimension, dimensionLength, reverseCopyStride, ret);
-}
+    SD_HOST sd::LongType *shapeInfoOnlyShapeAndStride(const sd::LongType *shapeInfo,
+                                                      sd::LongType *dimension,
+                                                      long long int dimensionLength,
+                                                      bool reverseCopyStride) {
+        int rank = dimensionLength == 1 ? 2 : dimensionLength;
 
-SD_HOST sd::LongType *createShapeInfo(sd::LongType *shape, sd::LongType *stride, int rank) {
-  traceNew(5);
+        traceNew(4);
 
-  sd::LongType *ret = new sd::LongType[shape::shapeInfoLength(rank)];
+        sd::LongType *ret = new sd::LongType[shape::shapeInfoLength(rank)];
+        return shapeInfoOnlyShapeAndStride(shapeInfo, dimension, dimensionLength, reverseCopyStride, ret);
+    }
 
-  return createShapeInfo(shape, stride, rank, ret);
-}
+    SD_HOST sd::LongType *createShapeInfo(sd::LongType *shape, sd::LongType *stride, int rank) {
+        traceNew(5);
 
-SD_HOST sd::LongType *createShapeInfo(sd::LongType *shape, sd::LongType *stride, int rank,
-                                      sd::LongType *buffer) {
-  buffer[0] = rank;
-  sd::LongType *retShape = shape::shapeOf(buffer);
-  sd::LongType *retStride = shape::stride(buffer);
-  for (int i = 0; i < rank; i++) {
-    retShape[i] = shape[i];
-    retStride[i] = stride[i];
-  }
+        sd::LongType *ret = new sd::LongType[shape::shapeInfoLength(rank)];
 
-  return buffer;
-}
+        return createShapeInfo(shape, stride, rank, ret);
+    }
+
+    SD_HOST sd::LongType *createShapeInfo(sd::LongType *shape, sd::LongType *stride, int rank,
+                                          sd::LongType *buffer) {
+        buffer[0] = rank;
+        sd::LongType *retShape = shape::shapeOf(buffer);
+        sd::LongType *retStride = shape::stride(buffer);
+        for (int i = 0; i < rank; i++) {
+            retShape[i] = shape[i];
+            retStride[i] = stride[i];
+        }
+
+        return buffer;
+    }
 
 
 #ifndef SD_CUDA
@@ -158,296 +160,340 @@ SD_HOST sd::LongType *createShapeInfo(sd::LongType *shape, sd::LongType *stride,
  * Length of a tad given
  * the shape information
  */
-SD_LIB_EXPORT SD_HOST sd::LongType tadLength(const sd::LongType *shapeInfo, sd::LongType *dimension, int dimensionLength) {
+    SD_LIB_EXPORT SD_HOST sd::LongType tadLength(const sd::LongType *shapeInfo, sd::LongType *dimension,
+                                                 long long int dimensionLength) {
 
-  if(shapeInfo == nullptr || dimension == nullptr) {
-    std::string  errorMessage;
-    errorMessage += "shape info null: %d";
-    errorMessage += std::to_string(shapeInfo == nullptr);
-    errorMessage += " dimension null: %d";
-    errorMessage += std::to_string(dimension == nullptr);
-    throw std::runtime_error(errorMessage.c_str());
-  }
+        if(shapeInfo == nullptr || dimension == nullptr) {
+            std::string  errorMessage;
+            errorMessage += "shape info null: %d";
+            errorMessage += std::to_string(shapeInfo == nullptr);
+            errorMessage += " dimension null: %d";
+            errorMessage += std::to_string(dimension == nullptr);
+            throw std::runtime_error(errorMessage.c_str());
+        }
 
-  if(dimensionLength == 0)
-    return 0;
+        if(dimensionLength == 0)
+            return 0;
 
-  if(shapeInfo[0] > SD_MAX_RANK || shapeInfo[0] < 0)
-    throw std::runtime_error("Corrupt shape information found. Potentially dellocated?");
+        if(shapeInfo[0] > SD_MAX_RANK || shapeInfo[0] < 0)
+            throw std::runtime_error("Corrupt shape information found. Potentially dellocated?");
 
 
 
-  if (dimensionLength == 1) {
-    if(dimension[0] > SD_MAX_RANK || dimension[0] < 0)
-      throw std::runtime_error("Corrupt dimension information found. Potentially dellocated?");
+        if (dimensionLength == 1) {
+            if(dimension[0] > SD_MAX_RANK || dimension[0] < 0)
+                throw std::runtime_error("Corrupt dimension information found. Potentially dellocated?");
 
-    return shape::shapeOf(shapeInfo)[dimension[0]];
-  } else {
-    sd::LongType ret = 1;
-    for (int i = 0; i < shape::rank(shapeInfo); i++) {
-      for (int j = 0; j < dimensionLength; j++) {
-        if (i == dimension[j]) ret *= shape::shapeOf(shapeInfo)[dimension[j]];
-      }
+            return shape::shapeOf(shapeInfo)[dimension[0]];
+        } else {
+            sd::LongType ret = 1;
+            for (int i = 0; i < shape::rank(shapeInfo); i++) {
+                for (int j = 0; j < dimensionLength; j++) {
+                    if (i == dimension[j]) ret *= shape::shapeOf(shapeInfo)[dimension[j]];
+                }
+            }
+
+            return ret;
+        }
     }
 
-    return ret;
-  }
-}
+
+    SD_LIB_EXPORT  SD_HOST sd::LongType tadElementWiseStride(sd::LongType *shapeInfo, sd::LongType *dimension,
+                                                             sd::LongType dimensionLength) {
+        return reductionIndexElementWiseStride(shapeInfo, dimension, dimensionLength);
+    }
 
 
-SD_LIB_EXPORT  SD_HOST int tadElementWiseStride(sd::LongType *shapeInfo, int *dimension, int dimensionLength) {
-  return reductionIndexElementWiseStride(shapeInfo, dimension, dimensionLength);
-}
+    SD_LIB_EXPORT SD_HOST bool isEmpty(const sd::LongType *shapeInfo) {
+        return ((shape::extra(shapeInfo) & ARRAY_EMPTY) == ARRAY_EMPTY);
+    }
 
 
-SD_LIB_EXPORT SD_HOST bool isEmpty(const sd::LongType *shapeInfo) {
-  return ((shape::extra(shapeInfo) & ARRAY_EMPTY) == ARRAY_EMPTY);
-}
+    SD_LIB_EXPORT SD_HOST bool strideDescendingCAscendingF(const sd::LongType *shapeBuffer) {
+        int rank = shape::rank(shapeBuffer);
+        sd::LongType *strides = shape::stride(const_cast<sd::LongType *>(shapeBuffer));
+        char order = shape::order(shapeBuffer);
 
+        if (shape::isRowVector(shapeBuffer) && strides[0] == 1 && strides[1] == 1) return true;
 
-SD_LIB_EXPORT SD_HOST bool strideDescendingCAscendingF(const sd::LongType *shapeBuffer) {
-  int rank = shape::rank(shapeBuffer);
-  sd::LongType *strides = shape::stride(const_cast<sd::LongType *>(shapeBuffer));
-  char order = shape::order(shapeBuffer);
-
-  if (shape::isRowVector(shapeBuffer) && strides[0] == 1 && strides[1] == 1) return true;
-
-  if (order == 'c') {
-    for (int i = 1; i < rank; i++)
-      if (strides[i - 1] <= strides[i]) return false;
-    return true;
-  } else if (order == 'f') {
-    for (int i = 1; i < rank; i++)
-      if (strides[i - 1] >= strides[i]) return false;
-    return true;
-  } else {
-    printf("Unknown order for array!\n");
-    return false;
-  }
-}
+        if (order == 'c') {
+            for (int i = 1; i < rank; i++)
+                if (strides[i - 1] <= strides[i]) return false;
+            return true;
+        } else if (order == 'f') {
+            for (int i = 1; i < rank; i++)
+                if (strides[i - 1] >= strides[i]) return false;
+            return true;
+        } else {
+            printf("Unknown order for array!\n");
+            return false;
+        }
+    }
 
 // max array is outer for min array, min array is sub-array of max array
 // function calculates the coordinates of min array (and saves them into minIdxs) given coordinates of max array
 // (already stored in maxIdxs)
-SD_LIB_EXPORT SD_HOST void maxIndToMinInd(long long int *maxIdxs, long long int *minIdxs, const sd::LongType *maxShapeInfo,
-                                          const sd::LongType *minShapeInfo,
-                                          const long long int *dimsToExclude, long long int dimsLen) {
-  const auto maxRank = shape::rank(maxShapeInfo);
-  const auto minRank = shape::rank(minShapeInfo);
+    SD_LIB_EXPORT SD_HOST void maxIndToMinInd(long long int *maxIdxs, long long int *minIdxs, const sd::LongType *maxShapeInfo,
+                                              const sd::LongType *minShapeInfo,
+                                              const long long int *dimsToExclude, long long int dimsLen) {
+        const auto maxRank = shape::rank(maxShapeInfo);
+        const auto minRank = shape::rank(minShapeInfo);
 
 
 
-  if (dimsLen == -1) dimsLen = maxRank - minRank;  // if size is not given (= -1) then it is equal to ranks difference
+        if (dimsLen == -1) dimsLen = maxRank - minRank;  // if size is not given (= -1) then it is equal to ranks difference
 
-  if (maxRank == minRank) {
-    if (dimsToExclude == nullptr) {  // --> means dimsToExclude == {0,1,2,...,dimsLen-1}
+        if (maxRank == minRank) {
+            if (dimsToExclude == nullptr) {  // --> means dimsToExclude == {0,1,2,...,dimsLen-1}
 
-      for (int i = 0; i < maxRank; ++i) {
-        if (i < dimsLen)
-          minIdxs[i] = maxIdxs[i];
-        else {
-          if (maxIdxs[i] > minShapeInfo[i + 1])
-            minIdxs[i] = maxIdxs[i] % minShapeInfo[i + 1];
-          else if (maxIdxs[i] == minShapeInfo[i + 1])
-            minIdxs[i] = 0;
-          else
-            minIdxs[i] = maxIdxs[i];
+                for (int i = 0; i < maxRank; ++i) {
+                    if (i < dimsLen)
+                        minIdxs[i] = maxIdxs[i];
+                    else {
+                        if (maxIdxs[i] > minShapeInfo[i + 1])
+                            minIdxs[i] = maxIdxs[i] % minShapeInfo[i + 1];
+                        else if (maxIdxs[i] == minShapeInfo[i + 1])
+                            minIdxs[i] = 0;
+                        else
+                            minIdxs[i] = maxIdxs[i];
+                    }
+                }
+            } else {
+                for (int i = 0, dim = 0; i < maxRank; ++i) {
+                    if (dim < dimsLen && dimsToExclude[dim] == i) {
+                        minIdxs[i] = maxIdxs[i];
+                        ++dim;
+                        continue;
+                    }
+
+                    if (maxIdxs[i] > minShapeInfo[i + 1])
+                        minIdxs[i] = maxIdxs[i] % minShapeInfo[i + 1];
+                    else if (maxIdxs[i] == minShapeInfo[i + 1])
+                        minIdxs[i] = 0;
+                    else
+                        minIdxs[i] = maxIdxs[i];
+                }
+            }
+        } else {
+            if (dimsToExclude == nullptr) {  // --> means dimsToExclude == {0,1,2,...,dimsLen-1}
+
+                for (int i = 0; i < minRank; ++i) {
+                    if (maxIdxs[i + dimsLen] > minShapeInfo[i + 1])
+                        minIdxs[i] = maxIdxs[i + dimsLen] % minShapeInfo[i + 1];
+                    else if (maxIdxs[i + dimsLen] == minShapeInfo[i + 1])
+                        minIdxs[i] = 0;
+                    else
+                        minIdxs[i] = maxIdxs[i + dimsLen];
+                }
+            } else {
+                for (int minI = 0, maxI = 0, dim = 0; maxI < maxRank; ++maxI) {
+                    if (dim < dimsLen && dimsToExclude[dim] == maxI) {
+                        ++dim;
+                        continue;
+                    }
+
+                    if (maxIdxs[maxI] == minShapeInfo[minI + 1])
+                        minIdxs[minI] = 0;
+                    else if (maxIdxs[maxI] > minShapeInfo[minI + 1])
+                        minIdxs[minI] = maxIdxs[maxI] % minShapeInfo[minI + 1];
+                    else
+                        minIdxs[minI] = maxIdxs[maxI];
+                    ++minI;
+                }
+            }
         }
-      }
-    } else {
-      for (int i = 0, dim = 0; i < maxRank; ++i) {
-        if (dim < dimsLen && dimsToExclude[dim] == i) {
-          minIdxs[i] = maxIdxs[i];
-          ++dim;
-          continue;
-        }
-
-        if (maxIdxs[i] > minShapeInfo[i + 1])
-          minIdxs[i] = maxIdxs[i] % minShapeInfo[i + 1];
-        else if (maxIdxs[i] == minShapeInfo[i + 1])
-          minIdxs[i] = 0;
-        else
-          minIdxs[i] = maxIdxs[i];
-      }
     }
-  } else {
-    if (dimsToExclude == nullptr) {  // --> means dimsToExclude == {0,1,2,...,dimsLen-1}
-
-      for (int i = 0; i < minRank; ++i) {
-        if (maxIdxs[i + dimsLen] > minShapeInfo[i + 1])
-          minIdxs[i] = maxIdxs[i + dimsLen] % minShapeInfo[i + 1];
-        else if (maxIdxs[i + dimsLen] == minShapeInfo[i + 1])
-          minIdxs[i] = 0;
-        else
-          minIdxs[i] = maxIdxs[i + dimsLen];
-      }
-    } else {
-      for (int minI = 0, maxI = 0, dim = 0; maxI < maxRank; ++maxI) {
-        if (dim < dimsLen && dimsToExclude[dim] == maxI) {
-          ++dim;
-          continue;
-        }
-
-        if (maxIdxs[maxI] == minShapeInfo[minI + 1])
-          minIdxs[minI] = 0;
-        else if (maxIdxs[maxI] > minShapeInfo[minI + 1])
-          minIdxs[minI] = maxIdxs[maxI] % minShapeInfo[minI + 1];
-        else
-          minIdxs[minI] = maxIdxs[maxI];
-        ++minI;
-      }
-    }
-  }
-}
 
 
 
 //////////////////////////////////////////////////////////////////////
-SD_LIB_EXPORT SD_HOST sd::LongType subArrayOffset(const sd::LongType maxIdx, const sd::LongType *maxShapeInfo,
-                                                  const sd::LongType *minShapeInfo, const sd::LongType  *dimsToExclude,
-                                                  const sd::LongType dimsLen) {
-  sd::LongType maxIdxs[SD_MAX_RANK];
-  shape::index2coords(const_cast<sd::LongType &>(maxIdx), maxShapeInfo, maxIdxs);
+    SD_LIB_EXPORT SD_HOST sd::LongType subArrayOffset(const sd::LongType maxIdx, const sd::LongType *maxShapeInfo,
+                                                      const sd::LongType *minShapeInfo, const sd::LongType  *dimsToExclude,
+                                                      const sd::LongType dimsLen) {
+        sd::LongType maxIdxs[SD_MAX_RANK];
+        shape::index2coords(const_cast<sd::LongType &>(maxIdx), maxShapeInfo, maxIdxs);
 
-  sd::LongType minIdxs[SD_MAX_RANK];
-  maxIndToMinInd(maxIdxs, minIdxs, maxShapeInfo, minShapeInfo, dimsToExclude, dimsLen);
+        sd::LongType minIdxs[SD_MAX_RANK];
+        maxIndToMinInd(maxIdxs, minIdxs, maxShapeInfo, minShapeInfo, dimsToExclude, dimsLen);
 
-  return getOffset(minShapeInfo, minIdxs);
-}
+        return getOffset(minShapeInfo, minIdxs);
+    }
 
 //////////////////////////////////////////////////////////////////////
-SD_LIB_EXPORT SD_HOST int outerArrayOffsets(sd::LongType *maxOffsets, const sd::LongType minIdx,
-                                            const sd::LongType *maxShapeInfo, const sd::LongType *minShapeInfo,
-                                            sd::LongType *memBuff, const sd::LongType *dimsToExclude) {
-  const auto rankMin = shape::rank(minShapeInfo);
-  const auto rankMax = shape::rank(maxShapeInfo);
+    SD_LIB_EXPORT SD_HOST int outerArrayOffsets(sd::LongType *maxOffsets, const sd::LongType minIdx,
+                                                const sd::LongType *maxShapeInfo, const sd::LongType *minShapeInfo,
+                                                sd::LongType *memBuff, const sd::LongType *dimsToExclude) {
+        const auto rankMin = shape::rank(minShapeInfo);
+        const auto rankMax = shape::rank(maxShapeInfo);
 
 
-  const auto diff = rankMax - rankMin;  // the size of dimsToExclude is equal to diff
+        const auto diff = rankMax - rankMin;  // the size of dimsToExclude is equal to diff
 
-  sd::LongType *indices = memBuff;
-  sd::LongType *increment = memBuff + rankMax;
+        sd::LongType *indices = memBuff;
+        sd::LongType *increment = memBuff + rankMax;
 
-  sd::LongType N, minI, maxI;
+        sd::LongType N, minI, maxI;
 
-  // calculate min per-dim-indices which corresponds to absolute minIdx index
-  shape::index2coords(minIdx, minShapeInfo, indices);
+        // calculate min per-dim-indices which corresponds to absolute minIdx index
+        shape::index2coords(minIdx, minShapeInfo, indices);
 
-  // transform storage indices to contain per-dim max indices, purpose - memory saving
-  // fill increment array as well
-  if (dimsToExclude == nullptr) {  // means dimsToExclude == {0,1,2,...,diff-1}
-    for (minI = rankMin - 1, maxI = rankMax - 1; maxI >= diff; --maxI, --minI) {
-      increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
-      indices[maxI] = indices[minI];
-    }
-    for (maxI = 0; maxI < diff; ++maxI) {
-      increment[maxI] = 1;
-      indices[maxI] = 0;
-    }
-  } else {
-    for (N = diff - 1, minI = rankMin - 1, maxI = rankMax - 1; maxI >= 0; --maxI) {
-      if (N >= 0 && dimsToExclude[N] == maxI) {
-        increment[maxI] = 1;
-        indices[maxI] = 0;
-        --N;
-      } else {
-        increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
-        indices[maxI] = indices[minI--];
-      }
-    }
-  }
+        // transform storage indices to contain per-dim max indices, purpose - memory saving
+        // fill increment array as well
+        if (dimsToExclude == nullptr) {  // means dimsToExclude == {0,1,2,...,diff-1}
+            for (minI = rankMin - 1, maxI = rankMax - 1; maxI >= diff; --maxI, --minI) {
+                increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
+                indices[maxI] = indices[minI];
+            }
+            for (maxI = 0; maxI < diff; ++maxI) {
+                increment[maxI] = 1;
+                indices[maxI] = 0;
+            }
+        } else {
+            for (N = diff - 1, minI = rankMin - 1, maxI = rankMax - 1; maxI >= 0; --maxI) {
+                if (N >= 0 && dimsToExclude[N] == maxI) {
+                    increment[maxI] = 1;
+                    indices[maxI] = 0;
+                    --N;
+                } else {
+                    increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
+                    indices[maxI] = indices[minI--];
+                }
+            }
+        }
 
-  maxI = rankMax - 1;
-  N = 0;
-  int step;
-  maxOffsets[N++] = shape::getOffset(maxShapeInfo, indices);
-
-  // nested loops - producing of absolute indices for max array
-  while (maxI >= 0) {
-    if (increment[maxI] != 0) {
-      indices[maxI] += increment[maxI];
-      if (indices[maxI] >= maxShapeInfo[maxI + 1]) {
-        indices[maxI] %= increment[maxI];  // restore initial value of indices[maxI]
-        step = -1;
-      } else {
+        maxI = rankMax - 1;
+        N = 0;
+        int step;
         maxOffsets[N++] = shape::getOffset(maxShapeInfo, indices);
-        step = rankMax - 1 - maxI;
-      }
-    } else if (maxI == rankMax - 1)
-      step = -1;
 
-    maxI += step;
-  }
-  return N;
-}
+        // nested loops - producing of absolute indices for max array
+        while (maxI >= 0) {
+            if (increment[maxI] != 0) {
+                indices[maxI] += increment[maxI];
+                if (indices[maxI] >= maxShapeInfo[maxI + 1]) {
+                    indices[maxI] %= increment[maxI];  // restore initial value of indices[maxI]
+                    step = -1;
+                } else {
+                    maxOffsets[N++] = shape::getOffset(maxShapeInfo, indices);
+                    step = rankMax - 1 - maxI;
+                }
+            } else if (maxI == rankMax - 1)
+                step = -1;
+
+            maxI += step;
+        }
+        return N;
+    }
 
 //////////////////////////////////////////////////////////////////////
-SD_LIB_EXPORT SD_HOST sd::LongType outerArrayIndexes(sd::LongType *maxIdxs, const sd::LongType minIdx,
-                                                     const sd::LongType *maxShapeInfo, const sd::LongType *minShapeInfo,
-                                                     const sd::LongType  *dimsToExclude) {
-  const auto rankMin = shape::rank(minShapeInfo);
-  const auto rankMax = shape::rank(maxShapeInfo);
 
-
-  const sd::LongType diff = rankMax - rankMin;  // the size of dimsToExclude is equal to diff
-
-  sd::LongType indices[SD_MAX_RANK], increment[SD_MAX_RANK];
-
-  sd::LongType N, minI, maxI;
-
-  // calculate min per-dim-indices which corresponds to absolute minIdx index
-  shape::index2coords(minIdx, minShapeInfo, indices);
-
-  // transform storage indices to contain per-dim max indices, purpose - memory saving
-  // fill increment array as well
-  if (dimsToExclude == nullptr) {  // means dimsToExclude == {0,1,2,...,diff-1}
-    for (minI = rankMin - 1, maxI = rankMax - 1; maxI >= diff; --maxI, --minI) {
-      increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
-      indices[maxI] = indices[minI];
-    }
-    for (maxI = 0; maxI < diff; ++maxI) {
-      increment[maxI] = 1;
-      indices[maxI] = 0;
-    }
-  } else {
-    for (N = diff - 1, minI = rankMin - 1, maxI = rankMax - 1; maxI >= 0; --maxI) {
-      if (N >= 0 && dimsToExclude[N] == maxI) {
-        increment[maxI] = 1;
-        indices[maxI] = 0;
-        --N;
-      } else {
-        increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
-        indices[maxI] = indices[minI--];
-      }
-    }
-  }
-
-  maxI = rankMax - 1;
-  N = 0;
-  int step;
-  maxIdxs[N++] = shape::coords2index(maxShapeInfo, indices);
-
-  // nested loops - producing of absolute indices for max array
-  while (maxI >= 0) {
-    if (increment[maxI] != 0) {
-      indices[maxI] += increment[maxI];
-      if (indices[maxI] >= maxShapeInfo[maxI + 1]) {
-        indices[maxI] %= increment[maxI];  // restore initial value of indices[maxI]
-        step = -1;
-      } else {
-        maxIdxs[N++] = shape::coords2index(maxShapeInfo, indices);
-        step = rankMax - 1 - maxI;
-      }
-    } else if (maxI == rankMax - 1)
-      step = -1;
-
-    maxI += step;
-  }
-  return N;
-}
 
 #endif
 
+    SD_LIB_EXPORT SD_HOST sd::LongType outerArrayIndexes(sd::LongType *maxIdxs, const sd::LongType minIdx,
+                                                         const sd::LongType *maxShapeInfo, const sd::LongType *minShapeInfo,
+                                                         const sd::LongType  *dimsToExclude) {
+      const auto rankMin = shape::rank(minShapeInfo);
+      const auto rankMax = shape::rank(maxShapeInfo);
+
+
+      const sd::LongType diff = rankMax - rankMin;  // the size of dimsToExclude is equal to diff
+
+      sd::LongType indices[SD_MAX_RANK], increment[SD_MAX_RANK];
+
+      sd::LongType N, minI, maxI;
+
+      // calculate min per-dim-indices which corresponds to absolute minIdx index
+      shape::index2coords(minIdx, minShapeInfo, indices);
+
+      // transform storage indices to contain per-dim max indices, purpose - memory saving
+      // fill increment array as well
+      if (dimsToExclude == nullptr) {  // means dimsToExclude == {0,1,2,...,diff-1}
+        for (minI = rankMin - 1, maxI = rankMax - 1; maxI >= diff; --maxI, --minI) {
+          increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
+          indices[maxI] = indices[minI];
+        }
+        for (maxI = 0; maxI < diff; ++maxI) {
+          increment[maxI] = 1;
+          indices[maxI] = 0;
+        }
+      } else {
+        for (N = diff - 1, minI = rankMin - 1, maxI = rankMax - 1; maxI >= 0; --maxI) {
+          if (N >= 0 && dimsToExclude[N] == maxI) {
+            increment[maxI] = 1;
+            indices[maxI] = 0;
+            --N;
+          } else {
+            increment[maxI] = (maxShapeInfo[maxI + 1] == minShapeInfo[minI + 1]) ? 0 : minShapeInfo[minI + 1];
+            indices[maxI] = indices[minI--];
+          }
+        }
+      }
+
+      maxI = rankMax - 1;
+      N = 0;
+      int step;
+      maxIdxs[N++] = shape::coords2index(maxShapeInfo, indices);
+
+      // nested loops - producing of absolute indices for max array
+      while (maxI >= 0) {
+        if (increment[maxI] != 0) {
+          indices[maxI] += increment[maxI];
+          if (indices[maxI] >= maxShapeInfo[maxI + 1]) {
+            indices[maxI] %= increment[maxI];  // restore initial value of indices[maxI]
+            step = -1;
+          } else {
+            maxIdxs[N++] = shape::coords2index(maxShapeInfo, indices);
+            step = rankMax - 1 - maxI;
+          }
+        } else if (maxI == rankMax - 1)
+          step = -1;
+
+        maxI += step;
+      }
+      return N;
+    }
+/**
+ * Computes the standard packed array strides for a given shape.
+ *
+ * @param shape    the shape of a matrix:
+ * @param startNum the start number for the strides
+ * @return the strides for a matrix of n dimensions
+ */
+    SD_HOST sd::LongType *calcStridesFortran(sd::LongType const *shape, sd::LongType rank, sd::LongType startNum) {
+        int dimensions = rank;
+
+        traceNew(5);
+
+        sd::LongType *stride = new sd::LongType[dimensions];
+        sd::LongType st = startNum;
+        for (int j = 0; j < rank; j++) {
+            stride[j] = st;
+            st *= shape[j];
+        }
+
+        return stride;
+    }
+
+    SD_HOST sd::LongType *calcStridesFortran(sd::LongType const *shape, int rank, int startNum,
+                                             sd::LongType *ret) {
+        // if (isVector(shape, rank)) {
+        //     for (int i = 0; i < rank; i++)
+        //         ret[i] = 1;
+        //     return ret;
+
+        // }
+
+        // int dimensions = rank;
+
+        sd::LongType st = startNum;
+        for (int j = 0; j < rank; j++) {
+            ret[j] = st;
+            st *= shape[j];
+        }
+
+        return ret;
+    }
 
 /**
  * Computes the standard packed array strides for a given shape.
@@ -456,398 +502,356 @@ SD_LIB_EXPORT SD_HOST sd::LongType outerArrayIndexes(sd::LongType *maxIdxs, cons
  * @param startNum the start number for the strides
  * @return the strides for a matrix of n dimensions
  */
-SD_HOST sd::LongType *calcStridesFortran(sd::LongType const *shape, sd::LongType rank, sd::LongType startNum) {
-  int dimensions = rank;
+    SD_HOST sd::LongType *calcStrides(sd::LongType const *shape, int rank, int startNum) {
+        traceNew(7);
 
-  traceNew(5);
+        sd::LongType *stride = new sd::LongType[rank];
 
-  sd::LongType *stride = new sd::LongType[dimensions];
-  sd::LongType st = startNum;
-  for (int j = 0; j < rank; j++) {
-    stride[j] = st;
-    st *= shape[j];
-  }
+        if (rank == 1) {
+            stride[0] = 1;
+            return stride;
+        }
 
-  return stride;
-}
+        // if (shape::isVector(shape, rank)) {
+        //     for (int i = 0; i < 2; i++)
+        //         stride[i] = 1;
+        //     return stride;
 
-SD_HOST sd::LongType *calcStridesFortran(sd::LongType const *shape, int rank, int startNum,
-                                         sd::LongType *ret) {
-  // if (isVector(shape, rank)) {
-  //     for (int i = 0; i < rank; i++)
-  //         ret[i] = 1;
-  //     return ret;
+        // }
 
-  // }
+        sd::LongType st = startNum;
+        for (int j = rank - 1; j >= 0; j--) {
+            stride[j] = st;
+            st *= shape[j];
+        }
 
-  // int dimensions = rank;
+        return stride;
+    }
 
-  sd::LongType st = startNum;
-  for (int j = 0; j < rank; j++) {
-    ret[j] = st;
-    st *= shape[j];
-  }
+    SD_HOST sd::LongType *calcStrides(sd::LongType const *shape, int rank, int startNum,
+                                      sd::LongType *ret) {
+        if (rank == 1) {
+            ret[0] = 1;
+            return ret;
+        }
 
-  return ret;
-}
+        // if (shape::isVector(shape, rank)) {
+        //     for (int i = 0; i < 2; i++)
+        //         ret[i] = 1;
+        //     return ret;
 
-/**
- * Computes the standard packed array strides for a given shape.
- *
- * @param shape    the shape of a matrix:
- * @param startNum the start number for the strides
- * @return the strides for a matrix of n dimensions
- */
-SD_HOST sd::LongType *calcStrides(sd::LongType const *shape, int rank, int startNum) {
-  traceNew(7);
+        // }
 
-  sd::LongType *stride = new sd::LongType[rank];
+        sd::LongType st = startNum;
+        for (int j = rank - 1; j >= 0; j--) {
+            ret[j] = st;
+            st *= shape[j];
+        }
 
-  if (rank == 1) {
-    stride[0] = 1;
-    return stride;
-  }
-
-  // if (shape::isVector(shape, rank)) {
-  //     for (int i = 0; i < 2; i++)
-  //         stride[i] = 1;
-  //     return stride;
-
-  // }
-
-  sd::LongType st = startNum;
-  for (int j = rank - 1; j >= 0; j--) {
-    stride[j] = st;
-    st *= shape[j];
-  }
-
-  return stride;
-}
-
-SD_HOST sd::LongType *calcStrides(sd::LongType const *shape, int rank, int startNum,
-                                  sd::LongType *ret) {
-  if (rank == 1) {
-    ret[0] = 1;
-    return ret;
-  }
-
-  // if (shape::isVector(shape, rank)) {
-  //     for (int i = 0; i < 2; i++)
-  //         ret[i] = 1;
-  //     return ret;
-
-  // }
-
-  sd::LongType st = startNum;
-  for (int j = rank - 1; j >= 0; j--) {
-    ret[j] = st;
-    st *= shape[j];
-  }
-
-  return ret;
-}
+        return ret;
+    }
 
 //////////////////////////////////////////////////////////////////////
-SD_HOST void updateStrides(sd::LongType *shapeInfo, const char order) {
-  int rank = shapeInfo[0];
-  int doubleRank = 2 * rank;
+    SD_HOST void updateStrides(sd::LongType *shapeInfo, const char order) {
+        int rank = shapeInfo[0];
+        int doubleRank = 2 * rank;
 
-  if (rank > 0) {
-    if (order == 'c') {
-      shapeInfo[doubleRank] = 1;  // set unity as last stride for c order
-      for (int j = 1; j < rank; ++j) {
-        shapeInfo[doubleRank - j] = shapeInfo[doubleRank - j + 1] * shapeInfo[rank + 1 - j];
-      }
-    } else {
-      shapeInfo[rank + 1] = 1;  // set unity as first stride for f order
-      for (int j = rank + 1; j < doubleRank; ++j) {
-        shapeInfo[j + 1] = shapeInfo[j] * shapeInfo[j - rank];
-      }
+        if (rank > 0) {
+            if (order == 'c') {
+                shapeInfo[doubleRank] = 1;  // set unity as last stride for c order
+                for (int j = 1; j < rank; ++j) {
+                    shapeInfo[doubleRank - j] = shapeInfo[doubleRank - j + 1] * shapeInfo[rank + 1 - j];
+                }
+            } else {
+                shapeInfo[rank + 1] = 1;  // set unity as first stride for f order
+                for (int j = rank + 1; j < doubleRank; ++j) {
+                    shapeInfo[j + 1] = shapeInfo[j] * shapeInfo[j - rank];
+                }
+            }
+        }
+        // set last 2 elements in shapeInfo
+        shapeInfo[doubleRank + 2] = 1;
+        shapeInfo[doubleRank + 3] = (int)order;
     }
-  }
-  // set last 2 elements in shapeInfo
-  shapeInfo[doubleRank + 2] = 1;
-  shapeInfo[doubleRank + 3] = (int)order;
-}
 
 //////////////////////////////////////////////////////////////////////
-SD_HOST void updateStrides(const int rank, const sd::LongType *shapeOnly, sd::LongType *stridesOnly,
-                           const char order) {
-  if (rank > 0) {
-    if (order == 'c') {
-      stridesOnly[rank - 1] = 1;  // set unity as last stride for c order
-      for (int j = 1; j < rank; ++j) stridesOnly[rank - 1 - j] = stridesOnly[rank - j] * shapeOnly[rank - j];
-    } else {
-      stridesOnly[0] = 1;  // set unity as first stride for f order
-      for (int j = 1; j < rank; ++j) {
-        stridesOnly[j] = stridesOnly[j - 1] * shapeOnly[j - 1];
-      }
+    SD_HOST void updateStrides(const int rank, const sd::LongType *shapeOnly, sd::LongType *stridesOnly,
+                               const char order) {
+        if (rank > 0) {
+            if (order == 'c') {
+                stridesOnly[rank - 1] = 1;  // set unity as last stride for c order
+                for (int j = 1; j < rank; ++j) stridesOnly[rank - 1 - j] = stridesOnly[rank - j] * shapeOnly[rank - j];
+            } else {
+                stridesOnly[0] = 1;  // set unity as first stride for f order
+                for (int j = 1; j < rank; ++j) {
+                    stridesOnly[j] = stridesOnly[j - 1] * shapeOnly[j - 1];
+                }
+            }
+        }
     }
-  }
-}
 /**
  * @param toCopy the shape to copy
  * @return a copy of the original struct
  */
-SD_HOST ShapeInformation *shapeCopy(ShapeInformation *toCopy) {
-  auto copy = new ShapeInformation;
+    SD_HOST ShapeInformation *shapeCopy(ShapeInformation *toCopy) {
+        auto copy = new ShapeInformation;
 
-  traceNew(8);
+        traceNew(8);
 
-  copy->shape = new sd::LongType[toCopy->rank];
+        copy->shape = new sd::LongType[toCopy->rank];
 
-  memcpy(copy->shape, toCopy->shape, toCopy->rank * sizeof(sd::LongType));
+        memcpy(copy->shape, toCopy->shape, toCopy->rank * sizeof(sd::LongType));
 
-  traceNew(9);
+        traceNew(9);
 
-  copy->stride = new sd::LongType[toCopy->rank];
-  for (int i = 0; i < toCopy->rank; i++) {
-    copy->stride[i] = toCopy->stride[i];
-  }
-  copy->order = toCopy->order;
-  copy->rank = toCopy->rank;
-  copy->offset = toCopy->offset;
-  copy->elementWiseStride = toCopy->elementWiseStride;
-  return copy;
-}
-
-SD_HOST int computeElementWiseStride(int rank, sd::LongType const *shape, sd::LongType const *stride,
-                                     int isFOrder) {
-  if (rank == 0) return 1;
-
-  if (shape::isVector(shape, rank)) {
-    return stride[rank - 1];
-  }
-
-  else {
-    int oldnd;
-    sd::LongType *oldDims = shape::copyOf(rank, shape);
-    sd::LongType *oldStrides = shape::copyOf(rank, stride);
-    sd::LongType np, op, last_stride;
-    sd::LongType oldStart, oldStop, ok, newStart, newStop, nk;
-
-    traceNew(10);
-
-    auto newStrides = new sd::LongType[rank];
-    oldnd = 0;
-    // set the shape to be 1 x length
-    int newShapeRank = 2;
-    auto newShape = new sd::LongType[newShapeRank];
-    newShape[0] = 1;
-    newShape[1] = shape::prodLong(shape, rank);
-
-    /*
-     * Remove axes with dimension 1 from the old array. They have no effect
-     * but would need special cases since their strides do not matter.
-     */
-    for (oldStart = 0; oldStart < rank; oldStart++) {
-      if (shape[oldStart] != 1) {
-        oldDims[oldnd] = shape[oldStart];
-        oldStrides[oldnd] = stride[oldStart];
-        oldnd++;
-      }
-    }
-
-    np = 1;
-    for (newStart = 0; newStart < newShapeRank; newStart++) {
-      np *= newShape[newStart];
-    }
-    op = 1;
-    for (oldStart = 0; oldStart < oldnd; oldStart++) {
-      op *= oldDims[oldStart];
-    }
-    if (np != op) {
-      /* different total sizes; no hope */
-      delete[] newStrides;
-      delete[] newShape;
-      delete[] oldStrides;
-      delete[] oldDims;
-      return 0;
-    }
-
-    if (np == 0) {
-      /* the current code does not handle 0-sized arrays, so give up */
-      delete[] newStrides;
-      delete[] newShape;
-      delete[] oldStrides;
-      delete[] oldDims;
-      return 0;
-    }
-
-    /* oldStart to oldStop and newStart to newStop give the axis ranges currently worked with */
-    oldStart = 0;
-    oldStop = 1;
-    newStart = 0;
-    newStop = 1;
-    while (newStart < newShapeRank && oldStart < oldnd) {
-      np = newShape[newStart];
-      op = oldDims[oldStart];
-
-      while (np != op) {
-        if (np < op) {
-          /* Misses trailing 1s, these are handled later */
-          np *= newShape[newStop++];
-        } else {
-          op *= oldDims[oldStop++];
+        copy->stride = new sd::LongType[toCopy->rank];
+        for (int i = 0; i < toCopy->rank; i++) {
+            copy->stride[i] = toCopy->stride[i];
         }
-      }
+        copy->order = toCopy->order;
+        copy->rank = toCopy->rank;
+        copy->offset = toCopy->offset;
+        copy->elementWiseStride = toCopy->elementWiseStride;
+        return copy;
+    }
 
-      /* Check whether the original axes can be combined */
-      for (ok = oldStart; ok < oldStop - 1; ok++) {
-        if (isFOrder) {
-          if (oldStrides[ok + 1] != oldDims[ok] * oldStrides[ok]) {
-            /* not contiguous enough */
+    SD_HOST int computeElementWiseStride(int rank, sd::LongType const *shape, sd::LongType const *stride,
+                                         int isFOrder) {
+        if (rank == 0) return 1;
+
+        if (shape::isVector(shape, rank)) {
+            return stride[rank - 1];
+        }
+
+        else {
+            int oldnd;
+            sd::LongType *oldDims = shape::copyOf(rank, shape);
+            sd::LongType *oldStrides = shape::copyOf(rank, stride);
+            sd::LongType np, op, last_stride;
+            sd::LongType oldStart, oldStop, ok, newStart, newStop, nk;
+
+            traceNew(10);
+
+            auto newStrides = new sd::LongType[rank];
+            oldnd = 0;
+            // set the shape to be 1 x length
+            int newShapeRank = 2;
+            auto newShape = new sd::LongType[newShapeRank];
+            newShape[0] = 1;
+            newShape[1] = shape::prodLong(shape, rank);
+
+            /*
+             * Remove axes with dimension 1 from the old array. They have no effect
+             * but would need special cases since their strides do not matter.
+             */
+            for (oldStart = 0; oldStart < rank; oldStart++) {
+                if (shape[oldStart] != 1) {
+                    oldDims[oldnd] = shape[oldStart];
+                    oldStrides[oldnd] = stride[oldStart];
+                    oldnd++;
+                }
+            }
+
+            np = 1;
+            for (newStart = 0; newStart < newShapeRank; newStart++) {
+                np *= newShape[newStart];
+            }
+            op = 1;
+            for (oldStart = 0; oldStart < oldnd; oldStart++) {
+                op *= oldDims[oldStart];
+            }
+            if (np != op) {
+                /* different total sizes; no hope */
+                delete[] newStrides;
+                delete[] newShape;
+                delete[] oldStrides;
+                delete[] oldDims;
+                return 0;
+            }
+
+            if (np == 0) {
+                /* the current code does not handle 0-sized arrays, so give up */
+                delete[] newStrides;
+                delete[] newShape;
+                delete[] oldStrides;
+                delete[] oldDims;
+                return 0;
+            }
+
+            /* oldStart to oldStop and newStart to newStop give the axis ranges currently worked with */
+            oldStart = 0;
+            oldStop = 1;
+            newStart = 0;
+            newStop = 1;
+            while (newStart < newShapeRank && oldStart < oldnd) {
+                np = newShape[newStart];
+                op = oldDims[oldStart];
+
+                while (np != op) {
+                    if (np < op) {
+                        /* Misses trailing 1s, these are handled later */
+                        np *= newShape[newStop++];
+                    } else {
+                        op *= oldDims[oldStop++];
+                    }
+                }
+
+                /* Check whether the original axes can be combined */
+                for (ok = oldStart; ok < oldStop - 1; ok++) {
+                    if (isFOrder) {
+                        if (oldStrides[ok + 1] != oldDims[ok] * oldStrides[ok]) {
+                            /* not contiguous enough */
+                            delete[] newStrides;
+                            delete[] newShape;
+                            delete[] oldStrides;
+                            delete[] oldDims;
+                            return 0;
+                        }
+                    } else {
+                        /* C order */
+                        if (oldStrides[ok] != oldDims[ok + 1] * oldStrides[ok + 1]) {
+                            /* not contiguous enough */
+                            delete[] newStrides;
+                            delete[] newShape;
+                            delete[] oldStrides;
+                            delete[] oldDims;
+                            return 0;
+                        }
+                    }
+                }
+
+                /* Calculate new strides for all axes currently worked with */
+                if (isFOrder) {
+                    newStrides[newStart] = oldStrides[oldStart];
+                    for (nk = newStart + 1; nk < newStop; nk++) {
+                        newStrides[nk] = newStrides[nk - 1] * newShape[nk - 1];
+                    }
+                } else {
+                    /* C order */
+                    newStrides[newStop - 1] = oldStrides[oldStop - 1];
+                    for (nk = newStop - 1; nk > newStart; nk--) {
+                        newStrides[nk - 1] = newStrides[nk] * newShape[nk];
+                    }
+                }
+                newStart = newStop++;
+                oldStart = oldStop++;
+            }
+
+            /*
+             * Set strides corresponding to trailing 1s of the new shape.
+             */
+            if (newStart >= 1) {
+                last_stride = newStrides[newStart - 1];
+            } else {
+                last_stride = stride[rank - 1];
+            }
+            if (isFOrder) {
+                if (newStart >= 1) last_stride *= newShape[newStart - 1];
+            }
+            for (nk = newStart; nk < newShapeRank; nk++) {
+                newStrides[nk] = last_stride;
+            }
+            // returns the last element of the new stride array
+            int ret = last_stride;
             delete[] newStrides;
             delete[] newShape;
             delete[] oldStrides;
             delete[] oldDims;
-            return 0;
-          }
-        } else {
-          /* C order */
-          if (oldStrides[ok] != oldDims[ok + 1] * oldStrides[ok + 1]) {
-            /* not contiguous enough */
-            delete[] newStrides;
-            delete[] newShape;
-            delete[] oldStrides;
-            delete[] oldDims;
-            return 0;
-          }
+            return ret;
         }
-      }
-
-      /* Calculate new strides for all axes currently worked with */
-      if (isFOrder) {
-        newStrides[newStart] = oldStrides[oldStart];
-        for (nk = newStart + 1; nk < newStop; nk++) {
-          newStrides[nk] = newStrides[nk - 1] * newShape[nk - 1];
-        }
-      } else {
-        /* C order */
-        newStrides[newStop - 1] = oldStrides[oldStop - 1];
-        for (nk = newStop - 1; nk > newStart; nk--) {
-          newStrides[nk - 1] = newStrides[nk] * newShape[nk];
-        }
-      }
-      newStart = newStop++;
-      oldStart = oldStop++;
     }
-
-    /*
-     * Set strides corresponding to trailing 1s of the new shape.
-     */
-    if (newStart >= 1) {
-      last_stride = newStrides[newStart - 1];
-    } else {
-      last_stride = stride[rank - 1];
-    }
-    if (isFOrder) {
-      if (newStart >= 1) last_stride *= newShape[newStart - 1];
-    }
-    for (nk = newStart; nk < newShapeRank; nk++) {
-      newStrides[nk] = last_stride;
-    }
-    // returns the last element of the new stride array
-    int ret = last_stride;
-    delete[] newStrides;
-    delete[] newShape;
-    delete[] oldStrides;
-    delete[] oldDims;
-    return ret;
-  }
-}
 
 /**
  * Get the shape info buffer
  * for the given rank and shape.
  */
-SD_HOST sd::LongType *shapeBuffer(int rank, sd::DataType dtype, sd::LongType const *shape) {
-  sd::LongType *stride = shape::calcStrides(shape, rank);
+    SD_HOST sd::LongType *shapeBuffer(int rank, sd::DataType dtype, sd::LongType const *shape) {
+        sd::LongType *stride = shape::calcStrides(shape, rank);
 
-  traceNew(11);
+        traceNew(11);
 
-  auto shapeInfo = new shape::ShapeInformation();
-  shapeInfo->shape = const_cast<sd::LongType *>(shape);
-  shapeInfo->stride = stride;
-  shapeInfo->offset = 0;
-  shapeInfo->rank = rank;
-  int elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
-  shapeInfo->order = 'c';
-  shapeInfo->elementWiseStride = elementWiseStride;
-  auto shapeInfoBuffer = shape::toShapeBuffer(shapeInfo);
-  delete[] stride;
-  delete shapeInfo;
-  sd::ArrayOptions::setDataType(shapeInfoBuffer, dtype);
-  return shapeInfoBuffer;
-}
+        auto shapeInfo = new shape::ShapeInformation();
+        shapeInfo->shape = const_cast<sd::LongType *>(shape);
+        shapeInfo->stride = stride;
+        shapeInfo->offset = 0;
+        shapeInfo->rank = rank;
+        int elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
+        shapeInfo->order = 'c';
+        shapeInfo->elementWiseStride = elementWiseStride;
+        auto shapeInfoBuffer = shape::toShapeBuffer(shapeInfo);
+        delete[] stride;
+        delete shapeInfo;
+        sd::ArrayOptions::setDataType(shapeInfoBuffer, dtype);
+        return shapeInfoBuffer;
+    }
 
 /**
  * This is special method, it returns ONLY 2D shapebuffer.
  *
  * This method is used only for SoftMax
  */
-SD_HOST sd::LongType *shapeBuffer(int rank, sd::DataType dtype, sd::LongType const *shape,
-                                  sd::LongType *buffer) {
-  sd::LongType stride[SD_MAX_RANK];
-  shape::calcStrides(shape, rank, stride);
+    SD_HOST sd::LongType *shapeBuffer(int rank, sd::DataType dtype, sd::LongType const *shape,
+                                      sd::LongType *buffer) {
+        sd::LongType stride[SD_MAX_RANK];
+        shape::calcStrides(shape, rank, stride);
 
-  shape::ShapeInformation shapeInfo;
-  shapeInfo.shape = const_cast<sd::LongType *>(shape);
-  shapeInfo.stride = stride;
-  shapeInfo.offset = 0;
-  shapeInfo.rank = rank;
-  auto elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
+        shape::ShapeInformation shapeInfo;
+        shapeInfo.shape = const_cast<sd::LongType *>(shape);
+        shapeInfo.stride = stride;
+        shapeInfo.offset = 0;
+        shapeInfo.rank = rank;
+        auto elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
 
-  shapeInfo.order = 'c';
-  shapeInfo.elementWiseStride = elementWiseStride;
-  shape::toShapeBuffer(&shapeInfo, buffer);
-  sd::ArrayOptions::setDataType(buffer, dtype);
-  return buffer;
-}
+        shapeInfo.order = 'c';
+        shapeInfo.elementWiseStride = elementWiseStride;
+        shape::toShapeBuffer(&shapeInfo, buffer);
+        sd::ArrayOptions::setDataType(buffer, dtype);
+        return buffer;
+    }
 
 /**
  * Get the shape info buffer
  * for the given rank and shape.
  */
-SD_HOST sd::LongType *shapeBufferFortran(int rank, sd::DataType dtype, sd::LongType const *shape) {
-  auto stride = shape::calcStridesFortran(shape, rank);
+    SD_HOST sd::LongType *shapeBufferFortran(int rank, sd::DataType dtype, sd::LongType const *shape) {
+        auto stride = shape::calcStridesFortran(shape, rank);
 
-  traceNew(12);
+        traceNew(12);
 
-  auto shapeInfo = new shape::ShapeInformation();
-  shapeInfo->shape = const_cast<sd::LongType *>(shape);
-  shapeInfo->stride = stride;
-  shapeInfo->offset = 0;
-  shapeInfo->rank = rank;
-  int elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
+        auto shapeInfo = new shape::ShapeInformation();
+        shapeInfo->shape = const_cast<sd::LongType *>(shape);
+        shapeInfo->stride = stride;
+        shapeInfo->offset = 0;
+        shapeInfo->rank = rank;
+        int elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
 
-  shapeInfo->order = 'f';
-  shapeInfo->elementWiseStride = elementWiseStride;
-  auto shapeInfoBuffer = shape::toShapeBuffer(shapeInfo);
-  delete[] stride;
-  delete shapeInfo;
-  sd::ArrayOptions::setDataType(shapeInfoBuffer, dtype);
-  return shapeInfoBuffer;
-}
+        shapeInfo->order = 'f';
+        shapeInfo->elementWiseStride = elementWiseStride;
+        auto shapeInfoBuffer = shape::toShapeBuffer(shapeInfo);
+        delete[] stride;
+        delete shapeInfo;
+        sd::ArrayOptions::setDataType(shapeInfoBuffer, dtype);
+        return shapeInfoBuffer;
+    }
 
-SD_HOST sd::LongType *shapeBufferFortran(int rank, sd::DataType dtype, sd::LongType const *shape,
-                                         sd::LongType *output) {
-  sd::LongType stride[SD_MAX_RANK];
-  shape::calcStridesFortran(shape, rank, stride);
+    SD_HOST sd::LongType *shapeBufferFortran(int rank, sd::DataType dtype, sd::LongType const *shape,
+                                             sd::LongType *output) {
+        sd::LongType stride[SD_MAX_RANK];
+        shape::calcStridesFortran(shape, rank, stride);
 
-  shape::ShapeInformation shapeInfo;
-  shapeInfo.shape = const_cast<sd::LongType *>(shape);
-  shapeInfo.stride = stride;
-  shapeInfo.offset = 0;
-  shapeInfo.rank = rank;
-  auto elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
+        shape::ShapeInformation shapeInfo;
+        shapeInfo.shape = const_cast<sd::LongType *>(shape);
+        shapeInfo.stride = stride;
+        shapeInfo.offset = 0;
+        shapeInfo.rank = rank;
+        auto elementWiseStride = shape::computeElementWiseStride(rank, shape, stride, 0);
 
-  shapeInfo.order = 'f';
-  shapeInfo.elementWiseStride = elementWiseStride;
-  shape::toShapeBuffer(&shapeInfo, output);
-  sd::ArrayOptions::setDataType(output, dtype);
-  return output;
-}
+        shapeInfo.order = 'f';
+        shapeInfo.elementWiseStride = elementWiseStride;
+        shape::toShapeBuffer(&shapeInfo, output);
+        sd::ArrayOptions::setDataType(output, dtype);
+        return output;
+    }
 
 /**
  *
@@ -856,14 +860,14 @@ SD_HOST sd::LongType *shapeBufferFortran(int rank, sd::DataType dtype, sd::LongT
  * @param rearrange
  * @return
  */
-SD_HOST sd::LongType *doPermuteSwap(int length, sd::LongType *shape, int *rearrange) {
-  traceNew(16);
-  sd::LongType *ret = new sd::LongType[length];
-  for (int i = 0; i < length; i++) {
-    ret[i] = shape[rearrange[i]];
-  }
-  return ret;
-}
+    SD_HOST sd::LongType *doPermuteSwap(long long int length, sd::LongType *shape, long long int *rearrange) {
+        traceNew(16);
+        sd::LongType *ret = new sd::LongType[length];
+        for (int i = 0; i < length; i++) {
+            ret[i] = shape[rearrange[i]];
+        }
+        return ret;
+    }
 
 /**
  *
@@ -872,303 +876,302 @@ SD_HOST sd::LongType *doPermuteSwap(int length, sd::LongType *shape, int *rearra
  * @param rearrange
  * @return
  */
-SD_HOST void doPermuteSwap(int length, sd::LongType **shape, long long int *rearrange) {
-  if (length == 1) {
-    return;
-  } else {
-    sd::LongType *shapeDeref = *shape;
-    if (shape::prodLong(shapeDeref, length) < 2) {
-      return;
-    }
-  }
+    SD_HOST void doPermuteSwap(int length, sd::LongType **shape, long long int *rearrange) {
+        if (length == 1) {
+            return;
+        } else {
+            sd::LongType *shapeDeref = *shape;
+            if (shape::prodLong(shapeDeref, length) < 2) {
+                return;
+            }
+        }
 
-  bool inOrder = true;
-  for (int i = 0; i < length - 1; i++) {
-    inOrder = inOrder && rearrange[i] + 1 == rearrange[i + 1];
-  }
+        bool inOrder = true;
+        for (int i = 0; i < length - 1; i++) {
+            inOrder = inOrder && rearrange[i] + 1 == rearrange[i + 1];
+        }
 
-  // all in order, nothing to do
-  if (inOrder) return;
+        // all in order, nothing to do
+        if (inOrder) return;
 
-  sd::LongType *shapeDeref = *shape;
-  // we know they are just reversed, dimension length of 2
-  if (length == 2) {
-    auto shapeFirst = shapeDeref[0];
-    auto shapeSecond = shapeDeref[1];
-    shapeDeref[0] = shapeSecond;
-    shapeDeref[1] = shapeFirst;
-    return;
-  } else if (length == 1) {
-    // no permute
-    return;
-  }
+        sd::LongType *shapeDeref = *shape;
+        // we know they are just reversed, dimension length of 2
+        if (length == 2) {
+            auto shapeFirst = shapeDeref[0];
+            auto shapeSecond = shapeDeref[1];
+            shapeDeref[0] = shapeSecond;
+            shapeDeref[1] = shapeFirst;
+            return;
+        } else if (length == 1) {
+            // no permute
+            return;
+        }
 
-  auto temp = new sd::LongType[length];
-  memcpy(temp, shapeDeref, sizeof(sd::LongType) * length);
-  for (int i = 0; i < length; i++) {
-    shapeDeref[i] = temp[rearrange[i]];
-  }
+        auto temp = new sd::LongType[length];
+        memcpy(temp, shapeDeref, sizeof(sd::LongType) * length);
+        for (int i = 0; i < length; i++) {
+            shapeDeref[i] = temp[rearrange[i]];
+        }
 
-  delete[] temp;
-}
-
-SD_HOST void permuteShapeBufferInPlace(sd::LongType *shapeBuffer, long long int *rearrange, sd::LongType *out) {
-  if (shapeBuffer != out) memcpy(out, shapeBuffer, sizeof(sd::LongType) * shape::shapeInfoLength(shapeBuffer));
-
-  shape::doPermuteShapeInfo(out, rearrange);
-}
-
-SD_HOST sd::LongType *permuteShapeBuffer(sd::LongType const *shapeBuffer, long long int *rearrange) {
-  auto len = shape::shapeInfoLength(shape::rank(shapeBuffer));
-  sd::LongType *copy = shape::copyOf(len, shapeBuffer);
-  shape::doPermuteShapeInfo(copy, rearrange);
-  return copy;
-}
-
-SD_HOST void doPermuteShapeInfo(sd::LongType *shapeInfo, const long long int *rearrange, sd::LongType len) {
-  if (len == -1)  // calculate array length if it is not given
-    len = shape::length(shapeInfo);
-
-  // check whether shape is like {1} or {1,1} or {1,1,1,1,...} - in this case we don't need permute
-  if (len == 1) return;
-
-  const int rank = shape::rank(shapeInfo);
-
-  // check whether rearrange is like {0,1,2,3,...}  - in this case we don't need permute as well
-  bool isPermutNecessary = false;
-  for (int i = 0; i < rank; ++i)
-    if (rearrange[i] != i) {
-      isPermutNecessary = true;
-      break;
+        delete[] temp;
     }
 
-  if (!isPermutNecessary) return;
+    SD_HOST void permuteShapeBufferInPlace(sd::LongType *shapeBuffer, long long int *rearrange, sd::LongType *out) {
+        if (shapeBuffer != out) memcpy(out, shapeBuffer, sizeof(sd::LongType) * shape::shapeInfoLength(shapeBuffer));
 
-  // check whether rearrange contains correct indexes
-  for (int i = 0; i < rank; ++i) {
-    if (rearrange[i] >= rank || rearrange[i] < 0) {
-      sd_printf(
-          "shape::doPermuteShapeInfo function failed: rearrange indexes are incorrect. Given permute indices must be < rank and >= 0.  Rearrange at index %d was %d\n",
-          i, rearrange[i]);
-      return;
+        shape::doPermuteShapeInfo(out, rearrange);
     }
-  }
-  // if everything is ok then perform permute
-  auto temp = new sd::LongType[shape::shapeInfoLength(rank) - 3];
-  memcpy(temp, shapeInfo, sizeof(sd::LongType) * (shape::shapeInfoLength(rank) - 3));
-  for (int i = 0; i < rank; ++i) {
-    shapeInfo[i + 1] = temp[rearrange[i] + 1];
-    shapeInfo[i + 1 + rank] = temp[rearrange[i] + 1 + rank];
-  }
 
-  shape::checkStridesEwsAndOrder(shapeInfo);
+    SD_HOST sd::LongType *permuteShapeBuffer(sd::LongType const *shapeBuffer, long long int *rearrange) {
+        auto len = shape::shapeInfoLength(shape::rank(shapeBuffer));
+        sd::LongType *copy = shape::copyOf(len, shapeBuffer);
+        shape::doPermuteShapeInfo(copy, rearrange);
+        return copy;
+    }
 
-  delete[] temp;
-}
+    SD_HOST void doPermuteShapeInfo(sd::LongType *shapeInfo, const long long int *rearrange, sd::LongType len) {
+        if (len == -1)  // calculate array length if it is not given
+            len = shape::length(shapeInfo);
 
-SD_HOST sd::LongType *createPermuteIndexes(int originalRank, int *dimension, int dimensionLength) {
-  int delta = originalRank - dimensionLength;
+        // check whether shape is like {1} or {1,1} or {1,1,1,1,...} - in this case we don't need permute
+        if (len == 1) return;
 
-  traceNew(17);
+        const int rank = shape::rank(shapeInfo);
 
-  sd::LongType *ret = new sd::LongType[originalRank];
-  for (int i = 0; i < delta; i++) {
-    ret[i] = i + dimensionLength;
-  }
+        // check whether rearrange is like {0,1,2,3,...}  - in this case we don't need permute as well
+        bool isPermutNecessary = false;
+        for (int i = 0; i < rank; ++i)
+            if (rearrange[i] != i) {
+                isPermutNecessary = true;
+                break;
+            }
 
-  for (int i = delta; i < originalRank; i++) {
-    ret[i] = i - delta;
-  }
+        if (!isPermutNecessary) return;
 
-  return ret;
-}
+        // check whether rearrange contains correct indexes
+        for (int i = 0; i < rank; ++i) {
+            if (rearrange[i] >= rank || rearrange[i] < 0) {
+                sd_printf(
+                        "shape::doPermuteShapeInfo function failed: rearrange indexes are incorrect. Given permute indices must be < rank and >= 0.  Rearrange at index %d was %d\n",
+                        i, rearrange[i]);
+                return;
+            }
+        }
+        // if everything is ok then perform permute
+        auto temp = new sd::LongType[shape::shapeInfoLength(rank) - 3];
+        memcpy(temp, shapeInfo, sizeof(sd::LongType) * (shape::shapeInfoLength(rank) - 3));
+        for (int i = 0; i < rank; ++i) {
+            shapeInfo[i + 1] = temp[rearrange[i] + 1];
+            shapeInfo[i + 1 + rank] = temp[rearrange[i] + 1 + rank];
+        }
+
+        shape::checkStridesEwsAndOrder(shapeInfo);
+
+        delete[] temp;
+    }
+
+    SD_HOST sd::LongType *createPermuteIndexes(long long int originalRank, long long int *dimension,
+                                               long long int dimensionLength) {
+        int delta = originalRank - dimensionLength;
+
+        traceNew(17);
+
+        sd::LongType *ret = new sd::LongType[originalRank];
+        for (int i = 0; i < delta; i++) {
+            ret[i] = i + dimensionLength;
+        }
+
+        for (int i = delta; i < originalRank; i++) {
+            ret[i] = i - delta;
+        }
+
+        return ret;
+    }
 /**
  * Permute the shape information
  * @param info the shape information to permute
  * @param rearrange the order to re arrange
  * @param rank the rank of the rearrange array
  */
-SD_HOST void permute(ShapeInformation **info, long long int *rearrange, int rank) {
-  ShapeInformation *infoDeref = *info;
-  checkArrangeArray(rearrange, rank, rank);
-  shape::doPermuteSwap(rank, &infoDeref->shape, rearrange);
-  shape::doPermuteSwap(rank, &infoDeref->stride, rearrange);
-  char order = getOrder(rank, infoDeref->shape, infoDeref->stride, infoDeref->elementWiseStride);
-  infoDeref->order = order;
-}
+    SD_HOST void permute(ShapeInformation **info, long long int *rearrange, int rank) {
+        ShapeInformation *infoDeref = *info;
+        checkArrangeArray(rearrange, rank, rank);
+        shape::doPermuteSwap(rank, &infoDeref->shape, rearrange);
+        shape::doPermuteSwap(rank, &infoDeref->stride, rearrange);
+        char order = getOrder(rank, infoDeref->shape, infoDeref->stride, infoDeref->elementWiseStride);
+        infoDeref->order = order;
+    }
 
 /**
  * Return a copy of a buffer.
  * This buffer allocates memory
  * that must be freed elsewhere.
  */
-SD_HOST void copyTo(int length, sd::LongType const *from, sd::LongType *to, sd::LongType *indexes) {
-  for (int i = 0; i < length; i++) {
-    to[i] = from[indexes[i]];
-  }
-}
+    SD_HOST void copyTo(int length, sd::LongType const *from, sd::LongType *to, sd::LongType *indexes) {
+        for (int i = 0; i < length; i++) {
+            to[i] = from[indexes[i]];
+        }
+    }
 
-SD_HOST sd::LongType *sliceOfShapeBuffer(sd::LongType sliceIdx, sd::LongType *shapeBuffer) {
-  int rank = shape::rank(shapeBuffer);
-  int newRank = rank - 1;
-  if (newRank < 2) newRank = 2;
-  sd::LongType *newShapeBuffer = new sd::LongType[shape::shapeInfoLength(newRank)];
-  newShapeBuffer[0] = newRank;
-  sd::LongType *currShape = shape::shapeOf(shapeBuffer);
-  sd::LongType *currStride = shape::stride(shapeBuffer);
-  // initialize new shape and stride by taking the shape and stride + 1
-  // and adding to the shape information
-  // a slice is always just taking the existing shape and cutting the first index off
-  // of the shape and stride
-  sd::LongType *newShape = shape::shapeOf(newShapeBuffer);
-  sd::LongType *newStride = shape::stride(newShapeBuffer);
-  if (shape::isVector(shapeBuffer)) {
-    sd::LongType *currShape = shape::shapeOf(shapeBuffer);
-    // row vector: slice index 0 is a valid index, just copy the whole thing
-    if (currShape[0] == 1) {
-      if (sliceIdx == 0) {
-        memcpy(newShapeBuffer, shapeBuffer, shape::shapeInfoByteLength(shape::rank(shapeBuffer)));
+    SD_HOST sd::LongType *sliceOfShapeBuffer(sd::LongType sliceIdx, sd::LongType *shapeBuffer) {
+        int rank = shape::rank(shapeBuffer);
+        int newRank = rank - 1;
+        if (newRank < 2) newRank = 2;
+        sd::LongType *newShapeBuffer = new sd::LongType[shape::shapeInfoLength(newRank)];
+        newShapeBuffer[0] = newRank;
+        sd::LongType *currShape = shape::shapeOf(shapeBuffer);
+        sd::LongType *currStride = shape::stride(shapeBuffer);
+        // initialize new shape and stride by taking the shape and stride + 1
+        // and adding to the shape information
+        // a slice is always just taking the existing shape and cutting the first index off
+        // of the shape and stride
+        sd::LongType *newShape = shape::shapeOf(newShapeBuffer);
+        sd::LongType *newStride = shape::stride(newShapeBuffer);
+        if (shape::isVector(shapeBuffer)) {
+            sd::LongType *currShape = shape::shapeOf(shapeBuffer);
+            // row vector: slice index 0 is a valid index, just copy the whole thing
+            if (currShape[0] == 1) {
+                if (sliceIdx == 0) {
+                    memcpy(newShapeBuffer, shapeBuffer, shape::shapeInfoByteLength(shape::rank(shapeBuffer)));
+                    return newShapeBuffer;
+                }
+            }
+                // column vector: this will be a scalar
+            else {
+                delete[] newShapeBuffer;
+                sd::LongType *scalar = shape::createScalarShapeInfo();
+                int offset = shape::offset(shapeBuffer);
+                scalar[shape::shapeInfoLength(2) - 3] = offset + sliceIdx;
+                return scalar;
+            }
+        } else if (shape::isMatrix(shapeBuffer)) {
+            newShape[0] = 1;
+            newShape[1] = currShape[1];
+            newStride[0] = 1;
+            newStride[1] = currStride[1];
+        } else {
+            for (int i = 0; i < newRank; i++) {
+                newShape[i] = currShape[i + 1];
+                newStride[i] = currStride[i + 1];
+            }
+        }
+
+        auto indices = new sd::LongType[rank];
+        memset((void *)indices, 0, rank * sizeof(sd::LongType));
+        indices[0] = sliceIdx;
+        sd::LongType offset = shape::getOffset(newShapeBuffer, indices);
+        newShapeBuffer[shape::shapeInfoLength(newRank) - 3] = offset;
+
+        // set current order and ews
+        newShapeBuffer[2 * newRank + 2] = shape::elementWiseStride(shapeBuffer);
+        newShapeBuffer[2 * newRank + 3] = shape::order(shapeBuffer);
+
+        // correct order and ews if necessary
+        shape::checkStridesEwsAndOrder(newShapeBuffer);
+
+        delete[] indices;
+
         return newShapeBuffer;
-      }
     }
-      // column vector: this will be a scalar
-    else {
-      delete[] newShapeBuffer;
-      sd::LongType *scalar = shape::createScalarShapeInfo();
-      int offset = shape::offset(shapeBuffer);
-      scalar[shape::shapeInfoLength(2) - 3] = offset + sliceIdx;
-      return scalar;
-    }
-  } else if (shape::isMatrix(shapeBuffer)) {
-    newShape[0] = 1;
-    newShape[1] = currShape[1];
-    newStride[0] = 1;
-    newStride[1] = currStride[1];
-  } else {
-    for (int i = 0; i < newRank; i++) {
-      newShape[i] = currShape[i + 1];
-      newStride[i] = currStride[i + 1];
-    }
-  }
-
-  auto indices = new sd::LongType[rank];
-  memset((void *)indices, 0, rank * sizeof(sd::LongType));
-  indices[0] = sliceIdx;
-  sd::LongType offset = shape::getOffset(newShapeBuffer, indices);
-  newShapeBuffer[shape::shapeInfoLength(newRank) - 3] = offset;
-
-  // set current order and ews
-  newShapeBuffer[2 * newRank + 2] = shape::elementWiseStride(shapeBuffer);
-  newShapeBuffer[2 * newRank + 3] = shape::order(shapeBuffer);
-
-  // correct order and ews if necessary
-  shape::checkStridesEwsAndOrder(newShapeBuffer);
-
-  delete[] indices;
-
-  return newShapeBuffer;
-}
 
 /**
  * Returns the element wise stride for this information
  * buffer relative to a dimension and reduction index
  */
-SD_HOST sd::LongType reductionIndexElementWiseStride(sd::LongType *buffer, int *dimension,
-                                                     int dimensionLength) {
-  if (dimensionLength > 1) {
-    if (shape::order(buffer) == 'f') {
-      /**
-       * The element wise stride belongs to a reduction index.
-       * When used out of order, we can get rid of the data
-       * dependencies and rely on using the max dimension
-       * specified for stride instead.
-       * Say we take the sum(0,1) along arr
-       * we can use arr.stride(1) as a representation
-       * along which to iterate.
-       */
-      if (shape::shapeOf(buffer)[dimension[dimensionLength - 1]] != 1) {
-        // int tadElementWiseStride = shape::stride(buffer)[dimension[dimensionLength - 1]];
-        // return tadElementWiseStride;
-        auto tadElementWiseStride = shape::stride(buffer)[dimension[0]];
-        return tadElementWiseStride;
-      }
+    SD_HOST sd::LongType reductionIndexElementWiseStride(sd::LongType *buffer, sd::LongType *dimension,
+                                                         sd::LongType dimensionLength) {
+        if (dimensionLength > 1) {
+            if (shape::order(buffer) == 'f') {
+                /**
+                 * The element wise stride belongs to a reduction index.
+                 * When used out of order, we can get rid of the data
+                 * dependencies and rely on using the max dimension
+                 * specified for stride instead.
+                 * Say we take the sum(0,1) along arr
+                 * we can use arr.stride(1) as a representation
+                 * along which to iterate.
+                 */
+                if (shape::shapeOf(buffer)[dimension[dimensionLength - 1]] != 1) {
+                    auto tadElementWiseStride = shape::stride(buffer)[dimension[0]];
+                    return tadElementWiseStride;
+                }
 
-      return 1;
+                return 1;
 
-    } else {
-      /**
-       * The element wise stride belongs to a reduction index.
-       * When used out of order, we can get rid of the data
-       * dependencies and rely on using the max dimension
-       * specified for stride instead.
-       * Say we take the sum(0,1) along arr
-       * we can use arr.stride(1) as a representation
-       * along which to iterate.
-       */
-      if (shape::shapeOf(buffer)[dimension[dimensionLength - 1]] != 1) {
-        auto tadElementWiseStride = shape::stride(buffer)[dimension[dimensionLength - 1]];
-        return tadElementWiseStride;
-      }
+            } else {
+                /**
+                 * The element wise stride belongs to a reduction index.
+                 * When used out of order, we can get rid of the data
+                 * dependencies and rely on using the max dimension
+                 * specified for stride instead.
+                 * Say we take the sum(0,1) along arr
+                 * we can use arr.stride(1) as a representation
+                 * along which to iterate.
+                 */
+                if (shape::shapeOf(buffer)[dimension[dimensionLength - 1]] != 1) {
+                    auto tadElementWiseStride = shape::stride(buffer)[dimension[dimensionLength - 1]];
+                    return tadElementWiseStride;
+                }
 
-      return 1;
-    }
-  } else {
-    if (shape::order(buffer) == 'f') {
-      /**
-       * The element wise stride belongs to a reduction index.
-       * When used out of order, we can get rid of the data
-       * dependencies and rely on using the max dimension
-       * specified for stride instead.
-       * Say we take the sum(0,1) along arr
-       * we can use arr.stride(1) as a representation
-       * along which to iterate.
-       */
-      auto tadElementWiseStride = shape::stride(buffer)[dimension[0]];
-      return tadElementWiseStride;
-    } else {
-      /**
-       * The element wise stride belongs to a reduction index.
-       * When used out of order, we can get rid of the data
-       * dependencies and rely on using the max dimension
-       * specified for stride instead.
-       * Say we take the sum(0,1) along arr
-       * we can use arr.stride(1) as a representation
-       * along which to iterate.
-       */
-      auto tadElementWiseStride = shape::stride(buffer)[dimension[dimensionLength - 1]];
-      return tadElementWiseStride;
-    }
-  }
-}
-
-
-
-SD_HOST sd::LongType *everyIndexBut(const sd::LongType *indexes, int indexesLength, int begin,
-                                    int end) {
-  int len = end - indexesLength;
-
-  traceNew(20);
-
-  auto ret = new sd::LongType[len];
-  int retIdx = 0;
-  // not here that we do 0 based indexing for end - this assumes things like:
-  // 0 to 4 are specified
-  for (int i = begin; i < end; i++) {
-    bool found = false;
-    for (int j = 0; j < indexesLength; j++) {
-      if (indexes[j] == i) {
-        found = true;
-        break;
-      }
+                return 1;
+            }
+        } else {
+            if (shape::order(buffer) == 'f') {
+                /**
+                 * The element wise stride belongs to a reduction index.
+                 * When used out of order, we can get rid of the data
+                 * dependencies and rely on using the max dimension
+                 * specified for stride instead.
+                 * Say we take the sum(0,1) along arr
+                 * we can use arr.stride(1) as a representation
+                 * along which to iterate.
+                 */
+                auto tadElementWiseStride = shape::stride(buffer)[dimension[0]];
+                return tadElementWiseStride;
+            } else {
+                /**
+                 * The element wise stride belongs to a reduction index.
+                 * When used out of order, we can get rid of the data
+                 * dependencies and rely on using the max dimension
+                 * specified for stride instead.
+                 * Say we take the sum(0,1) along arr
+                 * we can use arr.stride(1) as a representation
+                 * along which to iterate.
+                 */
+                auto tadElementWiseStride = shape::stride(buffer)[dimension[dimensionLength - 1]];
+                return tadElementWiseStride;
+            }
+        }
     }
 
-    if (!found) {
-      ret[retIdx++] = i;
-    }
-  }
 
-  return ret;
-}
+
+    SD_HOST sd::LongType *everyIndexBut(const sd::LongType *indexes, int indexesLength, int begin,
+                                        int end) {
+        int len = end - indexesLength;
+
+        traceNew(20);
+
+        auto ret = new sd::LongType[len];
+        int retIdx = 0;
+        // not here that we do 0 based indexing for end - this assumes things like:
+        // 0 to 4 are specified
+        for (int i = begin; i < end; i++) {
+            bool found = false;
+            for (int j = 0; j < indexesLength; j++) {
+                if (indexes[j] == i) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                ret[retIdx++] = i;
+            }
+        }
+
+        return ret;
+    }
 /**
  * Keep the given indexes in the data
  * @param data
@@ -1177,25 +1180,25 @@ SD_HOST sd::LongType *everyIndexBut(const sd::LongType *indexes, int indexesLeng
  * @param dataLength
  * @return
  */
-SD_HOST sd::LongType *keep(volatile sd::LongType *data, const long long int *index, int indexLength,
-                           int dataLength) {
-  traceNew(23);
+    SD_HOST sd::LongType *keep(volatile sd::LongType *data, const long long int *index, int indexLength,
+                               int dataLength) {
+        traceNew(23);
 
-  sd::LongType *ret = new sd::LongType[indexLength];
-  int count = 0;
-  for (int i = 0; i < dataLength; i++) {
-    int contains = 0;
-    for (int j = 0; j < indexLength; j++) {
-      if (i == index[j]) {
-        contains = 1;
-        break;
-      }
+        sd::LongType *ret = new sd::LongType[indexLength];
+        int count = 0;
+        for (int i = 0; i < dataLength; i++) {
+            int contains = 0;
+            for (int j = 0; j < indexLength; j++) {
+                if (i == index[j]) {
+                    contains = 1;
+                    break;
+                }
+            }
+
+            if (contains) ret[count++] = data[i];
+        }
+        return ret;
     }
-
-    if (contains) ret[count++] = data[i];
-  }
-  return ret;
-}
 /**
  * Get the length per slice of the
  * given shape and the dimension
@@ -1208,22 +1211,22 @@ SD_HOST sd::LongType *keep(volatile sd::LongType *data, const long long int *ind
  * @return the length per slice of the given shape
  * along the given dimension
  */
-SD_HOST sd::LongType lengthPerSlice(int rank, sd::LongType const *shape, const long long int *dimension,
-                                    int dimensionLength) {
-  if (shape::isVector(shape, rank)) {
-    // return total length for row vectors
-    if (dimensionLength == 1 && shape[0] == 1) {
-      return shape::prodLong(shape, rank);
+    SD_HOST sd::LongType lengthPerSlice(int rank, sd::LongType const *shape, const long long int *dimension,
+                                        long long int dimensionLength) {
+        if (shape::isVector(shape, rank)) {
+            // return total length for row vectors
+            if (dimensionLength == 1 && shape[0] == 1) {
+                return shape::prodLong(shape, rank);
+            }
+        } else if (rank == dimensionLength)
+            return shape::prodLong(shape, rank);
+        sd::LongType  absSelta = sd::math::sd_abs<sd::LongType >(rank - dimensionLength);
+        traceNew(27);
+        auto ret2 = shape::removeIndex<sd::LongType>(shape, dimension, rank, dimensionLength);
+        auto ret = prodLong(ret2, absSelta);
+        delete[] ret2;
+        return ret;
     }
-  } else if (rank == dimensionLength)
-    return shape::prodLong(shape, rank);
-  sd::LongType  absSelta = sd::math::sd_abs<sd::LongType >(rank - dimensionLength);
-  traceNew(27);
-  auto ret2 = shape::removeIndex<sd::LongType>(shape, dimension, rank, dimensionLength);
-  auto ret = prodLong(ret2, absSelta);
-  delete[] ret2;
-  return ret;
-}
 
 /**
  * calculates the offset for a tensor
@@ -1232,874 +1235,880 @@ SD_HOST sd::LongType lengthPerSlice(int rank, sd::LongType const *shape, const l
  * @param tensorShape
  * @return
  */
-SD_HOST sd::LongType sliceOffsetForTensor(int rank, int index, sd::LongType const *shape,
-                                          sd::LongType const *tensorShape, int tensorShapeLength,
-                                          const long long int *dimension, int dimensionLength) {
-  auto tensorLength = prodLong(tensorShape, tensorShapeLength);
-  auto lengthPerSlice2 = lengthPerSlice(rank, shape, dimension, dimensionLength);
-  if (lengthPerSlice2 <= 0) {
-    return 0;
-  }
+    SD_HOST sd::LongType sliceOffsetForTensor(int rank, int index, sd::LongType const *shape,
+                                              sd::LongType const *tensorShape, int tensorShapeLength,
+                                              const long long int *dimension, long long int dimensionLength) {
+        auto tensorLength = prodLong(tensorShape, tensorShapeLength);
+        auto lengthPerSlice2 = lengthPerSlice(rank, shape, dimension, dimensionLength);
+        if (lengthPerSlice2 <= 0) {
+            return 0;
+        }
 
-  sd::LongType offset = index * tensorLength / lengthPerSlice2;
-  return offset;
-}
+        sd::LongType offset = index * tensorLength / lengthPerSlice2;
+        return offset;
+    }
 /**
  * Computes the number
  * of tensors along
  * a given dimension
  */
-SD_HOST sd::LongType tensorsAlongDimension(volatile int rank, volatile int length,
-                                           volatile sd::LongType *shape,
-                                           long long int *dimension,
-                                           int dimensionLength) {
-  sd::LongType *tensorShape = shape::keep(shape, dimension, dimensionLength, rank);
-  sd::LongType ret = length / shape::prodLong(tensorShape, dimensionLength);
-  delete[] tensorShape;
-  return ret;
-}
-
-/**
- * Computes the number
- * of tensors along
- * a given dimension
- */
-SD_HOST sd::LongType tensorsAlongDimension(sd::LongType *shapeInfo, long long int *dimension,
-                                           int dimensionLength) {
-  sd::LongType *keepShape = shape::shapeOf(shapeInfo);
-  sd::LongType *tensorShape = shape::keep(keepShape, dimension, dimensionLength, rank(shapeInfo));
-  sd::LongType ret = shape::length(shapeInfo) / shape::prodLong(tensorShape, dimensionLength);
-  delete[] tensorShape;
-  return ret;
-}
-
-//////////////////////////////////////////////////////////////////////
-SD_HOST void getOffsetBroadcast(const sd::LongType &startInd, const sd::LongType ind,
-                                const sd::LongType *shapeInfo1, const sd::LongType *shapeInfo2,
-                                const sd::LongType *shapeInfo3, const bool sameOffsets12,
-                                const bool sameOffsets13, long long int *coords, sd::LongType &offset1,
-                                sd::LongType &offset2, sd::LongType &offset3) {
-  const sd::LongType *shape1 = shape::shapeOf(shapeInfo1);
-  const sd::LongType *strides1 = shape::stride(shapeInfo1);
-  const sd::LongType *shape2 = shape::shapeOf(shapeInfo2);
-  const sd::LongType *strides2 = shape::stride(shapeInfo2);
-  const sd::LongType *shape3 = shape::shapeOf(shapeInfo3);
-  const sd::LongType *strides3 = shape::stride(shapeInfo3);
-
-  if (startInd == ind) {
-    if (shape::rank(shapeInfo1) == 0) {
-      offset1 = offset2 = offset3 = 0;
-      return;
+    SD_HOST sd::LongType tensorsAlongDimension(volatile int rank, volatile int length,
+                                               volatile sd::LongType *shape,
+                                               long long int *dimension, long long int dimensionLength) {
+        sd::LongType *tensorShape = shape::keep(shape, dimension, dimensionLength, rank);
+        sd::LongType ret = length / shape::prodLong(tensorShape, dimensionLength);
+        delete[] tensorShape;
+        return ret;
     }
 
-    shape::index2coords(ind, shapeInfo1, coords);
-    offset1 = shape::getOffset(shapeInfo1, coords);
+/**
+ * Computes the number
+ * of tensors along
+ * a given dimension
+ */
+    SD_HOST sd::LongType tensorsAlongDimension(sd::LongType *shapeInfo, long long int *dimension,
+                                               long long int dimensionLength) {
+        sd::LongType *keepShape = shape::shapeOf(shapeInfo);
+        sd::LongType *tensorShape = shape::keep(keepShape, dimension, dimensionLength, rank(shapeInfo));
+        sd::LongType ret = shape::length(shapeInfo) / shape::prodLong(tensorShape, dimensionLength);
+        delete[] tensorShape;
+        return ret;
+    }
 
-    if (sameOffsets12)
-      offset2 = offset1;
-    else
-      offset2 = shape::getOffset(shapeInfo2, coords);
+//////////////////////////////////////////////////////////////////////
+    SD_HOST void getOffsetBroadcast(const sd::LongType &startInd, const sd::LongType ind,
+                                    const sd::LongType *shapeInfo1, const sd::LongType *shapeInfo2,
+                                    const sd::LongType *shapeInfo3, const bool sameOffsets12,
+                                    const bool sameOffsets13, long long int *coords, sd::LongType &offset1,
+                                    sd::LongType &offset2, sd::LongType &offset3) {
+        const sd::LongType *shape1 = shape::shapeOf(shapeInfo1);
+        const sd::LongType *strides1 = shape::stride(shapeInfo1);
+        const sd::LongType *shape2 = shape::shapeOf(shapeInfo2);
+        const sd::LongType *strides2 = shape::stride(shapeInfo2);
+        const sd::LongType *shape3 = shape::shapeOf(shapeInfo3);
+        const sd::LongType *strides3 = shape::stride(shapeInfo3);
 
-    if (sameOffsets13)
-      offset3 = offset1;
-    else
-      offset3 = shape::getOffset(shapeInfo3, coords);
+        if (startInd == ind) {
+            if (shape::rank(shapeInfo1) == 0) {
+                offset1 = offset2 = offset3 = 0;
+                return;
+            }
 
-    return;
-  }
+            shape::index2coords(ind, shapeInfo1, coords);
+            offset1 = shape::getOffset(shapeInfo1, coords);
 
-  int axis = shapeInfo1[0] - 1;
-  while (coords[axis] == shape1[axis] - 1) {
-    if (!sameOffsets12 && shape2[axis] != 1) offset2 -= (shape2[axis] - 1) * strides2[axis];
-    if (!sameOffsets13 && shape3[axis] != 1) offset3 -= (shape3[axis] - 1) * strides3[axis];
-    if (shape1[axis] != 1) offset1 -= (shape1[axis] - 1) * strides1[axis];
-    coords[axis--] = 0;
-  }
+            if (sameOffsets12)
+                offset2 = offset1;
+            else
+                offset2 = shape::getOffset(shapeInfo2, coords);
 
-  ++coords[axis];
-  offset1 += strides1[axis];
+            if (sameOffsets13)
+                offset3 = offset1;
+            else
+                offset3 = shape::getOffset(shapeInfo3, coords);
 
-  if (!sameOffsets12 && shape2[axis] != 1) offset2 += strides2[axis];
-  if (!sameOffsets13 && shape3[axis] != 1) offset3 += strides3[axis];
+            return;
+        }
 
-  if (sameOffsets12) offset2 = offset1;
-  if (sameOffsets13) offset3 = offset1;
-}
+        int axis = shapeInfo1[0] - 1;
+        while (coords[axis] == shape1[axis] - 1) {
+            if (!sameOffsets12 && shape2[axis] != 1) offset2 -= (shape2[axis] - 1) * strides2[axis];
+            if (!sameOffsets13 && shape3[axis] != 1) offset3 -= (shape3[axis] - 1) * strides3[axis];
+            if (shape1[axis] != 1) offset1 -= (shape1[axis] - 1) * strides1[axis];
+            coords[axis--] = 0;
+        }
+
+        ++coords[axis];
+        offset1 += strides1[axis];
+
+        if (!sameOffsets12 && shape2[axis] != 1) offset2 += strides2[axis];
+        if (!sameOffsets13 && shape3[axis] != 1) offset3 += strides3[axis];
+
+        if (sameOffsets12) offset2 = offset1;
+        if (sameOffsets13) offset3 = offset1;
+    }
 
 /**
  * Returns a shape buffer
  * for the shape information metadata.
  */
-SD_HOST sd::LongType *toShapeBuffer(ShapeInformation *info) {
-  traceNew(29);
+    SD_HOST sd::LongType *toShapeBuffer(ShapeInformation *info) {
+        traceNew(29);
 
-  auto ret = new sd::LongType[shapeInfoLength(info->rank)];
-  int count = 1;
-  int rank = info->rank;
+        auto ret = new sd::LongType[shapeInfoLength(info->rank)];
+        int count = 1;
+        int rank = info->rank;
 
-  ret[0] = info->rank;
+        ret[0] = info->rank;
 
-  for (int i = 0; i < rank; i++) {
-    ret[count++] = info->shape[i];
-  }
+        for (int i = 0; i < rank; i++) {
+            ret[count++] = info->shape[i];
+        }
 
-  for (int i = 0; i < rank; i++) {
-    ret[count++] = info->stride[i];
-  }
+        for (int i = 0; i < rank; i++) {
+            ret[count++] = info->stride[i];
+        }
 
-  ret[count++] = info->offset;
-  ret[count++] = info->elementWiseStride;
-  ret[count] = info->order;
+        ret[count++] = info->offset;
+        ret[count++] = info->elementWiseStride;
+        ret[count] = info->order;
 
-  return ret;
-}
-
-SD_HOST sd::LongType *toShapeBuffer(ShapeInformation *info, sd::LongType *ret) {
-  int count = 1;
-  int rank = info->rank;
-
-  ret[0] = info->rank;
-
-  if (ret[0] == 0) {
-    ret[1] = 0;
-    ret[2] = 1;
-    ret[3] = 99;
-    return ret;
-  }
-
-  for (int i = 0; i < rank; i++) {
-    ret[count++] = info->shape[i];
-  }
-
-  for (int i = 0; i < rank; i++) {
-    ret[count++] = info->stride[i];
-  }
-
-  ret[count++] = info->offset;
-  ret[count++] = info->elementWiseStride;
-  ret[count++] = info->order;
-
-  return ret;
-}
-
-SD_HOST void printIntArray(const sd::LongType *arr, const int length) {
-  for (int i = 0; i < length; i++) {
-    printf(" %lld ", (long long)arr[i]);
-  }
-
-  printf("\n");
-}
-
-SD_HOST void printIntArray(const int *arr, const int length) {
-  for (int i = 0; i < length; i++) {
-    printf(" %i ", arr[i]);
-  }
-
-  printf("\n");
-}
-
-SD_HOST void printShapeInfo(const sd::LongType *shapeInfo) {
-  if(shapeInfo == nullptr)
-    return;
-  if(shapeInfo != nullptr) {
-    if(shapeInfo[0] > 32 || shapeInfo[0] < 0)
-      return;
-  }
-  int rank = shape::rank(shapeInfo);
-  if(rank == 0)
-    return;
-
-  sd::LongType *shape = shape::shapeOf(shapeInfo);
-  printf("Rank %d\n", rank);
-  if(rank == 0) {
-    return;
-  }
-  printf("Shape:\n");
-  for (int i = 0; i < rank; i++) {
-    printf(" %lld ", (long long)shape[i]);
-  }
-
-  printf("\n");
-
-  sd::LongType *stride = shape::stride(shapeInfo);
-  printf("Stride:\n");
-  for (int i = 0; i < rank; i++) {
-    printf(" %lld ", (long long)stride[i]);
-  }
-
-  printf("\n");
-
-  printf("Order %c\n", shape::order(shapeInfo));
-}
-
-SD_HOST void printShapeInfoLinear(const sd::LongType *shapeInfo) {
-  int rank = shape::rank(shapeInfo);
-  int lim = shape::shapeInfoLength(rank);
-  printf("ShapeInfo: [");
-  for (int i = 0; i < lim; i++) {
-    printf("%lld", (long long)shapeInfo[i]);
-
-    if (i < lim - 1) {
-      printf(", ");
+        return ret;
     }
-  }
-  printf("]\n");
-#ifndef __CUDA_ARCH__
-  fflush(stdout);
-#endif
-}
 
-SD_HOST void printShapeInfoLinear(const char *msg, int rank, const sd::LongType *shape,
-                                  const sd::LongType *strides) {
-  printf("%s : [", msg);
-  for (int i = 0; i < rank; i++) {
-    printf("%lld, ", (long long)shape[i]);
-  }
+    SD_HOST sd::LongType *toShapeBuffer(ShapeInformation *info, sd::LongType *ret) {
+        int count = 1;
+        int rank = info->rank;
 
-  for (int i = 0; i < rank; i++) {
-    printf("%lld", (long long)strides[i]);
+        ret[0] = info->rank;
 
-    if (i < rank - 1) printf(", ");
-  }
-  printf("]\n");
+        if (ret[0] == 0) {
+            ret[1] = 0;
+            ret[2] = 1;
+            ret[3] = 99;
+            return ret;
+        }
 
-#ifndef __CUDA_ARCH__
-  fflush(stdout);
-#endif
-}
+        for (int i = 0; i < rank; i++) {
+            ret[count++] = info->shape[i];
+        }
 
-SD_HOST void printShapeInfoLinear(const char *msg, const sd::LongType *shapeInfo) {
-  int rank = shape::rank(shapeInfo);
-  int lim = shape::shapeInfoLength(rank);
-  printf("%s : [", msg);
-  for (int i = 0; i < lim; i++) {
-    printf("%lld", (long long)shapeInfo[i]);
+        for (int i = 0; i < rank; i++) {
+            ret[count++] = info->stride[i];
+        }
 
-    if (i < lim - 1) {
-      printf(", ");
+        ret[count++] = info->offset;
+        ret[count++] = info->elementWiseStride;
+        ret[count++] = info->order;
+
+        return ret;
     }
-  }
-  printf("]\n");
+
+    SD_HOST void printIntArray(const sd::LongType *arr, const int length) {
+        for (int i = 0; i < length; i++) {
+            printf(" %lld ", (long long)arr[i]);
+        }
+
+        printf("\n");
+    }
+
+    SD_HOST void printIntArray(const int *arr, const int length) {
+        for (int i = 0; i < length; i++) {
+            printf(" %i ", arr[i]);
+        }
+
+        printf("\n");
+    }
+
+    SD_HOST void printShapeInfo(const sd::LongType *shapeInfo) {
+        if(shapeInfo == nullptr)
+            return;
+        if(shapeInfo != nullptr) {
+            if(shapeInfo[0] > 32 || shapeInfo[0] < 0)
+               throw std::runtime_error("Input shape buffer is corrupt. First rank is < 0 or greater than the max rank of 32.");
+        }
+
+        int rank = shape::rank(shapeInfo);
+        if(rank == 0)
+            return;
+
+        sd::LongType *shape = shape::shapeOf(shapeInfo);
+        printf("Rank %d\n", rank);
+        if(rank == 0) {
+            return;
+        }
+        printf("Shape:\n");
+        for (int i = 0; i < rank; i++) {
+            printf(" %lld ", (long long)shape[i]);
+        }
+
+        printf("\n");
+
+        sd::LongType *stride = shape::stride(shapeInfo);
+        printf("Stride:\n");
+        for (int i = 0; i < rank; i++) {
+            printf(" %lld ", (long long)stride[i]);
+        }
+
+        printf("\n");
+
+        printf("Order %c\n", shape::order(shapeInfo));
+    }
+
+    SD_HOST void printShapeInfoLinear(const sd::LongType *shapeInfo) {
+        int rank = shape::rank(shapeInfo);
+        int lim = shape::shapeInfoLength(rank);
+        printf("ShapeInfo: [");
+        for (int i = 0; i < lim; i++) {
+            printf("%lld", (long long)shapeInfo[i]);
+
+            if (i < lim - 1) {
+                printf(", ");
+            }
+        }
+        printf("]\n");
+#ifndef __CUDA_ARCH__
+        fflush(stdout);
+#endif
+    }
+
+    SD_HOST void printShapeInfoLinear(const char *msg, int rank, const sd::LongType *shape,
+                                      const sd::LongType *strides) {
+        printf("%s : [", msg);
+        for (int i = 0; i < rank; i++) {
+            printf("%lld, ", (long long)shape[i]);
+        }
+
+        for (int i = 0; i < rank; i++) {
+            printf("%lld", (long long)strides[i]);
+
+            if (i < rank - 1) printf(", ");
+        }
+        printf("]\n");
+
+#ifndef __CUDA_ARCH__
+        fflush(stdout);
+#endif
+    }
+
+    SD_HOST void printShapeInfoLinear(const char *msg, const sd::LongType *shapeInfo) {
+        int rank = shape::rank(shapeInfo);
+        int lim = shape::shapeInfoLength(rank);
+        printf("%s : [", msg);
+        for (int i = 0; i < lim; i++) {
+            printf("%lld", (long long)shapeInfo[i]);
+
+            if (i < lim - 1) {
+                printf(", ");
+            }
+        }
+        printf("]\n");
 #ifndef __CUDACC__
-  fflush(stdout);
+        fflush(stdout);
 #endif
-}
+    }
 
-SD_HOST void printArray(float *arr, int length) {
-  printf("Array: [");
-  for (int i = 0; i < length; i++) {
-    printf("%f", arr[i]);
-    if (i + 1 < length) printf(", ");
-  }
-  printf("]\n");
-}
-SD_HOST void transposeInplace(sd::LongType *shapeBuffer) {
-  int rank = shape::rank(shapeBuffer);
-  sd::LongType *shape = shape::shapeOf(shapeBuffer);
-  sd::LongType *strides = shape::stride(shapeBuffer);
+    SD_HOST void printArray(float *arr, int length) {
+        printf("Array: [");
+        for (int i = 0; i < length; i++) {
+            printf("%f", arr[i]);
+            if (i + 1 < length) printf(", ");
+        }
+        printf("]\n");
+    }
+    SD_HOST void transposeInplace(sd::LongType *shapeBuffer) {
+        int rank = shape::rank(shapeBuffer);
+        sd::LongType *shape = shape::shapeOf(shapeBuffer);
+        sd::LongType *strides = shape::stride(shapeBuffer);
 
-  // swap shape
-  for (int e = 0; e < rank / 2; e++) {
-    int idx1 = rank - e - 1;
-    int idx2 = e;
-    int tmp = shape[idx2];
-    shape[idx2] = shape[idx1];
-    shape[idx1] = tmp;
-  }
+        // swap shape
+        for (int e = 0; e < rank / 2; e++) {
+            int idx1 = rank - e - 1;
+            int idx2 = e;
+            int tmp = shape[idx2];
+            shape[idx2] = shape[idx1];
+            shape[idx1] = tmp;
+        }
 
-  // swap strides
-  for (int e = 0; e < rank / 2; e++) {
-    int idx1 = rank - e - 1;
-    int idx2 = e;
-    int tmp = strides[idx2];
-    strides[idx2] = strides[idx1];
-    strides[idx1] = tmp;
-  }
+        // swap strides
+        for (int e = 0; e < rank / 2; e++) {
+            int idx1 = rank - e - 1;
+            int idx2 = e;
+            int tmp = strides[idx2];
+            strides[idx2] = strides[idx1];
+            strides[idx1] = tmp;
+        }
 
-  if (shape::order(shapeBuffer) == 'c')
-    shapeBuffer[shape::shapeInfoLength(shapeBuffer) - 1] = 102;
-  else
-    shapeBuffer[shape::shapeInfoLength(shapeBuffer) - 1] = 99;
-}
+        if (shape::order(shapeBuffer) == 'c')
+            shapeBuffer[shape::shapeInfoLength(shapeBuffer) - 1] = 102;
+        else
+            shapeBuffer[shape::shapeInfoLength(shapeBuffer) - 1] = 99;
+    }
 
-SD_HOST int rearMostLeftOverItem(sd::LongType *data, sd::LongType *dimension, int dimensionLength) {
-  sd::LongType *stride = shape::stride(data);
-  // corner case: return the final item when its greater than the max, since its guaranteed to be left over
-  // note here that strides are interpreted in reverse for tad
-  // start from the front rather than the back
+    SD_HOST int rearMostLeftOverItem(sd::LongType *data, sd::LongType *dimension, long long int dimensionLength) {
+        sd::LongType *stride = shape::stride(data);
+        // corner case: return the final item when its greater than the max, since its guaranteed to be left over
+        // note here that strides are interpreted in reverse for tad
+        // start from the front rather than the back
 
-  int rank = shape::rank(data);
+        int rank = shape::rank(data);
 
-  if (shape::order(data) == 'f') {
-    int dimIdx = dimensionLength - 1;
-    for (int i = rank - 1; i >= 0; i--) {
-      /**
-       * Needs to find an algorithm such that:
-       * looping backwards will find the highest dimension left
-       * that isn't included in the dimension index list.
-       *
-       * This can also be thought of as the last item of the first index
-       * of the difference between the full list of indices and
-       * the dimension indices.
-       *
-       * We should avoid excessive object creation by only looping backwards.
-       */
-      if (dimension[dimIdx--] != i) {
-        int ret = stride[i];
+        if (shape::order(data) == 'f') {
+            int dimIdx = dimensionLength - 1;
+            for (int i = rank - 1; i >= 0; i--) {
+                /**
+                 * Needs to find an algorithm such that:
+                 * looping backwards will find the highest dimension left
+                 * that isn't included in the dimension index list.
+                 *
+                 * This can also be thought of as the last item of the first index
+                 * of the difference between the full list of indices and
+                 * the dimension indices.
+                 *
+                 * We should avoid excessive object creation by only looping backwards.
+                 */
+                if (dimension[dimIdx--] != i) {
+                    int ret = stride[i];
+                    return ret;
+                }
+            }
+        }
+
+        else {
+            int dimIdx = dimensionLength - 1;
+
+            for (int i = rank - 1; i >= 0; i--) {
+                /**
+                 * Needs to find an algorithm such that:
+                 * looping backwards will find the highest dimension left
+                 * that isn't included in the dimension index list.
+                 *
+                 * This can also be thought of as the last item of the first index
+                 * of the difference between the full list of indices and
+                 * the dimension indices.
+                 *
+                 * We should avoid excessive object creation by only looping backwards.
+                 */
+                if (dimension[dimIdx--] != i) {
+                    int ret = stride[i];
+                    return ret;
+                }
+            }
+        }
+
+        int ret = stride[0];
         return ret;
-      }
-    }
-  }
-
-  else {
-    int dimIdx = dimensionLength - 1;
-
-    for (int i = rank - 1; i >= 0; i--) {
-      /**
-       * Needs to find an algorithm such that:
-       * looping backwards will find the highest dimension left
-       * that isn't included in the dimension index list.
-       *
-       * This can also be thought of as the last item of the first index
-       * of the difference between the full list of indices and
-       * the dimension indices.
-       *
-       * We should avoid excessive object creation by only looping backwards.
-       */
-      if (dimension[dimIdx--] != i) {
-        int ret = stride[i];
-        return ret;
-      }
-    }
-  }
-
-  int ret = stride[0];
-  return ret;
-}
-
-SD_HOST sd::LongType *shapeBufferOfNpy(cnpy::NpyArray arr) {
-  return shape::shapeBufferOfNpy(arr.shape.size(), (sd::LongType *)arr.shape.data(), arr.fortranOrder);
-}
-
-
-
-SD_HOST sd::LongType *shapeBufferOfNpy(sd::LongType rank, sd::LongType *shape, bool fortranOrder) {
-  if (fortranOrder) {
-    sd::LongType *shapeBufferRet = shape::shapeBufferFortran(rank, sd::FLOAT32, (sd::LongType *)shape);
-    return shapeBufferRet;
-  } else {
-    sd::LongType *newShape = new sd::LongType[rank];
-    for (int i = 0; i < rank; i++) {
-      newShape[i] = shape[i];
     }
 
-    sd::LongType *shapeBufferRet = shape::shapeBuffer(rank, sd::FLOAT32, newShape);
-    delete[] newShape;
-    return shapeBufferRet;
-  }
-}
+    SD_HOST sd::LongType *shapeBufferOfNpy(cnpy::NpyArray arr) {
+        return shape::shapeBufferOfNpy(arr.shape.size(), (sd::LongType *)arr.shape.data(), arr.fortranOrder);
+    }
+
+
+
+    SD_HOST sd::LongType *shapeBufferOfNpy(sd::LongType rank, sd::LongType *shape, bool fortranOrder) {
+        if (fortranOrder) {
+            sd::LongType *shapeBufferRet = shape::shapeBufferFortran(rank, sd::FLOAT32, (sd::LongType *)shape);
+            return shapeBufferRet;
+        } else {
+            sd::LongType *newShape = new sd::LongType[rank];
+            for (int i = 0; i < rank; i++) {
+                newShape[i] = shape[i];
+            }
+
+            sd::LongType *shapeBufferRet = shape::shapeBuffer(rank, sd::FLOAT32, newShape);
+            delete[] newShape;
+            return shapeBufferRet;
+        }
+    }
 
 
 
 //////////////////////////////////////////////////////////////////////////
 // copy-past from java hasDefaultStridesForShape function
-SD_HOST bool areStridesDefault(const sd::LongType *shapeInfo) {
-  const int rank = shape::rank(shapeInfo);
+    SD_HOST bool areStridesDefault(const sd::LongType *shapeInfo) {
+        const int rank = shape::rank(shapeInfo);
 
-  if (rank == 0) return true;
-  if (!strideDescendingCAscendingF(shapeInfo)) return false;
+        if (rank == 0) return true;
+        if (!strideDescendingCAscendingF(shapeInfo)) return false;
 
-  sd::LongType defaultShapeInfo[SD_MAX_SHAPEINFOLENGTH];
-  memcpy(defaultShapeInfo, shapeInfo, shape::shapeInfoByteLength(shapeInfo));
-  shape::updateStrides(defaultShapeInfo, shape::order(shapeInfo));
+        sd::LongType defaultShapeInfo[SD_MAX_SHAPEINFOLENGTH];
+        memcpy(defaultShapeInfo, shapeInfo, shape::shapeInfoByteLength(shapeInfo));
+        shape::updateStrides(defaultShapeInfo, shape::order(shapeInfo));
 
-  bool result = true;
-  for (int i = rank + 1; i <= 2 * rank; ++i)
-    if (defaultShapeInfo[i] != shapeInfo[i]) {
-      result = false;
-      break;
+        bool result = true;
+        for (int i = rank + 1; i <= 2 * rank; ++i)
+            if (defaultShapeInfo[i] != shapeInfo[i]) {
+                result = false;
+                break;
+            }
+
+        return result;
     }
-
-  return result;
-}
 
 //////////////////////////////////////////////////////////////////////
-SD_HOST bool reshapeC(const sd::LongType *oldShapeInfo, const char newOrder, const int newRank,
-                      const sd::LongType *newShape, sd::LongType *newShapeInfo) {
-  // copy shape from newShape into newShapeInfo
-  newShapeInfo[0] = newRank;
-  memcpy(newShapeInfo + 1, newShape, newRank * sizeof(sd::LongType));
+    SD_HOST bool reshapeC(const sd::LongType *oldShapeInfo, const char newOrder, const long long int newRank,
+                          const sd::LongType *newShape, sd::LongType *newShapeInfo) {
+        // copy shape from newShape into newShapeInfo
+        newShapeInfo[0] = newRank;
+        memcpy(newShapeInfo + 1, newShape, newRank * sizeof(sd::LongType));
 
-  // copy order
-  newShapeInfo[2 * newRank + 3] = newOrder;
+        // copy order
+        newShapeInfo[2 * newRank + 3] = newOrder;
 
-  return shape::reshapeC(oldShapeInfo, newShapeInfo);
-}
+        return shape::reshapeC(oldShapeInfo, newShapeInfo);
+    }
 
 //////////////////////////////////////////////////////////////////////
-SD_HOST bool reshapeC(const sd::LongType *oldShapeInfo, sd::LongType *newShapeInfo) {
-  // newShapeInfo contains rank, shape and order; but no strides, type and ews
+    SD_HOST bool reshapeC(const sd::LongType *oldShapeInfo, sd::LongType *newShapeInfo) {
+        // newShapeInfo contains rank, shape and order; but no strides, type and ews
 
-  const int newRank = shape::rank(newShapeInfo);
+        const int newRank = shape::rank(newShapeInfo);
 
-  // if oldShapeInfo is scalar or vector with length=1
-  if (shape::length(oldShapeInfo) == 1) {
-    for (sd::Unsigned i = 0; i < newRank; ++i) shape::stride(newShapeInfo)[i] = 1;
-    newShapeInfo[2 * newRank + 1] = shape::type(oldShapeInfo);
-    *shape::ews(newShapeInfo) = 1;
-    return true;
-  }
-
-  const auto oldOrder = shape::order(oldShapeInfo);
-  const auto newOrder = shape::order(newShapeInfo);
-  const auto oldEws = shape::elementWiseStride(const_cast<sd::LongType *>(oldShapeInfo));
-
-  if (oldEws > 0 && oldOrder != newOrder) return false;
-
-  // *** FIRST STAGE - exclude unity dimensions from oldShapeInfo and newShapeInfo (if such are present of course),
-  // since they don't affect on strides evaluation, however they complicate code
-
-  // FIXME - indeed we don't need to allocate so large memory amount (4*SD_MAX_RANK), sufficient amount is
-  // (2*oldNumOfNonUnities + 2*newNumOfNonUnities)
-  sd::LongType tempBuffer[4 * SD_MAX_RANK];
-  sd::LongType *oldShape = tempBuffer, *newShape = tempBuffer + 2 * SD_MAX_RANK, *oldStrides, *newStrides;
-
-  // exclude unities from oldShapeInfo
-  const int oldNumOfNonUnities = shape::excludeUnitiesFromShapeInfo(oldShapeInfo, oldShape, oldStrides);
-  const int newNumOfNonUnities = shape::excludeUnitiesFromShapeInfo(newShapeInfo, newShape, newStrides);
-
-  // *** SECOND STAGE - strides evaluation
-
-  int oldStart(0), oldStop(1), newStart(0), newStop(1), newDim, oldDim;
-
-  while (newStart < newNumOfNonUnities && oldStart < oldNumOfNonUnities) {
-    newDim = newShape[newStart];
-    oldDim = oldShape[oldStart];
-
-    while (newDim != oldDim && newDim > 0 && oldDim > 0) {
-      if (newDim < oldDim)
-        newDim *= newShape[newStop++];
-      else
-        oldDim *= oldShape[oldStop++];
-    }
-
-    // check c-contiguous of old axes range
-    for (sd::Unsigned i = oldStart; i < oldStop - 1; ++i)  // do not check value of last stride, it doesn't matter
-      if (oldStrides[i] != oldShape[i + 1] * oldStrides[i + 1]) return false;  // not contiguous
-
-    // fill newStrides in c manner
-    newStrides[newStop - 1] = oldStrides[oldStop - 1];  // copy last stride
-    for (int i = newStop - 2; i >= newStart; --i) newStrides[i] = newStrides[i + 1] * newShape[i + 1];
-
-    newStart = newStop++;
-    oldStart = oldStop++;
-  }
-
-  // fill new calculated strides into newShapeInfo, take into account possible unities in shape
-  for (int j = 0, i = 0; i < newRank; ++i)
-    shape::stride(newShapeInfo)[i] = (shape::shapeOf(newShapeInfo)[i] == 1) ? 1 : newStrides[j++];
-
-  // set ews
-  if (oldEws == 0)
-    shape::checkStridesEwsAndOrder(newShapeInfo, newOrder, newNumOfNonUnities, newShape,
-                                   newStrides);  // set ews and order
-  else {
-    newShapeInfo[2 * newRank + 3] = oldOrder;  // order
-    *shape::ews(newShapeInfo) = oldEws;        // ews
-  }
-  newShapeInfo[2 * newShapeInfo[0] + 1] = 0;
-  sd::ArrayOptions::copyDataType(newShapeInfo, oldShapeInfo);  // type
-
-  return true;
-}
-
-SD_HOST bool canReshape(const int oldRank, sd::LongType *oldShape, const int newRank,
-                        sd::LongType *newShapeOf, bool isFOrder) {
-  sd::LongType oldnd;
-  sd::LongType *oldDims = shape::copyOf(oldRank, shape::shapeOf(oldShape));
-  sd::LongType *oldStrides = shape::copyOf(oldRank, shape::stride(oldShape));
-  sd::LongType np, op, last_stride;
-  sd::LongType oldStart, oldStop, ok, newStart, newStop, nk;
-  auto newStrides = new sd::LongType[newRank];
-  oldnd = 0;
-
-  /*
-   * Remove axes with dimension 1 from the old array. They have no effect
-   * but would need special cases since their strides do not matter.
-   */
-  for (oldStart = 0; oldStart < oldRank; oldStart++) {
-    if (shape::shapeOf(oldShape)[oldStart] != 1) {
-      oldDims[oldnd] = shape::shapeOf(oldShape)[oldStart];
-      oldStrides[oldnd] = shape::stride(oldShape)[oldStart];
-      oldnd++;
-    }
-  }
-
-  np = 1;
-  for (newStart = 0; newStart < newRank; newStart++) {
-    np *= newShapeOf[newStart];
-  }
-  op = 1;
-  for (oldStart = 0; oldStart < oldnd; oldStart++) {
-    op *= oldDims[oldStart];
-  }
-  if (np != op) {
-    /* different total sizes; no hope */
-    delete[] oldDims;
-    delete[] oldStrides;
-    delete[] newStrides;
-
-    return false;
-  }
-
-  if (np == 0) {
-    /* the current code does not handle 0-sized arrays, so give up */
-    delete[] oldDims;
-    delete[] oldStrides;
-    delete[] newStrides;
-
-    return false;
-  }
-
-  /* oldStart to oldStop and newStart to newStop give the axis ranges currently worked with */
-  oldStart = 0;
-  oldStop = 1;
-  newStart = 0;
-  newStop = 1;
-
-  while (newStart < newRank && oldStart < oldnd) {
-    np = newShapeOf[newStart];
-    op = oldDims[oldStart];
-
-    while (np != op) {
-      if (np < op) {
-        /* Misses trailing 1s, these are handled later */
-        np *= newShapeOf[newStop++];
-      } else {
-        op *= oldDims[oldStop++];
-      }
-    }
-
-    /* Check whether the original axes can be combined */
-    for (ok = oldStart; ok < oldStop - 1; ok++) {
-      if (isFOrder) {
-        if (oldStrides[ok + 1] != oldDims[ok] * oldStrides[ok]) {
-          /* not contiguous enough */
-          delete[] oldDims;
-          delete[] oldStrides;
-          delete[] newStrides;
-
-          return false;
+        // if oldShapeInfo is scalar or vector with length=1
+        if (shape::length(oldShapeInfo) == 1) {
+            for (sd::Unsigned i = 0; i < newRank; ++i) shape::stride(newShapeInfo)[i] = 1;
+            newShapeInfo[2 * newRank + 1] = shape::type(oldShapeInfo);
+            *shape::ews(newShapeInfo) = 1;
+            return true;
         }
-      } else {
-        /* C order */
-        if (oldStrides[ok] != oldDims[ok + 1] * oldStrides[ok + 1]) {
-          /* not contiguous enough */
-          delete[] oldDims;
-          delete[] oldStrides;
-          delete[] newStrides;
 
-          return false;
+        const auto oldOrder = shape::order(oldShapeInfo);
+        const auto newOrder = shape::order(newShapeInfo);
+        const auto oldEws = shape::elementWiseStride(const_cast<sd::LongType *>(oldShapeInfo));
+
+        if (oldEws > 0 && oldOrder != newOrder) return false;
+
+        // *** FIRST STAGE - exclude unity dimensions from oldShapeInfo and newShapeInfo (if such are present of course),
+        // since they don't affect on strides evaluation, however they complicate code
+
+        // FIXME - indeed we don't need to allocate so large memory amount (4*SD_MAX_RANK), sufficient amount is
+        // (2*oldNumOfNonUnities + 2*newNumOfNonUnities)
+        sd::LongType tempBuffer[4 * SD_MAX_RANK];
+        sd::LongType *oldShape = tempBuffer, *newShape = tempBuffer + 2 * SD_MAX_RANK, *oldStrides, *newStrides;
+
+        // exclude unities from oldShapeInfo
+        const int oldNumOfNonUnities = shape::excludeUnitiesFromShapeInfo(oldShapeInfo, oldShape, oldStrides);
+        const int newNumOfNonUnities = shape::excludeUnitiesFromShapeInfo(newShapeInfo, newShape, newStrides);
+
+        // *** SECOND STAGE - strides evaluation
+
+        int oldStart(0), oldStop(1), newStart(0), newStop(1), newDim, oldDim;
+
+        while (newStart < newNumOfNonUnities && oldStart < oldNumOfNonUnities) {
+            newDim = newShape[newStart];
+            oldDim = oldShape[oldStart];
+
+            while (newDim != oldDim && newDim > 0 && oldDim > 0) {
+                if (newDim < oldDim)
+                    newDim *= newShape[newStop++];
+                else
+                    oldDim *= oldShape[oldStop++];
+            }
+
+            // check c-contiguous of old axes range
+            for (sd::Unsigned i = oldStart; i < oldStop - 1; ++i)  // do not check value of last stride, it doesn't matter
+                if (oldStrides[i] != oldShape[i + 1] * oldStrides[i + 1]) return false;  // not contiguous
+
+            // fill newStrides in c manner
+            newStrides[newStop - 1] = oldStrides[oldStop - 1];  // copy last stride
+            for (int i = newStop - 2; i >= newStart; --i) newStrides[i] = newStrides[i + 1] * newShape[i + 1];
+
+            newStart = newStop++;
+            oldStart = oldStop++;
         }
-      }
+
+        // fill new calculated strides into newShapeInfo, take into account possible unities in shape
+        for (int j = 0, i = 0; i < newRank; ++i)
+            shape::stride(newShapeInfo)[i] = (shape::shapeOf(newShapeInfo)[i] == 1) ? 1 : newStrides[j++];
+
+        // set ews
+        if (oldEws == 0)
+            shape::checkStridesEwsAndOrder(newShapeInfo, newOrder, newNumOfNonUnities, newShape,
+                                           newStrides);  // set ews and order
+        else {
+            newShapeInfo[2 * newRank + 3] = oldOrder;  // order
+            *shape::ews(newShapeInfo) = oldEws;        // ews
+        }
+        newShapeInfo[2 * newShapeInfo[0] + 1] = 0;
+        sd::ArrayOptions::copyDataType(newShapeInfo, oldShapeInfo);  // type
+
+        return true;
     }
 
-    /* Calculate new strides for all axes currently worked with */
-    if (isFOrder) {
-      newStrides[newStart] = oldStrides[oldStart];
-      for (nk = newStart + 1; nk < newStop; nk++) {
-        newStrides[nk] = newStrides[nk - 1] * newShapeOf[nk - 1];
-      }
-    } else {
-      /* C order */
-      newStrides[newStop - 1] = oldStrides[oldStop - 1];
-      for (nk = newStop - 1; nk > newStart; nk--) {
-        newStrides[nk - 1] = newStrides[nk] * newShapeOf[nk];
-      }
+    SD_HOST bool canReshape(const int oldRank, sd::LongType *oldShape, const int newRank,
+                            sd::LongType *newShapeOf, bool isFOrder) {
+        sd::LongType oldnd;
+        sd::LongType *oldDims = shape::copyOf(oldRank, shape::shapeOf(oldShape));
+        sd::LongType *oldStrides = shape::copyOf(oldRank, shape::stride(oldShape));
+        sd::LongType np, op, last_stride;
+        sd::LongType oldStart, oldStop, ok, newStart, newStop, nk;
+        auto newStrides = new sd::LongType[newRank];
+        oldnd = 0;
+
+        /*
+         * Remove axes with dimension 1 from the old array. They have no effect
+         * but would need special cases since their strides do not matter.
+         */
+        for (oldStart = 0; oldStart < oldRank; oldStart++) {
+            if (shape::shapeOf(oldShape)[oldStart] != 1) {
+                oldDims[oldnd] = shape::shapeOf(oldShape)[oldStart];
+                oldStrides[oldnd] = shape::stride(oldShape)[oldStart];
+                oldnd++;
+            }
+        }
+
+        np = 1;
+        for (newStart = 0; newStart < newRank; newStart++) {
+            np *= newShapeOf[newStart];
+        }
+        op = 1;
+        for (oldStart = 0; oldStart < oldnd; oldStart++) {
+            op *= oldDims[oldStart];
+        }
+        if (np != op) {
+            /* different total sizes; no hope */
+            delete[] oldDims;
+            delete[] oldStrides;
+            delete[] newStrides;
+
+            return false;
+        }
+
+        if (np == 0) {
+            /* the current code does not handle 0-sized arrays, so give up */
+            delete[] oldDims;
+            delete[] oldStrides;
+            delete[] newStrides;
+
+            return false;
+        }
+
+        /* oldStart to oldStop and newStart to newStop give the axis ranges currently worked with */
+        oldStart = 0;
+        oldStop = 1;
+        newStart = 0;
+        newStop = 1;
+
+        while (newStart < newRank && oldStart < oldnd) {
+            np = newShapeOf[newStart];
+            op = oldDims[oldStart];
+
+            while (np != op) {
+                if (np < op) {
+                    /* Misses trailing 1s, these are handled later */
+                    np *= newShapeOf[newStop++];
+                } else {
+                    op *= oldDims[oldStop++];
+                }
+            }
+
+            /* Check whether the original axes can be combined */
+            for (ok = oldStart; ok < oldStop - 1; ok++) {
+                if (isFOrder) {
+                    if (oldStrides[ok + 1] != oldDims[ok] * oldStrides[ok]) {
+                        /* not contiguous enough */
+                        delete[] oldDims;
+                        delete[] oldStrides;
+                        delete[] newStrides;
+
+                        return false;
+                    }
+                } else {
+                    /* C order */
+                    if (oldStrides[ok] != oldDims[ok + 1] * oldStrides[ok + 1]) {
+                        /* not contiguous enough */
+                        delete[] oldDims;
+                        delete[] oldStrides;
+                        delete[] newStrides;
+
+                        return false;
+                    }
+                }
+            }
+
+            /* Calculate new strides for all axes currently worked with */
+            if (isFOrder) {
+                newStrides[newStart] = oldStrides[oldStart];
+                for (nk = newStart + 1; nk < newStop; nk++) {
+                    newStrides[nk] = newStrides[nk - 1] * newShapeOf[nk - 1];
+                }
+            } else {
+                /* C order */
+                newStrides[newStop - 1] = oldStrides[oldStop - 1];
+                for (nk = newStop - 1; nk > newStart; nk--) {
+                    newStrides[nk - 1] = newStrides[nk] * newShapeOf[nk];
+                }
+            }
+            newStart = newStop++;
+            oldStart = oldStop++;
+        }
+
+        delete[] oldDims;
+        delete[] oldStrides;
+        delete[] newStrides;
+
+        return true;
     }
-    newStart = newStop++;
-    oldStart = oldStop++;
-  }
-
-  delete[] oldDims;
-  delete[] oldStrides;
-  delete[] newStrides;
-
-  return true;
-}
 
 
 
 
 //////////////////////////////////////////////////////////////////////
-void calcOffsets(const sd::LongType *shapeInfo, sd::LongType *offsets, const char order) {
-  // firstly consider simple case when ews > 0
-  const sd::LongType ews = shape::elementWiseStride(shapeInfo);
+    void calcOffsets(const sd::LongType *shapeInfo, sd::LongType *offsets, const char order) {
+        if(shapeInfo == nullptr)
+            throw std::runtime_error("calcOffsets: shapeInfo is nullptr !");
+        if(offsets == nullptr)
+            throw std::runtime_error("calcOffsets: offsets is nullptr !");
+        if(shapeInfo[0] < 0 || shapeInfo[0] > SD_MAX_RANK)
+            throw std::runtime_error("calcOffsets: shapeInfo[0] is invalid !");
+        // firstly consider simple case when ews > 0
+        const sd::LongType ews = shape::elementWiseStride(shapeInfo);
 
-  if (ews > 0) {
-    // set offset for first sub-array, it is equal to zero always
-    offsets[0] = 0;
+        if (ews > 0) {
+            // set offset for first sub-array, it is equal to zero always
+            offsets[0] = 0;
 
-    sd::LongType e = 0;
-    if (order != shape::order(shapeInfo))
-      for (int i = 1; i <= shape::rank(shapeInfo); ++i)
-        if (shapeInfo[i] != 1) ++e;  // check whether input is CommonVector
+            sd::LongType e = 0;
+            if (order != shape::order(shapeInfo))
+                for (int i = 1; i <= shape::rank(shapeInfo); ++i)
+                    if (shapeInfo[i] != 1) ++e;  // check whether input is CommonVector
 
-    if (order == shape::order(shapeInfo) || e == 1) {  // e==1 means common vector
-      e = 1;
-      sd::LongType len = shape::length(shapeInfo);
-      while (e < len) {
-        offsets[e] = offsets[e - 1] + ews;
-        e++;
-      }
-      return;
+            if (order == shape::order(shapeInfo) || e == 1) {  // e==1 means common vector
+                e = 1;
+                sd::LongType len = shape::length(shapeInfo);
+                while (e < len) {
+                    offsets[e] = offsets[e - 1] + ews;
+                    e++;
+                }
+                return;
+            }
+        }
+
+        shape::calcOffsets(shape::rank(shapeInfo), shape::shapeOf(const_cast<sd::LongType *>(shapeInfo)),
+                           shape::stride(const_cast<sd::LongType *>(shapeInfo)), offsets, order);
     }
-  }
-
-  shape::calcOffsets(shape::rank(shapeInfo), shape::shapeOf(const_cast<sd::LongType *>(shapeInfo)),
-                     shape::stride(const_cast<sd::LongType *>(shapeInfo)), offsets, order);
-}
 
 //////////////////////////////////////////////////////////////////////
-void calcOffsets(const int rank, const sd::LongType *shape, const sd::LongType *strides,
-                 sd::LongType *offsets, const char order) {
-  const uint64_t len = shape::prodLong(shape, rank);
+    void calcOffsets(const int rank, const sd::LongType *shape, const sd::LongType *strides,
+                     sd::LongType *offsets, const char order) {
+        const uint64_t len = shape::prodLong(shape, rank);
 
-  // set offset for first sub-array, it is equal to zero always
-  offsets[0] = 0;
+        // set offset for first sub-array, it is equal to zero always
+        offsets[0] = 0;
 
-  sd::Unsigned coords[SD_MAX_RANK];
-  memset(coords, 0, sizeof(sd::Unsigned) * rank);
+        sd::Unsigned coords[SD_MAX_RANK];
+        memset(coords, 0, sizeof(sd::Unsigned) * rank);
 
-  if (order == 'c') {
-    for (uint64_t i = 1; i < len; ++i) {
-      int axis = rank - 1;
-      offsets[i] = 0;
-      while (coords[axis] == shape[axis] - 1) {
-        offsets[i] -= (shape[axis] - 1) * strides[axis];
-        coords[axis--] = 0;
-      }
-      ++coords[axis];
-      offsets[i] += offsets[i - 1] + strides[axis];
+        if (order == 'c') {
+            for (uint64_t i = 1; i < len; ++i) {
+                int axis = rank - 1;
+                offsets[i] = 0;
+                while (coords[axis] == shape[axis] - 1) {
+                    offsets[i] -= (shape[axis] - 1) * strides[axis];
+                    coords[axis--] = 0;
+                }
+                ++coords[axis];
+                offsets[i] += offsets[i - 1] + strides[axis];
+            }
+        } else {
+            for (uint64_t i = 1; i < len; ++i) {
+                int axis = 0;
+                offsets[i] = 0;
+                while (coords[axis] == shape[axis] - 1) {
+                    offsets[i] -= (shape[axis] - 1) * strides[axis];
+                    coords[axis++] = 0;
+                }
+                ++coords[axis];
+                offsets[i] += offsets[i - 1] + strides[axis];
+            }
+        }
+
     }
-  } else {
-    for (uint64_t i = 1; i < len; ++i) {
-      int axis = 0;
-      offsets[i] = 0;
-      while (coords[axis] == shape[axis] - 1) {
-        offsets[i] -= (shape[axis] - 1) * strides[axis];
-        coords[axis++] = 0;
-      }
-      ++coords[axis];
-      offsets[i] += offsets[i - 1] + strides[axis];
-    }
-  }
-
-}
 
 //////////////////////////////////////////////////////////////////////
-void SD_HOST checkStridesEwsAndOrder(sd::LongType *shapeInfo) {
-  // FIXME - indeed we don't need to allocate so large memory amount (2*SD_MAX_RANK), sufficient amount is
-  // (2*oldNumOfNonUnities + 2*newNumOfNonUnities)
-  sd::LongType tempBuffer[2 * SD_MAX_RANK];
-  sd::LongType *shape = tempBuffer, *strides;
+    void SD_HOST checkStridesEwsAndOrder(sd::LongType *shapeInfo) {
+        // FIXME - indeed we don't need to allocate so large memory amount (2*SD_MAX_RANK), sufficient amount is
+        // (2*oldNumOfNonUnities + 2*newNumOfNonUnities)
+        sd::LongType tempBuffer[2 * SD_MAX_RANK];
+        sd::LongType *shape = tempBuffer, *strides;
 
-  // exclude unities from shapeInfo
-  const int numOfNonUnities = shape::excludeUnitiesFromShapeInfo(shapeInfo, shape, strides);
+        // exclude unities from shapeInfo
+        const int numOfNonUnities = shape::excludeUnitiesFromShapeInfo(shapeInfo, shape, strides);
 
-  shape::checkStridesEwsAndOrder(shapeInfo, shape::order(shapeInfo), numOfNonUnities, shape, strides);
-}
+        shape::checkStridesEwsAndOrder(shapeInfo, shape::order(shapeInfo), numOfNonUnities, shape, strides);
+    }
 
 //////////////////////////////////////////////////////////////////////
-void SD_HOST checkStridesEwsAndOrder(sd::LongType *shapeInfo, const char proposedOrder,
-                                     const int numOfNonUnities, const sd::LongType *shapeNoUnities,
-                                     const sd::LongType *stridesNoUnities) {
-  const int rank = shape::rank(shapeInfo);
+    void SD_HOST checkStridesEwsAndOrder(sd::LongType *shapeInfo, const char proposedOrder,
+                                         const int numOfNonUnities, const sd::LongType *shapeNoUnities,
+                                         const sd::LongType *stridesNoUnities) {
+        const int rank = shape::rank(shapeInfo);
 
-  if (shape::length(shapeInfo) == 1) {
-    *shape::ews(shapeInfo) = 1;
-    shapeInfo[rank * 2 + 3] = (int)proposedOrder;
-    return;
-  }
+        if (shape::length(shapeInfo) == 1) {
+            *shape::ews(shapeInfo) = 1;
+            shapeInfo[rank * 2 + 3] = (int)proposedOrder;
+            return;
+        }
 
-  if (numOfNonUnities == 1) {  // case of common vector
-    *shape::ews(shapeInfo) = *stridesNoUnities;
-    shapeInfo[rank * 2 + 3] = (int)proposedOrder;
-    return;
-  }
+        if (numOfNonUnities == 1) {  // case of common vector
+            *shape::ews(shapeInfo) = *stridesNoUnities;
+            shapeInfo[rank * 2 + 3] = (int)proposedOrder;
+            return;
+        }
 
-  bool contiguous = true;
+        bool contiguous = true;
 
-  //*** check whether strides are in c contiguous order ***//
-  for (sd::Unsigned i = 0; i < numOfNonUnities - 1; ++i) {
-    if (stridesNoUnities[i] != shapeNoUnities[i + 1] * stridesNoUnities[i + 1]) {
-      contiguous = false;
-      break;
+        //*** check whether strides are in c contiguous order ***//
+        for (sd::Unsigned i = 0; i < numOfNonUnities - 1; ++i) {
+            if (stridesNoUnities[i] != shapeNoUnities[i + 1] * stridesNoUnities[i + 1]) {
+                contiguous = false;
+                break;
+            }
+        }
+
+        if (contiguous) {
+            *shape::ews(shapeInfo) = stridesNoUnities[numOfNonUnities - 1];
+            shapeInfo[rank * 2 + 3] = 99;
+            return;
+        }
+
+        contiguous = true;
+
+        //*** check whether strides are in f contiguous order ***//
+        for (sd::Unsigned i = 1; i < numOfNonUnities; ++i) {
+            if (stridesNoUnities[i] != shapeNoUnities[i - 1] * stridesNoUnities[i - 1]) {
+                contiguous = false;
+                break;
+            }
+        }
+
+        if (contiguous) {
+            *shape::ews(shapeInfo) = stridesNoUnities[0];
+            shapeInfo[rank * 2 + 3] = 102;
+            return;
+        }
+
+        *shape::ews(shapeInfo) = 0;
+        shapeInfo[rank * 2 + 3] = (int)proposedOrder;
     }
-  }
-
-  if (contiguous) {
-    *shape::ews(shapeInfo) = stridesNoUnities[numOfNonUnities - 1];
-    shapeInfo[rank * 2 + 3] = 99;
-    return;
-  }
-
-  contiguous = true;
-
-  //*** check whether strides are in f contiguous order ***//
-  for (sd::Unsigned i = 1; i < numOfNonUnities; ++i) {
-    if (stridesNoUnities[i] != shapeNoUnities[i - 1] * stridesNoUnities[i - 1]) {
-      contiguous = false;
-      break;
-    }
-  }
-
-  if (contiguous) {
-    *shape::ews(shapeInfo) = stridesNoUnities[0];
-    shapeInfo[rank * 2 + 3] = 102;
-    return;
-  }
-
-  *shape::ews(shapeInfo) = 0;
-  shapeInfo[rank * 2 + 3] = (int)proposedOrder;
-}
 
 //////////////////////////////////////////////////////////////////////
-SD_HOST void calcSubArrsShapeInfoAndOffsets(const sd::LongType *wholeShapeInfo,
-                                            const sd::LongType numOfSubArrs, const int dimsSize, const long long int *dimsToExclude, sd::LongType *subArrShapeInfo,
-                                            sd::LongType *subArrOffsets, bool keepUnitiesInShape) {
-  const int rank = shape::rank(wholeShapeInfo);
+    SD_HOST void calcSubArrsShapeInfoAndOffsets(const sd::LongType *wholeShapeInfo,
+                                                const sd::LongType numOfSubArrs, const int dimsSize, const long long int *dimsToExclude, sd::LongType *subArrShapeInfo,
+                                                sd::LongType *subArrOffsets, bool keepUnitiesInShape) {
+        const int rank = shape::rank(wholeShapeInfo);
 
-  if (dimsSize == rank || dimsSize == 0) {  // means there is one sub-array and it coincides with whole array, return
-    // copy of wholeShapeInfo and one zero offset in this case
-    memcpy(subArrShapeInfo, wholeShapeInfo, shape::shapeInfoLength(rank) * sizeof(sd::LongType));
-    *subArrOffsets = 0;
-    return;
-  }
+        if (dimsSize == rank || dimsSize == 0) {  // means there is one sub-array and it coincides with whole array, return
+            // copy of wholeShapeInfo and one zero offset in this case
+            memcpy(subArrShapeInfo, wholeShapeInfo, shape::shapeInfoLength(rank) * sizeof(sd::LongType));
+            *subArrOffsets = 0;
+            return;
+        }
 
-  const int subArrRank = keepUnitiesInShape ? rank : rank - dimsSize;
+        const int subArrRank = keepUnitiesInShape ? rank : rank - dimsSize;
 
-  subArrShapeInfo[0] = subArrRank;                                     // rank
-  subArrShapeInfo[2 * subArrRank + 1] = 0;                             // clear (to avoid uninitialized)
-  sd::ArrayOptions::copyDataType(subArrShapeInfo, wholeShapeInfo);     // type
-  subArrShapeInfo[2 * subArrRank + 3] = shape::order(wholeShapeInfo);  // order
+        subArrShapeInfo[0] = subArrRank;                                     // rank
+        subArrShapeInfo[2 * subArrRank + 1] = 0;                             // clear (to avoid uninitialized)
+        sd::ArrayOptions::copyDataType(subArrShapeInfo, wholeShapeInfo);     // type
+        subArrShapeInfo[2 * subArrRank + 3] = shape::order(wholeShapeInfo);  // order
 
-  sd::LongType *shape = new sd::LongType[dimsSize];
-  sd::LongType *strides = new sd::LongType[dimsSize];
+        sd::LongType *shape = new sd::LongType[dimsSize];
+        sd::LongType *strides = new sd::LongType[dimsSize];
 
-  for (int k = subArrRank - 1, j = dimsSize - 1, i = rank - 1; i >= 0; --i) {
-    if (j >= 0 && i == dimsToExclude[j]) {
-      strides[j] = shape::stride(wholeShapeInfo)[i];
-      shape[j--] = shape::shapeOf(wholeShapeInfo)[i];
+        for (int k = subArrRank - 1, j = dimsSize - 1, i = rank - 1; i >= 0; --i) {
+            if (j >= 0 && i == dimsToExclude[j]) {
+                strides[j] = shape::stride(wholeShapeInfo)[i];
+                shape[j--] = shape::shapeOf(wholeShapeInfo)[i];
 
-      if (keepUnitiesInShape) {
-        shape::shapeOf(subArrShapeInfo)[k] = 1;
-        shape::stride(subArrShapeInfo)[k--] = shape::stride(wholeShapeInfo)[i];
-      }
-    } else {
-      shape::shapeOf(subArrShapeInfo)[k] = shape::shapeOf(wholeShapeInfo)[i];
-      shape::stride(subArrShapeInfo)[k--] = shape::stride(wholeShapeInfo)[i];
+                if (keepUnitiesInShape) {
+                    shape::shapeOf(subArrShapeInfo)[k] = 1;
+                    shape::stride(subArrShapeInfo)[k--] = shape::stride(wholeShapeInfo)[i];
+                }
+            } else {
+                shape::shapeOf(subArrShapeInfo)[k] = shape::shapeOf(wholeShapeInfo)[i];
+                shape::stride(subArrShapeInfo)[k--] = shape::stride(wholeShapeInfo)[i];
+            }
+        }
+
+        // calculation of sub-array offsets (subArrOffsets)
+        shape::calcOffsets(dimsSize, shape, strides, subArrOffsets);
+
+        // evaluate ews
+        shape::checkStridesEwsAndOrder(subArrShapeInfo);
+
+        delete[] strides;
+        delete[] shape;
     }
-  }
-
-  // calculation of sub-array offsets (subArrOffsets)
-  shape::calcOffsets(dimsSize, shape, strides, subArrOffsets);
-
-  // evaluate ews
-  shape::checkStridesEwsAndOrder(subArrShapeInfo);
-
-  delete[] strides;
-  delete[] shape;
-}
 
 //////////////////////////////////////////////////////////////////////
-void calcSubArrShapeInfoAndOffset(const sd::LongType *idx, const sd::LongType *maxShapeInfo,
-                                  sd::LongType *minShapeInfo, sd::LongType &minOffset,
-                                  const bool keepUnitiesInShape, const bool isStrided,
-                                  const int numOfUntiesInMinShape) {
-  const sd::Unsigned maxRank = shape::rank(maxShapeInfo);
-  minOffset = 0;
-  sd::Unsigned first, last, stride, n(isStrided ? 3 : 2);
+    void calcSubArrShapeInfoAndOffset(const sd::LongType *idx, const sd::LongType *maxShapeInfo,
+                                      sd::LongType *minShapeInfo, sd::LongType &minOffset,
+                                      const bool keepUnitiesInShape, const bool isStrided,
+                                      const int numOfUntiesInMinShape) {
+        const sd::Unsigned maxRank = shape::rank(maxShapeInfo);
+        minOffset = 0;
+        sd::Unsigned first, last, stride, n(isStrided ? 3 : 2);
 
-  minShapeInfo[0] = keepUnitiesInShape ? maxRank : maxRank - numOfUntiesInMinShape;
+        minShapeInfo[0] = keepUnitiesInShape ? maxRank : maxRank - numOfUntiesInMinShape;
 
-  for (sd::Unsigned step = 0, j = 0, i = 0; i < maxRank; ++i, step += n) {
-    if (idx[step] == idx[step + 1]) {  // means whole dimension
-      shape::shapeOf(minShapeInfo)[j] = shape::shapeOf(maxShapeInfo)[i];
-      shape::stride(minShapeInfo)[j++] = shape::stride(maxShapeInfo)[i];
-    } else {
-      first = idx[step] >= 0 ? idx[step] : idx[step] + shape::sizeAt(maxShapeInfo, i) + 1;
-      last = idx[step + 1] >= 0 ? idx[step + 1] : idx[step + 1] + shape::sizeAt(maxShapeInfo, i) + 1;
+        for (sd::Unsigned step = 0, j = 0, i = 0; i < maxRank; ++i, step += n) {
+            if (idx[step] == idx[step + 1]) {  // means whole dimension
+                shape::shapeOf(minShapeInfo)[j] = shape::shapeOf(maxShapeInfo)[i];
+                shape::stride(minShapeInfo)[j++] = shape::stride(maxShapeInfo)[i];
+            } else {
+                first = idx[step] >= 0 ? idx[step] : idx[step] + shape::sizeAt(maxShapeInfo, i) + 1;
+                last = idx[step + 1] >= 0 ? idx[step + 1] : idx[step + 1] + shape::sizeAt(maxShapeInfo, i) + 1;
 
-      if (last < first) throw("shape::calcSubArrShapeInfoAndOffset: negative range in input indexes is found!");
+                if (last < first) throw("shape::calcSubArrShapeInfoAndOffset: negative range in input indexes is found!");
 
-      if (isStrided) {
-        stride = idx[step + 2];
-        last /*resulting sub-array axis*/ = (last - first + stride - 1) / stride;  // ceil (last - first) / stride;
-      } else {
-        stride = 1;
-        last /*resulting sub-array axis*/ = last - first;
-      }
+                if (isStrided) {
+                    stride = idx[step + 2];
+                    last /*resulting sub-array axis*/ = (last - first + stride - 1) / stride;  // ceil (last - first) / stride;
+                } else {
+                    stride = 1;
+                    last /*resulting sub-array axis*/ = last - first;
+                }
 
-      minOffset += first * shape::stride(maxShapeInfo)[i];
+                minOffset += first * shape::stride(maxShapeInfo)[i];
 
-      if (!keepUnitiesInShape && last == 1) continue;
+                if (!keepUnitiesInShape && last == 1) continue;
 
-      shape::shapeOf(minShapeInfo)[j] = last;
-      shape::stride(minShapeInfo)[j++] =
-          last == 1 ? shape::stride(maxShapeInfo)[i] : shape::stride(maxShapeInfo)[i] * stride;
+                shape::shapeOf(minShapeInfo)[j] = last;
+                shape::stride(minShapeInfo)[j++] =
+                        last == 1 ? shape::stride(maxShapeInfo)[i] : shape::stride(maxShapeInfo)[i] * stride;
+            }
+        }
+
+        minShapeInfo[2 * shape::rank(minShapeInfo) + 1] = 0;                           // zero
+        minShapeInfo[2 * shape::rank(minShapeInfo) + 3] = shape::order(maxShapeInfo);  // order
+        sd::ArrayOptions::copyDataType(minShapeInfo, maxShapeInfo);                    // type
+
+        shape::checkStridesEwsAndOrder(minShapeInfo);
     }
-  }
-
-  minShapeInfo[2 * shape::rank(minShapeInfo) + 1] = 0;                           // zero
-  minShapeInfo[2 * shape::rank(minShapeInfo) + 3] = shape::order(maxShapeInfo);  // order
-  sd::ArrayOptions::copyDataType(minShapeInfo, maxShapeInfo);                    // type
-
-  shape::checkStridesEwsAndOrder(minShapeInfo);
-}
 
 //////////////////////////////////////////////////////////////////////
-SD_HOST int excludeUnitiesFromShapeInfo(const sd::LongType *inShapeInfo, sd::LongType *&shapeNoUnities,
-                                        sd::LongType *&stridesNoUnities) {
-  const int rank = shape::rank(inShapeInfo);
-  const int numOfNonUnities = shape::numOfNonUnitDims(rank, shape::shapeOf(inShapeInfo));
+    SD_HOST int excludeUnitiesFromShapeInfo(const sd::LongType *inShapeInfo, sd::LongType *&shapeNoUnities,
+                                            sd::LongType *&stridesNoUnities) {
+        const int rank = shape::rank(inShapeInfo);
+        const int numOfNonUnities = shape::numOfNonUnitDims(rank, shape::shapeOf(inShapeInfo));
 
-  if (numOfNonUnities == rank) {  // no unities in shape, no copy procedure
-    shapeNoUnities = const_cast<sd::LongType *>(inShapeInfo) + 1;
-    stridesNoUnities = const_cast<sd::LongType *>(inShapeInfo) + 1 + rank;
-    return numOfNonUnities;
-  }
+        if (numOfNonUnities == rank) {  // no unities in shape, no copy procedure
+            shapeNoUnities = const_cast<sd::LongType *>(inShapeInfo) + 1;
+            stridesNoUnities = const_cast<sd::LongType *>(inShapeInfo) + 1 + rank;
+            return numOfNonUnities;
+        }
 
-  for (sd::Unsigned j = 0, i = 0; i < rank; ++i) {
-    if (shape::shapeOf(inShapeInfo)[i] != 1) {
-      shapeNoUnities[j] = shape::shapeOf(inShapeInfo)[i];
-      shapeNoUnities[numOfNonUnities + j++] = shape::stride(inShapeInfo)[i];
+        for (sd::Unsigned j = 0, i = 0; i < rank; ++i) {
+            if (shape::shapeOf(inShapeInfo)[i] != 1) {
+                shapeNoUnities[j] = shape::shapeOf(inShapeInfo)[i];
+                shapeNoUnities[numOfNonUnities + j++] = shape::stride(inShapeInfo)[i];
+            }
+        }
+
+        stridesNoUnities = shapeNoUnities + numOfNonUnities;
+
+        return numOfNonUnities;
     }
-  }
-
-  stridesNoUnities = shapeNoUnities + numOfNonUnities;
-
-  return numOfNonUnities;
-}
 
 //////////////////////////////////////////////////////////////////////
-SD_HOST void excludeUnitiesFromShapeInfo(const sd::LongType *inShapeInfo, const sd::LongType *dimsToExclude,
-                                         const int dimsSize, sd::LongType *outShapeInfo) {
-  outShapeInfo[0] = inShapeInfo[0] - dimsSize;
+    SD_HOST void excludeUnitiesFromShapeInfo(const sd::LongType *inShapeInfo, const sd::LongType *dimsToExclude,
+                                             const int dimsSize, sd::LongType *outShapeInfo) {
+        outShapeInfo[0] = inShapeInfo[0] - dimsSize;
 
-  for (sd::Unsigned j = 0, k = 0, i = 0; i < inShapeInfo[0]; ++i) {
-    if (j < dimsSize && i == dimsToExclude[j]) {
-      ++j;
-      continue;
+        for (sd::Unsigned j = 0, k = 0, i = 0; i < inShapeInfo[0]; ++i) {
+            if (j < dimsSize && i == dimsToExclude[j]) {
+                ++j;
+                continue;
+            }
+
+            shape::shapeOf(outShapeInfo)[k] = shape::shapeOf(inShapeInfo)[i];
+            shape::stride(outShapeInfo)[k++] = shape::stride(inShapeInfo)[i];
+        }
+        outShapeInfo[2 * outShapeInfo[0] + 1] = 0;
+        sd::ArrayOptions::copyDataType(outShapeInfo, inShapeInfo);          // type
+        *shape::ews(outShapeInfo) = shape::elementWiseStride(inShapeInfo);  // ews
+        outShapeInfo[2 * outShapeInfo[0] + 3] = shape::order(inShapeInfo);  // order
     }
-
-    shape::shapeOf(outShapeInfo)[k] = shape::shapeOf(inShapeInfo)[i];
-    shape::stride(outShapeInfo)[k++] = shape::stride(inShapeInfo)[i];
-  }
-  outShapeInfo[2 * outShapeInfo[0] + 1] = 0;
-  sd::ArrayOptions::copyDataType(outShapeInfo, inShapeInfo);          // type
-  *shape::ews(outShapeInfo) = shape::elementWiseStride(inShapeInfo);  // ews
-  outShapeInfo[2 * outShapeInfo[0] + 3] = shape::order(inShapeInfo);  // order
-}
 
 }

--- a/libnd4j/include/legacy/cuda/NativeOpExecutioner.cu
+++ b/libnd4j/include/legacy/cuda/NativeOpExecutioner.cu
@@ -277,7 +277,7 @@ void NativeOpExecutioner::execInverseBroadcastBool(
     sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo, void const* dX,
     sd::LongType const* dXShapeInfo, void const* hY, sd::LongType const* hYShapeInfo, void const* dY,
     sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo, void* dZ,
-    sd::LongType const* dZShapeInfo, void* extraParams, sd::LongType* dimension, int dimensionLength,
+    sd::LongType const* dZShapeInfo, void* extraParams, sd::LongType* dimension, sd::LongType dimensionLength,
     sd::LongType const* tadOnlyShapeInfo, sd::LongType const* tadOffsets, sd::LongType const* tadOnlyShapeInfoZ,
     sd::LongType const* tadOffsetsZ) {
   auto stream = lc->getCudaStream();
@@ -309,7 +309,7 @@ void NativeOpExecutioner::execBroadcastInt(
     sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo, void const* dX,
     sd::LongType const* dXShapeInfo, void const* hY, sd::LongType const* hYShapeInfo, void const* dY,
     sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo, void* dZ,
-    sd::LongType const* dZShapeInfo, sd::LongType* dimension, int dimensionLength, sd::LongType const* tadOnlyShapeInfo,
+    sd::LongType const* dZShapeInfo, sd::LongType* dimension, sd::LongType dimensionLength, sd::LongType const* tadOnlyShapeInfo,
     sd::LongType const* tadOffsets, sd::LongType const* tadOnlyShapeInfoZ, sd::LongType const* tadOffsetsZ) {
   auto stream = lc->getCudaStream();
 
@@ -373,7 +373,7 @@ void NativeOpExecutioner::execInverseBroadcastInt(
     sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo, void const* dX,
     sd::LongType const* dXShapeInfo, void const* hY, sd::LongType const* hYShapeInfo, void const* dY,
     sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo, void* dZ,
-    sd::LongType const* dZShapeInfo, sd::LongType* dimension, int dimensionLength, sd::LongType const* tadOnlyShapeInfo,
+    sd::LongType const* dZShapeInfo, sd::LongType* dimension, sd::LongType dimensionLength, sd::LongType const* tadOnlyShapeInfo,
     sd::LongType const* tadOffsets, sd::LongType const* tadOnlyShapeInfoZ, sd::LongType const* tadOffsetsZ) {
   auto stream = lc->getCudaStream();
 
@@ -420,7 +420,7 @@ void NativeOpExecutioner::execBroadcast(sd::LaunchContext* lc, int opNum, void c
                                         sd::LongType const* dXShapeInfo, void const* hY,
                                         sd::LongType const* hYShapeInfo, void const* dY,
                                         sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo,
-                                        void* dZ, sd::LongType const* dZShapeInfo, sd::LongType* dimension, int dimensionLength,
+                                        void* dZ, sd::LongType const* dZShapeInfo, sd::LongType* dimension, sd::LongType dimensionLength,
                                         sd::LongType const* tadOnlyShapeInfo, sd::LongType const* tadOffsets,
                                         sd::LongType const* tadOnlyShapeInfoZ, sd::LongType const* tadOffsetsZ) {
   auto stream = lc->getCudaStream();
@@ -487,7 +487,7 @@ void NativeOpExecutioner::execInverseBroadcast(
     sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo, void const* dX,
     sd::LongType const* dXShapeInfo, void const* hY, sd::LongType const* hYShapeInfo, void const* dY,
     sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo, void* dZ,
-    sd::LongType const* dZShapeInfo, sd::LongType* dimension, int dimensionLength, sd::LongType const* tadOnlyShapeInfo,
+    sd::LongType const* dZShapeInfo, sd::LongType* dimension, sd::LongType dimensionLength, sd::LongType const* tadOnlyShapeInfo,
     sd::LongType const* tadOffsets, sd::LongType const* tadOnlyShapeInfoZ, sd::LongType const* tadOffsetsZ) {
   auto stream = lc->getCudaStream();
 
@@ -520,7 +520,7 @@ void NativeOpExecutioner::execReduceSame(sd::LaunchContext* lc, int opNum, void 
                                          sd::LongType const* hXShapeInfo, void const* dX,
                                          sd::LongType const* dXShapeInfo, void* extraParams, void* hZ,
                                          sd::LongType const* hZShapeInfo, void* dZ, sd::LongType const* dZShapeInfo,
-                                         sd::LongType* dimension, int dimensionLength) {
+                                         sd::LongType* dimension, sd::LongType dimensionLength) {
   auto stream = lc->getCudaStream();
   auto reductionPointer = lc->getReductionPointer();
 
@@ -548,7 +548,7 @@ void NativeOpExecutioner::execReduceLong(sd::LaunchContext* lc, int opNum, void 
                                          sd::LongType const* hXShapeInfo, void const* dX,
                                          sd::LongType const* dXShapeInfo, void* extraParams, void* hZ,
                                          sd::LongType const* hZShapeInfo, void* dZ, sd::LongType const* dZShapeInfo,
-                                         sd::LongType* dimension, int dimensionLength) {
+                                         sd::LongType* dimension, sd::LongType dimensionLength) {
   auto stream = lc->getCudaStream();
   auto reductionPointer = lc->getReductionPointer();
 
@@ -577,7 +577,7 @@ void NativeOpExecutioner::execReduceBool(sd::LaunchContext* lc, int opNum, void 
                                          sd::LongType const* hXShapeInfo, void const* dX,
                                          sd::LongType const* dXShapeInfo, void* extraParams, void* hZ,
                                          sd::LongType const* hZShapeInfo, void* dZ, sd::LongType const* dZShapeInfo,
-                                         sd::LongType* dimension, int dimensionLength) {
+                                         sd::LongType* dimension, sd::LongType dimensionLength) {
   auto stream = lc->getCudaStream();
   auto reductionPointer = lc->getReductionPointer();
 
@@ -613,7 +613,7 @@ void NativeOpExecutioner::execReduceFloat(sd::LaunchContext* lc, int opNum, cons
                                           const sd::LongType* hXShapeInfo, const void* dX,
                                           const sd::LongType* dXShapeInfo, void* extraParams, void* hZ,
                                           const sd::LongType* hZShapeInfo, void* dZ, const sd::LongType* dZShapeInfo,
-                                          sd::LongType* dimension, int dimensionLength) {
+                                          sd::LongType* dimension, sd::LongType dimensionLength) {
   auto stream = lc->getCudaStream();
   auto reductionPointer = lc->getReductionPointer();
 
@@ -744,9 +744,7 @@ void NativeOpExecutioner::execReduceFloatScalar(sd::LaunchContext* lc, int opNum
                                            dZShapeInfo, hZShapeInfo, nullptr, 0, reductionPointer, nullptr),
                         SD_COMMON_TYPES, SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execReduceFloatScalar failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -774,9 +772,7 @@ void NativeOpExecutioner::execReduceBoolScalar(sd::LaunchContext* lc, int opNum,
                                            dZShapeInfo, hZShapeInfo, nullptr, 0, reductionPointer, nullptr),
                         SD_COMMON_TYPES, SD_BOOL_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execReduceBoolScalar failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -805,9 +801,6 @@ void NativeOpExecutioner::execReduceSameScalar(sd::LaunchContext* lc, int opNum,
                                            dZShapeInfo, hZShapeInfo, nullptr, 0, reductionPointer, nullptr),
                         SD_COMMON_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execReduceSameScalar failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -836,9 +829,7 @@ void NativeOpExecutioner::execReduceLongScalar(sd::LaunchContext* lc, int opNum,
                                            dZShapeInfo, hZShapeInfo, nullptr, 0, reductionPointer, nullptr),
                         SD_COMMON_TYPES, SD_LONG_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execReduceLongScalar failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -868,9 +859,7 @@ void NativeOpExecutioner::execTransformSame(sd::LaunchContext* lc, int opNum, vo
                                                  dZShapeInfo, zRank, nullptr, nullptr, nullptr, nullptr),
                         SD_COMMON_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execTransformSame failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -900,9 +889,6 @@ void NativeOpExecutioner::execTransformBool(sd::LaunchContext* lc, int opNum, vo
                                                  dZShapeInfo, zRank, nullptr, nullptr, nullptr, nullptr),
                         SD_COMMON_TYPES, SD_BOOL_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execTransformBool failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -934,9 +920,6 @@ void NativeOpExecutioner::execTransformAny(sd::LaunchContext* lc, int opNum, voi
                           SD_COMMON_TYPES, SD_COMMON_TYPES);
   }
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execTransformAny failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -968,9 +951,6 @@ void NativeOpExecutioner::execTransformStrict(sd::LaunchContext* lc, int opNum, 
                                                  dZShapeInfo, zRank, nullptr, nullptr, nullptr, nullptr),
                         SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execTransformStrict failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -999,9 +979,6 @@ void NativeOpExecutioner::execTransformFloat(sd::LaunchContext* lc, int opNum, v
                                                  dZShapeInfo, zRank, nullptr, nullptr, nullptr, nullptr),
                         SD_COMMON_TYPES, SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execTransformFloat failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1028,9 +1005,6 @@ void NativeOpExecutioner::execSummaryStats(sd::LaunchContext* lc, int opNum, voi
                                hZShapeInfo, nullptr, nullptr, biasCorrected, reductionPointer),
       SD_COMMON_TYPES, SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execSummaryStats A failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1058,9 +1032,7 @@ void NativeOpExecutioner::execSummaryStats(sd::LaunchContext* lc, int opNum, voi
                                                  tadOffsets, biasCorrected, reductionPointer),
                         SD_COMMON_TYPES, SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execSummaryStats B failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1094,21 +1066,17 @@ void NativeOpExecutioner::execReduce3(sd::LaunchContext* lc, int opNum, void con
                                      dZShapeInfo, allocationPointer, reductionPointer, nullptr),
                         SD_COMMON_TYPES, SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execReduce3 failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExecutioner::execReduce3(sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo,
-                                      void const* dX, sd::LongType const* dXShapeInfo, void* extraParams,
-                                      void const* hY, sd::LongType const* hYShapeInfo, void const* dY,
-                                      sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo,
-                                      void* dZ, sd::LongType const* dZShapeInfo, sd::LongType* dimension, int dimensionLength,
-                                      sd::LongType const* tadOnlyShapeInfo, sd::LongType const* tadOffsets,
-                                      sd::LongType const* yTadOnlyShapeInfo, sd::LongType const* yTadOffsets) {
+void NativeOpExecutioner::execReduce3(sd::LaunchContext *lc, int opNum, const void *hX, const sd::LongType *hXShapeInfo,
+                                      const void *dX, const sd::LongType *dXShapeInfo, void *extraParamsVals, const void *hY,
+                                      const sd::LongType *hYShapeInfo, const void *dY, const sd::LongType *dYShapeInfo, void *hZ,
+                                      const sd::LongType *hZShapeInfo, void *dZ, const sd::LongType *dZShapeInfo,
+                                      sd::LongType *dimension, sd::LongType dimensionLength, const sd::LongType *xTadOnlyShapeInfo, const sd::LongType *xTadOffsets,
+                                      const sd::LongType *yTadOnlyShapeInfo, const sd::LongType *yTadOffsets) {
   if (shape::isScalar(hZShapeInfo)) {
-    NativeOpExecutioner::execReduce3(lc, opNum, hX, hXShapeInfo, dX, dXShapeInfo, extraParams, hY, hYShapeInfo, dY,
+    NativeOpExecutioner::execReduce3(lc, opNum, hX, hXShapeInfo, dX, dXShapeInfo, extraParamsVals, hY, hYShapeInfo, dY,
                                      dYShapeInfo, hZ, hZShapeInfo, dZ, dZShapeInfo);
     return;
   }
@@ -1133,13 +1101,10 @@ void NativeOpExecutioner::execReduce3(sd::LaunchContext* lc, int opNum, void con
 
   BUILD_DOUBLE_SELECTOR(
       xType, zType, functions::reduce3::Reduce3,
-      ::exec(launchDims, stream, opNum, dX, dXShapeInfo, dY, dYShapeInfo, extraParams, dZ, dZShapeInfo, dimension,
-             dimensionLength, 1, allocationPointer, tadOnlyShapeInfo, tadOffsets, yTadOnlyShapeInfo, yTadOffsets),
+      ::exec(launchDims, stream, opNum, dX, dXShapeInfo, dY, dYShapeInfo, extraParamsVals, dZ, dZShapeInfo, dimension,
+             dimensionLength, 1, allocationPointer, xTadOnlyShapeInfo, xTadOffsets, yTadOnlyShapeInfo, yTadOffsets),
       SD_COMMON_TYPES, SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execReduce3 B failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1175,9 +1140,6 @@ void NativeOpExecutioner::execReduce3Scalar(sd::LaunchContext* lc, int opNum, vo
                                      dZShapeInfo, allocationPointer, reductionPointer, nullptr),
                         SD_COMMON_TYPES, SD_FLOAT_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execReduce3Scalar failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1208,18 +1170,18 @@ void NativeOpExecutioner::execScalarBool(sd::LaunchContext* lc, int opNum, void 
       ::executeCudaShaped(launchDims, stream, opNum, dX, dXShapeInfo, dZ, dZShapeInfo, dScalar, extraParams),
       SD_COMMON_TYPES, SD_BOOL_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execScalarBool failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExecutioner::execScalarBool(
-    sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo, void const* dX,
-    sd::LongType const* dXShapeInfo, void* extraParams, void* hZ, sd::LongType const* hZShapeInfo, void* dZ,
-    sd::LongType const* dZShapeInfo, void const* hScalars, sd::LongType const* hScalarShapeInfo, void const* dScalars,
-    sd::LongType const* dScalarShapeInfo, sd::LongType* dimension, int dimensionLength, sd::LongType const* tadShapeInfo,
-    sd::LongType const* tadOffsets, sd::LongType const* tadShapeInfoZ, sd::LongType const* tadOffsetsZ) {
+void NativeOpExecutioner::execScalarBool(sd::LaunchContext *lc, int opNum, const void *hX, const sd::LongType *hXShapeInfo,
+                                         const void *dX, const sd::LongType *dXShapeInfo, void *extraParams, void *hZ,
+                                         const sd::LongType *hZShapeInfo, void *dZ, const sd::LongType *dZShapeInfo,
+                                         const void *hScalars, const sd::LongType *hScalarShapeInfo, const void *dScalars,
+                                         const sd::LongType *dScalarShapeInfo, sd::LongType *dimension,
+                                         sd::LongType dimensionLength,
+                                         const sd::LongType *tadShapeInfo, const sd::LongType *tadOffsets,
+                                         const sd::LongType *tadShapeInfoZ, const sd::LongType *tadOffsetsZ) {
   auto stream = lc->getCudaStream();
 
   dim3 launchDims(256, 512, 8192);
@@ -1241,9 +1203,6 @@ void NativeOpExecutioner::execScalarBool(
                                   dimension, dimensionLength, tadShapeInfo, tadOffsets, tadShapeInfoZ, tadOffsetsZ),
       SD_COMMON_TYPES, SD_BOOL_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execScalarBool B failed", res);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1275,18 +1234,18 @@ void NativeOpExecutioner::execScalarInt(sd::LaunchContext* lc, int opNum, void c
       ::executeCudaShaped(launchDims, stream, opNum, dX, dXShapeInfo, dZ, dZShapeInfo, dScalar, extraParams),
       SD_INTEGER_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execScalarInt failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExecutioner::execScalarInt(
-    sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo, void const* dX,
-    sd::LongType const* dXShapeInfo, void* extraParams, void* hZ, sd::LongType const* hZShapeInfo, void* dZ,
-    sd::LongType const* dZShapeInfo, void const* hScalars, sd::LongType const* hScalarShapeInfo, void const* dScalars,
-    sd::LongType const* dScalarShapeInfo, sd::LongType* dimension, int dimensionLength, sd::LongType const* tadShapeInfo,
-    sd::LongType const* tadOffsets, sd::LongType const* tadShapeInfoZ, sd::LongType const* tadOffsetsZ) {
+void NativeOpExecutioner::execScalarInt(sd::LaunchContext *lc, int opNum, const void *hX, const sd::LongType *hXShapeInfo,
+                                        const void *dX, const sd::LongType *dXShapeInfo, void *extraParams, void *hZ,
+                                        const sd::LongType *hZShapeInfo, void *dZ, const sd::LongType *dZShapeInfo,
+                                        const void *hScalars, const sd::LongType *hScalarShapeInfo, const void *dScalars,
+                                        const sd::LongType *dScalarShapeInfo, sd::LongType *dimension,
+                                        sd::LongType dimensionLength,
+                                        const sd::LongType *tadShapeInfo, const sd::LongType *tadOffsets,
+                                        const sd::LongType *tadShapeInfoZ, const sd::LongType *tadOffsetsZ) {
   auto stream = lc->getCudaStream();
 
   dim3 launchDims(256, 512, 8192);
@@ -1309,9 +1268,7 @@ void NativeOpExecutioner::execScalarInt(
                                   dimension, dimensionLength, tadShapeInfo, tadOffsets, tadShapeInfoZ, tadOffsetsZ),
       SD_INTEGER_TYPES);
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execScalarInt B failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1342,19 +1299,17 @@ void NativeOpExecutioner::execScalar(sd::LaunchContext* lc, int opNum, void cons
                                SD_COMMON_TYPES);
 #endif
 
-  // TODO: remove after the release
-  auto res = cudaStreamSynchronize(*stream);
-  if (res != 0) throw cuda_exception::build("execScalar failed", res);
+
 }
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExecutioner::execScalar(sd::LaunchContext* lc, int opNum, void const* hX, sd::LongType const* hXShapeInfo,
-                                     void const* dX, sd::LongType const* dXShapeInfo, void* extraParams, void* hZ,
-                                     sd::LongType const* hZShapeInfo, void* dZ, sd::LongType const* dZShapeInfo,
-                                     void const* hScalars, sd::LongType const* hScalarShapeInfo, void const* dScalars,
-                                     sd::LongType const* dScalarShapeInfo, sd::LongType* dimension, int dimensionLength,
-                                     sd::LongType const* tadShapeInfo, sd::LongType const* tadOffsets,
-                                     sd::LongType const* tadShapeInfoZ, sd::LongType const* tadOffsetsZ) {
+void NativeOpExecutioner::execScalar(sd::LaunchContext *lc, int opNum, void const *hX, sd::LongType const *hXShapeInfo,
+                                     void const *dX, sd::LongType const *dXShapeInfo, void *extraParams, void *hZ,
+                                     sd::LongType const *hZShapeInfo, void *dZ, sd::LongType const *dZShapeInfo,
+                                     void const *hScalars, sd::LongType const *hScalarShapeInfo, void const *dScalars,
+                                     sd::LongType const *dScalarShapeInfo, sd::LongType *dimension, sd::LongType dimensionLength,
+                                     sd::LongType const *tadShapeInfo, sd::LongType const *tadOffsets,
+                                     sd::LongType const *tadShapeInfoZ, sd::LongType const *tadOffsetsZ) {
   auto stream = lc->getCudaStream();
 
   auto xType = sd::ArrayOptions::dataType(hXShapeInfo);
@@ -1480,14 +1435,12 @@ void NativeOpExecutioner::execRandom(sd::LaunchContext* lc, int opNum, sd::Point
 }
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExecutioner::execReduce3All(sd::LaunchContext* lc, int opNum, void const* hX,
-                                         sd::LongType const* hXShapeInfo, void const* dX,
-                                         sd::LongType const* dXShapeInfo, void* extraParamsVals, void const* hY,
-                                         sd::LongType const* hYShapeInfo, void const* dY,
-                                         sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo,
-                                         void* dZ, sd::LongType const* dZShapeInfo, sd::LongType* dimension, int dimensionLength,
-                                         sd::LongType const* xTadShapeInfo, sd::LongType const* xOffsets,
-                                         sd::LongType const* yTadShapeInfo, sd::LongType const* yOffsets) {
+void NativeOpExecutioner::execReduce3All(sd::LaunchContext *lc, int opNum, const void *hX, const sd::LongType *hXShapeInfo,
+                                         const void *dX, const sd::LongType *dXShapeInfo, void *extraParamsVals, const void *hY,
+                                         const sd::LongType *hYShapeInfo, const void *dY, const sd::LongType *dYShapeInfo, void *hZ,
+                                         const sd::LongType *hZShapeInfo, void *dZ, const sd::LongType *dZShapeInfo,
+                                         sd::LongType *dimension, sd::LongType dimensionLength, const sd::LongType *xTadShapeInfo, const sd::LongType *xOffsets,
+                                         const sd::LongType *yTadShapeInfo, const sd::LongType *yOffsets) {
   auto stream = lc->getCudaStream();
   auto allocationPointer = lc->getAllocationPointer();
   auto reductionPointer = lc->getReductionPointer();
@@ -1518,16 +1471,14 @@ void NativeOpExecutioner::execReduce3All(sd::LaunchContext* lc, int opNum, void 
 }
 
 ////////////////////////////////////////////////////////////////////////
-void NativeOpExecutioner::execReduce3TAD(sd::LaunchContext* lc, int opNum, void const* hX,
-                                         sd::LongType const* hXShapeInfo, void const* dX,
-                                         sd::LongType const* dXShapeInfo, void* extraParams, void const* hY,
-                                         sd::LongType const* hYShapeInfo, void const* dY,
-                                         sd::LongType const* dYShapeInfo, void* hZ, sd::LongType const* hZShapeInfo,
-                                         void* dZ, sd::LongType const* dZShapeInfo, sd::LongType* dimension, int dimensionLength,
-                                         sd::LongType const* tadShapeInfo, sd::LongType const* tadOffsets,
-                                         sd::LongType const* yTadShapeInfo, sd::LongType const* yTadOffsets) {
+void NativeOpExecutioner::execReduce3TAD(sd::LaunchContext *lc, int opNum, const void *hX, const sd::LongType *hXShapeInfo,
+                                         const void *dX, const sd::LongType *dXShapeInfo, void *extraParamsVals, const void *hY,
+                                         const sd::LongType *hYShapeInfo, const void *dY, const sd::LongType *dYShapeInfo, void *hZ,
+                                         const sd::LongType *hZShapeInfo, void *dZ, const sd::LongType *dZShapeInfo,
+                                         long long int *dimension, long long int dimensionLength, const sd::LongType *tadShapeInfo, const sd::LongType *tadOffsets,
+                                         const sd::LongType *yTadShapeInfo, const sd::LongType *yTadOffsets) {
   if (shape::isScalar(hZShapeInfo)) {
-    NativeOpExecutioner::execReduce3(lc, opNum, hX, hXShapeInfo, dX, dXShapeInfo, extraParams, hY, hYShapeInfo, dY,
+    NativeOpExecutioner::execReduce3(lc, opNum, hX, hXShapeInfo, dX, dXShapeInfo, extraParamsVals, hY, hYShapeInfo, dY,
                                      dYShapeInfo, hZ, hZShapeInfo, dZ, dZShapeInfo);
     return;
   }
@@ -1552,7 +1503,7 @@ void NativeOpExecutioner::execReduce3TAD(sd::LaunchContext* lc, int opNum, void 
 
   BUILD_DOUBLE_SELECTOR(
       xType, zType, functions::reduce3::Reduce3,
-      ::exec(launchDims, stream, opNum, dX, dXShapeInfo, dY, dYShapeInfo, extraParams, dZ, dZShapeInfo, dimension,
+      ::exec(launchDims, stream, opNum, dX, dXShapeInfo, dY, dYShapeInfo, extraParamsVals, dZ, dZShapeInfo, dimension,
              dimensionLength, 1, allocationPointer, tadShapeInfo, tadOffsets, yTadShapeInfo, yTadOffsets),
       SD_COMMON_TYPES, SD_FLOAT_TYPES);
 

--- a/libnd4j/include/ops/declarable/generic/transforms/tear.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/tear.cpp
@@ -60,13 +60,13 @@ DECLARE_SHAPE_FN(tear) {
   if (dims.size() > 1) std::sort(dims.begin(), dims.end());
 
   auto tadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(inShape, dims);
-  auto numTads = tadPack.numberOfTads();
+  auto numTads = tadPack->numberOfTads();
 
   auto result = SHAPELIST();
   for (sd::LongType e = 0; e < numTads; e++) {
     auto newShape = ConstantShapeHelper::getInstance().createShapeInfo(block.dataType(), shape::order(inShape),
-                                                                       shape::rank(tadPack.primaryShapeInfo()),
-                                                                       shape::shapeOf(tadPack.primaryShapeInfo()));
+                                                                       shape::rank(tadPack->primaryShapeInfo()),
+                                                                       shape::shapeOf(tadPack->primaryShapeInfo()));
     result->push_back(newShape);
   }
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/adjust_hue.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/adjust_hue.cpp
@@ -59,14 +59,14 @@ static void adjustHue_(const NDArray *input, const NDArray *deltaScalarArr, NDAr
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimC);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimC);
 
-    const sd::LongType numOfTads = packX.numberOfTads();
+    const sd::LongType numOfTads = packX->numberOfTads();
     const sd::LongType xDimCstride = input->stridesOf()[dimC];
     const sd::LongType zDimCstride = output->stridesOf()[dimC];
 
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i++) {
-        const T *xTad = x + packX.platformOffsets()[i];
-        T *zTad = z + packZ.platformOffsets()[i];
+        const T *xTad = x + packX->platformOffsets()[i];
+        T *zTad = z + packZ->platformOffsets()[i];
 
         T h, s, v;
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/adjust_saturation.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/adjust_saturation.cpp
@@ -60,14 +60,14 @@ static void adjustSaturation_(const NDArray *input, const NDArray *factorScalarA
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimC);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimC);
 
-    const sd::LongType numOfTads = packX.numberOfTads();
+    const sd::LongType numOfTads = packX->numberOfTads();
     const sd::LongType xDimCstride = input->stridesOf()[dimC];
     const sd::LongType zDimCstride = output->stridesOf()[dimC];
 
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i++) {
-        const T *xTad = x + packX.platformOffsets()[i];
-        T *zTad = z + packZ.platformOffsets()[i];
+        const T *xTad = x + packX->platformOffsets()[i];
+        T *zTad = z + packZ->platformOffsets()[i];
 
         T h, s, v;
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/gather.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/gather.cpp
@@ -72,16 +72,16 @@ void gather(sd::LaunchContext* context, const NDArray* input, const NDArray* ind
         auto inTadPack = ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimsIn);
         auto outTadPack = ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimsOut);
 
-        auto inTadShapeInfo = inTadPack.primaryShapeInfo();
-        auto outTadShapeInfo = outTadPack.primaryShapeInfo();
+        auto inTadShapeInfo = inTadPack->primaryShapeInfo();
+        auto outTadShapeInfo = outTadPack->primaryShapeInfo();
 
         if (shape::order(inTadShapeInfo) == shape::order(outTadShapeInfo) && shape::order(inTadShapeInfo) == 'c' &&
             input->dataType() == output->dataType() && shape::elementWiseStride(inTadShapeInfo) == 1 &&
             shape::elementWiseStride(outTadShapeInfo) == 1) {
           auto func = PRAGMA_THREADS_FOR {
             for (auto i = start; i < stop; i++) {
-              auto inBuff = input->bufferWithOffset(inTadPack.primaryOffsets()[indices->e<sd::LongType>(i)]);
-              auto outBuff = output->bufferWithOffset(outTadPack.primaryOffsets()[i]);
+              auto inBuff = input->bufferWithOffset(inTadPack->primaryOffsets()[indices->e<sd::LongType>(i)]);
+              auto outBuff = output->bufferWithOffset(outTadPack->primaryOffsets()[i]);
 
               memcpy(outBuff, inBuff, shape::length(inTadShapeInfo) * input->sizeOfT());
             }
@@ -90,8 +90,8 @@ void gather(sd::LaunchContext* context, const NDArray* input, const NDArray* ind
         } else {
           auto func = PRAGMA_THREADS_FOR {
             for (auto i = start; i < stop; i++) {
-              auto inBuff = input->bufferWithOffset(inTadPack.primaryOffsets()[indices->e<sd::LongType>(i)]);
-              auto outBuff = output->bufferWithOffset(outTadPack.primaryOffsets()[i]);
+              auto inBuff = input->bufferWithOffset(inTadPack->primaryOffsets()[indices->e<sd::LongType>(i)]);
+              auto outBuff = output->bufferWithOffset(outTadPack->primaryOffsets()[i]);
 
               NativeOpExecutioner::execTransformAny(
                   input->getContext(), transform::Assign, inBuff, inTadShapeInfo, nullptr /*input specialBuffer*/,
@@ -118,16 +118,16 @@ void gather(sd::LaunchContext* context, const NDArray* input, const NDArray* ind
       auto inTadPack = ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dims);
       auto outTadPack = ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dims);
 
-      auto inTadShapeInfo = inTadPack.primaryShapeInfo();
-      auto outTadShapeInfo = outTadPack.primaryShapeInfo();
+      auto inTadShapeInfo = inTadPack->primaryShapeInfo();
+      auto outTadShapeInfo = outTadPack->primaryShapeInfo();
 
       if (shape::order(inTadShapeInfo) == shape::order(outTadShapeInfo) && shape::order(inTadShapeInfo) == 'c' &&
           input->dataType() == output->dataType() && shape::elementWiseStride(inTadShapeInfo) == 1 &&
           shape::elementWiseStride(outTadShapeInfo) == 1) {
         auto func = PRAGMA_THREADS_FOR {
           for (auto i = start; i < stop; i++) {
-            auto inBuff = input->bufferWithOffset(inTadPack.primaryOffsets()[intArgs[i + 1]]);
-            void* outBuff = output->bufferWithOffset(outTadPack.primaryOffsets()[i]);
+            auto inBuff = input->bufferWithOffset(inTadPack->primaryOffsets()[intArgs[i + 1]]);
+            void* outBuff = output->bufferWithOffset(outTadPack->primaryOffsets()[i]);
 
             std::memcpy(outBuff, inBuff, shape::length(inTadShapeInfo) * input->sizeOfT());
           }
@@ -137,8 +137,8 @@ void gather(sd::LaunchContext* context, const NDArray* input, const NDArray* ind
       } else {
         auto func = PRAGMA_THREADS_FOR {
           for (auto i = start; i < stop; i++) {
-            auto inBuff = input->bufferWithOffset(inTadPack.primaryOffsets()[intArgs[i + 1]]);
-            auto outBuff = output->bufferWithOffset(outTadPack.primaryOffsets()[i]);
+            auto inBuff = input->bufferWithOffset(inTadPack->primaryOffsets()[intArgs[i + 1]]);
+            auto outBuff = output->bufferWithOffset(outTadPack->primaryOffsets()[i]);
 
             NativeOpExecutioner::execTransformAny(
                 input->getContext(), transform::Assign, inBuff, inTadShapeInfo, nullptr /*input specialBuffer*/,

--- a/libnd4j/include/ops/declarable/helpers/cpu/gatherTransforms.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/gatherTransforms.cpp
@@ -37,14 +37,14 @@ static void gatherND_(NDArray& input, NDArray& indices, NDArray& output) {
   const Y* y = reinterpret_cast<Y*>(indices.buffer());
   X* z = reinterpret_cast<X*>(output.buffer());
 
-  const int xRank = input.rankOf();
-  const int yRank = indices.rankOf();
-  const int zRank = output.rankOf();
-  const int maxRank = sd::math::sd_max<int>(yRank, sd::math::sd_max<int>(xRank, zRank));
+  const sd::LongType xRank = input.rankOf();
+  const sd::LongType yRank = indices.rankOf();
+  const sd::LongType zRank = output.rankOf();
+  const sd::LongType maxRank = sd::math::sd_max<sd::LongType>(yRank, sd::math::sd_max<sd::LongType>(xRank, zRank));
 
   const sd::LongType zLen = output.lengthOf();
 
-  const sd::Unsigned yLastDim = indices.sizeAt(-1);
+  const sd::LongType yLastDim = indices.sizeAt(-1);
 
   const int diff = zRank - xRank;
   const bool bEqual = yLastDim == xRank;
@@ -63,11 +63,11 @@ static void gatherND_(NDArray& input, NDArray& indices, NDArray& output) {
       zCoords[yRank - 1] = temp;
 
       if (bEqual)
-        memcpy(xCoords, zCoords, zRank * sizeof(int));
+        memcpy(xCoords, zCoords, zRank * sizeof(sd::LongType));
       else if (diff >= 0)
-        memcpy(xCoords, zCoords + diff, xRank * sizeof(int));
+        memcpy(xCoords, zCoords + diff, xRank * sizeof(sd::LongType));
       else
-        memcpy(xCoords - diff, zCoords, zRank * sizeof(int));
+        memcpy(xCoords - diff, zCoords, zRank * sizeof(sd::LongType));
 
       for (sd::Unsigned j = 0; j < yLastDim; ++j)
         xCoords[j] = y[yOffset + j * indices.stridesOf()[yRank - 1]];  // last stride
@@ -116,8 +116,8 @@ static void gather_(NDArray* input, const NDArray* indices, NDArray* output, con
         auto tadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
 
         auto tadArr = NDArray(reinterpret_cast<void*>(reinterpret_cast<T*>(input->buffer()) +
-                                                      tadPack.primaryOffsets()[indices->e<sd::LongType>(0)]),
-                              tadPack.primaryShapeInfo(), output->getContext());
+                                                      tadPack->primaryOffsets()[indices->e<sd::LongType>(0)]),
+                              tadPack->primaryShapeInfo(), output->getContext());
         output->assign(&tadArr);
       }
     } else if (input->rankOf() == 1 && indices->isVector()) {

--- a/libnd4j/include/ops/declarable/helpers/cpu/imagesHelpers.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/imagesHelpers.cpp
@@ -98,14 +98,14 @@ SD_INLINE static void tripleTransformer(const NDArray* input, NDArray* output, c
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimC);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimC);
 
-    const sd::LongType numOfTads = packX.numberOfTads();
+    const sd::LongType numOfTads = packX->numberOfTads();
     const sd::LongType xDimCstride = input->stridesOf()[dimC];
     const sd::LongType zDimCstride = output->stridesOf()[dimC];
 
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i++) {
-        const T* xTad = x + packX.platformOffsets()[i];
-        T* zTad = z + packZ.platformOffsets()[i];
+        const T* xTad = x + packX->platformOffsets()[i];
+        T* zTad = z + packZ->platformOffsets()[i];
         // simple M*v //tr.T*v
         T x0, x1, x2;
         x0 = xTad[0];
@@ -159,14 +159,14 @@ SD_INLINE static void hsvRgb(const NDArray* input, NDArray* output, const int di
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimC);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimC);
 
-    const sd::LongType numOfTads = packX.numberOfTads();
+    const sd::LongType numOfTads = packX->numberOfTads();
     const sd::LongType xDimCstride = input->stridesOf()[dimC];
     const sd::LongType zDimCstride = output->stridesOf()[dimC];
 
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i += increment) {
-        const T* xTad = x + packX.platformOffsets()[i];
-        T* zTad = z + packZ.platformOffsets()[i];
+        const T* xTad = x + packX->platformOffsets()[i];
+        T* zTad = z + packZ->platformOffsets()[i];
         sd::ops::helpers::hsvToRgb<T>(xTad[0], xTad[xDimCstride], xTad[2 * xDimCstride], zTad[0], zTad[zDimCstride],
                                       zTad[2 * zDimCstride]);
       }
@@ -196,14 +196,14 @@ SD_INLINE static void rgbHsv(const NDArray* input, NDArray* output, const int di
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimC);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimC);
 
-    const sd::LongType numOfTads = packX.numberOfTads();
+    const sd::LongType numOfTads = packX->numberOfTads();
     const sd::LongType xDimCstride = input->stridesOf()[dimC];
     const sd::LongType zDimCstride = output->stridesOf()[dimC];
 
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i += increment) {
-        const T* xTad = x + packX.platformOffsets()[i];
-        T* zTad = z + packZ.platformOffsets()[i];
+        const T* xTad = x + packX->platformOffsets()[i];
+        T* zTad = z + packZ->platformOffsets()[i];
         sd::ops::helpers::rgbToHsv<T>(xTad[0], xTad[xDimCstride], xTad[2 * xDimCstride], zTad[0], zTad[zDimCstride],
                                       zTad[2 * zDimCstride]);
       }
@@ -235,14 +235,14 @@ SD_INLINE static void rgbYuv_(const NDArray& input, NDArray& output, const int d
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), dimC);
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output.shapeInfo(), dimC);
 
-  const sd::LongType numOfTads = packX.numberOfTads();
+  const sd::LongType numOfTads = packX->numberOfTads();
   const sd::LongType xDimCstride = input.stridesOf()[dimC];
   const sd::LongType zDimCstride = output.stridesOf()[dimC];
 
   auto func = PRAGMA_THREADS_FOR {
     for (auto i = start; i < stop; i += increment) {
-      const T* xTad = x + packX.platformOffsets()[i];
-      T* zTad = z + packZ.platformOffsets()[i];
+      const T* xTad = x + packX->platformOffsets()[i];
+      T* zTad = z + packZ->platformOffsets()[i];
       sd::ops::helpers::rgbYuv<T>(xTad[0], xTad[xDimCstride], xTad[2 * xDimCstride], zTad[0], zTad[zDimCstride],
                                   zTad[2 * zDimCstride]);
     }
@@ -274,14 +274,14 @@ SD_INLINE static void yuvRgb_(const NDArray& input, NDArray& output, const int d
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), dimC);
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output.shapeInfo(), dimC);
 
-  const sd::LongType numOfTads = packX.numberOfTads();
+  const sd::LongType numOfTads = packX->numberOfTads();
   const sd::LongType xDimCstride = input.stridesOf()[dimC];
   const sd::LongType zDimCstride = output.stridesOf()[dimC];
 
   auto func = PRAGMA_THREADS_FOR {
     for (auto i = start; i < stop; i += increment) {
-      const T* xTad = x + packX.platformOffsets()[i];
-      T* zTad = z + packZ.platformOffsets()[i];
+      const T* xTad = x + packX->platformOffsets()[i];
+      T* zTad = z + packZ->platformOffsets()[i];
       sd::ops::helpers::yuvRgb<T>(xTad[0], xTad[xDimCstride], xTad[2 * xDimCstride], zTad[0], zTad[zDimCstride],
                                   zTad[2 * zDimCstride]);
     }

--- a/libnd4j/include/ops/declarable/helpers/cpu/ismax.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/ismax.cpp
@@ -118,19 +118,19 @@ static void ismax_(const NDArray* input, NDArray* output, const std::vector<Long
     auto tadPackZ = sd::ConstantTadHelper::getInstance().tadForDimensions(
         output->shapeInfo(), const_cast<sd::LongType *>(dimensions.data()), dimensionsLength);
 
-    auto tadShapeShapeInfo = tadPack.primaryShapeInfo();
-    auto tadOffsets = tadPack.primaryOffsets();
-    auto zOfsets = tadPackZ.platformOffsets();
+    auto tadShapeShapeInfo = tadPack->primaryShapeInfo();
+    auto tadOffsets = tadPack->primaryOffsets();
+    auto zOfsets = tadPackZ->platformOffsets();
 
     int tadLength = shape::length(tadShapeShapeInfo);
-    int tads = tadPack.numberOfTads();
+    int tads = tadPack->numberOfTads();
 
     int tadsPerThread = tads / TAD_THRESHOLD;
     int num_threads = sd::math::sd_max<int>(1, tadsPerThread);
     num_threads = sd::math::sd_min<int>(num_threads, omp_get_max_threads());
 
     auto tadEWS = shape::elementWiseStride(tadShapeShapeInfo);
-    auto zEWS = shape::elementWiseStride(tadPackZ.primaryShapeInfo());
+    auto zEWS = shape::elementWiseStride(tadPackZ->primaryShapeInfo());
 
     int span = (tads / num_threads) + 8;
 
@@ -176,7 +176,7 @@ static void ismax_(const NDArray* input, NDArray* output, const std::vector<Long
 
           PRAGMA_OMP_SIMD
           for (sd::LongType i = 0; i < tadLength; i++) {
-            auto zOffset = shape::getIndexOffset(i, tadPackZ.primaryShapeInfo());
+            auto zOffset = shape::getIndexOffset(i, tadPackZ->primaryShapeInfo());
             rZ[zOffset] = maxIdx == i ? (Z)1 : (Z)0;
           }
         }

--- a/libnd4j/include/ops/declarable/helpers/cpu/lrn.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/lrn.cpp
@@ -35,22 +35,22 @@ static sd::Status lrnFunctor_(sd::graph::Context& block, NDArray* input, NDArray
 
   const int rank = input->rankOf();
 
-  TadPack inTadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), {rank - 1});
-  TadPack outTadPack;
+  TadPack *inTadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), {rank - 1});
+  TadPack *outTadPack;
 
   if (shape::haveSameShapeAndStrides(input->shapeInfo(), output->shapeInfo()))
     outTadPack = inTadPack;
   else
     outTadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), {rank - 1});
 
-  const sd::LongType numOfTads = inTadPack.numberOfTads();
+  const sd::LongType numOfTads = inTadPack->numberOfTads();
   const sd::LongType tadLen = input->sizeAt(-1);
 
-  const sd::LongType* inTadOffsets = inTadPack.primaryOffsets();
-  const sd::LongType* outTadOffsets = outTadPack.primaryOffsets();
+  const sd::LongType* inTadOffsets = inTadPack->primaryOffsets();
+  const sd::LongType* outTadOffsets = outTadPack->primaryOffsets();
 
-  const sd::LongType inTadEws = shape::elementWiseStride(inTadPack.primaryShapeInfo());
-  const sd::LongType outTadEws = shape::elementWiseStride(outTadPack.primaryShapeInfo());
+  const sd::LongType inTadEws = shape::elementWiseStride(inTadPack->primaryShapeInfo());
+  const sd::LongType outTadEws = shape::elementWiseStride(outTadPack->primaryShapeInfo());
 
   const T* inBuff = reinterpret_cast<T*>(input->buffer());
   T* outBuff = reinterpret_cast<T*>(output->buffer());
@@ -151,22 +151,22 @@ static void lrnBP_(const NDArray& input, const NDArray& gradO, NDArray& gradI, c
                    const float alpha, const float beta) {
   const int rank = input.rankOf();
 
-  TadPack inTadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), {rank - 1});
-  TadPack gradITadPack;
+  TadPack *inTadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), {rank - 1});
+  TadPack *gradITadPack;
 
   if (shape::haveSameShapeAndStrides(input.shapeInfo(), gradI.shapeInfo()))
     gradITadPack = inTadPack;
   else
     gradITadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(gradI.shapeInfo(), {rank - 1});
 
-  const sd::LongType numOfTads = inTadPack.numberOfTads();
+  const sd::LongType numOfTads = inTadPack->numberOfTads();
   const sd::LongType tadLen = input.sizeAt(-1);
 
-  const sd::LongType* inTadOffsets = inTadPack.primaryOffsets();
-  const sd::LongType* gradITadOffsets = gradITadPack.primaryOffsets();
+  const sd::LongType* inTadOffsets = inTadPack->primaryOffsets();
+  const sd::LongType* gradITadOffsets = gradITadPack->primaryOffsets();
 
-  const sd::LongType inTadEws = shape::elementWiseStride(inTadPack.primaryShapeInfo());
-  const sd::LongType gradITadEws = shape::elementWiseStride(gradITadPack.primaryShapeInfo());
+  const sd::LongType inTadEws = shape::elementWiseStride(inTadPack->primaryShapeInfo());
+  const sd::LongType gradITadEws = shape::elementWiseStride(gradITadPack->primaryShapeInfo());
 
   const X* inBuff = reinterpret_cast<X const*>(input.buffer());
   Y* gradIBuff = reinterpret_cast<Y*>(gradI.buffer());

--- a/libnd4j/include/ops/declarable/helpers/cpu/nth_element.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/nth_element.cpp
@@ -42,7 +42,7 @@ void nthElementFunctor_(NDArray* input, sd::LongType n, NDArray* output, bool re
     auto pack = sd::ConstantTadHelper::getInstance().tadForDimensions(sortedVals.shapeInfo(), lastDims);
 
     SpecialMethods<T>::sortTadGeneric(sortedVals.buffer(), sortedVals.shapeInfo(), lastDims.data(), lastDims.size(),
-                                      pack.primaryShapeInfo(), pack.primaryOffsets(), reverse);
+                                      pack->primaryShapeInfo(), pack->primaryOffsets(), reverse);
 
     ResultSet rows = sortedVals.allTensorsAlongDimension(lastDims);
     sd::LongType oL = output->lengthOf();

--- a/libnd4j/include/ops/declarable/helpers/cpu/one_hot.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/one_hot.cpp
@@ -37,9 +37,9 @@ static void onehot_(void* voutput, sd::LongType const* zShapeInfo, void const* v
   auto tadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(zShapeInfo, {axis});
 
   auto iLen = static_cast<unsigned int>(shape::length(iShapeInfo));
-  auto tLen = static_cast<unsigned int>(shape::length(tadPack.primaryShapeInfo()));
-  auto numTads = static_cast<unsigned int>(tadPack.numberOfTads());
-  auto tadEws = shape::elementWiseStride(tadPack.primaryShapeInfo());
+  auto tLen = static_cast<unsigned int>(shape::length(tadPack->primaryShapeInfo()));
+  auto numTads = static_cast<unsigned int>(tadPack->numberOfTads());
+  auto tadEws = shape::elementWiseStride(tadPack->primaryShapeInfo());
 
   if (iLen != numTads) throw std::runtime_error("OneHot: number of TADs should be equal to number of indices");
 
@@ -52,7 +52,7 @@ static void onehot_(void* voutput, sd::LongType const* zShapeInfo, void const* v
   if (tadEws >= 1) {
     auto func = PRAGMA_THREADS_FOR {
       for (auto e = 0; e < stop; e++) {
-        auto cO = output + tadPack.primaryOffsets()[e];
+        auto cO = output + tadPack->primaryOffsets()[e];
 
         auto idx = static_cast<int>(indices[e]);
         if (idx < 0 || idx >= tLen) {
@@ -73,18 +73,18 @@ static void onehot_(void* voutput, sd::LongType const* zShapeInfo, void const* v
   } else {
     auto func = PRAGMA_THREADS_FOR {
       for (auto e = start; e < stop; e++) {
-        auto cO = output + tadPack.primaryOffsets()[e];
+        auto cO = output + tadPack->primaryOffsets()[e];
 
         auto idx = static_cast<int>(indices[e]);
         if (idx < 0 || idx >= tLen) {
           PRAGMA_OMP_SIMD
           for (sd::LongType t = 0; t < tLen; t++) {
-            cO[shape::getIndexOffset(t, tadPack.primaryShapeInfo())] = zero;
+            cO[shape::getIndexOffset(t, tadPack->primaryShapeInfo())] = zero;
           }
         } else {
           PRAGMA_OMP_SIMD
           for (sd::LongType t = 0; t < tLen; t++) {
-            cO[shape::getIndexOffset(t, tadPack.primaryShapeInfo())] = idx == t ? one : zero;
+            cO[shape::getIndexOffset(t, tadPack->primaryShapeInfo())] = idx == t ? one : zero;
           }
         }
       }

--- a/libnd4j/include/ops/declarable/helpers/cpu/softmax.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/softmax.cpp
@@ -172,10 +172,10 @@ static void softmax_(sd::LaunchContext* context, const NDArray& input, NDArray& 
     else
       output = 1.;
   } else if (input.isSameShapeStrict(output)) {
-    TadPack tadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), dimension);
-    auto tadShapeInfo = tadPack.primaryShapeInfo();
-    auto tadOffsets = tadPack.primaryOffsets();
-    const sd::Unsigned numOfSubArrs = tadPack.numberOfTads();
+    TadPack *tadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), dimension);
+    auto tadShapeInfo = tadPack->primaryShapeInfo();
+    auto tadOffsets = tadPack->primaryOffsets();
+    const sd::Unsigned numOfSubArrs = tadPack->numberOfTads();
     const sd::Unsigned tadLen = shape::length(tadShapeInfo);
 
     if (shape::elementWiseStride(tadShapeInfo) == 1) {

--- a/libnd4j/include/ops/declarable/helpers/cpu/stack.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/stack.cpp
@@ -44,11 +44,11 @@ static void stack_(const std::vector<const NDArray*>& inArrs, NDArray& output, c
   } else if(!output.isEmpty()) {
     auto zTadPack = ConstantTadHelper::getInstance().tadForDimensions(
         output.shapeInfo(), ShapeUtils::evalDimsToExclude(output.rankOf(), {dim}));
-    auto zTadShapeInfo = zTadPack.primaryShapeInfo();
+    auto zTadShapeInfo = zTadPack->primaryShapeInfo();
 
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i++) {
-        void* zBuff = output.bufferWithOffset(zTadPack.primaryOffsets()[i]);
+        void* zBuff = output.bufferWithOffset(zTadPack->primaryOffsets()[i]);
 
         NativeOpExecutioner::execTransformAny(inArrs[0]->getContext(), transform::Assign, inArrs[i]->buffer(),
                                               inArrs[i]->shapeInfo(), nullptr /*input specialBuffer*/,
@@ -83,11 +83,11 @@ static void unstack_(const NDArray& input, const std::vector<NDArray*>& outArrs,
   } else {
     auto xTadPack = ConstantTadHelper::getInstance().tadForDimensions(
         input.shapeInfo(), ShapeUtils::evalDimsToExclude(input.rankOf(), {dim}));
-    auto xTadShapeInfo = xTadPack.primaryShapeInfo();
+    auto xTadShapeInfo = xTadPack->primaryShapeInfo();
 
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i++) {
-        auto xBuff = input.bufferWithOffset(xTadPack.primaryOffsets()[i]);
+        auto xBuff = input.bufferWithOffset(xTadPack->primaryOffsets()[i]);
 
         NativeOpExecutioner::execTransformAny(
             input.getContext(), transform::Assign, xBuff, xTadShapeInfo, nullptr /*input specialBuffer*/,

--- a/libnd4j/include/ops/declarable/helpers/cuda/adjust_hue.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/adjust_hue.cu
@@ -83,7 +83,7 @@ void adjustHue(sd::LaunchContext* context, const NDArray* input, const NDArray* 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), {dimC});
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), {dimC});
 
-  const sd::LongType numOfTads = packX.numberOfTads();
+  const sd::LongType numOfTads = packX->numberOfTads();
 
   const int threadsPerBlock = SD_MAX_NUM_THREADS / 2;
   const int blocksPerGrid = (numOfTads + threadsPerBlock - 1) / threadsPerBlock;
@@ -93,8 +93,8 @@ void adjustHue(sd::LaunchContext* context, const NDArray* input, const NDArray* 
   NDArray::prepareSpecialUse({output}, {input, deltaScalarArr});
   BUILD_SINGLE_SELECTOR(input->dataType(), adjustHueCudaLauncher,
                         (blocksPerGrid, threadsPerBlock, context->getCudaStream(), input->specialBuffer(),
-                         input->specialShapeInfo(), packX.platformOffsets(), output->specialBuffer(),
-                         output->specialShapeInfo(), packZ.platformOffsets(), numOfTads, deltaScalarArr, dimC),
+                         input->specialShapeInfo(), packX->platformOffsets(), output->specialBuffer(),
+                         output->specialShapeInfo(), packZ->platformOffsets(), numOfTads, deltaScalarArr, dimC),
                         SD_FLOAT_TYPES);
   NDArray::registerSpecialUse({output}, {input, deltaScalarArr});
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/confusion.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/confusion.cu
@@ -118,7 +118,7 @@ predictions->syncToDevice();
  dim3 launchDims(32, 32, 1024);
  confusionFunctorKernel<Z><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(
      labelsLongBuffer, predictionLongBuffer, bufferLength, weights != nullptr ? weights->specialBuffer() : nullptr,
-     output->specialBuffer(), pack.specialShapeInfo(), pack.specialOffsets());
+     output->specialBuffer(), pack->specialShapeInfo(), pack->specialOffsets());
 
  manager.synchronize();
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/dynamic.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/dynamic.cu
@@ -147,8 +147,8 @@ static void _dynamicPartitionFunctor(sd::LaunchContext *context, NDArray const *
       auto packZ = ConstantTadHelper::getInstance().tadForDimensions(outputList.at(i)->shapeInfo(), outDims);
 
       outBuffers[i] = outputList.at(i)->specialBuffer();
-      tadShapes[i] = packZ.platformShapeInfo();
-      tadOffsets[i] = packZ.platformOffsets();
+      tadShapes[i] = packZ->platformShapeInfo();
+      tadOffsets[i] = packZ->platformOffsets();
     }
 
     // we copy pointers to device
@@ -160,8 +160,8 @@ static void _dynamicPartitionFunctor(sd::LaunchContext *context, NDArray const *
         pm.replicatePointer(tadOffsets.data(), tadOffsets.size() * sizeof(sd::LongType *)));
     // run kernel on device
     dynamicPartitionTadKernel<X, Y><<<256, 256, 1024, *context->getCudaStream()>>>(
-        input->specialBuffer(), packX.platformShapeInfo(), packX.platformOffsets(),
-        shape::length(packX.primaryShapeInfo()), indices->specialBuffer(), indices->specialShapeInfo(),
+        input->specialBuffer(), packX->platformShapeInfo(), packX->platformOffsets(),
+        shape::length(packX->primaryShapeInfo()), indices->specialBuffer(), indices->specialShapeInfo(),
         indices->lengthOf(), dOutBuffers, dOutTadShapes, dOutTadOffsets, outSize);
 
   } else {  // linear case
@@ -302,8 +302,8 @@ static sd::Status _dynamicStitchFunctor(sd::LaunchContext *context, std::vector<
       indicesShapes[e] = indices[e]->specialShapeInfo();
 
       inputBuffers[e] = inputs[e]->specialBuffer();
-      inputTadShapes[e] = packX.platformShapeInfo();
-      inputTadOffsets[e] = packX.platformOffsets();
+      inputTadShapes[e] = packX->platformShapeInfo();
+      inputTadOffsets[e] = packX->platformOffsets();
     }
 
     // copying pointers to buffers to device
@@ -321,7 +321,7 @@ static sd::Status _dynamicStitchFunctor(sd::LaunchContext *context, std::vector<
 
     dynamicStitchTadKernel<X, Y><<<256, 256, 1024, *context->getCudaStream()>>>(
         dInputBuffers, dInputTadShapes, dInputTadOffsets, dIndicesBuffers, dIndicesShapes, inputSize,
-        output->specialBuffer(), packZ.platformShapeInfo(), packZ.platformOffsets());
+        output->specialBuffer(), packZ->platformShapeInfo(), packZ->platformOffsets());
   }
 
   pm.synchronize();

--- a/libnd4j/include/ops/declarable/helpers/cuda/extract_patches.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/extract_patches.cu
@@ -121,7 +121,7 @@ static void _extractPatches(sd::LaunchContext* context, NDArray* images, NDArray
       sd::ConstantTadHelper::getInstance().tadForDimensions(images->shapeInfo(), restDims.data(), restDims.size());
   auto packZ =
       sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), restDims.data(), restDims.size());
-  int batchCount = packX.numberOfTads();
+  int batchCount = packX->numberOfTads();
 
   PointersManager manager(context, "helpers::extractPatches");
 
@@ -131,8 +131,8 @@ static void _extractPatches(sd::LaunchContext* context, NDArray* images, NDArray
 
   globalExtractPatchesKernel<T><<<128, 128, 1024, *stream>>>(
       theSame, batchCount, sizeRow, sizeCol, rowDim, colDim, outRowDim, outColDim, strideRow, strideCol, rateRow,
-      rateCol, rowCast, colCast, lastDim, imagesBuffer, packX.specialShapeInfo(), packX.specialOffsets(), outputBuffer,
-      packZ.specialShapeInfo(), packZ.specialOffsets());
+      rateCol, rowCast, colCast, lastDim, imagesBuffer, packX->specialShapeInfo(), packX->specialOffsets(), outputBuffer,
+      packZ->specialShapeInfo(), packZ->specialOffsets());
 
   manager.synchronize();
   NDArray::registerSpecialUse({output}, {images});

--- a/libnd4j/include/ops/declarable/helpers/cuda/image_draw_bounding_boxes.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/image_draw_bounding_boxes.cu
@@ -82,15 +82,9 @@ static SD_KERNEL void drawBoundingBoxesKernel(T const* images, const sd::LongTyp
       auto colEnd = sd::LongType((width - 1) * boxes[shape::getOffset(boxesShape, indices3, 0)]);
       auto colEndBound = sd::math::sd_min(sd::LongType(width - 1), colEnd);
       if (rowStart > rowEnd || colStart > colEnd) {
-        //                    printf("helpers::drawBoundingBoxesFunctor: Bounding box (%lld, %lld, %lld, %lld) is
-        //                    inverted "
-        //                                "and will not be drawn\n", rowStart, colStart, rowEnd, colEnd);
         continue;
       }
       if (rowStart >= height || rowEnd < 0 || colStart >= width || colEnd < 0) {
-        //                    printf("helpers::drawBoundingBoxesFunctor: Bounding box (%lld, %lld, %lld, %lld) is
-        //                    completely "
-        //                                "outside the image and not be drawn\n", rowStart, colStart, rowEnd, colEnd);
         continue;
       }
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/imagesHelpers.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/imagesHelpers.cu
@@ -73,7 +73,7 @@ void transformRgbYuv(sd::LaunchContext* context, const NDArray& input, NDArray& 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), {dimC});
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output.shapeInfo(), {dimC});
 
-  const sd::LongType numOfTads = packX.numberOfTads();
+  const sd::LongType numOfTads = packX->numberOfTads();
 
   const int threadsPerBlock = SD_MAX_NUM_THREADS / 2;
   const int blocksPerGrid = (numOfTads + threadsPerBlock - 1) / threadsPerBlock;
@@ -83,8 +83,8 @@ void transformRgbYuv(sd::LaunchContext* context, const NDArray& input, NDArray& 
   NDArray::prepareSpecialUse({&output}, {&input});
   BUILD_SINGLE_SELECTOR(input.dataType(), rgbToYuvCudaLauncher,
                         (blocksPerGrid, threadsPerBlock, context->getCudaStream(), input.specialBuffer(),
-                         input.specialShapeInfo(), packX.platformOffsets(), output.specialBuffer(),
-                         output.specialShapeInfo(), packZ.platformOffsets(), numOfTads, dimC),
+                         input.specialShapeInfo(), packX->platformOffsets(), output.specialBuffer(),
+                         output.specialShapeInfo(), packZ->platformOffsets(), numOfTads, dimC),
                         SD_FLOAT_TYPES);
   NDArray::registerSpecialUse({&output}, {&input});
 
@@ -134,7 +134,7 @@ void transformYuvRgb(sd::LaunchContext* context, const NDArray& input, NDArray& 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), {dimC});
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output.shapeInfo(), {dimC});
 
-  const sd::LongType numOfTads = packX.numberOfTads();
+  const sd::LongType numOfTads = packX->numberOfTads();
 
   const int threadsPerBlock = SD_MAX_NUM_THREADS / 2;
   const int blocksPerGrid = (numOfTads + threadsPerBlock - 1) / threadsPerBlock;
@@ -144,8 +144,8 @@ void transformYuvRgb(sd::LaunchContext* context, const NDArray& input, NDArray& 
   NDArray::prepareSpecialUse({&output}, {&input});
   BUILD_SINGLE_SELECTOR(input.dataType(), yuvToRgbCudaLauncher,
                         (blocksPerGrid, threadsPerBlock, context->getCudaStream(), input.specialBuffer(),
-                         input.specialShapeInfo(), packX.platformOffsets(), output.specialBuffer(),
-                         output.specialShapeInfo(), packZ.platformOffsets(), numOfTads, dimC),
+                         input.specialShapeInfo(), packX->platformOffsets(), output.specialBuffer(),
+                         output.specialShapeInfo(), packZ->platformOffsets(), numOfTads, dimC),
                         SD_FLOAT_TYPES);
   NDArray::registerSpecialUse({&output}, {&input});
 
@@ -300,7 +300,7 @@ void transformHsvRgb(sd::LaunchContext* context, const NDArray* input, NDArray* 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), {dimC});
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), {dimC});
 
-  const sd::LongType numOfTads = packX.numberOfTads();
+  const sd::LongType numOfTads = packX->numberOfTads();
 
   const int threadsPerBlock = SD_MAX_NUM_THREADS / 2;
   const int blocksPerGrid = (numOfTads + threadsPerBlock - 1) / threadsPerBlock;
@@ -310,8 +310,8 @@ void transformHsvRgb(sd::LaunchContext* context, const NDArray* input, NDArray* 
   NDArray::prepareSpecialUse({output}, {input});
   BUILD_SINGLE_SELECTOR(input->dataType(), hsvToRgbCudaLauncher,
                         (blocksPerGrid, threadsPerBlock, context->getCudaStream(), input->specialBuffer(),
-                         input->specialShapeInfo(), packX.platformOffsets(), output->specialBuffer(),
-                         output->specialShapeInfo(), packZ.platformOffsets(), numOfTads, dimC),
+                         input->specialShapeInfo(), packX->platformOffsets(), output->specialBuffer(),
+                         output->specialShapeInfo(), packZ->platformOffsets(), numOfTads, dimC),
                         SD_FLOAT_TYPES);
   NDArray::registerSpecialUse({output}, {input});
 
@@ -323,7 +323,7 @@ void transformRgbHsv(sd::LaunchContext* context, const NDArray* input, NDArray* 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), {dimC});
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), {dimC});
 
-  const sd::LongType numOfTads = packX.numberOfTads();
+  const sd::LongType numOfTads = packX->numberOfTads();
 
   const int threadsPerBlock = SD_MAX_NUM_THREADS / 2;
   const int blocksPerGrid = (numOfTads + threadsPerBlock - 1) / threadsPerBlock;
@@ -333,8 +333,8 @@ void transformRgbHsv(sd::LaunchContext* context, const NDArray* input, NDArray* 
   NDArray::prepareSpecialUse({output}, {input});
   BUILD_SINGLE_SELECTOR(input->dataType(), rgbToHsvCudaLauncher,
                         (blocksPerGrid, threadsPerBlock, context->getCudaStream(), input->specialBuffer(),
-                         input->specialShapeInfo(), packX.platformOffsets(), output->specialBuffer(),
-                         output->specialShapeInfo(), packZ.platformOffsets(), numOfTads, dimC),
+                         input->specialShapeInfo(), packX->platformOffsets(), output->specialBuffer(),
+                         output->specialShapeInfo(), packZ->platformOffsets(), numOfTads, dimC),
                         SD_FLOAT_TYPES);
   NDArray::registerSpecialUse({output}, {input});
 
@@ -407,9 +407,9 @@ static void rgbYiq(sd::LaunchContext* context, const NDArray* input, NDArray* ou
 
   NDArray::prepareSpecialUse({output}, {input});
   return tripleTransformerCuda<T><<<256, 256, 8192, *context->getCudaStream()>>>(
-      input->specialBuffer(), input->specialShapeInfo(), packX.platformShapeInfo(), packX.platformOffsets(),
-      output->specialBuffer(), output->specialShapeInfo(), packZ.platformShapeInfo(), packZ.platformOffsets(), dimC, 1,
-      packZ.numberOfTads());
+      input->specialBuffer(), input->specialShapeInfo(), packX->platformShapeInfo(), packX->platformOffsets(),
+      output->specialBuffer(), output->specialShapeInfo(), packZ->platformShapeInfo(), packZ->platformOffsets(), dimC, 1,
+      packZ->numberOfTads());
   NDArray::registerSpecialUse({output}, {input});
 }
 
@@ -420,9 +420,9 @@ SD_INLINE static void yiqRgb(sd::LaunchContext* context, const NDArray* input, N
 
   NDArray::prepareSpecialUse({output}, {input});
   return tripleTransformerCuda<T><<<256, 256, 8192, *context->getCudaStream()>>>(
-      input->specialBuffer(), input->specialShapeInfo(), packX.platformShapeInfo(), packX.platformOffsets(),
-      output->specialBuffer(), output->specialShapeInfo(), packZ.platformShapeInfo(), packZ.platformOffsets(), dimC, 2,
-      packZ.numberOfTads());
+      input->specialBuffer(), input->specialShapeInfo(), packX->platformShapeInfo(), packX->platformOffsets(),
+      output->specialBuffer(), output->specialShapeInfo(), packZ->platformShapeInfo(), packZ->platformOffsets(), dimC, 2,
+      packZ->numberOfTads());
   NDArray::registerSpecialUse({output}, {input});
 }
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/indexReductions.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/indexReductions.cu
@@ -41,7 +41,7 @@ void argMax(const NDArray& input, NDArray& output, const std::vector<sd::LongTyp
                                          input.shapeInfo(), input.specialBuffer(), input.specialShapeInfo(), nullptr,
                                          output.buffer(), output.shapeInfo(), output.specialBuffer(),
                                          output.specialShapeInfo(), (sd::LongType*)nullptr, dimensions.size(),
-                                         tadPack.specialShapeInfo(), tadPack.specialOffsets());
+                                         tadPack->specialShapeInfo(), tadPack->specialOffsets());
   }
 
   NDArray::registerSpecialUse({&output}, {&input});
@@ -61,7 +61,7 @@ void argMin(const NDArray& input, NDArray& output, const std::vector<sd::LongTyp
                                          input.shapeInfo(), input.specialBuffer(), input.specialShapeInfo(), nullptr,
                                          output.buffer(), output.shapeInfo(), output.specialBuffer(),
                                          output.specialShapeInfo(), (sd::LongType*)nullptr, dimensions.size(),
-                                         tadPack.specialShapeInfo(), tadPack.specialOffsets());
+                                         tadPack->specialShapeInfo(), tadPack->specialOffsets());
   }
 
   NDArray::registerSpecialUse({&output}, {&input});
@@ -81,7 +81,7 @@ void argAbsMax(const NDArray& input, NDArray& output, const std::vector<sd::Long
                                          input.buffer(), input.shapeInfo(), input.specialBuffer(),
                                          input.specialShapeInfo(), nullptr, output.buffer(), output.shapeInfo(),
                                          output.specialBuffer(), output.specialShapeInfo(), (sd::LongType*)nullptr,
-                                         dimensions.size(), tadPack.specialShapeInfo(), tadPack.specialOffsets());
+                                         dimensions.size(), tadPack->specialShapeInfo(), tadPack->specialOffsets());
   }
 
   NDArray::registerSpecialUse({&output}, {&input});
@@ -101,7 +101,7 @@ void argAbsMin(const NDArray& input, NDArray& output, const std::vector<sd::Long
                                          input.buffer(), input.shapeInfo(), input.specialBuffer(),
                                          input.specialShapeInfo(), nullptr, output.buffer(), output.shapeInfo(),
                                          output.specialBuffer(), output.specialShapeInfo(), (sd::LongType*)nullptr,
-                                         dimensions.size(), tadPack.specialShapeInfo(), tadPack.specialOffsets());
+                                         dimensions.size(), tadPack->specialShapeInfo(), tadPack->specialOffsets());
   }
 
   NDArray::registerSpecialUse({&output}, {&input});

--- a/libnd4j/include/ops/declarable/helpers/cuda/ismax.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/ismax.cu
@@ -62,8 +62,8 @@ static void ismax_(sd::LaunchContext* context, const NDArray* input, NDArray* ou
   } else {
     sd::LongType* hostYShapeInfo = nullptr;
     sd::LongType* hostTShapeInfo = nullptr;
-    int* dimension = nullptr;
-    int dimensionLength = dimensions.size();
+    sd::LongType* dimension = nullptr;
+    sd::LongType dimensionLength = dimensions.size();
     std::vector<sd::LongType> copy(dimensions);
 
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), copy.data(), copy.size());
@@ -72,13 +72,13 @@ static void ismax_(sd::LaunchContext* context, const NDArray* input, NDArray* ou
     auto indexMaxArr = input->applyIndexReduce(indexreduce::IndexMax, dimensions);
 
     dim3 launchDims(256, 256, 16384);
-    dimension = (int*)manager.replicatePointer(dimensions.data(), dimensions.size() * sizeof(int));
+    dimension = (sd::LongType*)manager.replicatePointer(dimensions.data(), dimensions.size() * sizeof(sd::LongType));
 
     // at this point, all IMax indexes are gathered, and we execute filler
     BUILD_SINGLE_SELECTOR(
         zType, fillDimensionalIsMaxGeneric,
         (launchDims, stream, indexMaxArr.specialBuffer(), output->specialBuffer(), output->specialShapeInfo(),
-         packZ.specialShapeInfo(), dimension, dimensionLength, packZ.specialOffsets()),
+         packZ->specialShapeInfo(), dimension, dimensionLength, packZ->specialOffsets()),
         SD_COMMON_TYPES);
     manager.synchronize();
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/lrn.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/lrn.cu
@@ -121,16 +121,16 @@ static void lrnBP_(sd::graph::Context& block, const NDArray& input, const NDArra
   auto packX = ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), {rank - 1});
   auto packZ = ConstantTadHelper::getInstance().tadForDimensions(gradI.shapeInfo(), {rank - 1});
 
-  const auto tadLength = shape::length(packX.primaryShapeInfo());
-  const int numBlocks = sd::math::sd_min<sd::LongType>(1024, packX.numberOfTads());
+  const auto tadLength = shape::length(packX->primaryShapeInfo());
+  const int numBlocks = sd::math::sd_min<sd::LongType>(1024, packX->numberOfTads());
   const int numThreads = tadLength;
 
   if (tadLength > 1024 || tadLength < 1) throw std::runtime_error("LRN: tadLength > 1024 isn't implemented yet");
 
   lrnBPKernel<X, Z><<<numBlocks, numThreads, numThreads * sizeof(X) + numThreads * sizeof(Z) + 1024,
                       *block.launchContext()->getCudaStream()>>>(
-      input.specialBuffer(), packX.platformShapeInfo(), packX.platformOffsets(), gradI.specialBuffer(),
-      packZ.platformShapeInfo(), packZ.platformOffsets(), packX.numberOfTads(), tadLength, depth, bias, alpha, beta);
+      input.specialBuffer(), packX->platformShapeInfo(), packX->platformOffsets(), gradI.specialBuffer(),
+      packZ->platformShapeInfo(), packZ->platformOffsets(), packX->numberOfTads(), tadLength, depth, bias, alpha, beta);
 
   gradI.tickWriteDevice();
   gradI *= gradO;
@@ -154,15 +154,15 @@ static void lrnFunctor_(sd::graph::Context& block, NDArray* input, NDArray* outp
   auto packX = ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), {rank - 1});
   auto packZ = ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), {rank - 1});
 
-  const auto tadLength = shape::length(packX.primaryShapeInfo());
-  const int numBlocks = sd::math::sd_min<sd::LongType>(1024, packX.numberOfTads());
+  const auto tadLength = shape::length(packX->primaryShapeInfo());
+  const int numBlocks = sd::math::sd_min<sd::LongType>(1024, packX->numberOfTads());
   const int numThreads = tadLength;
 
   if (tadLength > 1024 || tadLength < 1) throw std::runtime_error("LRN: tadLength > 1024 isn't implemented yet");
 
   lrnKernel<T><<<numBlocks, numThreads, numThreads * sizeof(T), *block.launchContext()->getCudaStream()>>>(
-      input->specialBuffer(), packX.platformShapeInfo(), packX.platformOffsets(), output->specialBuffer(),
-      packZ.platformShapeInfo(), packZ.platformOffsets(), packX.numberOfTads(), tadLength, depth, bias, alpha, beta);
+      input->specialBuffer(), packX->platformShapeInfo(), packX->platformOffsets(), output->specialBuffer(),
+      packZ->platformShapeInfo(), packZ->platformOffsets(), packX->numberOfTads(), tadLength, depth, bias, alpha, beta);
 }
 
 sd::Status lrnFunctor(sd::graph::Context& block, NDArray* input, NDArray* output, int depth, double bias, double alpha,

--- a/libnd4j/include/ops/declarable/helpers/cuda/lstsq.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/lstsq.cu
@@ -56,8 +56,8 @@ static void fillRegularizer(sd::LaunchContext* context, NDArray& ioMatrix, doubl
   auto rows = ioMatrix.sizeAt(-2);
   // auto cols = ioMatrix.sizeAt(-1);
   fillRegularizerKernel<T><<<256, 256, 128, *stream>>>(
-      ioMatrix.dataBuffer()->specialAsT<T>(), ioMatrix.specialShapeInfo(), lastDimsTads.specialShapeInfo(),
-      lastDimsTads.specialOffsets(), lastDimsTads.numberOfTads(), rows, (T)value);
+      ioMatrix.dataBuffer()->specialAsT<T>(), ioMatrix.specialShapeInfo(), lastDimsTads->specialShapeInfo(),
+      lastDimsTads->specialOffsets(), lastDimsTads->numberOfTads(), rows, (T)value);
 }
 
 template <typename T>

--- a/libnd4j/include/ops/declarable/helpers/cuda/matrix_band.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/matrix_band.cu
@@ -97,12 +97,12 @@ void matrixBandPart_(sd::LaunchContext* context, NDArray* input, NDArray* output
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), lastDims);
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), lastDims);
 
-  const sd::LongType numTads = packX.numberOfTads();
+  const sd::LongType numTads = packX->numberOfTads();
 
   NDArray::prepareSpecialUse({output}, {input});
   matrixBandKernel<T><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(
       input->specialBuffer(), input->specialShapeInfo(), output->specialBuffer(), output->specialShapeInfo(), lowerBand,
-      upperBand, packX.specialShapeInfo(), packX.specialOffsets(), packZ.specialShapeInfo(), packZ.specialOffsets(),
+      upperBand, packX->specialShapeInfo(), packX->specialOffsets(), packZ->specialShapeInfo(), packZ->specialOffsets(),
       numTads, input->lengthOf());
   NDArray::registerSpecialUse({output}, {input});
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/matrix_diag_part.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/matrix_diag_part.cu
@@ -84,8 +84,8 @@ static sd::Status _matrixDiagPart(sd::LaunchContext* context, const NDArray* inp
 
   dim3 launchDims(256, 512, 8192);
   matrixDiagPartKernel<T><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(
-      input->specialBuffer(), output->specialBuffer(), numTads, lastDimension, packX.specialShapeInfo(),
-      packX.specialOffsets(), packZ.specialShapeInfo(), packZ.specialOffsets());
+      input->specialBuffer(), output->specialBuffer(), numTads, lastDimension, packX->specialShapeInfo(),
+      packX->specialOffsets(), packZ->specialShapeInfo(), packZ->specialOffsets());
 
   return sd::Status::OK;
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/meshgrid.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/meshgrid.cu
@@ -106,9 +106,9 @@ static void meshgrid_(sd::LaunchContext *context, const std::vector<NDArray *> &
     hOutBuffers[i] = outArrs[i]->specialBuffer();
 
     auto pack = ConstantTadHelper::getInstance().tadForDimensions(outArrs[i]->shapeInfo(), {inIndices[i]});
-    hOutTadShapes[i] = pack.specialShapeInfo();
-    hOutTadOffsets[i] = pack.specialOffsets();
-    hNumTads[i] = pack.numberOfTads();
+    hOutTadShapes[i] = pack->specialShapeInfo();
+    hOutTadOffsets[i] = pack->specialOffsets();
+    hNumTads[i] = pack->numberOfTads();
 
     // auto list = outArrs[i]->allTensorsAlongDimension({inIndices[i]});
     // for(int j = 0; j < list->size(); ++j)

--- a/libnd4j/include/ops/declarable/helpers/cuda/nth_element.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/nth_element.cu
@@ -70,9 +70,9 @@ void nthElementFunctor_(sd::LaunchContext* context, NDArray* input, sd::LongType
 
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(sortedVals.shapeInfo(), lastDims);
 
-    auto pTadShape = packX.specialShapeInfo();
-    auto pTadShapeH = packX.primaryShapeInfo();
-    auto pTadOffsets = packX.specialOffsets();
+    auto pTadShape = packX->specialShapeInfo();
+    auto pTadShapeH = packX->primaryShapeInfo();
+    auto pTadOffsets = packX->specialOffsets();
     sortTad(params, sortedVals.buffer(), sortedVals.shapeInfo(), sortedVals.specialBuffer(),
             sortedVals.specialShapeInfo(), lastDims.data(), lastDims.size(), pTadShape, pTadOffsets, reverse);
     sortedVals.tickWriteDevice();

--- a/libnd4j/include/ops/declarable/helpers/cuda/percentile.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/percentile.cu
@@ -96,7 +96,7 @@ static void _percentile(sd::LaunchContext* context, const NDArray& input, NDArra
   auto tempArray = input.dup();
   auto packX = ConstantTadHelper::getInstance().tadForDimensions(tempArray.shapeInfo(), axis);
 
-  auto tadLength = shape::length(packX.primaryShapeInfo());
+  auto tadLength = shape::length(packX->primaryShapeInfo());
 
   const float fraction = 1.f - q / 100.;
   sd::LongType position = 0;
@@ -115,7 +115,7 @@ static void _percentile(sd::LaunchContext* context, const NDArray& input, NDArra
   position = tadLength - position - 1;
 
   percentileKernel<T><<<256, 512, 1024, *context->getCudaStream()>>>(
-      tempArray.specialBuffer(), packX.platformShapeInfo(), packX.platformOffsets(), packX.numberOfTads(), tadLength,
+      tempArray.specialBuffer(), packX->platformShapeInfo(), packX->platformOffsets(), packX->numberOfTads(), tadLength,
       output.specialBuffer(), output.specialShapeInfo(), output.lengthOf(), position);
 
   sd::DebugHelper::checkErrorCode(context->getCudaStream(), "percentile");

--- a/libnd4j/include/ops/declarable/helpers/cuda/prefix.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/prefix.cu
@@ -138,7 +138,7 @@ void prefix(sd::LaunchContext* context, scalar::Ops op, const NDArray* x, NDArra
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
   auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(z->shapeInfo(), dims);
 
-  const sd::LongType numTads = packX.numberOfTads();
+  const sd::LongType numTads = packX->numberOfTads();
   const sd::LongType tadLen = x->lengthOf() / numTads;
 
   const int threadsPerBlock = SD_MAX_NUM_THREADS / 2;
@@ -150,8 +150,8 @@ void prefix(sd::LaunchContext* context, scalar::Ops op, const NDArray* x, NDArra
   NDArray::prepareSpecialUse({z}, {x});
   BUILD_SINGLE_SELECTOR(x->dataType(), prefixPerBlockCudaLauncher,
                         (blocksPerGrid, threadsPerBlock, sharedMem, context->getCudaStream(), op, x->specialBuffer(),
-                         packX.platformShapeInfo(), packX.platformOffsets(), z->specialBuffer(),
-                         packZ.platformShapeInfo(), packZ.platformOffsets(), numTads, tadLen, exclusive, reverse),
+                         packX->platformShapeInfo(), packX->platformOffsets(), z->specialBuffer(),
+                         packZ->platformShapeInfo(), packZ->platformOffsets(), numTads, tadLen, exclusive, reverse),
                         SD_NUMERIC_TYPES);
   NDArray::registerSpecialUse({z}, {x});
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/reverse.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/reverse.cu
@@ -56,8 +56,7 @@ static SD_KERNEL void reverseTadKernel(const void* vinput, const sd::LongType* i
     // now finding out element within tad
     auto idx = e % div;
 
-    // printf("TID: %i; numTads: %lld; tadLength: %lld; tadId: %i, idx: %lld\n", tid, numTads, numOfElemsToReverse,
-    // tadId, idx);
+
 
     auto tadInput = input + inputTadOffsets[tadId];
     auto tadOutput = output + outputTadOffsets[tadId];
@@ -226,13 +225,13 @@ void reverse(sd::LaunchContext* context, const NDArray* input, NDArray* output, 
 
   NDArray::prepareSpecialUse({output}, {input});
 
-  if (packX.numberOfTads() == 1) {
+  if (packX->numberOfTads() == 1) {
     BUILD_SINGLE_SELECTOR(input->dataType(), reverseArray, (context, input, output, 0), SD_COMMON_TYPES);
   } else {
     BUILD_SINGLE_SELECTOR(
         input->dataType(), reverseTad,
-        (context, input, output, packX.platformShapeInfo(), packX.platformOffsets(), packZ.platformShapeInfo(),
-         packZ.platformOffsets(), (uint64_t)(input->lengthOf() / packX.numberOfTads())),
+        (context, input, output, packX->platformShapeInfo(), packX->platformOffsets(), packZ->platformShapeInfo(),
+         packZ->platformOffsets(), (uint64_t)(input->lengthOf() / packX->numberOfTads())),
         SD_COMMON_TYPES);
   }
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/roll.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/roll.cu
@@ -266,21 +266,21 @@ static void rollFunctorFull_(NDArray *input, NDArray *output, std::vector<sd::Lo
 
       auto packZ = ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dims);
 
-      int numTads = packZ.numberOfTads();
+      int numTads = packZ->numberOfTads();
       int sizeAt = input->sizeAt(axe);
-      auto tadLength = shape::length(packZ.primaryShapeInfo());
+      auto tadLength = shape::length(packZ->primaryShapeInfo());
 
       int theShift = shifts[i];
 
       if (theShift) {
         for (int dim = 0; dim < numTads / sizeAt; ++dim) {
           rollKernelFullAnyDimensionStage1<T><<<1, 256, 1024, *(output->getContext()->getCudaStream())>>>(
-              output->specialBuffer(), packZ.platformShapeInfo(), packZ.platformOffsets(), output->specialBuffer(),
-              packZ.platformShapeInfo(), packZ.platformOffsets(), numTads, tadLength, dim, sizeAt, theShift);
+              output->specialBuffer(), packZ->platformShapeInfo(), packZ->platformOffsets(), output->specialBuffer(),
+              packZ->platformShapeInfo(), packZ->platformOffsets(), numTads, tadLength, dim, sizeAt, theShift);
 
           rollKernelFullAnyDimensionStage2<T><<<1, 256, 1024, *(output->getContext()->getCudaStream())>>>(
-              output->specialBuffer(), packZ.platformShapeInfo(), packZ.platformOffsets(), output->specialBuffer(),
-              packZ.platformShapeInfo(), packZ.platformOffsets(), numTads, tadLength, dim, sizeAt, theShift);
+              output->specialBuffer(), packZ->platformShapeInfo(), packZ->platformOffsets(), output->specialBuffer(),
+              packZ->platformShapeInfo(), packZ->platformOffsets(), numTads, tadLength, dim, sizeAt, theShift);
         }
       }
     }

--- a/libnd4j/include/ops/declarable/helpers/cuda/scatter_simple.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/scatter_simple.cu
@@ -57,12 +57,12 @@ void scatterSimple_(sd::LaunchContext* context, const int opId, NDArray& input, 
   auto dims = ShapeUtils::evalDimsToExclude(input.rankOf(), dimensions);
   auto packX = ConstantTadHelper::getInstance().tadForDimensions(input.shapeInfo(), dims);
 
-  auto xLength = shape::length(packX.primaryShapeInfo());
+  auto xLength = shape::length(packX->primaryShapeInfo());
   auto iLength = indices.lengthOf();
   auto uLength = updates.lengthOf();
 
   scatterSimpleKernel<X, Y><<<256, 256, 1024, *context->getCudaStream()>>>(
-      input.specialBuffer(), packX.platformShapeInfo(), packX.platformOffsets(), xLength, packX.numberOfTads(),
+      input.specialBuffer(), packX->platformShapeInfo(), packX->platformOffsets(), xLength, packX->numberOfTads(),
       indices.specialBuffer(), indices.specialShapeInfo(), iLength, updates.specialBuffer(), updates.specialShapeInfo(),
       uLength);
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/scatter_update.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/scatter_update.cu
@@ -119,9 +119,9 @@ void scatterUpdate(sd::LaunchContext* context, NDArray& input, NDArray& updates,
 
   NDArray::prepareSpecialUse({&input}, {&input, &updates, &indices});
   BUILD_SINGLE_SELECTOR(input.dataType(), scatterUpdateCudaLauncher,
-                        (context->getCudaStream(), opCode, numOfInd, input.specialBuffer(), packX.platformShapeInfo(),
-                         packX.platformOffsets(), updates.specialBuffer(), packY.platformShapeInfo(),
-                         packY.platformOffsets(), reinterpret_cast<sd::LongType *>(indices.specialBuffer())),
+                        (context->getCudaStream(), opCode, numOfInd, input.specialBuffer(), packX->platformShapeInfo(),
+                         packX->platformOffsets(), updates.specialBuffer(), packY->platformShapeInfo(),
+                         packY->platformOffsets(), reinterpret_cast<sd::LongType *>(indices.specialBuffer())),
                         SD_COMMON_TYPES);
   NDArray::registerSpecialUse({&input}, {&input, &updates, &indices});
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_max.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_max.cu
@@ -184,11 +184,11 @@ static void segmentMaxFunctor_(LaunchContext* context, NDArray* input, NDArray* 
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    segmentMaxTadKernel<T, I><<<packX.numberOfTads(), 512, 2048, *stream>>>(
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    segmentMaxTadKernel<T, I><<<packX->numberOfTads(), 512, 2048, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numOfClasses, output->specialBuffer(),
         output->specialShapeInfo(), outputTads, outputTadOffsets);
@@ -228,10 +228,10 @@ static void unsortedSegmentMaxFunctor_(sd::LaunchContext* context, NDArray* inpu
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     dims.x = input->sizeAt(0);
     output->assign(-DataTypeUtils::max<T>());
     segmentMaxTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
@@ -361,14 +361,14 @@ sd::Status segmentMaxFunctorBP_(sd::LaunchContext* context, NDArray* input, NDAr
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradIn = sd::ConstantTadHelper::getInstance().tadForDimensions(tempRes.shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    sd::LongType const* inputTads = packX.specialShapeInfo();
-    sd::LongType const* inputTadOffsets = packX.specialOffsets();
-    sd::LongType const* outputTads = packZ.specialShapeInfo();
-    sd::LongType const* outputTadOffsets = packZ.specialOffsets();
-    sd::LongType const* gradInTads = packGradIn.specialShapeInfo();
-    sd::LongType const* gradInTadOffsets = packGradIn.specialOffsets();
-    sd::LongType const* gradOutTads = packGradOut.specialShapeInfo();
-    sd::LongType const* gradOutTadOffsets = packGradOut.specialOffsets();
+    sd::LongType const* inputTads = packX->specialShapeInfo();
+    sd::LongType const* inputTadOffsets = packX->specialOffsets();
+    sd::LongType const* outputTads = packZ->specialShapeInfo();
+    sd::LongType const* outputTadOffsets = packZ->specialOffsets();
+    sd::LongType const* gradInTads = packGradIn->specialShapeInfo();
+    sd::LongType const* gradInTadOffsets = packGradIn->specialOffsets();
+    sd::LongType const* gradOutTads = packGradOut->specialShapeInfo();
+    sd::LongType const* gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentMaxBPTadKernel<T, I><<<gradOut->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), tempRes.specialBuffer(), tempRes.specialShapeInfo(),
@@ -412,14 +412,14 @@ static sd::Status unsortedSegmentMaxFunctorBP_(sd::LaunchContext* context, NDArr
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradIn = sd::ConstantTadHelper::getInstance().tadForDimensions(tempRes.shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    sd::LongType const* inputTads = packX.specialShapeInfo();
-    sd::LongType const* inputTadOffsets = packX.specialOffsets();
-    sd::LongType const* outputTads = packZ.specialShapeInfo();
-    sd::LongType const* outputTadOffsets = packZ.specialOffsets();
-    sd::LongType const* gradInTads = packGradIn.specialShapeInfo();
-    sd::LongType const* gradInTadOffsets = packGradIn.specialOffsets();
-    sd::LongType const* gradOutTads = packGradOut.specialShapeInfo();
-    sd::LongType const* gradOutTadOffsets = packGradOut.specialOffsets();
+    sd::LongType const* inputTads = packX->specialShapeInfo();
+    sd::LongType const* inputTadOffsets = packX->specialOffsets();
+    sd::LongType const* outputTads = packZ->specialShapeInfo();
+    sd::LongType const* outputTadOffsets = packZ->specialOffsets();
+    sd::LongType const* gradInTads = packGradIn->specialShapeInfo();
+    sd::LongType const* gradInTadOffsets = packGradIn->specialOffsets();
+    sd::LongType const* gradOutTads = packGradOut->specialShapeInfo();
+    sd::LongType const* gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentMaxBPTadKernel<T, I><<<gradOut->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), tempRes.specialBuffer(), tempRes.specialShapeInfo(),

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_mean.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_mean.cu
@@ -181,10 +181,10 @@ static void segmentMeanFunctor_(LaunchContext* context, NDArray* input, NDArray*
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     segmentMeanTadKernel<T, I><<<input->sizeAt(0), 512, 2048, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numClasses, output->specialBuffer(),
@@ -228,10 +228,10 @@ static void unsortedSegmentMeanFunctor_(sd::LaunchContext* context, NDArray* inp
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    sd::LongType const* inputTads = packX.specialShapeInfo();
-    sd::LongType const* inputTadOffsets = packX.specialOffsets();
-    sd::LongType const* outputTads = packZ.specialShapeInfo();
-    sd::LongType const* outputTadOffsets = packZ.specialOffsets();
+    sd::LongType const* inputTads = packX->specialShapeInfo();
+    sd::LongType const* inputTadOffsets = packX->specialOffsets();
+    sd::LongType const* outputTads = packZ->specialShapeInfo();
+    sd::LongType const* outputTadOffsets = packZ->specialOffsets();
     dims.x = input->sizeAt(0);
     segmentMeanTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
@@ -354,12 +354,12 @@ sd::Status segmentMeanFunctorBP_(sd::LaunchContext* context, NDArray* input, NDA
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    sd::LongType const* inputTads = packX.specialShapeInfo();
-    sd::LongType const* inputTadOffsets = packX.specialOffsets();
-    sd::LongType const* outputTads = packZ.specialShapeInfo();
-    sd::LongType const* outputTadOffsets = packZ.specialOffsets();
-    sd::LongType const* gradOutTads = packGradOut.specialShapeInfo();
-    sd::LongType const* gradOutTadOffsets = packGradOut.specialOffsets();
+    sd::LongType const* inputTads = packX->specialShapeInfo();
+    sd::LongType const* inputTadOffsets = packX->specialOffsets();
+    sd::LongType const* outputTads = packZ->specialShapeInfo();
+    sd::LongType const* outputTadOffsets = packZ->specialOffsets();
+    sd::LongType const* gradOutTads = packGradOut->specialShapeInfo();
+    sd::LongType const* gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentMeanBPTadKernel<T, I><<<indices->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), gradOut->specialBuffer(), gradOut->specialShapeInfo(),
@@ -411,12 +411,12 @@ static sd::Status unsortedSegmentMeanFunctorBP_(sd::LaunchContext* context, NDAr
     //            auto packGradIn = sd::ConstantTadHelper::getInstance().tadForDimensions(tempRes.shapeInfo(),
     //            dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    sd::LongType const* inputTads = packX.specialShapeInfo();
-    sd::LongType const* inputTadOffsets = packX.specialOffsets();
-    sd::LongType const* outputTads = packZ.specialShapeInfo();
-    sd::LongType const* outputTadOffsets = packZ.specialOffsets();
-    sd::LongType const* gradOutTads = packGradOut.specialShapeInfo();
-    sd::LongType const* gradOutTadOffsets = packGradOut.specialOffsets();
+    sd::LongType const* inputTads = packX->specialShapeInfo();
+    sd::LongType const* inputTadOffsets = packX->specialOffsets();
+    sd::LongType const* outputTads = packZ->specialShapeInfo();
+    sd::LongType const* outputTadOffsets = packZ->specialOffsets();
+    sd::LongType const* gradOutTads = packGradOut->specialShapeInfo();
+    sd::LongType const* gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentMeanBPTadKernel<T, I><<<indices->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), gradOut->specialBuffer(), gradOut->specialShapeInfo(),

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_min.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_min.cu
@@ -175,10 +175,10 @@ static void segmentMinFunctor_(LaunchContext* context, NDArray* input, NDArray* 
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     segmentMinTadKernel<T, I><<<input->sizeAt(0), 512, 2048, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numClasses, output->specialBuffer(),
@@ -224,10 +224,10 @@ static void unsortedSegmentMinFunctor_(sd::LaunchContext* context, NDArray* inpu
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     dims.x = input->sizeAt(0);
     segmentMinTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
@@ -356,14 +356,14 @@ sd::Status segmentMinFunctorBP_(sd::LaunchContext* context, NDArray* input, NDAr
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradIn = sd::ConstantTadHelper::getInstance().tadForDimensions(tempRes.shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    auto gradInTads = packGradIn.specialShapeInfo();
-    auto gradInTadOffsets = packGradIn.specialOffsets();
-    auto gradOutTads = packGradOut.specialShapeInfo();
-    auto gradOutTadOffsets = packGradOut.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    auto gradInTads = packGradIn->specialShapeInfo();
+    auto gradInTadOffsets = packGradIn->specialOffsets();
+    auto gradOutTads = packGradOut->specialShapeInfo();
+    auto gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentMinBPTadKernel<T, I><<<gradOut->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), tempRes.specialBuffer(), tempRes.specialShapeInfo(),
@@ -407,14 +407,14 @@ static sd::Status unsortedSegmentMinFunctorBP_(sd::LaunchContext* context, NDArr
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradIn = sd::ConstantTadHelper::getInstance().tadForDimensions(tempRes.shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    auto gradInTads = packGradIn.specialShapeInfo();
-    auto gradInTadOffsets = packGradIn.specialOffsets();
-    auto gradOutTads = packGradOut.specialShapeInfo();
-    auto gradOutTadOffsets = packGradOut.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    auto gradInTads = packGradIn->specialShapeInfo();
+    auto gradInTadOffsets = packGradIn->specialOffsets();
+    auto gradOutTads = packGradOut->specialShapeInfo();
+    auto gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentMinBPTadKernel<T, I><<<gradOut->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), tempRes.specialBuffer(), tempRes.specialShapeInfo(),

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_prod.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_prod.cu
@@ -145,10 +145,10 @@ static void segmentProdFunctor_(sd::LaunchContext* context, NDArray* input, NDAr
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     segmentProdTadKernel<T, I><<<128, 512, 2048, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numClasses, output->specialBuffer(),
@@ -188,10 +188,10 @@ static void unsortedSegmentProdFunctor_(sd::LaunchContext* context, NDArray* inp
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     dims.x = input->sizeAt(0);
     segmentProdTadKernel<T, I>
         <<<128, 256, 256, *stream>>>(input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
@@ -313,14 +313,14 @@ sd::Status segmentProdFunctorBP_(sd::LaunchContext* context, NDArray* input, NDA
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradIn = sd::ConstantTadHelper::getInstance().tadForDimensions(tempRes.shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    auto gradInTads = packGradIn.specialShapeInfo();
-    auto gradInTadOffsets = packGradIn.specialOffsets();
-    auto gradOutTads = packGradOut.specialShapeInfo();
-    auto gradOutTadOffsets = packGradOut.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    auto gradInTads = packGradIn->specialShapeInfo();
+    auto gradInTadOffsets = packGradIn->specialOffsets();
+    auto gradOutTads = packGradOut->specialShapeInfo();
+    auto gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentProdBPTadKernel<T, I><<<gradOut->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), tempRes.specialBuffer(), tempRes.specialShapeInfo(),
@@ -366,14 +366,14 @@ static sd::Status unsortedSegmentProdFunctorBP_(sd::LaunchContext* context, NDAr
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradIn = sd::ConstantTadHelper::getInstance().tadForDimensions(tempRes.shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    auto gradInTads = packGradIn.specialShapeInfo();
-    auto gradInTadOffsets = packGradIn.specialOffsets();
-    auto gradOutTads = packGradOut.specialShapeInfo();
-    auto gradOutTadOffsets = packGradOut.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    auto gradInTads = packGradIn->specialShapeInfo();
+    auto gradInTadOffsets = packGradIn->specialOffsets();
+    auto gradOutTads = packGradOut->specialShapeInfo();
+    auto gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentProdBPTadKernel<T, I><<<indices->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), tempRes.specialBuffer(), tempRes.specialShapeInfo(),

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_sqrtn.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_sqrtn.cu
@@ -116,10 +116,10 @@ static void unsortedSegmentSqrtNFunctor_(sd::LaunchContext* context, NDArray* in
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     dims.x = input->sizeAt(0);
     segmentSqrtNTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
         input->dataBuffer()->specialAsT<T>(), input->specialShapeInfo(), inputTads, inputTadOffsets,
@@ -243,12 +243,12 @@ static sd::Status unsortedSegmentSqrtNFunctorBP_(sd::LaunchContext* context, NDA
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    auto gradOutTads = packGradOut.specialShapeInfo();
-    auto gradOutTadOffsets = packGradOut.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    auto gradOutTads = packGradOut->specialShapeInfo();
+    auto gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentSqrtNBPTadKernel<T, I><<<indices->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), gradOut->specialBuffer(), gradOut->specialShapeInfo(),

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
@@ -172,10 +172,10 @@ static void segmentSumFunctor_(sd::LaunchContext* context, NDArray* input, NDArr
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     segmentSumTadKernel<T, I><<<input->sizeAt(0), 512, 2048, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numClasses, output->specialBuffer(),
@@ -218,10 +218,10 @@ static void unsortedSegmentSumFunctor_(sd::LaunchContext* context, NDArray* inpu
     std::vector<sd::LongType> dimensions = ShapeUtils::evalDimsToExclude(input->rankOf(), {0});
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
     dims.x = input->sizeAt(0);
     segmentSumTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
@@ -328,12 +328,12 @@ sd::Status segmentSumFunctorBP_(sd::LaunchContext* context, NDArray* input, NDAr
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    auto gradOutTads = packGradOut.specialShapeInfo();
-    auto gradOutTadOffsets = packGradOut.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    auto gradOutTads = packGradOut->specialShapeInfo();
+    auto gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentSumBPTadKernel<T, I><<<gradOut->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), gradOut->specialBuffer(), gradOut->specialShapeInfo(),
@@ -369,12 +369,12 @@ static sd::Status unsortedSegmentSumFunctorBP_(sd::LaunchContext* context, NDArr
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), dimensions);
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(output->shapeInfo(), dimensions);
     auto packGradOut = sd::ConstantTadHelper::getInstance().tadForDimensions(gradOut->shapeInfo(), dimensions);
-    auto inputTads = packX.specialShapeInfo();
-    auto inputTadOffsets = packX.specialOffsets();
-    auto outputTads = packZ.specialShapeInfo();
-    auto outputTadOffsets = packZ.specialOffsets();
-    auto gradOutTads = packGradOut.specialShapeInfo();
-    auto gradOutTadOffsets = packGradOut.specialOffsets();
+    auto inputTads = packX->specialShapeInfo();
+    auto inputTadOffsets = packX->specialOffsets();
+    auto outputTads = packZ->specialShapeInfo();
+    auto outputTadOffsets = packZ->specialOffsets();
+    auto gradOutTads = packGradOut->specialShapeInfo();
+    auto gradOutTadOffsets = packGradOut->specialOffsets();
 
     segmentSumBPTadKernel<T, I><<<gradOut->lengthOf(), input->lengthOf(), 256, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), gradOut->specialBuffer(), gradOut->specialShapeInfo(),

--- a/libnd4j/include/ops/declarable/helpers/cuda/solve.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/solve.cu
@@ -84,16 +84,16 @@ static sd::Status solveFunctor_(sd::LaunchContext* context, NDArray* leftInput, 
   auto leftLowerTad = ConstantTadHelper::getInstance().tadForDimensions(leftLower.shapeInfo(), {-2, -1});
   auto stream = context->getCudaStream();
   oneOnDiagonalKernel<T><<<128, 256, 256, *stream>>>(
-      leftLower.dataBuffer()->specialAsT<T>(), leftLower.specialShapeInfo(), leftLowerTad.specialShapeInfo(),
-      leftLowerTad.specialOffsets(), leftLowerTad.numberOfTads(), leftLower.sizeAt(-1));
+      leftLower.dataBuffer()->specialAsT<T>(), leftLower.specialShapeInfo(), leftLowerTad->specialShapeInfo(),
+      leftLowerTad->specialOffsets(), leftLowerTad->numberOfTads(), leftLower.sizeAt(-1));
   auto P = leftOutput.ulike();
   P.nullify();
   auto PTad = ConstantTadHelper::getInstance().tadForDimensions(P.shapeInfo(), {-2, -1});
   auto permutationsTad = ConstantTadHelper::getInstance().tadForDimensions(permutations.shapeInfo(), {-1});
   restorePermutationsKernel<T><<<128, 256, 256, *stream>>>(
       P.dataBuffer()->specialAsT<T>(), P.specialShapeInfo(), permutations.dataBuffer()->specialAsT<int>(),
-      PTad.specialShapeInfo(), PTad.specialOffsets(), permutationsTad.specialShapeInfo(),
-      permutationsTad.specialOffsets(), permutationsTad.numberOfTads(), permutations.sizeAt(-1));
+      PTad->specialShapeInfo(), PTad->specialOffsets(), permutationsTad->specialShapeInfo(),
+      permutationsTad->specialOffsets(), permutationsTad->numberOfTads(), permutations.sizeAt(-1));
   P.tickWriteDevice();
   auto rightPart = rightInput->ulike();
   MmulHelper::matmul(&P, rightInput, &rightPart, 0, 0);
@@ -140,8 +140,8 @@ static void adjointMatrix_(sd::LaunchContext* context, NDArray const* input, NDA
   auto rows = input->sizeAt(-2);
   auto columns = input->sizeAt(-1);
   output->assign(input);
-  adjointKernel<T><<<128, 256, 256, *stream>>>(outputBuf, outputTads.numberOfTads(), rows, columns,
-                                               outputTads.specialShapeInfo(), outputTads.specialOffsets());
+  adjointKernel<T><<<128, 256, 256, *stream>>>(outputBuf, outputTads->numberOfTads(), rows, columns,
+                                               outputTads->specialShapeInfo(), outputTads->specialOffsets());
   NDArray::registerSpecialUse({output}, {input});
 }
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/stack.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/stack.cu
@@ -87,14 +87,14 @@ static void stack_(sd::LaunchContext* context, const std::vector<const NDArray*>
   } else {
     auto zTadPack = ConstantTadHelper::getInstance().tadForDimensions(
         output.shapeInfo(), ShapeUtils::evalDimsToExclude(output.rankOf(), {dim}));
-    auto zTadShapeInfo = zTadPack.primaryShapeInfo();
+    auto zTadShapeInfo = zTadPack->primaryShapeInfo();
 
     for (sd::Unsigned i = 0; i < numOfSubArrs; ++i) {
-      void* zBuff = output.specialBufferWithOffset(zTadPack.primaryOffsets()[i]);
+      void* zBuff = output.specialBufferWithOffset(zTadPack->primaryOffsets()[i]);
 
       NativeOpExecutioner::execTransformAny(context, transform::Assign, nullptr, inArrs[i]->shapeInfo(),
                                             inArrs[i]->specialBuffer(), inArrs[i]->specialShapeInfo(), nullptr,
-                                            zTadShapeInfo, zBuff, zTadPack.specialShapeInfo(), nullptr, nullptr,
+                                            zTadShapeInfo, zBuff, zTadPack->specialShapeInfo(), nullptr, nullptr,
                                             nullptr, false /*allowParallelism*/);
     }
   }
@@ -169,13 +169,13 @@ static void unstack_(sd::LaunchContext* context, const NDArray& input, const std
   } else {
     auto xTadPack = ConstantTadHelper::getInstance().tadForDimensions(
         input.shapeInfo(), ShapeUtils::evalDimsToExclude(input.rankOf(), {dim}));
-    auto xTadShapeInfo = xTadPack.primaryShapeInfo();
+    auto xTadShapeInfo = xTadPack->primaryShapeInfo();
 
     for (sd::Unsigned i = 0; i < numOfSubArrs; ++i) {
-      auto xBuff = input.specialBufferWithOffset(xTadPack.primaryOffsets()[i]);
+      auto xBuff = input.specialBufferWithOffset(xTadPack->primaryOffsets()[i]);
 
       NativeOpExecutioner::execTransformAny(input.getContext(), transform::Assign, nullptr, xTadShapeInfo, xBuff,
-                                            xTadPack.specialShapeInfo(), nullptr, outArrs[i]->shapeInfo(),
+                                            xTadPack->specialShapeInfo(), nullptr, outArrs[i]->shapeInfo(),
                                             outArrs[i]->specialBuffer(), outArrs[i]->specialShapeInfo(), nullptr,
                                             nullptr, nullptr, false /*allowParallelism*/);
     }

--- a/libnd4j/include/ops/declarable/helpers/cuda/summaryStatReductions.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/summaryStatReductions.cu
@@ -42,8 +42,8 @@ void variance(const NDArray& input, NDArray& output, const std::vector<sd::LongT
     NativeOpExecutioner::execSummaryStats(
         LaunchContext::defaultContext(), variance::SummaryStatsVariance, input.buffer(), input.shapeInfo(),
         input.specialBuffer(), input.specialShapeInfo(), nullptr, output.buffer(), output.shapeInfo(),
-        output.specialBuffer(), output.specialShapeInfo(), (sd::LongType *)nullptr, dimensions.size(), tadPack.specialShapeInfo(),
-        tadPack.specialOffsets(), biasCorrected);
+        output.specialBuffer(), output.specialShapeInfo(), (sd::LongType *)nullptr, dimensions.size(), tadPack->specialShapeInfo(),
+        tadPack->specialOffsets(), biasCorrected);
   }
   // inform that we are done with those specialBuffers. it matches arrays used in the prepareSpecialUse
   NDArray::registerSpecialUse({&output}, {&input});
@@ -64,8 +64,8 @@ void standardDeviation(const NDArray& input, NDArray& output, const std::vector<
     NativeOpExecutioner::execSummaryStats(
         LaunchContext::defaultContext(), variance::SummaryStatsStandardDeviation, input.buffer(), input.shapeInfo(),
         input.specialBuffer(), input.specialShapeInfo(), nullptr, output.buffer(), output.shapeInfo(),
-        output.specialBuffer(), output.specialShapeInfo(), (sd::LongType *)nullptr, dimensions.size(), tadPack.specialShapeInfo(),
-        tadPack.specialOffsets(), biasCorrected);
+        output.specialBuffer(), output.specialShapeInfo(), (sd::LongType *)nullptr, dimensions.size(), tadPack->specialShapeInfo(),
+        tadPack->specialOffsets(), biasCorrected);
   }
   // inform that we are done with those specialBuffers. it matches arrays used in the prepareSpecialUse
   NDArray::registerSpecialUse({&output}, {&input});

--- a/libnd4j/include/ops/declarable/helpers/cuda/triangular_solve.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/triangular_solve.cu
@@ -158,8 +158,8 @@ static sd::Status triangularSolveFunctor_(sd::LaunchContext* context, NDArray* l
   T* outputBuf = reinterpret_cast<T*>(output->specialBuffer());
   triangularSolveKernel<T><<<128, 128, 256, *stream>>>(
       leftBuf, leftInput->specialShapeInfo(), rightBuf, rightInput->specialShapeInfo(), lower, unitsOnDiag, outputBuf,
-      output->specialShapeInfo(), leftTads.specialShapeInfo(), leftTads.specialOffsets(), rightTads.specialShapeInfo(),
-      rightTads.specialOffsets(), outputTads.specialShapeInfo(), outputTads.specialOffsets(), leftTads.numberOfTads());
+      output->specialShapeInfo(), leftTads->specialShapeInfo(), leftTads->specialOffsets(), rightTads->specialShapeInfo(),
+      rightTads->specialOffsets(), outputTads->specialShapeInfo(), outputTads->specialOffsets(), leftTads->numberOfTads());
 
   NDArray::registerSpecialUse({output}, {leftInput, rightInput});
 
@@ -267,13 +267,13 @@ static void adjointTriangularMatrix_(sd::LaunchContext* context, NDArray const* 
   auto columns = input->sizeAt(-1);
 
   if (lower) {
-    lowerAdjointKernel<T><<<128, 256, 256, *stream>>>(inputBuf, outputBuf, outputTads.numberOfTads(), rows, columns,
-                                                      inputTads.specialShapeInfo(), inputTads.specialOffsets(),
-                                                      outputTads.specialShapeInfo(), outputTads.specialOffsets());
+    lowerAdjointKernel<T><<<128, 256, 256, *stream>>>(inputBuf, outputBuf, outputTads->numberOfTads(), rows, columns,
+                                                      inputTads->specialShapeInfo(), inputTads->specialOffsets(),
+                                                      outputTads->specialShapeInfo(), outputTads->specialOffsets());
   } else {
-    upperAdjointKernel<T><<<128, 256, 256, *stream>>>(inputBuf, outputBuf, outputTads.numberOfTads(), rows, columns,
-                                                      inputTads.specialShapeInfo(), inputTads.specialOffsets(),
-                                                      outputTads.specialShapeInfo(), outputTads.specialOffsets());
+    upperAdjointKernel<T><<<128, 256, 256, *stream>>>(inputBuf, outputBuf, outputTads->numberOfTads(), rows, columns,
+                                                      inputTads->specialShapeInfo(), inputTads->specialOffsets(),
+                                                      outputTads->specialShapeInfo(), outputTads->specialOffsets());
   }
 }
 

--- a/libnd4j/include/ops/declarable/impl/LegacyBroadcastBoolOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyBroadcastBoolOp.cpp
@@ -44,17 +44,17 @@ sd::Status LegacyBroadcastBoolOp::validateAndExecute(Context &block) {
 
   PointersManager manager(block.launchContext(), "LegacyBroadcastBoolOp");
   auto pTadShape = Environment::getInstance().isCPU()
-                   ? packX.primaryShapeInfo()
-                   : packX.specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
+                   ? packX->primaryShapeInfo()
+                   : packX->specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
   //shape::shapeInfoByteLength(tad.tadOnlyShapeInfo));
   auto pTadOffsets = Environment::getInstance().isCPU()
-                     ? packX.primaryOffsets()
-                     : packX.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
+                     ? packX->primaryOffsets()
+                     : packX->specialOffsets();  //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
   //tad.numTads * sizeof(sd::LongType));
 
-  REQUIRE_TRUE(shape::length(packX.primaryShapeInfo()) == y->lengthOf(), 0,
+  REQUIRE_TRUE(shape::length(packX->primaryShapeInfo()) == y->lengthOf(), 0,
                "Length of broadcast TAD should be equal to length of Y operand, but got [%i] vs [%i]",
-               (int)shape::length(packX.primaryShapeInfo()), (int)y->lengthOf());
+               (int)shape::length(packX->primaryShapeInfo()), (int)y->lengthOf());
 
   if (x == z)
     NativeOpExecutioner::execBroadcast(block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(),
@@ -69,11 +69,11 @@ sd::Status LegacyBroadcastBoolOp::validateAndExecute(Context &block) {
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(z->shapeInfo(), dims);
 
     auto zTadShape = Environment::getInstance().isCPU()
-                     ? packZ.primaryShapeInfo()
-                     : packZ.specialShapeInfo();
+                     ? packZ->primaryShapeInfo()
+                     : packZ->specialShapeInfo();
     auto zTadOffsets = Environment::getInstance().isCPU()
-                       ? packZ.primaryOffsets()
-                       : packZ.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tadZ.tadOffsets,
+                       ? packZ->primaryOffsets()
+                       : packZ->specialOffsets();  //(sd::LongType *) manager.replicatePointer(tadZ.tadOffsets,
 
     NativeOpExecutioner::execBroadcast(block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(),
                                        x->specialShapeInfo(), y->buffer(), y->shapeInfo(), y->specialBuffer(),

--- a/libnd4j/include/ops/declarable/impl/LegacyBroadcastOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyBroadcastOp.cpp
@@ -48,19 +48,19 @@ sd::Status LegacyBroadcastOp::validateAndExecute(Context &block) {
 
   auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
 
-  auto tadLen = shape::length(packX.primaryShapeInfo());
+  auto tadLen = shape::length(packX->primaryShapeInfo());
   REQUIRE_TRUE(tadLen == y->lengthOf(), 0,
                "Length of broadcast TAD should be equal to length of Y operand, but got [%i] vs [%i]", tadLen,
                (int)y->lengthOf());
 
   PointersManager manager(block.launchContext(), "LegacyBroadcastOp");
   auto pTadShape = Environment::getInstance().isCPU()
-                       ? packX.primaryShapeInfo()
-                       : packX.specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
+                       ? packX->primaryShapeInfo()
+                       : packX->specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
                                                     //shape::shapeInfoByteLength(tad.tadOnlyShapeInfo));
   auto pTadOffsets = Environment::getInstance().isCPU()
-                         ? packX.primaryOffsets()
-                         : packX.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
+                         ? packX->primaryOffsets()
+                         : packX->specialOffsets();  //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
                                                     //tad.numTads * sizeof(sd::LongType));
 
   if (x == z)
@@ -75,12 +75,12 @@ sd::Status LegacyBroadcastOp::validateAndExecute(Context &block) {
     auto packZ = sd::ConstantTadHelper::getInstance().tadForDimensions(z->shapeInfo(), dims);
 
     auto zTadShape = Environment::getInstance().isCPU()
-                         ? packZ.primaryShapeInfo()
-                         : packZ.specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tadZ.tadOnlyShapeInfo,
+                         ? packZ->primaryShapeInfo()
+                         : packZ->specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tadZ.tadOnlyShapeInfo,
                                                       //shape::shapeInfoByteLength(tadZ.tadOnlyShapeInfo));
     auto zTadOffsets = Environment::getInstance().isCPU()
-                           ? packZ.primaryOffsets()
-                           : packZ.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tadZ.tadOffsets,
+                           ? packZ->primaryOffsets()
+                           : packZ->specialOffsets();  //(sd::LongType *) manager.replicatePointer(tadZ.tadOffsets,
                                                       //tadZ.numTads * sizeof(sd::LongType));
 
     NativeOpExecutioner::execBroadcast(block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(),

--- a/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyIndexReduceOp.cpp
@@ -144,8 +144,8 @@ sd::Status LegacyIndexReduceOp::validateAndExecute(Context &block) {
           block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(), x->specialShapeInfo(),
           extras.argumentsAsT(x->dataType()), reinterpret_cast<sd::LongType *>(z->buffer()), z->shapeInfo(),
           z->specialBuffer(), z->specialShapeInfo(), nullptr, (int)dims.size(),
-          Environment::getInstance().isCPU() ? tadPack.primaryShapeInfo() : tadPack.specialShapeInfo(),
-          Environment::getInstance().isCPU() ? tadPack.primaryOffsets() : tadPack.specialOffsets());
+          Environment::getInstance().isCPU() ? tadPack->primaryShapeInfo() : tadPack->specialShapeInfo(),
+          Environment::getInstance().isCPU() ? tadPack->primaryOffsets() : tadPack->specialOffsets());
     }
   } else {
     // TF mode
@@ -175,8 +175,8 @@ sd::Status LegacyIndexReduceOp::validateAndExecute(Context &block) {
           block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(), x->specialShapeInfo(),
           extras.argumentsAsT(x->dataType()), reinterpret_cast<sd::LongType *>(z->buffer()), z->shapeInfo(),
           z->specialBuffer(), z->specialShapeInfo(), nullptr, (int)axis.size(),
-          Environment::getInstance().isCPU() ? tadPack.primaryShapeInfo() : tadPack.specialShapeInfo(),
-          Environment::getInstance().isCPU() ? tadPack.primaryOffsets() : tadPack.specialOffsets());
+          Environment::getInstance().isCPU() ? tadPack->primaryShapeInfo() : tadPack->specialShapeInfo(),
+          Environment::getInstance().isCPU() ? tadPack->primaryOffsets() : tadPack->specialOffsets());
     }
   }
 

--- a/libnd4j/include/ops/declarable/impl/LegacyReduce3Op.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyReduce3Op.cpp
@@ -60,18 +60,18 @@ sd::Status LegacyReduce3Op::validateAndExecute(Context &block) {
     REQUIRE_TRUE(dims.size() > 0, 0, "Some dimensions requuired for reduction!");
 
     auto xTadShape = Environment::getInstance().isCPU()
-                         ? packX.primaryShapeInfo()
-                         : packX.specialShapeInfo();
+                         ? packX->primaryShapeInfo()
+                         : packX->specialShapeInfo();
     auto xTadOffsets = Environment::getInstance().isCPU()
-                           ? packX.primaryOffsets()
-                           : packX.specialOffsets();
+                           ? packX->primaryOffsets()
+                           : packX->specialOffsets();
 
     auto yTadShape = Environment::getInstance().isCPU()
-                         ? packZ.primaryShapeInfo()
-                         : packZ.specialOffsets();
+                         ? packZ->primaryShapeInfo()
+                         : packZ->specialOffsets();
     auto yTadOffsets = Environment::getInstance().isCPU()
-                           ? packZ.primaryOffsets()
-                           : packZ.specialOffsets();
+                           ? packZ->primaryOffsets()
+                           : packZ->specialOffsets();
 
     NativeOpExecutioner::execReduce3(block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(),
                                      x->specialShapeInfo(), extras.argumentsAsT(z->dataType()), y->buffer(),

--- a/libnd4j/include/ops/declarable/impl/LegacyStatsOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyStatsOp.cpp
@@ -63,13 +63,12 @@ sd::Status LegacyStatsOp::validateAndExecute(Context &block) {
     auto packX = sd::ConstantTadHelper::getInstance().tadForDimensions(x->shapeInfo(), dims);
 
     auto pTadShape = Environment::getInstance().isCPU()
-                         ? packX.primaryShapeInfo()
-                         : packX.specialShapeInfo();  //(sd::LongType *) manager.replicatePointer(tad.tadOnlyShapeInfo,
-                                                      //shape::shapeInfoByteLength(tad.tadOnlyShapeInfo));
+                         ? packX->primaryShapeInfo()
+                         : packX->specialShapeInfo();
+
     auto pTadOffsets = Environment::getInstance().isCPU()
-                           ? packX.primaryOffsets()
-                           : packX.specialOffsets();  //(sd::LongType *) manager.replicatePointer(tad.tadOffsets,
-                                                      //tad.numTads * sizeof(sd::LongType));
+                           ? packX->primaryOffsets()
+                           : packX->specialOffsets();
 
     NativeOpExecutioner::execSummaryStats(block.launchContext(), opNum, x->buffer(), x->shapeInfo(), x->specialBuffer(),
                                           x->specialShapeInfo(), extras.argumentsAsT(z->dataType()), z->buffer(),

--- a/libnd4j/include/ops/impl/specials_double.hpp
+++ b/libnd4j/include/ops/impl/specials_double.hpp
@@ -232,15 +232,15 @@ void DoubleMethods<X, Y>::sortTadByKey(void *vx, sd::LongType const *xShapeInfo,
   auto packY = ConstantTadHelper::getInstance().tadForDimensions(yShapeInfo, dimension, dimensionLength);
 
   auto xLength = shape::length(xShapeInfo);
-  auto xTadLength = shape::length(packX.primaryShapeInfo());
-  auto numTads = packX.numberOfTads();
+  auto xTadLength = shape::length(packX->primaryShapeInfo());
+  auto numTads = packX->numberOfTads();
 
   auto func = PRAGMA_THREADS_FOR {
     for (auto r = start; r < stop; r++) {
-      auto dx = x + packX.primaryOffsets()[r];
-      auto dy = y + packY.primaryOffsets()[r];
+      auto dx = x + packX->primaryOffsets()[r];
+      auto dy = y + packY->primaryOffsets()[r];
 
-      quickSort_parallel_key<X, Y>(dx, packX.primaryShapeInfo(), dy, packY.primaryShapeInfo(), xTadLength, 1,
+      quickSort_parallel_key<X, Y>(dx, packX->primaryShapeInfo(), dy, packY->primaryShapeInfo(), xTadLength, 1,
                                    descending);
     }
   };
@@ -259,15 +259,15 @@ void DoubleMethods<X, Y>::sortTadByValue(void *vx, sd::LongType const *xShapeInf
   auto packY = ConstantTadHelper::getInstance().tadForDimensions(yShapeInfo, dimension, dimensionLength);
 
   auto xLength = shape::length(xShapeInfo);
-  auto xTadLength = shape::length(packX.primaryShapeInfo());
-  auto numTads = packX.numberOfTads();
+  auto xTadLength = shape::length(packX->primaryShapeInfo());
+  auto numTads = packX->numberOfTads();
 
   auto func = PRAGMA_THREADS_FOR {
     for (auto r = start; r < stop; r++) {
-      auto dx = x + packX.primaryOffsets()[r];
-      auto dy = y + packY.primaryOffsets()[r];
+      auto dx = x + packX->primaryOffsets()[r];
+      auto dy = y + packY->primaryOffsets()[r];
 
-      quickSort_parallel_value<X, Y>(dx, packX.primaryShapeInfo(), dy, packY.primaryShapeInfo(), xTadLength, 1,
+      quickSort_parallel_value<X, Y>(dx, packX->primaryShapeInfo(), dy, packY->primaryShapeInfo(), xTadLength, 1,
                                      descending);
     }
   };

--- a/libnd4j/tests_cpu/layers_tests/TadTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/TadTests.cpp
@@ -51,7 +51,7 @@ TEST_F(TadTests, Test4DTad1) {
   NDArray* arrayExp = new NDArray(buff.data(), goodShape);
   NDArray* arrayBad = new NDArray(buff.data(), badShape);
 
-  int dim = 1;
+  sd::LongType dim = 1;
   shape::TAD tad;
   tad.init(arrayBad->shapeInfo(), &dim, 1);
   tad.createTadOnlyShapeInfo();
@@ -70,7 +70,7 @@ TEST_F(TadTests, TestNumTads1) {
   auto x = NDArrayFactory::create<float>('c', {2, 3});
   auto y = NDArrayFactory::create<float>('c', {2, 2});
 
-  std::vector<int> dim({0});
+  std::vector<sd::LongType> dim({0});
 
   sd::LongType tadLengthX = shape::tadLength(x.shapeInfo(), dim.data(), dim.size());
   sd::LongType numTadsX = x.lengthOf() / tadLengthX;
@@ -91,7 +91,7 @@ TEST_F(TadTests, TestShapeTad_1) {
 
   NDArray input(buff, shapeInfo);
 
-  std::vector<int> dimensions = {0, 1, 2};
+  std::vector<sd::LongType> dimensions = {0, 1, 2};
   sd::LongType tadLength = shape::tadLength(input.shapeInfo(), dimensions.data(), dimensions.size());
   sd::LongType numTads = input.lengthOf() / tadLength;
 
@@ -156,42 +156,42 @@ TEST_F(TadTests, TadEdgeCase_2) {
 TEST_F(TadTests, test_Tad_Ews_optimization_1) {
   shape::TAD xTad;
 
-  std::array<int, 2> array = {1, 2};
+  std::array<sd::LongType, 2> array = {1, 2};
   ASSERT_TRUE(xTad.dimensionsDescending(3, array.data(), array.size()));
 }
 
 TEST_F(TadTests, test_Tad_Ews_optimization_2) {
   shape::TAD xTad;
 
-  std::array<int, 2> array = {0, 2};
+  std::array<sd::LongType, 2> array = {0, 2};
   ASSERT_FALSE(xTad.dimensionsDescending(3, array.data(), array.size()));
 }
 
 TEST_F(TadTests, test_Tad_Ews_optimization_3) {
   shape::TAD xTad;
 
-  std::array<int, 1> array = {1};
+  std::array<sd::LongType, 1> array = {1};
   ASSERT_TRUE(xTad.dimensionsDescending(2, array.data(), array.size()));
 }
 
 TEST_F(TadTests, test_Tad_Ews_optimization_4) {
   shape::TAD xTad;
 
-  std::array<int, 1> array = {0};
+  std::array<sd::LongType, 1> array = {0};
   ASSERT_TRUE(xTad.dimensionsDescending(1, array.data(), array.size()));
 }
 
 TEST_F(TadTests, test_Tad_Ews_optimization_5) {
   shape::TAD xTad;
 
-  std::array<int, 2> array = {2, 3};
+  std::array<sd::LongType, 2> array = {2, 3};
   ASSERT_TRUE(xTad.dimensionsDescending(4, array.data(), array.size()));
 }
 
 TEST_F(TadTests, test_TAD_empty_dims_1) {
   sd::LongType xShape[8] = {2, 150, 1, 3, 1, 16384, 3, 99};
   shape::TAD xTad;
-  xTad.init(xShape, reinterpret_cast<int*>(112L), 0);
+  xTad.init(xShape, reinterpret_cast<sd::LongType*>(112L), 0);
   xTad.createTadOnlyShapeInfo();
   xTad.createOffsets();
 }
@@ -200,7 +200,7 @@ TEST_F(TadTests, test_tad_order_1) {
   sd::LongType xShape[8] = {2, 150, 10, 10, 1, 8192, 1, 99};
   sd::LongType tShape[8] = {2, 1, 10, 1, 1, 8192, 1, 99};
   shape::TAD xTad;
-  int dim = 1;
+  sd::LongType dim = 1;
   xTad.init(xShape, &dim, 1);
   xTad.createTadOnlyShapeInfo();
 
@@ -211,7 +211,7 @@ TEST_F(TadTests, test_tad_order_2) {
   sd::LongType xShape[8] = {2, 150, 10, 10, 1, 8192, 1, 99};
   sd::LongType tShape[8] = {2, 1, 150, 1, 10, 8192, 10, 99};
   shape::TAD xTad;
-  int dim = 0;
+  sd::LongType dim = 0;
   xTad.init(xShape, &dim, 1);
   xTad.createTadOnlyShapeInfo();
 
@@ -222,7 +222,7 @@ TEST_F(TadTests, test_tad_order_3) {
   sd::LongType xShape[10] = {3, 10, 20, 30, 600, 30, 1, 8192, 1, 99};
   sd::LongType tShape[8] = {2, 1, 30, 1, 1, 8192, 1, 99};
   shape::TAD xTad;
-  int dim = 2;
+  sd::LongType dim = 2;
   xTad.init(xShape, &dim, 1);
   xTad.createTadOnlyShapeInfo();
 
@@ -233,7 +233,7 @@ TEST_F(TadTests, test_tad_order_4) {
   sd::LongType xShape[10] = {3, 10, 20, 30, 600, 30, 1, 8192, 1, 99};
   sd::LongType tShape[8] = {2, 20, 30, 30, 1, 8192, 1, 99};
   shape::TAD xTad;
-  int dim[2] = {1, 2};
+  sd::LongType dim[2] = {1, 2};
   xTad.init(xShape, dim, 2);
   xTad.createTadOnlyShapeInfo();
 
@@ -244,13 +244,13 @@ TEST_F(TadTests, test_column_1) {
   auto x = NDArrayFactory::create<float>('c', {5, 2});
   auto tadPack = sd::ConstantTadHelper::getInstance().tadForDimensions(x.shapeInfo(), 0);
 
-  ASSERT_EQ(1, shape::rank(tadPack.primaryShapeInfo()));
-  ASSERT_EQ(5, shape::length(tadPack.primaryShapeInfo()));
-  ASSERT_TRUE(shape::isVector(tadPack.primaryShapeInfo()));
+  ASSERT_EQ(1, shape::rank(tadPack->primaryShapeInfo()));
+  ASSERT_EQ(5, shape::length(tadPack->primaryShapeInfo()));
+  ASSERT_TRUE(shape::isVector(tadPack->primaryShapeInfo()));
 
-  auto scalarViewPack = sd::ConstantTadHelper::getInstance().tadForDimensions(tadPack.primaryShapeInfo(), 0);
+  auto scalarViewPack = sd::ConstantTadHelper::getInstance().tadForDimensions(tadPack->primaryShapeInfo(), 0);
 
-  ASSERT_TRUE(shape::equalsStrict(tadPack.primaryShapeInfo(), scalarViewPack.primaryShapeInfo()));
+  ASSERT_TRUE(shape::equalsStrict(tadPack->primaryShapeInfo(), scalarViewPack->primaryShapeInfo()));
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -281,10 +281,10 @@ TEST_F(TadTests, calcOffsets_1) {
 /////////////////////////////////////////////////////////////////
 TEST_F(TadTests, outerArrayIndexes_1) {
   NDArray x('c', {2, 3, 4, 5}, sd::DataType::FLOAT32);
-  int maxIdxs[120];
+  sd::LongType maxIdxs[120];
 
   NDArray y1('c', {3, 5}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude1 = {0, 2};
+  const std::vector<sd::LongType> dimsToExclude1 = {0, 2};
   const int n1[] = {20, 25, 30, 35, 80, 85, 90, 95};
   int minIdx = 5;
 
@@ -293,7 +293,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n1[i] == maxIdxs[i]);
 
   NDArray y2('c', {4, 5}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude2 = {0, 1};
+  const std::vector<sd::LongType> dimsToExclude2 = {0, 1};
   const int n2[] = {12, 32, 52, 72, 92, 112};
   minIdx = 12;
 
@@ -302,7 +302,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n2[i] == maxIdxs[i]);
 
   NDArray y3('c', {2, 5}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude3 = {1, 2};
+  const std::vector<sd::LongType> dimsToExclude3 = {1, 2};
   const int n3[] = {64, 69, 74, 79, 84, 89, 94, 99, 104, 109, 114, 119};
   minIdx = 9;
 
@@ -311,7 +311,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n3[i] == maxIdxs[i]);
 
   NDArray y4('c', {2, 3}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude4 = {2, 3};
+  const std::vector<sd::LongType> dimsToExclude4 = {2, 3};
   const int n4[] = {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39};
   minIdx = 1;
 
@@ -320,7 +320,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n4[i] == maxIdxs[i]);
 
   NDArray y5('c', {2, 4}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude5 = {1, 3};
+  const std::vector<sd::LongType> dimsToExclude5 = {1, 3};
   const int n5[] = {65, 66, 67, 68, 69, 85, 86, 87, 88, 89, 105, 106, 107, 108, 109};
   minIdx = 5;
 
@@ -329,7 +329,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n5[i] == maxIdxs[i]);
 
   NDArray y6('c', {2, 3, 4}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude6 = {3};
+  const std::vector<sd::LongType> dimsToExclude6 = {3};
   const int n6[] = {65, 66, 67, 68, 69};
   minIdx = 13;
 
@@ -338,7 +338,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n6[i] == maxIdxs[i]);
 
   NDArray y7('c', {4}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude7 = {0, 1, 3};
+  const std::vector<sd::LongType> dimsToExclude7 = {0, 1, 3};
   const int n7[] = {15, 16, 17, 18, 19, 35, 36, 37, 38, 39, 55,  56,  57,  58,  59,
                     75, 76, 77, 78, 79, 95, 96, 97, 98, 99, 115, 116, 117, 118, 119};
   minIdx = 3;
@@ -348,7 +348,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n7[i] == maxIdxs[i]);
 
   NDArray y8('c', {5}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude8 = {0, 1, 2};
+  const std::vector<sd::LongType> dimsToExclude8 = {0, 1, 2};
   const int n8[] = {0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115};
   minIdx = 0;
 
@@ -357,7 +357,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n8[i] == maxIdxs[i]);
 
   NDArray y9('c', {2}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude9 = {1, 2, 3};
+  const std::vector<sd::LongType> dimsToExclude9 = {1, 2, 3};
   const int n9[] = {60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
                     80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
                     100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119};
@@ -368,7 +368,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n9[i] == maxIdxs[i]);
 
   NDArray y10('c', {3, 4, 5}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude10 = {0};
+  const std::vector<sd::LongType> dimsToExclude10 = {0};
   const int n10[] = {11, 71};
   minIdx = 11;
 
@@ -377,7 +377,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n10[i] == maxIdxs[i]);
 
   NDArray y11('c', {2, 4, 5}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude11 = {1};
+  const std::vector<sd::LongType> dimsToExclude11 = {1};
   const int n11[] = {66, 86, 106};
   minIdx = 26;
 
@@ -386,7 +386,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n11[i] == maxIdxs[i]);
 
   NDArray y12('c', {3, 2}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude12 = {0, 2};
+  const std::vector<sd::LongType> dimsToExclude12 = {0, 2};
   const int n12[] = {0, 2, 4, 5, 7, 9, 10, 12, 14, 15, 17, 19, 60, 62, 64, 65, 67, 69, 70, 72, 74, 75, 77, 79};
   minIdx = 0;
 
@@ -394,7 +394,7 @@ TEST_F(TadTests, outerArrayIndexes_1) {
   for (int i = 0; i < N; ++i) ASSERT_TRUE(n12[i] == maxIdxs[i]);
 
   NDArray y13('c', {3, 2}, sd::DataType::FLOAT32);
-  const std::vector<int> dimsToExclude13 = {0, 2};
+  const std::vector<sd::LongType> dimsToExclude13 = {0, 2};
   const int n13[] = {1, 3, 6, 8, 11, 13, 16, 18, 61, 63, 66, 68, 71, 73, 76, 78};
   minIdx = 1;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Some crashes can occur with TAD packs when stack allocation is used. Migrates cached TADPacks to heap
to avoid his.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
