### PR TITLE
Fixes #9972

### DIFF
--- a/libnd4j/include/ops/declarable/generic/updaters/adamUpdater.cpp
+++ b/libnd4j/include/ops/declarable/generic/updaters/adamUpdater.cpp
@@ -40,8 +40,8 @@ CONFIGURABLE_OP_IMPL(adam_updater, 3, 3, true, 0, 0) {
   auto stateU = OUTPUT_VARIABLE(1);
   auto stateM = OUTPUT_VARIABLE(2);
 
-  // todo maybe we need an error like on Java side
-  if (gradient->isEmpty() || initStateU->isEmpty() || initStateM->isEmpty()) return sd::Status::OK;
+  if (gradient->isEmpty() || initStateU->isEmpty() || initStateM->isEmpty())
+    throw std::runtime_error("adam_updater: Unable to apply empty update");
 
   REQUIRE_TRUE(gradient->isSameShape(initStateU), 0,
                "ADAM UPDATER OP: input state V must have the same shape as gradient,"
@@ -87,6 +87,7 @@ CONFIGURABLE_OP_IMPL(adam_updater, 3, 3, true, 0, 0) {
     dBeta2 = T_ARG(2);
     dEpsilon = T_ARG(3);
   }
+
 
   helpers::updaterAdam(block.launchContext(), *gradient, *initStateU, *initStateM, *update, *stateU, *stateM, dLr,
                        dBeta1, dBeta2, dEpsilon, iteration);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaBelief.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaBelief.cpp
@@ -48,7 +48,11 @@ static void adaBeliefUpdater_(const NDArray& gradient, const NDArray& initStateU
   const T lr = static_cast<T>(dLr);
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
-  const T epsilon = static_cast<T>(dEpsilon);
+  T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
 
   const T beta1T = sd::math::sd_pow<T, T, T>(beta1, (iteration + 1));

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaDelta.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaDelta.cpp
@@ -44,7 +44,11 @@ static void adaDeltaUpdater_(const NDArray& gradient, const NDArray& initStateMs
   T* stMsdx = stateMsdx.bufferAsT<T>();
 
   const T rho = static_cast<T>(dRho);
-  const T epsilon = static_cast<T>(dEpsilon);
+  T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T rhoT = (1 - rho);
 
   bool bEws1 = 1 == gradient.ews() && 1 == update.ews() && 1 == stateMsg.ews() && 1 == initStateMsg.ews() &&

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaGrad.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaGrad.cpp
@@ -41,8 +41,11 @@ static void adaGradUpdater_(const NDArray& gradient, const NDArray& initState, N
   T* st = stateH.bufferAsT<T>();
 
   const T lr = static_cast<T>(dLr);
-  const T epsilon = static_cast<T>(dEpsilon);
-
+  T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   bool bEws1 = 1 == gradient.ews() && 1 == update.ews() && 1 == stateH.ews() && 1 == initState.ews();
   bool bSameOrdering = gradient.ordering() == update.ordering() && update.ordering() == stateH.ordering() &&
                        stateH.ordering() == initState.ordering();

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaMax.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaMax.cpp
@@ -46,7 +46,11 @@ static void adaMaxUpdater_(const NDArray& gradient, const NDArray& initStateU, c
   const T lr = static_cast<T>(dLr);
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
-  const T epsilon = static_cast<T>(dEpsilon);
+  T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
   const T beta1T = sd::math::sd_pow<T, T, T>(beta1, (iteration + 1));
   T epsilonT = lr / (1.0 - beta1T);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdam.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdam.cpp
@@ -46,7 +46,11 @@ static void adamUpdater_(const NDArray& gradient, const NDArray& initStateU, con
   const T lr = static_cast<T>(dLr);
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
-  const T epsilon = static_cast<T>(dEpsilon);
+  T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
 
   const T beta1T = sd::math::sd_pow<T, T, T>(beta1, (iteration + 1));

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAmsGrad.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAmsGrad.cpp
@@ -49,7 +49,11 @@ static void amsGradUpdater_(const NDArray& gradient, const NDArray& initStateV, 
   const T lr = static_cast<T>(dLr);
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
-  const T epsilon = static_cast<T>(dEpsilon);
+  T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
 
   T epsilonT = lr * sd::math::sd_sqrt<T, T>(1.0 - sd::math::sd_pow<T, T, T>(beta2, (iteration + 1))) /

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterNadam.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterNadam.cpp
@@ -46,7 +46,11 @@ static void nadamUpdater_(const NDArray& gradient, const NDArray& initStateV, co
   const T lr = static_cast<T>(dLr);
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
-  const T epsilon = static_cast<T>(dEpsilon);
+  T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
 
   const T mbeta1T = 1.0 - sd::math::sd_pow<T, T, T>(beta1, (iteration + 1));

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaBelief.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaBelief.cu
@@ -113,6 +113,10 @@ void adaBeliefUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerB
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
   const T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
   adaBeliefUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(
       vx, xShapeInfo, vinv, invShapeInfo, vinm, inmShapeInfo, vz, zShapeInfo, vstV, stvShapeInfo, vstM, stmShapeInfo,

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaDelta.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaDelta.cu
@@ -104,7 +104,10 @@ void adaDeltaUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerBl
                                  const sd::LongType* stMsdxShapeInfo, const double dRho, const double dEpsilon) {
   const T rho = static_cast<T>(dRho);
   const T epsilon = static_cast<T>(dEpsilon);
-
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   adaDeltaUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(
       vx, xShapeInfo, vinMsg, inMsgShapeInfo, vinMsdx, inMsdxShapeInfo, vz, zShapeInfo, vstMsg, stMsgShapeInfo, vstMsdx,
       stMsdxShapeInfo, rho, epsilon);

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaGrad.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaGrad.cu
@@ -84,7 +84,10 @@ void adaGradUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerBlo
                                 const sd::LongType* stShapeInfo, const double dLr, const double dEpsilon) {
   const T lr = static_cast<T>(dLr);
   const T epsilon = static_cast<T>(dEpsilon);
-
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   adaGradUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(vx, xShapeInfo, vin, inShapeInfo, vz,
                                                                           zShapeInfo, vst, stShapeInfo, lr, epsilon);
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaMax.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaMax.cu
@@ -108,6 +108,10 @@ void adaMaxUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerBloc
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
   const T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
 
   adaMaxUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdam.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdam.cu
@@ -91,7 +91,6 @@ SD_KERNEL void adamUpdaterCuda(const void* vx, const sd::LongType* xShapeInfo, c
 
     stM[stMOffset] = beta1 * initM[initMOffset] + grad[xOffset] * (1 - beta1);
     stU[stUOffset] = beta2 * initU[initUOffset] + grad[xOffset] * grad[xOffset] * (1 - beta2);
-
     up[zOffset] = (stM[stMOffset] * epsilonT) / (sd::math::sd_sqrt<T, T>(stU[stUOffset]) + epsilon);
   }
 }
@@ -108,6 +107,10 @@ void adamUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerBlock,
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
   const T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
   adamUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(
       vx, xShapeInfo, vinv, invShapeInfo, vinm, inmShapeInfo, vz, zShapeInfo, vstV, stvShapeInfo, vstM, stmShapeInfo,

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAmsGrad.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAmsGrad.cu
@@ -126,6 +126,10 @@ void amsGradUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerBlo
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
   const T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
 
   amsGradUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterNadam.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterNadam.cu
@@ -109,6 +109,10 @@ void nadamUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerBlock
   const T beta1 = static_cast<T>(dBeta1);
   const T beta2 = static_cast<T>(dBeta2);
   const T epsilon = static_cast<T>(dEpsilon);
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   const T iteration = static_cast<T>(nIteration);
 
   nadamUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterRmsProp.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterRmsProp.cu
@@ -86,7 +86,10 @@ void rmsPropUpdaterCudaLauncher(const int blocksPerGrid, const int threadsPerBlo
   const T lr = static_cast<T>(dLr);
   const T rmsDecay = static_cast<T>(dRmsDecay);
   const T epsilon = static_cast<T>(dEpsilon);
-
+  //fp16 to prevent underflow
+  if(epsilon == 0.0) {
+    epsilon = static_cast<T>(1e-7);
+  }
   rmsPropUpdaterCuda<T><<<blocksPerGrid, threadsPerBlock, 256, *stream>>>(
       vx, xShapeInfo, vin, inShapeInfo, vz, zShapeInfo, vst, stShapeInfo, lr, rmsDecay, epsilon);
 }

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/learning/UpdaterTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/learning/UpdaterTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.nd4j.common.tests.tags.NativeTag;
 import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.linalg.BaseNd4jTestWithBackends;
+import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.rng.distribution.Distribution;
 import org.nd4j.linalg.factory.Nd4j;
@@ -41,12 +42,12 @@ import org.nd4j.linalg.learning.config.Nadam;
 import org.nd4j.linalg.learning.config.Nesterovs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.nd4j.linalg.api.buffer.DataType.FLOAT16;
 
 @Tag(TagNames.TRAINING)
 @NativeTag
 @Tag(TagNames.DL4J_OLD_API)
 public class UpdaterTest extends BaseNd4jTestWithBackends {
-
 
 
     @ParameterizedTest
@@ -57,7 +58,7 @@ public class UpdaterTest extends BaseNd4jTestWithBackends {
 
 
         org.nd4j.linalg.learning.legacy.AdaGrad grad = new org.nd4j.linalg.learning.legacy.AdaGrad(rows, cols, 1e-3);
-        grad.setStateViewArray(Nd4j.zeros(1, rows * cols), new int[] {rows, cols}, 'c', true);
+        grad.setStateViewArray(Nd4j.zeros(1, rows * cols), new int[]{rows, cols}, 'c', true);
         INDArray w = Nd4j.ones(rows, cols);
         grad.getGradient(w, 0);
         assertEquals(1e-1, w.getDouble(0), 1e-1);
@@ -70,15 +71,13 @@ public class UpdaterTest extends BaseNd4jTestWithBackends {
         int cols = 2;
 
         NesterovsUpdater grad = new NesterovsUpdater(new Nesterovs(0.5, 0.9));
-        grad.setStateViewArray(Nd4j.zeros(1, rows * cols), new long[] {rows, cols}, 'c', true);
+        grad.setStateViewArray(Nd4j.zeros(1, rows * cols), new long[]{rows, cols}, 'c', true);
         INDArray W = Nd4j.zeros(rows, cols);
         Distribution dist = Nd4j.getDistributions().createNormal(1, 1);
         for (int i = 0; i < W.rows(); i++)
             W.putRow(i, Nd4j.create(dist.sample(W.columns())));
 
         for (int i = 0; i < 5; i++) {
-            //            String learningRates = String.valueOf("\nAdagrad\n " + grad.applyUpdater(W, i)).replaceAll(";", "\n");
-            //            System.out.println(learningRates);
             W.addi(Nd4j.randn(rows, cols));
         }
     }
@@ -90,15 +89,13 @@ public class UpdaterTest extends BaseNd4jTestWithBackends {
         int cols = 2;
 
         AdaGradUpdater grad = new AdaGradUpdater(new AdaGrad(0.1, AdaGrad.DEFAULT_ADAGRAD_EPSILON));
-        grad.setStateViewArray(Nd4j.zeros(1, rows * cols), new long[] {rows, cols}, 'c', true);
+        grad.setStateViewArray(Nd4j.zeros(1, rows * cols), new long[]{rows, cols}, 'c', true);
         INDArray W = Nd4j.zeros(rows, cols);
         Distribution dist = Nd4j.getDistributions().createNormal(1, 1);
         for (int i = 0; i < W.rows(); i++)
             W.putRow(i, Nd4j.create(dist.sample(W.columns())));
 
         for (int i = 0; i < 5; i++) {
-            //            String learningRates = String.valueOf("\nAdagrad\n " + grad.applyUpdater(W, i)).replaceAll(";", "\n");
-            //            System.out.println(learningRates);
             W.addi(Nd4j.randn(rows, cols));
         }
 
@@ -112,15 +109,13 @@ public class UpdaterTest extends BaseNd4jTestWithBackends {
 
 
         AdaDeltaUpdater grad = new AdaDeltaUpdater(new AdaDelta());
-        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[] {rows, cols}, 'c', true);
+        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[]{rows, cols}, 'c', true);
         INDArray W = Nd4j.zeros(rows, cols);
         Distribution dist = Nd4j.getDistributions().createNormal(1e-3, 1e-3);
         for (int i = 0; i < W.rows(); i++)
             W.putRow(i, Nd4j.create(dist.sample(W.columns())));
 
         for (int i = 0; i < 5; i++) {
-            //            String learningRates = String.valueOf("\nAdaelta\n " + grad.applyUpdater(W, i)).replaceAll(";", "\n");
-            //            System.out.println(learningRates);
             W.addi(Nd4j.randn(rows, cols));
         }
     }
@@ -133,15 +128,13 @@ public class UpdaterTest extends BaseNd4jTestWithBackends {
 
 
         AdamUpdater grad = new AdamUpdater(new Adam());
-        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[] {rows, cols}, 'c', true);
+        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[]{rows, cols}, 'c', true);
         INDArray W = Nd4j.zeros(rows, cols);
         Distribution dist = Nd4j.getDistributions().createNormal(1e-3, 1e-3);
         for (int i = 0; i < W.rows(); i++)
             W.putRow(i, Nd4j.create(dist.sample(W.columns())));
 
         for (int i = 0; i < 5; i++) {
-            //            String learningRates = String.valueOf("\nAdamUpdater\n " + grad.applyUpdater(W, i)).replaceAll(";", "\n");
-            //            System.out.println(learningRates);
             W.addi(Nd4j.randn(rows, cols));
         }
     }
@@ -153,15 +146,13 @@ public class UpdaterTest extends BaseNd4jTestWithBackends {
         int cols = 2;
 
         NadamUpdater grad = new NadamUpdater(new Nadam());
-        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[] {rows, cols}, 'c', true);
+        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[]{rows, cols}, 'c', true);
         INDArray W = Nd4j.zeros(rows, cols);
         Distribution dist = Nd4j.getDistributions().createNormal(1e-3, 1e-3);
         for (int i = 0; i < W.rows(); i++)
             W.putRow(i, Nd4j.create(dist.sample(W.columns())));
 
         for (int i = 0; i < 5; i++) {
-            //            String learningRates = String.valueOf("\nAdamUpdater\n " + grad.applyUpdater(W, i)).replaceAll(";", "\n");
-            //            System.out.println(learningRates);
             W.addi(Nd4j.randn(rows, cols));
         }
     }
@@ -174,18 +165,51 @@ public class UpdaterTest extends BaseNd4jTestWithBackends {
 
 
         AdaMaxUpdater grad = new AdaMaxUpdater(new AdaMax());
-        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[] {rows, cols}, 'c', true);
+        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols), new long[]{rows, cols}, 'c', true);
         INDArray W = Nd4j.zeros(rows, cols);
         Distribution dist = Nd4j.getDistributions().createNormal(1e-3, 1e-3);
         for (int i = 0; i < W.rows(); i++)
             W.putRow(i, Nd4j.create(dist.sample(W.columns())));
 
         for (int i = 0; i < 5; i++) {
-            //            String learningRates = String.valueOf("\nAdaMax\n " + grad.getGradient(W, i)).replaceAll(";", "\n");
-            //            System.out.println(learningRates);
             W.addi(Nd4j.randn(rows, cols));
         }
     }
+
+
+    @ParameterizedTest
+    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
+    public void testAdamFp16(Nd4jBackend backend) {
+        int rows = 10;
+        int cols = 2;
+        Adam adam = new Adam();
+        adam.setEpsilon(1e-6);
+        AdamUpdater grad = new AdamUpdater(adam);
+
+        INDArray originalGradients = Nd4j.zeros(rows, cols).castTo(FLOAT16);
+        Distribution dist = Nd4j.getDistributions().createNormal(1e-3, 1e-3);
+        for (int i = 0; i < originalGradients.rows(); i++) {
+            originalGradients.putRow(i, Nd4j.create(dist.sample(originalGradients.columns())).castTo(FLOAT16));
+        }
+        INDArray gradientsCloned = originalGradients.dup();
+        INDArray updates = Nd4j.randn(rows, cols);
+
+        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols).castTo(FLOAT16), new long[]{rows, cols}, 'c', true);
+        for (int i = 0; i < 5; i++) {
+            grad.applyUpdater(originalGradients, i, 0);
+            originalGradients.addi(updates);
+        }
+
+        grad.setStateViewArray(Nd4j.zeros(1, 2 * rows * cols).castTo(FLOAT16), new long[]{rows, cols}, 'c', true);
+        for (int i = 0; i < 5; i++) {
+            grad.applyUpdater(gradientsCloned, i, 0);
+            gradientsCloned.addi(updates);
+        }
+
+        assertEquals(originalGradients, gradientsCloned);
+
+    }
+
 
     @Override
     public char ordering() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add better updater default for fp16
When an epsilon in an updater is below a representable value in fp16 we truncate it to 1e-7 as a better default value
to prevent divergence. The user can otherwise specify a better epsilon. This is just to catch better defaults at the op level.

Fixes #9972 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
