### PR TITLE
Remove extra graph scale out reference

### DIFF
--- a/deeplearning4j/deeplearning4j-graph/pom.xml
+++ b/deeplearning4j/deeplearning4j-graph/pom.xml
@@ -27,9 +27,8 @@
 
     <parent>
         <groupId>org.deeplearning4j</groupId>
-        <artifactId>deeplearning4j-scaleout</artifactId>
+        <artifactId>deeplearning4j</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../deeplearning4j-scaleout/pom.xml</relativePath>
     </parent>
 
     <artifactId>deeplearning4j-graph</artifactId>

--- a/deeplearning4j/deeplearning4j-graph/pom.xml
+++ b/deeplearning4j/deeplearning4j-graph/pom.xml
@@ -27,7 +27,7 @@
 
     <parent>
         <groupId>org.deeplearning4j</groupId>
-        <artifactId>deeplearning4j</artifactId>
+        <artifactId>deeplearning4j-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 

--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -174,7 +174,6 @@
                 <configuration>
                     <directories>
                         <directory>deeplearning4j-core</directory>
-                        <directory>deeplearning4j-scaleout</directory>
                         <directory>deeplearning4j-ui-parent</directory>
                         <directory>deeplearning4j-graph</directory>
                         <directory>deeplearning4j-nlp-parent</directory>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removes extra scale out reference from deeplearning4j-graph
Fixes #9987 
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
