### PR TITLE
streamline calculate output shape/opexecution

### DIFF
--- a/libnd4j/include/helpers/impl/ShapeBuilders.cpp
+++ b/libnd4j/include/helpers/impl/ShapeBuilders.cpp
@@ -43,6 +43,9 @@ LongType* ShapeBuilders::createShapeInfoFrom(ShapeDescriptor* descriptor) {
 
   shape::setElementWiseStride(ret, descriptor->ews());
   shape::setExtra(ret, descriptor->extra());
+  if(ArrayOptions::dataType(ret) != descriptor->dataType()) {
+    ArrayOptions::setDataType(ret, descriptor->dataType());
+  }
   return ret;
 }
 

--- a/libnd4j/include/legacy/NativeOps.h
+++ b/libnd4j/include/legacy/NativeOps.h
@@ -173,9 +173,7 @@ SD_LIB_EXPORT void execRandom3(sd::Pointer *extraPointers, int opNum, sd::Pointe
 
 SD_LIB_EXPORT sd::LongType const *getShape(OpaqueShapeList *list, sd::LongType i);
 
-SD_LIB_EXPORT OpaqueShapeList  *calculateOutputShapes2(sd::Pointer *extraPointers, sd::LongType hash, OpaqueNDArrayArr inputs, int numInputs,
-                                                     double *tArgs, int numTArgs, sd::LongType *iArgs, int numIArgs,
-                                                     bool *bArgs, int numBArgs, int *dArgs, int numDArgs);
+SD_LIB_EXPORT OpaqueShapeList *calculateOutputShapes2(sd::Pointer *extraPointers, sd::LongType hash, OpaqueContext *context);
 SD_LIB_EXPORT sd::LongType getShapeListSize(OpaqueShapeList *list);
 
 SD_LIB_EXPORT void dbPrintAllocationTrace(OpaqueDataBuffer *db) ;
@@ -280,6 +278,7 @@ SD_LIB_EXPORT int lengthForShapeBufferPointer(sd::Pointer buffer) ;
 SD_LIB_EXPORT sd::Pointer pointerForAddress(sd::LongType address) ;
 SD_LIB_EXPORT void prescanArrayRecursive(sd::Pointer *extras, int *dZ, int *dX, int numElements, int level) ;
 SD_LIB_EXPORT void deleteNDArray(OpaqueNDArray array) ;
+SD_LIB_EXPORT bool checkOpaqueNDArrayElementsNull(OpaqueNDArrayArr elements,int numElements);
 SD_LIB_EXPORT sd::LongType getOpaqueNDArrayOffset(OpaqueNDArray array) ;
 SD_LIB_EXPORT void* getOpaqueNDArrayBuffer(OpaqueNDArray array) ;
 SD_LIB_EXPORT void* getOpaqueNDArraySpecialBuffer(OpaqueNDArray array) ;

--- a/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
+++ b/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
@@ -1059,7 +1059,7 @@ void setGraphContextBArguments(Context *ptr, bool *arguments, int numberOfArgume
 
 void setGraphContextDArguments(OpaqueContext *ptr, int *arguments, int numberOfArguments) {
   std::vector<sd::DataType> dtypes(numberOfArguments);
-  for (int e = 0; e < numberOfArguments; e++) dtypes[e] = (sd::DataType)arguments[e];
+  for (int e = 0; e < numberOfArguments; e++) dtypes[e] = sd::DataTypeUtils::fromInt(arguments[e]);
 
   ptr->setDArguments(dtypes);
 }

--- a/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
+++ b/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
@@ -53,6 +53,7 @@ DECLARE_SHAPE_FN(cast) {
     DataType newType = block.dataType(0);
     DataType secondComp = block.getDArguments()->at(0);
     auto desc = new ShapeDescriptor(inShape, newType, true);
+   printf("cast new data type: %s", DataTypeUtils::asString(desc->dataType()).c_str());
     auto newShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
     auto compDataType = ArrayOptions::dataType(newShapeInfo);
     if(compDataType != newType) {
@@ -68,6 +69,8 @@ DECLARE_SHAPE_FN(cast) {
     return ret;
 
   } else {
+    printf("block d arguments is empty trying to use int\n");
+    fflush(stdout);
     auto it = INT_ARG(0);
     DataType newType = DataTypeUtils::fromInt(it);
     auto desc = new ShapeDescriptor(inShape, newType, false);

--- a/libnd4j/include/ops/declarable/generic/shape/reshape_no_copy.cpp
+++ b/libnd4j/include/ops/declarable/generic/shape/reshape_no_copy.cpp
@@ -103,8 +103,6 @@ DECLARE_SHAPE_FN(reshape_no_copy) {
     ArrayOptions::toggleIsEmpty(newShapeInfo);
   } else {
     bool needsCopy = helpers::reshapeNoAlloc(inShape, newShape, order, newShapeInfo);
-    printf("reshape no copy Needs copy: %i\n", needsCopy);
-    fflush(stdout);
     if (!needsCopy) {
       newShapeInfo[0] = newShape.size();
       shape::setElementWiseStride(newShapeInfo, 0);
@@ -114,8 +112,6 @@ DECLARE_SHAPE_FN(reshape_no_copy) {
       ArrayOptions::resetFlags(newShapeInfo);
       ArrayOptions::setDataType(newShapeInfo, dtype);
     } else {
-      printf("Setting needs copy\n");
-      fflush(stdout);
       // If reshape is not possible without allocation, fall back to regular reshape
       shape::updateStrides(newShapeInfo, order,true);
       shape::setElementWiseStride(newShapeInfo, 0);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/CustomOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/CustomOp.java
@@ -21,7 +21,6 @@
 package org.nd4j.linalg.api.ops;
 
 import lombok.val;
-import org.jetbrains.annotations.NotNull;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/CustomOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/CustomOp.java
@@ -21,6 +21,7 @@
 package org.nd4j.linalg.api.ops;
 
 import lombok.val;
+import org.jetbrains.annotations.NotNull;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -154,6 +155,45 @@ public interface CustomOp  {
   * Clear the input and output INDArrays, if any are set
   */
  void clearArrays();
+
+
+ default void setupOpContextFromCustomOp(OpContext opContext) {
+  // Set input arguments
+  val inputArgs = inputArguments();
+  if (inputArgs != null && !inputArgs.isEmpty()) {
+   opContext.setInputArrays(inputArgs.toArray(new INDArray[0]));
+  }
+
+  // Set integer arguments
+  val iArgs = iArgs();
+  if (iArgs != null && iArgs.length > 0) {
+   opContext.setIArguments(iArgs);
+  }
+
+  // Set floating point arguments
+  val tArgs = tArgs();
+  if (tArgs != null && tArgs.length > 0) {
+   opContext.setTArguments(tArgs);
+  }
+
+  // Set boolean arguments
+  val bArgs = bArgs();
+  if (bArgs != null && bArgs.length > 0) {
+   opContext.setBArguments(bArgs);
+  }
+
+  // Set data type arguments
+  val dArgs = dArgs();
+  if (dArgs != null && dArgs.length > 0) {
+   opContext.setDArguments(dArgs);
+  }
+
+  // Set output arguments
+  val outputArgs = outputArguments();
+  if (outputArgs != null && !outputArgs.isEmpty()) {
+   opContext.setOutputArrays(outputArgs.toArray(new INDArray[0]));
+  }
+ }
 
  /**
   * Initialize the output arrays, if required.

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutioner.java
@@ -62,6 +62,8 @@ public interface OpExecutioner {
     }
 
 
+
+
     /**
      * When {@link Environment#isLogNDArrayEvents()}
      *  is true all arrays will log to {@link #getNd4jEventLog()}

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/NativeOps.java
@@ -106,9 +106,8 @@ public interface NativeOps {
                                         PointerPointer inputShapes,
                                        IntPointer inputIndices, int numInputs);
  LongPointer getShape(OpaqueShapeList list, long i);
- OpaqueShapeList calculateOutputShapes2(PointerPointer extraPointers, long hash, OpaqueNDArrayArr inputs, int numInputs,
-                                        DoublePointer tArgs, int numTArgs, LongPointer iArgs, int numIArgs,
-                                        BooleanPointer bArgs, int numBArgs, IntPointer dArgs, int numDArgs);
+ boolean checkOpaqueNDArrayElementsNull(OpaqueNDArrayArr elements,int numElements);
+ OpaqueShapeList calculateOutputShapes2(PointerPointer extraPointers, long hash, OpaqueContext context);
 
  void dbPrintAllocationTrace(org.nd4j.nativeblas.OpaqueDataBuffer db);
  int numIntermediateResults(org.nd4j.nativeblas.OpaqueContext contextPointer);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueNDArray.java
@@ -196,7 +196,7 @@ public class OpaqueNDArray extends Pointer {
         return create(
                 shapeInfo.opaqueBuffer(),
                 array.isEmpty() ? null : buffer.opaqueBuffer(),
-                array.isEmpty() ? null : array.data().opaqueBuffer(),
+                array.isEmpty() ? null :buffer.opaqueBuffer(),
                 array.offset()
         );
     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueNDArrayArr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueNDArrayArr.java
@@ -20,6 +20,10 @@
 package org.nd4j.nativeblas;
 
 import org.bytedeco.javacpp.PointerPointer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class OpaqueNDArrayArr extends PointerPointer<OpaqueNDArray> {
 
@@ -27,5 +31,34 @@ public class OpaqueNDArrayArr extends PointerPointer<OpaqueNDArray> {
     public OpaqueNDArrayArr(OpaqueNDArray... array) { super(array); }
 
 
+    /**
+     * @see {@link #createFrom(INDArray...)}
+     * @param array
+     * @return
+     */
+    public static OpaqueNDArrayArr createFrom(List<INDArray> array) {
+        OpaqueNDArray[] inputs = array.stream()
+                .map(OpaqueNDArray::fromINDArray).toArray(OpaqueNDArray[]::new);
+        OpaqueNDArrayArr inputsOpaque = (OpaqueNDArrayArr) new OpaqueNDArrayArr().capacity(inputs.length);
+        inputsOpaque.put(inputs);
+        return inputsOpaque;
+    }
+
+
+    /**
+     * Simple creation method
+     * that handles ensuring a proper 
+     * instantiation of the array with capacity
+     * and putting the result pointers in the array.
+     * @param array the array to create the OpaqueNDArrayArr from
+     * @return
+     */
+    public static OpaqueNDArrayArr createFrom(INDArray... array) {
+        OpaqueNDArray[] inputs = Arrays.stream(array)
+                .map(OpaqueNDArray::fromINDArray).toArray(OpaqueNDArray[]::new);
+        OpaqueNDArrayArr inputsOpaque = (OpaqueNDArrayArr) new OpaqueNDArrayArr().capacity(inputs.length);
+        inputsOpaque.put(inputs);
+        return inputsOpaque;
+    }
 
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -71,7 +71,6 @@ import java.util.*;
 
 @Slf4j
 public class NativeOpExecutioner extends DefaultOpExecutioner {
-    private NativeOps loop =Nd4j.getNativeOps();
     private ConstantHandler constantHandler = Nd4j.getConstantHandler();
     @Getter
     private CpuTADManager tadManager = new CpuTADManager();
@@ -84,9 +83,9 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
 
     public NativeOpExecutioner() {
-        tadManager.init(loop, constantHandler);
+        tadManager.init(Nd4j.getNativeOps(), constantHandler);
 
-        experimentalMode.set(loop.isExperimentalEnabled());
+        experimentalMode.set(Nd4j.getNativeOps().isExperimentalEnabled());
 
         // filling vars for possible overrides
         val env = System.getenv(ND4JEnvironmentVars.ND4J_MKL_FALLBACK);
@@ -182,13 +181,13 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
         val zb = OpaqueNDArray.fromINDArray(z);
 
         if (z.isScalar()) {
-            loop.execIndexReduceScalar(dummy,op.opNum(),xb,zb,null);
+            Nd4j.getNativeOps().execIndexReduceScalar(dummy,op.opNum(),xb,zb,null);
         } else {
             OpaqueNDArray fromDims = OpaqueNDArray.fromINDArray(op.dimensions());
-            loop.execIndexReduce(dummy,op.opNum(),xb,zb,fromDims, null);
+            Nd4j.getNativeOps().execIndexReduce(dummy,op.opNum(),xb,zb,fromDims, null);
         }
 
-        if (loop.lastErrorCode() != 0) {
+        if (Nd4j.getNativeOps().lastErrorCode() != 0) {
             DifferentialFunction differentialFunction = (DifferentialFunction) op;
             StringBuilder errorMessage = new StringBuilder();
             errorMessage.append("Op [").append(op.getClass().getSimpleName()).append("] execution failed\n");
@@ -199,7 +198,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
             errorMessage.append("Z:\n");
             errorMessage.append(z);
             errorMessage.append("\n");
-            errorMessage.append(loop.lastErrorMessage());
+            errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
             errorMessage.append(differentialFunction.debugInfo());
             throw new RuntimeException(errorMessage.toString());
         }
@@ -313,12 +312,12 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
         val zb = OpaqueNDArray.fromINDArray(z);
         if (op instanceof Variance) {
             if (ret.isScalar()) {
-                loop.execSummaryStatsScalar(null,op.opNum(),xb,zb,null,((Variance) op).isBiasCorrected());
+                Nd4j.getNativeOps().execSummaryStatsScalar(null,op.opNum(),xb,zb,null,((Variance) op).isBiasCorrected());
 
             } else {
                 try {
 
-                    loop.execSummaryStatsTad(
+                    Nd4j.getNativeOps().execSummaryStatsTad(
                             null,op.
                                     opNum(),
                             xb,
@@ -344,7 +343,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
             if (op.isComplexAccumulation()) {
                 try {
                     //use opaque ndarrays instead here
-                    loop.execReduce3All(null,
+                    Nd4j.getNativeOps().execReduce3All(null,
                             op.opNum(),
                             xb,yb,zb,OpaqueNDArray.fromINDArray(op.dimensions()),null);
                 } catch (Throwable t) {
@@ -356,10 +355,10 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                     throw new RuntimeException(errorMessage.toString());
                 }
             } else if (ret.isScalar()) {
-                loop.execReduce3Scalar(null,op.opNum(),xb,null,yb,zb);
+                Nd4j.getNativeOps().execReduce3Scalar(null,op.opNum(),xb,null,yb,zb);
             } else {
                 try {
-                    loop.execReduce3Tad(null,op.opNum(),xb,null, yb, zb, OpaqueNDArray.fromINDArray(op.dimensions()));
+                    Nd4j.getNativeOps().execReduce3Tad(null,op.opNum(),xb,null, yb, zb, OpaqueNDArray.fromINDArray(op.dimensions()));
 
                 } catch (Throwable t) {
                     String str = opInfoString(op, Optional.of(dimension));
@@ -380,16 +379,16 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                     extraz.set(new PointerPointer(32));
                 switch (op.getOpType()) {
                     case REDUCE_FLOAT:
-                        loop.execReduceFloat(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb);
+                        Nd4j.getNativeOps().execReduceFloat(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb);
                         break;
                     case REDUCE_BOOL:
-                        loop.execReduceBool(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb,dims);
+                        Nd4j.getNativeOps().execReduceBool(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb,dims);
                         break;
                     case REDUCE_SAME:
-                        loop.execReduceSame(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb);
+                        Nd4j.getNativeOps().execReduceSame(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb);
                         break;
                     case REDUCE_LONG:
-                        loop.execReduceLong(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb,dims);
+                        Nd4j.getNativeOps().execReduceLong(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb,dims);
                         break;
                     default:
                         throw new UnsupportedOperationException("Unsupported op used in reduce: " + op.getOpType());
@@ -399,16 +398,16 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                     extraz.set(new PointerPointer(32));
                 switch (op.getOpType()) {
                     case REDUCE_FLOAT:
-                        loop.execReduceFloat2(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()), zb,OpaqueNDArray.fromINDArray(op.dimensions()));
+                        Nd4j.getNativeOps().execReduceFloat2(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()), zb,OpaqueNDArray.fromINDArray(op.dimensions()));
                         break;
                     case REDUCE_LONG:
-                        loop.execReduceLong2(null, op.opNum(), xb,getPointerForExtraArgs(op, x.dataType()), zb, OpaqueNDArray.fromINDArray(op.dimensions()));
+                        Nd4j.getNativeOps().execReduceLong2(null, op.opNum(), xb,getPointerForExtraArgs(op, x.dataType()), zb, OpaqueNDArray.fromINDArray(op.dimensions()));
                         break;
                     case REDUCE_SAME:
-                        loop.execReduceSame2(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb, OpaqueNDArray.fromINDArray(op.dimensions()));
+                        Nd4j.getNativeOps().execReduceSame2(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb, OpaqueNDArray.fromINDArray(op.dimensions()));
                         break;
                     case REDUCE_BOOL:
-                        loop.execReduceBool2(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb, OpaqueNDArray.fromINDArray(op.dimensions()));
+                        Nd4j.getNativeOps().execReduceBool2(null, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb, OpaqueNDArray.fromINDArray(op.dimensions()));
                         break;
 
                     default:
@@ -417,13 +416,13 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
             }
         }
 
-        if (loop.lastErrorCode() != 0) {
+        if (Nd4j.getNativeOps().lastErrorCode() != 0) {
             String str = opInfoString(op, Optional.of(dimension));
             StringBuilder errorMessage = new StringBuilder();
             DifferentialFunction differentialFunction = (DifferentialFunction) op;
             errorMessage.append("Native AccumulationOp execution (double) failed: " + str);
             errorMessage.append(differentialFunction.debugInfo());
-            errorMessage.append(loop.lastErrorMessage());
+            errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
             throw new RuntimeException(errorMessage.toString());
         }
         profilingConfigurableHookOut(op, oc, st);
@@ -454,7 +453,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
         val zb = OpaqueNDArray.fromINDArray(z);
         switch (op.getOpType()) {
             case SCALAR:
-                loop.execScalarTad(null, op.opNum(),
+                Nd4j.getNativeOps().execScalarTad(null, op.opNum(),
                         xb,
                         zb,
                         yb,
@@ -463,7 +462,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                 );
                 break;
             case SCALAR_BOOL:
-                loop.execScalarTad(null, op.opNum(),
+                Nd4j.getNativeOps().execScalarTad(null, op.opNum(),
                         xb,
                         zb,
                         yb,
@@ -475,13 +474,13 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                 throw new UnsupportedOperationException();
         }
 
-        if (loop.lastErrorCode() != 0) {
+        if (Nd4j.getNativeOps().lastErrorCode() != 0) {
             String str = opInfoString(op, Optional.of(dimension));
             StringBuilder errorMessage = new StringBuilder();
             DifferentialFunction differentialFunction = (DifferentialFunction) op;
             errorMessage.append("Native  execution exec failed: " + str);
             errorMessage.append(differentialFunction.debugInfo());
-            errorMessage.append(loop.lastErrorMessage());
+            errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
             throw new RuntimeException(errorMessage.toString());
         }
     }
@@ -518,22 +517,22 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
         switch (op.getOpType()) {
             case SCALAR:
-                loop.execScalar(null,op.opNum(),x,z,scalar,getPointerForExtraArgs(op, x.dataType()));
+                Nd4j.getNativeOps().execScalar(null,op.opNum(),x,z,scalar,getPointerForExtraArgs(op, x.dataType()));
                 break;
             case SCALAR_BOOL:
-                loop.execScalarBool(null,op.opNum(),x,z,scalar,getPointerForExtraArgs(op, x.dataType()));
+                Nd4j.getNativeOps().execScalarBool(null,op.opNum(),x,z,scalar,getPointerForExtraArgs(op, x.dataType()));
                 break;
             default:
                 throw new ND4JIllegalStateException("Unknown op type: [" + op.getOpType() +"]");
         }
 
-        if (loop.lastErrorCode() != 0) {
+        if (Nd4j.getNativeOps().lastErrorCode() != 0) {
             // the variable is mainly for ease of use with the debugger
             StringBuilder errorMessage = new StringBuilder();
             DifferentialFunction differentialFunction = (DifferentialFunction) op;
             errorMessage.append("Native  execution exec failed: ");
             errorMessage.append(differentialFunction.debugInfo());
-            errorMessage.append(loop.lastErrorMessage());
+            errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
             throw new RuntimeException(errorMessage.toString());
         }
         profilingConfigurableHookOut(op, oc, st);
@@ -633,13 +632,13 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                     case TRANSFORM_FLOAT:
                     case TRANSFORM_STRICT:
                     case TRANSFORM_SAME:
-                        loop.execPairwiseTransform(dummy,op.opNum(),xb,yb,zb, getPointerForExtraArgs(op, x.dataType()));
+                        Nd4j.getNativeOps().execPairwiseTransform(dummy,op.opNum(),xb,yb,zb, getPointerForExtraArgs(op, x.dataType()));
                         break;
                     case TRANSFORM_BOOL:
-                        loop.execTransformBool(dummy, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb);
+                        Nd4j.getNativeOps().execTransformBool(dummy, op.opNum(), xb, getPointerForExtraArgs(op, x.dataType()),zb);
                         break;
                     case PAIRWISE_BOOL:
-                        loop.execPairwiseTransformBool(dummy, op.opNum(), xb, yb, getPointerForExtraArgs(op, x.dataType()),zb);
+                        Nd4j.getNativeOps().execPairwiseTransformBool(dummy, op.opNum(), xb, yb, getPointerForExtraArgs(op, x.dataType()),zb);
                         break;
                 }
             } else {
@@ -660,17 +659,17 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                 switch (op.getOpType()) {
                     case TRANSFORM_FLOAT: {
                         val xtraz = getPointerForExtraArgs(op, z.dataType());
-                        loop.execTransformFloat(dummy, op.opNum(), xb,xtraz, zb);
+                        Nd4j.getNativeOps().execTransformFloat(dummy, op.opNum(), xb,xtraz, zb);
                         break;
                     }
                     case TRANSFORM_STRICT: {
                         val xtraz = getPointerForExtraArgs(op, z.dataType());
-                        loop.execTransformStrict(dummy, op.opNum(), xb, xtraz,zb);
+                        Nd4j.getNativeOps().execTransformStrict(dummy, op.opNum(), xb, xtraz,zb);
                         break;
                     }
                     case TRANSFORM_SAME: {
                         val xtraz = getPointerForExtraArgs(op, z.dataType());
-                        loop.execTransformSame(dummy, op.opNum(), xb,xtraz, zb);
+                        Nd4j.getNativeOps().execTransformSame(dummy, op.opNum(), xb,xtraz, zb);
                         break;
                     }
 
@@ -681,12 +680,12 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
             }
 
-            if (loop.lastErrorCode() != 0) {
+            if (Nd4j.getNativeOps().lastErrorCode() != 0) {
                 StringBuilder errorMessage = new StringBuilder();
                 DifferentialFunction differentialFunction = (DifferentialFunction) op;
                 errorMessage.append("Native  execution exec failed: ");
                 errorMessage.append(differentialFunction.debugInfo());
-                errorMessage.append(loop.lastErrorMessage());
+                errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
                 throw new RuntimeException(errorMessage.toString());
             }
         }
@@ -740,22 +739,22 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
         OpaqueNDArray dimArray = OpaqueNDArray.fromINDArray(op.dimensions());
         switch (op.getOpType()) {
             case BROADCAST:
-                loop.execBroadcast(dummy,op.opNum(),xb, yb, zb,extraz.get(),dimArray);
+                Nd4j.getNativeOps().execBroadcast(dummy,op.opNum(),xb, yb, zb,extraz.get(),dimArray);
 
                 break;
             case BROADCAST_BOOL:
-                loop.execBroadcastBool(dummy,op.opNum(),xb, yb,zb,extraz.get(),dimArray);
+                Nd4j.getNativeOps().execBroadcastBool(dummy,op.opNum(),xb, yb,zb,extraz.get(),dimArray);
                 break;
             default:
                 throw new UnsupportedOperationException("Unknown operation type: [" + op.getOpType() + "]");
         }
 
-        if (loop.lastErrorCode() != 0) {
+        if (Nd4j.getNativeOps().lastErrorCode() != 0) {
             StringBuilder errorMessage = new StringBuilder();
             DifferentialFunction differentialFunction = (DifferentialFunction) op;
             errorMessage.append("Native  execution exec failed: ");
             errorMessage.append(differentialFunction.debugInfo());
-            errorMessage.append(loop.lastErrorMessage());
+            errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
             throw new RuntimeException(errorMessage.toString());
         }
         profilingConfigurableHookOut(op,oc,st);
@@ -777,7 +776,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
     public Properties getEnvironmentInformation() {
         Properties properties = super.getEnvironmentInformation();
         properties.put(Nd4jEnvironment.BACKEND_KEY, "CPU");
-        properties.put(Nd4jEnvironment.OMP_THREADS_KEY, loop.ompGetMaxThreads());
+        properties.put(Nd4jEnvironment.OMP_THREADS_KEY, Nd4j.getNativeOps().ompGetMaxThreads());
         properties.put(Nd4jEnvironment.BLAS_THREADS_KEY, Nd4j.factory().blas().getMaxThreads());
         properties.put(Nd4jEnvironment.BLAS_VENDOR_KEY, (Nd4j.factory().blas()).getBlasVendor().toString());
         properties.put(Nd4jEnvironment.HOST_FREE_MEMORY_KEY, Pointer.maxBytes() - Pointer.totalBytes());
@@ -846,21 +845,21 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
         if (x != null && y != null && z != null) {
             DataBuffer dataBuffer = op.extraArgsDataBuff(z.dataType());
-            loop.execRandom3(null,op.opNum(),rng.getStatePointer(),xb,yb,zb,dataBuffer.addressPointer());
+            Nd4j.getNativeOps().execRandom3(null,op.opNum(),rng.getStatePointer(),xb,yb,zb,dataBuffer.addressPointer());
         } else if (x != null && z != null) {
             DataBuffer dataBuffer = op.extraArgsDataBuff(z.dataType());
-            loop.execRandom2(null,op.opNum(),rng.getStatePointer(),xb,zb,dataBuffer.addressPointer());
+            Nd4j.getNativeOps().execRandom2(null,op.opNum(),rng.getStatePointer(),xb,zb,dataBuffer.addressPointer());
         } else {
             DataBuffer dataBuffer = op.extraArgsDataBuff(z.dataType());
-            loop.execRandom(null,op.opNum(),rng.getStatePointer(),zb,dataBuffer.addressPointer());
+            Nd4j.getNativeOps().execRandom(null,op.opNum(),rng.getStatePointer(),zb,dataBuffer.addressPointer());
         }
 
-        if (loop.lastErrorCode() != 0) {
+        if (Nd4j.getNativeOps().lastErrorCode() != 0) {
             StringBuilder errorMessage = new StringBuilder();
             DifferentialFunction differentialFunction = (DifferentialFunction) op;
             errorMessage.append("Native  execution exec failed: ");
             errorMessage.append(differentialFunction.debugInfo());
-            errorMessage.append(loop.lastErrorMessage());
+            errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
             throw new RuntimeException(errorMessage.toString());
         }
 
@@ -876,7 +875,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
     @Override
     public synchronized Map<String, CustomOpDescriptor> getCustomOperations() {
         if (customOps == null) {
-            String list = loop.getAllCustomOps();
+            String list = Nd4j.getNativeOps().getAllCustomOps();
 
             if (list == null || list.isEmpty()) {
                 log.warn("No customs ops available!");
@@ -922,9 +921,10 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
      */
     @Override
     public  INDArray[] exec(@NonNull CustomOp op) {
-        boolean shapeOverride = op.initializeOutputs(null);
         val name = op.opName();
         try (val context = buildContext()) {
+            op.setupOpContextFromCustomOp(context);
+            boolean shapeOverride = op.initializeOutputs(context);
             long start = profilingConfigurableHookIn(op,context);
             initOpContext(op, shapeOverride, context);
 
@@ -947,315 +947,9 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
     }
 
-    protected LongShapeDescriptor getShapeFromPointer(LongPointer ptr) {
-        val rank = (int) ptr.get(0);
+   
 
-        val shape = new long[rank * 2 + 4];
-        for (int i = 0; i < shape.length; i++) {
-            shape[i] = ptr.get(i);
-        }
-
-        LongShapeDescriptor ret = LongShapeDescriptor.builder()
-                .shape(Shape.shape(shape))
-                .stride(Shape.stride(shape))
-                .order(Shape.order(shape))
-                .ews(Shape.elementWiseStride(shape))
-                .extras(Shape.extras(shape))
-                .build();
-        return ret;
-    }
-
-    @Override
-    public List<LongShapeDescriptor> calculateOutputShape(@NonNull CustomOp op) {
-        return calculateOutputShape(op, null);
-    }
-
-    @Override
-    public List<LongShapeDescriptor> calculateOutputShape(@NonNull CustomOp op, OpContext opContext) {
-        DifferentialFunction func = (DifferentialFunction) op;
-        String opName = func.getOwnName();
-        val lc = op.opName().toLowerCase();
-        val hash = op.opHash();
-
-        val result = new ArrayList<LongShapeDescriptor>();
-        int nIn = opContext != null ? opContext.numInputArguments() : op.numInputArguments();
-        if (nIn == 0 && op.getDescriptor().getNumInputs() >= 1) {
-            if (log.isTraceEnabled()) {
-                log.trace("Could not calculate output shape for op {}: number of input args was 0",
-                        op.getClass().getName());
-            }
-            return Collections.emptyList();
-        }
-
-        val inputBuffers = new PointerPointer<>(nIn);
-        val inputShapes = new PointerPointer<>(nIn);
-        val inputArgs = opContext != null && opContext.getInputArrays() != null && !opContext.getInputArrays().isEmpty()
-                ? opContext.getInputArrays() : op.inputArguments();
-        int cnt = 0;
-        int numProcessed = 0;
-        long[] offsets = new long[nIn];
-        for (val in : inputArgs) {
-            if (!in.isEmpty())
-                inputBuffers.put(cnt, in.data().addressPointer());
-            offsets[cnt] = in.offset();
-
-            inputShapes.put(cnt++, in.shapeInfoDataBuffer().addressPointer());
-            numProcessed++;
-        }
-
-        if (numProcessed != nIn) {
-            throw new ND4JIllegalStateException("Number of processed inputs should match number of inputs. " +
-                    "Got " + numProcessed + " inputs but should have been " + nIn + " . This is likely due a null input.");
-        }
-
-        int nIArgs = opContext != null ? opContext.numIArguments() : op.numIArguments();
-        val iArgs = nIArgs > 0 ? new LongPointer(nIArgs) : null;
-        cnt = 0;
-        if (opContext != null) {
-            if (iArgs != null)
-                for (val i : opContext.getIArguments())
-                    iArgs.put(cnt++, i);
-        } else {
-            if (iArgs != null)
-                for (val i : op.iArgs())
-                    iArgs.put(cnt++, i);
-        }
-
-        int nTArgs = opContext != null ? opContext.numTArguments() : op.numTArguments();
-        val tArgs = nTArgs > 0 ? new DoublePointer(nTArgs) : null;
-
-        int nBArgs = opContext != null ? opContext.numBArguments() : op.numBArguments();
-        val bArgs = nBArgs > 0 ? new BooleanPointer(nBArgs) : null;
-
-        int nDArgs = opContext != null ? opContext.numDArguments() : op.numDArguments();
-        val dArgs = nDArgs > 0 ? new IntPointer(nDArgs) : null;
-
-        cnt = 0;
-        if (opContext != null) {
-            if (bArgs != null)
-                for (val b : opContext.getBArguments())
-                    bArgs.put(cnt++, b);
-        } else {
-            if (bArgs != null)
-                for (val b : op.bArgs())
-                    bArgs.put(cnt++, b);
-        }
-
-        cnt = 0;
-        if (opContext != null) {
-            if (tArgs != null)
-                for (val b : opContext.getTArguments())
-                    tArgs.put(cnt++, b);
-        } else {
-            if (tArgs != null)
-                for (val b : op.tArgs())
-                    tArgs.put(cnt++, b);
-        }
-
-        cnt = 0;
-        if (opContext != null) {
-            if (dArgs != null)
-                for (val b : opContext.getDArguments())
-                    dArgs.put(cnt++, b.toInt());
-        } else {
-            if (dArgs != null)
-                for (val b : op.dArgs())
-                    dArgs.put(cnt++, b.toInt());
-        }
-
-        if (numProcessed != nIn) {
-            throw new ND4JIllegalStateException("Number of processed inputs should match number of inputs. " +
-                    "Got " + numProcessed + " inputs but should have been " + nIn + " . This is likely due a null input.");
-        }
-
-        OpaqueShapeList ptrptr;
-        try {
-            OpaqueNDArrayArr inputsOpaque = new OpaqueNDArrayArr(inputArgs.stream().map(OpaqueNDArray::fromINDArray).toArray(OpaqueNDArray[]::new));
-            ptrptr = loop.calculateOutputShapes2(null, hash, inputsOpaque, nIn, tArgs, nTArgs, iArgs, nIArgs, bArgs, nBArgs, dArgs, nDArgs);
-
-            if (loop.lastErrorCode() != 0) {
-                StringBuilder errorMessage = new StringBuilder();
-                DifferentialFunction differentialFunction = (DifferentialFunction) op;
-                errorMessage.append("Native execution exec failed: ");
-                errorMessage.append(differentialFunction.debugInfo());
-                errorMessage.append(loop.lastErrorMessage());
-                throw new RuntimeException(errorMessage.toString());
-            }
-            if (ptrptr == null)
-                throw new RuntimeException();
-
-        } catch (Throwable t) {
-            StringBuilder sb = new StringBuilder();
-            DifferentialFunction differentialFunction = (DifferentialFunction) op;
-            sb.append("Inputs: [(");
-            for (int i = 0; i < inputArgs.size(); i++) {
-                if (i > 0)
-                    sb.append("), (");
-                sb.append(Shape.shapeToStringShort(inputArgs.get(i)));
-            }
-            sb.append(")]");
-            sb.append(differentialFunction.debugInfo());
-
-            int nOut = opContext != null ? opContext.numOutputArguments() : op.numOutputArguments();
-            log.error("Failed to calculate output shapes for op {}. Attempted to execute with {} inputs, {} outputs, " +
-                            "{} targs, {} iargs, {} bargs and {} dargs. {} - Please see above message (printed out from c++) for a possible cause of error.",
-                    op.opName(), nIn, nOut, nTArgs, nIArgs, nBArgs, nDArgs, sb.toString());
-            throw t;
-        }
-
-        if (loop.lastErrorCode() != 0) {
-            StringBuilder errorMessage = new StringBuilder();
-            DifferentialFunction differentialFunction = (DifferentialFunction) op;
-            errorMessage.append("Native execution exec failed: ");
-            errorMessage.append(differentialFunction.debugInfo());
-            errorMessage.append(loop.lastErrorMessage());
-            throw new RuntimeException(errorMessage.toString());
-        }
-        if (ptrptr == null)
-            throw new RuntimeException();
-
-        for (int e = 0; e < loop.getShapeListSize(ptrptr); e++)
-            result.add(getShapeFromPointer(new PagedPointer(loop.getShape(ptrptr, e)).asLongPointer()));
-
-        if (log.isTraceEnabled()) {
-            String[] arr = new String[result.size()];
-            for (int i = 0; i < result.size(); i++) {
-                arr[i] = result.get(i).toString();
-            }
-
-            DifferentialFunction differentialFunction = (DifferentialFunction) op;
-            log.trace("Calculated output shapes for op of name {} and type {} - {}", differentialFunction.getOwnName(), op.getClass().getName(), Arrays.toString(arr));
-        }
-        return result;
-    }
-
-    @Override
-    public void enableDebugMode(boolean reallyEnable) {
-        debug.set(reallyEnable);
-        loop.enableDebugMode(reallyEnable);
-    }
-
-    @Override
-    public void enableVerboseMode(boolean reallyEnable) {
-        verbose.set(reallyEnable);
-        loop.enableVerboseMode(reallyEnable);
-    }
-
-
-    @Override
-    public void registerGraph(long id, Pointer graph) {
-        loop.registerGraph(null, id, graph);
-
-        if (loop.lastErrorCode() != 0)
-            throw new RuntimeException(loop.lastErrorMessage());
-    }
-
-    @Override
-    public Map<String, INDArray> executeGraph(long id, @NonNull Map<String, INDArray> map, @NonNull Map<String, Integer> reverseMap) {
-
-        val ptrBuffers = new PointerPointer(map.size());
-        val ptrShapes = new PointerPointer(map.size());
-        val ptrIndices = new IntPointer(map.size());
-
-        int cnt = 0;
-        val keySet = new ArrayList<String>(map.keySet());
-        for (val key: keySet) {
-            val array = map.get(key);
-
-            ptrBuffers.put(cnt, array.data().addressPointer());
-            ptrShapes.put(cnt, array.shapeInfoDataBuffer().addressPointer());
-            ptrIndices.put(cnt, reverseMap.get(key));
-
-            cnt++;
-        }
-
-        val newMap = new LinkedHashMap<String, INDArray>();
-
-        OpaqueVariablesSet result = loop.executeStoredGraph(null, id, ptrBuffers, ptrShapes, ptrIndices, map.size());
-
-        if (loop.lastErrorCode() != 0)
-            throw new RuntimeException(loop.lastErrorMessage());
-
-        OpStatus status = OpStatus.byNumber(loop.getVariablesSetStatus(result));
-
-        if (status != OpStatus.ND4J_STATUS_OK)
-            throw new ND4JIllegalStateException("Op execution failed: " + status);
-
-        for (int e = 0; e < loop.getVariablesSetSize(result); e++) {
-            OpaqueVariable var = loop.getVariable(result, e);
-            int nodeId = loop.getVariableId(var);
-            int index = loop.getVariableIndex(var);
-            LongPointer shapeInfo = loop.getVariableShape(var);
-            Pointer buffer = loop.getVariableBuffer(var);
-
-            val rank = (int) shapeInfo.get(0);
-            val jshape = new long[rank * 2 + 4];
-            for (int i = 0; i < jshape.length; i++) {
-                jshape[i] = shapeInfo.get(i);
-            }
-
-            val shapeOf = Shape.shapeOf(jshape);
-            val stridesOf = Shape.stridesOf(jshape);
-            val order = Shape.order(jshape);
-            val array = Nd4j.create(shapeOf, stridesOf, 0, order);
-
-            val perfX = PerformanceTracker.getInstance().helperStartTransaction();
-
-            Pointer.memcpy(array.data().addressPointer(), buffer, Shape.lengthOf(shapeOf) * Nd4j.sizeOfDataType(array.dataType()));
-
-            PerformanceTracker.getInstance().helperRegisterTransaction(0, perfX, Shape.lengthOf(shapeOf) * Nd4j.sizeOfDataType(array.dataType()), MemcpyDirection.HOST_TO_HOST);
-
-            String nodeName = loop.getVariableName(var);
-            newMap.put(nodeName, array);
-        }
-
-        // loop.deleteVariablesSet(result);
-
-        return newMap;
-    }
-
-    @Override
-    public void forgetGraph(long id) {
-        loop.unregisterGraph(null, id);
-        if (loop.lastErrorCode() != 0)
-            throw new RuntimeException(loop.lastErrorMessage());
-    }
-
-    /**
-     * This method allows to set desired number of elements per thread, for performance optimization purposes.
-     * I.e. if array contains 2048 elements, and threshold is set to 1024, 2 threads will be used for given op execution.
-     * <p>
-     * Default value: 1024
-     *
-     * @param threshold
-     */
-    @Override
-    public void setElementsThreshold(int threshold) {
-        loop.setElementThreshold(threshold);
-    }
-
-    /**
-     * This method allows to set desired number of sub-arrays per thread, for performance optimization purposes.
-     * I.e. if matrix has shape of 64 x 128, and threshold is set to 8, each thread will be processing 8 sub-arrays (sure, if you have 8 core cpu).
-     * If your cpu has, say, 4, cores, only 4 threads will be spawned, and each will process 16 sub-arrays
-     * <p>
-     * Default value: 8
-     *
-     * @param threshold
-     */
-    @Override
-    public void setTadThreshold(int threshold) {
-        loop.setTADThreshold(threshold);
-    }
-
-    @Override
-    public String getString(DataBuffer buffer, long index) {
-        Preconditions.checkArgument(buffer instanceof Utf8Buffer, "Expected Utf8Buffer");
-
-        val addr = ((LongIndexer) buffer.indexer()).get(index);
-        val ptr = new PagedPointer(addr);
-        return "";
-    }
+  
 
     @Override
     public ExecutionerType type() {
@@ -1282,9 +976,9 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
         INDArray dimm = Nd4j.createFromArray(axis);
         val dimmOpaque = OpaqueNDArray.fromINDArray(dimm);
 
-        loop.scatterUpdate(null,op.ordinal(),arrayOpaque,indicesOpaque,updatesOpaque,dimmOpaque);
-        if (loop.lastErrorCode() != 0)
-            throw new RuntimeException(loop.lastErrorMessage());
+        Nd4j.getNativeOps().scatterUpdate(null,op.ordinal(),arrayOpaque,indicesOpaque,updatesOpaque,dimmOpaque);
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
     }
 
     @Override
@@ -1311,7 +1005,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
 
 
-            val status = loop.execCustomOp2(null, op.opHash(), context.contextPointer());
+            val status = Nd4j.getNativeOps().execCustomOp2(null, op.opHash(), context.contextPointer());
 
 
             if (status != 0) {
@@ -1319,7 +1013,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                 DifferentialFunction differentialFunction = (DifferentialFunction) op;
                 errorMessage.append("Native  execution exec failed: ");
                 errorMessage.append(differentialFunction.debugInfo());
-                errorMessage.append(loop.lastErrorMessage());
+                errorMessage.append(Nd4j.getNativeOps().lastErrorMessage());
                 throw new RuntimeException(errorMessage.toString());
             }
             if (context.getOutputArrays().isEmpty())
@@ -1416,7 +1110,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
             Shape.setElementWiseStride(merged,(int) elementWiseStride);
             LongPointer longPointer = new LongPointer(merged);
-            loop.setShapeBuffer(longPointer,dtype.toInt(),new LongPointer(ret.addressPointer()),order,(int) elementWiseStride,empty,isView);
+            Nd4j.getNativeOps().setShapeBuffer(longPointer,dtype.toInt(),new LongPointer(ret.addressPointer()),order,(int) elementWiseStride,empty,isView);
             longPointer.deallocate();
             longPointer.releaseReference();
             if(isView != ArrayOptionsHelper.isView(Shape.options(ret))) {
@@ -1477,11 +1171,11 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
     public DataBuffer createShapeInfo(long[] shape, long[] stride, long elementWiseStride, char order, DataType dtype, long extras) {
         LongPointer shapePointer = new LongPointer(shape);
         LongPointer stridePointer = new LongPointer(stride);
-        OpaqueConstantShapeBuffer dbf = loop.shapeBufferEx(shape.length, shapePointer, stridePointer, dtype.toInt(), order, elementWiseStride, extras);
-        if (loop.lastErrorCode() != 0)
-            throw new RuntimeException(loop.lastErrorMessage());
+        OpaqueConstantShapeBuffer dbf = Nd4j.getNativeOps().shapeBufferEx(shape.length, shapePointer, stridePointer, dtype.toInt(), order, elementWiseStride, extras);
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val result = new LongBuffer(loop.getConstantShapeBufferPrimary(dbf), Shape.shapeInfoLength(shape.length));
+        val result = new LongBuffer(Nd4j.getNativeOps().getConstantShapeBufferPrimary(dbf), Shape.shapeInfoLength(shape.length));
 
         return result;
     }
@@ -1493,13 +1187,13 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
             inputDimensions[i] = dimension[i];
         }
         try {
-            OpaqueTadPack pack = loop.tadOnlyShapeInfo(array.shapeInfoDataBuffer().opaqueBuffer(), new LongPointer(inputDimensions), dimension.length);
+            OpaqueTadPack pack = Nd4j.getNativeOps().tadOnlyShapeInfo(array.shapeInfoDataBuffer().opaqueBuffer(), new LongPointer(inputDimensions), dimension.length);
 
-            if (loop.lastErrorCode() != 0)
-                throw new RuntimeException(loop.lastErrorMessage());
+            if (Nd4j.getNativeOps().lastErrorCode() != 0)
+                throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-            val tadShape = new LongBuffer(loop.getPrimaryShapeInfo(pack), loop.getShapeInfoLength(pack));
-            val tadOffsets = new LongBuffer(loop.getPrimaryOffsets(pack), loop.getNumberOfTads(pack));
+            val tadShape = new LongBuffer(Nd4j.getNativeOps().getPrimaryShapeInfo(pack), Nd4j.getNativeOps().getShapeInfoLength(pack));
+            val tadOffsets = new LongBuffer(Nd4j.getNativeOps().getPrimaryOffsets(pack), Nd4j.getNativeOps().getNumberOfTads(pack));
             return new TadPack(tadShape, tadOffsets);
         }catch(Exception e) {
             throw new RuntimeException(e);
@@ -1519,7 +1213,7 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
 
     @Override
     public int useCount(DataBuffer buffer) {
-        return loop.dbUseCount(((BaseCpuDataBuffer) buffer).getOpaqueDataBuffer());
+        return Nd4j.getNativeOps().dbUseCount(((BaseCpuDataBuffer) buffer).getOpaqueDataBuffer());
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -673,7 +673,10 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
                         break;
                     }
 
-
+                    case TRANSFORM_BOOL: {
+                        Nd4j.getNativeOps().execTransformBool(dummy, op.opNum(), xb, getPointerForExtraArgs(op, z.dataType()), zb);
+                        break;
+                    }
                     default:
                         throw new UnsupportedOperationException("Unknown transform type: [" + op.getOpType() + "]");
                 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/ops/executioner/CudaExecutioner.java
@@ -85,8 +85,6 @@ import static org.bytedeco.cuda.global.cudart.*;
 @Slf4j
 public class CudaExecutioner extends DefaultOpExecutioner {
 
-    protected static NativeOps nativeOps = NativeOpsHolder.getInstance().getDeviceNativeOps();
-
 
     @Getter
     protected static TADManager tadManager = new DeviceTADManager();
@@ -100,12 +98,9 @@ public class CudaExecutioner extends DefaultOpExecutioner {
     protected AtomicBoolean experimentalMode = new AtomicBoolean(false);
 
     public CudaExecutioner() {
-        experimentalMode.set(nativeOps.isExperimentalEnabled());
+        experimentalMode.set(Nd4j.getNativeOps().isExperimentalEnabled());
     }
 
-    public NativeOps getNativeOps() {
-        return nativeOps;
-    }
 
     @Override
     public String getLastOp() {
@@ -164,7 +159,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
         switch (op.getOpType()) {
             case BROADCAST:
-                nativeOps.execBroadcast(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execBroadcast(xShapeInfoHostPointer, op.opNum(),
                         x,
                         y,
                         z,
@@ -172,7 +167,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                         dimension);
                 break;
             case BROADCAST_BOOL:
-                nativeOps.execBroadcastBool(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execBroadcastBool(xShapeInfoHostPointer, op.opNum(),
                         x,
                         y,
                         z,
@@ -183,8 +178,8 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                 throw new UnsupportedOperationException("Unknown op type: " + op.getOpType());
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, null, st);
 
@@ -311,13 +306,13 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         val dim = OpaqueNDArray.fromINDArray(dimArr);
         if (op instanceof Variance) {
             if (ret.isScalar()) {
-                nativeOps.execSummaryStatsScalar(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execSummaryStatsScalar(xShapeInfoHostPointer, op.opNum(),
                         x,
                         extraArgs,
                         z,
                         ((Variance) op).isBiasCorrected());
             } else {
-                nativeOps.execSummaryStatsTad(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execSummaryStatsTad(xShapeInfoHostPointer, op.opNum(),
                         x,
                         extraArgs,
                         z,
@@ -326,39 +321,39 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             }
         } else if (op.y() != null) {
             if (ret.isScalar()) {
-                nativeOps.execReduce3Scalar(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execReduce3Scalar(xShapeInfoHostPointer, op.opNum(),
                         x,
                         extraArgs,
                         y,
                         z);
             } else {
-                nativeOps.execReduce3Tad(xShapeInfoHostPointer, op.opNum(),x
+                Nd4j.getNativeOps().execReduce3Tad(xShapeInfoHostPointer, op.opNum(),x
                         ,extraArgs,y,z,dim);
             }
         } else {
             if (ret.isScalar()) {
                 switch (op.getOpType()) {
                     case REDUCE_FLOAT:
-                        nativeOps.execReduceFloat(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceFloat(xShapeInfoHostPointer, op.opNum(),
                                 x,
                                 extraArgs,
                                 z);
                         break;
                     case REDUCE_BOOL:
-                        nativeOps.execReduceBool(xShapeInfoHostPointer,
+                        Nd4j.getNativeOps().execReduceBool(xShapeInfoHostPointer,
                                 op.opNum(),
                                 x,
                                 extraArgs,
                                 z,dim);
                         break;
                     case REDUCE_LONG:
-                        nativeOps.execReduceLong(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceLong(xShapeInfoHostPointer, op.opNum(),
                                 x,
                                 extraArgs,
                                 z,dim);
                         break;
                     case REDUCE_SAME:
-                        nativeOps.execReduceSame(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceSame(xShapeInfoHostPointer, op.opNum(),
                                 x,
                                 extraArgs,
                                 z);
@@ -369,20 +364,20 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             } else {
                 switch (op.getOpType()) {
                     case REDUCE_FLOAT:
-                        nativeOps.execReduceFloat2(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceFloat2(xShapeInfoHostPointer, op.opNum(),
                                 x,
                                 extraArgs,z,dim);
                         break;
                     case REDUCE_BOOL:
-                        nativeOps.execReduceBool2(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceBool2(xShapeInfoHostPointer, op.opNum(),
                                 x,extraArgs,z,dim);
                         break;
                     case REDUCE_SAME:
-                        nativeOps.execReduceSame2(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceSame2(xShapeInfoHostPointer, op.opNum(),
                                 x, extraArgs, z,dim);
                         break;
                     case REDUCE_LONG:
-                        nativeOps.execReduceLong2(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceLong2(xShapeInfoHostPointer, op.opNum(),
                                 x, extraArgs, z,dim);
                         break;
                     default:
@@ -391,8 +386,8 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             }
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, null, st);
 
@@ -553,14 +548,14 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         val z = OpaqueNDArray.fromINDArray(op.z());
         INDArray dim1 = op.dimensions().castTo(DataType.LONG);
         val dimension2 = OpaqueNDArray.fromINDArray(dim1);
-        nativeOps.execIndexReduce(xShapeInfoHostPointer, op.opNum(),
+        Nd4j.getNativeOps().execIndexReduce(xShapeInfoHostPointer, op.opNum(),
                 x,
                 extraArgs,
                 z,
                 dimension2);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, null, st);
 
@@ -686,7 +681,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
         switch (op.getOpType()) {
             case BROADCAST:
-                nativeOps.execBroadcast(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execBroadcast(xShapeInfoHostPointer, op.opNum(),
                         xb,
                         yb,
                         zb,
@@ -694,7 +689,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                         dimension);
                 break;
             case BROADCAST_BOOL:
-                nativeOps.execBroadcastBool(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execBroadcastBool(xShapeInfoHostPointer, op.opNum(),
                         xb,
                         yb,
                         zb,
@@ -705,8 +700,8 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                 throw new UnsupportedOperationException("Unknown opType: " + op.getOpType());
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, oc, st);
 
@@ -788,7 +783,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                 hostYShapeInfo, hostZShapeInfo, hostTadShapeInfo, devTadShapeInfo, devTadOffsets);
 
         if (z.isScalar() || dimension == null || dimension[0] == Integer.MAX_VALUE) {
-            nativeOps.execIndexReduceScalar(xShapeInfoHostPointer, op.opNum(),
+            Nd4j.getNativeOps().execIndexReduceScalar(xShapeInfoHostPointer, op.opNum(),
                     xb,
                     extraArgs,
                     zb);
@@ -799,15 +794,15 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             val dim = Nd4j.createFromArray(dimension);
             val dimPointer = OpaqueNDArray.fromINDArray(dim);
 
-            nativeOps.execIndexReduce(xShapeInfoHostPointer, op.opNum(),
+            Nd4j.getNativeOps().execIndexReduce(xShapeInfoHostPointer, op.opNum(),
                     xb,
                     extraArgs,
                     zb,
                     dimPointer);
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, oc, st);
 
@@ -955,13 +950,13 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
         if (z.isScalar()) {
             if (op instanceof Variance) {
-                nativeOps.execSummaryStatsScalar(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execSummaryStatsScalar(xShapeInfoHostPointer, op.opNum(),
                         xb,
                         extraArgs,
                         zb,
                         ((Variance) op).isBiasCorrected());
             } else if (y != null) {
-                nativeOps.execReduce3Scalar(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execReduce3Scalar(xShapeInfoHostPointer, op.opNum(),
                         xb,
                         extraArgs,
                         yb,
@@ -969,25 +964,25 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             } else {
                 switch (op.getOpType()) {
                     case REDUCE_FLOAT:
-                        nativeOps.execReduceFloat(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceFloat(xShapeInfoHostPointer, op.opNum(),
                                 xb,
                                 extraArgs,
                                 zb);
                         break;
                     case REDUCE_BOOL:
-                        nativeOps.execReduceBool(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceBool(xShapeInfoHostPointer, op.opNum(),
                                 xb,
                                 extraArgs,
                                 zb,dimensionPointer);
                         break;
                     case REDUCE_SAME:
-                        nativeOps.execReduceSame(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceSame(xShapeInfoHostPointer, op.opNum(),
                                 xb,
                                 extraArgs,
                                 zb);
                         break;
                     case REDUCE_LONG:
-                        nativeOps.execReduceLong(xShapeInfoHostPointer, op.opNum(),
+                        Nd4j.getNativeOps().execReduceLong(xShapeInfoHostPointer, op.opNum(),
                                 xb,
                                 extraArgs,
                                 zb,dimensionPointer);
@@ -999,7 +994,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         } else {
 
             if (y != null) {
-                nativeOps.execReduce3Tad(
+                Nd4j.getNativeOps().execReduce3Tad(
                         xShapeInfoHostPointer,
                         op.opNum(),
                         xb,
@@ -1008,7 +1003,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                         zb,dimensionPointer);
             } else {
                 if (op instanceof Variance) {
-                    nativeOps.execSummaryStatsTad(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execSummaryStatsTad(xShapeInfoHostPointer, op.opNum(),
                             xb, (LongPointer)
                                     extraArgs,
                             zb,
@@ -1017,26 +1012,26 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                 } else {
                     switch (op.getOpType()) {
                         case REDUCE_FLOAT:
-                            nativeOps.execReduceFloat2(xShapeInfoHostPointer, op.opNum(),
+                            Nd4j.getNativeOps().execReduceFloat2(xShapeInfoHostPointer, op.opNum(),
                                     xb,
                                     extraArgs,
                                     zb, dimensionPointer);
 
                             break;
                         case REDUCE_SAME:
-                            nativeOps.execReduceSame2(xShapeInfoHostPointer, op.opNum(),
+                            Nd4j.getNativeOps().execReduceSame2(xShapeInfoHostPointer, op.opNum(),
                                     xb,
                                     extraArgs,
                                     zb, dimensionPointer);
                             break;
                         case REDUCE_BOOL:
-                            nativeOps.execReduceBool2(xShapeInfoHostPointer, op.opNum(),
+                            Nd4j.getNativeOps().execReduceBool2(xShapeInfoHostPointer, op.opNum(),
                                     xb,
                                     extraArgs,
                                     zb, dimensionPointer);
                             break;
                         case REDUCE_LONG:
-                            nativeOps.execReduceLong2(xShapeInfoHostPointer, op.opNum(),
+                            Nd4j.getNativeOps().execReduceLong2(xShapeInfoHostPointer, op.opNum(),
                                     xb,
                                     extraArgs,
                                     zb, dimensionPointer);
@@ -1048,8 +1043,8 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             }
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, oc, st);
 
@@ -1112,7 +1107,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         val dimensionPointer = OpaqueNDArray.fromINDArray(dim);
         switch (op.getOpType()) {
             case SCALAR:
-                nativeOps.execScalarTad(extraPointers, op.opNum(),
+                Nd4j.getNativeOps().execScalarTad(extraPointers, op.opNum(),
                         x,
                         z,
                         y,
@@ -1121,7 +1116,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
                 break;
             case SCALAR_BOOL:
-                nativeOps.execScalarBoolTad(extraPointers, op.opNum(),
+                Nd4j.getNativeOps().execScalarBoolTad(extraPointers, op.opNum(),
                         x,
                         z,
                         y,
@@ -1132,8 +1127,8 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                 throw new UnsupportedOperationException();
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, null, st);
 
@@ -1210,14 +1205,14 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
         switch (op.getOpType()) {
             case SCALAR_BOOL:
-                nativeOps.execScalarBool(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execScalarBool(xShapeInfoHostPointer, op.opNum(),
                         xb,
                         zb,
                         yb,
                         extraArgs);
                 break;
             case SCALAR:
-                nativeOps.execScalar(xShapeInfoHostPointer, op.opNum(),
+                Nd4j.getNativeOps().execScalar(xShapeInfoHostPointer, op.opNum(),
                         xb,
                         zb,
                         yb,
@@ -1227,8 +1222,8 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                 throw new UnsupportedOperationException("Unknown op type: " + op.getOpType());
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, oc, st);
 
@@ -1330,14 +1325,14 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             switch (op.getOpType()) {
                 case TRANSFORM_BOOL:
                 case PAIRWISE_BOOL:
-                    nativeOps.execPairwiseTransformBool(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execPairwiseTransformBool(xShapeInfoHostPointer, op.opNum(),
                             xb,
                             yb,
                             extraArgs,
                             zb );
                     break;
                 default:
-                    nativeOps.execPairwiseTransform(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execPairwiseTransform(xShapeInfoHostPointer, op.opNum(),
                             xb,
                             yb,
                             zb,
@@ -1347,31 +1342,31 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         } else {
             switch (op.getOpType()) {
                 case TRANSFORM_ANY:
-                    nativeOps.execTransformAny(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execTransformAny(xShapeInfoHostPointer, op.opNum(),
                             xb,
                             extraArgs,
                             zb);
                     break;
                 case TRANSFORM_FLOAT:
-                    nativeOps.execTransformFloat(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execTransformFloat(xShapeInfoHostPointer, op.opNum(),
                             xb,
                             extraArgs,
                             zb);
                     break;
                 case TRANSFORM_BOOL:
-                    nativeOps.execTransformBool(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execTransformBool(xShapeInfoHostPointer, op.opNum(),
                             xb,
                             extraArgs,
                             zb);
                     break;
                 case TRANSFORM_SAME:
-                    nativeOps.execTransformSame(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execTransformSame(xShapeInfoHostPointer, op.opNum(),
                             xb,
                             extraArgs,
                             zb);
                     break;
                 case TRANSFORM_STRICT:
-                    nativeOps.execTransformStrict(xShapeInfoHostPointer, op.opNum(),
+                    Nd4j.getNativeOps().execTransformStrict(xShapeInfoHostPointer, op.opNum(),
                             xb,
                             extraArgs,
                             zb);
@@ -1381,8 +1376,8 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             }
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         if (extraArgs != null)
             extraArgs.address();
@@ -1453,7 +1448,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
         if (x != null && y != null && z != null) {
             // triple arg call
-            nativeOps.execRandom3(extraZZ, op.opNum(), rng.getStatePointer(), // rng state ptr
+            Nd4j.getNativeOps().execRandom3(extraZZ, op.opNum(), rng.getStatePointer(), // rng state ptr
                     xb,
                     yb,
                     zb,
@@ -1461,7 +1456,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
         } else if (x != null && z != null) {
             //double arg call
-            nativeOps.execRandom2(extraZZ, op.opNum(),
+            Nd4j.getNativeOps().execRandom2(extraZZ, op.opNum(),
                     rng.getStatePointer(), // rng state ptr
                     xb,
                     zb,
@@ -1470,13 +1465,13 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
         } else {
             // single arg call
-            nativeOps.execRandom(extraZZ, op.opNum(), rng.getStatePointer(), // rng state ptr
+            Nd4j.getNativeOps().execRandom(extraZZ, op.opNum(), rng.getStatePointer(), // rng state ptr
                     zb,
                     AtomicAllocator.getInstance().getPointer(op.extraArgsDataBuff(z.dataType()),context));
         }
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         profilingConfigurableHookOut(op, oc, st);
 
@@ -1498,21 +1493,21 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             List<Map<String, Object>> devicesList = new ArrayList<>();
 
             // fill with per-device information: name, memory, versions
-            for (int i = 0; i < nativeOps.getAvailableDevices(); i++) {
+            for (int i = 0; i < Nd4j.getNativeOps().getAvailableDevices(); i++) {
                 Map<String, Object> deviceProps = new HashMap<>();
 
-                deviceProps.put(Nd4jEnvironment.CUDA_DEVICE_NAME_KEY, nativeOps.getDeviceName(i));
-                deviceProps.put(Nd4jEnvironment.CUDA_FREE_MEMORY_KEY, nativeOps.getDeviceFreeMemory(i));
-                deviceProps.put(Nd4jEnvironment.CUDA_TOTAL_MEMORY_KEY, nativeOps.getDeviceTotalMemory(i));
-                deviceProps.put(Nd4jEnvironment.CUDA_DEVICE_MAJOR_VERSION_KEY, (long) nativeOps.getDeviceMajor(i));
-                deviceProps.put(Nd4jEnvironment.CUDA_DEVICE_MINOR_VERSION_KEY, (long) nativeOps.getDeviceMinor(i));
+                deviceProps.put(Nd4jEnvironment.CUDA_DEVICE_NAME_KEY, Nd4j.getNativeOps().getDeviceName(i));
+                deviceProps.put(Nd4jEnvironment.CUDA_FREE_MEMORY_KEY, Nd4j.getNativeOps().getDeviceFreeMemory(i));
+                deviceProps.put(Nd4jEnvironment.CUDA_TOTAL_MEMORY_KEY, Nd4j.getNativeOps().getDeviceTotalMemory(i));
+                deviceProps.put(Nd4jEnvironment.CUDA_DEVICE_MAJOR_VERSION_KEY, (long) Nd4j.getNativeOps().getDeviceMajor(i));
+                deviceProps.put(Nd4jEnvironment.CUDA_DEVICE_MINOR_VERSION_KEY, (long) Nd4j.getNativeOps().getDeviceMinor(i));
 
                 devicesList.add(i, deviceProps);
             }
 
             // fill with basic general info
             props.put(Nd4jEnvironment.BACKEND_KEY, "CUDA");
-            props.put(Nd4jEnvironment.CUDA_NUM_GPUS_KEY, nativeOps.getAvailableDevices());
+            props.put(Nd4jEnvironment.CUDA_NUM_GPUS_KEY, Nd4j.getNativeOps().getAvailableDevices());
             props.put(Nd4jEnvironment.CUDA_DEVICE_INFORMATION_KEY, devicesList);
             props.put(Nd4jEnvironment.BLAS_VENDOR_KEY, (Nd4j.factory().blas()).getBlasVendor().toString());
             props.put(Nd4jEnvironment.HOST_FREE_MEMORY_KEY, Pointer.maxBytes() - Pointer.totalBytes());
@@ -1526,11 +1521,11 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             List<Map<String, Object>> devicesList = (List<Map<String, Object>>) properties.get(Nd4jEnvironment.CUDA_DEVICE_INFORMATION_KEY);
 
             // just update information that might change over time
-            for (int i = 0; i < nativeOps.getAvailableDevices(); i++) {
+            for (int i = 0; i < Nd4j.getNativeOps().getAvailableDevices(); i++) {
                 Map<String, Object> dev = devicesList.get(i);
 
-                dev.put(Nd4jEnvironment.CUDA_FREE_MEMORY_KEY, nativeOps.getDeviceFreeMemory(i));
-                dev.put(Nd4jEnvironment.CUDA_TOTAL_MEMORY_KEY, nativeOps.getDeviceTotalMemory(i));
+                dev.put(Nd4jEnvironment.CUDA_FREE_MEMORY_KEY, Nd4j.getNativeOps().getDeviceFreeMemory(i));
+                dev.put(Nd4jEnvironment.CUDA_TOTAL_MEMORY_KEY, Nd4j.getNativeOps().getDeviceTotalMemory(i));
             }
 
             properties.put(Nd4jEnvironment.CUDA_DEVICE_INFORMATION_KEY, devicesList);
@@ -1563,7 +1558,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
     @Override
     public synchronized Map<String, CustomOpDescriptor> getCustomOperations() {
         if(customOps == null) {
-            String list = nativeOps.getAllCustomOps();
+            String list = Nd4j.getNativeOps().getAllCustomOps();
 
             if (list == null || list.isEmpty()) {
                 log.warn("No customs ops available!");
@@ -1612,96 +1607,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         val t = ArrayOptionsHelper.arrayType(shape);
         return LongShapeDescriptor.fromShape(Shape.shape(shape), Shape.stride(shape), Shape.elementWiseStride(shape), Shape.order(shape), ArrayOptionsHelper.dataType(shape), t == ArrayType.EMPTY);
     }
-
-    @Override
-    public List<LongShapeDescriptor> calculateOutputShape(@NonNull CustomOp op) {
-        return calculateOutputShape(op, null);
-    }
-
-    @Override
-    public List<LongShapeDescriptor> calculateOutputShape(@NonNull CustomOp op, OpContext opContext) {
-
-        Nd4j.getExecutioner().commit();
-
-        val lc = op.opName().toLowerCase();
-        val hash = op.opHash();
-
-        val result = new ArrayList<LongShapeDescriptor>();
-        int nIn = opContext != null ? opContext.numInputArguments() : op.numInputArguments();
-        if (nIn == 0 && op.getDescriptor().getNumInputs() >= 1) {
-            if (log.isTraceEnabled()) {
-                log.trace("Could not calculate output shape for op {}: number of input args was 0",
-                        op.getClass().getName());
-            }
-            return Collections.emptyList();
-        }
-
-        val inputArgs = opContext != null ? opContext.getInputArrays() : op.inputArguments();
-        OpaqueNDArrayArr inputsOpaque = new OpaqueNDArrayArr(inputArgs.stream().map(OpaqueNDArray::fromINDArray).toArray(OpaqueNDArray[]::new));
-
-        int nIArgs = opContext != null ? opContext.numIArguments() : op.numIArguments();
-        val iArgs = nIArgs > 0 ? new LongPointer(nIArgs) : null;
-        int cnt = 0;
-        if (opContext != null) {
-            for (val i : opContext.getIArguments())
-                iArgs.put(cnt++, i);
-        } else {
-            for (val i : op.iArgs())
-                iArgs.put(cnt++, i);
-        }
-
-        int nTArgs = opContext != null ? opContext.numTArguments() : op.numTArguments();
-        val tArgs = nTArgs > 0 ? new DoublePointer(nTArgs) : null;
-
-        int nBArgs = opContext != null ? opContext.numBArguments() : op.numBArguments();
-        val bArgs = nBArgs > 0 ? new BooleanPointer(nBArgs) : null;
-
-        int nDArgs = opContext != null ? opContext.numDArguments() : op.numDArguments();
-        val dArgs = nDArgs > 0 ? new IntPointer(nDArgs) : null;
-
-        cnt = 0;
-        if (opContext != null) {
-            for (val b : opContext.getBArguments())
-                bArgs.put(cnt++, b);
-        } else {
-            for (val b : op.bArgs())
-                bArgs.put(cnt++, b);
-        }
-
-        cnt = 0;
-        if (opContext != null) {
-            for (val b : opContext.getTArguments())
-                tArgs.put(cnt++, b);
-        } else {
-            for (val b : op.tArgs())
-                tArgs.put(cnt++, b);
-        }
-
-        cnt = 0;
-        if (opContext != null) {
-            for (val b : opContext.getDArguments())
-                dArgs.put(cnt++, b.toInt());
-        } else {
-            for (val b : op.dArgs())
-                dArgs.put(cnt++, b.toInt());
-        }
-
-        OpaqueShapeList ptrptr = nativeOps.calculateOutputShapes2(null, hash, inputsOpaque, nIn, tArgs, nTArgs, iArgs, nIArgs, bArgs, nBArgs, dArgs, nDArgs);
-
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
-
-        if (ptrptr == null)
-            throw new RuntimeException();
-
-        for (int e = 0; e < nativeOps.getShapeListSize(ptrptr); e++)
-            result.add(getShapeFromPointer(new PagedPointer(nativeOps.getShape(ptrptr, e)).asLongPointer()));
-
-        nativeOps.deleteShapeList(ptrptr);
-
-        return result;
-    }
-
+    
     /**
      * This method executes given CustomOp
      *
@@ -1769,128 +1675,7 @@ public class CudaExecutioner extends DefaultOpExecutioner {
             throw new RuntimeException(message.toString(), e);
         }
     }
-
-    @Override
-    public void enableDebugMode(boolean reallyEnable) {
-        debug.set(reallyEnable);
-        nativeOps.enableDebugMode(reallyEnable);
-    }
-
-    @Override
-    public void enableVerboseMode(boolean reallyEnable) {
-        verbose.set(reallyEnable);
-        nativeOps.enableVerboseMode(reallyEnable);
-    }
-
-    @Override
-    public void registerGraph(long id, Pointer graph) {
-        nativeOps.registerGraph(null, id, graph);
-
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
-    }
-
-    @Override
-    public Map<String, INDArray> executeGraph(long id, @NonNull Map<String, INDArray> map, @NonNull Map<String, Integer> reverseMap) {
-
-        Nd4j.getExecutioner().commit();
-
-        val ptrBuffers = new PointerPointer(map.size() * 2);
-        val ptrShapes = new PointerPointer(map.size() * 2);
-        val ptrIndices = new IntPointer(map.size());
-
-        int cnt = 0;
-        val keySet = new ArrayList<>(map.keySet());
-        for (val key: keySet) {
-            val array = map.get(key);
-
-            ptrBuffers.put(cnt, AtomicAllocator.getInstance().getHostPointer(array));
-            ptrShapes.put(cnt, AtomicAllocator.getInstance().getHostPointer(array.shapeInfoDataBuffer()));
-            ptrIndices.put(cnt, reverseMap.get(key));
-
-            cnt++;
-        }
-
-        val newMap = new LinkedHashMap<String, INDArray>();
-
-        OpaqueVariablesSet result = nativeOps.executeStoredGraph(null, id, ptrBuffers, ptrShapes, ptrIndices, map.size());
-
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
-
-        OpStatus status = OpStatus.byNumber(nativeOps.getVariablesSetStatus(result));
-
-        if (status != OpStatus.ND4J_STATUS_OK)
-            throw new ND4JIllegalStateException("Op execution failed: " + status);
-
-        for (int e = 0; e < nativeOps.getVariablesSetSize(result); e++) {
-            OpaqueVariable var = nativeOps.getVariable(result, e);
-            int nodeId = nativeOps.getVariableId(var);
-            int index = nativeOps.getVariableIndex(var);
-            LongPointer shapeInfo = nativeOps.getVariableShape(var);
-            Pointer buffer = nativeOps.getVariableBuffer(var);
-
-            val rank = (int) shapeInfo.get(0);
-            val jshape = new long[rank * 2 + 4];
-            for (int i = 0; i < jshape.length; i++) {
-                jshape[i] = shapeInfo.get(i);
-            }
-
-            val shapeOf = Shape.shapeOf(jshape);
-            val stridesOf = Shape.stridesOf(jshape);
-            val order = Shape.order(jshape);
-            val array = Nd4j.create(shapeOf, stridesOf, 0, order);
-
-            Pointer.memcpy(AtomicAllocator.getInstance().getHostPointer(array), buffer, ArrayUtil.prod(shapeOf) * array.dataType().width());
-
-
-            String nodeName = nativeOps.getVariableName(var);
-            newMap.put(nodeName, array);
-        }
-
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
-
-        nativeOps.deleteVariablesSet(result);
-
-        return newMap;
-    }
-
-    @Override
-    public void forgetGraph(long id) {
-        nativeOps.unregisterGraph(null, id);
-
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
-    }
-
-    /**
-     * This method allows to set desired number of elements per thread, for performance optimization purposes.
-     * I.e. if array contains 2048 elements, and threshold is set to 1024, 2 threads will be used for given op execution.
-     * <p>
-     * Default value: 1024
-     *
-     * @param threshold
-     */
-    @Override
-    public void setElementsThreshold(int threshold) {
-        nativeOps.setElementThreshold(threshold);
-    }
-
-    /**
-     * This method allows to set desired number of sub-arrays per thread, for performance optimization purposes.
-     * I.e. if matrix has shape of 64 x 128, and threshold is set to 8, each thread will be processing 8 sub-arrays (sure, if you have 8 core cpu).
-     * If your cpu has, say, 4, cores, only 4 threads will be spawned, and each will process 16 sub-arrays
-     * <p>
-     * Default value: 8
-     *
-     * @param threshold
-     */
-    @Override
-    public void setTadThreshold(int threshold) {
-        nativeOps.setTADThreshold(threshold);
-    }
-
+    
 
     @Override
     public ExecutionerType type() {
@@ -1933,13 +1718,13 @@ public class CudaExecutioner extends DefaultOpExecutioner {
         OpaqueNDArray zb = OpaqueNDArray.fromINDArray(indices);
         INDArray axisArray = Nd4j.createFromArray(axis);
         OpaqueNDArray axis2 = OpaqueNDArray.fromINDArray(axisArray);
-        nativeOps.scatterUpdate(
+        Nd4j.getNativeOps().scatterUpdate(
                 stuff,
                 op.ordinal(),
                 xb,zb,yb,axis2);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
     }
 
     @Override
@@ -1958,9 +1743,9 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
 
 
-        val status = nativeOps.execCustomOp2(null, op.opHash(), context.contextPointer());
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        val status = Nd4j.getNativeOps().execCustomOp2(null, op.opHash(), context.contextPointer());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         if (status != 0)
             throw new RuntimeException("Op [" + op.opName() + "] execution failed");
@@ -2007,10 +1792,10 @@ public class CudaExecutioner extends DefaultOpExecutioner {
                 ctx.getBufferSpecial());
 
 
-        nativeOps.inspectArray(extras, AtomicAllocator.getInstance().getHostPointer(array), (LongPointer) AtomicAllocator.getInstance().getHostPointer(array.shapeInfoDataBuffer()), AtomicAllocator.getInstance().getPointer(array, ctx), (LongPointer) AtomicAllocator.getInstance().getPointer(array.shapeInfoDataBuffer()), debugInfo);
+        Nd4j.getNativeOps().inspectArray(extras, AtomicAllocator.getInstance().getHostPointer(array), (LongPointer) AtomicAllocator.getInstance().getHostPointer(array.shapeInfoDataBuffer()), AtomicAllocator.getInstance().getPointer(array, ctx), (LongPointer) AtomicAllocator.getInstance().getPointer(array.shapeInfoDataBuffer()), debugInfo);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
         return INDArrayStatistics.builder()
                 .minValue(debugInfo._minValue())
@@ -2028,15 +1813,15 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
     @Override
     public DataBuffer createShapeInfo(long[] shape, long[] stride, long elementWiseStride, char order, DataType dtype, boolean empty) {
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val dbf = nativeOps.shapeBuffer(shape.length, new LongPointer(shape), new LongPointer(stride), dtype.toInt(), order, elementWiseStride, empty);
+        val dbf = Nd4j.getNativeOps().shapeBuffer(shape.length, new LongPointer(shape), new LongPointer(stride), dtype.toInt(), order, elementWiseStride, empty);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val result = new CudaLongDataBuffer(nativeOps.getConstantShapeBufferPrimary(dbf), nativeOps.getConstantShapeBufferSpecial(dbf), Shape.shapeInfoLength(shape.length));
+        val result = new CudaLongDataBuffer(Nd4j.getNativeOps().getConstantShapeBufferPrimary(dbf), Nd4j.getNativeOps().getConstantShapeBufferSpecial(dbf), Shape.shapeInfoLength(shape.length));
 
 
         return result;
@@ -2044,15 +1829,15 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
     @Override
     public DataBuffer createShapeInfo(long[] shape, long[] stride, long elementWiseStride, char order, DataType dtype, long extras) {
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val dbf = nativeOps.shapeBufferEx(shape.length, new LongPointer(shape), new LongPointer(stride), dtype.toInt(), order, elementWiseStride, extras);
+        val dbf = Nd4j.getNativeOps().shapeBufferEx(shape.length, new LongPointer(shape), new LongPointer(stride), dtype.toInt(), order, elementWiseStride, extras);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val result = new CudaLongDataBuffer(nativeOps.getConstantShapeBufferPrimary(dbf), nativeOps.getConstantShapeBufferSpecial(dbf), Shape.shapeInfoLength(shape.length));
+        val result = new CudaLongDataBuffer(Nd4j.getNativeOps().getConstantShapeBufferPrimary(dbf), Nd4j.getNativeOps().getConstantShapeBufferSpecial(dbf), Shape.shapeInfoLength(shape.length));
 
 
         return result;
@@ -2060,16 +1845,16 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
     @Override
     public TadPack tadShapeInfoAndOffsets(INDArray array, long[] dimension) {
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        OpaqueTadPack pack = nativeOps.tadOnlyShapeInfo( array.shapeInfoDataBuffer().opaqueBuffer(), new LongPointer(ArrayUtil.toLongArray(dimension)), dimension.length);
+        OpaqueTadPack pack = Nd4j.getNativeOps().tadOnlyShapeInfo( array.shapeInfoDataBuffer().opaqueBuffer(), new LongPointer(ArrayUtil.toLongArray(dimension)), dimension.length);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val tadShape = new CudaLongDataBuffer(nativeOps.getPrimaryShapeInfo(pack), nativeOps.getSpecialShapeInfo(pack), nativeOps.getShapeInfoLength(pack));
-        val tadOffsets = new CudaLongDataBuffer(nativeOps.getPrimaryOffsets(pack), nativeOps.getSpecialOffsets(pack), nativeOps.getNumberOfTads(pack));
+        val tadShape = new CudaLongDataBuffer(Nd4j.getNativeOps().getPrimaryShapeInfo(pack), Nd4j.getNativeOps().getSpecialShapeInfo(pack), Nd4j.getNativeOps().getShapeInfoLength(pack));
+        val tadOffsets = new CudaLongDataBuffer(Nd4j.getNativeOps().getPrimaryOffsets(pack), Nd4j.getNativeOps().getSpecialOffsets(pack), Nd4j.getNativeOps().getNumberOfTads(pack));
 
 
         return new TadPack(tadShape, tadOffsets);
@@ -2077,15 +1862,15 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
     @Override
     public DataBuffer createConstantBuffer(long[] values, DataType desiredType) {
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val dbf = nativeOps.constantBufferLong(desiredType.toInt(), new LongPointer(values), values.length);
+        val dbf = Nd4j.getNativeOps().constantBufferLong(desiredType.toInt(), new LongPointer(values), values.length);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val buffer = Nd4j.createBuffer(nativeOps.getConstantDataBufferPrimary(dbf), nativeOps.getConstantDataBufferSpecial(dbf), values.length, desiredType);
+        val buffer = Nd4j.createBuffer(Nd4j.getNativeOps().getConstantDataBufferPrimary(dbf), Nd4j.getNativeOps().getConstantDataBufferSpecial(dbf), values.length, desiredType);
         buffer.setConstant(true);
 
         return buffer;
@@ -2093,24 +1878,21 @@ public class CudaExecutioner extends DefaultOpExecutioner {
 
     @Override
     public DataBuffer createConstantBuffer(double[] values, DataType desiredType)  {
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val dbf = nativeOps.constantBufferDouble(desiredType.toInt(), new DoublePointer(values), values.length);
+        val dbf = Nd4j.getNativeOps().constantBufferDouble(desiredType.toInt(), new DoublePointer(values), values.length);
 
-        if (nativeOps.lastErrorCode() != 0)
-            throw new RuntimeException(nativeOps.lastErrorMessage());
+        if (Nd4j.getNativeOps().lastErrorCode() != 0)
+            throw new RuntimeException(Nd4j.getNativeOps().lastErrorMessage());
 
-        val buffer = Nd4j.createBuffer(nativeOps.getConstantDataBufferPrimary(dbf), nativeOps.getConstantDataBufferSpecial(dbf), values.length, desiredType);
+        val buffer = Nd4j.createBuffer(Nd4j.getNativeOps().getConstantDataBufferPrimary(dbf), Nd4j.getNativeOps().getConstantDataBufferSpecial(dbf), values.length, desiredType);
         buffer.setConstant(true);
 
         return buffer;
     }
 
-    @Override
-    public int useCount(DataBuffer buffer){
-        return nativeOps.dbUseCount(((BaseCudaDataBuffer) buffer).getOpaqueDataBuffer());
-    }
+
 
 
 }

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/mixed/MixedDataTypesTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/mixed/MixedDataTypesTests.java
@@ -387,21 +387,6 @@ public class MixedDataTypesTests extends BaseNd4jTestWithBackends {
     }
 
 
-    @ParameterizedTest
-    @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
-    public void testTypesValidation_2(Nd4jBackend backend) {
-        assertThrows(RuntimeException.class,() -> {
-            val arrayX = Nd4j.create(new int[]{1, 2, 3, 4}, new  long[]{4}, DataType.INT);
-            val arrayY = Nd4j.create(new int[]{1, 0, 0, 4}, new  long[]{4}, DataType.LONG);
-            val exp = new long[]{1, 0, 0, 1};
-
-            val result = Nd4j.getExecutioner().exec(new EqualTo(arrayX, arrayY, arrayX.ulike().castTo(DataType.BOOL)))[0];
-            val arr = result.data().asLong();
-
-            assertArrayEquals(exp, arr);
-        });
-
-    }
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")


### PR DESCRIPTION


## What changes were proposed in this pull request?

fixes issue with concat
and calculating output shapes.
Some elements were null no matter
how the arrays were set.
Instead we just pass in a context now.
moves some methods up to default opexecutioner
for easier maintenance.

## How was this patch tested?

Tested using BalanceMiniBatches which used  concat and was crashing.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
