### PR TITLE
#10068 Fix CSVVariableSlidingWindowRecordReader

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVVariableSlidingWindowRecordReader.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/records/reader/impl/csv/CSVVariableSlidingWindowRecordReader.java
@@ -39,7 +39,6 @@ public class CSVVariableSlidingWindowRecordReader extends CSVRecordReader implem
     public static final String LINES_PER_SEQUENCE = NAME_SPACE + ".nlinespersequence";
 
     private int maxLinesPerSequence;
-    private String delimiter;
     private int stride;
     private LinkedList<List<Writable>> queue;
     private boolean exhausted;
@@ -55,7 +54,7 @@ public class CSVVariableSlidingWindowRecordReader extends CSVRecordReader implem
      * @param maxLinesPerSequence Number of lines in each sequence, use default delemiter(,) between entries in the same line
      */
     public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence) {
-        this(maxLinesPerSequence, 0, 1, String.valueOf(CSVRecordReader.DEFAULT_DELIMITER));
+        this(maxLinesPerSequence, 0, 1, CSVRecordReader.DEFAULT_DELIMITER);
     }
 
     /**
@@ -63,15 +62,45 @@ public class CSVVariableSlidingWindowRecordReader extends CSVRecordReader implem
      * @param stride Number of lines between records (increment window > 1 line)
      */
     public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int stride) {
-        this(maxLinesPerSequence, 0, stride, String.valueOf(CSVRecordReader.DEFAULT_DELIMITER));
+        this(maxLinesPerSequence, 0, stride, CSVRecordReader.DEFAULT_DELIMITER);
+    }
+
+    /**
+     * @param maxLinesPerSequence Number of lines in each sequence, use default delemiter(,) between entries in the same line
+     * @param stride Number of lines between records (increment window > 1 line)
+     * @deprecated Use the constructor using char for delimiter instead
+     */
+    @Deprecated
+    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int stride, String delimiter) {
+        this(maxLinesPerSequence, 0, stride, CSVRecordReader.DEFAULT_DELIMITER);
+    }
+
+    /**
+     *
+     * @param maxLinesPerSequence Number of lines in each sequences
+     * @param skipNumLines Number of lines to skip at the start of the file (only skipped once, not per sequence)
+     * @param stride Number of lines between records (increment window > 1 line)
+     * @param delimiter Delimiter between entries in the same line, for example ","
+     * @deprecated Use the constructor using char for delimiter instead
+     */
+    @Deprecated
+    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int skipNumLines, int stride, String delimiter) {
+        super(skipNumLines, delimiter.charAt(0));
+        if(stride < 1)
+            throw new IllegalArgumentException("Stride must be greater than 1");
+
+        this.maxLinesPerSequence = maxLinesPerSequence;
+        this.stride = stride;
+        this.queue = new LinkedList<>();
+        this.exhausted = false;
     }
 
     /**
      * @param maxLinesPerSequence Number of lines in each sequence, use default delemiter(,) between entries in the same line
      * @param stride Number of lines between records (increment window > 1 line)
      */
-    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int stride, String delimiter) {
-        this(maxLinesPerSequence, 0, stride, String.valueOf(CSVRecordReader.DEFAULT_DELIMITER));
+    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int stride, char delimiter) {
+        this(maxLinesPerSequence, 0, stride, delimiter);
     }
 
     /**
@@ -81,12 +110,11 @@ public class CSVVariableSlidingWindowRecordReader extends CSVRecordReader implem
      * @param stride Number of lines between records (increment window > 1 line)
      * @param delimiter Delimiter between entries in the same line, for example ","
      */
-    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int skipNumLines, int stride, String delimiter) {
-        super(skipNumLines);
+    public CSVVariableSlidingWindowRecordReader(int maxLinesPerSequence, int skipNumLines, int stride, char delimiter) {
+        super(skipNumLines, delimiter);
         if(stride < 1)
             throw new IllegalArgumentException("Stride must be greater than 1");
 
-        this.delimiter = delimiter;
         this.maxLinesPerSequence = maxLinesPerSequence;
         this.stride = stride;
         this.queue = new LinkedList<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove delimiter from CSVVariableSlidingWindowRecordReader and replace it with the char implementation.
Deprecate the old constructors.
Use first char of String delimiter in deprecated constructor.

## How was this patch tested?

Local testing

## Quick checklist

The following checklist helps ensure your PR is complete:

- [x] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [x] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [x] Created tests for any significant new code additions.
- [x] Relevant tests for your changes are passing.
