### PR TITLE
deeplearning4j-core  remove unused dependency deeplearning4j-datasets

### DIFF
--- a/deeplearning4j/deeplearning4j-core/pom.xml
+++ b/deeplearning4j/deeplearning4j-core/pom.xml
@@ -74,11 +74,6 @@
 
         <dependency>
             <groupId>org.deeplearning4j</groupId>
-            <artifactId>deeplearning4j-datasets</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-datavec-iterators</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Clean up pom.xml dependencies for deeplearning4j-core. Remove unused dependency deeplearning4j-datasets. (#10041)

## What changes were proposed in this pull request?

Remove unused dependency deeplearning4j-datasets from project deeplearning4j-core pom.xml

## How was this patch tested?

Source review, maven compiled successfully

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [X] Relevant tests for your changes are passing.
