### PR TITLE
Fix up strings/segment kernels. Add string debugging to ndarrays.

### DIFF
--- a/libnd4j/include/array/NDArray.h
+++ b/libnd4j/include/array/NDArray.h
@@ -1095,6 +1095,11 @@ class SD_LIB_EXPORT NDArray {
   bool reshapei(const std::initializer_list<sd::LongType> &shape, const bool copyToNewBuff = true);
   bool reshapei(const std::vector<sd::LongType> &shape, const bool copyToNewBuff = true);
 
+  void printInternalState();
+  void printStringType();
+  void checkIfStringArrayAndNotEmpty();
+
+  void debugStringArray();
   /**
    *  creates new array with corresponding order and shape, new array will point on _buffer of this array
    *  order - order to set

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -2394,7 +2394,60 @@ NDArray NDArray::asT() const {
   return result;
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArray::asT, () const, SD_COMMON_TYPES);
+void NDArray::checkIfStringArrayAndNotEmpty()  {
+  if (!isS()) {
+    auto actualType = DataTypeUtils::asString(dataType());
+    std::string errorMessage;
+    errorMessage += "checkIfStringArrayAndNotEmpty: Expected String array but found ";
+    errorMessage += actualType;
+    THROW_EXCEPTION(errorMessage.c_str());
+  }
 
+  if (isEmpty()) {
+    THROW_EXCEPTION("checkIfStringArrayAndNotEmpty: Array is empty. Cannot proceed");
+  }
+}
+
+void NDArray::printStringType()  {
+  switch (dataType()) {
+    case DataType::UTF8:
+      std::cout << "Data Type: UTF8" << "\n";
+      break;
+    case DataType::UTF16:
+      std::cout << "Data Type: UTF16" << "\n";
+      break;
+    case DataType::UTF32:
+      std::cout << "Data Type: UTF32" << "\n";
+      break;
+    default:
+      THROW_EXCEPTION("printStringType: Unsupported data type");
+  }
+}
+
+void NDArray::printInternalState()  {
+  checkIfStringArrayAndNotEmpty();
+  printStringType();
+
+  // Length of offsets (header)
+  sd::LongType offsetsLength = ShapeUtils::stringBufferHeaderRequirements(lengthOf());
+
+  // Getting the buffer pointer
+  const auto nInputoffsets = bufferAsT<sd::LongType>();
+  std::cout << "Number of elements: " << lengthOf() << "\n";
+
+  int numStrings = isScalar() ? 1 : lengthOf();
+  for (sd::LongType e = 0; e < numStrings; e++) {
+    sd::LongType start = nInputoffsets[e];
+    sd::LongType stop = nInputoffsets[e + 1];
+    sd::LongType stringLength = stop - start;
+
+    std::cout << "String at index " << e << " Offset: " << start << " Length: " << stringLength << "\n";
+  }
+}
+
+void NDArray::debugStringArray() {
+  printInternalState();
+}
 //////////////////////////////////////////////////////////////////////////
 template <typename T>
 NDArray NDArray::asS() const {
@@ -2434,8 +2487,9 @@ NDArray NDArray::asS() const {
   sd::LongType start = 0, stop = 0;
   sd::LongType dataLength = 0;
 
+  int numStrings = isScalar() ? 1 : lengthOf();
   auto data = bufferAsT<int8_t>() + offsetsLength;
-  for (sd::LongType e = 0; e < lengthOf(); e++) {
+  for (sd::LongType e = 0; e < numStrings; e++) {
     offsets[e] = dataLength;
     start = nInputoffsets[e];
     stop = nInputoffsets[e + 1];
@@ -2457,7 +2511,8 @@ NDArray NDArray::asS() const {
   std::shared_ptr<DataBuffer> pBuffer =
       std::make_shared<DataBuffer>(offsetsLength + dataLength, dtype, getContext()->getWorkspace(), true);
 
-  auto desc = new ShapeDescriptor(dtype, ordering(), getShapeAsVector());
+  std::vector<sd::LongType> shape = isScalar() ? std::vector<sd::LongType>({1}) : getShapeAsVector();
+  auto desc = new ShapeDescriptor(dtype, ordering(), shape);
   NDArray res(pBuffer, desc, getContext());
   res.setAttached(getContext()->getWorkspace() != nullptr);
 
@@ -2495,7 +2550,7 @@ NDArray NDArray::asS() const {
     }
   };
 
-  samediff::Threads::parallel_for(func, 0, lengthOf(), 1);
+  samediff::Threads::parallel_for(func, 0, numStrings, 1);
 
   registerPrimaryUse({&res}, {this});
 

--- a/libnd4j/include/loops/cuda/indexreduce.cu
+++ b/libnd4j/include/loops/cuda/indexreduce.cu
@@ -279,17 +279,14 @@ SD_DEVICE void IndexReduce<X, Z>::transform(void const *vdx, sd::LongType const 
         reduction = OpType::update(reduction, comp, extraParams);
       }
 
-      //printf("After xEleStride > 1 && order == c\n");
 
     } else {
-      printf("xEleStride < 1 && order == c\n");
       for (sd::LongType i = tid; i < n; i += (gridDimX * blockDimX)) {
         auto xOffset = shape::getIndexOffset(i, xShapeInfo);
         IndexValue<X> comp{dx[xOffset], i};
         reduction = OpType::update(reduction, comp, extraParams);
       }
 
-    //  printf("xEleStride < 1 && order == c\n");
 
     }
     sPartials[threadIdxX] = reduction;

--- a/libnd4j/include/ops/declarable/helpers/cuda/betaInc.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/betaInc.cu
@@ -108,6 +108,8 @@ SD_KERNEL void betaIncForArrayCuda(const void* va, const sd::LongType* aShapeInf
     xOffset = shape::getIndexOffset(j, xShapeInfo);
     zOffset = shape::getIndexOffset(j, zShapeInfo);
 
+    if(aOffset >= aLen || bOffset >= bLen || xOffset >= xLen || zOffset >= zLen)
+      return;
 
     a = *(reinterpret_cast<const T*>(va) + aOffset);
     b = *(reinterpret_cast<const T*>(vb) + bOffset);
@@ -124,12 +126,12 @@ SD_KERNEL void betaIncForArrayCuda(const void* va, const sd::LongType* aShapeInf
   __syncthreads();
 
   // t^{n-1} * (1 - t)^{n-1} is symmetric function with respect to x = 0.5
-  if (a == b && x == static_cast<T>(0.5)) {
+  if (zOffset < zLen && a == b && x == static_cast<T>(0.5)) {
     z[zOffset] = static_cast<T>(0.5);
     return;
   }
 
-  if (x == static_cast<T>(0) || x == static_cast<T>(1)) {
+  if (zOffset < zLen && x == static_cast<T>(0) || x == static_cast<T>(1)) {
     z[zOffset] = symmCond ? static_cast<T>(1) - x : x;
     return;
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_mean.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_mean.cu
@@ -121,12 +121,13 @@ static SD_KERNEL void segmentMeanTadKernel(void* inputBuf, sd::LongType const* i
                                            sd::LongType const* inputTads, sd::LongType const* inputTadOffsets,
                                            I* indices, sd::LongType* starts, sd::LongType* lengths,
                                            sd::LongType numOfClasses, void* outputBuf, sd::LongType const* outputShape,
-                                           sd::LongType const* outputTads, sd::LongType const* outputTadOffsets) {
+                                           sd::LongType const* outputTads, sd::LongType const* outputTadOffsets,
+                                           sd::LongType indicesLen) {
   __shared__ T* val;
   __shared__ sd::LongType len, zIndex, total;
   __shared__ T* z;
   __shared__ int threadsPerSegment, start, finish;
-  if(blockIdx.x >= numOfClasses)
+  if(blockIdx.x >= indicesLen)
     return;
 
 
@@ -194,7 +195,7 @@ static void segmentMeanFunctor_(LaunchContext* context, NDArray* input, NDArray*
     segmentMeanTadKernel<T, I><<<launchDims.y, launchDims.x, launchDims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numClasses, output->specialBuffer(),
-        output->specialShapeInfo(), outputTads, outputTadOffsets);
+        output->specialShapeInfo(), outputTads, outputTadOffsets,indices->lengthOf());
     delete dimensions;
   }
   NDArray::registerSpecialUse({output}, {input, indices});
@@ -241,7 +242,7 @@ static void unsortedSegmentMeanFunctor_(sd::LaunchContext* context, NDArray* inp
     segmentMeanTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numOfClasses, output->specialBuffer(),
-        output->specialShapeInfo(), outputTads, outputTadOffsets);
+        output->specialShapeInfo(), outputTads, outputTadOffsets, indices->lengthOf());
     delete dimensions;
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_prod.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_prod.cu
@@ -103,7 +103,11 @@ static SD_KERNEL void segmentProdTadKernel(void* inputBuf, sd::LongType const* i
                                            sd::LongType const* inputTads, sd::LongType const* inputTadOffsets,
                                            I* indices, sd::LongType* starts, sd::LongType* lengths,
                                            sd::LongType numOfClasses, void* outputBuf, sd::LongType const* outputShape,
-                                           sd::LongType const* outputTads, sd::LongType const* outputTadOffsets) {
+                                           sd::LongType const* outputTads, sd::LongType const* outputTadOffsets,
+                                           sd::LongType indicesLen) {
+
+ if(blockIdx.x >= indicesLen)
+    return;
   __shared__ sd::LongType len, total;
 
   if (threadIdx.x == 0) {
@@ -160,7 +164,7 @@ static void segmentProdFunctor_(sd::LaunchContext* context, NDArray* input, NDAr
     segmentProdTadKernel<T, I><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numClasses, output->specialBuffer(),
-        output->specialShapeInfo(), outputTads, outputTadOffsets);
+        output->specialShapeInfo(), outputTads, outputTadOffsets, indices->lengthOf());
     delete dimensions;
   }
 }
@@ -206,7 +210,7 @@ static void unsortedSegmentProdFunctor_(sd::LaunchContext* context, NDArray* inp
     segmentProdTadKernel<T, I><<<launchDims.y, launchDims.x, launchDims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numOfClasses, output->specialBuffer(),
-        output->specialShapeInfo(), outputTads, outputTadOffsets);
+        output->specialShapeInfo(), outputTads, outputTadOffsets, indices->lengthOf());
     delete dimensions;
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_sqrtn.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_sqrtn.cu
@@ -66,7 +66,10 @@ static SD_KERNEL void segmentSqrtNTadKernel(T* inputBuf, sd::LongType const* inp
                                             sd::LongType const* inputTadOffsets, I* indices, sd::LongType* starts,
                                             sd::LongType* lengths, sd::LongType numOfClasses, void* outputBuf,
                                             sd::LongType const* outputShape, sd::LongType const* outputTads,
-                                            sd::LongType const* outputTadOffsets) {
+                                            sd::LongType const* outputTadOffsets, sd::LongType numIndices) {
+
+  if(blockIdx.x >= numIndices)
+    return;
   __shared__ sd::LongType len, total;
 
 
@@ -123,7 +126,7 @@ static void unsortedSegmentSqrtNFunctor_(sd::LaunchContext* context, NDArray* in
     segmentSqrtNTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
         input->dataBuffer()->specialAsT<T>(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         indices->dataBuffer()->specialAsT<I>(), begins, lengths, numOfClasses, output->specialBuffer(),
-        output->specialShapeInfo(), outputTads, outputTadOffsets);
+        output->specialShapeInfo(), outputTads, outputTadOffsets, indices->lengthOf());
     delete dimensions;
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
@@ -189,7 +189,7 @@ static void segmentSumFunctor_(sd::LaunchContext* context, NDArray* input, NDArr
     segmentSumTadKernel<T, I><<<segmentTadDims.y,segmentTadDims.x,segmentTadDims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numClasses, output->specialBuffer(),
-        output->specialShapeInfo(), outputTads, outputTadOffsets, 0);
+        output->specialShapeInfo(), outputTads, outputTadOffsets, indices->lengthOf());
     delete dimensions;
   }
 }
@@ -234,7 +234,7 @@ static void unsortedSegmentSumFunctor_(sd::LaunchContext* context, NDArray* inpu
     segmentSumTadKernel<T, I><<<dims.x, dims.y, dims.z, *stream>>>(
         input->specialBuffer(), input->specialShapeInfo(), inputTads, inputTadOffsets,
         reinterpret_cast<I*>(indices->specialBuffer()), begins, lengths, numOfClasses, output->specialBuffer(),
-        output->specialShapeInfo(), outputTads, outputTadOffsets, 0);
+        output->specialShapeInfo(), outputTads, outputTadOffsets, indices->lengthOf());
     delete dimensions;
   }
 }

--- a/libnd4j/tests_cpu/run_tests.sh
+++ b/libnd4j/tests_cpu/run_tests.sh
@@ -128,7 +128,7 @@ if [[ "$TEST_FILTER" != "none" ]]; then
 
    echo "Running with filter"
    env
-   ../blasbuild/${CHIP}/tests_cpu/layers_tests/runtests --gtest_filter="$TEST_FILTER"
+   /usr/local/cuda-12.1/bin/compute-sanitizer ../blasbuild/${CHIP}/tests_cpu/layers_tests/runtests --gtest_filter="$TEST_FILTER"
 
 else
   export GRID_SIZE_TRANSFORM_SCAN=1
@@ -189,7 +189,7 @@ else
   export BLOCK_SIZE_INVERT_PERMUTATION=128
   echo "Running without filter"
   env
-   ../blasbuild/${CHIP}/tests_cpu/layers_tests/runtests
+   /usr/local/cuda-12.1/bin/compute-sanitizer --print-limit=10 ../blasbuild/${CHIP}/tests_cpu/layers_tests/runtests
 fi
 # Workaround to fix posix path conversion problem on Windows (http://mingw.org/wiki/Posix_path_conversion)
 [ -f "${GTEST_OUTPUT#*:}" ] && cp -a surefire-reports/ ../target && rm -rf surefire-reports/


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes string creation. NDArrays weren't being initialized correctly when created with scalars.
It caused the strings to be corrupt.

Ensures a minimum of 1 string is created when the shape is a scalar.

## How was this patch tested?

Ran c++ string tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
