### PR TITLE
leftover cpu op changes (cnns, merge, sampling,..) and gpu buffers

### DIFF
--- a/libnd4j/include/array/impl/ExtraArguments.cpp
+++ b/libnd4j/include/array/impl/ExtraArguments.cpp
@@ -34,14 +34,14 @@
 namespace sd {
 ExtraArguments::ExtraArguments(std::initializer_list<double> arguments) { _fpArgs = arguments; }
 
-ExtraArguments::ExtraArguments(std::initializer_list<sd::LongType> arguments) { _intArgs = arguments; }
+ExtraArguments::ExtraArguments(std::initializer_list<LongType> arguments) { _intArgs = arguments; }
 
 ExtraArguments::ExtraArguments(const std::vector<double> &arguments) { _fpArgs = arguments; }
 
-ExtraArguments::ExtraArguments(const std::vector<sd::LongType> &arguments) { _intArgs = arguments; }
+ExtraArguments::ExtraArguments(const std::vector<LongType> &arguments) { _intArgs = arguments; }
 
 ExtraArguments::ExtraArguments(const std::vector<int> &arguments) {
-  for (const auto &v : arguments) _intArgs.emplace_back(static_cast<sd::LongType>(v));
+  for (const auto &v : arguments) _intArgs.emplace_back(static_cast<LongType>(v));
 }
 
 ExtraArguments::ExtraArguments() {
@@ -53,13 +53,13 @@ ExtraArguments::~ExtraArguments() {
 #ifdef __CUDABLAS__
     cudaFree(p);
 #else  // CPU branch
-    delete[] reinterpret_cast<int8_t *>(p);
+    delete reinterpret_cast<int8_t *>(p);
 #endif
   }
 }
 
 template <typename T>
-void ExtraArguments::convertAndCopy(sd::Pointer pointer, sd::LongType offset) {
+void ExtraArguments::convertAndCopy(Pointer pointer, LongType offset) {
   auto length = this->length();
   auto target = reinterpret_cast<T *>(pointer);
 #ifdef __CUDABLAS__
@@ -79,7 +79,7 @@ void ExtraArguments::convertAndCopy(sd::Pointer pointer, sd::LongType offset) {
 #ifdef __CUDABLAS__
   // TODO: maybe make it asynchronous eventually?
   cudaMemcpy(pointer, target, length * DataTypeUtils::sizeOf(DataTypeUtils::fromT<T>()), cudaMemcpyHostToDevice);
-  delete[] target;
+  delete target;
 #endif
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void ExtraArguments::convertAndCopy,
@@ -87,7 +87,7 @@ BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void ExtraArguments::convertAndCopy
 
 void *ExtraArguments::allocate(size_t length, size_t elementSize) {
 #ifdef __CUDABLAS__
-  sd::Pointer ptr;
+  Pointer ptr;
   auto res = cudaMalloc(reinterpret_cast<void **>(&ptr), length * elementSize);
   if (res != 0) THROW_EXCEPTION("Can't allocate CUDA memory");
 #else  // CPU branch
@@ -108,13 +108,13 @@ size_t ExtraArguments::length() {
 }
 
 template <typename T>
-void *ExtraArguments::argumentsAsT(sd::LongType offset) {
+void *ExtraArguments::argumentsAsT(LongType offset) {
   return argumentsAsT(DataTypeUtils::fromT<T>(), offset);
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void *ExtraArguments::argumentsAsT, (sd::LongType offset),
                       SD_COMMON_TYPES);
 
-void *ExtraArguments::argumentsAsT(sd::DataType dataType, sd::LongType offset) {
+void *ExtraArguments::argumentsAsT(DataType dataType, LongType offset) {
   if (_fpArgs.empty() && _intArgs.empty()) return nullptr;
 
   // we allocate pointer

--- a/libnd4j/include/array/impl/NDArrayFactory.cpp
+++ b/libnd4j/include/array/impl/NDArrayFactory.cpp
@@ -36,24 +36,21 @@
 
 namespace sd {
 
-SD_LIB_EXPORT NDArray NDArrayFactory::create(ShapeDescriptor *shapeDescriptor, sd::LaunchContext* context) {
+SD_LIB_EXPORT NDArray NDArrayFactory::create(ShapeDescriptor *shapeDescriptor, LaunchContext* context) {
   auto status = shapeDescriptor->validate();
   if (status != SHAPE_DESC_OK) {
-    sd_printf("NDArrayFactory::create: ShapeDescriptor status code [%d]\n", status);
     THROW_EXCEPTION("NDArrayFactory::create: invalid ShapeDescriptor ");
   }
-  sd::LongType allocSize = shapeDescriptor->allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor->dataType());
-  std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(allocSize, shapeDescriptor->dataType(), context->getWorkspace());
+  LongType allocSize = shapeDescriptor->allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor->dataType());
+  DataBuffer *  buffer =
+      new DataBuffer(allocSize, shapeDescriptor->dataType(), context->getWorkspace());
   NDArray result(buffer, shapeDescriptor, context);
   result.nullify();
   return result;
 }
 
-SD_LIB_EXPORT NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>& shape,
-                                             sd::DataType dataType, const std::vector<sd::LongType>& paddings,
-                                             const std::vector<sd::LongType>& paddingOffsets,
-                                             sd::LaunchContext* context) {
+SD_LIB_EXPORT NDArray NDArrayFactory::create(const char order, const std::vector<LongType>& shape, DataType dataType, const std::vector<LongType>& paddings,
+                                             const std::vector<LongType>& paddingOffsets, LaunchContext* context) {
   int rank = shape.size();
   if (rank > SD_MAX_RANK) THROW_EXCEPTION("NDArrayFactory::create: rank of NDArray can't exceed 32");
 
@@ -63,36 +60,34 @@ SD_LIB_EXPORT NDArray NDArrayFactory::create(const char order, const std::vector
 
   auto shapeDescriptor = ShapeDescriptor::paddedBufferDescriptor(dataType, order, shape, paddings);
 
-  sd::LongType allocSize = shapeDescriptor->allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor->dataType());
-  std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(allocSize, shapeDescriptor->dataType(), context->getWorkspace());
+  LongType allocSize = shapeDescriptor->allocLength() * DataTypeUtils::sizeOfElement(shapeDescriptor->dataType());
+  DataBuffer *  buffer =
+      new DataBuffer(allocSize, shapeDescriptor->dataType(), context->getWorkspace());
 
   // lets check offsets
   int check_size = paddingOffsets.size() < rank ? paddingOffsets.size() : rank;
 
   for (int i = 0; i < check_size; i++) {
     if (paddingOffsets[i] > paddings[i]) {
-      THROW_EXCEPTION(
-          "NDArrayFactory::create: paddingOffsets numbers should not exceed corresponding paddings");
+      THROW_EXCEPTION("NDArrayFactory::create: paddingOffsets numbers should not exceed corresponding paddings");
     }
   }
 
-  sd::LongType offset = offset_from_coords(shapeDescriptor->stridesPtr(), paddingOffsets.data(), check_size);
+  LongType offset = offset_from_coords(shapeDescriptor->stridesPtr(), paddingOffsets.data(), check_size);
 
   NDArray result(buffer, shapeDescriptor, context, offset);
-  delete shapeDescriptor;
   result.nullify();
   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////
 template <>
-SD_LIB_EXPORT NDArray NDArrayFactory::create<bool>(const char order, const std::vector<sd::LongType>& shape,
-                                                   const std::vector<bool>& data, sd::LaunchContext* context) {
+SD_LIB_EXPORT NDArray NDArrayFactory::create<bool>(const char order, const std::vector<LongType>& shape,
+                                                   const std::vector<bool>& data, LaunchContext* context) {
   if ((int)shape.size() > SD_MAX_RANK)
     THROW_EXCEPTION("NDArrayFactory::create: rank of NDArray can't exceed 32 !");
 
-  ShapeDescriptor *descriptor = new ShapeDescriptor(sd::DataType::BOOL, order, shape);
+  ShapeDescriptor *descriptor = new ShapeDescriptor(BOOL, order, shape);
 
   if (descriptor->arrLength() != data.size()) {
     sd_printf("NDArrayFactory::create: data size [%i] doesn't match shape length [%lld]\n", data.size(),
@@ -104,18 +99,16 @@ SD_LIB_EXPORT NDArray NDArrayFactory::create<bool>(const char order, const std::
   ALLOCATE(hostBuffer, context->getWorkspace(), data.size(), bool);
   std::copy(data.begin(), data.end(), hostBuffer);
 
-  std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(hostBuffer, data.size() * sizeof(bool),
-                                                                    sd::DataType::BOOL, true, context->getWorkspace());
+  DataBuffer * buffer = new DataBuffer(hostBuffer, data.size() * sizeof(bool), BOOL, true, context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
-  delete descriptor;
   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>& shape, const std::vector<T>& data,
-                               sd::LaunchContext* context) {
+NDArray NDArrayFactory::create(const char order, const std::vector<LongType>& shape, const std::vector<T>& data,
+                               LaunchContext* context) {
   if (shape.size() > SD_MAX_RANK)
     THROW_EXCEPTION("NDArrayFactory::create: rank of NDArray can't exceed 32 !");
   ShapeDescriptor *descriptor = new ShapeDescriptor(DataTypeUtils::fromT<T>(), order, shape);
@@ -136,11 +129,10 @@ NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>
   //note here we use data.size() to work around the scalar case. If the shape is zero but the data is actually length 1 we need this reflected
   //to create a correct length data buffer
   auto dtypeString = DataTypeUtils::asString(descriptor->dataType());
-  std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(
+  DataBuffer *  buffer = new DataBuffer(
       data.data(), DataTypeUtils::fromT<T>(), data.size() * sizeof(T), context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
-  delete descriptor;
   return result;
 }
 
@@ -164,7 +156,7 @@ TMPL_INSTANTIATE_CREATE_A(bool)
 #undef TMPL_INSTANTIATE_CREATE_A
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray* NDArrayFactory::create_(const char order, const std::vector<sd::LongType>& shape, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::create_(const char order, const std::vector<LongType>& shape, LaunchContext* context) {
   return create_(order, shape, DataTypeUtils::fromT<T>(), context);
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray* NDArrayFactory::create_,
@@ -180,7 +172,7 @@ void NDArrayFactory::memcpyFromVector(void* ptr, const std::vector<T>& vector) {
 template <>
 void SD_LIB_EXPORT NDArrayFactory::memcpyFromVector(void* ptr, const std::vector<bool>& vector) {
   auto p = reinterpret_cast<bool*>(ptr);
-  for (sd::LongType e = 0; e < vector.size(); e++) p[e] = vector[e];
+  for (LongType e = 0; e < vector.size(); e++) p[e] = vector[e];
 }
 
 
@@ -203,9 +195,9 @@ TMPL_INSTANTIATE_MEMCPY(bool)
 #ifndef __JAVACPP_HACK__
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray* NDArrayFactory::valueOf(const std::initializer_list<sd::LongType>& shape, const T value, const char order,
-                                 sd::LaunchContext* context) {
-  return valueOf(std::vector<sd::LongType>(shape), value, order);
+NDArray* NDArrayFactory::valueOf(const std::initializer_list<LongType>& shape, const T value, const char order,
+                                 LaunchContext* context) {
+  return valueOf(std::vector<LongType>(shape), value, order);
 }
 
 #define TMPL_INSTANTIATE_VALUEOF_A(TYPE) \
@@ -237,15 +229,14 @@ template SD_LIB_EXPORT NDArray NDArrayFactory::create<TYPE>(const char order, co
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray* NDArrayFactory::create_(const T scalar, sd::LaunchContext* context) {
-  std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(1 * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
+NDArray* NDArrayFactory::create_(const T scalar, LaunchContext* context) {
+  DataBuffer *  buffer =
+      new DataBuffer(1 * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
 
   auto desc = ShapeDescriptor::scalarDescriptor(DataTypeUtils::fromT<T>());
   auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-  auto recast = const_cast<sd::LongType *>(constDesc->primary());
+  auto recast = const_cast<LongType*>(constDesc->primary());
   NDArray* res = new NDArray(buffer, recast, context);
-  delete desc;
   res->bufferAsT<T>()[0] = scalar;
 
   res->tickWriteHost();
@@ -274,14 +265,14 @@ TMPL_INSTANTIATE_CREATE_C(bool)
 #undef TMPL_INSTANTIATE_CREATE_C
 
 template <typename T>
-NDArray NDArrayFactory::create(sd::DataType type, const T scalar, sd::LaunchContext* context) {
+NDArray NDArrayFactory::create(DataType type, const T scalar, LaunchContext* context) {
   if (type == DataTypeUtils::fromT<T>()) return NDArrayFactory::create(scalar, context);
 
-  NDArray res(type, context);
-  res.p(0, scalar);
-  res.syncToDevice();
+  NDArray *res = new NDArray(type, context);
+  res->p(0, scalar);
+  res->syncToDevice();
 
-  return res;
+  return *res;
 }
 
 #define TMPL_INSTANTIATE_CREATE_D(TYPE) \
@@ -304,13 +295,12 @@ TMPL_INSTANTIATE_CREATE_D(bool)
 #undef TMPL_INSTANTIATE_CREATE_D
 
 template <typename T>
-NDArray NDArrayFactory::create(const T scalar, sd::LaunchContext* context) {
-  std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(1 * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
+NDArray NDArrayFactory::create(const T scalar, LaunchContext* context) {
+  DataBuffer *  buffer =
+      new DataBuffer(1 * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
 
   auto desc = ShapeDescriptor::scalarDescriptor(DataTypeUtils::fromT<T>());
   NDArray res(buffer,desc , context);
-  delete desc;
   res.bufferAsT<T>()[0] = scalar;
 
   res.tickWriteHost();
@@ -340,8 +330,8 @@ TMPL_INSTANTIATE_CREATE_E(bool)
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray* NDArrayFactory::create_(const char order, const std::vector<sd::LongType>& shape, const std::vector<T>& data,
-                                 sd::LaunchContext* context) {
+NDArray* NDArrayFactory::create_(const char order, const std::vector<LongType>& shape, const std::vector<T>& data,
+                                 LaunchContext* context) {
   return new NDArray(NDArrayFactory::create<T>(order, shape, data, context));
 }
 
@@ -367,24 +357,24 @@ TMPL_INSTANTIATE_CREATE_F(bool)
 
 ////////////////////////////////////////////////////////////////////////
 template <>
-SD_LIB_EXPORT NDArray* NDArrayFactory::valueOf(const std::vector<sd::LongType>& shape, NDArray* value, const char order,
-                                               sd::LaunchContext* context) {
+SD_LIB_EXPORT NDArray* NDArrayFactory::valueOf(const std::vector<LongType>& shape, NDArray* value, const char order,
+                                               LaunchContext* context) {
   auto result = create_(order, shape, value->dataType(), context);
   result->assign(*value);
   return result;
 }
 
 template <>
-SD_LIB_EXPORT NDArray* NDArrayFactory::valueOf(const std::vector<sd::LongType>& shape, NDArray& value, const char order,
-                                               sd::LaunchContext* context) {
+SD_LIB_EXPORT NDArray* NDArrayFactory::valueOf(const std::vector<LongType>& shape, NDArray& value, const char order,
+                                               LaunchContext* context) {
   auto result = create_(order, shape, value.dataType(), context);
   result->assign(value);
   return result;
 }
 
 template <typename T>
-NDArray* NDArrayFactory::valueOf(const std::vector<sd::LongType>& shape, const T value, const char order,
-                                 sd::LaunchContext* context) {
+NDArray* NDArrayFactory::valueOf(const std::vector<LongType>& shape, const T value, const char order,
+                                 LaunchContext* context) {
   auto result = create_(order, shape, DataTypeUtils::fromT<T>());
   result->assign(value);
   return result;
@@ -410,10 +400,10 @@ TMPL_INSTANTIATE_VALUEOF(bool)
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray* NDArrayFactory::linspace(const T from, const T to, const sd::LongType numElements) {
+NDArray* NDArrayFactory::linspace(const T from, const T to, const LongType numElements) {
   NDArray* result = NDArrayFactory::vector<T>(numElements);
   // TO DO: linspace should be executed on DEVICE, but only CPU version implemnted!
-  for (sd::LongType e = 0; e < numElements; e++) {
+  for (LongType e = 0; e < numElements; e++) {
     T step = (T)e / ((T)numElements - (T)1);
     result->p<T>(e, (from * ((T)1 - step) + step * to));
   }
@@ -441,14 +431,13 @@ TMPL_INSTANTIATE_LINSPACE(bool)
 #undef TMPL_INSTANTIATE_LINSPACE
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray* NDArrayFactory::vector(sd::LongType length, const T value, sd::LaunchContext* context) {
-  std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(length * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
+NDArray* NDArrayFactory::vector(LongType length, const T value, LaunchContext* context) {
+  DataBuffer *  buffer =
+      new DataBuffer(length * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
   auto desc = ShapeDescriptor::vectorDescriptor(length, DataTypeUtils::fromT<T>());
   auto constDesc = ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
-  auto recast = const_cast<sd::LongType *>(constDesc->primary());
+  auto recast = const_cast<LongType*>(constDesc->primary());
   auto res = new NDArray(buffer, recast, context);
-  delete desc;
   if (value == (T)0.0f)
     res->nullify();
   else
@@ -477,7 +466,7 @@ TMPL_INSTANTIATE_VECTOR(bool)
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>& shape, sd::LaunchContext* context) {
+NDArray NDArrayFactory::create(const char order, const std::vector<LongType>& shape, LaunchContext* context) {
   return create(order, shape, DataTypeUtils::fromT<T>(), context);
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArrayFactory::create,
@@ -485,51 +474,48 @@ BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArrayFactory::create,
                       SD_COMMON_TYPES_ALL);
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::create(const char order, const std::vector<sd::LongType>& shape, sd::DataType dtype,
-                               sd::LaunchContext* context) {
+NDArray NDArrayFactory::create(const char order, const std::vector<LongType>& shape, DataType dtype,
+                               LaunchContext* context) {
   if ((int)shape.size() > SD_MAX_RANK)
     THROW_EXCEPTION("NDArrayFactory::create: rank of NDArray can't exceed 32");
 
 
   ShapeDescriptor *descriptor = new ShapeDescriptor(dtype, order, shape);
 
-  std::shared_ptr<DataBuffer> buffer = std::make_shared<DataBuffer>(
+  DataBuffer *  buffer = new DataBuffer(
       descriptor->arrLength() * DataTypeUtils::sizeOfElement(dtype), dtype, context->getWorkspace());
 
   NDArray result(buffer, descriptor, context);
-  delete descriptor;
   result.nullify();
 
   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::create(sd::DataType dtype, sd::LaunchContext* context) {
-  std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(DataTypeUtils::sizeOfElement(dtype), dtype, context->getWorkspace(), true);
+NDArray NDArrayFactory::create(DataType dtype, LaunchContext* context) {
+  DataBuffer *  buffer =
+      new DataBuffer(DataTypeUtils::sizeOfElement(dtype), dtype, context->getWorkspace(), true);
   auto desc = ShapeDescriptor::scalarDescriptor(dtype);
   NDArray res(buffer, desc, context);
-  delete desc;
   res.nullify();
 
   return res;
 }
 
-NDArray* NDArrayFactory::create_(sd::DataType dtype, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::create_(DataType dtype, LaunchContext* context) {
   auto result = new NDArray();
-  *result = NDArrayFactory::create(dtype, context);
+  *result = create(dtype, context);
   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray NDArrayFactory::create(const std::vector<T>& values, sd::LaunchContext* context) {
-  std::shared_ptr<DataBuffer> buffer =
-      std::make_shared<DataBuffer>(values.size() * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
+NDArray NDArrayFactory::create(const std::vector<T>& values, LaunchContext* context) {
+  DataBuffer *  buffer =
+      new DataBuffer(values.size() * sizeof(T), DataTypeUtils::fromT<T>(), context->getWorkspace(), true);
 
   auto desc = ShapeDescriptor::vectorDescriptor(values.size(), DataTypeUtils::fromT<T>());
   NDArray res(buffer, desc, context);
-  delete desc;
   memcpyFromVector<T>(res.buffer(), values);
 
   res.tickWriteHost();
@@ -559,7 +545,7 @@ TMPL_INSTANTIATE_CREATE_G(bool)
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray* NDArrayFactory::empty_(sd::LaunchContext* context) {
+NDArray* NDArrayFactory::empty_(LaunchContext* context) {
   auto shapeInfo = ShapeBuilders::createScalarShapeInfo(DataTypeUtils::fromT<T>(), context->getWorkspace());
   ArrayOptions::setPropertyBit(shapeInfo, ARRAY_EMPTY);
   auto result = new NDArray(nullptr, shapeInfo, context, false);
@@ -571,8 +557,8 @@ NDArray* NDArrayFactory::empty_(sd::LaunchContext* context) {
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray* NDArrayFactory::empty_, (sd::LaunchContext * context),
                       SD_COMMON_TYPES_ALL);
 
-NDArray* NDArrayFactory::empty_(sd::DataType dataType, sd::LaunchContext* context) {
-  if (context == nullptr) context = sd::LaunchContext ::defaultContext();
+NDArray* NDArrayFactory::empty_(DataType dataType, LaunchContext* context) {
+  if (context == nullptr) context = LaunchContext ::defaultContext();
 
   auto shapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, context->getWorkspace());
   ArrayOptions::setPropertyBit(shapeInfo, ARRAY_EMPTY);
@@ -585,14 +571,14 @@ NDArray* NDArrayFactory::empty_(sd::DataType dataType, sd::LaunchContext* contex
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray NDArrayFactory::empty(sd::LaunchContext* context) {
+NDArray NDArrayFactory::empty(LaunchContext* context) {
   return empty(DataTypeUtils::fromT<T>(), context);
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT NDArray NDArrayFactory::empty, (sd::LaunchContext * context),
                       SD_COMMON_TYPES_ALL);
 
 ////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::empty(sd::DataType dataType, sd::LaunchContext* context) {
+NDArray NDArrayFactory::empty(DataType dataType, LaunchContext* context) {
   auto shapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, context->getWorkspace());
   ArrayOptions::setPropertyBit(shapeInfo, ARRAY_EMPTY);
   NDArray result(nullptr, shapeInfo, context, false);
@@ -603,34 +589,35 @@ NDArray NDArrayFactory::empty(sd::DataType dataType, sd::LaunchContext* context)
 }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::valueOf(const std::vector<sd::LongType>& shape, const NDArray& value, const char order,
-                                 sd::LaunchContext* context) {
-  auto res = NDArrayFactory::create_(order, shape, value.dataType(), context);
+NDArray* NDArrayFactory::valueOf(const std::vector<LongType>& shape, const NDArray& value, const char order,
+                                 LaunchContext* context) {
+  auto res = create_(order, shape, value.dataType(), context);
   res->assign(const_cast<NDArray&>(value));
   return res;
 }
 
 ////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::create_(const char order, const std::vector<sd::LongType>& shape, sd::DataType dataType,
-                                 sd::LaunchContext* context) {
+NDArray* NDArrayFactory::create_(const char order, const std::vector<LongType>& shape, DataType dataType,
+                                 LaunchContext* context) {
   return new NDArray(order, shape, dataType, context);
 }
 
 ////////////////////////////////////////////////////////////////////////
 template <typename T>
-NDArray NDArrayFactory::create(T* buffer, const char order, const std::initializer_list<sd::LongType>& shape,
-                               sd::LaunchContext* context) {
+NDArray NDArrayFactory::create(T* buffer, const char order, const std::initializer_list<LongType>& shape,
+                               LaunchContext* context) {
   if ((int)shape.size() > SD_MAX_RANK)
     THROW_EXCEPTION("NDArrayFactory::create: Rank of NDArray can't exceed 32");
 
-  std::vector<sd::LongType> shp(shape);
+  std::vector<LongType> shp(shape);
   ShapeDescriptor *descriptor = new ShapeDescriptor(DataTypeUtils::fromT<T>(), order, shp);
 
-  std::shared_ptr<DataBuffer> pBuffer = std::make_shared<DataBuffer>(
+  DataBuffer *  pBuffer = new DataBuffer(
       buffer, descriptor->arrLength() * sizeof(T), descriptor->dataType(), false, context->getWorkspace());
 
   NDArray result(pBuffer, descriptor, context);
-  delete descriptor;
+ // Note we used to delete descriptor here but due to double deletions we avoid that due to reuse in the Constant
+ // ShapeHelpoer
   return result;
 }
 
@@ -657,197 +644,197 @@ TMPL_INSTANTIATE_CREATE_H(bool)
 
 
 /////////////////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const char16_t* u16string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const char16_t* u16string, DataType dtype, LaunchContext* context) {
   return NDArray(u16string, dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const char16_t* u16string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const char16_t* u16string, DataType dtype, LaunchContext* context) {
   return string_(std::u16string(u16string), dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::u16string& u16string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::u16string& u16string, DataType dtype, LaunchContext* context) {
   auto res = new NDArray();
   *res = NDArray(u16string, dtype, context);
   return res;
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::u16string& u16string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::u16string& u16string, DataType dtype, LaunchContext* context) {
   return NDArray(u16string, dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const char32_t* u32string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const char32_t* u32string, DataType dtype, LaunchContext* context) {
   return NDArray(u32string, dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const char32_t* u32string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const char32_t* u32string, DataType dtype, LaunchContext* context) {
   return string_(std::u32string(u32string), dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::u32string& u32string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::u32string& u32string, DataType dtype, LaunchContext* context) {
   auto res = new NDArray();
   *res = NDArray(u32string, dtype, context);
   return res;
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::u32string& u32string, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::u32string& u32string, DataType dtype, LaunchContext* context) {
   return NDArray(u32string, dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const char* str, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const char* str, DataType dtype, LaunchContext* context) {
   return NDArray(str, dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const char* str, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const char* str, DataType dtype, LaunchContext* context) {
   return string_(std::string(str), dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::string& str, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::string& str, DataType dtype, LaunchContext* context) {
   auto res = new NDArray();
   *res = NDArray(str, dtype, context);
   return res;
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::string& str, sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::string& str, DataType dtype, LaunchContext* context) {
   return NDArray(str, dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape, const std::vector<const char*>& strings,
-                               sd::DataType dataType, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape, const std::vector<const char*>& strings,
+                               DataType dataType, LaunchContext* context) {
   return NDArray(shape, strings, dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape, const std::vector<const char*>& strings,
-                                 sd::DataType dataType, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape, const std::vector<const char*>& strings,
+                                 DataType dataType, LaunchContext* context) {
   std::vector<std::string> vec(strings.size());
   int cnt = 0;
   for (auto s : strings) vec[cnt++] = std::string(s);
 
-  return NDArrayFactory::string_(shape, vec, dataType, context);
+  return string_(shape, vec, dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape, const std::vector<std::string>& string,
-                               sd::DataType dataType, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape, const std::vector<std::string>& string,
+                               DataType dataType, LaunchContext* context) {
   return NDArray(shape, string, dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape, const std::vector<std::string>& string,
-                                 sd::DataType dataType, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape, const std::vector<std::string>& string,
+                                 DataType dataType, LaunchContext* context) {
   auto res = new NDArray();
   *res = NDArray(shape, string, dataType, context);
   return res;
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape,
-                               const std::initializer_list<const char16_t*>& strings, sd::DataType dataType,
-                               sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape,
+                               const std::initializer_list<const char16_t*>& strings, DataType dataType,
+                               LaunchContext* context) {
   return NDArray(shape, std::vector<const char16_t*>(strings), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape, const std::vector<const char16_t*>& strings,
-                               sd::DataType dataType, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape, const std::vector<const char16_t*>& strings,
+                               DataType dataType, LaunchContext* context) {
   return NDArray(shape, strings, dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape,
-                               const std::initializer_list<std::u16string>& string, sd::DataType dataType,
-                               sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape,
+                               const std::initializer_list<std::u16string>& string,
+                               DataType dataType, LaunchContext* context) {
   return NDArray(shape, std::vector<std::u16string>(string), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape,
-                                 const std::initializer_list<const char16_t*>& strings, sd::DataType dataType,
-                                 sd::LaunchContext* context) {
-  return NDArrayFactory::string_(shape, std::vector<const char16_t*>(strings), dataType, context);
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape,
+                                 const std::initializer_list<const char16_t*>& strings, DataType dataType,
+                                 LaunchContext* context) {
+  return string_(shape, std::vector<const char16_t*>(strings), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape, const std::vector<const char16_t*>& strings,
-                                 sd::DataType dataType, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape, const std::vector<const char16_t*>& strings,
+                                 DataType dataType, LaunchContext* context) {
   std::vector<std::u16string> vec(strings.size());
   int cnt = 0;
   for (auto s : strings) vec[cnt++] = std::u16string(s);
 
-  return NDArrayFactory::string_(shape, vec, dataType, context);
+  return string_(shape, vec, dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape,
-                                 const std::initializer_list<std::u16string>& string, sd::DataType dataType,
-                                 sd::LaunchContext* context) {
-  return NDArrayFactory::string_(shape, std::vector<std::u16string>(string), dataType, context);
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape,
+                                 const std::initializer_list<std::u16string>& string, DataType dataType,
+                                 LaunchContext* context) {
+  return string_(shape, std::vector<std::u16string>(string), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape, const std::vector<std::u16string>& string,
-                                 sd::DataType dataType, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape, const std::vector<std::u16string>& string,
+                                 DataType dataType, LaunchContext* context) {
   auto res = new NDArray();
   *res = NDArray(shape, string, dataType, context);
   return res;
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape, const std::vector<std::u16string>& string,
-                               sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape, const std::vector<std::u16string>& string,
+                               DataType dtype, LaunchContext* context) {
   return NDArray(shape, string, dtype, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape,
-                               const std::initializer_list<const char32_t*>& strings, sd::DataType dataType,
-                               sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape,
+                               const std::initializer_list<const char32_t*>& strings, DataType dataType,
+                               LaunchContext* context) {
   return NDArray(shape, std::vector<const char32_t*>(strings), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape, const std::vector<const char32_t*>& strings,
-                               sd::DataType dataType, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape, const std::vector<const char32_t*>& strings,
+                               DataType dataType, LaunchContext* context) {
   return NDArray(shape, strings, dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape,
-                               const std::initializer_list<std::u32string>& string, sd::DataType dataType,
-                               sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape,
+                               const std::initializer_list<std::u32string>& string,
+                               DataType dataType, LaunchContext* context) {
   return NDArray(shape, std::vector<std::u32string>(string), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape,
-                                 const std::initializer_list<const char32_t*>& strings, sd::DataType dataType,
-                                 sd::LaunchContext* context) {
-  return NDArrayFactory::string_(shape, std::vector<const char32_t*>(strings), dataType, context);
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape,
+                                 const std::initializer_list<const char32_t*>& strings, DataType dataType,
+                                 LaunchContext* context) {
+  return string_(shape, std::vector<const char32_t*>(strings), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape, const std::vector<const char32_t*>& strings,
-                                 sd::DataType dataType, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape, const std::vector<const char32_t*>& strings,
+                                 DataType dataType, LaunchContext* context) {
   std::vector<std::u32string> vec(strings.size());
   int cnt = 0;
   for (auto s : strings) vec[cnt++] = std::u32string(s);
-  return NDArrayFactory::string_(shape, vec, dataType, context);
+  return string_(shape, vec, dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape,
-                                 const std::initializer_list<std::u32string>& string, sd::DataType dataType,
-                                 sd::LaunchContext* context) {
-  return NDArrayFactory::string_(shape, std::vector<std::u32string>(string), dataType, context);
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape,
+                                 const std::initializer_list<std::u32string>& string, DataType dataType,
+                                 LaunchContext* context) {
+  return string_(shape, std::vector<std::u32string>(string), dataType, context);
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray* NDArrayFactory::string_(const std::vector<sd::LongType>& shape, const std::vector<std::u32string>& string,
-                                 sd::DataType dataType, sd::LaunchContext* context) {
+NDArray* NDArrayFactory::string_(const std::vector<LongType>& shape, const std::vector<std::u32string>& string,
+                                 DataType dataType, LaunchContext* context) {
   auto res = new NDArray();
   *res = NDArray(shape, string, dataType, context);
   return res;
 }
 /////////////////////////////////////////////////////////////////////////
-NDArray NDArrayFactory::string(const std::vector<sd::LongType>& shape, const std::vector<std::u32string>& string,
-                               sd::DataType dtype, sd::LaunchContext* context) {
+NDArray NDArrayFactory::string(const std::vector<LongType>& shape, const std::vector<std::u32string>& string,
+                               DataType dtype, LaunchContext* context) {
   return NDArray(shape, string, dtype, context);
 }
 
 NDArray NDArrayFactory::fromNpyFile(const char* fileName) {
-  auto size = sd::graph::getFileSize(fileName);
+  auto size = getFileSize(fileName);
   if (size < 0) THROW_EXCEPTION("File doesn't exit");
 
-  auto pNPY = reinterpret_cast<char*>(::numpyFromFile(std::string(fileName)));
+  auto pNPY = reinterpret_cast<char*>(numpyFromFile(std::string(fileName)));
 
-  auto nBuffer = reinterpret_cast<void*>(::dataPointForNumpy(pNPY));
-  auto shape = reinterpret_cast<sd::LongType*>(::shapeBufferForNumpy(pNPY));
+  auto nBuffer = reinterpret_cast<void*>(dataPointForNumpy(pNPY));
+  auto shape = reinterpret_cast<LongType*>(shapeBufferForNumpy(pNPY));
 
   auto length = shape::length(shape);
   int8_t* buffer = nullptr;
-  sd::memory::Workspace* workspace = nullptr;
+  memory::Workspace* workspace = nullptr;
   auto byteLen = length * DataTypeUtils::sizeOfElement(ArrayOptions::dataType(shape));
 
   ALLOCATE(buffer, workspace, byteLen, int8_t);

--- a/libnd4j/include/array/impl/ResultSet.cpp
+++ b/libnd4j/include/array/impl/ResultSet.cpp
@@ -27,16 +27,16 @@ ResultSet::ResultSet() {
   //
 }
 
-ResultSet::ResultSet(const sd::graph::FlatResult* result) {
+ResultSet::ResultSet(const graph::FlatResult* result) {
   for (int e = 0; e < result->variables()->size(); e++) {
     auto var = result->variables()->Get(e);
 
     NDArray* array;
 
     if (var->ndarray() != nullptr) {
-      array = sd::graph::FlatUtils::fromFlatArray(var->ndarray());
+      array = graph::FlatUtils::fromFlatArray(var->ndarray());
     } else if (var->shape() != nullptr) {
-      std::vector<sd::LongType> shapeInfo;
+      std::vector<LongType> shapeInfo;
       for (int i = 0; i < var->shape()->size(); i++) {
         shapeInfo.emplace_back(var->shape()->Get(i));
       }
@@ -44,7 +44,7 @@ ResultSet::ResultSet(const sd::graph::FlatResult* result) {
       // we just create empty array here
       int s0 = shapeInfo.at(0);
 
-      std::vector<sd::LongType> shape;
+      std::vector<LongType> shape;
       for (int i = 0; i < s0; i++) {
         shape.emplace_back(shapeInfo.at(i + 1));
       }
@@ -107,7 +107,7 @@ ResultSet& ResultSet::operator=(const ResultSet& other) noexcept {
 
 void ResultSet::delContent() {
   if (_removable) {
-    std::vector<std::shared_ptr<DataBuffer>> deleted;
+    std::vector<DataBuffer *> deleted;
     for (auto v : _content) {
       auto buffer = v->dataBuffer();
       deleted.push_back(buffer);
@@ -120,19 +120,27 @@ void ResultSet::delContent() {
 
 ResultSet::~ResultSet() { delContent(); }
 
+void ResultSet::printIndexedBuffers() {
+  for (int e = 0; e < _content.size(); e++) {
+    auto array = _content.at(e);
+    auto strVal = "Array e: " + std::to_string(e) + " is: ";
+    array->printIndexedBuffer(strVal.c_str());
+  }
+
+}
 void ResultSet::setNonRemovable() { _removable = false; }
 
 int ResultSet::size() { return (int)_content.size(); }
 
-sd::NDArray* ResultSet::at(const unsigned long idx) const { return _content.at(idx); }
+NDArray* ResultSet::at(const unsigned long idx) const { return _content.at(idx); }
 
-sd::NDArray* ResultSet::operator[](const unsigned long idx) const { return _content[idx]; }
+NDArray* ResultSet::operator[](const unsigned long idx) const { return _content[idx]; }
 
-void ResultSet::push_back(sd::NDArray* array) { _content.emplace_back(array); }
+void ResultSet::push_back(NDArray* array) { _content.emplace_back(array); }
 
-sd::Status ResultSet::status() { return _status; }
+Status ResultSet::status() { return _status; }
 
-void ResultSet::setStatus(sd::Status status) { _status = status; }
+void ResultSet::setStatus(Status status) { _status = status; }
 
 void ResultSet::purge() { _content.clear(); }
 }  // namespace sd

--- a/libnd4j/include/helpers/TAD.h
+++ b/libnd4j/include/helpers/TAD.h
@@ -107,7 +107,7 @@ class TAD {
                                                           const long long int *rearrange,
                                                           sd::LongType *out);
 
-  SD_INLINE SD_HOST_DEVICE sd::LongType *permuteShapeBuffer(sd::LongType const *shapeBuffer, long long int *rearrange);
+  SD_INLINE SD_HOST_DEVICE sd::LongType *permuteShapeBuffer(sd::LongType const *shapeBuffer, sd::LongType *rearrange);
 
   SD_INLINE SD_HOST_DEVICE void createTadOnlyShapeInfo();
 
@@ -212,18 +212,16 @@ SD_INLINE void TAD::initWithExternalTAD(sd::LongType *existingTAD, sd::LongType 
   this->dimension = dimension;
   this->dimensionLength = dimensionLength;
 
-  this->tadShape = shape::shapeOf(existingTAD);
-  this->tadStride = shape::stride(existingTAD);
+  this->tadShape = shapeOf(existingTAD);
+  this->tadStride = stride(existingTAD);
 
-  sd::LongType ews = shape::elementWiseStride(originalShape);
+  sd::LongType ews = elementWiseStride(originalShape);
 
-  this->numTads =
-      shape::length(originalShape) /
-      shape::length(
+  this->numTads = length(originalShape) / length(
           existingTAD);
   this->wholeThing =
       this->numTads == 1 ||
-      ((this->dimensionLength == this->rank || this->numTads == shape::length(this->shapeInfo)) && ews == 1);
+      ((this->dimensionLength == this->rank || this->numTads == length(this->shapeInfo)) && ews == 1);
 }
 
 SD_INLINE void TAD::init(int tadIndex, sd::LongType const *shapeInfo, const long long int *dimension,
@@ -244,26 +242,26 @@ SD_INLINE void TAD::init(sd::LongType const *shapeInfo, const long long int *dim
   this->numTads =
       dimensionLength == 0 ? 1 : this->tensorsAlongDimension(this->shapeInfo, this->dimension, this->dimensionLength);
 
-  sd::LongType ews = shape::elementWiseStride(shapeInfo);
+  sd::LongType ews = elementWiseStride(shapeInfo);
 
   if (dimensionLength == 0) {
     wholeThing = true;
-  } else if (!shape::isVector(shapeInfo)) {
+  } else if (!isVector(shapeInfo)) {
     wholeThing = this->numTads == 1  // if number of TADs is 1, we just have input shape == TAD shape
                  ||
                  ((this->dimensionLength == this->rank  // if number of dimensions is the same as input rank, that'll be
                                                         // wholeTad too, but only if EWS==1 (aka - not a View)
-                   || (this->numTads == shape::length(shapeInfo) &&
-                       shape::order(shapeInfo) == 'c'))  // OR  number of tads equals to shapeInfo length AND input is
+                   || (this->numTads == length(shapeInfo) &&
+                          order(shapeInfo) == 'c'))  // OR  number of tads equals to shapeInfo length AND input is
                                                          // in C order. if order is F - we'll have to calculate offsets
                   && ews == 1);                          // as mentioned above - last 2 rules apply only to non-views
-  } else if (shape::isScalar(shapeInfo)) {
+  } else if (isScalar(shapeInfo)) {
     wholeThing = true;
     // vector case
   } else {
     // if(dimensionLength == 1 && shape::shapeOf(shapeInfo)[dimension[0]] == 1) {
     // if(dimension == 0 && ) {
-    if (dimensionLength != 0 && dimension != nullptr && shape::shapeOf(shapeInfo)[dimension[0]] == 1) {
+    if (dimensionLength != 0 && dimension != nullptr && shapeOf(shapeInfo)[dimension[0]] == 1) {
       wholeThing = true;
     }
   }
@@ -272,7 +270,7 @@ SD_INLINE void TAD::init(sd::LongType const *shapeInfo, const long long int *dim
 template <typename T>
 SD_INLINE void TAD::printTADsND(T *x) {
   if (wholeThing) {
-    for (int i = 0; i < shape::length(tadOnlyShapeInfo); i++) {
+    for (int i = 0; i < length(tadOnlyShapeInfo); i++) {
       printf(" %f ", x[i]);
     }
     printf("\n");
@@ -285,8 +283,7 @@ SD_INLINE void TAD::printTADsND(T *x) {
       int rankIter = shape::rank(tadOnlyShapeInfo);
       sd::LongType xStridesIter[SD_MAX_RANK];
       T *xPointer = x + offset;
-      if (PrepareOneRawArrayIter<T>(rankIter, shape::shapeOf(tadOnlyShapeInfo), xPointer,
-                                    shape::stride(tadOnlyShapeInfo), &rankIter, shapeIter, &xPointer,
+      if (PrepareOneRawArrayIter<T>(rankIter, shapeOf(tadOnlyShapeInfo), xPointer, stride(tadOnlyShapeInfo), &rankIter, shapeIter, &xPointer,
                                     xStridesIter) >= 0) {
         ND4J_RAW_ITER_START(dim, shape::rank(tadOnlyShapeInfo), coord, shapeIter);
         {
@@ -303,20 +300,20 @@ SD_INLINE void TAD::printTADsND(T *x) {
   }
 }
 
-SD_INLINE void TAD::permuteShapeBufferInPlace(sd::LongType const *shapeBuffer, const long long int *rearrange,
+SD_INLINE void TAD::permuteShapeBufferInPlace(sd::LongType const *shapeBuffer, const sd::LongType *rearrange,
                                               sd::LongType *out) {
-  memcpy(out, shapeBuffer, sizeof(sd::LongType) * shape::shapeInfoLength(this->rank));
+  memcpy(out, shapeBuffer, sizeof(sd::LongType) * shapeInfoLength(this->rank));
   doPermuteShapeInfo(out, rearrange);
 }
 
-SD_INLINE sd::LongType *TAD::permuteShapeBuffer(sd::LongType const *shapeBuffer, long long int *rearrange) {
-  int len = shape::shapeInfoLength(this->rank);
-  sd::LongType *copy = shape::copyOf(len, shapeBuffer);
+SD_INLINE sd::LongType *TAD::permuteShapeBuffer(sd::LongType const *shapeBuffer, sd::LongType *rearrange) {
+  int len = shapeInfoLength(this->rank);
+  sd::LongType *copy = copyOf(len, shapeBuffer);
   doPermuteShapeInfo(copy, rearrange);
   return copy;
 }
 
-SD_INLINE bool TAD::dimensionsDescending(int rank, const long long int *dimensions, int length) {
+SD_INLINE bool TAD::dimensionsDescending(int rank, const sd::LongType *dimensions, int length) {
   int desired = rank - 1;
   for (int e = length - 1; e >= 0; e--) {
     if (dimensions[e] != desired--) return false;
@@ -329,35 +326,35 @@ SD_INLINE void TAD::createTadOnlyShapeInfo() {
   sd::ArrayOptions::setDataType(this->tadOnlyShapeInfo, sd::ArrayOptions::dataType(this->originalShapeInfo));
 
   // possible optimization goes here
-  if (shape::order(this->originalShapeInfo) == 'c' && shape::strideDescendingCAscendingF(this->originalShapeInfo) &&
+  if (order(this->originalShapeInfo) == 'c' && strideDescendingCAscendingF(this->originalShapeInfo) &&
       dimensionsDescending(shape::rank(this->originalShapeInfo), this->originalDimension,
                            this->originalDimensionLength)) {
     // for C order, if outer dimensions are used, continuous layout is preserved
-    this->tadOnlyShapeInfo[shape::shapeInfoLength(this->tadOnlyShapeInfo) - 2] =
-        this->originalShapeInfo[shape::shapeInfoLength(this->originalShapeInfo) - 2];
+    this->tadOnlyShapeInfo[shapeInfoLength(this->tadOnlyShapeInfo) - 2] =
+        this->originalShapeInfo[shapeInfoLength(this->originalShapeInfo) - 2];
   }
 
   // do not swap order if positive elementwise stride preserved
-  if (shape::elementWiseStride(this->tadOnlyShapeInfo) >= 1) {
-    this->tadOnlyShapeInfo[shape::shapeInfoLength(this->tadOnlyShapeInfo) - 1] = shape::order(this->originalShapeInfo);
+  if (elementWiseStride(this->tadOnlyShapeInfo) >= 1) {
+    this->tadOnlyShapeInfo[shapeInfoLength(this->tadOnlyShapeInfo) - 1] = order(this->originalShapeInfo);
   }
 
-  if (this->tadShape != nullptr) delete[] this->tadShape;
+//  if (this->tadShape != nullptr) delete[] this->tadShape;
 
-  this->tadShape = shape::shapeOf(this->tadOnlyShapeInfo);
-  this->tadStride = shape::stride(this->tadOnlyShapeInfo);
+  this->tadShape = shapeOf(this->tadOnlyShapeInfo);
+  this->tadStride = stride(this->tadOnlyShapeInfo);
 }
 
 SD_INLINE sd::LongType TAD::lengthPerSlice(sd::LongType const *shapeBuffer) {
   int dimension = 0;
-  sd::LongType *remove = shape::removeIndex(shape::shapeOf(shapeBuffer), &dimension, shape::rank(shapeBuffer), 1);
-  sd::LongType prod = shape::prodLong(remove, shape::rank(shapeBuffer) - 1);
+  sd::LongType *remove = removeIndex(shapeOf(shapeBuffer), &dimension, shape::rank(shapeBuffer), 1);
+  sd::LongType prod = prodLong(remove, shape::rank(shapeBuffer) - 1);
   delete[] remove;
   return prod;
 }
 
 SD_INLINE sd::LongType *TAD::tad2Sub(sd::LongType index) {
-  sd::LongType *shape = shape::shapeOf(shapeInfo);
+  sd::LongType *shape = shapeOf(shapeInfo);
   int rank = shape::rank(shapeInfo);
   int leftOverIndexLen = rank - originalDimensionLength;
 
@@ -370,7 +367,7 @@ SD_INLINE sd::LongType *TAD::tad2Sub(sd::LongType index) {
   // indexes not specified in the tad indexes
 
   // every coordinate starts as zero
-  memset(ret, 0, shape::shapeInfoByteLength(rank));
+  memset(ret, 0, shapeInfoByteLength(rank));
 
   // find the length of the elements we
   // are iterating over
@@ -402,10 +399,7 @@ SD_INLINE sd::LongType *TAD::tad2Sub(sd::LongType index) {
   }
 
   // sub for indices
-  /* int *sub = new int[leftOverIndexLen];
-   shape::ind2subOrder(tadShape,index,len,sub);
-  */
-  shape::index2coords(index, leftOverIndexLen, tadShape, sub);
+  index2coords(index, leftOverIndexLen, tadShape, sub);
 
   for (int i = 0; i < leftOverIndexLen; i++) {
     ret[leftOverIndexes[i]] = sub[i];
@@ -481,22 +475,22 @@ SD_INLINE sd::LongType TAD::tadOffset(sd::LongType index) {
   if (dimensionLength > 1) {
     sd::LongType *tad2Sub = this->tad2Sub(index, ptrManager);
 
-    sd::LongType ret = shape::getOffset(shapeInfo, tad2Sub);
+    sd::LongType ret = getOffset(shapeInfo, tad2Sub);
 
     if (ret < 0) {
-      if (ptrManager == nullptr) delete[] tad2Sub;
+   //   if (ptrManager == nullptr) delete[] tad2Sub;
       return -1;
     }
-    if (ptrManager == nullptr) delete[] tad2Sub;
+   // if (ptrManager == nullptr) delete[] tad2Sub;
 
     return ret;
 
   } else {
     sd::LongType *tad2Sub = this->tad2Sub(index, ptrManager);
 
-    sd::LongType ret = shape::getOffset(shapeInfo, tad2Sub);
+    sd::LongType ret = getOffset(shapeInfo, tad2Sub);
 
-    if (ptrManager == nullptr) delete[] tad2Sub;
+ //   if (ptrManager == nullptr) delete[] tad2Sub;
 
     return ret;
   }
@@ -505,15 +499,15 @@ SD_INLINE sd::LongType TAD::tadOffset(sd::LongType index) {
 SD_INLINE sd::LongType *TAD::tensorShape() {
   if (this->tadShape != nullptr) return this->tadShape;
 
-  sd::LongType *theShape = shape::shapeOf(shapeInfo);
-  sd::LongType *tensorShape = shape::keep(theShape, this->dimension, dimensionLength, shape::rank(shapeInfo));
+  sd::LongType *theShape = shapeOf(shapeInfo);
+  sd::LongType *tensorShape = keep(theShape, this->dimension, dimensionLength, shape::rank(shapeInfo));
   this->tadShape = tensorShape;
   this->tadRank = dimensionLength;
   return tensorShape;
 }
 
 SD_INLINE sd::LongType *TAD::tad2Sub(sd::LongType index, void *ptrManager) {
-  auto shape = shape::shapeOf(shapeInfo);
+  auto shape = shapeOf(shapeInfo);
   int rank = shape::rank(shapeInfo);
   int leftOverIndexLen = rank - originalDimensionLength;
   sd::LongType *tadShape;
@@ -562,7 +556,7 @@ SD_INLINE sd::LongType *TAD::tad2Sub(sd::LongType index, void *ptrManager) {
   }
 
   // sub for indices
-  shape::index2coords(index, leftOverIndexLen, tadShape, sub);
+  index2coords(index, leftOverIndexLen, tadShape, sub);
 
   for (int i = 0; i < leftOverIndexLen; i++) {
     ret[leftOverIndexes[i]] = sub[i];
@@ -587,57 +581,56 @@ SD_INLINE void TAD::createOffsets() {
 SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
 
   // ensure tad shapes get setup right for vectors
-  if (dimensionLength > 1 && shape::isVector(shapeInfo))
-    return shape::copyOf(shape::shapeInfoLength(shape::rank(shapeInfo)), shapeInfo);
+  if (dimensionLength > 1 && isVector(shapeInfo))
+    return copyOf(shapeInfoLength(shape::rank(shapeInfo)), shapeInfo);
 
   // case when tad coincides with whole array
   if (this->numTads == 1 &&
       ((shape::rank(originalShapeInfo) == originalDimensionLength) || originalDimensionLength == 0)) {
     // we might have special case here: skipped dimensions might be just full of ones
-    sd::LongType *ret = shape::copyOf(shape::shapeInfoLength(shape::rank(shapeInfo)), shapeInfo);
+    sd::LongType *ret = copyOf(shapeInfoLength(shape::rank(shapeInfo)), shapeInfo);
     if (shape::isDimPermuted<sd::LongType >(dimension, (sd::LongType)dimensionLength))  // check whether we need permutation
       doPermuteShapeInfo(ret, dimension);
 
     return ret;
   }
 
-  sd::LongType *theShape = shape::shapeOf(shapeInfo);
+  sd::LongType *theShape = shapeOf(shapeInfo);
   int rank = shape::rank(shapeInfo);
 
   if (dimensionLength == 1) {
-    if (dimension[0] == 0 && shape::isVector(shapeInfo) && theShape[1] == 1) {
+    if (dimension[0] == 0 && isVector(shapeInfo) && theShape[1] == 1) {
       sd::LongType permuted[2] = {1, 0};
       sd::LongType *permutedRet2 = shape::permuteShapeBuffer(shapeInfo, permuted);
       return permutedRet2;
-    } else if (dimension[0] == 1 && shape::isVector(shapeInfo) && theShape[0] == 1) {
-      sd::LongType *ret = shape::copyOf(shape::shapeInfoLength(shape::rank(shapeInfo)), shapeInfo);
+    } else if (dimension[0] == 1 && isVector(shapeInfo) && theShape[0] == 1) {
+      sd::LongType *ret = copyOf(shapeInfoLength(shape::rank(shapeInfo)), shapeInfo);
       return ret;
-    } else if (shape::shapeOf(shapeInfo)[dimension[0]] == 1) {
-      sd::LongType *scalarInfo = shape::createScalarShapeInfo();
-      scalarInfo[shape::shapeInfoLength(shape::rank(scalarInfo)) - 3] = this->tadIndex;
+    } else if (shapeOf(shapeInfo)[dimension[0]] == 1) {
+      sd::LongType *scalarInfo = createScalarShapeInfo();
+      scalarInfo[shapeInfoLength(shape::rank(scalarInfo)) - 3] = this->tadIndex;
       return scalarInfo;
     }
   }
 
   sd::LongType *tensorShape = this->tensorShape();
-  sd::LongType *reverseDimensions = shape::reverseCopy(dimension, dimensionLength);
+  sd::LongType *reverseDimensions = reverseCopy(dimension, dimensionLength);
   sd::LongType  *rankRange = shape::range<sd::LongType >(0, rank);
   sd::LongType  *remove = shape::removeIndex<sd::LongType >(rankRange, dimension, (sd::LongType)rank, (sd::LongType)dimensionLength);
   // concat is wrong here with the length
-  sd::LongType *newPermuteDims = shape::concat(remove, rank - dimensionLength, reverseDimensions, dimensionLength);
+  sd::LongType *newPermuteDims = concat(remove, rank - dimensionLength, reverseDimensions, dimensionLength);
 
   sd::LongType *permuted = shape::permuteShapeBuffer(shapeInfo, newPermuteDims);
 
-  sd::LongType sliceIndex =
-      shape::sliceOffsetForTensor(shape::rank(permuted), this->tadIndex, shape::shapeOf(shapeInfo), tensorShape,
+  sd::LongType sliceIndex = sliceOffsetForTensor(shape::rank(permuted), this->tadIndex, shapeOf(shapeInfo), tensorShape,
                                   dimensionLength, dimension, dimensionLength);
 
-  sd::LongType *ret2 = shape::sliceOfShapeBuffer(sliceIndex, permuted);
-  sd::LongType tensorLength = shape::prodLong(tensorShape, tadRank);
+  sd::LongType *ret2 = sliceOfShapeBuffer(sliceIndex, permuted);
+  sd::LongType tensorLength = prodLong(tensorShape, tadRank);
 
-  sd::LongType compLength = shape::isVector(ret2) ? shape::length(ret2) : shape::prodLong(tensorShape, tadRank);
-  if (dimensionLength == tadRank && compLength == shape::length(ret2)) {
-    if (dimensionLength == 1 && shape::isVector(ret2) && shape::shapeOf(ret2)[0] == 1) {
+  sd::LongType compLength = isVector(ret2) ? length(ret2) : prodLong(tensorShape, tadRank);
+  if (dimensionLength == tadRank && compLength == length(ret2)) {
+    if (dimensionLength == 1 && isVector(ret2) && shapeOf(ret2)[0] == 1) {
       // go to the bottom and return ret2 after proper freeing of pointers
       // basic idea; we *don't* permute row vectors
     } else if (dimensionLength > 1) {
@@ -648,7 +641,7 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
         finalPermuteDims[forward++] = i;
       }
       shape::permuteShapeBufferInPlace(ret2, finalPermuteDims, ret2);
-      delete[] finalPermuteDims;
+     // delete[] finalPermuteDims;
     }
 
   } else {
@@ -660,7 +653,7 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
 
     sd::LongType offset = tadIndex * tensorLength / lengthPerSlice;
     if (sliceIndex == 0 && length == lengthPerSlice) {
-      sd::LongType *newRet2 = shape::sliceOfShapeBuffer(offset, ret2);
+      sd::LongType *newRet2 = sliceOfShapeBuffer(offset, ret2);
       delete[] ret2;
       ret2 = newRet2;
       sd::LongType  *finalPermuteDims = new sd::LongType [shape::rank(ret2)];
@@ -669,19 +662,19 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
         finalPermuteDims[forward++] = i;
       }
       // bool isRowVector2 = shape::isRowVector(ret2) && !isLikeVector;
-      bool isRowVector2 = shape::isRowVector(ret2);
+      bool isRowVector2 = isRowVector(ret2);
       if (isRowVector2 == false) {
         shape::permuteShapeBufferInPlace(ret2, finalPermuteDims, ret2);
       }
 
-      delete[] finalPermuteDims;
+     // delete[] finalPermuteDims;
 
     } else if (length == lengthPerSlice) {
-      offset -= shape::slices(ret2) * (offset / shape::slices(ret2));
-      sd::LongType *newRet2 = shape::sliceOfShapeBuffer(offset, ret2);
+      offset -= slices(ret2) * (offset / slices(ret2));
+      sd::LongType *newRet2 = sliceOfShapeBuffer(offset, ret2);
       delete[] ret2;
       ret2 = newRet2;
-      if (dimensionLength == 1 && shape::isVector(ret2) && shape::shapeOf(ret2)[0] == 1) {
+      if (dimensionLength == 1 && isVector(ret2) && shapeOf(ret2)[0] == 1) {
         // go to the bottom and return ret2 after proper freeing of pointers
         // basic idea; we *don't* permute row vectors
       } else {
@@ -691,8 +684,8 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
           finalPermuteDims[forward++] = i;
         }
         sd::LongType *newRet = shape::permuteShapeBuffer(ret2, finalPermuteDims);
-        delete[] ret2;
-        delete[] finalPermuteDims;
+      //  delete[] ret2;
+       // delete[] finalPermuteDims;
         ret2 = newRet;
       }
 
@@ -702,14 +695,14 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
       while (shape::length(ret2) > length) {
         auto lengthPerSlice2 = this->lengthPerSlice(ret2);
         sliceIndex = sliceOffsetForTensor(sliceIndex, shape::length(ret2), lengthPerSlice2);
-        sliceIndex -= shape::slices(ret2) * (sliceIndex / shape::slices(ret2));
-        auto newRet2 = shape::sliceOfShapeBuffer(sliceIndex, ret2);
-        delete[] ret2;
+        sliceIndex -= slices(ret2) * (sliceIndex / slices(ret2));
+        auto newRet2 = sliceOfShapeBuffer(sliceIndex, ret2);
+       // delete[] ret2;
         ret2 = newRet2;
       }
 
       // don't permute on a row vector
-      if (dimensionLength == 1 && shape::isVector(ret2) && shape::shapeOf(ret2)[0] == 1) {
+      if (dimensionLength == 1 && isVector(ret2) && shapeOf(ret2)[0] == 1) {
         // go to the bottom and return ret2 after proper freeing of pointers
         // basic idea; we *don't* permute row vectors
       } else if (dimensionLength > 1) {
@@ -727,23 +720,23 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
     }
   }
 
-  delete[] permuted;
-  delete[] newPermuteDims;
-  delete[] rankRange;
-  delete[] remove;
-  delete[] reverseDimensions;
+ // delete[] permuted;
+ // delete[] newPermuteDims;
+ // delete[] rankRange;
+//  delete[] remove;
+//  delete[] reverseDimensions;
   return ret2;
 }
 
 SD_INLINE sd::LongType TAD::tadLength(sd::LongType const *shapeInfo, const sd::LongType *dimension,
                                       sd::LongType dimensionLength) {
   if (dimensionLength == 1) {
-    return shape::shapeOf(shapeInfo)[dimension[0]];
+    return shapeOf(shapeInfo)[dimension[0]];
   } else {
     sd::LongType ret = 1;
     for (int i = 0; i < shape::rank(shapeInfo); i++) {
       for (int j = 0; j < dimensionLength; j++) {
-        if (i == dimension[j]) ret *= shape::shapeOf(shapeInfo)[dimension[j]];
+        if (i == dimension[j]) ret *= shapeOf(shapeInfo)[dimension[j]];
       }
     }
     return ret;
@@ -752,11 +745,11 @@ SD_INLINE sd::LongType TAD::tadLength(sd::LongType const *shapeInfo, const sd::L
 
 SD_INLINE sd::LongType TAD::tensorsAlongDimension(sd::LongType const *shapeInfo, const sd::LongType *dimension,
                                                   sd::LongType dimensionLength) {
-  return shape::length(shapeInfo) / this->tadLength(shapeInfo, dimension, dimensionLength);
+  return length(shapeInfo) / this->tadLength(shapeInfo, dimension, dimensionLength);
 }
 
 SD_INLINE void TAD::collapse() {
-  auto shape = shape::shapeOf(shapeInfo);
+  auto shape = shapeOf(shapeInfo);
   // handle negative dimensions/backwards indexing
   for (int i = 0; i < dimensionLength; i++) {
     if ((dimension)[i] < 0) (dimension)[i] += shape::rank(this->shapeInfo);
@@ -821,8 +814,7 @@ SD_INLINE void TAD::collapse() {
       dimension[0] = -1;
       break;
     }
-    // captures intermediary result from the for loop
-    traceNew(3);
+
 
     int intermediaryResult[SD_MAX_RANK];
     for (int i = 0; i < dimensionLength; i++) {

--- a/libnd4j/include/helpers/TAD.h
+++ b/libnd4j/include/helpers/TAD.h
@@ -339,7 +339,7 @@ SD_INLINE void TAD::createTadOnlyShapeInfo() {
     this->tadOnlyShapeInfo[shapeInfoLength(this->tadOnlyShapeInfo) - 1] = order(this->originalShapeInfo);
   }
 
-//  if (this->tadShape != nullptr) delete[] this->tadShape;
+  if (this->tadShape != nullptr) delete[] this->tadShape;
 
   this->tadShape = shapeOf(this->tadOnlyShapeInfo);
   this->tadStride = stride(this->tadOnlyShapeInfo);
@@ -478,10 +478,10 @@ SD_INLINE sd::LongType TAD::tadOffset(sd::LongType index) {
     sd::LongType ret = getOffset(shapeInfo, tad2Sub);
 
     if (ret < 0) {
-   //   if (ptrManager == nullptr) delete[] tad2Sub;
+     if (ptrManager == nullptr) delete[] tad2Sub;
       return -1;
     }
-   // if (ptrManager == nullptr) delete[] tad2Sub;
+   if (ptrManager == nullptr) delete[] tad2Sub;
 
     return ret;
 
@@ -490,7 +490,7 @@ SD_INLINE sd::LongType TAD::tadOffset(sd::LongType index) {
 
     sd::LongType ret = getOffset(shapeInfo, tad2Sub);
 
- //   if (ptrManager == nullptr) delete[] tad2Sub;
+    if (ptrManager == nullptr) delete[] tad2Sub;
 
     return ret;
   }
@@ -641,7 +641,7 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
         finalPermuteDims[forward++] = i;
       }
       shape::permuteShapeBufferInPlace(ret2, finalPermuteDims, ret2);
-     // delete[] finalPermuteDims;
+      delete[] finalPermuteDims;
     }
 
   } else {
@@ -667,7 +667,7 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
         shape::permuteShapeBufferInPlace(ret2, finalPermuteDims, ret2);
       }
 
-     // delete[] finalPermuteDims;
+      delete[] finalPermuteDims;
 
     } else if (length == lengthPerSlice) {
       offset -= slices(ret2) * (offset / slices(ret2));
@@ -684,8 +684,8 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
           finalPermuteDims[forward++] = i;
         }
         sd::LongType *newRet = shape::permuteShapeBuffer(ret2, finalPermuteDims);
-      //  delete[] ret2;
-       // delete[] finalPermuteDims;
+        delete[] ret2;
+        delete[] finalPermuteDims;
         ret2 = newRet;
       }
 
@@ -697,7 +697,7 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
         sliceIndex = sliceOffsetForTensor(sliceIndex, shape::length(ret2), lengthPerSlice2);
         sliceIndex -= slices(ret2) * (sliceIndex / slices(ret2));
         auto newRet2 = sliceOfShapeBuffer(sliceIndex, ret2);
-       // delete[] ret2;
+        delete[] ret2;
         ret2 = newRet2;
       }
 
@@ -720,11 +720,11 @@ SD_INLINE sd::LongType *TAD::shapeInfoOnlyShapeAndStride() {
     }
   }
 
- // delete[] permuted;
- // delete[] newPermuteDims;
- // delete[] rankRange;
-//  delete[] remove;
-//  delete[] reverseDimensions;
+  delete[] permuted;
+  delete[] newPermuteDims;
+  delete[] rankRange;
+  delete[] remove;
+  delete[] reverseDimensions;
   return ret2;
 }
 
@@ -890,7 +890,7 @@ SD_INLINE void TAD::collapse() {
 
     // converge when there are no singular dimensions specified in the reduce
     done = (!oneEncountered && nonOneEncountered) || hitBeginning;
-    // delete[] intermediaryResult;
+    delete[] intermediaryResult;
   }
 
   // nothing changed but need to collapse dimension

--- a/libnd4j/include/ops/declarable/generic/nn/convo/col2im.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/convo/col2im.cpp
@@ -45,9 +45,9 @@ CUSTOM_OP_IMPL(col2im, 1, 1, false, 0, 9) {
   LongType dX = INT_ARG(7);  // Dilation in width/x dimension
 
   LaunchContext* ctx = block.launchContext();
-  helpers::col2im(*ctx, *x, *z, strideY, strideX, padHeight, padWidth, imgHeight, imgWidth, dY, dX);
+  helpers::col2im(*ctx, x, z, strideY, strideX, padHeight, padWidth, imgHeight, imgWidth, dY, dX);
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 DECLARE_SHAPE_FN(col2im) {
   auto inShape = inputShape->at(0);
@@ -65,7 +65,7 @@ DECLARE_SHAPE_FN(col2im) {
   LongType dX = INT_ARG(7);  // Dilation, width/x dimension
   bool isSameMode = INT_ARG(8) > 0;
 
-  sd::LongType* zShape;
+  LongType* zShape;
   ALLOCATE(zShape, block.getWorkspace(), shape::shapeInfoLength(4), sd::LongType);
 
   zShape[0] = 4;
@@ -84,8 +84,8 @@ DECLARE_SHAPE_FN(col2im) {
 
 DECLARE_TYPES(col2im) {
   getOpDescriptor()
-      ->setAllowedInputTypes(0, DataType::ANY)
-      ->setAllowedOutputTypes(0, DataType::INHERIT)
+      ->setAllowedInputTypes(0, ANY)
+      ->setAllowedOutputTypes(0, INHERIT)
       ->setSameMode(true);
 }
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/avgpool3d.cpp
@@ -61,15 +61,15 @@ CUSTOM_OP_IMPL(avgpool3dnew, 1, 1, false, 0, 14) {
   ConvolutionUtils::getSizesAndIndexesConv3d(isNCDHW, 0, *input, *output, bS, iC, iD, iH, iW, oC, oD, oH, oW, indIOioC,
                                              indIOioD, indWiC, indWoC, indWkD);
 
-  std::vector<sd::LongType> expectedOutputShape =
+  std::vector<LongType> expectedOutputShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, oD, oH, oW, 0, indIOioC, indIOioD, indIOioD + 1, indIOioD + 2});
   REQUIRE_TRUE(output->isSameShape(expectedOutputShape), 0,
                "AVGPOOL3DNEW OP: wrong shape of output array, expected is %s, but got %s instead !",
                ShapeUtils::shapeAsString(expectedOutputShape).c_str(), ShapeUtils::shapeAsString(output).c_str());
 
   if (!isNCDHW) {
-    input = new NDArray(input->permute({0, 4, 1, 2, 3}));    // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-    output = new NDArray(output->permute({0, 4, 1, 2, 3}));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
+    input = new NDArray(input->permute({0, 4, 1, 2, 3}, false));    // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
+    output = new NDArray(output->permute({0, 4, 1, 2, 3}, false));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
   }
 
   if (isSameMode)  // SAME
@@ -79,15 +79,15 @@ CUSTOM_OP_IMPL(avgpool3dnew, 1, 1, false, 0, 14) {
   ConvolutionUtils::pooling3d(block, *input, *output, kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, 1, extraParam0);
 
   if (!isNCDHW) {
-    delete input;
-    delete output;
+     delete input;
+     delete output;
   }
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 
 DECLARE_TYPES(avgpool3dnew) {
-  getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setAllowedOutputTypes({ALL_FLOATS});
+  getOpDescriptor()->setAllowedInputTypes(ANY)->setAllowedOutputTypes({ALL_FLOATS});
 }
 
 DECLARE_SHAPE_FN(avgpool3dnew) {
@@ -130,7 +130,7 @@ DECLARE_SHAPE_FN(avgpool3dnew) {
   ConvolutionUtils::calcOutSizePool3D(oD, oH, oW, kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, iD, iH, iW,
                                       isSameMode);
 
-  sd::LongType outputShape[5];
+  LongType outputShape[5];
 
   outputShape[0] = bS;
 
@@ -148,12 +148,12 @@ DECLARE_SHAPE_FN(avgpool3dnew) {
   // TF DOC: A Tensor. Has the same type as input.
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5);
   auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
-  delete desc;
+  if (Environment::getInstance().isDeleteShapeInfo()) delete desc;
   return ret;
 }
 
 DECLARE_TYPES(avgpool3dnew_bp) {
-  getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setAllowedOutputTypes({ALL_FLOATS});
+  getOpDescriptor()->setAllowedInputTypes(ANY)->setAllowedOutputTypes({ALL_FLOATS});
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -189,9 +189,9 @@ CUSTOM_OP_IMPL(avgpool3dnew_bp, 2, 1, false, 0, 14) {
   ConvolutionUtils::getSizesAndIndexesConv3d(isNCDHW, 0, *input, *gradO, bS, iC, iD, iH, iW, oC, oD, oH, oW, indIOioC,
                                              indIOioD, indWiC, indWoC, indWkD);
 
-  std::vector<sd::LongType> expectedGradOShape =
+  std::vector<LongType> expectedGradOShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, oD, oH, oW, 0, indIOioC, indIOioD, indIOioD + 1, indIOioD + 2});
-  std::vector<sd::LongType> expectedGradIShape =
+  std::vector<LongType> expectedGradIShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, iD, iH, iW, 0, indIOioC, indIOioD, indIOioD + 1, indIOioD + 2});
   REQUIRE_TRUE(gradO->isSameShape(expectedGradOShape), 0,
                "AVGPOOL3DNEW_BP op: wrong shape of output's gradients array (next epsilon), expected is %s, but got %s "
@@ -203,9 +203,9 @@ CUSTOM_OP_IMPL(avgpool3dnew_bp, 2, 1, false, 0, 14) {
       ShapeUtils::shapeAsString(expectedGradIShape).c_str(), ShapeUtils::shapeAsString(gradI).c_str());
 
   if (!isNCDHW) {
-    input = new NDArray(input->permute({0, 4, 1, 2, 3}));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-    gradI = new NDArray(gradI->permute({0, 4, 1, 2, 3}));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-    gradO = new NDArray(gradO->permute({0, 4, 1, 2, 3}));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
+    input = new NDArray(input->permute({0, 4, 1, 2, 3}, false));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
+    gradI = new NDArray(gradI->permute({0, 4, 1, 2, 3}, false));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
+    gradO = new NDArray(gradO->permute({0, 4, 1, 2, 3}, false));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
   }
 
   if (isSameMode)  // SAME
@@ -222,13 +222,13 @@ CUSTOM_OP_IMPL(avgpool3dnew_bp, 2, 1, false, 0, 14) {
     delete gradO;
   }
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 
 DECLARE_SHAPE_FN(avgpool3dnew_bp) {
   auto desc = new ShapeDescriptor(inputShape->at(0), ArrayOptions::dataType(inputShape->at(1)));
   auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
-  delete desc;
+  if (Environment::getInstance().isDeleteShapeInfo()) delete desc;
   return ret;
 }
 

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool2d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool2d.cpp
@@ -46,8 +46,8 @@ CUSTOM_OP_IMPL(maxpool2d, 1, 1, false, 0, 9) {
   const LongType kW = INT_ARG(1);
   const LongType sH = INT_ARG(2);
   const LongType sW = INT_ARG(3);
-  sd::LongType pH = INT_ARG(4);
-  sd::LongType  pW = INT_ARG(5);
+  LongType pH = INT_ARG(4);
+  LongType pW = INT_ARG(5);
   const LongType dH = INT_ARG(6);
   const LongType dW = INT_ARG(7);
   const bool isSameMode = INT_ARG(8);
@@ -63,8 +63,8 @@ CUSTOM_OP_IMPL(maxpool2d, 1, 1, false, 0, 9) {
   const LongType iW = isNCHW ? input->sizeAt(3) : input->sizeAt(2);
 
   if (!isNCHW) {
-    input = new NDArray(input->permute({0, 3, 1, 2}));    // [bS, iH, iW, iC] -> [bS, iC, iH, iW]
-    output = new NDArray(output->permute({0, 3, 1, 2}));  // [bS, oH, oW, iC] -> [bS, iC, oH, oW]
+    input = new NDArray(input->permute({0, 3, 1, 2}, false));    // [bS, iH, iW, iC] -> [bS, iC, iH, iW]
+    output = new NDArray(output->permute({0, 3, 1, 2}, false));  // [bS, oH, oW, iC] -> [bS, iC, oH, oW]
   }
 
   ConvolutionUtils::calcOutSizePool2D(oH, oW, kH, kW, sH, sW, pH, pW, dH, dW, iH, iW, isSameMode);
@@ -72,21 +72,21 @@ CUSTOM_OP_IMPL(maxpool2d, 1, 1, false, 0, 9) {
 
   // 0,1 - kernel Height/Width; 2,3 - stride Height/Width; 4,5 - pad Height/Width; 6,7 - dilation Height/Width;
   // poolingMode; 9 - divisor;
-  ConvolutionUtils::pooling2d(block, *input, *output, kH, kW, sH, sW, pH, pW, dH, dW, PoolingType::MAX_POOL, 1);
+  ConvolutionUtils::pooling2d(block, *input, *output, kH, kW, sH, sW, pH, pW, dH, dW, MAX_POOL, 1);
 
   if (!isNCHW) {
     delete input;
     delete output;
   }
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 
 DECLARE_SYN(MaxPool2D, maxpool2d);
 DECLARE_SYN(MaxPool, maxpool2d);
 DECLARE_SYN(maxpool, maxpool2d);
 
-DECLARE_TYPES(maxpool2d) { getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setSameMode(true); }
+DECLARE_TYPES(maxpool2d) { getOpDescriptor()->setAllowedInputTypes(ANY)->setSameMode(true); }
 
 DECLARE_SHAPE_FN(maxpool2d) {
   // NDArray<T> *x = block.getVariables().at(0)->getNDArray();
@@ -119,7 +119,7 @@ DECLARE_SHAPE_FN(maxpool2d) {
   ConvolutionUtils::calcOutSizePool2D(oH, oW, kH, kW, sH, sW, pH, pW, dH, dW, iH, iW, isSameMode);
 
   // allocate memory for new shape
-  sd::LongType newShape[4];
+  LongType newShape[4];
 
   newShape[0] = bS;
   if (isNCHW) {
@@ -134,12 +134,12 @@ DECLARE_SHAPE_FN(maxpool2d) {
 
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inShape), order, newShape, 4);
   auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
-  delete desc;
+  if (Environment::getInstance().isDeleteShapeInfo()) delete desc;
   return ret;
 }
 
 DECLARE_TYPES(maxpool2d_bp) {
-  getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setAllowedOutputTypes({ALL_FLOATS});
+  getOpDescriptor()->setAllowedInputTypes(ANY)->setAllowedOutputTypes({ALL_FLOATS});
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -152,8 +152,8 @@ CUSTOM_OP_IMPL(maxpool2d_bp, 2, 1, false, 0, 10) {
   LongType kW = INT_ARG(1);                                                 // filter(kernel) width
   LongType sH = INT_ARG(2);                                                 // strides height
   LongType sW = INT_ARG(3);                                                 // strides width
-  sd::LongType  pH = INT_ARG(4);                                                 // paddings height
-  sd::LongType  pW = INT_ARG(5);                                                 // paddings width
+  LongType pH = INT_ARG(4);                                                 // paddings height
+  LongType pW = INT_ARG(5);                                                 // paddings width
   LongType dH = INT_ARG(6);                                                 // dilations height
   LongType dW = INT_ARG(7);                                                 // dilations width
   int isSameMode = INT_ARG(8);                                         // 0-VALID, 1-SAME
@@ -169,9 +169,9 @@ CUSTOM_OP_IMPL(maxpool2d_bp, 2, 1, false, 0, 10) {
   ConvolutionUtils::getSizesAndIndexesConv2d(isNCHW, 0, *input, *gradO, bS, iC, iH, iW, oC, oH, oW, indIOioC, indIiH,
                                              indWiC, indWoC, indWkH, indOoH);
 
-  std::vector<sd::LongType> expectedGradOShape =
+  std::vector<LongType> expectedGradOShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, oH, oW, 0, indIOioC, indIiH, indIiH + 1});
-  std::vector<sd::LongType> expectedGradIShape =
+  std::vector<LongType> expectedGradIShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, iH, iW, 0, indIOioC, indIiH, indIiH + 1});
   REQUIRE_TRUE(
       gradO->isSameShape(expectedGradOShape), 0,
@@ -183,9 +183,9 @@ CUSTOM_OP_IMPL(maxpool2d_bp, 2, 1, false, 0, 10) {
       ShapeUtils::shapeAsString(expectedGradIShape).c_str(), ShapeUtils::shapeAsString(gradI).c_str());
 
   if (!isNCHW) {
-    input = new NDArray(input->permute({0, 3, 1, 2}));  // [bS, iH, iW, iC] -> [bS, iC, iH, iW]
-    gradI = new NDArray(gradI->permute({0, 3, 1, 2}));  // [bS, iH, iW, iC] -> [bS, iC, iH, iW]
-    gradO = new NDArray(gradO->permute({0, 3, 1, 2}));  // [bS, oH, oW, iC] -> [bS, iC, oH, oW]
+    input = new NDArray(input->permute({0, 3, 1, 2}, false));  // [bS, iH, iW, iC] -> [bS, iC, iH, iW]
+    gradI = new NDArray(gradI->permute({0, 3, 1, 2}, false));  // [bS, iH, iW, iC] -> [bS, iC, iH, iW]
+    gradO = new NDArray(gradO->permute({0, 3, 1, 2}, false));  // [bS, oH, oW, iC] -> [bS, iC, oH, oW]
   }
 
   if (isSameMode)  // SAME
@@ -200,7 +200,7 @@ CUSTOM_OP_IMPL(maxpool2d_bp, 2, 1, false, 0, 10) {
     delete gradO;
   }
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 DECLARE_SYN(MaxPool2D_bp, maxpool2d_bp);
 DECLARE_SYN(MaxPool_bp, maxpool2d_bp);

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool3d.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool3d.cpp
@@ -61,7 +61,7 @@ CUSTOM_OP_IMPL(maxpool3dnew, 1, 1, false, 0, 14) {
   ConvolutionUtils::getSizesAndIndexesConv3d(isNCDHW, 0, *input, *output, bS, iC, iD, iH, iW, oC, oD, oH, oW, indIOioC,
                                              indIOioD, indWiC, indWoC, indWkD);
 
-  std::vector<sd::LongType> expectedOutputShape =
+  std::vector<LongType> expectedOutputShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, oD, oH, oW, 0, indIOioC, indIOioD, indIOioD + 1, indIOioD + 2});
   REQUIRE_TRUE(output->isSameShape(expectedOutputShape), 0,
                "MAXPOOL3D op: wrong shape of output array, expected is %s, but got %s instead !",
@@ -73,8 +73,8 @@ CUSTOM_OP_IMPL(maxpool3dnew, 1, 1, false, 0, 14) {
   // pD,pH,pW, kD,kH,kW);
 
   if (!isNCDHW) {
-    input = new NDArray(input->permute({0, 4, 1, 2, 3}));    // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-    output = new NDArray(output->permute({0, 4, 1, 2, 3}));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
+    input = new NDArray(input->permute({0, 4, 1, 2, 3}, false));    // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
+    output = new NDArray(output->permute({0, 4, 1, 2, 3}, false));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
   }
 
   if (isSameMode)  // SAME
@@ -87,10 +87,10 @@ CUSTOM_OP_IMPL(maxpool3dnew, 1, 1, false, 0, 14) {
     delete output;
   }
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 
-DECLARE_TYPES(maxpool3dnew) { getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setSameMode(true); }
+DECLARE_TYPES(maxpool3dnew) { getOpDescriptor()->setAllowedInputTypes(ANY)->setSameMode(true); }
 
 DECLARE_SHAPE_FN(maxpool3dnew) {
   LongType kD = INT_ARG(0);           // filter(kernel) depth
@@ -133,7 +133,7 @@ DECLARE_SHAPE_FN(maxpool3dnew) {
   ConvolutionUtils::calcOutSizePool3D(oD, oH, oW, kD, kH, kW, sD, sH, sW, pD, pH, pW, dD, dH, dW, iD, iH, iW,
                                       isSameMode);
 
-  sd::LongType outputShape[5];
+  LongType outputShape[5];
 
   outputShape[0] = bS;
   if (isNCDHW) {
@@ -150,12 +150,12 @@ DECLARE_SHAPE_FN(maxpool3dnew) {
 
   auto desc = new ShapeDescriptor(ArrayOptions::dataType(inputShapeInfo), shape::order(inputShapeInfo), outputShape, 5);
   auto ret = SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
-  delete desc;
+  if (Environment::getInstance().isDeleteShapeInfo()) delete desc;
   return ret;
 }
 
 DECLARE_TYPES(maxpool3dnew_bp) {
-  getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setAllowedOutputTypes({ALL_FLOATS});
+  getOpDescriptor()->setAllowedInputTypes(ANY)->setAllowedOutputTypes({ALL_FLOATS});
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -191,9 +191,9 @@ CUSTOM_OP_IMPL(maxpool3dnew_bp, 2, 1, false, 0, 14) {
   ConvolutionUtils::getSizesAndIndexesConv3d(isNCDHW, 0, *input, *gradO, bS, iC, iD, iH, iW, oC, oD, oH, oW, indIOioC,
                                              indIOioD, indWiC, indWoC, indWkD);
 
-  std::vector<sd::LongType> expectedGradOShape =
+  std::vector<LongType> expectedGradOShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, oD, oH, oW, 0, indIOioC, indIOioD, indIOioD + 1, indIOioD + 2});
-  std::vector<sd::LongType> expectedGradIShape =
+  std::vector<LongType> expectedGradIShape =
       ShapeUtils::composeShapeUsingDimsAndIdx({bS, iC, iD, iH, iW, 0, indIOioC, indIOioD, indIOioD + 1, indIOioD + 2});
   REQUIRE_TRUE(gradO->isSameShape(expectedGradOShape), 0,
                "MAXPOOL3DNEW_BP op: wrong shape of output's gradients array (next epsilon), expected is %s, but got %s "
@@ -205,9 +205,9 @@ CUSTOM_OP_IMPL(maxpool3dnew_bp, 2, 1, false, 0, 14) {
       ShapeUtils::shapeAsString(expectedGradIShape).c_str(), ShapeUtils::shapeAsString(gradI).c_str());
 
   if (!isNCDHW) {
-    input = new NDArray(input->permute({0, 4, 1, 2, 3}));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-    gradI = new NDArray(gradI->permute({0, 4, 1, 2, 3}));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
-    gradO = new NDArray(gradO->permute({0, 4, 1, 2, 3}));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
+    input = new NDArray(input->permute({0, 4, 1, 2, 3}, false));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
+    gradI = new NDArray(gradI->permute({0, 4, 1, 2, 3}, false));  // [bS, iD, iH, iW, iC] -> [bS, iC, iD, iH, iW]
+    gradO = new NDArray(gradO->permute({0, 4, 1, 2, 3}, false));  // [bS, oD, oH, oW, iC] -> [bS, iC, oD, oH, oW]
   }
 
   if (isSameMode)  // SAME
@@ -224,7 +224,7 @@ CUSTOM_OP_IMPL(maxpool3dnew_bp, 2, 1, false, 0, 14) {
     delete gradO;
   }
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 
 DECLARE_SHAPE_FN(maxpool3dnew_bp) {

--- a/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool_with_argmax.cpp
+++ b/libnd4j/include/ops/declarable/generic/nn/pooling/maxpool_with_argmax.cpp
@@ -41,25 +41,27 @@ CUSTOM_OP_IMPL(max_pool_with_argmax, 1, 2, false, 0, 9) {
 
   helpers::maxPoolingFunctor(block.launchContext(), block, x, z, argI, indices);
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 
 DECLARE_TYPES(max_pool_with_argmax) {
   getOpDescriptor()
-      ->setAllowedInputTypes(sd::DataType::ANY)
+      ->setAllowedInputTypes(ANY)
       ->setAllowedOutputTypes(0, {ALL_FLOATS, ALL_INTS})
       ->setAllowedOutputTypes(1, {ALL_INDICES});
 }
 
 DECLARE_SHAPE_FN(max_pool_with_argmax) {
   auto in = inputShape->at(0);
-  auto dtype = block.numD() ? D_ARG(0) : sd::DataType::INT64;
+  auto dtype = block.numD() ? D_ARG(0) : INT64;
   auto desc = new ShapeDescriptor(in);
   auto desc2 = new ShapeDescriptor(in, dtype);
   auto valuesShape = ConstantShapeHelper::getInstance().createShapeInfo(desc);
   auto indicesShape = ConstantShapeHelper::getInstance().createShapeInfo(desc2);
-  delete desc;
-  delete desc2;
+  if (Environment::getInstance().isDeleteShapeInfo()) {
+    delete desc;
+    delete desc2;
+  }
   return SHAPELIST(valuesShape, indicesShape);
 }
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/transforms/repeat.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/repeat.cpp
@@ -34,7 +34,7 @@ CUSTOM_OP_IMPL(repeat, 1, 1, true, 0, -1) {
   auto input = INPUT_VARIABLE(0);
   auto output = OUTPUT_VARIABLE(0);
 
-  std::vector<sd::LongType> repeats = *block.getIArguments();
+  std::vector<LongType> repeats = *block.getIArguments();
 
   const int axis = repeats.back() < 0 ? repeats.back() + input->rankOf() : repeats.back();
 
@@ -51,15 +51,15 @@ CUSTOM_OP_IMPL(repeat, 1, 1, true, 0, -1) {
 
   input->repeat(axis, repeats, *output);
 
-  return sd::Status::OK;
+  return Status::OK;
 }
 
-DECLARE_TYPES(repeat) { getOpDescriptor()->setAllowedInputTypes(sd::DataType::ANY)->setSameMode(true); }
+DECLARE_TYPES(repeat) { getOpDescriptor()->setAllowedInputTypes(ANY)->setSameMode(true); }
 
 DECLARE_SHAPE_FN(repeat) {
   auto input = INPUT_VARIABLE(0);
 
-  std::vector<sd::LongType> repeats = *block.getIArguments();
+  std::vector<LongType> repeats = *block.getIArguments();
 
   const int axis = repeats.back() < 0 ? repeats.back() + input->rankOf() : repeats.back();
 
@@ -69,7 +69,7 @@ DECLARE_SHAPE_FN(repeat) {
 
   auto desc = new ShapeDescriptor(input->dataType(), input->ordering(), outShape);
   auto ret =  SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(desc));
-  delete desc;
+  if (Environment::getInstance().isDeleteShapeInfo()) delete desc;
   return ret;
 }
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/transforms/split.cpp
+++ b/libnd4j/include/ops/declarable/generic/transforms/split.cpp
@@ -116,13 +116,13 @@ DECLARE_SHAPE_FN(split) {
   auto shapes = SHAPELIST();
 
   // Edge case: splitting empty array (mainly for TF import compatibility) -> return N empty arrays
-  // if(INPUT_VARIABLE(inputVar)->isEmpty()){
-  //     for (int e = 0; e < num_splits; e++) {
-  //               auto empty = ConstantShapeHelper::getInstance().emptyShapeInfo(dataType);
-  //         shapes->push_back(empty);
-  //     }
-  //     return shapes;
-  // }
+   if(INPUT_VARIABLE(inputVar)->isEmpty()) {
+       for (int e = 0; e < num_splits; e++) {
+                 auto empty = ConstantShapeHelper::getInstance().emptyShapeInfo(dataType);
+           shapes->push_back(empty);
+       }
+       return shapes;
+   }
 
   if (block.numI() == 2) axis = INT_ARG(1);
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/convolutions_vol2col.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/convolutions_vol2col.cpp
@@ -28,50 +28,49 @@ namespace ops {
 //////////////////////////////////////////////////////////////////////////
 // [bS, iC, iD, iH, iW] is convoluted to [bS, iC, kD, kH, kW, oD, oH, oW]
 template <typename T>
-static void vol2col_(const NDArray& volume, NDArray& columns, const LongType sD, const LongType sH, const LongType sW, const LongType pD,
-                     const LongType pH, const LongType pW, const LongType dD, const LongType dH, const LongType dW) {
-  const LongType bS = volume.sizeAt(0);
-  const LongType iC = volume.sizeAt(1);
-  const LongType iD = volume.sizeAt(2);
-  const LongType iH = volume.sizeAt(3);
-  const LongType iW = volume.sizeAt(4);
-  const LongType kD = columns.sizeAt(2);
-  const LongType kH = columns.sizeAt(3);
-  const LongType kW = columns.sizeAt(4);
-  const LongType oD = columns.sizeAt(5);
-  const LongType oH = columns.sizeAt(6);
-  const LongType oW = columns.sizeAt(7);
-  const sd::LongType colStride0 = columns.stridesOf()[0];
-  const sd::LongType colStride1 = columns.stridesOf()[1];
-  const sd::LongType colStride2 = columns.stridesOf()[2];
-  const sd::LongType colStride3 = columns.stridesOf()[3];
-  const sd::LongType colStride4 = columns.stridesOf()[4];
-  const sd::LongType colStride5 = columns.stridesOf()[5];
-  const sd::LongType colStride6 = columns.stridesOf()[6];
-  const sd::LongType colStride7 = columns.stridesOf()[7];
-  const sd::LongType volStride0 = volume.stridesOf()[0];
-  const sd::LongType volStride1 = volume.stridesOf()[1];
-  const sd::LongType volStride2 = volume.stridesOf()[2];
-  const sd::LongType volStride3 = volume.stridesOf()[3];
-  const sd::LongType volStride4 = volume.stridesOf()[4];
+static void vol2col_(NDArray* volume, NDArray* columns, const int sD, const int sH, const int sW, const int pD,
+                     const int pH, const int pW, const int dD, const int dH, const int dW) {
+  const int bS = volume->sizeAt(0);
+  const int iC = volume->sizeAt(1);
+  const int iD = volume->sizeAt(2);
+  const int iH = volume->sizeAt(3);
+  const int iW = volume->sizeAt(4);
+  const int kD = columns->sizeAt(2);
+  const int kH = columns->sizeAt(3);
+  const int kW = columns->sizeAt(4);
+  const int oD = columns->sizeAt(5);
+  const int oH = columns->sizeAt(6);
+  const int oW = columns->sizeAt(7);
+  const int colStride0 = columns->stridesOf()[0];
+  const int colStride1 = columns->stridesOf()[1];
+  const int colStride2 = columns->stridesOf()[2];
+  const int colStride3 = columns->stridesOf()[3];
+  const int colStride4 = columns->stridesOf()[4];
+  const int colStride5 = columns->stridesOf()[5];
+  const int colStride6 = columns->stridesOf()[6];
+  const int colStride7 = columns->stridesOf()[7];
+  const int volStride0 = volume->stridesOf()[0];
+  const int volStride1 = volume->stridesOf()[1];
+  const int volStride2 = volume->stridesOf()[2];
+  const int volStride3 = volume->stridesOf()[3];
+  const int volStride4 = volume->stridesOf()[4];
+  T* colBuff = columns->bufferAsT<T>();
+  T* volBuff = volume->bufferAsT<T>();
 
-  T* colBuff = columns.bufferAsT<T>();
-  T* volBuff = const_cast<NDArray&>(volume).bufferAsT<T>();
-
-  if (volume.ordering() == 'c' && columns.ordering() == 'c' && shape::strideDescendingCAscendingF(volume.shapeInfo()) &&
-      shape::strideDescendingCAscendingF(columns.shapeInfo())) {
+  if (volume->ordering() == 'c' && columns->ordering() == 'c' && shape::strideDescendingCAscendingF(volume->shapeInfo()) &&
+      shape::strideDescendingCAscendingF(columns->shapeInfo())) {
     auto func = PRAGMA_THREADS_FOR_3D {
       T *col, *vol;
       int volDep, volRow, volCol;
 
-      for (sd::LongType b = start_x; b < stop_x; b += inc_x) {
-        for (sd::LongType c = start_y; c < stop_y; c += inc_y) {
-          for (sd::LongType kDep = start_z; kDep < stop_z; kDep += inc_z) {
-            for (sd::LongType kRow = 0; kRow < kH; ++kRow) {
-              for (sd::LongType kCol = 0; kCol < kW; ++kCol) {
-                for (sd::LongType colD = 0; colD < oD; ++colD) {
-                  for (sd::LongType colH = 0; colH < oH; ++colH) {
-                    for (sd::LongType colW = 0; colW < oW; ++colW) {
+      for (int b = start_x; b < stop_x; b += inc_x) {
+        for (int c = start_y; c < stop_y; c += inc_y) {
+          for (int kDep = start_z; kDep < stop_z; kDep += inc_z) {
+            for (int kRow = 0; kRow < kH; ++kRow) {
+              for (int kCol = 0; kCol < kW; ++kCol) {
+                for (int colD = 0; colD < oD; ++colD) {
+                  for (int colH = 0; colH < oH; ++colH) {
+                    for (int colW = 0; colW < oW; ++colW) {
                       volDep = (-pD + kDep * dD) + colD * sD;
                       volRow = (-pH + kRow * dH) + colH * sH;
                       volCol = (-pW + kCol * dW) + colW * sW;
@@ -79,14 +78,14 @@ static void vol2col_(const NDArray& volume, NDArray& columns, const LongType sD,
                       col = colBuff + b * colStride0 + c * colStride1 + kDep * colStride2 + kRow * colStride3 +
                             kCol * colStride4 + colD * colStride5 + colH * colStride6 + colW * colStride7;
 
-                      if (volDep < 0 || volDep >= iD ||
-                          volRow < 0 || volRow >= iH ||
-                          volCol < 0 || volCol >= iW)
+                      if (static_cast<unsigned>(volDep) >= static_cast<unsigned>(iD) ||
+                          static_cast<unsigned>(volRow) >= static_cast<unsigned>(iH) ||
+                          static_cast<unsigned>(volCol) >= static_cast<unsigned>(iW))
                         *col = static_cast<T>(0.);
                       else {
                         vol = volBuff + b * volStride0 + c * volStride1 + volDep * volStride2 + volRow * volStride3 +
                               volCol * volStride4;
-                        *col = *vol;
+                        *col = static_cast<T>(*vol);
                       }
                     }
                   }
@@ -103,31 +102,30 @@ static void vol2col_(const NDArray& volume, NDArray& columns, const LongType sD,
   } else {
     auto func = PRAGMA_THREADS_FOR_2D {
       T *col, *vol;
-      sd::LongType volDep, volRow, volCol;
+      int volDep, volRow, volCol;
 
-      for (LongType b = start_x; b < stop_x; b++) {
-        for (LongType colD = start_y; colD < stop_y; colD++) {
-          for (LongType colH = 0; colH < oH; ++colH) {
-            for (LongType colW = 0; colW < oW; ++colW) {
-              for (LongType c = 0; c < iC; ++c) {
-                for (LongType kDep = 0; kDep < kD; ++kDep) {
-                  for (LongType kRow = 0; kRow < kH; ++kRow) {
-                    for (LongType kCol = 0; kCol < kW; ++kCol) {
+      for (int b = start_x; b < stop_x; b++) {
+        for (int colD = start_y; colD < stop_y; colD++) {
+          for (int colH = 0; colH < oH; ++colH) {
+            for (int colW = 0; colW < oW; ++colW) {
+              for (int c = 0; c < iC; ++c) {
+                for (int kDep = 0; kDep < kD; ++kDep) {
+                  for (int kRow = 0; kRow < kH; ++kRow) {
+                    for (int kCol = 0; kCol < kW; ++kCol) {
                       volDep = (-pD + kDep * dD) + colD * sD;
                       volRow = (-pH + kRow * dH) + colH * sH;
                       volCol = (-pW + kCol * dW) + colW * sW;
 
                       col = colBuff + b * colStride0 + c * colStride1 + kDep * colStride2 + kRow * colStride3 +
                             kCol * colStride4 + colD * colStride5 + colH * colStride6 + colW * colStride7;
-
-                      if (volDep < 0 || volDep >= iD ||
-                          volRow < 0 || volRow >= iH ||
-                          volCol < 0 || volCol >= iW)
-                        *col = static_cast<T>(0.f);
+                      if (static_cast<unsigned>(volDep) >= static_cast<unsigned>(iD) ||
+                          static_cast<unsigned>(volRow) >= static_cast<unsigned>(iH) ||
+                          static_cast<unsigned>(volCol) >= static_cast<unsigned>(iW))
+                        *col = static_cast<T>(0.0);
                       else {
                         vol = volBuff + b * volStride0 + c * volStride1 + volDep * volStride2 + volRow * volStride3 +
                               volCol * volStride4;
-                        *col = *vol;
+                        *col = static_cast<T>(*vol);
                       }
                     }
                   }
@@ -143,10 +141,10 @@ static void vol2col_(const NDArray& volume, NDArray& columns, const LongType sD,
   }
 }
 
-void ConvolutionUtils::vol2col(sd::graph::Context& block, const NDArray& volume, NDArray& columns, const LongType sD,
-                               const LongType sH, const LongType sW, const LongType pD, const LongType pH, const LongType pW, const LongType dD,
-                               const LongType dH, const LongType dW) {
-  BUILD_SINGLE_SELECTOR(volume.dataType(), vol2col_, (volume, columns, sD, sH, sW, pD, pH, pW, dD, dH, dW),
+void ConvolutionUtils::vol2col(graph::Context& block, NDArray* vol, NDArray* col, const int sD,
+                               const int sH, const int sW, const int pD, const int pH, const int pW, const int dD,
+                               const int dH, const int dW) {
+  BUILD_SINGLE_SELECTOR(vol->dataType(), vol2col_, (vol, col, sD, sH, sW, pD, pH, pW, dD, dH, dW),
                         SD_FLOAT_TYPES);
 }
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/image_resize.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/image_resize.cpp
@@ -87,10 +87,8 @@ static void resizeImage_(T const* pInputBuf, sd::LongType batchSize, sd::LongTyp
   sd::LongType inBatchNumValues = inHeight * inRowSize;
   sd::LongType outRowSize = outWidth * channels;
 
-  //        T const *pInputBuf = images->getDataBuffer()->primaryAsT<T>(); // this works only with 'c' direction
   BilinearInterpolationData const* xsPtr = xs.data();
 
-  //        T* pOutputBuf = output->dataBuffer()->primaryAsT<T>();
   auto computeBilinear = [](double topLeft, double topRight, double bottomLeft, double bottomRight, double xVal,
                             double yVal) {
     double top = topLeft + (topRight - topLeft) * xVal;


### PR DESCRIPTION
## What changes were proposed in this pull request?

leftover cnn cpu changes
adds functrace to gpu databuffer
more conversion of data buffer from shared pointer to normal pointer to avoid "smart" deletions that crash java programs
adapt col2im signature change
add permute calls for determining whether to copy buffers or not (new permute function signature allows this)
## How was this patch tested?

manually in #10052 
## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
