### PR TITLE
Remove parallel iterations for skipgram/cbow

### DIFF
--- a/libnd4j/include/ops/declarable/helpers/cpu/sg_cb.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/sg_cb.cpp
@@ -423,7 +423,6 @@ void skipgramBatchExec_(NDArray &s0, NDArray &s1, NDArray &s1n, NDArray &vexpTab
   } else {
     // regular mode provides 0 guarantees for reproducibility
     auto numTargets = targets.lengthOf();
-    PRAGMA_OMP_PARALLEL_FOR_THREADS(numThreads)
     for(int iteration = 0; iteration < iterations; iteration++) {
       for (auto t = 0; t < numTargets; t++) {
         doSkipGramLoop_(s0, s1, s1n, vinfVector, targets, negStarters, indices, codes, lr, nextRandom, nsRounds,
@@ -564,7 +563,6 @@ void cbowBatchExec_(NDArray &s0, NDArray &s1, NDArray &s1n, NDArray &vexpTable, 
   } else {
     // regular mode provides 0 guarantees for reproducibility
     auto numTargets = targets.lengthOf();
-    PRAGMA_OMP_PARALLEL_FOR_THREADS(numThreads)
     for(int iteration = 0; iteration < iterations; iteration++) {
       for (auto t = 0; t < numTargets; t++) {
         doCbowLoop_(s0, s1, s1n, negStarters, indices, codes, lr, nextRandom, nLabels, nsRounds, vocabSize,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Parallel omp parallel isn't guaranteed to be deterministic depending on the compiler.
Due to this we need to remove parallel iterations in order to ensure determinism.

This was discovered when benchmarking paragraph vectors infervector.

## How was this patch tested?

Manually

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
