### PR TITLE
MemoryUtils clean up

### DIFF
--- a/libnd4j/blas/CMakeLists.txt
+++ b/libnd4j/blas/CMakeLists.txt
@@ -162,7 +162,12 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"  AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Aurora")
     # using GCC
     SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${ARCH_TUNE} ${INFORMATIVE_FLAGS}  -std=c++11")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,$ORIGIN/,--no-undefined,-z,--verbose")
+    # windows doesn't support -z linker flag:  https://stackoverflow.com/questions/55418931/ld-exe-unrecognized-option-z
+    if(UNIX)
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,$ORIGIN/,-z,--no-undefined,--verbose")
+    else() # windows
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,$ORIGIN/,--no-undefined,--verbose")
+    endif()
     # keep this, we need to ensure that all symbols are defined or it may fail on mac based platforms
     if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT(APPLE) AND NOT(WIN32))
         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -rdynamic -Wl,-export-dynamic,--verbose")

--- a/libnd4j/include/memory/impl/MemoryUtils.cpp
+++ b/libnd4j/include/memory/impl/MemoryUtils.cpp
@@ -40,19 +40,6 @@
 bool sd::memory::MemoryUtils::retrieveMemoryStatistics(sd::memory::MemoryReport &report) {
 #if defined(__APPLE__)
   sd_debug("APPLE route\n", "");
-  /*
-      struct task_basic_info t_info;
-      mach_msg_type_number_t t_info_count = TASK_BASIC_INFO_COUNT;
-
-      if (KERN_SUCCESS != task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count))
-          return false;
-
-      report.setVM(t_info.resident_size);
-      report.setRSS(t_info.resident_size);
-
-
-      sd_debug("RSS: %lld; VM: %lld;\n", report.getRSS(), report.getVM());
-  */
   struct rusage _usage;
 
   auto res = getrusage(RUSAGE_SELF, &_usage);
@@ -62,7 +49,7 @@ bool sd::memory::MemoryUtils::retrieveMemoryStatistics(sd::memory::MemoryReport 
   sd_debug("Usage: %lld; %lld; %lld; %lld;\n", _usage.ru_ixrss, _usage.ru_idrss, _usage.ru_isrss, _usage.ru_maxrss);
 
   return true;
-#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)  || defined(__MINGW32__) || defined(__CYGWIN__)
   sd_debug("WIN32 route\n", "");
 
 #else

--- a/libnd4j/include/ops/declarable/helpers/cpu/sg_cb.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/sg_cb.cpp
@@ -392,7 +392,7 @@ class AlignedAllocator
   pointer allocate(size_type n, const void* = nullptr)
   {
 #if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
-    void* ptr = _aligned_malloc(n * sizeof(T), Alignment);
+    void* ptr = this->_aligned_malloc(n * sizeof(T), Alignment);
 #else
     void* ptr = nullptr;
     if(posix_memalign(&ptr, Alignment, n * sizeof(T)) != 0)

--- a/libnd4j/include/ops/declarable/helpers/cpu/sg_cb.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/sg_cb.cpp
@@ -391,7 +391,7 @@ class AlignedAllocator
 
   pointer allocate(size_type n, const void* = nullptr)
   {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
     void* ptr = _aligned_malloc(n * sizeof(T), Alignment);
 #else
     void* ptr = nullptr;

--- a/libnd4j/include/system/op_boilerplate.h
+++ b/libnd4j/include/system/op_boilerplate.h
@@ -2653,6 +2653,7 @@ SD_INLINE void internal_release_host(WW workspace, TT_PTR var) {
 }
 
 
+#ifndef __JAVACPP_HACK__
 
 #if defined(SD_GCC_FUNCTRACE) && !defined(OP_BOILER_PLATE_THROW_EXCEPTIONS)
 #pragma once
@@ -2665,7 +2666,7 @@ void throwException(const char* exceptionMessage);
 void throwException(const char* exceptionMessage);
 
 #endif
-
+#endif
 #if defined(SD_GCC_FUNCTRACE)
 #define THROW_EXCEPTION(exceptionMessage) throwException(exceptionMessage);
 #else

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -368,6 +368,7 @@
                                 <linkResource>/org/bytedeco/openblas/${javacpp.platform}/lib/</linkResource>
                             </linkResources>
                             <compilerOptions>
+                                <compilerOption>-D_WIN32</compilerOption>
                                 <compilerOption>${javacpp.compiler.options}</compilerOption>
                             </compilerOptions>
                         </configuration>
@@ -785,6 +786,12 @@
                         <artifactId>javacpp</artifactId>
                         <configuration>
                             <properties>${javacpp.platform}-mingw</properties>
+                            <!-- Add the _WIN32 macro to gcc forcibly. Depending on what version
+                            within msys2/mingw is used it will use the wrong code path in the generated javacpp
+                            code that reads in a file.-->
+                            <compilerOptions>
+                                <compilerOption>-D_WIN32</compilerOption>
+                            </compilerOptions>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-native/pom.xml
@@ -368,7 +368,6 @@
                                 <linkResource>/org/bytedeco/openblas/${javacpp.platform}/lib/</linkResource>
                             </linkResources>
                             <compilerOptions>
-                                <compilerOption>-D_WIN32</compilerOption>
                                 <compilerOption>${javacpp.compiler.options}</compilerOption>
                             </compilerOptions>
                         </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes MSYS2 build issues:
1. Gets rid of the -z flag when gcc is used on windows
2. Forces javacpp to use _WIN32 when opening files. _WIN32 by default isn't defined on MSYS2.

These build issues appear to be recent. MSYS2 recently changed some defaults so build changes were needed.


## How was this patch tested?

Running builds on msys2
## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
