### PR TITLE
fix reshape and databuffer memcpy

### DIFF
--- a/libnd4j/include/array/cpu/DataBuffer.cpp
+++ b/libnd4j/include/array/cpu/DataBuffer.cpp
@@ -117,6 +117,10 @@ void DataBuffer::copyBufferFromHost(const void* hostBuffer, size_t sizeToCopyinB
 
 template <typename T>
 void memcpyWithT(DataBuffer* dst, DataBuffer* src, sd::LongType startingOffset, sd::LongType dstOffset) {
+  if(src->getLenInBytes() != dst->getLenInBytes()) {
+    THROW_EXCEPTION("DataBuffer::memcpy: source and destination buffers have different length in bytes");
+  }
+
   std::memcpy(dst->primaryAtOffset<T>(dstOffset), src->primaryAtOffset<T>(startingOffset), src->getLenInBytes());
   dst->readPrimary();
 }

--- a/libnd4j/include/array/impl/DataBuffer.cpp
+++ b/libnd4j/include/array/impl/DataBuffer.cpp
@@ -357,8 +357,6 @@ size_t DataBuffer::getLenInBytes() const {
    if(_dataType == DataType::UNKNOWN) {
      THROW_EXCEPTION("DataBuffer getLenInBytes: dataType is UNKNOWN !");
    }
-   printf("Getting size for %s\n", DataTypeUtils::asString(_dataType).c_str());
-   fflush(stdout);
     return DataTypeUtils::sizeOfElement(_dataType);
   }
   return _lenInBytes;

--- a/libnd4j/include/helpers/impl/reshapeNoCopy.cpp
+++ b/libnd4j/include/helpers/impl/reshapeNoCopy.cpp
@@ -45,16 +45,10 @@ bool reshapeNoAlloc(const sd::LongType* inShape,
     op *= olddims[oi];
   }
   if (np != op) {
-    printf("failed to reshape allocation point 1\n");
-    fflush(stdout);
-
     return false;  // total sizes must match
   }
 
   if (np == 0) {
-    printf("failed to reshape allocation point 2\n");
-    fflush(stdout);
-
     return false;  // don't support empty arrays
   }
 
@@ -81,15 +75,11 @@ bool reshapeNoAlloc(const sd::LongType* inShape,
     for (ok = oi; ok < oj - 1; ok++) {
       if (isFOrder) {
         if (oldstrides[ok + 1] != olddims[ok] * oldstrides[ok]) {
-          printf("failed to reshape allocation point 3\n");
-          fflush(stdout);
           return false;  // not contiguous enough
         }
       } else {
         // C order
         if (oldstrides[ok] != olddims[ok + 1] * oldstrides[ok + 1]) {
-          printf("failed to reshape allocation point 4\n");
-          fflush(stdout);
           return false;  // not contiguous enough
         }
       }
@@ -130,8 +120,6 @@ bool reshapeNoAlloc(const sd::LongType* inShape,
   // Update the output shape info
   outShape[0] = newnd;  // Set rank
 
-  printf("final no reshape alloc\n");
-  fflush(stdout);
   shape::setShape(outShape, const_cast<sd::LongType*>(newShape.data()));
   shape::setStride(outShape, newStrides.data());
   shape::setOrder(outShape, order);

--- a/libnd4j/include/helpers/shape.h
+++ b/libnd4j/include/helpers/shape.h
@@ -1210,8 +1210,8 @@ SD_LIB_EXPORT void calcSubArrShapeInfoAndOffset(const sd::LongType *idx, const s
 * will point on corresponding places in inShapeInfo
 */
 SD_LIB_EXPORT SD_HOST_DEVICE int excludeUnitiesFromShapeInfo(const sd::LongType *inShapeInfo,
-                                                             sd::LongType *&shapeNoUnities,
-                                                             sd::LongType *&stridesNoUnities);
+                                                             sd::LongType *shapeNoUnities,
+                                                             sd::LongType *stridesNoUnities);
 
 /**
 * for example inShapeInfo is {3, 2,1,3,1,4,  12,12,4,4,1, 16384,1,99}, dimsToExclude(points on unity dimensions) =
@@ -3933,8 +3933,8 @@ SD_LIB_EXPORT SD_INLINE SD_HOST sd::LongType tadLength(const sd::LongType *shape
   }
 }
 
-SD_LIB_EXPORT SD_INLINE SD_HOST int excludeUnitiesFromShapeInfo(const sd::LongType *inShapeInfo, sd::LongType *&shapeNoUnities,
-                                                                sd::LongType *&stridesNoUnities) {
+SD_LIB_EXPORT SD_INLINE SD_HOST int excludeUnitiesFromShapeInfo(const sd::LongType *inShapeInfo, sd::LongType *shapeNoUnities,
+                                                                sd::LongType *stridesNoUnities) {
   const int rank = shape::rank(inShapeInfo);
   const int numOfNonUnities = numOfNonUnitDims(rank, shapeOf(inShapeInfo));
 
@@ -3945,7 +3945,7 @@ SD_LIB_EXPORT SD_INLINE SD_HOST int excludeUnitiesFromShapeInfo(const sd::LongTy
   }
 
   int j = 0;
-  for (int i = 0; i < rank; ++i) {
+  for (int i = 0; i < rank; i++) {
     if (shapeOf(inShapeInfo)[i] != 1) {
       shapeNoUnities[j] = shapeOf(inShapeInfo)[i];
       stridesNoUnities[j++] = stride(inShapeInfo)[i];
@@ -3960,7 +3960,7 @@ SD_LIB_EXPORT SD_INLINE void SD_HOST checkStridesEwsAndOrder(sd::LongType *shape
   // FIXME - indeed we don't need to allocate so large memory amount (2*SD_MAX_RANK), sufficient amount is
   // (2*oldNumOfNonUnities + 2*newNumOfNonUnities)
   sd::LongType tempBuffer[2 * SD_MAX_RANK];
-  sd::LongType *shape = tempBuffer, *strides;
+  sd::LongType *shape = tempBuffer, *strides = tempBuffer + shape::rank(shapeInfo);
 
   // exclude unities from shapeInfo
   const sd::LongType numOfNonUnities = excludeUnitiesFromShapeInfo(shapeInfo, shape, strides);

--- a/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
+++ b/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
@@ -648,11 +648,7 @@ OpaqueNDArray createOpaqueNDArray(OpaqueDataBuffer *shapeInfo,
 
 
 void copyBuffer(OpaqueDataBuffer *target, long n,  OpaqueDataBuffer *from, long fromOffset, long targetOffset) {
-  OpaqueDataBuffer *copyFrom = dbCreateView(from, n);
-  OpaqueDataBuffer *targetView = dbCreateView(target, n);
-  sd::DataBuffer *targetBuf = copyFrom->dataBuffer();
-  sd::DataBuffer *srcBuf = targetView->dataBuffer();
-  sd::DataBuffer::memcpy(targetBuf, srcBuf, targetOffset, fromOffset);
+  sd::DataBuffer::memcpy(target->dataBuffer(), from->dataBuffer(), targetOffset, fromOffset);
 }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/evaluation/BaseEvaluation.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/evaluation/BaseEvaluation.java
@@ -245,7 +245,9 @@ public abstract class BaseEvaluation<T extends BaseEvaluation> implements IEvalu
             size0 *= labels.size(permuteDims[i]);
         }
 
-        INDArray lOut = labels.permute(permuteDims).dup('c').reshape('c',size0, labels.size(axis));
+        INDArray labelsPerm = labels.permute(permuteDims);
+        INDArray dupped = labelsPerm.dup('c');
+        INDArray lOut = dupped.reshape('c',size0, labels.size(axis));
         INDArray pOut = predictions.permute(permuteDims).dup('c').reshape('c',size0, labels.size(axis));
         INDArray mOut = mask == null ? null : mask.permute(permuteDims).dup('c').reshape('c',size0, labels.size(axis));
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -4779,7 +4779,7 @@ public class Nd4j {
     public static INDArray vstack(@NonNull INDArray... arrs) {
         Preconditions.checkState(arrs != null && arrs.length > 0, "No input specified to vstack (null or length 0)");
         //noinspection ConstantConditions
-        if(arrs[0].rank() == 1){
+        if(arrs[0].rank() == 1) {
             //Edge case: vstack rank 1 arrays - gives rank 2... vstack([3],[3]) -> [2,3]
             return pile(arrs);
         }

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/evaluation/RegressionEvalTest.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/evaluation/RegressionEvalTest.java
@@ -283,8 +283,10 @@ public class RegressionEvalTest  extends BaseNd4jTestWithBackends {
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testRegressionEval4d(Nd4jBackend backend) {
-        INDArray prediction = Nd4j.rand(DataType.FLOAT, 2, 3, 10, 10);
-        INDArray label = Nd4j.rand(DataType.FLOAT, 2, 3, 10, 10);
+        Nd4j.getRandom().setSeed(1234);
+        Nd4j.getEnvironment().setCheckInputChange(true);
+        INDArray prediction = Nd4j.linspace(1,600,600).reshape(2, 3, 10, 10);
+        INDArray label = Nd4j.linspace(1,600,600).addi(1).reshape(2, 3, 10, 10);
 
 
         List<INDArray> rowsP = new ArrayList<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

clean up reshape no copy to still copy buffers based on  underlying databuffer
but not necessarily when things are views.

clean up data buffer memcpy with adding more validation
and ensuring data is copied correctly. 
This fixes an underlying issue with ndarray.dup() which calls databuffer.dup()
## How was this patch tested?

Tested using the regression eval tests.
## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
