### PR TITLE
Add test hack allowing us to debug surefire java tests

### DIFF
--- a/libnd4j/include/array/NDArray.h
+++ b/libnd4j/include/array/NDArray.h
@@ -51,9 +51,12 @@
 #include <types/bfloat16.h>
 #include <iostream>
 namespace sd {
-
-
-
+#ifndef __JAVACPP_HACK__
+static void printFormatted(std::ostream& os, const sd::NDArray& arr, sd::LongType depth, sd::LongType limit);
+//used in google test for printing
+SD_LIB_EXPORT std::ostream& operator<<(std::ostream &os,  const NDArray& arr);
+void PrintTo(const sd::NDArray &arr, std::ostream *os);
+#endif
 template <typename T, typename = typename std::enable_if<DataTypeUtils::scalarTypesForNDarray<T>::value>::type>
 SD_LIB_EXPORT NDArray operator+(const NDArray &arr, const T &scalar);
 template <typename T, typename = typename std::enable_if<DataTypeUtils::scalarTypesForNDarray<T>::value>::type>
@@ -201,6 +204,9 @@ class SD_LIB_EXPORT NDArray {
 
  public:
   NDArray() = default;
+
+
+  void PrintTo(const sd::NDArray &arr, std::ostream *os);
 
   /**
    *  do not allocate memory, memory for array is passed from outside
@@ -1148,10 +1154,6 @@ class SD_LIB_EXPORT NDArray {
    *  check whether array is unitary matrix
    */
   bool isUnitary();
-
-  //used in google test for printing
-  //See gtest-printers.h for more information.
-  void PrintTo(std::ostream*);
 
 
   std::ostream& operator<<(std::ostream &os);

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -942,7 +942,6 @@ NDArray::NDArray(const std::vector<sd::LongType> &shape, const std::vector<const
 }
 
 
-
 //google test print statement
 static void printFormatted(std::ostream& os, const sd::NDArray& arr, sd::LongType depth, sd::LongType limit) {
   // adapted printFormatted function
@@ -1007,8 +1006,13 @@ static void printFormatted(std::ostream& os, const sd::NDArray& arr, sd::LongTyp
   }
 }
 
+std::ostream& operator<<(std::ostream &os,  const NDArray& arr) {
+  printFormatted(os, arr, 0, -1);
+  return os;
+}
 
- std::ostream& NDArray::operator<<(std::ostream &os) {
+
+std::ostream& NDArray::operator<<(std::ostream &os) {
   syncToHost();
 
 
@@ -1051,12 +1055,6 @@ static void printFormatted(std::ostream& os, const sd::NDArray& arr, sd::LongTyp
 }
 
 
-
-
-//used in gtest printing
-void NDArray::PrintTo(std::ostream *os) {
-  *os << this;
-}
 
 #endif
 //end google test print statement
@@ -1165,9 +1163,11 @@ std::string NDArray::asString(sd::LongType limit) {
       os << toStringValue(this->e<sd::LongType>(e));
     else if (this->isB())
       os << toStringValue(this->e<bool>(e));
-    else if (this->isS())  // todo add utf16 and utf32
-      os << this->e<std::string>(e);
-    if (e < limit - 1) os << ", ";
+    else if (this->isS()) {  // todo add utf16 and utf32
+      if(this->dataType() == DataType::UTF8)
+        os << this->e<std::string>(e);
+
+    }if (e < limit - 1) os << ", ";
   }
   os << "]";
   return os.str();
@@ -5347,6 +5347,12 @@ void NDArray::printAllTensorsAlongDimension(const std::vector<LongType> &dimensi
   }
 
 }
+
+//used in gtest printing
+void NDArray::PrintTo(const sd::NDArray &arr, std::ostream *os) {
+  *os << &arr;
+}
+
 void NDArray::printAllTensorsAlongDimension(const std::initializer_list<LongType> &dimensions) const {
   printAllTensorsAlongDimension(std::vector<sd::LongType>(dimensions));
 }
@@ -6147,5 +6153,4 @@ template SD_LIB_EXPORT NDArray operator/
 template SD_LIB_EXPORT NDArray operator/<NDArray, const NDArray &, void>(NDArray &&arr1, const NDArray &arr2);
 template SD_LIB_EXPORT NDArray operator/<NDArray, NDArray, void>(NDArray &&arr1, NDArray &&arr2);
 
-#endif
 }

--- a/libnd4j/include/array/cuda/NDArray.cu
+++ b/libnd4j/include/array/cuda/NDArray.cu
@@ -52,6 +52,11 @@ namespace sd {
 
 
 
+void PrintTo(const sd::NDArray &arr, std::ostream *os) {
+  NDArray constCast = const_cast<NDArray &>(arr);
+  *os << arr;
+}
+
 
 void* NDArray::platformBuffer() { return specialBuffer(); }
 void const* NDArray::platformBuffer() const { return specialBuffer(); }

--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests11.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests11.cpp
@@ -1740,7 +1740,7 @@ TEST_F(DeclarableOpsTests11, Cholesky_Test_2x2x2) {
   auto res = op.evaluate({&a});
   ASSERT_EQ(res.status(), sd::Status::OK);
   auto z = res.at(0);
-  ASSERT_EQ(exp, *z);
+  ASSERT_TRUE(exp.equalsTo(z, 1.e-4));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libnd4j/tests_cpu/layers_tests/ThreadsTests.cpp
+++ b/libnd4j/tests_cpu/layers_tests/ThreadsTests.cpp
@@ -125,7 +125,7 @@ TEST_F(ThreadsTests, test_span_converage_1) {
     for (int c = 1; c <= 64; c++) {
       for (int t = 1; t <= 64; t++) {
         auto threads = ThreadsHelper::numberOfThreads2d(t, b, c);
-        auto loop = ThreadsHelper::pickLoop2d(threads, b, c)
+        auto loop = ThreadsHelper::pickLoop2d(threads, b, c);
 
         auto sum = 0;
         for (auto a = 0; a < threads; a++) {

--- a/platform-tests/bin/README.md
+++ b/platform-tests/bin/README.md
@@ -1,0 +1,9 @@
+# Java configuration for surefire
+
+The "java" file here is actually a shell script we use
+to allow us to customize surefire test execution
+via the <jvm> parameter in surefire.
+
+Surefire "detects" java by checking for a parent bin directory
+and a java executable. There is no configurable way
+to pass a wrapper script. Thus we do this.

--- a/platform-tests/bin/java
+++ b/platform-tests/bin/java
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+#
+# /* ******************************************************************************
+#  *
+#  *
+#  * This program and the accompanying materials are made available under the
+#  * terms of the Apache License, Version 2.0 which is available at
+#  * https://www.apache.org/licenses/LICENSE-2.0.
+#  *
+#  *  See the NOTICE file distributed with this work for additional
+#  *  information regarding copyright ownership.
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  * License for the specific language governing permissions and limitations
+#  * under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ******************************************************************************/
+#
+
+set -exo pipefail
+TEST_FILTER="none"
+
+
+
+CHIP="${CHIP:-cpu}"
+
+if [[ "$TEST_FILTER" != "none" ]]; then
+   export BLOCK_SIZE_SCALAR_SCAN=1
+   export GRID_SIZE_SCALAR_SCAN=1
+   export GRID_SIZE_TRANSFORM_SCAN=1
+   export BLOCK_SIZE_TRANSFORM_SCAN=1
+   export SHARED_MEM_SIZE_TRANSFORM_SCAN=256
+   export GRID_SIZE_COL2IM=256
+   export BLOCK_SIZE_COL2IM=256
+   export SHARED_MEM_SIZE_COL2IM=16000
+   export GRID_SIZE_IM2COL=256
+   export BLOCK_SIZE_IM2COL=256
+   export SHARED_MEM_SIZE_IM2COL=16000
+   export BLOCK_SIZE_RANDOM=128
+   export GRID_SIZE_RANDOM=128
+   export GRID_SIZE_POOLING=256
+   export BLOCK_SIZE_POOLING=256
+   export GRID_SIZE_MERGE=256
+   export   BLOCK_SIZE_MERGE=256
+   export  SHARED_MEM_SIZE_MERGE=256
+   export GRID_SIZE_DIAG_PART=128
+   export BLOCK_SIZE_DIAG_PART=128
+   export GRID_SIZE_SEGMENT_MEAN=128
+   export BLOCK_SIZE_SEGMENT_MEAN=128
+   export GRID_SIZE_CLIP=128
+   export BLOCK_SIZE_CLIP=128
+   export GRID_SIZE_SWAP_UNSAFE=128
+   export  BLOCK_SIZE_SWAP_UNSAFE=256
+   export GRID_SIZE_SEGMENT=128
+   export BLOCK_SIZE_SEGMENT=128
+   export GRID_SIZE_SEGMENT_MEAN=128
+   export BLOCK_SIZE_SEGMENT_MEAN=128
+   export GRID_SIZE_GATHER=128
+   export BLOCK_SIZE_GATHER=128
+   export GRID_SIZE_PREFIX=128
+   export BLOCK_SIZE_PREFIX=128
+   export GRID_SIZE_ADJUST=128
+   export BLOCK_SIZE_ADJUST=128
+   export GRID_SIZE_SEGMENT_TAD=128
+   export BLOCK_SIZE_SEGMENT_TAD=128
+   export GRID_SIZE_MATRIX_DIAG=128
+   export BLOCK_SIZE_MATRIX_DIAG=128
+   export GRID_SIZE_SEGMENT_PROD_2_TAD=128
+   export BLOCK_SIZE_SEGMENT_PROD_2_TAD=128
+   export GRID_SIZE_ZETA=64
+   export BLOCK_SIZE_ZETA=64
+   export GRID_SIZE_SCATTER_SIMPLE=256
+   export BLOCK_SIZE_SCATTER_SIMPLE=128
+   export GRID_SIZE_MIRROR_PAD_LINEAR=128
+   export BLOCK_SIZE_MIRROR_PAD_LINEAR=128
+   export GRID_SIZE_POLYGAMMA=64
+   export BLOCK_SIZE_POLYGAMMA=64
+   export GRID_SIZE_DIGAMMA=128
+   export BLOCK_SIZE_DIGAMMA=128
+   export GRID_SIZE_BETA_INC=128
+   export BLOCK_SIZE_BETA_INC=128
+   export GRID_SIZE_INVERT_PERMUTATION=128
+  export BLOCK_SIZE_INVERT_PERMUTATION=128
+   $TEST_RUNNER_PREFIX java "$@"
+
+
+else
+  export GRID_SIZE_TRANSFORM_SCAN=1
+  export BLOCK_SIZE_TRANSFORM_SCAN=1
+  export BLOCK_SIZE_SCALAR_SCAN=1
+  export GRID_SIZE_SCALAR_SCAN=1
+  export SHARED_MEM_SIZE_TRANSFORM_SCAN=1024
+  export GRID_SIZE_COL2IM=128
+  export BLOCK_SIZE_COL2IM=128
+  export SHARED_MEM_SIZE_COL2IM=16000
+  export GRID_SIZE_IM2COL=128
+  export BLOCK_SIZE_IM2COL=128
+  export SHARED_MEM_SIZE_IM2COL=16000
+  export BLOCK_SIZE_RANDOM=128
+  export GRID_SIZE_RANDOM=128
+  export GRID_SIZE_POOLING=256
+  export BLOCK_SIZE_POOLING=256
+  export GRID_SIZE_MERGE=256
+  export BLOCK_SIZE_MERGE=256
+  export SHARED_MEM_SIZE_MERGE=256
+  export GRID_SIZE_DIAG_PART=128
+  export BLOCK_SIZE_DIAG_PART=128
+  export GRID_SIZE_CLIP=128
+  export BLOCK_SIZE_CLIP=128
+  export GRID_SIZE_SWAP_UNSAFE=128
+  export  BLOCK_SIZE_SWAP_UNSAFE=256
+  export GRID_SIZE_SEGMENT_MEAN=128
+  export BLOCK_SIZE_SEGMENT_MEAN=128
+  export GRID_SIZE_SEGMENT=128
+  export BLOCK_SIZE_SEGMENT=128
+  export GRID_SIZE_GATHER=128
+  export BLOCK_SIZE_GATHER=128
+  export GRID_SIZE_PREFIX=128
+  export BLOCK_SIZE_PREFIX=128
+  export GRID_SIZE_ADJUST=128
+  export BLOCK_SIZE_ADJUST=128
+  export GRID_SIZE_SEGMENT_TAD=128
+  export BLOCK_SIZE_SEGMENT_TAD=128
+  export GRID_SIZE_MATRIX_DIAG=128
+  export BLOCK_SIZE_MATRIX_DIAG=128
+  export GRID_SIZE_SEGMENT_PROD_2_TAD=128
+  export BLOCK_SIZE_SEGMENT_PROD_2_TAD=128
+  export GRID_SIZE_ZETA=64
+  export BLOCK_SIZE_ZETA=64
+  export GRID_SIZE_SCATTER_SIMPLE=256
+  export BLOCK_SIZE_SCATTER_SIMPLE=128
+  export GRID_SIZE_MIRROR_PAD_LINEAR=128
+  export BLOCK_SIZE_MIRROR_PAD_LINEAR=128
+  export GRID_SIZE_DIGAMMA=128
+  export BLOCK_SIZE_DIGAMMA=128
+  export GRID_SIZE_POLYGAMMA=64
+  export BLOCK_SIZE_POLYGAMMA=64
+  export GRID_SIZE_ADJUST_WEIGHTS=128
+  export BLOCK_SIZE_ADJUST_WEIGHTS=128
+  export GRID_SIZE_BETA_INC=128
+  export BLOCK_SIZE_BETA_INC=128
+  export GRID_SIZE_INVERT_PERMUTATION=128
+  export BLOCK_SIZE_INVERT_PERMUTATION=128
+   $TEST_RUNNER_PREFIX  java "$@"
+
+fi

--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -902,6 +902,7 @@
                         <MALLOC_CONF>${jemalloc.mallocconf}</MALLOC_CONF>
                         <ASAN_OPTIONS>${test.asan.options}</ASAN_OPTIONS>
                         <ASAN_SHADOW_OFFSET>0</ASAN_SHADOW_OFFSET>
+                        <!-- For usage with the wrapper script in bin. Do NOT delete that script. See the readme in the bin directory for more information.-->
                         <TEST_RUNNER_PREFIX>/usr/local/cuda-12.1/bin/compute-sanitizer</TEST_RUNNER_PREFIX>
                         <TEST_FILTER></TEST_FILTER>
                     </environmentVariables>
@@ -923,6 +924,7 @@
                     <properties>
                         <org.bytedeco.javacpp.logger.debug>true</org.bytedeco.javacpp.logger.debug>
                     </properties>
+                   <!-- Do not delete this. This is used to specify a wrapper script allowing us to insert valgrind and other things in to the surefire sub processes.-->
                     <jvm>${project.basedir}/bin/java</jvm>
                 </configuration>
             </plugin>

--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -51,7 +51,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dl4j.version>1.0.0-SNAPSHOT</dl4j.version>
         <platform.classifier>${javacpp.platform}</platform.classifier>
-        <backend.artifactId>nd4j-native</backend.artifactId>
+        <backend.artifactId>nd4j-cuda-12.1</backend.artifactId>
         <!-- UDF package names for TestUdf -->
         <org.nd4j.linalg.api.ops.udf.packages>org.nd4j.linalg.api.ops</org.nd4j.linalg.api.ops.udf.packages>
         <lombok.version>1.18.24</lombok.version>
@@ -177,6 +177,12 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>maven-surefire-common</artifactId>
+                <version>${maven-surefire.version}</version>
             </dependency>
 
 
@@ -878,8 +884,9 @@
 
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
+                <version>${maven-surefire.version}</version>
 
                 <configuration>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -895,6 +902,8 @@
                         <MALLOC_CONF>${jemalloc.mallocconf}</MALLOC_CONF>
                         <ASAN_OPTIONS>${test.asan.options}</ASAN_OPTIONS>
                         <ASAN_SHADOW_OFFSET>0</ASAN_SHADOW_OFFSET>
+                        <TEST_RUNNER_PREFIX>/usr/local/cuda-12.1/bin/compute-sanitizer</TEST_RUNNER_PREFIX>
+                        <TEST_FILTER></TEST_FILTER>
                     </environmentVariables>
                     <shutdown>kill</shutdown>
                     <classpathDependencyExcludes>
@@ -914,6 +923,7 @@
                     <properties>
                         <org.bytedeco.javacpp.logger.debug>true</org.bytedeco.javacpp.logger.debug>
                     </properties>
+                    <jvm>${project.basedir}/bin/java</jvm>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Fix left over test issue
Add hack that configures surefire to use a wrapper that allows us to debug tests

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
