### PR TITLE
Rename rand methods with seed

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -3060,17 +3060,17 @@ public class Nd4j {
      * @param seed  the  seed to use
      * @return the random ndarray with the specified shape
      */
-    public static INDArray rand(long seed, @NonNull long... shape) {
+    public static INDArray randWithSeed(long seed, @NonNull long... shape) {
         INDArray ret = createUninitialized(shape, Nd4j.order());//;INSTANCE.rand(shape, seed);
-        return rand(ret, seed);
+        return randWithSeed(ret, seed);
     }
 
     /**
-     * @deprecated use {@link Nd4j#rand(long, long...)}
+     * @deprecated use {@link Nd4j#randWithSeed(long, long...)}
      */
     @Deprecated
-    public static INDArray rand(int[] shape, long seed) {
-        return rand(seed, ArrayUtil.toLongArray(shape)).castTo(Nd4j.defaultFloatingPointType());
+    public static INDArray randWithSeed(int[] shape, long seed) {
+        return randWithSeed(seed, ArrayUtil.toLongArray(shape)).castTo(Nd4j.defaultFloatingPointType());
     }
 
 
@@ -3360,7 +3360,7 @@ public class Nd4j {
      * @param seed the  seed to use
      * @return the given target array
      */
-    public static INDArray rand(INDArray target, long seed) {
+    public static INDArray randWithSeed(INDArray target, long seed) {
         Nd4j.getRandom().setSeed(seed);
         return getExecutioner().exec(new UniformDistribution(target), Nd4j.getRandom());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename `Nd4j.rand(...)` methods in which seed can be set

I am using ND4J in a Kotlin project and I have a compilation problem with the example Nd4jEx2_CreatingINDArrays.java. Once transformed to Kotlin, I have the error "Overload resolution ambiguity" :
<img width="958" alt="image" src="https://github.com/deeplearning4j/deeplearning4j/assets/5040418/593fc529-f102-41f9-8c6c-7524314e489e">

I can not figure how Java can compile with this two methods which seem to me to be strictly equivalent 😅 :

```java
public static INDArray rand(@NonNull long... shape) {
```
```java
public static INDArray rand(long seed, @NonNull long... shape) { 
```

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
