### PR TITLE
add new smoke tests for indexing, fix index2coords/coords2index

### DIFF
--- a/datavec/datavec-api/src/main/java/org/datavec/api/transform/schema/InferredSchema.java
+++ b/datavec/datavec-api/src/main/java/org/datavec/api/transform/schema/InferredSchema.java
@@ -20,7 +20,7 @@
 
 package org.datavec.api.transform.schema;
 
-import au.com.bytecode.opencsv.CSVParser;
+import com.opencsv.CSVParser;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -6136,7 +6136,7 @@ NDArray& NDArray::operator()(const sd::LongType subArrIdx,
     std::vector<sd::LongType> shapeOfSubArr(subArrRank), indexes(subArrRank);
     for (sd::LongType i = 0; i < subArrRank; ++i) shapeOfSubArr[i] = sizeAt(dimsToExclude[i]);
 
-    INDEX2COORDS(subArrIdx, subArrRank, shapeOfSubArr.data(), indexes.data());
+    INDEX2COORDS(subArrIdx, subArrRank, shape::shapeOf(shapeOfSubArr.data()), indexes.data());
     for (sd::LongType i = 0; i < subArrRank; ++i) {
       sd::LongType currIdx = 2 * dimsToExclude[i];
       idxRanges[currIdx] = indexes[i];

--- a/libnd4j/include/array/NDArrayLambda.hXX
+++ b/libnd4j/include/array/NDArrayLambda.hXX
@@ -124,10 +124,10 @@ static SD_KERNEL void lambdaKernel(const void *vx, const sd::LongType *xShapeInf
     sd::LongType xOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = lambda(x[xOffset]);
   }
@@ -149,10 +149,10 @@ static SD_KERNEL void lambdaIndexedKernel(const void *vx, const sd::LongType *xS
     sd::LongType xOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = lambda(e, x[xOffset]);
   }
@@ -179,12 +179,12 @@ static SD_KERNEL void lambdaIndexedPairwiseKernel(const void *vx, const sd::Long
     sd::LongType yOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
-    INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = lambda(e, x[xOffset], y[yOffset]);
   }
@@ -211,12 +211,12 @@ static SD_KERNEL void lambdaPairwiseKernel(const void *vx, const sd::LongType *x
     sd::LongType yOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
-    INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = lambda(x[xOffset], y[yOffset]);
   }
@@ -241,10 +241,10 @@ static SD_KERNEL void lambdaPairwiseKernel(const void *scalarPtr, const void *vx
     sd::LongType xOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = lambda(x[xOffset], yVal);
   }
@@ -274,14 +274,14 @@ static SD_KERNEL void lambdaTriplewiseKernel(const void *vw, const sd::LongType 
     sd::LongType yOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(e, shape::rank(wShapeInfo), wShapeInfo, wCoords);
-    COORDS2INDEX(shape::rank(wShapeInfo), shape::shapeOf(wShapeInfo), wCoords, wOffset);
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
-    INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(wShapeInfo), shape::shapeOf(wShapeInfo), wCoords);
+    COORDS2INDEX(shape::rank(wShapeInfo), shape::stride(wShapeInfo), wCoords, wOffset);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = lambda(w[wOffset], x[xOffset], y[yOffset]);
   }

--- a/libnd4j/include/array/cuda/NDArray.cu
+++ b/libnd4j/include/array/cuda/NDArray.cu
@@ -116,10 +116,10 @@ SD_KERNEL static void fillAsTriangularCuda(const void* vx, const LongType* xShap
   bool dirU = direction == 'u';
   bool dirL = direction == 'l';
   for (LongType i = tid; i < zLen; i += totalThreads) {
-    INDEX2COORDS(i, zRank, zShapeInfo, coords);
+    INDEX2COORDS(i, zRank, shape::shapeOf(zShapeInfo), coords);
 
     LongType zOffset;
-    COORDS2INDEX(zRank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(zRank, shape::stride(zShapeInfo), coords, zOffset);
 
     auto row = coords[zRank - 2];
     auto col = coords[zRank - 1];
@@ -130,7 +130,7 @@ SD_KERNEL static void fillAsTriangularCuda(const void* vx, const LongType* xShap
     } else if (vx != vz) {  // when x and z are different arrays
       if (xRank != zRank) coords[0] = coords[1];
       LongType xOffset;
-      COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(xRank, shape::stride(xShapeInfo), coords, xOffset);
       z[zOffset] = x[xOffset];
     }
   }
@@ -188,9 +188,9 @@ SD_KERNEL static void identityMatrixCuda(void* vx, const LongType* xShapeInfo, c
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < len; i += totalThreads) {
-    INDEX2COORDS(i, rank, xShapeInfo, coords);
+    INDEX2COORDS(i, rank, shape::shapeOf(xShapeInfo), coords);
     LongType offset;
-    COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, offset);
+    COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, offset);
 
     if (coords[rank - 2] == coords[rank - 1])  // row == col -> on diagonal
       x[offset] = val;

--- a/libnd4j/include/helpers/cpu/MmulHelper.cpp
+++ b/libnd4j/include/helpers/cpu/MmulHelper.cpp
@@ -69,7 +69,7 @@ static void usualGemm(NDArray* vA, NDArray* vB, NDArray* vC, const int aMaxis, c
 
     for (auto i = start; i < stop; i++) {
       // evaluate C coordinates
-      INDEX2COORDS(i, shape::rank(cShapeInfo), cShapeInfo, cCoords.data());
+      INDEX2COORDS(i, shape::rank(cShapeInfo), shape::shapeOf(cShapeInfo), cCoords.data());
 
       // evaluate A coordinates
       aCoords[aMaxis] = cCoords[cMaxis];
@@ -80,8 +80,8 @@ static void usualGemm(NDArray* vA, NDArray* vB, NDArray* vC, const int aMaxis, c
       bCoords[bNaxis] = cCoords[cNaxis];
 
       sd::LongType aOffset, bOffset, cOffset;
-      COORDS2INDEX(shape::rank(aShapeInfo), shape::shapeOf(aShapeInfo), aCoords.data(), aOffset);
-      COORDS2INDEX(shape::rank(bShapeInfo), shape::shapeOf(bShapeInfo), bCoords.data(), bOffset);
+      COORDS2INDEX(shape::rank(aShapeInfo), shape::stride(aShapeInfo), aCoords.data(), aOffset);
+      COORDS2INDEX(shape::rank(bShapeInfo), shape::stride(bShapeInfo), bCoords.data(), bOffset);
 
       T3 val = A[aOffset] * B[bOffset];  // first iteration
 
@@ -91,7 +91,7 @@ static void usualGemm(NDArray* vA, NDArray* vB, NDArray* vC, const int aMaxis, c
         val += A[aOffset] * B[bOffset];
       }
 
-      COORDS2INDEX(shape::rank(cShapeInfo), shape::shapeOf(cShapeInfo), cCoords.data(), cOffset);
+      COORDS2INDEX(shape::rank(cShapeInfo), shape::stride(cShapeInfo), cCoords.data(), cOffset);
       if (betaPresent) {
         C[cOffset] = alphaZ * val + betaZ * C[cOffset];
       } else {
@@ -474,19 +474,19 @@ static void batchedGemm(NDArray* vA, NDArray* vB, NDArray* vC, LongType* aBatchD
 
     for (sd::LongType i = start; i < stop; ++i) {
       // evaluate C coordinates
-      INDEX2COORDS(i, shape::rank(cShapeInfo), cShapeInfo, cCoords.data());
+      INDEX2COORDS(i, shape::rank(cShapeInfo), shape::shapeOf(cShapeInfo), cCoords.data());
 
       // calculate index of current batch
       sd::LongType batchInd;
-      if (cRank > 2) COORDS2INDEX(shape::rank(cShapeInfo), shape::shapeOf(cShapeInfo), cCoords.data(), batchInd);
+      if (cRank > 2) COORDS2INDEX(shape::rank(cShapeInfo), shape::stride(cShapeInfo), cCoords.data(), batchInd);
 
       // evaluate A coordinates
-      if (aRank > 2) INDEX2COORDS(batchInd, shape::rank(aShapeInfo), aShapeInfo, aCoords.data());
+      if (aRank > 2) INDEX2COORDS(batchInd, shape::rank(aShapeInfo), shape::shapeOf(aShapeInfo), aCoords.data());
       aCoords[aMaxis] = cCoords[cMaxis];
       aCoords[aKaxis] = 0;
 
       // evaluate B coordinates
-      if (bRank > 2) INDEX2COORDS(batchInd, shape::rank(bShapeInfo), bShapeInfo, bCoords.data());
+      if (bRank > 2) INDEX2COORDS(batchInd, shape::rank(bShapeInfo), shape::shapeOf(bShapeInfo), bCoords.data());
       bCoords[bKaxis] = 0;
       bCoords[bNaxis] = cCoords[cNaxis];
 

--- a/libnd4j/include/helpers/shape.h
+++ b/libnd4j/include/helpers/shape.h
@@ -768,7 +768,7 @@ SD_LIB_EXPORT SD_INLINE SD_HOST int outerArrayOffsets(sd::LongType *maxOffsets, 
   sd::LongType N, minI, maxI;
 
   // calculate min per-dim-indices which corresponds to absolute minIdx index
-  INDEX2COORDS(minIdx, rankMin, minShapeInfo, indices);
+  INDEX2COORDS(minIdx, rankMin, shape::shapeOf(minShapeInfo), indices);
 
   // transform storage indices to contain per-dim max indices, purpose - memory saving
   // fill increment array as well
@@ -1132,7 +1132,7 @@ SD_LIB_EXPORT SD_INLINE SD_HOST void getOffsetBroadcast(const sd::LongType &star
       return;
     }
 
-    INDEX2COORDS(startInd, rank(shapeInfo1), shape1, coords);
+    INDEX2COORDS(startInd, rank(shapeInfo1), shape::shapeOf(shape1), coords);
     COORDS2INDEX(rank(shapeInfo1), strides1, coords, offset1);
 
     if (sameOffsets12)

--- a/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
@@ -796,6 +796,7 @@ void NativeOpExecutioner::execScalar(sd::LaunchContext *lc, int opNum, const voi
   };
 
   auto zLen = shape::length(hZShapeInfo);
+ printf("Start %lld Stop %lld\n", 0, zLen);
   samediff::Threads::parallel_for(
       func, 0, zLen, 1,
       !allowParallelism

--- a/libnd4j/include/legacy/cpu/NativeOps.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOps.cpp
@@ -345,10 +345,10 @@ void pullRowsGeneric(OpaqueNDArray vx, OpaqueNDArray vz, const int n, OpaqueNDAr
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(idx, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(idx, shape::rank(zTadShapeInfo), zTadShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(idx, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(idx, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zCoords, zOffset);
 
       for (LongType i = 0; i < tadLength; i++) {
         hZ[zOffset + i] = hX[xOffset + i];
@@ -403,10 +403,10 @@ void tearGeneric(void *vx, LongType const *hXShapeInfo, Pointer *targets, LongTy
         sd::LongType xOffset;
         sd::LongType zOffset;
 
-        INDEX2COORDS(j, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
-        INDEX2COORDS(j, shape::rank(hZShapeInfo), hZShapeInfo, zCoords);
-        COORDS2INDEX(shape::rank(hZShapeInfo), shape::shapeOf(hZShapeInfo), zCoords, zOffset);
+        INDEX2COORDS(j, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), xCoords, xOffset);
+        INDEX2COORDS(j, shape::rank(hZShapeInfo), shape::shapeOf(hZShapeInfo), zCoords);
+        COORDS2INDEX(shape::rank(hZShapeInfo), shape::stride(hZShapeInfo), zCoords, zOffset);
 
         hZ[zOffset] = s[xOffset];
       }
@@ -503,10 +503,10 @@ void shuffleGeneric(OpaqueNDArrayArr hX, OpaqueNDArrayArr hZ, int N, int *shuffl
           sd::LongType xOffset;
           sd::LongType zOffset;
 
-          INDEX2COORDS(r, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-          COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-          INDEX2COORDS(swapIdx, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-          COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+          INDEX2COORDS(r, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+          COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+          INDEX2COORDS(swapIdx, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+          COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
           math::sd_swap<T>(hX2[xOffset], hZ2[zOffset]);
         }
@@ -526,10 +526,10 @@ void shuffleGeneric(OpaqueNDArrayArr hX, OpaqueNDArrayArr hZ, int N, int *shuffl
             sd::LongType xOffset;
             sd::LongType zOffset;
 
-            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoX), tadOnlyShapeInfoX, xCoords);
-            COORDS2INDEX(shape::rank(tadOnlyShapeInfoX), shape::shapeOf(tadOnlyShapeInfoX), xCoords, xOffset);
-            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoZ), tadOnlyShapeInfoZ, zCoords);
-            COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), zCoords, zOffset);
+            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoX), shape::shapeOf(tadOnlyShapeInfoX), xCoords);
+            COORDS2INDEX(shape::rank(tadOnlyShapeInfoX), shape::stride(tadOnlyShapeInfoX), xCoords, xOffset);
+            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), zCoords);
+            COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::stride(tadOnlyShapeInfoZ), zCoords, zOffset);
 
             math::sd_swap<T>(rX[xOffset], rZ[zOffset]);
           }
@@ -1475,6 +1475,8 @@ void execReduce3Tad(Pointer *extraPointers, int opNum, NDArray *x, void *extraPa
 void execScalar(Pointer *extraPointers, int opNum, NDArray *x, NDArray *z,
                 NDArray *scalar, void *extraParams) {
   try {
+    printf("Trying to run exec scalar op num %d\n",opNum);
+    fflush(stdout);
     NativeOpExecutioner::execScalar(nullptr, opNum,
                                     x->buffer(), x->shapeInfo(), x->specialBuffer(), x->specialShapeInfo(),
                                     z->buffer(), z->shapeInfo(), z->specialBuffer(), z->specialShapeInfo(),

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -2951,10 +2951,10 @@ SD_KERNEL static void scatterUpdateCuda(const int opCode, const int numOfSubArrs
       sd::LongType xOffset;
       sd::LongType yOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
 
       switch (opCode) {
         case 0:

--- a/libnd4j/include/loops/cpu/broadcasting_int.hpp
+++ b/libnd4j/include/loops/cpu/broadcasting_int.hpp
@@ -132,9 +132,9 @@ void BroadcastInt<X>::exec(const void *vx, const sd::LongType *xShapeInfo, const
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(xTadShapeShapeInfo), xTadShapeShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords);
         sd::LongType offset;
-        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::stride(xTadShapeShapeInfo), coords, offset);
         oZ[offset] = OpType::op(oX[offset], y[offset]);
       }
     };
@@ -146,10 +146,10 @@ void BroadcastInt<X>::exec(const void *vx, const sd::LongType *xShapeInfo, const
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(xTadShapeShapeInfo), xTadShapeShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords);
         sd::LongType offset, zOffset;
-        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::stride(xTadShapeShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), coords, zOffset);
         oZ[zOffset] = OpType::op(oX[offset], y[offset]);
       }
     };
@@ -161,10 +161,10 @@ void BroadcastInt<X>::exec(const void *vx, const sd::LongType *xShapeInfo, const
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(xTadShapeShapeInfo), xTadShapeShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords);
         sd::LongType offset, yOffset;
-        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
+        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::stride(xTadShapeShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
         oZ[offset] = OpType::op(oX[offset], y[yOffset]);
       }
     };
@@ -176,10 +176,10 @@ void BroadcastInt<X>::exec(const void *vx, const sd::LongType *xShapeInfo, const
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(yShapeInfo), yShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords);
         sd::LongType xOffset, offset;
-        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::stride(xTadShapeShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, offset);
         oZ[offset] = OpType::op(oX[xOffset], y[offset]);
       }
     };
@@ -191,11 +191,11 @@ void BroadcastInt<X>::exec(const void *vx, const sd::LongType *xShapeInfo, const
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(zTadShapeInfo), zTadShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), coords);
         sd::LongType xOffset, yOffset, zOffset;
-        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::shapeOf(xTadShapeShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
-        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xTadShapeShapeInfo), shape::stride(xTadShapeShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
+        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), coords, zOffset);
         oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
       }
     };
@@ -270,9 +270,9 @@ void BroadcastInt<X>::execInverse(const void *vx, const sd::LongType *xShapeInfo
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(yTadShapeShapeInfo), yTadShapeShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(yTadShapeShapeInfo), shape::shapeOf(yTadShapeShapeInfo), coords);
         sd::LongType offset;
-        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::shapeOf(yTadShapeShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::stride(yTadShapeShapeInfo), coords, offset);
         oZ[offset] = OpType::op(x[offset], oY[offset]);
       }
     };
@@ -283,10 +283,10 @@ void BroadcastInt<X>::execInverse(const void *vx, const sd::LongType *xShapeInfo
 
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(yTadShapeShapeInfo), yTadShapeShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(yTadShapeShapeInfo), shape::shapeOf(yTadShapeShapeInfo), coords);
         sd::LongType offset, zOffset;
-        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::shapeOf(yTadShapeShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::stride(yTadShapeShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), coords, zOffset);
         oZ[zOffset] = OpType::op(x[offset], oY[offset]);
       }
     };
@@ -300,8 +300,8 @@ void BroadcastInt<X>::execInverse(const void *vx, const sd::LongType *xShapeInfo
         sd::LongType coords[SD_MAX_RANK];
         INDEX2COORDS(f, shape::rank(yTadShapeShapeInfo), yTadShapeShapeInfo, coords);
         sd::LongType offset, xOffset;
-        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::shapeOf(yTadShapeShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::stride(yTadShapeShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
         oZ[offset] = OpType::op(x[xOffset], oY[offset]);
       }
     };
@@ -313,10 +313,10 @@ void BroadcastInt<X>::execInverse(const void *vx, const sd::LongType *xShapeInfo
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType yOffset, offset;
-        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::shapeOf(yTadShapeShapeInfo), coords, yOffset);
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(yTadShapeShapeInfo), shape::stride(yTadShapeShapeInfo), coords, yOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
         oZ[offset] = OpType::op(x[offset], oY[yOffset]);
       }
     };
@@ -328,7 +328,7 @@ void BroadcastInt<X>::execInverse(const void *vx, const sd::LongType *xShapeInfo
       PRAGMA_OMP_SIMD
       for (sd::LongType f = 0; f < tadLength; f++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(f, shape::rank(zTadShapeInfo), zTadShapeInfo, coords);
+        INDEX2COORDS(f, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), coords);
         sd::LongType xOffset, yOffset, zOffset;
         COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
         COORDS2INDEX(shape::rank(yTadShapeInfo), shape::shapeOf(yTadShapeInfo), coords, yOffset);
@@ -544,11 +544,19 @@ static void execDefault(const X *x, const sd::LongType *xShapeInfo, const X *y, 
     sd::LongType xOffset, yOffset, zOffset;
 
     for (auto i = start; i < stop; ++i) {
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, coords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
-      xOffset = xzSameOffsets ? zOffset : COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-      yOffset = yzSameOffsets ? zOffset : COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
+      if (xzSameOffsets) {
+        xOffset = zOffset;
+      } else {
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+      }
 
+      if (yzSameOffsets) {
+        yOffset = zOffset;
+      } else {
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
+      }
       z[zOffset] = OpType::op(x[xOffset], y[yOffset]);
     }
   };

--- a/libnd4j/include/loops/cpu/pairwise.hpp
+++ b/libnd4j/include/loops/cpu/pairwise.hpp
@@ -110,11 +110,11 @@ SD_INLINE void PairWiseTransform<X, Y, Z>::exec(const void *vx,
 
     PRAGMA_OMP_SIMD
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
       sd::LongType xOffset, yOffset, zOffset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), zCoords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), zCoords, yOffset);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), zCoords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), zCoords, yOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
       z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
     }
   } else if ((shape::haveSameShapeAndStrides(xShapeInfo, yShapeInfo)
@@ -125,9 +125,9 @@ SD_INLINE void PairWiseTransform<X, Y, Z>::exec(const void *vx,
     for (sd::LongType i = start; i < stop; i++) {
       INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
       sd::LongType xOffset, yOffset, zOffset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), zCoords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), zCoords, yOffset);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), zCoords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), zCoords, yOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
       z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
     }
   } else if (shape::haveSameShapeAndStrides(yShapeInfo, zShapeInfo)
@@ -138,22 +138,22 @@ SD_INLINE void PairWiseTransform<X, Y, Z>::exec(const void *vx,
 
     PRAGMA_OMP_SIMD
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
       sd::LongType xOffset, yOffset, zOffset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), zCoords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), zCoords, yOffset);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), zCoords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), zCoords, yOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
       z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
     }
   } else {
     sd::LongType zCoords[SD_MAX_RANK];
 
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
       sd::LongType xOffset, yOffset, zOffset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), zCoords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), zCoords, yOffset);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), zCoords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), zCoords, yOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
       z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
     }
   }

--- a/libnd4j/include/loops/cpu/pairwise_bool.cpp
+++ b/libnd4j/include/loops/cpu/pairwise_bool.cpp
@@ -81,19 +81,19 @@ void PairWiseBoolTransform<X, Z>::exec(const void *vx, const sd::LongType *xShap
       PRAGMA_OMP_SIMD
       for (sd::LongType i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(zShapeInfo), coords);
         sd::LongType offset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
         z[offset] = OpType::op(x[offset], y[0], extraParams);
       };
     } else {
       PRAGMA_OMP_SIMD
       for (sd::LongType i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType xOffset, zOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
         z[zOffset] = OpType::op(x[xOffset], y[0], extraParams);
       };
     }
@@ -114,50 +114,50 @@ void PairWiseBoolTransform<X, Z>::exec(const void *vx, const sd::LongType *xShap
       PRAGMA_OMP_SIMD
       for (sd::LongType i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType offset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
         z[offset] = OpType::op(x[offset], y[offset], extraParams);
       };
     } else if (shape::haveSameShapeAndStrides(xShapeInfo, yShapeInfo)) {
       PRAGMA_OMP_SIMD
       for (sd::LongType i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType offset, zOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
         z[zOffset] = OpType::op(x[offset], y[offset], extraParams);
       };
     } else if (shape::haveSameShapeAndStrides(xShapeInfo, zShapeInfo)) {
       PRAGMA_OMP_SIMD
       for (sd::LongType i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType offset, yOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
         z[offset] = OpType::op(x[offset], y[yOffset], extraParams);
       };
     } else if (shape::haveSameShapeAndStrides(yShapeInfo, zShapeInfo)) {
       PRAGMA_OMP_SIMD
       for (sd::LongType i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords);
         sd::LongType xOffset, offset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, offset);
         z[offset] = OpType::op(x[xOffset], y[offset], extraParams);
       };
     } else {
       PRAGMA_OMP_SIMD
       for (sd::LongType i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords);
         sd::LongType xOffset, yOffset, zOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
         z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
       };
     }

--- a/libnd4j/include/loops/cpu/pairwise_int.cpp
+++ b/libnd4j/include/loops/cpu/pairwise_int.cpp
@@ -84,19 +84,19 @@ void PairWiseIntTransform<X>::exec(const void *vx, const sd::LongType *xShapeInf
       PRAGMA_OMP_SIMD
       for (auto i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType offset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
         z[offset] = OpType::op(x[offset], y[0], extraParams);
       };
     } else {
       PRAGMA_OMP_SIMD
       for (auto i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType xOffset, zOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
         z[zOffset] = OpType::op(x[xOffset], y[0], extraParams);
       };
     }
@@ -117,7 +117,7 @@ void PairWiseIntTransform<X>::exec(const void *vx, const sd::LongType *xShapeInf
       PRAGMA_OMP_SIMD
       for (auto i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType offset;
         COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
         z[offset] = OpType::op(x[offset], y[offset], extraParams);
@@ -126,20 +126,20 @@ void PairWiseIntTransform<X>::exec(const void *vx, const sd::LongType *xShapeInf
       PRAGMA_OMP_SIMD
       for (auto i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType offset, zOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
         z[zOffset] = OpType::op(x[offset], y[offset], extraParams);
       }
     } else if (shape::haveSameShapeAndStrides(xShapeInfo, zShapeInfo)) {
       PRAGMA_OMP_SIMD
       for (auto i = start; i < stop; i++) {
         sd::LongType coords[SD_MAX_RANK];
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
         sd::LongType offset, yOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
         z[offset] = OpType::op(x[offset], y[yOffset], extraParams);
       }
 
@@ -147,21 +147,21 @@ void PairWiseIntTransform<X>::exec(const void *vx, const sd::LongType *xShapeInf
     PRAGMA_OMP_SIMD
     for (auto i = start; i < stop; i++) {
       sd::LongType coords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, coords);
+      INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords);
       sd::LongType xOffset, offset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, offset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, offset);
       z[offset] = OpType::op(x[xOffset], y[offset], extraParams);
     }
   } else {
     PRAGMA_OMP_SIMD
     for (auto i = start; i < stop; i++) {
       sd::LongType coords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, coords);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(xShapeInfo), coords);
       sd::LongType xOffset, yOffset, zOffset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
       z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
     }
   }

--- a/libnd4j/include/loops/cpu/random.hpp
+++ b/libnd4j/include/loops/cpu/random.hpp
@@ -65,9 +65,9 @@ void RandomFunction<X>::execTransform(sd::Pointer state, const void *vx, const s
       for (auto i = start; i < stop; i++) {
         INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
         sd::LongType xOffset, yOffset, zOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
         z[zOffset] = OpClass::op(x[xOffset], y[yOffset], i, length, rng, extraArguments);
       }
     };
@@ -93,7 +93,7 @@ void RandomFunction<X>::execTransform(sd::Pointer state, const void *vx, const s
       for (auto i = start; i < stop; i++) {
         INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
         sd::LongType offset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
         z[offset] = OpClass::op(x[offset], i, length, rng, extraArguments);
       }
     };
@@ -105,8 +105,8 @@ void RandomFunction<X>::execTransform(sd::Pointer state, const void *vx, const s
       for (auto i = start; i < stop; i++) {
         INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, coords);
         sd::LongType xOffset, zOffset;
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
         z[zOffset] = OpClass::op(x[xOffset], i, length, rng, extraArguments);
       }
     };
@@ -130,7 +130,7 @@ void RandomFunction<X>::execTransform(sd::Pointer state, void *vz, const sd::Lon
     for (auto i = start; i < stop; i++) {
       INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, coords);
       sd::LongType offset;
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, offset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, offset);
       z[offset] = OpClass::op(i, length, rng, extraArguments);
     }
   };

--- a/libnd4j/include/loops/cpu/reduce/reduce_long.hpp
+++ b/libnd4j/include/loops/cpu/reduce/reduce_long.hpp
@@ -55,10 +55,6 @@ void SD_HOST ReduceLongFunction<X, Z>::execScalar(const void *vx, const sd::Long
     for (sd::LongType i = 0; i < length; i++) z[i] = startingVal;
     return;
   }
-
-  if (xEws >= 1) {
-    z[0] = execScalar<OpType>(x, xEws, length, extraParams);
-  } else {
     auto startingValue = OpType::startingValue(x);
     sd::LongType xShapeInfoCast[SD_MAX_RANK];
     const bool canCastX = sd::DataTypeUtils::castShapeInfo(xShapeInfo, xShapeInfoCast);
@@ -87,7 +83,7 @@ void SD_HOST ReduceLongFunction<X, Z>::execScalar(const void *vx, const sd::Long
 
     // write out results
     z[0] = OpType::postProcess(intermediate[0], length, extraParams);
-  }
+
 }
 
 template <typename X, typename Z>

--- a/libnd4j/include/loops/cpu/scalar.hpp
+++ b/libnd4j/include/loops/cpu/scalar.hpp
@@ -38,82 +38,57 @@ namespace scalar {
 template <typename X, typename Y, typename Z>
 template <typename OpType>
 void ScalarTransform<X, Y, Z>::transform(const void *vx, const sd::LongType *xShapeInfo, void *vextraParams, void *vz,
-                                        const sd::LongType *zShapeInfo, const void *vscalars,sd::LongType *dimension,
-                                        sd::LongType dimensionLength, const sd::LongType *xTadShapeInfo,
-                                        const sd::LongType *xTadOffsets, const sd::LongType *zTadShapeInfo,
-                                        const sd::LongType *zTadOffsets, sd::LongType start, sd::LongType stop) {
- auto x = reinterpret_cast<const X *>(vx);
- auto z = reinterpret_cast<Z *>(vz);
- auto scalars = reinterpret_cast<const Y *>(vscalars);
- auto extraParams = reinterpret_cast<Z *>(vextraParams);
+                                         const sd::LongType *zShapeInfo, const void *vscalars, sd::LongType *dimension,
+                                         sd::LongType dimensionLength, const sd::LongType *xTadShapeInfo,
+                                         const sd::LongType *xTadOffsets, const sd::LongType *zTadShapeInfo,
+                                         const sd::LongType *zTadOffsets, sd::LongType start, sd::LongType stop) {
+  auto x = reinterpret_cast<const X *>(vx);
+  auto z = reinterpret_cast<Z *>(vz);
+  auto scalars = reinterpret_cast<const Y *>(vscalars);
+  auto extraParams = reinterpret_cast<Z *>(vextraParams);
 
- if (zTadShapeInfo == nullptr) {
-   zTadShapeInfo = xTadShapeInfo;
-   zTadOffsets = xTadOffsets;
- }
+  if (zTadShapeInfo == nullptr) {
+    zTadShapeInfo = xTadShapeInfo;
+    zTadOffsets = xTadOffsets;
+  }
 
- const int xTadEws = shape::elementWiseStride(xTadShapeInfo);
- const int zTadEws = shape::elementWiseStride(zTadShapeInfo);
- const int tadLength = shape::tadLength(xShapeInfo, dimension, dimensionLength);
- const int numTads = shape::length(xShapeInfo) / tadLength;
-
- sd::LoopKind::Kind kindOfLoop = sd::LoopKind::deduceKindOfLoopXZ(xTadShapeInfo, zTadShapeInfo);
-
- if (kindOfLoop != sd::LoopKind::EWS1 && kindOfLoop != sd::LoopKind::EWSNONZERO) {
-   printf("ScalarTransform<X, Z>::transform: super-bad loop visited. Shouldn't ever happen\n");
-   return;
- }
-
- int num_threads = sd::math::sd_min<int>(numTads, sd::Environment::getInstance().maxThreads());
-
- if (kindOfLoop == sd::LoopKind::EWS1) {
-   for (auto r = start; r < stop; r++) {
-     auto oZ = z + zTadOffsets[r];
-     auto oX = x + xTadOffsets[r];
-
-     PRAGMA_OMP_SIMD
-     for (int f = 0; f < tadLength; f++) oZ[f] = OpType::op(oX[f], scalars[r], extraParams);
-   };
- } else {
-   for (auto r = start; r < stop; r++) {
-     auto oZ = z + zTadOffsets[r];
-     auto oX = x + xTadOffsets[r];
-
-     PRAGMA_OMP_SIMD
-     for (int f = 0; f < tadLength; f++) oZ[f * zTadEws] = OpType::op(oX[f * xTadEws], scalars[r], extraParams);
-   };
- }
+  const int tadLength = shape::tadLength(xShapeInfo, dimension, dimensionLength);
+  for (auto r = start; r < stop; r++) {
+    auto oZ = z + zTadOffsets[r];
+    auto oX = x + xTadOffsets[r];
+    PRAGMA_OMP_SIMD
+    for (int f = 0; f < tadLength; f++) {
+      sd::LongType coords[SD_MAX_RANK];
+      sd::LongType xOffset, zOffset;
+      INDEX2COORDS(f, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), coords);
+      INDEX2COORDS(f, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), coords);
+      COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), coords, xOffset);
+      COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), coords, zOffset);
+      oZ[zOffset] = OpType::op(oX[xOffset], scalars[r], extraParams);
+    }
+  }
 }
-
-////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////
 template <typename X, typename Y, typename Z>
 void ScalarTransform<X, Y, Z>::transform(int opNum, const void *x, const sd::LongType *xShapeInfo, void *extraParams,
-                                        void *z, const sd::LongType *zShapeInfo, const void *scalars,
-                                        sd::LongType *dimension,
-                                        sd::LongType dimensionLength, const sd::LongType *xTadShapeInfo,
-                                        const sd::LongType *xTadOffsets, const sd::LongType *zTadShapeInfo,
-                                        const sd::LongType *zTadOffsets,
-                                        sd::LongType start, sd::LongType stop) {
- DISPATCH_BY_OPNUM_TTT(transform,
-                       PARAMS(x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength,
-                              xTadShapeInfo, xTadOffsets, zTadShapeInfo, zTadOffsets, start, stop),
-                       SCALAR_OPS);
-}
-
-////////////////////////////////////////////////////////////////////////
-template <typename X, typename Y, typename Z>
-void ScalarTransform<X, Y, Z>::transform(const int opNum, const void *x, sd::LongType xStride, void *z,
-                                        sd::LongType zStride, const void *scalar, void *extraParams, const sd::LongType n,
-                                        const sd::LongType start, const sd::LongType stop) {
- DISPATCH_BY_OPNUM_TTT(transform, PARAMS(x, xStride, z, zStride, scalar, extraParams, n, start, stop), SCALAR_OPS);
+                                         void *z, const sd::LongType *zShapeInfo, const void *scalars,
+                                         sd::LongType *dimension,
+                                         sd::LongType dimensionLength, const sd::LongType *xTadShapeInfo,
+                                         const sd::LongType *xTadOffsets, const sd::LongType *zTadShapeInfo,
+                                         const sd::LongType *zTadOffsets,
+                                         sd::LongType start, sd::LongType stop) {
+  DISPATCH_BY_OPNUM_TTT(transform,
+                        PARAMS(x, xShapeInfo, extraParams, z, zShapeInfo, scalars, dimension, dimensionLength,
+                               xTadShapeInfo, xTadOffsets, zTadShapeInfo, zTadOffsets, start, stop),
+                        SCALAR_OPS);
 }
 
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Y, typename Z>
 void ScalarTransform<X, Y, Z>::transform(const int opNum, const void *x, const sd::LongType *xShapeInfo, void *z,
-                                        const sd::LongType *zShapeInfo, const void *scalar, void *extraParams,
-                                        const sd::LongType start, const sd::LongType stop) {
- DISPATCH_BY_OPNUM_TTT(transform, PARAMS(x, xShapeInfo, z, zShapeInfo, scalar, extraParams, start, stop), SCALAR_OPS);
+                                         const sd::LongType *zShapeInfo, const void *scalar, void *extraParams,
+                                         const sd::LongType start, const sd::LongType stop) {
+  DISPATCH_BY_OPNUM_TTT(transform, PARAMS(x, xShapeInfo, z, zShapeInfo, scalar, extraParams, start, stop), SCALAR_OPS);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -128,47 +103,21 @@ void ScalarTransform<X, Y, Z>::transform(const void *vx, const sd::LongType *xSh
   auto scalar = reinterpret_cast<const Y *>(vscalar)[0];
   auto extraParams = reinterpret_cast<Z *>(vextraParams);
 
-  if (shape::haveSameShapeAndStrides(xShapeInfo, zShapeInfo)) {
-    PRAGMA_OMP_SIMD
-    for (auto i = start; i < stop; i++) {
-      sd::LongType coords[SD_MAX_RANK];
-      sd::LongType offset;
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
-      z[offset] = OpType::op(x[offset], scalar, extraParams);
-    };
-  } else {
-    PRAGMA_OMP_SIMD
-    for (auto i = start; i < stop; i++) {
-      sd::LongType coords[SD_MAX_RANK];
-      sd::LongType xOffset, zOffset;
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
-      z[zOffset] = OpType::op(x[xOffset], scalar, extraParams);
-    };
-  }
+  PRAGMA_OMP_SIMD
+  for (auto i = start; i < stop; i++) {
+    sd::LongType coords[SD_MAX_RANK];
+    sd::LongType zCoords[SD_MAX_RANK];
+    sd::LongType xOffset, zOffset;
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
+    z[zOffset] = OpType::op(x[xOffset], scalar, extraParams);
+  };
 
 }
 ////////////////////////////////////////////////////////////////////////
-template <typename X, typename Y, typename Z>
-template <typename OpType>
-void ScalarTransform<X, Y, Z>::transform(const void *vx, sd::LongType xEws, void *vz, sd::LongType zEws,
-                                        const void *vscalar, void *vextraParams, const sd::LongType len,
-                                        const sd::LongType start, const sd::LongType stop) {
- auto x = reinterpret_cast<const X *>(vx);
- auto z = reinterpret_cast<Z *>(vz);
- auto scalar = reinterpret_cast<const Y *>(vscalar)[0];
- auto extraParams = reinterpret_cast<Z *>(vextraParams);
 
- if (xEws == 1 && zEws == 1) {
-   PRAGMA_OMP_SIMD
-   for (auto i = start; i < stop; i++) z[i] = OpType::op(x[i], scalar, extraParams);
- } else {
-   PRAGMA_OMP_SIMD
-   for (auto i = start; i < stop; i++) z[i * zEws] = OpType::op(x[i * xEws], scalar, extraParams);
- }
-}
 
 
 }  // namespace scalar

--- a/libnd4j/include/loops/cpu/scalar_int.cpp
+++ b/libnd4j/include/loops/cpu/scalar_int.cpp
@@ -135,19 +135,19 @@ void ScalarIntTransform<X>::transform(const void *vx, const sd::LongType *xShape
     PRAGMA_OMP_SIMD
     for (auto i = start; i < stop; i++) {
       sd::LongType coords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
       sd::LongType offset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
       z[offset] = OpType::op(x[offset], scalar, extraParams);
     };
   } else {
     PRAGMA_OMP_SIMD
     for (auto i = start; i < stop; i++) {
       sd::LongType coords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
       sd::LongType xOffset, zOffset;
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
       z[zOffset] = OpType::op(x[xOffset], scalar, extraParams);
     };
   }

--- a/libnd4j/include/loops/cuda/broadcasting.chpp
+++ b/libnd4j/include/loops/cuda/broadcasting.chpp
@@ -155,12 +155,12 @@ SD_DEVICE void Broadcast<X,Y,Z>::transformInverseCuda(
       sd::LongType yOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, yCoords);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), yCoords, yOffset);
-      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoZ), tadOnlyShapeInfoZ, zCoords);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), yCoords);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), zCoords);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::stride(tadOnlyShapeInfoZ), zCoords, zOffset);
 
       rZ[zOffset] = OpType::op(x[xOffset], rY[yOffset]);
     }
@@ -198,9 +198,9 @@ SD_DEVICE void Broadcast<X,Y,Z>::transformCuda(
 
     for (sd::LongType i = threadIdx.x; i < tadLength; i += blockDim.x) {
       sd::LongType xOffset, yOffset, zOffset;
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), &i, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), &i, yOffset);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), &i, zOffset);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), &i, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), &i, yOffset);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::stride(tadOnlyShapeInfoZ), &i, zOffset);
       rZ[zOffset] = OpType::op(rX[xOffset], y[yOffset]);
     }
   }
@@ -234,20 +234,20 @@ SD_DEVICE void Broadcast<X,Y,Z>::transformCuda(
   sd::LongType coords[SD_MAX_RANK];
 
   for (int i = tid; i < zLen; i += blockDim.x * gridDim.x) {
-    INDEX2COORDS(i, rank, zShapeInfo, coords);
+    INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), coords);
 
     sd::LongType zOffset, xOffset, yOffset;
-    COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
     if (xzSameOffsets) {
       xOffset = zOffset;
     } else {
-      COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
     }
 
     if (yzSameOffsets) {
       yOffset = zOffset;
     } else {
-      COORDS2INDEX(rank, shape::shapeOf(yShapeInfo), coords, yOffset);
+      COORDS2INDEX(rank, shape::stride(yShapeInfo), coords, yOffset);
     }
     z[zOffset] = OpType::op(x[xOffset], y[yOffset]);
   }

--- a/libnd4j/include/loops/cuda/broadcasting_bool.cu
+++ b/libnd4j/include/loops/cuda/broadcasting_bool.cu
@@ -197,12 +197,12 @@ SD_DEVICE void BroadcastBool<X, Z>::transformInverseCuda(
       sd::LongType yOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, yCoords);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), yCoords, yOffset);
-      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoZ), tadOnlyShapeInfoZ, zCoords);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), yCoords);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), zCoords);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::stride(tadOnlyShapeInfoZ), zCoords, zOffset);
 
       rZ[zOffset] = OpType::op(x[xOffset], rY[yOffset], extraParams);
     }
@@ -249,11 +249,11 @@ SD_DEVICE void BroadcastBool<X, Z>::transformCuda(void const* vx, sd::LongType c
 
     for (sd::LongType i = threadIdx.x; i < tadLength; i += blockDim.x) {
       sd::LongType coords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, coords);
+      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), coords);
       sd::LongType xOffset, yOffset, zOffset;
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), coords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), coords, zOffset);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), coords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::stride(tadOnlyShapeInfoZ), coords, zOffset);
 
       rZ[zOffset] = OpType::op(rX[xOffset], y[yOffset], extraParams);
     }
@@ -292,19 +292,19 @@ SD_DEVICE void BroadcastBool<X, Z>::transformCuda(const void* vx,
 
   for (sd::LongType i = tid; i < zLen; i += blockDim.x * gridDim.x) {
     sd::LongType coords[SD_MAX_RANK];
-    INDEX2COORDS(i, zRank, zShapeInfo, coords);
+    INDEX2COORDS(i, zRank, shape::shapeOf(zShapeInfo), coords);
     sd::LongType zOffset, xOffset, yOffset;
-    COORDS2INDEX(zRank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(zRank, shape::stride(zShapeInfo), coords, zOffset);
     if (xzSameOffsets) {
       xOffset = zOffset;
     } else {
-      COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(xRank, shape::stride(xShapeInfo), coords, xOffset);
     }
 
     if (yzSameOffsets) {
       yOffset = zOffset;
     } else {
-      COORDS2INDEX(yRank, shape::shapeOf(yShapeInfo), coords, yOffset);
+      COORDS2INDEX(yRank, shape::stride(yShapeInfo), coords, yOffset);
     }
     z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
   }

--- a/libnd4j/include/loops/cuda/broadcasting_int.cu
+++ b/libnd4j/include/loops/cuda/broadcasting_int.cu
@@ -188,10 +188,10 @@ SD_DEVICE void BroadcastInt<X>::transformInverseCuda(
       sd::LongType xOffset, yOffset, zOffset;
       sd::LongType coords[SD_MAX_RANK];
 
-      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, coords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), coords, yOffset);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), coords, zOffset);
+      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), coords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), coords, yOffset);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::stride(tadOnlyShapeInfoZ), coords, zOffset);
 
       rZ[zOffset] = OpType::op(x[xOffset], rY[yOffset]);
     }
@@ -238,10 +238,10 @@ SD_DEVICE void BroadcastInt<X>::transformCuda(void const* vx, sd::LongType const
       sd::LongType xOffset, yOffset, zOffset;
       sd::LongType coords[SD_MAX_RANK];
 
-      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, coords);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), coords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), coords, yOffset);
-      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::shapeOf(tadOnlyShapeInfoZ), coords, zOffset);
+      INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), coords);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), coords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), coords, yOffset);
+      COORDS2INDEX(shape::rank(tadOnlyShapeInfoZ), shape::stride(tadOnlyShapeInfoZ), coords, zOffset);
 
       rZ[zOffset] = OpType::op(rX[xOffset], y[yOffset]);
     }
@@ -276,20 +276,20 @@ SD_DEVICE void BroadcastInt<X>::transformCuda(const void* vx, const sd::LongType
   sd::LongType coords[SD_MAX_RANK];
 
   for (sd::LongType i = tid; i < zLen; i += blockDim.x * gridDim.x) {
-    INDEX2COORDS(i, rank, zShapeInfo, coords);
+    INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), coords);
 
     sd::LongType zOffset, xOffset, yOffset;
-    COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
     if (xzSameOffsets) {
       xOffset = zOffset;
     } else {
-      COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
     }
 
     if (yzSameOffsets) {
       yOffset = zOffset;
     } else {
-      COORDS2INDEX(rank, shape::shapeOf(yShapeInfo), coords, yOffset);
+      COORDS2INDEX(rank, shape::stride(yShapeInfo), coords, yOffset);
     }
 
     z[zOffset] = OpType::op(x[xOffset], y[yOffset]);

--- a/libnd4j/include/loops/cuda/indexreduce.cu
+++ b/libnd4j/include/loops/cuda/indexreduce.cu
@@ -235,8 +235,8 @@ SD_DEVICE void IndexReduce<X, Z>::transform(void const *vdx, sd::LongType const 
         for (sd::LongType i = threadIdxX; i < tadLength; i += blockDimX) {
           sd::LongType xCoords[SD_MAX_RANK];
           sd::LongType xOffset;
-          INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, xCoords);
-          COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords, xOffset);
+          INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords);
+          COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), xCoords, xOffset);
           IndexValue<X> comp{dx[tadOffsetForBlock + xOffset], i};
           sPartials[threadIdxX] = OpType::update(sPartials[threadIdxX], comp, extraParams);
         }
@@ -259,8 +259,8 @@ SD_DEVICE void IndexReduce<X, Z>::transform(void const *vdx, sd::LongType const 
         for (sd::LongType x = threadIdxX; x < tadLength; x += blockDimX) {
           sd::LongType xCoords[SD_MAX_RANK];
           sd::LongType xOffset;
-          INDEX2COORDS(x, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, xCoords);
-          COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords, xOffset);
+          INDEX2COORDS(x, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords);
+          COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), xCoords, xOffset);
           IndexValue<X> comp{dx[tadOffsetForBlock + xOffset], x};
           sPartials[threadIdxX] = OpType::update(sPartials[threadIdxX], comp, extraParams);
         }
@@ -280,8 +280,8 @@ SD_DEVICE void IndexReduce<X, Z>::transform(void const *vdx, sd::LongType const 
     for (sd::LongType i = tid; i < n; i += (gridDimX * blockDimX)) {
       sd::LongType xCoords[SD_MAX_RANK];
       sd::LongType xOffset;
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
       IndexValue<X> comp{dx[xOffset], i};
       reduction = OpType::update(reduction, comp, extraParams);
     }

--- a/libnd4j/include/loops/cuda/inplace_loops/reduce_same_inplace.h
+++ b/libnd4j/include/loops/cuda/inplace_loops/reduce_same_inplace.h
@@ -113,8 +113,8 @@ SD_INLINE void SD_DEVICE ReduceSameInplace<X>::execScalarCuda(void *vx, sd::Long
   for (int i = tid; i < len; i += blockDim.x * gridDim.x) {
     sd::LongType xCoords[SD_MAX_RANK];
     sd::LongType xOffset;
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(x[xOffset], extraParams), extraParams);
   }
 

--- a/libnd4j/include/loops/cuda/inplace_loops/scalar_inplace.h
+++ b/libnd4j/include/loops/cuda/inplace_loops/scalar_inplace.h
@@ -74,10 +74,10 @@ SD_INLINE SD_DEVICE void ScalarInplace<X, Y, Z>::transformCuda(void *vscalar, vo
     sd::LongType yOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = OpType::op(y[yOffset], scalar, params);
   }

--- a/libnd4j/include/loops/cuda/inplace_loops/transform_strict_inplace.h
+++ b/libnd4j/include/loops/cuda/inplace_loops/transform_strict_inplace.h
@@ -72,10 +72,10 @@ SD_INLINE SD_DEVICE void TransformStrictInplace<X>::transformCuda(void *vdy, sd:
     sd::LongType xOffset2;
     sd::LongType zOffset2;
 
-    INDEX2COORDS(i, shape::rank(shapeInfo), shapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(shapeInfo), shape::shapeOf(shapeInfo), xCoords, xOffset2);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset2);
+    INDEX2COORDS(i, shape::rank(shapeInfo), shape::shapeOf(shapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(shapeInfo), shape::stride(shapeInfo), xCoords, xOffset2);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset2);
 
     result[zOffset2] = OpType::op(dy[xOffset2], params);
   }

--- a/libnd4j/include/loops/cuda/pairwise.chpp
+++ b/libnd4j/include/loops/cuda/pairwise.chpp
@@ -53,12 +53,12 @@ SD_KERNEL static void pairwiseSimpleShaped(void const* vx, sd::LongType const* x
     sd::LongType yOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
   }

--- a/libnd4j/include/loops/cuda/pairwise_bool.cu
+++ b/libnd4j/include/loops/cuda/pairwise_bool.cu
@@ -54,12 +54,12 @@ SD_KERNEL static void pairwiseSimpleShaped(void const* vx, sd::LongType const* x
     sd::LongType yOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
   }

--- a/libnd4j/include/loops/cuda/pairwise_int.cu
+++ b/libnd4j/include/loops/cuda/pairwise_int.cu
@@ -54,12 +54,12 @@ SD_KERNEL static void pairwiseSimpleShaped(void const* vx, sd::LongType const* x
     sd::LongType yOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = OpType::op(x[xOffset], y[yOffset], extraParams);
   }

--- a/libnd4j/include/loops/cuda/random.cu
+++ b/libnd4j/include/loops/cuda/random.cu
@@ -160,12 +160,12 @@ void SD_DEVICE RandomFunction<T>::execTransformCuda(sd::Pointer state, void cons
       sd::LongType yOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeBuffer), xShapeBuffer, xCoords);
-      COORDS2INDEX(shape::rank(xShapeBuffer), shape::shapeOf(xShapeBuffer), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(yShapeBuffer), yShapeBuffer, yCoords);
-      COORDS2INDEX(shape::rank(yShapeBuffer), shape::shapeOf(yShapeBuffer), yCoords, yOffset);
-      INDEX2COORDS(i, shape::rank(zShapeBuffer), zShapeBuffer, zCoords);
-      COORDS2INDEX(shape::rank(zShapeBuffer), shape::shapeOf(zShapeBuffer), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(xShapeBuffer), shape::shapeOf(xShapeBuffer), xCoords);
+      COORDS2INDEX(shape::rank(xShapeBuffer), shape::stride(xShapeBuffer), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(yShapeBuffer), shape::shapeOf(yShapeBuffer), yCoords);
+      COORDS2INDEX(shape::rank(yShapeBuffer), shape::stride(yShapeBuffer), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(zShapeBuffer), shape::shapeOf(zShapeBuffer), zCoords);
+      COORDS2INDEX(shape::rank(zShapeBuffer), shape::stride(zShapeBuffer), zCoords, zOffset);
 
       z[zOffset] = OpClass::op(x[xOffset], y[yOffset], i, length, buffer, extraArguments);
     }
@@ -213,10 +213,10 @@ void SD_DEVICE RandomFunction<T>::execTransformCuda(sd::Pointer state, void cons
     sd::LongType xOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeBuffer), xShapeBuffer, xCoords);
-    COORDS2INDEX(shape::rank(xShapeBuffer), shape::shapeOf(xShapeBuffer), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(zShapeBuffer), zShapeBuffer, zCoords);
-    COORDS2INDEX(shape::rank(zShapeBuffer), shape::shapeOf(zShapeBuffer), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeBuffer), shape::shapeOf(xShapeBuffer), xCoords);
+    COORDS2INDEX(shape::rank(xShapeBuffer), shape::stride(xShapeBuffer), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(zShapeBuffer), shape::shapeOf(zShapeBuffer), zCoords);
+    COORDS2INDEX(shape::rank(zShapeBuffer), shape::stride(zShapeBuffer), zCoords, zOffset);
 
     z[zOffset] = OpClass::op(x[xOffset], i, length, buffer, extraArguments);
   }
@@ -255,8 +255,8 @@ void SD_DEVICE RandomFunction<T>::execTransformCuda(sd::Pointer state, void* vz,
     sd::LongType zCoords[SD_MAX_RANK];
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(zShapeBuffer), zShapeBuffer, zCoords);
-    COORDS2INDEX(shape::rank(zShapeBuffer), shape::shapeOf(zShapeBuffer), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(zShapeBuffer), shape::shapeOf(zShapeBuffer), zCoords);
+    COORDS2INDEX(shape::rank(zShapeBuffer), shape::stride(zShapeBuffer), zCoords, zOffset);
 
     z[zOffset] = OpClass::op(i, length, buffer, extraArguments);
   }

--- a/libnd4j/include/loops/cuda/reduce/reduce_bool.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_bool.cu
@@ -112,13 +112,13 @@ SD_DEVICE void ReduceBoolFunction<X, Z>::transformCudaXD(const void *vx, const s
   sd::LongType coords[SD_MAX_RANK];
 
   for (sd::LongType r = blockIdx.x; r < numTads; r += gridDim.x) {
-    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), outerXTadShapeInfo, coords);
+    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords);
     sd::LongType outerOffset, zOffset;
-    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords, outerOffset);
+    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::stride(outerXTadShapeInfo), coords, outerOffset);
     if (sameOffsets) {
       zOffset = outerOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     const X *xTad = x + outerOffset;
@@ -126,7 +126,7 @@ SD_DEVICE void ReduceBoolFunction<X, Z>::transformCudaXD(const void *vx, const s
 
     for (int i = threadIdx.x; i < tadLen; i += blockDim.x) {
       sd::LongType innerOffset;
-      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::shapeOf(innerXTadShapeInfo), coords, innerOffset);
+      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::stride(innerXTadShapeInfo), coords, innerOffset);
       sPartials[threadIdx.x] =
           OpType::update(sPartials[threadIdx.x],
                          OpType::op(xTad[innerOffset], extraParams), extraParams);
@@ -169,8 +169,8 @@ SD_DEVICE void ReduceBoolFunction<X, Z>::execScalarCuda(const void *vx, const sd
   for (int i = tid; i < len; i += blockDim.x * gridDim.x) {
     sd::LongType xCoords[SD_MAX_RANK];
     sd::LongType xOffset;
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(x[xOffset], extraParams), extraParams);
   }
 

--- a/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
+++ b/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
@@ -116,20 +116,20 @@ SD_DEVICE void ReduceFloatFunction<X,Z>::transformCudaXD(const void *vx, const s
 
   for (sd::LongType r = blockIdx.x; r < numTads; r += gridDim.x) {
 
-    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), outerXTadShapeInfo, coords);
+    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords);
     sd::LongType outerOffset,zOffset;
-    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords, outerOffset);
+    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::stride(outerXTadShapeInfo), coords, outerOffset);
     if(sameOffsets) {
       sameOffsets = outerOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
     const X* xTad = x + outerOffset;
     sPartials[threadIdx.x] = OpType::startingValue(xTad);
 
     for (int i = threadIdx.x; i < tadLen; i += blockDim.x) {
       sd::LongType innerOffset;
-      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::shapeOf(innerXTadShapeInfo), coords, innerOffset);
+      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::stride(innerXTadShapeInfo), coords, innerOffset);
       sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(xTad[innerOffset], extraParams), extraParams);
     }
     __syncthreads();
@@ -169,8 +169,8 @@ SD_DEVICE void ReduceFloatFunction<X, Z>::execScalarCuda(const void *vx, const s
   for (int i = tid; i < len; i += blockDim.x * gridDim.x) {
     sd::LongType xCoords[SD_MAX_RANK];
     sd::LongType xOffset;
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(x[xOffset], extraParams), extraParams);
   }
 

--- a/libnd4j/include/loops/cuda/reduce/reduce_long.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_long.cu
@@ -121,21 +121,21 @@ SD_DEVICE void ReduceLongFunction<X, Z>::transformCudaXD(const void *vx, const s
   sd::LongType coords[SD_MAX_RANK];
 
   for (sd::LongType r = blockIdx.x; r < numTads; r += gridDim.x) {
-    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), outerXTadShapeInfo, coords);
+    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords);
     sd::LongType outerOffset, zOffset;
-    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords, outerOffset);
+    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::stride(outerXTadShapeInfo), coords, outerOffset);
     if(sameOffsets) {
       sameOffsets = outerOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
     const X *xTad = x + outerOffset;
     sPartials[threadIdx.x] = OpType::startingValue(xTad);
 
     for (sd::LongType i = threadIdx.x; i < tadLen; i += blockDim.x) {
       sd::LongType xOffset;
-      INDEX2COORDS(i, shape::rank(innerXTadShapeInfo), innerXTadShapeInfo, coords);
-      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::shapeOf(innerXTadShapeInfo), coords, xOffset);
+      INDEX2COORDS(i, shape::rank(innerXTadShapeInfo), shape::shapeOf(innerXTadShapeInfo), coords);
+      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::stride(innerXTadShapeInfo), coords, xOffset);
       sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(xTad[xOffset], extraParams), extraParams);
     }
     __syncthreads();
@@ -175,8 +175,8 @@ SD_DEVICE void ReduceLongFunction<X, Z>::execScalarCuda(const void *vx, const sd
   for (int i = tid; i < len; i += blockDim.x * gridDim.x) {
     sd::LongType xCoords[SD_MAX_RANK];
     sd::LongType xOffset;
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(x[xOffset], extraParams), extraParams);
   }
 

--- a/libnd4j/include/loops/cuda/reduce/reduce_same.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_same.cu
@@ -111,14 +111,14 @@ SD_DEVICE void ReduceSameFunction<X>::transformCudaXD(const void *vx, const sd::
   sd::LongType coords[SD_MAX_RANK];
 
   for (sd::LongType r = blockIdx.x; r < numTads; r += gridDim.x) {
-    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), outerXTadShapeInfo, coords);
+    INDEX2COORDS(r, shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords);
     sd::LongType outerOffset;
-    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::shapeOf(outerXTadShapeInfo), coords, outerOffset);
+    COORDS2INDEX(shape::rank(outerXTadShapeInfo), shape::stride(outerXTadShapeInfo), coords, outerOffset);
     sd::LongType zOffset;
     if(sameOffsets) {
       sameOffsets = outerOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     const X *xTad = x + outerOffset;
@@ -126,7 +126,7 @@ SD_DEVICE void ReduceSameFunction<X>::transformCudaXD(const void *vx, const sd::
 
     for (int i = threadIdx.x; i < tadLen; i += blockDim.x) {
       sd::LongType innerOffset;
-      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::shapeOf(innerXTadShapeInfo), coords, innerOffset);
+      COORDS2INDEX(shape::rank(innerXTadShapeInfo), shape::stride(innerXTadShapeInfo), coords, innerOffset);
       sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(xTad[innerOffset], extraParams), extraParams);
     }
     __syncthreads();
@@ -176,8 +176,8 @@ SD_DEVICE void ReduceSameFunction<X>::execScalarCuda(void const *vx, sd::LongTyp
   for (int i = tid; i < len; i += blockDim.x * gridDim.x) {
     sd::LongType xCoords[SD_MAX_RANK];
     sd::LongType xOffset;
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::op(x[xOffset], extraParams), extraParams);
   }
 

--- a/libnd4j/include/loops/cuda/reduce3.chpp
+++ b/libnd4j/include/loops/cuda/reduce3.chpp
@@ -148,10 +148,10 @@ SD_DEVICE void Reduce3<X,Z>::execScalarCuda( void const* vx, sd::LongType const*
       sd::LongType yCoords[SD_MAX_RANK];
       sd::LongType xOffset;
       sd::LongType yOffset;
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
       sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::opAtomic(x[xOffset], y[yOffset], extraZ), extraZ);
     }
   } else {
@@ -162,10 +162,10 @@ SD_DEVICE void Reduce3<X,Z>::execScalarCuda( void const* vx, sd::LongType const*
       sd::LongType yCoords[SD_MAX_RANK];
       sd::LongType xOffset;
       sd::LongType yOffset;
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
       sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::opAtomic(x[xOffset], y[yOffset], extraZ), extraZ);
     }
   }
@@ -283,8 +283,8 @@ SD_DEVICE void Reduce3<X,Z>::transformAll( void const* vx, sd::LongType const* x
     if (threadIdx.x < xTadLength && threadIdx.x < maxBlock) {
       sd::LongType xCoords[SD_MAX_RANK];
       sd::LongType xOffset;
-      INDEX2COORDS(threadIdx.x, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(threadIdx.x, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, xOffset);
       tempX[threadIdx.x] = x[xOffset];
     }
     __syncthreads();
@@ -307,16 +307,16 @@ SD_DEVICE void Reduce3<X,Z>::transformAll( void const* vx, sd::LongType const* x
           if (threadIdx.x + (t * maxBlock) < xTadLength) {
             sd::LongType xCoords[SD_MAX_RANK];
             sd::LongType xOffset;
-            INDEX2COORDS(threadIdx.x + (t * maxBlock), shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-            COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, xOffset);
+            INDEX2COORDS(threadIdx.x + (t * maxBlock), shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+            COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, xOffset);
             tempX[threadIdx.x] = x[xOffset];
           }
 
         for (int f = threadIdx.x + (t * maxBlock); f < xTadLength && f < threadIdx.x + ((t + 1) * maxBlock); f += blockDim.x * gridDim.x) {
           sd::LongType yCoords[SD_MAX_RANK];
           sd::LongType yOffset;
-          INDEX2COORDS(f, shape::rank(yTadShapeInfo), yTadShapeInfo, yCoords);
-          COORDS2INDEX(shape::rank(yTadShapeInfo), shape::shapeOf(yTadShapeInfo), yCoords, yOffset);
+          INDEX2COORDS(f, shape::rank(yTadShapeInfo), shape::shapeOf(yTadShapeInfo), yCoords);
+          COORDS2INDEX(shape::rank(yTadShapeInfo), shape::stride(yTadShapeInfo), yCoords, yOffset);
           sPartials[threadIdx.x] = OpType::update(sPartials[threadIdx.x], OpType::opAtomic(tempX[threadIdx.x], y[yOffset], extraZ), extraZ);
         }
 
@@ -405,8 +405,8 @@ SD_DEVICE void Reduce3<X,Z>::transform(void const* vx, sd::LongType const* xShap
         sd::LongType yCoords[SD_MAX_RANK];
         sd::LongType xOffset2;
         sd::LongType yOffset2;
-        INDEX2COORDS(j, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, xCoords);
-        INDEX2COORDS(j, shape::rank(yTadOnlyShapeInfo), yTadOnlyShapeInfo, yCoords);
+        INDEX2COORDS(j, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords);
+        INDEX2COORDS(j, shape::rank(yTadOnlyShapeInfo), shape::shapeOf(yTadOnlyShapeInfo), yCoords);
         COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords, xOffset2);
         COORDS2INDEX(shape::rank(yTadOnlyShapeInfo), shape::shapeOf(yTadOnlyShapeInfo), yCoords, yOffset2);
         sPartials[threadIdx.x] =  j < blockDim.x ? OpType::opAtomic(x[xOffset + xOffset2], y[yOffset + yOffset2], extraZ) : OpType::update(sPartials[threadIdx.x], OpType::opAtomic(x[xOffset + xOffset2], y[yOffset + yOffset2], extraZ), extraZ);
@@ -440,8 +440,8 @@ SD_DEVICE void Reduce3<X,Z>::transform(void const* vx, sd::LongType const* xShap
         sd::LongType yCoords[SD_MAX_RANK];
         sd::LongType xOffset2;
         sd::LongType yOffset2;
-        INDEX2COORDS(j, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, xCoords);
-        INDEX2COORDS(j, shape::rank(yTadOnlyShapeInfo), yTadOnlyShapeInfo, yCoords);
+        INDEX2COORDS(j, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords);
+        INDEX2COORDS(j, shape::rank(yTadOnlyShapeInfo), shape::shapeOf(yTadOnlyShapeInfo), yCoords);
         COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords, xOffset2);
         COORDS2INDEX(shape::rank(yTadOnlyShapeInfo), shape::shapeOf(yTadOnlyShapeInfo), yCoords, yOffset2);
         sPartials[threadIdx.x] =  j < blockDim.x ? OpType::opAtomic(x[xOffset + xOffset2], y[yOffset + yOffset2], extraZ) : OpType::update(sPartials[threadIdx.x], OpType::opAtomic(x[xOffset + xOffset2], y[yOffset + yOffset2], extraZ), extraZ);

--- a/libnd4j/include/loops/cuda/scalar.chpp
+++ b/libnd4j/include/loops/cuda/scalar.chpp
@@ -55,10 +55,10 @@ SD_KERNEL static void scalarSimpleShaped(void const* x, void const* y, sd::LongT
     sd::LongType xOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z2[zOffset] = OpType::op(x2[xOffset], scalar, params2);
   }
@@ -99,10 +99,10 @@ SD_KERNEL static void scalarAlongDimension(void const* x, sd::LongType const* xS
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(f, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(f, shape::rank(tadShapeInfoZ), tadShapeInfoZ, zCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfoZ), shape::shapeOf(tadShapeInfoZ), zCoords, zOffset);
+      INDEX2COORDS(f, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(f, shape::rank(tadShapeInfoZ), shape::shapeOf(tadShapeInfoZ), zCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfoZ), shape::stride(tadShapeInfoZ), zCoords, zOffset);
 
       oZ[zOffset] = OpType::op(oX[xOffset], s, extraParams2);
     }

--- a/libnd4j/include/loops/cuda/scalar_bool.cu
+++ b/libnd4j/include/loops/cuda/scalar_bool.cu
@@ -84,12 +84,12 @@ SD_DEVICE void ScalarBoolTransform<X, Z>::transformCuda(void const* vscalar, voi
   for (sd::LongType i = tid; i < len; i += totalThreads) {
     sd::LongType yCoords[SD_MAX_RANK];
     sd::LongType yOffset;
-    INDEX2COORDS(i, yRank, yShapeInfo, yCoords);
+    INDEX2COORDS(i, yRank, shape::shapeOf(yShapeInfo), yCoords);
     COORDS2INDEX(yRank, yShape, yCoords, yOffset);
 
     sd::LongType zCoords[SD_MAX_RANK];
     sd::LongType zOffset;
-    INDEX2COORDS(i, zRank, zShapeInfo, zCoords);
+    INDEX2COORDS(i, zRank, shape::shapeOf(zShapeInfo), zCoords);
     COORDS2INDEX(zRank, zShape, zCoords, zOffset);
 
     z[zOffset] = OpType::op(y[yOffset], scalar, params);
@@ -147,13 +147,13 @@ SD_DEVICE void ScalarBoolTransform<X, Z>::transformCuda(
     for (int f = threadIdx.x; f < tadLength; f += blockDim.x) {
       sd::LongType xCoords[SD_MAX_RANK];
       sd::LongType xOffset;
-      INDEX2COORDS(f, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(f, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), xCoords, xOffset);
 
       sd::LongType zCoords[SD_MAX_RANK];
       sd::LongType zOffset;
-      INDEX2COORDS(f, shape::rank(tadShapeInfoZ), tadShapeInfoZ, zCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfoZ), shape::shapeOf(tadShapeInfoZ), zCoords, zOffset);
+      INDEX2COORDS(f, shape::rank(tadShapeInfoZ), shape::shapeOf(tadShapeInfoZ), zCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfoZ), shape::stride(tadShapeInfoZ), zCoords, zOffset);
 
       oZ[zOffset] = OpType::op(oX[xOffset], s, extraParams);
     }

--- a/libnd4j/include/loops/cuda/scalar_int.cu
+++ b/libnd4j/include/loops/cuda/scalar_int.cu
@@ -81,12 +81,12 @@ SD_DEVICE void ScalarIntTransform<X>::transformCuda(void const* vscalar, void co
   for (sd::LongType i = tid; i < len; i += totalThreads) {
     sd::LongType yCoords[SD_MAX_RANK];
     sd::LongType yOffset;
-    INDEX2COORDS(i, yRank, yShapeInfo, yCoords);
+    INDEX2COORDS(i, yRank, shape::shapeOf(yShapeInfo), yCoords);
     COORDS2INDEX(yRank, yShape, yCoords, yOffset);
 
     sd::LongType zCoords[SD_MAX_RANK];
     sd::LongType zOffset;
-    INDEX2COORDS(i, zRank, zShapeInfo, zCoords);
+    INDEX2COORDS(i, zRank, shape::shapeOf(zShapeInfo), zCoords);
     COORDS2INDEX(zRank, zShape, zCoords, zOffset);
 
     z[zOffset] = OpType::op(y[yOffset], scalar, params);
@@ -149,10 +149,10 @@ SD_DEVICE void ScalarIntTransform<X>::transformCuda(void const* vx, sd::LongType
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(f, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(f, shape::rank(tadShapeInfoZ), tadShapeInfoZ, zCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfoZ), shape::shapeOf(tadShapeInfoZ), zCoords, zOffset);
+      INDEX2COORDS(f, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(f, shape::rank(tadShapeInfoZ), shape::shapeOf(tadShapeInfoZ), zCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfoZ), shape::stride(tadShapeInfoZ), zCoords, zOffset);
 
       oZ[zOffset] = OpType::op(oX[xOffset], s, extraParams);
     }

--- a/libnd4j/include/loops/cuda/specials/bitonicArbitraryStep.cu
+++ b/libnd4j/include/loops/cuda/specials/bitonicArbitraryStep.cu
@@ -80,10 +80,10 @@ SD_KERNEL void bitonicArbitraryStepKernelKey(void *vx, sd::LongType const *xShap
         sd::LongType itOffset;
         sd::LongType ijOffset;
 
-        INDEX2COORDS(it, shape::rank(xShapeInfo), xShapeInfo, itCoords);
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), itCoords, itOffset);
-        INDEX2COORDS(ij, shape::rank(xShapeInfo), xShapeInfo, ijCoords);
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ijCoords, ijOffset);
+        INDEX2COORDS(it, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), itCoords);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), itCoords, itOffset);
+        INDEX2COORDS(ij, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ijCoords);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), ijCoords, ijOffset);
 
         X v0 = x[ijOffset];
         X v1 = x[itOffset];
@@ -160,10 +160,10 @@ SD_KERNEL void execBitonicArbitraryStepKernel(void *vx, sd::LongType const *xSha
         sd::LongType itOffset;
         sd::LongType ijOffset;
 
-        INDEX2COORDS(it, shape::rank(xShapeInfo), xShapeInfo, itCoords);
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), itCoords, itOffset);
-        INDEX2COORDS(ij, shape::rank(xShapeInfo), xShapeInfo, ijCoords);
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ijCoords, ijOffset);
+        INDEX2COORDS(it, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), itCoords);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), itCoords, itOffset);
+        INDEX2COORDS(ij, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ijCoords);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), ijCoords, ijOffset);
 
         shmem[threadIdx.x] = x[ijOffset];
         shmem[threadIdx.x + blockDim.x] = x[itOffset];

--- a/libnd4j/include/loops/cuda/specials/bitonicSortStep.cu
+++ b/libnd4j/include/loops/cuda/specials/bitonicSortStep.cu
@@ -49,10 +49,10 @@ SD_KERNEL void bitonicSortStepKernelKey(void *vx, sd::LongType const *xShapeInfo
     sd::LongType iOffset;
     sd::LongType ixjOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, iCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), iCoords, iOffset);
-    INDEX2COORDS(ixj, shape::rank(xShapeInfo), xShapeInfo, ixjCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ixjCoords, ixjOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), iCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), iCoords, iOffset);
+    INDEX2COORDS(ixj, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ixjCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), ixjCoords, ixjOffset);
 
     if ((i & k) == 0) {
       /* Sort ascending */
@@ -107,10 +107,10 @@ SD_KERNEL void bitonicSortStepKernel(void *vx, sd::LongType const *xShapeInfo, i
     sd::LongType iOffset;
     sd::LongType ixjOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, iCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), iCoords, iOffset);
-    INDEX2COORDS(ixj, shape::rank(xShapeInfo), xShapeInfo, ixjCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ixjCoords, ixjOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), iCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), iCoords, iOffset);
+    INDEX2COORDS(ixj, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), ixjCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), ixjCoords, ixjOffset);
 
     if ((i & k) == 0) {
       /* Sort ascending */

--- a/libnd4j/include/loops/cuda/specials/concatKernel.cu
+++ b/libnd4j/include/loops/cuda/specials/concatKernel.cu
@@ -103,21 +103,21 @@ SD_DEVICE void concatKernel(int numArrays, Pointer *data, Pointer *inputShapeInf
 
         LongType sub[SD_MAX_RANK];
 
-        INDEX2COORDS(arrOffset, shape::rank(zTadShape), zTadShape, sub);
+        INDEX2COORDS(arrOffset, shape::rank(zTadShape), shape::shapeOf(zTadShape), sub);
 
         LongType baseOffset;
-        COORDS2INDEX(shape::rank(zTadShape), shape::shapeOf(zTadShape), sub, baseOffset);
+        COORDS2INDEX(shape::rank(zTadShape), shape::stride(zTadShape), sub, baseOffset);
 
         resultTAD += baseOffset;
 
         auto yRank = shape::rank(currentTad);
         auto tadRank = shape::rank(zTadShape);
 
-        INDEX2COORDS(0, yRank, currentTad, sub);
+        INDEX2COORDS(0, yRank, shape::shapeOf(currentTad), sub);
 
         LongType yOffset;
-        COORDS2INDEX(yRank, shape::shapeOf(currentTad), sub, yOffset);
-        COORDS2INDEX(tadRank, shape::shapeOf(zTadShape), sub, resultOffset);
+        COORDS2INDEX(yRank, shape::stride(currentTad), sub, yOffset);
+        COORDS2INDEX(tadRank, shape::stride(zTadShape), sub, resultOffset);
 
         resultTAD[resultOffset] = dataTAD[yOffset];
       }
@@ -131,9 +131,9 @@ SD_DEVICE void concatKernel(int numArrays, Pointer *data, Pointer *inputShapeInf
 
         LongType sub[SD_MAX_RANK];
 
-        INDEX2COORDS(arrOffset, shape::rank(zTadShape), zTadShape, sub);
+        INDEX2COORDS(arrOffset, shape::rank(zTadShape), shape::shapeOf(zTadShape), sub);
         LongType baseOffset;
-        COORDS2INDEX(shape::rank(zTadShape), shape::shapeOf(zTadShape), sub, baseOffset);
+        COORDS2INDEX(shape::rank(zTadShape), shape::stride(zTadShape), sub, baseOffset);
 
         resultTAD += baseOffset;
 
@@ -173,8 +173,8 @@ SD_DEVICE void concatKernel(int numArrays, Pointer *data, Pointer *inputShapeInf
             LongType yIdx[SD_MAX_RANK];
 
             for (LongType i = threadIdx.x; i < yLength; i += blockDim.x) {
-              INDEX2COORDS(i, shape::rank(currentTad), currentTad, yIdx);
-              INDEX2COORDS(i, shape::rank(zTadShape), zTadShape, zIdx);
+              INDEX2COORDS(i, shape::rank(currentTad), shape::shapeOf(currentTad), yIdx);
+              INDEX2COORDS(i, shape::rank(zTadShape), shape::shapeOf(zTadShape), zIdx);
 
               LongType yOffset;
               COORDS2INDEX(shape::rank(currentTad), shape::shapeOf(currentTad), yIdx, yOffset);

--- a/libnd4j/include/loops/cuda/specials/fillDimensionalIsMax.cu
+++ b/libnd4j/include/loops/cuda/specials/fillDimensionalIsMax.cu
@@ -50,8 +50,8 @@ SD_DEVICE void fillDimensionalIsMax(const void *vdX, void *vdZ, const LongType *
       for (LongType e = threadIdx.x; e < tadLength; e += blockDim.x) {
         sd::LongType xCoords[SD_MAX_RANK];
         sd::LongType xOffset;
-        INDEX2COORDS(e, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords, xOffset);
+        INDEX2COORDS(e, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), xCoords, xOffset);
         auto finalOffset = tadOffsetForBlock + xOffset;
         dZ[finalOffset] = (e == highestElement ? (T)1 : (T)0);
       }
@@ -59,8 +59,8 @@ SD_DEVICE void fillDimensionalIsMax(const void *vdX, void *vdZ, const LongType *
       for (LongType e = threadIdx.x; e < tadLength; e += blockDim.x) {
         sd::LongType xCoords[SD_MAX_RANK];
         sd::LongType xOffset;
-        INDEX2COORDS(e, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords, xOffset);
+        INDEX2COORDS(e, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), xCoords, xOffset);
         auto finalOffset = tadOffsetForBlock + xOffset;
         dZ[finalOffset] = (e == highestElement ? (T)1 : (T)0);
       }

--- a/libnd4j/include/loops/cuda/specials/fillIsMax.cu
+++ b/libnd4j/include/loops/cuda/specials/fillIsMax.cu
@@ -34,8 +34,8 @@ SD_KERNEL void execFillIsMax(void *vdZ, const LongType *xShapeInfo, LongType len
   for (LongType i = tid; i < length; i += blockDim.x * gridDim.x) {
     sd::LongType iCoords[SD_MAX_RANK];
     sd::LongType iOffset;
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, iCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), iCoords, iOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), iCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), iCoords, iOffset);
     dz[iOffset] = (i == idx ? (T)1 : (T)0);
   }
 }

--- a/libnd4j/include/loops/cuda/specials/flatten.cu
+++ b/libnd4j/include/loops/cuda/specials/flatten.cu
@@ -45,8 +45,8 @@ SD_KERNEL void flattenKernel(Pointer *extraPointers, int dOffset, char order, vo
   for (auto i = tid; i < lenY; i += gridDim.x * blockDim.x) {
     LongType yOffset;
     sd::LongType yCoords[SD_MAX_RANK];
-    INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
     z[i + dOffset] = y[yOffset];
   }
 }

--- a/libnd4j/include/loops/cuda/specials/oesTad.cu
+++ b/libnd4j/include/loops/cuda/specials/oesTad.cu
@@ -56,10 +56,10 @@ SD_KERNEL void execOesTadKernelKey(void *vx, sd::LongType const *xShapeInfo, voi
             sd::LongType t1Coords[SD_MAX_RANK];
             sd::LongType t0Offset;
             sd::LongType t1Offset;
-            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), tadShapeInfo, t0Coords);
-            COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords, t0Offset);
-            INDEX2COORDS(top, shape::rank(tadShapeInfo), tadShapeInfo, t1Coords);
-            COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords, t1Offset);
+            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords);
+            COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), t0Coords, t0Offset);
+            INDEX2COORDS(top, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords);
+            COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), t1Coords, t1Offset);
 
             if (!descending == (dx[t0Offset] > dx[t1Offset])) {
               X dt0 = dx[t0Offset];
@@ -80,10 +80,10 @@ SD_KERNEL void execOesTadKernelKey(void *vx, sd::LongType const *xShapeInfo, voi
             sd::LongType t1Coords[SD_MAX_RANK];
             sd::LongType t0Offset;
             sd::LongType t1Offset;
-            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), tadShapeInfo, t0Coords);
-            COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords, t0Offset);
-            INDEX2COORDS(top, shape::rank(tadShapeInfo), tadShapeInfo, t1Coords);
-            COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords, t1Offset);
+            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords);
+            COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), t0Coords, t0Offset);
+            INDEX2COORDS(top, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords);
+            COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), t1Coords, t1Offset);
 
             if (!descending == (dx[t0Offset] > dx[t1Offset])) {
               X dt0 = dx[t0Offset];
@@ -135,8 +135,8 @@ SD_KERNEL void execOesTadKernel(void *vx, sd::LongType const *xShapeInfo, sd::Lo
       for (int tid = threadIdx.x; tid < xTadLength; tid += blockDim.x) {
         sd::LongType xCoords[SD_MAX_RANK];
         sd::LongType xOffset;
-        INDEX2COORDS(tid, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
+        INDEX2COORDS(tid, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), xCoords, xOffset);
         shmem[tid] = dx[xOffset];
       }
 
@@ -153,10 +153,10 @@ SD_KERNEL void execOesTadKernel(void *vx, sd::LongType const *xShapeInfo, sd::Lo
             sd::LongType t1Coords[SD_MAX_RANK];
             sd::LongType t0Offset;
             sd::LongType t1Offset;
-            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), tadShapeInfo, t0Coords);
-            COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords, t0Offset);
-            INDEX2COORDS(top, shape::rank(tadShapeInfo), tadShapeInfo, t1Coords);
-            COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords, t1Offset);
+            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords);
+            COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), t0Coords, t0Offset);
+            INDEX2COORDS(top, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords);
+            COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), t1Coords, t1Offset);
 
             if (!descending == (dx[t0Offset] > dx[t1Offset])) {
               T dt0 = dx[t0Offset];
@@ -173,9 +173,9 @@ SD_KERNEL void execOesTadKernel(void *vx, sd::LongType const *xShapeInfo, sd::Lo
             sd::LongType t1Coords[SD_MAX_RANK];
             sd::LongType t0Offset;
             sd::LongType t1Offset;
-            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), tadShapeInfo, t0Coords);
+            INDEX2COORDS(top - 1, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords);
             COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t0Coords, t0Offset);
-            INDEX2COORDS(top, shape::rank(tadShapeInfo), tadShapeInfo, t1Coords);
+            INDEX2COORDS(top, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords);
             COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), t1Coords, t1Offset);
 
             if (!descending == (dx[t0Offset] > dx[t1Offset])) {
@@ -194,7 +194,7 @@ SD_KERNEL void execOesTadKernel(void *vx, sd::LongType const *xShapeInfo, sd::Lo
       for (int tid = threadIdx.x; tid < xTadLength; tid += blockDim.x) {
         sd::LongType xCoords[SD_MAX_RANK];
         sd::LongType xOffset;
-        INDEX2COORDS(tid, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
+        INDEX2COORDS(tid, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
         COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
         dx[xOffset] = shmem[tid];
       }

--- a/libnd4j/include/loops/cuda/specials/pullRowsKernel.cu
+++ b/libnd4j/include/loops/cuda/specials/pullRowsKernel.cu
@@ -43,10 +43,10 @@ SD_DEVICE void pullRowsKernel(void *vx, void *vz, LongType len, LongType *indexe
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(tadShapeInfo), tadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(zTadShapeInfo), zTadShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(tadShapeInfo), shape::shapeOf(tadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(tadShapeInfo), shape::stride(tadShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zCoords, zOffset);
 
       rZ[zOffset] = rX[xOffset];
     }

--- a/libnd4j/include/loops/cuda/specials/shuffleKernel.cu
+++ b/libnd4j/include/loops/cuda/specials/shuffleKernel.cu
@@ -62,10 +62,10 @@ SD_KERNEL void execShuffleKernel(void **vdX, LongType **dxShapeInfo, void **vdZ,
           sd::LongType xOffset;
           sd::LongType swapOffset;
 
-          INDEX2COORDS(r, xRank, xShapeInfo, xCoords);
-          COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), xCoords, xOffset);
-          INDEX2COORDS(swapIndex, xRank, xShapeInfo, swapCoords);
-          COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), swapCoords, swapOffset);
+          INDEX2COORDS(r, xRank, shape::shapeOf(xShapeInfo), xCoords);
+          COORDS2INDEX(xRank, shape::stride(xShapeInfo), xCoords, xOffset);
+          INDEX2COORDS(swapIndex, xRank, shape::shapeOf(xShapeInfo), swapCoords);
+          COORDS2INDEX(xRank, shape::stride(xShapeInfo), swapCoords, swapOffset);
 
           T oldX = x[xOffset];
           x[xOffset] = x[swapOffset];
@@ -91,10 +91,10 @@ SD_KERNEL void execShuffleKernel(void **vdX, LongType **dxShapeInfo, void **vdZ,
             sd::LongType xOffset;
             sd::LongType yOffset;
 
-            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo[f]), tadOnlyShapeInfo[f], xCoords);
-            COORDS2INDEX(shape::rank(tadOnlyShapeInfo[f]), shape::shapeOf(tadOnlyShapeInfo[f]), xCoords, xOffset);
-            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo[f]), tadOnlyShapeInfo[f], yCoords);
-            COORDS2INDEX(shape::rank(tadOnlyShapeInfo[f]), shape::shapeOf(tadOnlyShapeInfo[f]), yCoords, yOffset);
+            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo[f]), shape::shapeOf(tadOnlyShapeInfo[f]), xCoords);
+            COORDS2INDEX(shape::rank(tadOnlyShapeInfo[f]), shape::stride(tadOnlyShapeInfo[f]), xCoords, xOffset);
+            INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo[f]), shape::shapeOf(tadOnlyShapeInfo[f]), yCoords);
+            COORDS2INDEX(shape::rank(tadOnlyShapeInfo[f]), shape::stride(tadOnlyShapeInfo[f]), yCoords, yOffset);
 
             xOffset += oldOffset;
             yOffset += newOffset;

--- a/libnd4j/include/loops/cuda/specials/swapUnsafeKernel.cu
+++ b/libnd4j/include/loops/cuda/specials/swapUnsafeKernel.cu
@@ -57,10 +57,10 @@ static SD_KERNEL void swapUnsafeKernel(void* theFirstBuffer, LongType const* the
     sd::LongType xOffset;
     sd::LongType yOffset;
 
-    INDEX2COORDS(i, shape::rank(theFirstShape), theFirstShape, xCoords);
-    COORDS2INDEX(shape::rank(theFirstShape), shape::shapeOf(theFirstShape), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(theSecondShape), theSecondShape, yCoords);
-    COORDS2INDEX(shape::rank(theSecondShape), shape::shapeOf(theSecondShape), yCoords, yOffset);
+    INDEX2COORDS(i, shape::rank(theFirstShape), shape::shapeOf(theFirstShape), xCoords);
+    COORDS2INDEX(shape::rank(theFirstShape), shape::stride(theFirstShape), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(theSecondShape), shape::shapeOf(theSecondShape), yCoords);
+    COORDS2INDEX(shape::rank(theSecondShape), shape::stride(theSecondShape), yCoords, yOffset);
 
     if (sameOrders && xOffset >= 0 && yOffset >= 0) {
       math::sd_swap(output[xOffset], input[yOffset]);

--- a/libnd4j/include/loops/cuda/specials/tileKernel.cu
+++ b/libnd4j/include/loops/cuda/specials/tileKernel.cu
@@ -43,8 +43,8 @@ static SD_KERNEL void tileKernel(void const* inputBuffer, LongType const* inputS
       sd::LongType yCoords[SD_MAX_RANK];
       sd::LongType yOffset;
 
-      INDEX2COORDS(i, shape::rank(outputShape), outputShape, yCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(outputShape), shape::shapeOf(outputShape), yCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), yCoords, yOffset);
 
       *(reinterpret_cast<T*>(outputBuffer) + i) = *(reinterpret_cast<T const*>(inputBuffer) + yOffset);
     }
@@ -55,10 +55,10 @@ static SD_KERNEL void tileKernel(void const* inputBuffer, LongType const* inputS
       sd::LongType xOffset;
       sd::LongType yOffset;
 
-      INDEX2COORDS(i, shape::rank(outputShape), outputShape, xCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(inputShape), inputShape, yCoords);
-      COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(outputShape), shape::shapeOf(outputShape), xCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(inputShape), shape::shapeOf(inputShape), yCoords);
+      COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), yCoords, yOffset);
 
       *(reinterpret_cast<T*>(outputBuffer) + xOffset) = *(reinterpret_cast<T const*>(inputBuffer) + yOffset);
     }
@@ -101,8 +101,8 @@ static SD_KERNEL void tileKernelDouble(void const* inputBuffer, LongType const* 
       sd::LongType yCoords[SD_MAX_RANK];
       sd::LongType yOffset;
 
-      INDEX2COORDS(i, shape::rank(outputShape), outputShape, yCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(outputShape), shape::shapeOf(outputShape), yCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), yCoords, yOffset);
 
       *(reinterpret_cast<X*>(outputBuffer) + i) = static_cast<X>(*(reinterpret_cast<Y const*>(inputBuffer) + yOffset));
     }
@@ -113,9 +113,9 @@ static SD_KERNEL void tileKernelDouble(void const* inputBuffer, LongType const* 
       sd::LongType xOffset;
       sd::LongType yOffset;
 
-      INDEX2COORDS(i, shape::rank(outputShape), outputShape, xCoords);
+      INDEX2COORDS(i, shape::rank(outputShape), shape::shapeOf(outputShape), xCoords);
       COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(inputShape), inputShape, yCoords);
+      INDEX2COORDS(i, shape::rank(inputShape), shape::shapeOf(inputShape), yCoords);
       COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), yCoords, yOffset);
 
       *(reinterpret_cast<X*>(outputBuffer) + xOffset) = static_cast<X>(*(reinterpret_cast<Y const*>(inputBuffer) + yOffset));

--- a/libnd4j/include/loops/cuda/summarystatsreduce.cu
+++ b/libnd4j/include/loops/cuda/summarystatsreduce.cu
@@ -181,8 +181,8 @@ SD_DEVICE void SummaryStatsReduce<X, Z>::transform(void const* vx, sd::LongType 
       for (int i = threadIdx.x; i < tadLength; i += blockDim.x) {
         sd::LongType xCoords[SD_MAX_RANK];
         sd::LongType xOffset;
-        INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), tadOnlyShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords, xOffset);
+        INDEX2COORDS(i, shape::rank(tadOnlyShapeInfo), shape::shapeOf(tadOnlyShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(tadOnlyShapeInfo), shape::stride(tadOnlyShapeInfo), xCoords, xOffset);
         auto xOffsetFinal = tadOffsetForBlock + xOffset;
         SummaryStatsData<X> indexVal2;
         indexVal2.initWithValue(dx[xOffsetFinal]);
@@ -208,8 +208,8 @@ SD_DEVICE void SummaryStatsReduce<X, Z>::transform(void const* vx, sd::LongType 
     for (sd::LongType i = tid; i < n; i += blockDim.x * gridDim.x) {
       sd::LongType xCoords[SD_MAX_RANK];
       sd::LongType xOffset;
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
       SummaryStatsData<X> indexVal2;
       indexVal2.initWithValue(dx[xOffset]);
       reduction = update(reduction, indexVal2, extraParams);

--- a/libnd4j/include/loops/cuda/transform/transform_any.cu
+++ b/libnd4j/include/loops/cuda/transform/transform_any.cu
@@ -92,10 +92,10 @@ SD_DEVICE void TransformAny<X, Z>::transformCuda(const void *vx, const sd::LongT
     sd::LongType xOffset;
     sd::LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = OpType::op(x[xOffset], params);
   }

--- a/libnd4j/include/loops/cuda/transform/transform_bool.cu
+++ b/libnd4j/include/loops/cuda/transform/transform_bool.cu
@@ -90,10 +90,10 @@ SD_DEVICE void TransformBool<X, Z>::transformCuda(const void *vx, const sd::Long
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       z[zOffset] = OpType::op(x[xOffset], params);
     }

--- a/libnd4j/include/loops/cuda/transform/transform_float.cu
+++ b/libnd4j/include/loops/cuda/transform/transform_float.cu
@@ -92,10 +92,10 @@ SD_DEVICE void TransformFloat<X, Z>::transformCuda(const void *vx, const sd::Lon
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       z[zOffset] = OpType::op(x[xOffset], params);
     }

--- a/libnd4j/include/loops/cuda/transform/transform_same.cu
+++ b/libnd4j/include/loops/cuda/transform/transform_same.cu
@@ -89,10 +89,10 @@ SD_DEVICE void TransformSame<X>::transformCuda(const void *vx, const sd::LongTyp
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       z[zOffset] = OpType::op(x[xOffset], params);
     }

--- a/libnd4j/include/loops/cuda/transform/transform_strict.cu
+++ b/libnd4j/include/loops/cuda/transform/transform_strict.cu
@@ -90,10 +90,10 @@ SD_DEVICE void TransformStrict<X>::transformCuda(const void *vx, const sd::LongT
       sd::LongType xOffset;
       sd::LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       z[zOffset] = OpType::op(x[xOffset], params);
     }

--- a/libnd4j/include/loops/reduce_bool.h
+++ b/libnd4j/include/loops/reduce_bool.h
@@ -140,16 +140,6 @@ class SD_LIB_HIDDEN ReduceBoolFunction {
   static void SD_HOST exec(const void *x, const sd::LongType *xShapeInfo, void *extraParams, void *result,
                            const sd::LongType *resultShapeInfo);
 
-  /**
-   * Reduce down to 1 number
-   * @param x the input
-   * @param xShapeInfo the shape information
-   * for the input
-   * @param extraParams the extra params
-   * @return
-   */
-  template <typename OpType>
-  static Z SD_HOST execScalar(const void *x, sd::LongType xElementWiseStride, sd::LongType length, void *extraParams);
 #endif
 };
 

--- a/libnd4j/include/loops/scalar.h
+++ b/libnd4j/include/loops/scalar.h
@@ -103,8 +103,6 @@ class ScalarTransform {
                         const sd::LongType *resultShapeInfo, const void *scalar, void *extraParams, sd::LongType start,
                         sd::LongType stop);
 
-  static void transform(int opNum, const void *x, sd::LongType xStride, void *result, sd::LongType resultStride,
-                        const void *scalar, void *extraParams, sd::LongType len, sd::LongType start, sd::LongType stop);
 
   /*
    * ScalarOp along dimension
@@ -127,21 +125,6 @@ class ScalarTransform {
                         const sd::LongType *resultShapeInfo, const void *scalar, void *extraParams, sd::LongType start,
                         sd::LongType stop);
 
-  /**
-   * CPU implementation of scalar operation
-   * @param x the input
-   * @param xStride the stride for the input
-   * @param result the result buffer
-   * @param resultStride the stride for the result
-   * @param scalar the scalar to apply
-   * @param extraParams the extra parameters where
-   * necessary
-   * @param len the number of elements to loop over
-   */
-
-  template <typename OpType>
-  static void transform(const void *x, sd::LongType xStride, void *result, sd::LongType resultStride,
-                        const void *scalar, void *extraParams, sd::LongType len, sd::LongType start, sd::LongType stop);
 #endif
 };
 }  // namespace scalar

--- a/libnd4j/include/loops/scalar_bool.h
+++ b/libnd4j/include/loops/scalar_bool.h
@@ -118,8 +118,6 @@ class ScalarBoolTransform {
                         const sd::LongType *resultShapeInfo, const void *scalar, void *extraParams, sd::LongType start,
                         sd::LongType stop);
 
-  static void transform(int opNum, const void *x, sd::LongType xStride, void *result, sd::LongType resultStride,
-                        const void *scalar, void *extraParams, sd::LongType n, sd::LongType start, sd::LongType stop);
 
   /*
    * ScalarOp along dimension
@@ -142,21 +140,7 @@ class ScalarBoolTransform {
                         const sd::LongType *resultShapeInfo, const void *scalar, void *extraParams, sd::LongType start,
                         sd::LongType stop);
 
-  /**
-   * CPU implementation of scalar operation
-   * @param x the input
-   * @param xStride the stride for the input
-   * @param result the result buffer
-   * @param resultStride the stride for the result
-   * @param scalar the scalar to apply
-   * @param extraParams the extra parameters where
-   * neccssary
-   * @param n the number of elements to loop over
-   */
 
-  template <typename OpType>
-  static void transform(const void *x, sd::LongType xStride, void *result, sd::LongType resultStride,
-                        const void *scalar, void *extraParams, sd::LongType n, sd::LongType start, sd::LongType stop);
 #endif
 };
 }  // namespace scalar

--- a/libnd4j/include/ops/declarable/generic/compat/compat_string_split.cpp
+++ b/libnd4j/include/ops/declarable/generic/compat/compat_string_split.cpp
@@ -53,7 +53,7 @@ CUSTOM_OP_IMPL(compat_string_split, 2, 2, false, 0, 0) {
     auto s = input->e<std::string>(e);
 
     // getting base index
-    INDEX2COORDS(e, input->rankOf(), input->shapeInfo(), icoords.data());
+    INDEX2COORDS(e, input->rankOf(), shape::shapeOf(input->shapeInfo()), icoords.data());
 
     // getting number of substrings
     auto cnt = StringUtils::countSubarrays(s.c_str(), s.length(), d.c_str(), d.length());

--- a/libnd4j/include/ops/declarable/helpers/cpu/activations.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/activations.cpp
@@ -46,21 +46,21 @@ void static _softMaxDerivForVector(sd::LaunchContext* context, const void* input
   LongType offset;
 
   for (sd::LongType i = 0; i < length; i++) {
-    INDEX2COORDS(i, shape::rank(inShapeInfo), inShapeInfo, coords);
-    COORDS2INDEX(shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords, offset);
+    INDEX2COORDS(i, shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords);
+    COORDS2INDEX(shape::rank(inShapeInfo), shape::stride(inShapeInfo), coords, offset);
     max = sd::math::sd_max<T>(max, inBuff[offset]);
   }
 
   for (sd::LongType i = 0; i < length; i++) {
-    INDEX2COORDS(i, shape::rank(inShapeInfo), inShapeInfo, coords);
-    COORDS2INDEX(shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords, offset);
+    INDEX2COORDS(i, shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords);
+    COORDS2INDEX(shape::rank(inShapeInfo), shape::stride(inShapeInfo), coords, offset);
     outBuff[offset] = sd::math::sd_exp<T, T>(inBuff[offset] - max);
     sum += outBuff[offset];
   }
 
   for (sd::LongType i = 0; i < length; i++) {
-    INDEX2COORDS(i, shape::rank(inShapeInfo), inShapeInfo, coords);
-    COORDS2INDEX(shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords, offset);
+    INDEX2COORDS(i, shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords);
+    COORDS2INDEX(shape::rank(inShapeInfo), shape::stride(inShapeInfo), coords, offset);
     outBuff[offset] /= sum;
     outBuff[offset] *= (1.f - outBuff[offset]);  // derivative
   }

--- a/libnd4j/include/ops/declarable/helpers/cpu/assign.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/assign.cpp
@@ -35,12 +35,12 @@ static void assign_(const void* vx, const sd::LongType* xShapeInfo,
   sd::LongType zCoords[SD_MAX_RANK];
 
   for (sd::LongType i = start; i < stop; i++) {
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
 
     sd::LongType xOffset, zOffset;
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
     z[zOffset] = static_cast<Z>(x[xOffset]);
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cpu/batchnorm.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/batchnorm.cpp
@@ -78,12 +78,12 @@ static void batchnorm_(NDArray* input, NDArray* mean, NDArray* variance, NDArray
       LongType gammaOffset;
       LongType betaOffset;
 
-      INDEX2COORDS(j, shape::rank(mean->shapeInfo()), mean->shapeInfo(), meanCoords);
-      COORDS2INDEX(shape::rank(mean->shapeInfo()), shape::shapeOf(mean->shapeInfo()), meanCoords, meanOffset);
+      INDEX2COORDS(j, shape::rank(mean->shapeInfo()), shape::shapeOf(mean->shapeInfo()), meanCoords);
+      COORDS2INDEX(shape::rank(mean->shapeInfo()), shape::stride(mean->shapeInfo()), meanCoords, meanOffset);
       varOffset = paramSameOffset ? meanOffset : 0;
       if (!paramSameOffset) {
-        INDEX2COORDS(j, shape::rank(variance->shapeInfo()), variance->shapeInfo(), varCoords);
-        COORDS2INDEX(shape::rank(variance->shapeInfo()), shape::shapeOf(variance->shapeInfo()), varCoords, varOffset);
+        INDEX2COORDS(j, shape::rank(variance->shapeInfo()), shape::shapeOf(variance->shapeInfo()), varCoords);
+        COORDS2INDEX(shape::rank(variance->shapeInfo()), shape::stride(variance->shapeInfo()), varCoords, varOffset);
       }
 
       const auto meanVal = m[meanOffset];
@@ -92,8 +92,8 @@ static void batchnorm_(NDArray* input, NDArray* mean, NDArray* variance, NDArray
       if (g != nullptr) {
         gammaOffset = paramSameOffset ? meanOffset : 0;
         if (!paramSameOffset) {
-          INDEX2COORDS(j, shape::rank(gamma->shapeInfo()), gamma->shapeInfo(), gammaCoords);
-          COORDS2INDEX(shape::rank(gamma->shapeInfo()), shape::shapeOf(gamma->shapeInfo()), gammaCoords, gammaOffset);
+          INDEX2COORDS(j, shape::rank(gamma->shapeInfo()), shape::shapeOf(gamma->shapeInfo()), gammaCoords);
+          COORDS2INDEX(shape::rank(gamma->shapeInfo()), shape::stride(gamma->shapeInfo()), gammaCoords, gammaOffset);
         }
         sigmaInvGam *= g[gammaOffset];
       }
@@ -102,8 +102,8 @@ static void batchnorm_(NDArray* input, NDArray* mean, NDArray* variance, NDArray
       if (b != nullptr) {
         betaOffset = paramSameOffset ? meanOffset : 0;
         if (!paramSameOffset) {
-          INDEX2COORDS(j, shape::rank(beta->shapeInfo()), beta->shapeInfo(), betaCoords);
-          COORDS2INDEX(shape::rank(beta->shapeInfo()), shape::shapeOf(beta->shapeInfo()), betaCoords, betaOffset);
+          INDEX2COORDS(j, shape::rank(beta->shapeInfo()), shape::shapeOf(beta->shapeInfo()), betaCoords);
+          COORDS2INDEX(shape::rank(beta->shapeInfo()), shape::stride(beta->shapeInfo()), betaCoords, betaOffset);
         }
         betaVal = b[betaOffset];
       }
@@ -162,13 +162,13 @@ static void batchnorm2_(NDArray* input, NDArray* mean, NDArray* variance, NDArra
         ++j;
 
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, xRank, input->shapeInfo(), xzCoords);
+      INDEX2COORDS(i, xRank, shape::shapeOf(input->shapeInfo()), xzCoords);
 
       sd::LongType xOffset;
-      COORDS2INDEX(xRank, shape::shapeOf(input->shapeInfo()), xzCoords, xOffset);
+      COORDS2INDEX(xRank, shape::stride(input->shapeInfo()), xzCoords, xOffset);
       sd::LongType zOffset = xzSameOffset ? xOffset : 0;
       if (!xzSameOffset) {
-        COORDS2INDEX(xRank, shape::shapeOf(output->shapeInfo()), xzCoords, zOffset);
+        COORDS2INDEX(xRank, shape::stride(output->shapeInfo()), xzCoords, zOffset);
       }
 
       if (minRank == xRank) {
@@ -177,10 +177,10 @@ static void batchnorm2_(NDArray* input, NDArray* mean, NDArray* variance, NDArra
         minCoords[0] = xzCoords[axes[0]];
 
       sd::LongType meanOffset, varianceOffset;
-      COORDS2INDEX(minRank, shape::shapeOf(mean->shapeInfo()), minCoords, meanOffset);
+      COORDS2INDEX(minRank, shape::stride(mean->shapeInfo()), minCoords, meanOffset);
       varianceOffset = paramSameOffset ? meanOffset : 0;
       if (!paramSameOffset) {
-        COORDS2INDEX(minRank, shape::shapeOf(variance->shapeInfo()), minCoords, varianceOffset);
+        COORDS2INDEX(minRank, shape::stride(variance->shapeInfo()), minCoords, varianceOffset);
       }
 
       T sigmaInvGam = 1. / sd::math::sd_sqrt<T, T>(v[varianceOffset] + epsilon);
@@ -188,7 +188,7 @@ static void batchnorm2_(NDArray* input, NDArray* mean, NDArray* variance, NDArra
       if (g != nullptr) {
         sd::LongType gammaOffset = paramSameOffset ? meanOffset : 0;
         if (!paramSameOffset) {
-          COORDS2INDEX(minRank, shape::shapeOf(gamma->shapeInfo()), minCoords, gammaOffset);
+          COORDS2INDEX(minRank, shape::stride(gamma->shapeInfo()), minCoords, gammaOffset);
         }
         sigmaInvGam *= g[gammaOffset];
       }
@@ -198,7 +198,7 @@ static void batchnorm2_(NDArray* input, NDArray* mean, NDArray* variance, NDArra
       if (b != nullptr) {
         sd::LongType betaOffset = paramSameOffset ? meanOffset : 0;
         if (!paramSameOffset) {
-          COORDS2INDEX(minRank, shape::shapeOf(beta->shapeInfo()), minCoords, betaOffset);
+          COORDS2INDEX(minRank, shape::stride(beta->shapeInfo()), minCoords, betaOffset);
         }
         z[zOffset] += b[betaOffset];
       }

--- a/libnd4j/include/ops/declarable/helpers/cpu/flatten.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/flatten.cpp
@@ -48,8 +48,8 @@ static void flatten_(std::vector<NDArray *> &inputs, NDArray *output, const char
     for (sd::LongType i = 0; i < xLength; i++) {
       sd::LongType xOffset;
       sd::LongType xCoords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
       z[i] = xBuffer[xOffset];
     }
   }

--- a/libnd4j/include/ops/declarable/helpers/cpu/gatherTransforms.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/gatherTransforms.cpp
@@ -53,16 +53,16 @@ static void gatherND_(NDArray& input, NDArray& indices, NDArray& output) {
     sd::LongType xCoords[SD_MAX_RANK], zCoords[SD_MAX_RANK], temp;
 
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, output.rankOf(), output.shapeInfo(), zCoords);
+      INDEX2COORDS(i, output.rankOf(), shape::shapeOf(output.shapeInfo()), zCoords);
 
       sd::LongType zOffset;
-      COORDS2INDEX(output.rankOf(), shape::shapeOf(output.shapeInfo()), zCoords, zOffset);
+      COORDS2INDEX(output.rankOf(), shape::stride(output.shapeInfo()), zCoords, zOffset);
 
       temp = zCoords[yRank - 1];
       zCoords[yRank - 1] = 0;
 
       sd::LongType yOffset;
-      COORDS2INDEX(indices.rankOf(), shape::shapeOf(indices.shapeInfo()), zCoords, yOffset);
+      COORDS2INDEX(indices.rankOf(), shape::stride(indices.shapeInfo()), zCoords, yOffset);
 
       zCoords[yRank - 1] = temp;
 
@@ -77,7 +77,7 @@ static void gatherND_(NDArray& input, NDArray& indices, NDArray& output) {
         xCoords[j] = y[yOffset + j * indices.stridesOf()[yRank - 1]];  // last stride
 
       sd::LongType xOffset;
-      COORDS2INDEX(input.rankOf(), shape::shapeOf(input.shapeInfo()), xCoords, xOffset);
+      COORDS2INDEX(input.rankOf(), shape::stride(input.shapeInfo()), xCoords, xOffset);
 
       z[zOffset] = x[xOffset];
     }

--- a/libnd4j/include/ops/declarable/helpers/cpu/imagesHelpers.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/imagesHelpers.cpp
@@ -52,14 +52,14 @@ static void rgbToGrs_(NDArray& input, NDArray& output, const int dimC) {
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (auto i = start; i < stop; i++) {
-      INDEX2COORDS(i, rank, output.shapeInfo(), coords);
+      INDEX2COORDS(i, rank, shape::shapeOf(output.shapeInfo()), coords);
       sd::LongType zOffset, xOffset0, xOffset1, xOffset2;
-      COORDS2INDEX(rank, shape::shapeOf(output.shapeInfo()), coords, zOffset);
-      COORDS2INDEX(rank, shape::shapeOf(input.shapeInfo()), coords, xOffset0);
+      COORDS2INDEX(rank, shape::stride(output.shapeInfo()), coords, zOffset);
+      COORDS2INDEX(rank, shape::stride(input.shapeInfo()), coords, xOffset0);
       coords[dimC]++;
-      COORDS2INDEX(rank, shape::shapeOf(input.shapeInfo()), coords, xOffset1);
+      COORDS2INDEX(rank, shape::stride(input.shapeInfo()), coords, xOffset1);
       coords[dimC]++;
-      COORDS2INDEX(rank, shape::shapeOf(input.shapeInfo()), coords, xOffset2);
+      COORDS2INDEX(rank, shape::stride(input.shapeInfo()), coords, xOffset2);
       z[zOffset] = 0.2989f * x[xOffset0] + 0.5870f * x[xOffset1] + 0.1140f * x[xOffset2];
     }
   };

--- a/libnd4j/include/ops/declarable/helpers/cpu/ismax.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/ismax.cpp
@@ -104,8 +104,8 @@ static void ismax_(NDArray* input, NDArray* output, const std::vector<LongType>&
         LongType zOffset;
 
         for (sd::LongType i = 0; i < tadLength; i++) {
-          INDEX2COORDS(i, shape::rank(tadShapeShapeInfo), tadShapeShapeInfo, xCoords);
-          COORDS2INDEX(shape::rank(tadShapeShapeInfo), shape::shapeOf(tadShapeShapeInfo), xCoords, xOffset);
+          INDEX2COORDS(i, shape::rank(tadShapeShapeInfo), shape::shapeOf(tadShapeShapeInfo), xCoords);
+          COORDS2INDEX(shape::rank(tadShapeShapeInfo), shape::stride(tadShapeShapeInfo), xCoords, xOffset);
           if (rX[xOffset] > maxValue) {
             maxIdx = i;
             maxValue = rX[xOffset];
@@ -114,8 +114,8 @@ static void ismax_(NDArray* input, NDArray* output, const std::vector<LongType>&
 
         PRAGMA_OMP_SIMD
         for (sd::LongType i = 0; i < tadLength; i++) {
-          INDEX2COORDS(i, shape::rank(tadPackZ->primaryShapeInfo()), tadPackZ->primaryShapeInfo(), zCoords);
-          COORDS2INDEX(shape::rank(tadPackZ->primaryShapeInfo()), shape::shapeOf(tadPackZ->primaryShapeInfo()), zCoords, zOffset);
+          INDEX2COORDS(i, shape::rank(tadPackZ->primaryShapeInfo()), shape::shapeOf(tadPackZ->primaryShapeInfo()), zCoords);
+          COORDS2INDEX(shape::rank(tadPackZ->primaryShapeInfo()), shape::stride(tadPackZ->primaryShapeInfo()), zCoords, zOffset);
           rZ[zOffset] = maxIdx == i ? (Z)1 : (Z)0;
         }
       }

--- a/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
@@ -301,10 +301,10 @@ static void luNN_(LaunchContext* context, NDArray* compound, NDArray* permutatio
       sd::LongType firstIndex;
       sd::LongType secondIndex;
 
-      INDEX2COORDS(i, shape::rank(permutationShape), permutationShape, firstIndexCoords);
-      COORDS2INDEX(shape::rank(permutationShape), shape::shapeOf(permutationShape), firstIndexCoords, firstIndex);
-      INDEX2COORDS(pivotIndex, shape::rank(permutationShape), permutationShape, secondIndexCoords);
-      COORDS2INDEX(shape::rank(permutationShape), shape::shapeOf(permutationShape), secondIndexCoords, secondIndex);
+      INDEX2COORDS(i, shape::rank(permutationShape), shape::shapeOf(permutationShape), firstIndexCoords);
+      COORDS2INDEX(shape::rank(permutationShape), shape::stride(permutationShape), firstIndexCoords, firstIndex);
+      INDEX2COORDS(pivotIndex, shape::rank(permutationShape), shape::shapeOf(permutationShape), secondIndexCoords);
+      COORDS2INDEX(shape::rank(permutationShape), shape::stride(permutationShape), secondIndexCoords, secondIndex);
 
       math::sd_swap(permutationBuf[firstIndex], permutationBuf[secondIndex]);
       swapRows(compoundBuf, compoundShape, i, pivotIndex);

--- a/libnd4j/include/ops/declarable/helpers/cpu/matrixSetDiag.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/matrixSetDiag.cpp
@@ -52,22 +52,22 @@ void matrixSetDiag_(NDArray& input, NDArray& diagonal, NDArray& output, const bo
     sd::LongType coords[SD_MAX_RANK];
 
     for (sd::LongType i = 0; i < xLen; ++i) {
-      INDEX2COORDS(i, xRank, xShapeInfo, coords);
+      INDEX2COORDS(i, xRank, shape::shapeOf(xShapeInfo), coords);
 
       sd::LongType xOffset;
-      COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(xRank, shape::stride(xShapeInfo), coords, xOffset);
 
       sd::LongType zOffset;
       if (areSameOffsets) {
         zOffset = xOffset;
       } else {
-        COORDS2INDEX(xRank, shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(xRank, shape::stride(zShapeInfo), coords, zOffset);
       }
 
       // condition to be on diagonal of innermost matrix
       if (coords[xRank - 2] == coords[xRank - 1]) {
         sd::LongType yOffset;
-        COORDS2INDEX(xRank - 1, shape::shapeOf(yShapeInfo), coords, yOffset);
+        COORDS2INDEX(xRank - 1, shape::stride(yShapeInfo), coords, yOffset);
         z[zOffset] = y[yOffset];
       } else {
         z[zOffset] = zeroPad ? static_cast<T>(0) : x[xOffset];

--- a/libnd4j/include/ops/declarable/helpers/cpu/merge.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/merge.cpp
@@ -136,10 +136,10 @@ static void mergeMaxBp_(const std::vector<NDArray*>& inArrs, std::vector<NDArray
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (auto e = start; e < stop; e++) {
-      INDEX2COORDS(e, shape::rank(gradShape), gradShape, coords);
+      INDEX2COORDS(e, shape::rank(gradShape), shape::shapeOf(gradShape), coords);
 
       sd::LongType gradOffset;
-      COORDS2INDEX(shape::rank(gradShape), shape::shapeOf(gradShape), coords, gradOffset);
+      COORDS2INDEX(shape::rank(gradShape), shape::stride(gradShape), coords, gradOffset);
 
       T max = -DataTypeUtils::max<T>();
       sd::LongType nMaxIndex = 0;
@@ -149,7 +149,7 @@ static void mergeMaxBp_(const std::vector<NDArray*>& inArrs, std::vector<NDArray
         if (vbSameShaepeAndStrides[i]) {
           xOffset = gradOffset;
         } else {
-          COORDS2INDEX(shape::rank(inArrs[i]->shapeInfo()), shape::shapeOf(inArrs[i]->shapeInfo()), coords, xOffset);
+          COORDS2INDEX(shape::rank(inArrs[i]->shapeInfo()), shape::stride(inArrs[i]->shapeInfo()), coords, xOffset);
         }
         const T* v = inArrs[i]->bufferAsT<T>();
         if (v[xOffset] > max) {
@@ -162,7 +162,7 @@ static void mergeMaxBp_(const std::vector<NDArray*>& inArrs, std::vector<NDArray
       if (vbSameShaepeAndStrides[nMaxIndex]) {
         zOffset = gradOffset;
       } else {
-        COORDS2INDEX(shape::rank(outArrs[nMaxIndex]->shapeInfo()), shape::shapeOf(outArrs[nMaxIndex]->shapeInfo()), coords, zOffset);
+        COORDS2INDEX(shape::rank(outArrs[nMaxIndex]->shapeInfo()), shape::stride(outArrs[nMaxIndex]->shapeInfo()), coords, zOffset);
       }
 
       T* z = outArrs[nMaxIndex]->bufferAsT<T>();

--- a/libnd4j/include/ops/declarable/helpers/cpu/one_hot.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/one_hot.cpp
@@ -54,18 +54,18 @@ static void onehot_(void* voutput, sd::LongType const* zShapeInfo, void const* v
         PRAGMA_OMP_SIMD
         for (sd::LongType t = 0; t < tLen; t++) {
           sd::LongType coords[SD_MAX_RANK];
-          INDEX2COORDS(t, shape::rank(tadPack->primaryShapeInfo()), tadPack->primaryShapeInfo(), coords);
+          INDEX2COORDS(t, shape::rank(tadPack->primaryShapeInfo()), shape::shapeOf(tadPack->primaryShapeInfo()), coords);
           LongType offset;
-          COORDS2INDEX(shape::rank(tadPack->primaryShapeInfo()), shape::shapeOf(tadPack->primaryShapeInfo()), coords, offset);
+          COORDS2INDEX(shape::rank(tadPack->primaryShapeInfo()), shape::stride(tadPack->primaryShapeInfo()), coords, offset);
           cO[offset] = zero;
         }
       } else {
         PRAGMA_OMP_SIMD
         for (sd::LongType t = 0; t < tLen; t++) {
           sd::LongType coords[SD_MAX_RANK];
-          INDEX2COORDS(t, shape::rank(tadPack->primaryShapeInfo()), tadPack->primaryShapeInfo(), coords);
+          INDEX2COORDS(t, shape::rank(tadPack->primaryShapeInfo()), shape::shapeOf(tadPack->primaryShapeInfo()), coords);
           LongType offset;
-          COORDS2INDEX(shape::rank(tadPack->primaryShapeInfo()), shape::shapeOf(tadPack->primaryShapeInfo()), coords, offset);
+          COORDS2INDEX(shape::rank(tadPack->primaryShapeInfo()), shape::stride(tadPack->primaryShapeInfo()), coords, offset);
           cO[offset] = idx == t ? one : zero;
         }
       }

--- a/libnd4j/include/ops/declarable/helpers/cpu/pad.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/pad.cpp
@@ -166,7 +166,7 @@ void pad_(const int mode, NDArray& input, NDArray& paddings, NDArray& output, ND
       sd::LongType zCoords[SD_MAX_RANK], xCoords[SD_MAX_RANK];
 
       for (auto i = start; i < stop; i++) {
-        INDEX2COORDS(i, rank, output.shapeInfo(), zCoords);
+        INDEX2COORDS(i, rank, shape::shapeOf(output.shapeInfo()), zCoords);
         sd::LongType zOffset;
         COORDS2INDEX(rank, shape::stride(output.shapeInfo()), zCoords, zOffset);
 
@@ -229,7 +229,7 @@ static void mirrorPad_(NDArray& input, NDArray& paddings, NDArray& output, const
       sd::LongType inIdx[SD_MAX_RANK], outIdx[SD_MAX_RANK];
 
       for (sd::LongType i = start; i < stop; i++) {
-        INDEX2COORDS(i, rank, output.shapeInfo(), outIdx);
+        INDEX2COORDS(i, rank, shape::shapeOf(output.shapeInfo()), outIdx);
 
         for (int j = 0; j < rank; ++j) {
           const sd::LongType inLen = input.sizeAt(j);

--- a/libnd4j/include/ops/declarable/helpers/cpu/prefix.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/prefix.cpp
@@ -44,10 +44,10 @@ static void prefix_(scalar::Ops op, const void* vx, sd::LongType const* xShapeIn
 
   if (reverse) {
     for (sd::LongType e = length - 1; e >= 0; --e) {
-      INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       sum = op == scalar::Add ? simdOps::Add<T, T, T>::op(sum, x[xOffset])
                               : simdOps::Multiply<T, T, T>::op(sum, x[xOffset]);
@@ -59,10 +59,10 @@ static void prefix_(scalar::Ops op, const void* vx, sd::LongType const* xShapeIn
     }
   } else {
     for (sd::LongType e = 0; e < length; e++) {
-      INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       sum = op == scalar::Add ? simdOps::Add<T, T, T>::op(sum, x[xOffset])
                               : simdOps::Multiply<T, T, T>::op(sum, x[xOffset]);

--- a/libnd4j/include/ops/declarable/helpers/cpu/reverse.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/reverse.cpp
@@ -57,10 +57,10 @@ static void reverseArray(sd::LaunchContext* context, void const* vinArr, sd::Lon
   if (inArr == outArr) {
     auto func = PRAGMA_THREADS_FOR {
       for (sd::LongType e = start; e < stop; e++) {
-        INDEX2COORDS(e, shape::rank(inShapeBuffer), inShapeBuffer, inCoords);
-        COORDS2INDEX(shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), inCoords, inOffset);
-        INDEX2COORDS(sLength - e, shape::rank(inShapeBuffer), inShapeBuffer, outCoords);
-        COORDS2INDEX(shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), outCoords, outOffset);
+        INDEX2COORDS(e, shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), inCoords);
+        COORDS2INDEX(shape::rank(inShapeBuffer), shape::stride(inShapeBuffer), inCoords, inOffset);
+        INDEX2COORDS(sLength - e, shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), outCoords);
+        COORDS2INDEX(shape::rank(inShapeBuffer), shape::stride(inShapeBuffer), outCoords, outOffset);
         swap(const_cast<T*>(inArr), inOffset, outOffset);
       }
     };
@@ -69,10 +69,10 @@ static void reverseArray(sd::LaunchContext* context, void const* vinArr, sd::Lon
     // single step phase here
     auto func = PRAGMA_THREADS_FOR {
       for (sd::LongType e = start; e < stop; e++) {
-        INDEX2COORDS(e, shape::rank(inShapeBuffer), inShapeBuffer, inCoords);
-        COORDS2INDEX(shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), inCoords, inOffset);
-        INDEX2COORDS(sLength - e, shape::rank(outShapeBuffer), outShapeBuffer, outCoords);
-        COORDS2INDEX(shape::rank(outShapeBuffer), shape::shapeOf(outShapeBuffer), outCoords, outOffset);
+        INDEX2COORDS(e, shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), inCoords);
+        COORDS2INDEX(shape::rank(inShapeBuffer), shape::stride(inShapeBuffer), inCoords, inOffset);
+        INDEX2COORDS(sLength - e, shape::rank(outShapeBuffer), shape::shapeOf(outShapeBuffer), outCoords);
+        COORDS2INDEX(shape::rank(outShapeBuffer), shape::stride(outShapeBuffer), outCoords, outOffset);
         outArr[outOffset] = inArr[inOffset];
       }
     };
@@ -81,10 +81,10 @@ static void reverseArray(sd::LaunchContext* context, void const* vinArr, sd::Lon
     if (inLength != numOfElemsToReverse) {
       auto f2 = PRAGMA_THREADS_FOR {
         for (sd::LongType e = start; e < stop; e++) {
-          INDEX2COORDS(e, shape::rank(inShapeBuffer), inShapeBuffer, inCoords);
-          COORDS2INDEX(shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), inCoords, inOffset);
-          INDEX2COORDS(e, shape::rank(outShapeBuffer), outShapeBuffer, outCoords);
-          COORDS2INDEX(shape::rank(outShapeBuffer), shape::shapeOf(outShapeBuffer), outCoords, outOffset);
+          INDEX2COORDS(e, shape::rank(inShapeBuffer), shape::shapeOf(inShapeBuffer), inCoords);
+          COORDS2INDEX(shape::rank(inShapeBuffer), shape::stride(inShapeBuffer), inCoords, inOffset);
+          INDEX2COORDS(e, shape::rank(outShapeBuffer), shape::shapeOf(outShapeBuffer), outCoords);
+          COORDS2INDEX(shape::rank(outShapeBuffer), shape::stride(outShapeBuffer), outCoords, outOffset);
           outArr[outOffset] = inArr[inOffset];
         }
       };

--- a/libnd4j/include/ops/declarable/helpers/cpu/s_t_b.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/s_t_b.cpp
@@ -127,7 +127,7 @@ static void batchToSpaceND_(NDArray& input, NDArray& crop, NDArray& output,
     sd::LongType zCoords[SD_MAX_RANK], xCoords[SD_MAX_RANK];
 
     for (auto i = start; i < stop; i++) {
-      INDEX2COORDS(i, rank, output.shapeInfo(), zCoords);
+      INDEX2COORDS(i, rank, shape::shapeOf(output.shapeInfo()), zCoords);
 
       memcpy(xCoords, zCoords, rank * sizeof(sd::LongType));
 
@@ -136,8 +136,8 @@ static void batchToSpaceND_(NDArray& input, NDArray& crop, NDArray& output,
         xCoords[j] += crop.e<sd::LongType>(j - 1, 0);  // add crop left
 
       sd::LongType zOffset, xOffset;
-      COORDS2INDEX(rank, shape::shapeOf(output.shapeInfo()), zCoords, zOffset);
-      COORDS2INDEX(rank, shape::shapeOf(input.shapeInfo()), xCoords, xOffset);
+      COORDS2INDEX(rank, shape::stride(output.shapeInfo()), zCoords, zOffset);
+      COORDS2INDEX(rank, shape::stride(input.shapeInfo()), xCoords, xOffset);
 
       z[zOffset] = x[xOffset];
     }
@@ -308,7 +308,7 @@ static void spaceToBatchND_(NDArray& input, NDArray& padding, NDArray& output,
     sd::LongType zCoords[SD_MAX_RANK], xCoords[SD_MAX_RANK];
 
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, rank, output.shapeInfo(), zCoords);
+      INDEX2COORDS(i, rank, shape::shapeOf(output.shapeInfo()), zCoords);
 
       sd::LongType zOffset;
       COORDS2INDEX(rank, shape::stride(output.shapeInfo()), zCoords, zOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/scatter.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/scatter.cpp
@@ -46,7 +46,7 @@ sd::LongType checkIndices_(NDArray& indices, NDArray& output, const int axis) {
     sd::LongType xCoords[SD_MAX_RANK];
 
     for (auto i = start; i < stop; i++) {
-      INDEX2COORDS(i, xRank, xShapeInfo, xCoords);
+      INDEX2COORDS(i, xRank, shape::shapeOf(xShapeInfo), xCoords);
 
       sd::LongType xOffset;
       COORDS2INDEX(xRank, shape::stride(xShapeInfo), xCoords, xOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/split.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/split.cpp
@@ -96,7 +96,7 @@ static void split_(NDArray& input, const std::vector<NDArray*>& outArrs, const L
     sd::LongType coords[SD_MAX_RANK], temp;
 
     for (auto i = start; i < stop; i += increment) {
-      INDEX2COORDS(i, input.rankOf(), input.shapeInfo(), coords);
+      INDEX2COORDS(i, input.rankOf(), shape::shapeOf(input.shapeInfo()), coords);
       sd::LongType xOffset;
       COORDS2INDEX(input.rankOf(), shape::stride(input.shapeInfo()), coords, xOffset);
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/tile.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/tile.cpp
@@ -45,10 +45,10 @@ static void tileBP_(NDArray& gradO /*input*/, NDArray& gradI /*output*/, const s
   LongType gradIOffset;
 
   for (sd::LongType i = 0; i < gradOLen; ++i) {
-    INDEX2COORDS(i, shape::rank(gradO.shapeInfo()), gradO.shapeInfo(), gradOCoords);
-    COORDS2INDEX(shape::rank(gradO.shapeInfo()), shape::shapeOf(gradO.shapeInfo()), gradOCoords, gradOOffset);
-    INDEX2COORDS(i, shape::rank(gradI.shapeInfo()), gradI.shapeInfo(), gradICoords);
-    COORDS2INDEX(shape::rank(gradI.shapeInfo()), shape::shapeOf(gradI.shapeInfo()), gradICoords, gradIOffset);
+    INDEX2COORDS(i, shape::rank(gradO.shapeInfo()), shape::shapeOf(gradO.shapeInfo()), gradOCoords);
+    COORDS2INDEX(shape::rank(gradO.shapeInfo()), shape::stride(gradO.shapeInfo()), gradOCoords, gradOOffset);
+    INDEX2COORDS(i, shape::rank(gradI.shapeInfo()), shape::shapeOf(gradI.shapeInfo()), gradICoords);
+    COORDS2INDEX(shape::rank(gradI.shapeInfo()), shape::stride(gradI.shapeInfo()), gradICoords, gradIOffset);
     gradI.p(gradIOffset, gradI.e<T>(gradIOffset) + gradOBuff[gradOOffset]);
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaBelief.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaBelief.cpp
@@ -90,14 +90,14 @@ static void adaBeliefUpdater_(NDArray& gradient, NDArray& initStateU, NDArray& i
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType  i = start; i < stop; i++) {
-      INDEX2COORDS(i, shape::rank(gradient.shapeInfo()), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, shape::rank(gradient.shapeInfo()), shape::shapeOf(gradient.shapeInfo()), coords);
       sd::LongType xOffset, zOffset, initUOffset, stUOffset, initMOffset, stMOffset;
-      COORDS2INDEX(shape::rank(gradient.shapeInfo()), shape::shapeOf(gradient.shapeInfo()), coords, xOffset);
-      COORDS2INDEX(shape::rank(update.shapeInfo()), shape::shapeOf(update.shapeInfo()), coords, zOffset);
-      COORDS2INDEX(shape::rank(initStateU.shapeInfo()), shape::shapeOf(initStateU.shapeInfo()), coords, initUOffset);
-      COORDS2INDEX(shape::rank(stateU.shapeInfo()), shape::shapeOf(stateU.shapeInfo()), coords, stUOffset);
-      COORDS2INDEX(shape::rank(initStateM.shapeInfo()), shape::shapeOf(initStateM.shapeInfo()), coords, initMOffset);
-      COORDS2INDEX(shape::rank(stateM.shapeInfo()), shape::shapeOf(stateM.shapeInfo()), coords, stMOffset);
+      COORDS2INDEX(shape::rank(gradient.shapeInfo()), shape::stride(gradient.shapeInfo()), coords, xOffset);
+      COORDS2INDEX(shape::rank(update.shapeInfo()), shape::stride(update.shapeInfo()), coords, zOffset);
+      COORDS2INDEX(shape::rank(initStateU.shapeInfo()), shape::stride(initStateU.shapeInfo()), coords, initUOffset);
+      COORDS2INDEX(shape::rank(stateU.shapeInfo()), shape::stride(stateU.shapeInfo()), coords, stUOffset);
+      COORDS2INDEX(shape::rank(initStateM.shapeInfo()), shape::stride(initStateM.shapeInfo()), coords, initMOffset);
+      COORDS2INDEX(shape::rank(stateM.shapeInfo()), shape::stride(stateM.shapeInfo()), coords, stMOffset);
       stM[stMOffset] = beta1 * initM[initMOffset] + grad[xOffset] * (1 - beta1);
       stU[stUOffset] = beta2 * initU[initUOffset] +
                        (grad[xOffset] - stM[stMOffset]) * (grad[xOffset] - stM[stMOffset]) * (1 - beta2) + epsilon;

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaDelta.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaDelta.cpp
@@ -83,7 +83,7 @@ static void adaDeltaUpdater_(NDArray& gradient, NDArray& initStateMsg, NDArray& 
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType i = start; i < gradient.lengthOf(); i++) {
-      INDEX2COORDS(i, gradient.rankOf(), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords);
 
       sd::LongType xOffset;
       COORDS2INDEX(gradient.rankOf(), shape::stride(gradient.shapeInfo()), coords, xOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaGrad.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaGrad.cpp
@@ -69,30 +69,30 @@ static void adaGradUpdater_(NDArray& gradient, NDArray& initState, NDArray& upda
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, gradient.rankOf(), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords);
 
       sd::LongType xOffset;
-      COORDS2INDEX(gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords, xOffset);
+      COORDS2INDEX(gradient.rankOf(), shape::stride(gradient.shapeInfo()), coords, xOffset);
 
       sd::LongType zOffset;
       if (bXZsame) {
         zOffset = xOffset;
       } else {
-        COORDS2INDEX(update.rankOf(), shape::shapeOf(update.shapeInfo()), coords, zOffset);
+        COORDS2INDEX(update.rankOf(), shape::stride(update.shapeInfo()), coords, zOffset);
       }
 
       sd::LongType initOffset;
       if (bXInSame) {
         initOffset = xOffset;
       } else {
-        COORDS2INDEX(initState.rankOf(), shape::shapeOf(initState.shapeInfo()), coords, initOffset);
+        COORDS2INDEX(initState.rankOf(), shape::stride(initState.shapeInfo()), coords, initOffset);
       }
 
       sd::LongType stOffset;
       if (bXStSame) {
         stOffset = xOffset;
       } else {
-        COORDS2INDEX(stateH.rankOf(), shape::shapeOf(stateH.shapeInfo()), coords, stOffset);
+        COORDS2INDEX(stateH.rankOf(), shape::stride(stateH.shapeInfo()), coords, stOffset);
       }
 
       st[stOffset] = init[initOffset] + grad[xOffset] * grad[xOffset];

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaMax.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdaMax.cpp
@@ -87,7 +87,7 @@ static void adaMaxUpdater_(NDArray& gradient, NDArray& initStateU, NDArray& init
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, gradient.rankOf(), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords);
 
       sd::LongType xOffset;
       COORDS2INDEX(gradient.rankOf(), shape::stride(gradient.shapeInfo()), coords, xOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAdam.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAdam.cpp
@@ -87,7 +87,7 @@ static void adamUpdater_(NDArray& gradient, NDArray& initStateU, NDArray& initSt
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, gradient.rankOf(), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords);
 
       sd::LongType xOffset;
       COORDS2INDEX(gradient.rankOf(), shape::stride(gradient.shapeInfo()), coords, xOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterAmsGrad.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterAmsGrad.cpp
@@ -97,7 +97,7 @@ static void amsGradUpdater_(NDArray& gradient, NDArray& initStateV, NDArray& ini
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, gradient.rankOf(), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords);
 
       sd::LongType xOffset;
       COORDS2INDEX(gradient.rankOf(), shape::stride(gradient.shapeInfo()), coords, xOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterNadam.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterNadam.cpp
@@ -88,7 +88,7 @@ static void nadamUpdater_(NDArray& gradient, NDArray& initStateV, NDArray& initS
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, gradient.rankOf(), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords);
 
       sd::LongType xOffset;
       COORDS2INDEX(gradient.rankOf(), shape::stride(gradient.shapeInfo()), coords, xOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterNesterovs.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterNesterovs.cpp
@@ -68,7 +68,7 @@ static void nesterovsUpdater_(NDArray& gradient, NDArray& initState, NDArray& up
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (auto i = start; i < stop; i++) {
-      INDEX2COORDS(i, gradient.rankOf(), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, gradient.rankOf(), shape::shapeOf(gradient.shapeInfo()), coords);
 
       sd::LongType xOffset;
       COORDS2INDEX(gradient.rankOf(), shape::stride(gradient.shapeInfo()), coords, xOffset);

--- a/libnd4j/include/ops/declarable/helpers/cpu/updaterRmsProp.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/updaterRmsProp.cpp
@@ -66,23 +66,23 @@ static void rmsPropUpdater_(NDArray& gradient, NDArray& initState, NDArray& upda
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK];
     for (sd::LongType i = start; i < stop; i++) {
-      INDEX2COORDS(i, shape::rank(gradient.shapeInfo()), gradient.shapeInfo(), coords);
+      INDEX2COORDS(i, shape::rank(gradient.shapeInfo()), shape::shapeOf(gradient.shapeInfo()), coords);
       sd::LongType xOffset, zOffset, initOffset, stOffset;
-      COORDS2INDEX(shape::rank(gradient.shapeInfo()), shape::shapeOf(gradient.shapeInfo()), coords, xOffset);
+      COORDS2INDEX(shape::rank(gradient.shapeInfo()), shape::stride(gradient.shapeInfo()), coords, xOffset);
       if (bXZsame) {
         zOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(update.shapeInfo()), shape::shapeOf(update.shapeInfo()), coords, zOffset);
+        COORDS2INDEX(shape::rank(update.shapeInfo()), shape::stride(update.shapeInfo()), coords, zOffset);
       }
       if (bXInSame) {
         initOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(initState.shapeInfo()), shape::shapeOf(initState.shapeInfo()), coords, initOffset);
+        COORDS2INDEX(shape::rank(initState.shapeInfo()), shape::stride(initState.shapeInfo()), coords, initOffset);
       }
       if (bXStSame) {
         stOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(stateG.shapeInfo()), shape::shapeOf(stateG.shapeInfo()), coords, stOffset);
+        COORDS2INDEX(shape::rank(stateG.shapeInfo()), shape::stride(stateG.shapeInfo()), coords, stOffset);
       }
 
       st[stOffset] = init[initOffset] * rmsDecay + grad[xOffset] * grad[xOffset] * (1 - rmsDecay);

--- a/libnd4j/include/ops/declarable/helpers/cuda/addBias.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/addBias.cu
@@ -67,12 +67,12 @@ SD_KERNEL static void addBiasCuda(const void* vx, const LongType* xShapeInfo, co
   auto coords = sharedMem + threadIdx.x * rank;
 
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < len; i += blockDim.x * gridDim.x) {
-    INDEX2COORDS(i, rank, xShapeInfo, coords);
+    INDEX2COORDS(i, rank, shape::shapeOf(xShapeInfo), coords);
 
     LongType xOffsets;
-    COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffsets);
+    COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffsets);
     LongType zOffsets;
-    COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffsets);
+    COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffsets);
     LongType yOffsets = coords[channelPosition] * shape::stride(yShapeInfo)[posOfNonUnityDim];
 
     if (xzAreSame)

--- a/libnd4j/include/ops/declarable/helpers/cuda/assign.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/assign.cu
@@ -31,12 +31,12 @@ SD_KERNEL static void assignKernel(const void* vx, const LongType* xShapeInfo, v
   LongType xCoords[SD_MAX_RANK], zCoords[SD_MAX_RANK];
 
   for (LongType i = tid; i < len; i += totalThreads) {
-    INDEX2COORDS(i, rank, zShapeInfo, zCoords);
-    INDEX2COORDS(i, rank, xShapeInfo, xCoords);
+    INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), zCoords);
+    INDEX2COORDS(i, rank, shape::shapeOf(xShapeInfo), xCoords);
 
     LongType xIndex, zIndex;
-    COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), xCoords, xIndex);
-    COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), zCoords, zIndex);
+    COORDS2INDEX(rank, shape::stride(xShapeInfo), xCoords, xIndex);
+    COORDS2INDEX(rank, shape::stride(zShapeInfo), zCoords, zIndex);
 
     z[zIndex] = static_cast<Z>(x[xIndex]);
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/batchnorm.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/batchnorm.cu
@@ -68,11 +68,11 @@ SD_KERNEL static void batchnormCuda2(const void* vx, const LongType* xShapeInfo,
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < xLen; i += totalThreads) {
-    INDEX2COORDS(i, xRank, xShapeInfo, coords);
+    INDEX2COORDS(i, xRank, shape::shapeOf(xShapeInfo), coords);
 
     LongType xOffset, zOffset;
-    COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), coords, xOffset);
-    COORDS2INDEX(xRank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(xRank, shape::stride(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(xRank, shape::stride(zShapeInfo), coords, zOffset);
 
     if (minRank == xRank) {
       for (LongType i = 0, j = 0; i < xRank; ++i) {
@@ -85,14 +85,14 @@ SD_KERNEL static void batchnormCuda2(const void* vx, const LongType* xShapeInfo,
       coords[0] = coords[dims[0]];
 
     LongType meanOffset, varianceOffset;
-    COORDS2INDEX(minRank, shape::shapeOf(meanShapeInfo), coords, meanOffset);
-    COORDS2INDEX(minRank, shape::shapeOf(varianceShapeInfo), coords, varianceOffset);
+    COORDS2INDEX(minRank, shape::stride(meanShapeInfo), coords, meanOffset);
+    COORDS2INDEX(minRank, shape::stride(varianceShapeInfo), coords, varianceOffset);
 
     T sigmaInvGam = 1. / math::sd_sqrt<T, T>(variance[varianceOffset] + epsilon);
 
     if (gamma != nullptr) {
       LongType gammaOffset;
-      COORDS2INDEX(minRank, shape::shapeOf(gammaShapeInfo), coords, gammaOffset);
+      COORDS2INDEX(minRank, shape::stride(gammaShapeInfo), coords, gammaOffset);
       sigmaInvGam *= gamma[gammaOffset];
     }
 
@@ -100,7 +100,7 @@ SD_KERNEL static void batchnormCuda2(const void* vx, const LongType* xShapeInfo,
 
     if (beta != nullptr) {
       LongType betaOffset;
-      COORDS2INDEX(minRank, shape::shapeOf(betaShapeInfo), coords, betaOffset);
+      COORDS2INDEX(minRank, shape::stride(betaShapeInfo), coords, betaOffset);
       z[zOffset] += beta[betaOffset];
     }
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/betaInc.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/betaInc.cu
@@ -108,14 +108,14 @@ SD_KERNEL void betaIncForArrayCuda(const void* va, const LongType* aShapeInfo, c
     LongType xCoords[SD_MAX_RANK];
     LongType zCoords[SD_MAX_RANK];
 
-    INDEX2COORDS(j, shape::rank(aShapeInfo), aShapeInfo, aCoords);
-    COORDS2INDEX(shape::rank(aShapeInfo), shape::shapeOf(aShapeInfo), aCoords, aOffset);
-    INDEX2COORDS(j, shape::rank(bShapeInfo), bShapeInfo, bCoords);
-    COORDS2INDEX(shape::rank(bShapeInfo), shape::shapeOf(bShapeInfo), bCoords, bOffset);
-    INDEX2COORDS(j, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(j, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(j, shape::rank(aShapeInfo), shape::shapeOf(aShapeInfo), aCoords);
+    COORDS2INDEX(shape::rank(aShapeInfo), shape::stride(aShapeInfo), aCoords, aOffset);
+    INDEX2COORDS(j, shape::rank(bShapeInfo), shape::shapeOf(bShapeInfo), bCoords);
+    COORDS2INDEX(shape::rank(bShapeInfo), shape::stride(bShapeInfo), bCoords, bOffset);
+    INDEX2COORDS(j, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(j, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     if (aOffset >= aLen || bOffset >= bLen || xOffset >= xLen || zOffset >= zLen)
       return;

--- a/libnd4j/include/ops/declarable/helpers/cuda/col2im.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/col2im.cu
@@ -58,10 +58,10 @@ static SD_KERNEL void col2imCuda(const void* columns, const LongType* colShapeIn
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < imLen; i += gridDim.x * blockDim.x) {
-    INDEX2COORDS(i, shape::rank(imShapeInfo), imShapeInfo, coords);
+    INDEX2COORDS(i, shape::rank(imShapeInfo), shape::shapeOf(imShapeInfo), coords);
 
     LongType imOffset;
-    COORDS2INDEX(shape::rank(imShapeInfo), shape::shapeOf(imShapeInfo), coords, imOffset);
+    COORDS2INDEX(shape::rank(imShapeInfo), shape::stride(imShapeInfo), coords, imOffset);
 
     const auto bSiCoffset = coords[0] * colShapeInfo[7] + coords[1] * colShapeInfo[8];
 
@@ -85,7 +85,7 @@ static SD_KERNEL void col2imCuda(const void* columns, const LongType* colShapeIn
         if (coords[3] % dW != 0) continue;
 
         LongType colOffset;
-        COORDS2INDEX(shape::rank(colShapeInfo), shape::shapeOf(colShapeInfo), coords, colOffset);
+        COORDS2INDEX(shape::rank(colShapeInfo), shape::stride(colShapeInfo), coords, colOffset);
 
         val += col[bSiCoffset + colOffset];
       }

--- a/libnd4j/include/ops/declarable/helpers/cuda/compare_elem.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/compare_elem.cu
@@ -41,10 +41,10 @@ static SD_KERNEL void comparator(void *vx, const LongType *xShapeInfo, LongType 
 
   // each thread will compare 2 elements: E and E+1
   for (int e = tid; e < length - 1; e += blockDim.x * gridDim.x) {
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset0);
-    INDEX2COORDS(e + 1, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset1);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset0);
+    INDEX2COORDS(e + 1, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset1);
 
     auto val0 = x[xOffset0];
     auto val1 = x[xOffset1];

--- a/libnd4j/include/ops/declarable/helpers/cuda/concat.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/concat.cu
@@ -60,10 +60,10 @@ SD_KERNEL static void concatCuda(void* pVx, void* pxShapeInfo, void* vz, const s
   LongType coords[SD_MAX_RANK];
 
   for (LongType i = tid; i < zLen; i += totalThreads) {
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, coords);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords);
 
     LongType zOffset;
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
 
     int inArrIdx = 0;
     LongType* xShapeInfo = reinterpret_cast<sd::LongType**>(pxShapeInfo)[inArrIdx];
@@ -75,7 +75,7 @@ SD_KERNEL static void concatCuda(void* pVx, void* pxShapeInfo, void* vz, const s
 
     const auto* x = reinterpret_cast<T*>(reinterpret_cast<void**>(pVx)[inArrIdx]);
     LongType xOffset;
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
 
     z[zOffset] = x[xOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/confusion.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/confusion.cu
@@ -74,8 +74,8 @@ SD_KERNEL static void confusionFunctorKernel(LongType* labelsBuffer, LongType* p
     auto tZ = z + tadOffsets[label];
     T val = (weightsBuffer == nullptr ? (T)1.0f : w[t]);
 
-    INDEX2COORDS(pred, shape::rank(tadShape), tadShape, predCoords);
-    COORDS2INDEX(shape::rank(tadShape), shape::shapeOf(tadShape), predCoords, predOffset);
+    INDEX2COORDS(pred, shape::rank(tadShape), shape::shapeOf(tadShape), predCoords);
+    COORDS2INDEX(shape::rank(tadShape), shape::stride(tadShape), predCoords, predOffset);
     tZ[predOffset] = val;
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_col2vol.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_col2vol.cu
@@ -64,10 +64,10 @@ static SD_KERNEL void col2volCuda(const void* columns, const LongType* colShapeI
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < volLen; i += gridDim.x * blockDim.x) {
-    INDEX2COORDS(i, shape::rank(volShapeInfo), volShapeInfo, coords);
+    INDEX2COORDS(i, shape::rank(volShapeInfo), shape::shapeOf(volShapeInfo), coords);
 
     sd::LongType volOffset;
-    COORDS2INDEX(shape::rank(volShapeInfo), shape::shapeOf(volShapeInfo), coords, volOffset);
+    COORDS2INDEX(shape::rank(volShapeInfo), shape::stride(volShapeInfo), coords, volOffset);
 
     const auto bSiCoffset = coords[0] * colShapeInfo[9] + coords[1] * colShapeInfo[10];
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_pooling3d.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_pooling3d.cu
@@ -73,10 +73,10 @@ SD_KERNEL static void pooling3dCuda(const void* vx, const LongType* xShapeInfo, 
 
   auto coords = sharedMem + threadIdx.x * rank;
 
-  INDEX2COORDS(zInd, rank, zShapeInfo, coords);
+  INDEX2COORDS(zInd, rank, shape::shapeOf(zShapeInfo), coords);
 
   LongType zOffset;
-  COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+  COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
   int dstart = coords[2] * sD - pD;
   int hstart = coords[3] * sH - pH;
@@ -100,7 +100,7 @@ SD_KERNEL static void pooling3dCuda(const void* vx, const LongType* xShapeInfo, 
         for (coords[3] = hstart; coords[3] < hend; coords[3] += dH) {
           for (coords[4] = wstart; coords[4] < wend; coords[4] += dW) {
             LongType xOffset;
-            COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+            COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
             T val = x[xOffset];
             if (val > max) max = val;
           }
@@ -116,7 +116,7 @@ SD_KERNEL static void pooling3dCuda(const void* vx, const LongType* xShapeInfo, 
         for (coords[3] = hstart; coords[3] < hend; coords[3] += dH)
           for (coords[4] = wstart; coords[4] < wend; coords[4] += dW) {
             LongType xOffset;
-            COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+            COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
             sum += x[xOffset];
           }
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_pooling3dBP.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_pooling3dBP.cu
@@ -76,10 +76,10 @@ SD_KERNEL static void pooling3dBPCuda(const void* vx, const LongType* xShapeInfo
 
   auto coords = sharedMem + threadIdx.x * rank;
 
-  INDEX2COORDS(yInd, rank, yShapeInfo, coords);
+  INDEX2COORDS(yInd, rank, shape::shapeOf(yShapeInfo), coords);
 
   LongType yOffset;
-  COORDS2INDEX(rank, shape::shapeOf(yShapeInfo), coords, yOffset);
+  COORDS2INDEX(rank, shape::stride(yShapeInfo), coords, yOffset);
 
   int dstart = coords[2] * sD - pD;
   int hstart = coords[3] * sH - pH;
@@ -103,7 +103,7 @@ SD_KERNEL static void pooling3dBPCuda(const void* vx, const LongType* xShapeInfo
         for (coords[3] = hstart; coords[3] < hend; coords[3] += dH) {
           for (coords[4] = wstart; coords[4] < wend; coords[4] += dW) {
             LongType xOffset;
-            COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+            COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
             T val = x[xOffset];
             if (val > max) {
               max = val;
@@ -118,7 +118,7 @@ SD_KERNEL static void pooling3dBPCuda(const void* vx, const LongType* xShapeInfo
       coords[3] = coord3;
       coords[4] = coord4;
       LongType zOffset;
-      COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
       math::atomics::sd_atomicAdd<T>(&z[zOffset], y[yOffset]);
     } break;
 
@@ -138,7 +138,7 @@ SD_KERNEL static void pooling3dBPCuda(const void* vx, const LongType* xShapeInfo
         for (coords[3] = hstart; coords[3] < hend; coords[3] += dH)
           for (coords[4] = wstart; coords[4] < wend; coords[4] += dW) {
             LongType zOffset;
-            COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+            COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
             math::atomics::sd_atomicAdd<T>(&z[zOffset], val);
           }
     } break;
@@ -152,7 +152,7 @@ SD_KERNEL static void pooling3dBPCuda(const void* vx, const LongType* xShapeInfo
         for (coords[3] = hstart; coords[3] < hend; coords[3] += dH)
           for (coords[4] = wstart; coords[4] < wend; coords[4] += dW) {
             LongType xOffset;
-            COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+            COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
             sum += math::sd_pow<T, T, T>(math::sd_abs<T,T>(x[xOffset]), extraParam0);
           }
 
@@ -162,8 +162,8 @@ SD_KERNEL static void pooling3dBPCuda(const void* vx, const LongType* xShapeInfo
         for (coords[3] = hstart; coords[3] < hend; coords[3] += dH) {
           for (coords[4] = wstart; coords[4] < wend; coords[4] += dW) {
             LongType xOffset, zOffset;
-            COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
-            COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+            COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
+            COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
             math::atomics::sd_atomicAdd<T>(
                 &z[zOffset], val * math::sd_pow<T, T, T>(math::sd_abs<T,T>(x[xOffset]), extraParam0 - 1.f) *
                                  math::sd_sgn<T, T>(x[xOffset]));

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling2d.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling2d.cu
@@ -61,16 +61,16 @@ SD_KERNEL static void upsampling2dCuda(const void* vx, const LongType* xShapeInf
 
   auto coords = sharedMem + threadIdx.x * rank;
 
-  INDEX2COORDS(zInd, rank, zShapeInfo, coords);
+  INDEX2COORDS(zInd, rank, shape::shapeOf(zShapeInfo), coords);
 
   LongType zOffset;
-  COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+  COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
   coords[dimIH] /= factorH;
   coords[dimIH + 1] /= factorW;
 
   LongType xOffset;
-  COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+  COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
 
   z[zOffset] = x[xOffset];
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling2dBP.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling2dBP.cu
@@ -64,10 +64,10 @@ SD_KERNEL static void upsampling2dBPCuda(const void* vx, const LongType* xShapeI
 
   auto coords = sharedMem + threadIdx.x * rank;
 
-  INDEX2COORDS(zInd, rank, zShapeInfo, coords);
+  INDEX2COORDS(zInd, rank, shape::shapeOf(zShapeInfo), coords);
 
   LongType zOffset;
-  COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+  COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
   z[zOffset] = 0;
 
@@ -77,7 +77,7 @@ SD_KERNEL static void upsampling2dBPCuda(const void* vx, const LongType* xShapeI
   for (coords[dimIH] = zCoord2; coords[dimIH] < zCoord2 + factorH; ++coords[dimIH])
     for (coords[dimIH + 1] = zCoord3; coords[dimIH + 1] < zCoord3 + factorW; ++coords[dimIH + 1]) {
       LongType xOffset;
-      COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+      COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
       z[zOffset] += x[xOffset];
     }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling3d.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling3d.cu
@@ -62,17 +62,17 @@ SD_KERNEL static void upsampling3dCuda(const void* vx, const LongType* xShapeInf
 
   auto coords = sharedMem + threadIdx.x * rank;
 
-  INDEX2COORDS(zInd, rank, zShapeInfo, coords);
+  INDEX2COORDS(zInd, rank, shape::shapeOf(zShapeInfo), coords);
 
   LongType zOffset;
-  COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+  COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
   coords[dimID] /= factorD;
   coords[dimID + 1] /= factorH;
   coords[dimID + 2] /= factorW;
 
   LongType xOffset;
-  COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+  COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
 
   z[zOffset] = x[xOffset];
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling3dBP.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_upsampling3dBP.cu
@@ -66,10 +66,10 @@ SD_KERNEL static void upsampling3dBPCuda(const void* vx, const LongType* xShapeI
 
   auto coords = sharedMem + threadIdx.x * rank;
 
-  INDEX2COORDS(zInd, rank, zShapeInfo, coords);
+  INDEX2COORDS(zInd, rank, shape::shapeOf(zShapeInfo), coords);
 
   LongType zOffset;
-  COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+  COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
   z[zOffset] = 0;
 
@@ -81,7 +81,7 @@ SD_KERNEL static void upsampling3dBPCuda(const void* vx, const LongType* xShapeI
     for (coords[dimID + 1] = zCoord3; coords[dimID + 1] < zCoord3 + factorH; ++coords[dimID + 1])
       for (coords[dimID + 2] = zCoord4; coords[dimID + 2] < zCoord4 + factorW; ++coords[dimID + 2]) {
         LongType xOffset;
-        COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+        COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
         z[zOffset] += x[xOffset];
       }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/convolutions_vol2col.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/convolutions_vol2col.cu
@@ -64,10 +64,10 @@ static SD_KERNEL void vol2colCuda(const void* volume, const LongType* volShapeIn
 
   auto coords = sharedMem + threadIdx.x * colRank;
 
-  INDEX2COORDS(colInd, colRank, colShapeInfo, coords);
+  INDEX2COORDS(colInd, colRank, shape::shapeOf(colShapeInfo), coords);
 
   LongType colOffset;
-  COORDS2INDEX(colRank, shape::shapeOf(colShapeInfo), coords, colOffset);
+  COORDS2INDEX(colRank, shape::stride(colShapeInfo), coords, colOffset);
 
   coords[2] = -pD + coords[2] * dD + coords[5] * sD;  // const auto volDep = (-pD + kDep * dD) + colD * sD;
   coords[3] = -pH + coords[3] * dH + coords[6] * sH;  // const auto volRow = (-pH + kRow * dH) + colH * sH;
@@ -79,7 +79,7 @@ static SD_KERNEL void vol2colCuda(const void* volume, const LongType* volShapeIn
     col[colOffset] = static_cast<T>(0.);
   else {
     LongType volOffset;
-    COORDS2INDEX(volRank, shape::shapeOf(volShapeInfo), coords, volOffset);
+    COORDS2INDEX(volRank, shape::stride(volShapeInfo), coords, volOffset);
     col[colOffset] = vol[volOffset];
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/cross.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/cross.cu
@@ -58,13 +58,13 @@ SD_KERNEL static void crossCuda(const void* vx, const LongType* xShapeInfo, cons
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < lenWithoutLastDim; i += totalThreads) {
-    INDEX2COORDS(i, rank - 1, xShapeInfo + 1, coords);
+    INDEX2COORDS(i, rank - 1, shape::shapeOf(xShapeInfo), coords);
 
     coords[rank - 1] = 0;
 
     LongType xOffset, yOffset, zOffset;
-    COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
-    COORDS2INDEX(rank, shape::shapeOf(yShapeInfo), coords, yOffset);
+    COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(rank, shape::stride(yShapeInfo), coords, yOffset);
 
     const auto x0 = x[xOffset];
     const auto y0 = y[yOffset];
@@ -81,7 +81,7 @@ SD_KERNEL static void crossCuda(const void* vx, const LongType* xShapeInfo, cons
     const auto x2 = x[xOffset];
     const auto y2 = y[yOffset];
 
-    COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
     z[zOffset] = x1 * y2 - x2 * y1;
 
     zOffset += shape::stride(zShapeInfo)[rank - 1];

--- a/libnd4j/include/ops/declarable/helpers/cuda/diGamma.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/diGamma.cu
@@ -52,13 +52,13 @@ SD_KERNEL static void diGammaCuda(const void *vx, const LongType *xShapeInfo, vo
   LongType zOffset;
 
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < len; i += gridDim.x * blockDim.x) {
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     if (sameOffset) {
       zOffset = xOffset;
     } else {
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
     }
 
     z[zOffset] = diGammaScalar<T>(x[xOffset]);

--- a/libnd4j/include/ops/declarable/helpers/cuda/diag.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/diag.cu
@@ -61,10 +61,10 @@ static SD_KERNEL void diagFunctorKernel(void* outputBuffer, const LongType* outp
   LongType xOffset;
 
   for (int t = tid; t < inputLength; t += step) {  // for all vals in input, put all on diagonal position to output
-    INDEX2COORDS(t * (inputLength + 1), shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zOffset);
-    INDEX2COORDS(t, shape::rank(inputShape), inputShape, xCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
+    INDEX2COORDS(t * (inputLength + 1), shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zOffset);
+    INDEX2COORDS(t, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
     z[zOffset] = x[xOffset];
   }
 }
@@ -99,10 +99,10 @@ static SD_KERNEL void diagPartFunctorKernel(void* outputBuffer, const LongType* 
   LongType i = threadIdx.x * (outputLength + 1);  // pos to diagonal value
 
   for (int t = tid; t < outputLength && i < inputLength; t += step) {  // loop by output, but input matrix may not be square
-    INDEX2COORDS(t, shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zOffset);
-    INDEX2COORDS(i, shape::rank(inputShape), inputShape, xCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
+    INDEX2COORDS(t, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
     z[zOffset] = x[xOffset];
     i += outputLength + 1;  // shift to next diagonal value
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/dilation2d.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/dilation2d.cu
@@ -72,7 +72,7 @@ SD_KERNEL static void dilation2dCuda(const void* vx, const LongType* xShapeInfo,
   auto xzCoords = sharedMem + threadIdx.x * (xzRank + yRank);
   auto yCoords = xzCoords + xzRank;
 
-  INDEX2COORDS(zInd, xzRank, zShapeInfo, xzCoords);
+  INDEX2COORDS(zInd, xzRank, shape::shapeOf(zShapeInfo), xzCoords);
 
   LongType zOffset;
   COORDS2INDEX(xzRank, shape::shapeOf(zShapeInfo), xzCoords, zOffset);
@@ -93,8 +93,8 @@ SD_KERNEL static void dilation2dCuda(const void* vx, const LongType* xShapeInfo,
       if (xzCoords[2] < 0 || xzCoords[2] >= iW) continue;
 
       LongType xOffset, yOffset;
-      COORDS2INDEX(xzRank, shape::shapeOf(xShapeInfo), xzCoords, xOffset);
-      COORDS2INDEX(yRank, shape::shapeOf(yShapeInfo), yCoords, yOffset);
+      COORDS2INDEX(xzRank, shape::stride(xShapeInfo), xzCoords, xOffset);
+      COORDS2INDEX(yRank, shape::stride(yShapeInfo), yCoords, yOffset);
 
       const X val = x[xOffset] + y[yOffset];
       if (val > max) max = val;

--- a/libnd4j/include/ops/declarable/helpers/cuda/dropout.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/dropout.cu
@@ -53,10 +53,10 @@ static SD_KERNEL void dropoutSimpleKernel(void const* inputBuf, LongType const* 
 
     // if probability is ok - we're saving scaled value
     if (double(val) < probVal) {
-      INDEX2COORDS(e, shape::rank(outputShape), outputShape, outputCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
-      INDEX2COORDS(e, shape::rank(inputShape), inputShape, inputCoords);
-      COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords, inputOffset);
+      INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
+      INDEX2COORDS(e, shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords);
+      COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), inputCoords, inputOffset);
       output[outputOffset] = T(input[inputOffset] / probVal);
     }
   }
@@ -168,10 +168,10 @@ static SD_KERNEL void dropoutBPKernel(void* outputBuf, LongType const* outputSha
   LongType gradOutOffset;
 
   for (int e = tid; e < len; e += step) {
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, outputCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, zOffset);
-    INDEX2COORDS(e, shape::rank(gradOutShape), gradOutShape, gradOutCoords);
-    COORDS2INDEX(shape::rank(gradOutShape), shape::shapeOf(gradOutShape), gradOutCoords, gradOutOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(gradOutShape), shape::shapeOf(gradOutShape), gradOutCoords);
+    COORDS2INDEX(shape::rank(gradOutShape), shape::stride(gradOutShape), gradOutCoords, gradOutOffset);
 
     // if probability was non-zero on FF step, we'll scale grads back
     if (output[zOffset] != T(0.)) output[zOffset] = T(input[gradOutOffset] / probValue);
@@ -217,10 +217,10 @@ static SD_KERNEL void alphaDropoutSimpleKernel(void const* inputBuf, LongType co
 
   for (auto e = tid; e < inLen; e += step) {
     T val = nodeRng->relativeT(e, T(0.f), T(1.f));
-    INDEX2COORDS(e, shape::rank(inputShape), inputShape, inputCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords, inputOffset);
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, outputCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
+    INDEX2COORDS(e, shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), inputCoords, inputOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
     output[outputOffset] = (val >= T(probValue) ? T(alpha * beta + alpha1) : T(alpha * (double)input[inputOffset] + alpha1));
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/dynamic.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/dynamic.cu
@@ -65,8 +65,8 @@ static SD_KERNEL void dynamicPartitionScalarKernel(const void *vx, const LongTyp
       if (e < iLength) {
         LongType iOffset;
         LongType iCoords[SD_MAX_RANK];
-        INDEX2COORDS(e, shape::rank(iShapeInfo), iShapeInfo, iCoords);
-        COORDS2INDEX(shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords, iOffset);
+        INDEX2COORDS(e, shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords);
+        COORDS2INDEX(shape::rank(iShapeInfo), shape::stride(iShapeInfo), iCoords, iOffset);
         rawIndices[threadIdx.x] = i[iOffset];
       }
       __syncthreads();
@@ -88,8 +88,8 @@ static SD_KERNEL void dynamicPartitionScalarKernel(const void *vx, const LongTyp
         if (trueIndices[threadIdx.x] >= 0) {
           LongType xOffset;
           LongType xCoords[SD_MAX_RANK];
-          INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-          COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+          INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+          COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
           z[trueIndices[threadIdx.x]] = x[xOffset];
         }
       }
@@ -117,8 +117,8 @@ static SD_KERNEL void dynamicPartitionTadKernel(const void *vx, const LongType *
     for (LongType e = 0; e < iLength; e++) {
       LongType iCoords[SD_MAX_RANK];
       LongType iOffset;
-      INDEX2COORDS(e, shape::rank(iShapeInfo), iShapeInfo, iCoords);
-      COORDS2INDEX(shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords, iOffset);
+      INDEX2COORDS(e, shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords);
+      COORDS2INDEX(shape::rank(iShapeInfo), shape::stride(iShapeInfo), iCoords, iOffset);
 
       if (indices[iOffset] == i) {
         auto dx = x + xTadOffsets[e];
@@ -128,10 +128,10 @@ static SD_KERNEL void dynamicPartitionTadKernel(const void *vx, const LongType *
           LongType fCoords[SD_MAX_RANK];
           LongType xOffset;
           LongType zOffset;
-          INDEX2COORDS(f, shape::rank(xTadShapeInfo), xTadShapeInfo, fCoords);
-          COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), fCoords, xOffset);
-          INDEX2COORDS(f, shape::rank(zTadShapeInfos[i]), zTadShapeInfos[i], fCoords);
-          COORDS2INDEX(shape::rank(zTadShapeInfos[i]), shape::shapeOf(zTadShapeInfos[i]), fCoords, zOffset);
+          INDEX2COORDS(f, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), fCoords);
+          COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), fCoords, xOffset);
+          INDEX2COORDS(f, shape::rank(zTadShapeInfos[i]), shape::shapeOf(zTadShapeInfos[i]), fCoords);
+          COORDS2INDEX(shape::rank(zTadShapeInfos[i]), shape::stride(zTadShapeInfos[i]), fCoords, zOffset);
 
           dz[zOffset] = dx[xOffset];
         }
@@ -242,16 +242,16 @@ static SD_KERNEL void dynamicStitchScalarKernel(void **vx, LongType **xShapeInfo
       LongType xOffset;
       LongType zOffset;
 
-      INDEX2COORDS(i, shape::rank(iShapeInfo), iShapeInfo, iCoords);
-      COORDS2INDEX(shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords, iOffset);
+      INDEX2COORDS(i, shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords);
+      COORDS2INDEX(shape::rank(iShapeInfo), shape::stride(iShapeInfo), iCoords, iOffset);
 
       auto idx = indices[iOffset];
       if (idx >= 0 && idx < zLength) {
-        INDEX2COORDS(idx, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+        INDEX2COORDS(idx, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
-        INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+        INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
 
         z[zOffset] = x[xOffset];
       }
@@ -287,8 +287,8 @@ static SD_KERNEL void dynamicStitchTadKernel(void **vx, LongType **xTadShapeInfo
     for (int i = 0; i < iLength; i++) {
       LongType iCoords[SD_MAX_RANK];
       LongType iOffset;
-      INDEX2COORDS(i, shape::rank(iShapeInfo), iShapeInfo, iCoords);
-      COORDS2INDEX(shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords, iOffset);
+      INDEX2COORDS(i, shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), iCoords);
+      COORDS2INDEX(shape::rank(iShapeInfo), shape::stride(iShapeInfo), iCoords, iOffset);
 
       auto idx = indices[iOffset];
 
@@ -301,10 +301,10 @@ static SD_KERNEL void dynamicStitchTadKernel(void **vx, LongType **xTadShapeInfo
         LongType xIdx;
         LongType zIdx;
 
-        INDEX2COORDS(j, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, xIdx);
-        INDEX2COORDS(j, shape::rank(zTadShapeInfo), zTadShapeInfo, zCoords);
-        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords, zIdx);
+        INDEX2COORDS(j, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, xIdx);
+        INDEX2COORDS(j, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords);
+        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zCoords, zIdx);
 
         if (xIdx < xTadLength && xIdx >= 0 && zIdx < zLength && zIdx >= 0) zTad[zIdx] = x[xIdx];
       }

--- a/libnd4j/include/ops/declarable/helpers/cuda/fake_quantization.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/fake_quantization.cu
@@ -100,16 +100,16 @@ static SD_KERNEL void fakeQuantWithMinMaxKernel(const T* input, const LongType* 
     nudge(min[i], max[i], lowIntBound, upperIntBound, &scale, &nudgedMin, &nudgedMax);
     // loop over blocks to quantization between nudged min and max
     for (auto b = threadIdx.x; b < block; b += blockDim.x) {
-      INDEX2COORDS(b * channels + i, shape::rank(inputShape), inputShape, inputCoords);
-      COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords, inputOffset);
+      INDEX2COORDS(b * channels + i, shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords);
+      COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), inputCoords, inputOffset);
       T val = input[inputOffset];
       if (val < nudgedMin) {
         val = nudgedMin;
       } else if (val > nudgedMax) {
         val = nudgedMax;
       }
-      INDEX2COORDS(b * channels + i, shape::rank(outputShape), outputShape, outputCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
+      INDEX2COORDS(b * channels + i, shape::rank(outputShape), shape::shapeOf(ouputShape), outputCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
       output[outputOffset] = (math::sd_floor<T, T>((val - nudgedMin) / scale + T(0.5f)) * scale + nudgedMin);
     }
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/flatten.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/flatten.cu
@@ -45,8 +45,8 @@ static void SD_KERNEL flattenKernel(void **xBuffers, LongType **xShapeInfos, Lon
     for (LongType i = threadIdx.x; i < xLength; i += blockDim.x) {
       LongType xOffset;
       sd::LongType xCoords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
       z[i] = xBuffer[xOffset];
     }
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/gather.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/gather.cu
@@ -57,12 +57,12 @@ SD_KERNEL static void gatherCudaLinearKernel(const void* vx, const LongType* xSh
   for (LongType j = start; j < zLen; j += step) {
     LongType zIndex, yIndex, xIndex;
     LongType zCoords[SD_MAX_RANK], yCoords[SD_MAX_RANK], xCoords[SD_MAX_RANK];
-    INDEX2COORDS(j, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zIndex);
-    INDEX2COORDS(j, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yIndex);
+    INDEX2COORDS(j, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zIndex);
+    INDEX2COORDS(j, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yIndex);
     INDEX2COORDS(y[yIndex], shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xIndex);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xIndex);
     z[zIndex] = x[xIndex];
   }
 }
@@ -81,12 +81,12 @@ SD_KERNEL static void gatherCuda(const int numOfSubArrs, const void* vx, const L
     if (threadIdx.x == 0) {
       LongType yIndex, xOffset, zOffset;
       LongType yCoords[SD_MAX_RANK], xCoords[SD_MAX_RANK], zCoords[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yIndex);
-      INDEX2COORDS(y[yIndex], shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yIndex);
+      INDEX2COORDS(y[yIndex], shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
       x = reinterpret_cast<const X*>(vx) + xOffsets[xOffset];
       z = reinterpret_cast<X*>(vz) + zOffsets[zOffset];
     }
@@ -95,10 +95,10 @@ SD_KERNEL static void gatherCuda(const int numOfSubArrs, const void* vx, const L
     for (LongType j = threadIdx.x; j < len; j += blockDim.x) {
       LongType zIndex, xIndex;
       LongType zCoords[SD_MAX_RANK], xCoords[SD_MAX_RANK];
-      INDEX2COORDS(j, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zIndex);
-      INDEX2COORDS(j, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xIndex);
+      INDEX2COORDS(j, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zIndex);
+      INDEX2COORDS(j, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xIndex);
       z[zIndex] = x[xIndex];
     }
     __syncthreads();

--- a/libnd4j/include/ops/declarable/helpers/cuda/gather_nd.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/gather_nd.cu
@@ -84,10 +84,10 @@ SD_KERNEL static void gatherNDCuda(const void *vx, const LongType *xShapeInfo, c
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < zLen; i += totalThreads) {
-    INDEX2COORDS(i, zRank, zShapeInfo, zCoordStart);
+    INDEX2COORDS(i, zRank, shape::shapeOf(zShapeInfo), zCoordStart);
 
     LongType zOffset;
-    COORDS2INDEX(zRank, shape::shapeOf(zShapeInfo), zCoordStart, zOffset);
+    COORDS2INDEX(zRank, shape::stride(zShapeInfo), zCoordStart, zOffset);
 
     // last y coordinate
     int coordToRestore;
@@ -95,7 +95,7 @@ SD_KERNEL static void gatherNDCuda(const void *vx, const LongType *xShapeInfo, c
 
     zCoordStart[yRank - 1] = 0;  // last y coordinate
     LongType yOffset;
-    COORDS2INDEX(yRank, shape::shapeOf(yShapeInfo), zCoordStart, yOffset);
+    COORDS2INDEX(yRank, shape::stride(yShapeInfo), zCoordStart, yOffset);
 
     // restore z coordinate
     if (yLastDim != xRank) zCoordStart[yRank - 1] = coordToRestore;
@@ -104,7 +104,7 @@ SD_KERNEL static void gatherNDCuda(const void *vx, const LongType *xShapeInfo, c
     for (LongType j = 0; j < yLastDim; ++j) xCoordStart[j] = y[yOffset + j * yShapeInfo[2 * yRank]];  // last stride
 
     LongType xOffset;
-    COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), xCoordStart, xOffset);
+    COORDS2INDEX(xRank, shape::stride(xShapeInfo), xCoordStart, xOffset);
 
     z[zOffset] = x[xOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/hamming.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/hamming.cu
@@ -48,10 +48,10 @@ static SD_KERNEL void _hammingKernel(const void *vx, const LongType *xShapeInfo,
   LongType yOffset;
 
   for (LongType e = tid; e < length; e += blockDim.x * gridDim.x) {
-    INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
 
     auto _x = static_cast<unsigned long long>(x[xOffset]);
     auto _y = static_cast<unsigned long long>(y[yOffset]);

--- a/libnd4j/include/ops/declarable/helpers/cuda/histogramFixedWidth.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/histogramFixedWidth.cu
@@ -57,8 +57,8 @@ SD_KERNEL static void histogramFixedWidthCuda(const void* vx, const LongType* xS
   for (LongType i = tid; i < xLen; i += totalThreads) {
     LongType xCoords[SD_MAX_RANK];
     LongType xOffset;
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
 
     const X value = x[xOffset];
 
@@ -73,8 +73,8 @@ SD_KERNEL static void histogramFixedWidthCuda(const void* vx, const LongType* xS
 
     LongType zCoords[SD_MAX_RANK];
     LongType zOffset;
-    INDEX2COORDS(zIndex, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(zIndex, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     math::atomics::sd_atomicAdd<Z>(&z[zOffset], 1);
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/im2col.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/im2col.cu
@@ -57,10 +57,10 @@ SD_KERNEL static void im2colCuda(const void *image, void *columns, const LongTyp
 
   LongType coords[SD_MAX_RANK];
 
-  INDEX2COORDS(colInd, colRank, colShapeInfo, coords);
+  INDEX2COORDS(colInd, colRank, shape::shapeOf(colShapeInfo), coords);
 
   LongType colOffset;
-  COORDS2INDEX(colRank, shape::shapeOf(colShapeInfo), coords, colOffset);
+  COORDS2INDEX(colRank, shape::stride(colShapeInfo), coords, colOffset);
 
   coords[2] = (-pH + coords[2] * dH) + coords[4] * sH;  // imH
   coords[3] = (-pW + coords[3] * dW) + coords[5] * sW;  // imW
@@ -72,7 +72,7 @@ SD_KERNEL static void im2colCuda(const void *image, void *columns, const LongTyp
       col[colOffset] = zeroPadVal;
   } else {
     LongType imOffset;
-    COORDS2INDEX(imRank, shape::shapeOf(imShapeInfo), coords, imOffset);
+    COORDS2INDEX(imRank, shape::stride(imShapeInfo), coords, imOffset);
     if (imOffset < imLen && colOffset < colLen)
       col[colOffset] = im[imOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/image_draw_bounding_boxes.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/image_draw_bounding_boxes.cu
@@ -35,18 +35,18 @@ static NDArray DefaultColorTable(int depth, LaunchContext* context) {
   const LongType kDefaultTableLength = 10;
   const LongType kDefaultChannelLength = 4;
   std::vector<sd::LongType> shape = {kDefaultTableLength, kDefaultChannelLength};
- std::vector<double> table =   {
-                                1,   1,   0,   1,  // yellow
-                                0,   0,   1,   1,  // 1: blue
-                                1,   0,   0,   1,  // 2: red
-                                0,   1,   0,   1,  // 3: lime
-                                0.5, 0,   0.5, 1,  // 4: purple
-                                0.5, 0.5, 0,   1,  // 5: olive
-                                0.5, 0,   0,   1,  // 6: maroon
-                                0,   0,   0.5, 1,  // 7: navy blue
-                                0,   1,   1,   1,  // 8: aqua
-                                1,   0,   1,   1   // 9: fuchsia
-                            };
+  std::vector<double> table =   {
+      1,   1,   0,   1,  // yellow
+      0,   0,   1,   1,  // 1: blue
+      1,   0,   0,   1,  // 2: red
+      0,   1,   0,   1,  // 3: lime
+      0.5, 0,   0.5, 1,  // 4: purple
+      0.5, 0.5, 0,   1,  // 5: olive
+      0.5, 0,   0,   1,  // 6: maroon
+      0,   0,   0.5, 1,  // 7: navy blue
+      0,   1,   1,   1,  // 8: aqua
+      1,   0,   1,   1   // 9: fuchsia
+  };
   NDArray colorTable('c', shape,
                      table,
                      FLOAT32, context);
@@ -74,10 +74,10 @@ static SD_KERNEL void drawBoundingBoxesKernel(T const* images, const LongType* i
       LongType indices3[] = {batch, boxIndex, 3};
 
       LongType rowStartOffset, rowEndOffset, colStartOffset, colEndOffset;
-      COORDS2INDEX(3, boxesShape + 1, indices0, rowStartOffset);
-      COORDS2INDEX(3, boxesShape + 1, indices2, rowEndOffset);
-      COORDS2INDEX(3, boxesShape + 1, indices1, colStartOffset);
-      COORDS2INDEX(3, boxesShape + 1, indices3, colEndOffset);
+      COORDS2INDEX(3, shape::stride(boxesShape), indices0, rowStartOffset);
+      COORDS2INDEX(3, shape::stride(boxesShape), indices2, rowEndOffset);
+      COORDS2INDEX(3,shape::stride(boxesShape), indices1, colStartOffset);
+      COORDS2INDEX(3, shape::stride(boxesShape), indices3, colEndOffset);
 
       auto rowStart = LongType((height - 1) * boxes[rowStartOffset]);
       auto rowStartBound = math::sd_max(LongType(0), rowStart);
@@ -102,8 +102,8 @@ static SD_KERNEL void drawBoundingBoxesKernel(T const* images, const LongType* i
             LongType zPos[] = {batch, rowStart, j, c};
             LongType cPos[] = {colorIndex, c};
             LongType cIndex, zIndex;
-            COORDS2INDEX(2, colorTableShape + 1, cPos, cIndex);
-            COORDS2INDEX(4, outputShape + 1, zPos, zIndex);
+            COORDS2INDEX(2,  shape::stride(colorTableShape), cPos, cIndex);
+            COORDS2INDEX(4, shape::stride(outputShape), zPos, zIndex);
             output[zIndex] = (T)colorTable[cIndex];
           }
       }
@@ -114,8 +114,8 @@ static SD_KERNEL void drawBoundingBoxesKernel(T const* images, const LongType* i
             LongType zPos[] = {batch, rowEnd, j, c};
             LongType cPos[] = {colorIndex, c};
             LongType cIndex, zIndex;
-            COORDS2INDEX(2, colorTableShape + 1, cPos, cIndex);
-            COORDS2INDEX(4, outputShape + 1, zPos, zIndex);
+            COORDS2INDEX(2,  shape::stride(colorTableShape), cPos, cIndex);
+            COORDS2INDEX(4, shape::stride(outputShape), zPos, zIndex);
             output[zIndex] = (T)colorTable[cIndex];
           }
       }
@@ -127,8 +127,8 @@ static SD_KERNEL void drawBoundingBoxesKernel(T const* images, const LongType* i
             LongType zPos[] = {batch, i, colStart, c};
             LongType cPos[] = {colorIndex, c};
             LongType cIndex, zIndex;
-            COORDS2INDEX(2, colorTableShape + 1, cPos, cIndex);
-            COORDS2INDEX(4, outputShape + 1, zPos, zIndex);
+            COORDS2INDEX(2, shape::stride(colorTableShape), cPos, cIndex);
+            COORDS2INDEX(4, shape::stride(outputShape), zPos, zIndex);
             output[zIndex] = (T)colorTable[cIndex];
           }
       }
@@ -139,8 +139,8 @@ static SD_KERNEL void drawBoundingBoxesKernel(T const* images, const LongType* i
             LongType zPos[] = {batch, i, colEnd, c};
             LongType cPos[] = {colorIndex, c};
             LongType cIndex, zIndex;
-            COORDS2INDEX(2, colorTableShape + 1, cPos, cIndex);
-            COORDS2INDEX(4, outputShape + 1, zPos, zIndex);
+            COORDS2INDEX(2, shape::stride(colorTableShape), cPos, cIndex);
+            COORDS2INDEX(4, shape::stride(outputShape), zPos, zIndex);
             output[zIndex] = (T)colorTable[cIndex];
           }
       }

--- a/libnd4j/include/ops/declarable/helpers/cuda/image_resize.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/image_resize.cu
@@ -933,10 +933,10 @@ static SD_KERNEL void cropAndResizeKernel(T const* images, LongType const* image
     LongType y2Pos[] = {b, 2};
     LongType x2Pos[] = {b, 3};
     LongType y1Offset, x1Offset, y2Offset, x2Offset;
-    COORDS2INDEX(2, boxesShape, y1Pos, y1Offset);
-    COORDS2INDEX(2, boxesShape, x1Pos, x1Offset);
-    COORDS2INDEX(2, boxesShape, y2Pos, y2Offset);
-    COORDS2INDEX(2, boxesShape, x2Pos, x2Offset);
+    COORDS2INDEX(2, shape::stride(boxesShape), y1Pos, y1Offset);
+    COORDS2INDEX(2, shape::stride(boxesShape), x1Pos, x1Offset);
+    COORDS2INDEX(2, shape::stride(boxesShape), y2Pos, y2Offset);
+    COORDS2INDEX(2, shape::stride(boxesShape), x2Pos, x2Offset);
     Z y1 = boxes[y1Offset];
     Z x1 = boxes[x1Offset];
     Z y2 = boxes[y2Offset];
@@ -960,7 +960,7 @@ static SD_KERNEL void cropAndResizeKernel(T const* images, LongType const* image
           for (int d = start; d < depth; d += step) {
             LongType zPos[] = {b, y, x, d};
             LongType zOffset;
-            COORDS2INDEX(4, outputShape, zPos, zOffset);
+            COORDS2INDEX(4, shape::stride(outputShape), zPos, zOffset);
             output[zOffset] = (Z)extrapolationVal;
           }
         }
@@ -981,7 +981,7 @@ static SD_KERNEL void cropAndResizeKernel(T const* images, LongType const* image
             for (int d = start; d < depth; d += step) {
               LongType zPos[] = {b, y, x, d};
               LongType zOffset;
-              COORDS2INDEX(4, outputShape, zPos, zOffset);
+              COORDS2INDEX(4, shape::stride(outputShape), zPos, zOffset);
               output[zOffset] = (Z)extrapolationVal;
             }
             continue;
@@ -998,10 +998,10 @@ static SD_KERNEL void cropAndResizeKernel(T const* images, LongType const* image
             LongType bottomLeftPos[] = {bIn, bottomYIndex, left_x_index, d};
             LongType bottomRightPos[] = {bIn, bottomYIndex, right_x_index, d};
             LongType topLeftOffset, topRightOffset, bottomLeftOffset, bottomRightOffset;
-            COORDS2INDEX(4, imagesShape, topLeftPos, topLeftOffset);
-            COORDS2INDEX(4, imagesShape, topRightPos, topRightOffset);
-            COORDS2INDEX(4, imagesShape, bottomLeftPos, bottomLeftOffset);
-            COORDS2INDEX(4, imagesShape, bottomRightPos, bottomRightOffset);
+            COORDS2INDEX(4, shape::stride(imagesShape), topLeftPos, topLeftOffset);
+            COORDS2INDEX(4, shape::stride(imagesShape), topRightPos, topRightOffset);
+            COORDS2INDEX(4, shape::stride(imagesShape), bottomLeftPos, bottomLeftOffset);
+            COORDS2INDEX(4, shape::stride(imagesShape), bottomRightPos, bottomRightOffset);
             const T topLeft = images[topLeftOffset];
             const T topRight = images[topRightOffset];
             const T bottomLeft = images[bottomLeftOffset];
@@ -1010,7 +1010,7 @@ static SD_KERNEL void cropAndResizeKernel(T const* images, LongType const* image
             const T bottom = bottomLeft + (bottomRight - bottomLeft) * x_lerp;
             LongType zPos[] = {b, y, x, d};
             LongType zOffset;
-            COORDS2INDEX(4, outputShape, zPos, zOffset);
+            COORDS2INDEX(4, shape::stride(outputShape), zPos, zOffset);
             output[zOffset] = Z(top + (bottom - top) * y_lerp);
           }
         }
@@ -1024,7 +1024,7 @@ static SD_KERNEL void cropAndResizeKernel(T const* images, LongType const* image
             for (int d = start; d < depth; d += step) {
               LongType zPos[] = {b, y, x, d};
               LongType zOffset;
-              COORDS2INDEX(4, outputShape, zPos, zOffset);
+              COORDS2INDEX(4, shape::stride(outputShape), zPos, zOffset);
               output[zOffset] = (Z)extrapolationVal;
             }
             continue;
@@ -1037,8 +1037,8 @@ static SD_KERNEL void cropAndResizeKernel(T const* images, LongType const* image
             LongType zPos[] = {b, y, x, d};
             LongType xPos[] = {bIn, closestYIndex, closestXIndex, d};
             LongType zOffset, xOffset;
-            COORDS2INDEX(4, outputShape, zPos, zOffset);
-            COORDS2INDEX(4, imagesShape, xPos, xOffset);
+            COORDS2INDEX(4, shape::stride(outputShape), zPos, zOffset);
+            COORDS2INDEX(4, shape::stride(imagesShape), xPos, xOffset);
             output[zOffset] = images[xOffset];
           }
         }

--- a/libnd4j/include/ops/declarable/helpers/cuda/image_suppression.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/image_suppression.cu
@@ -57,14 +57,14 @@ static SD_DEVICE bool needToSuppressWithThreshold(T* boxes, LongType const* boxe
   LongType prevOffset0, prevOffset1, prevOffset2, prevOffset3;
   LongType nextOffset0, nextOffset1, nextOffset2, nextOffset3;
 
-  COORDS2INDEX(2, boxesShape + 1, previous0, prevOffset0);
-  COORDS2INDEX(2, boxesShape + 1, previous1, prevOffset1);
-  COORDS2INDEX(2, boxesShape + 1, previous2, prevOffset2);
-  COORDS2INDEX(2, boxesShape + 1, previous3, prevOffset3);
-  COORDS2INDEX(2, boxesShape + 1, next0, nextOffset0);
-  COORDS2INDEX(2, boxesShape + 1, next1, nextOffset1);
-  COORDS2INDEX(2, boxesShape + 1, next2, nextOffset2);
-  COORDS2INDEX(2, boxesShape + 1, next3, nextOffset3);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous0, prevOffset0);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous1, prevOffset1);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous2, prevOffset2);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous3, prevOffset3);
+  COORDS2INDEX(2, shape::stride(boxesShape), next0, nextOffset0);
+  COORDS2INDEX(2, shape::stride(boxesShape), next1, nextOffset1);
+  COORDS2INDEX(2, shape::stride(boxesShape), next2, nextOffset2);
+  COORDS2INDEX(2, shape::stride(boxesShape), next3, nextOffset3);
 
   // we have rectangle with given max values. Compute vexes of rectangle first
 
@@ -137,14 +137,14 @@ static SD_DEVICE T similirityV3(T* boxes, LongType const* boxesShape, int previo
   LongType prevOffset0, prevOffset1, prevOffset2, prevOffset3;
   LongType nextOffset0, nextOffset1, nextOffset2, nextOffset3;
 
-  COORDS2INDEX(2, boxesShape + 1, previous0, prevOffset0);
-  COORDS2INDEX(2, boxesShape + 1, previous1, prevOffset1);
-  COORDS2INDEX(2, boxesShape + 1, previous2, prevOffset2);
-  COORDS2INDEX(2, boxesShape + 1, previous3, prevOffset3);
-  COORDS2INDEX(2, boxesShape + 1, next0, nextOffset0);
-  COORDS2INDEX(2, boxesShape + 1, next1, nextOffset1);
-  COORDS2INDEX(2, boxesShape + 1, next2, nextOffset2);
-  COORDS2INDEX(2, boxesShape + 1, next3, nextOffset3);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous0, prevOffset0);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous1, prevOffset1);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous2, prevOffset2);
+  COORDS2INDEX(2, shape::stride(boxesShape), previous3, prevOffset3);
+  COORDS2INDEX(2, shape::stride(boxesShape), next0, nextOffset0);
+  COORDS2INDEX(2, shape::stride(boxesShape), next1, nextOffset1);
+  COORDS2INDEX(2, shape::stride(boxesShape), next2, nextOffset2);
+  COORDS2INDEX(2, shape::stride(boxesShape), next3, nextOffset3);
 
   // we have rectangle with given max values. Compute vexes of rectangle first
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/imagesHelpers.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/imagesHelpers.cu
@@ -183,7 +183,7 @@ SD_KERNEL void rgbToGrsCuda(const void* vx, const LongType* xShapeInfo, void* vz
   auto coords = sharedMem + threadIdx.x * rank;
 
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < zLen; i += gridDim.x * blockDim.x) {
-    INDEX2COORDS(i, rank, zShapeInfo, coords);
+    INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), coords);
 
     LongType zOffset;
     COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);

--- a/libnd4j/include/ops/declarable/helpers/cuda/lup.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/lup.cu
@@ -312,8 +312,8 @@ static SD_KERNEL void fillMatrix(void *output, const LongType *outShape, const v
     LongType coords[SD_MAX_RANK];
     LongType xIndex;
 
-    INDEX2COORDS(k, shape::rank(inputShape), inputShape, coords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), coords, xIndex);
+    INDEX2COORDS(k, shape::rank(inputShape), shape::shapeOf(inputShape), coords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), coords, xIndex);
 
     matrix[j] = (F)inputBuf[xIndex];
   }
@@ -341,8 +341,8 @@ static SD_KERNEL void returnMatrix(void *output, const LongType *outputShape, co
     LongType zCoords[SD_MAX_RANK];
     LongType zIndex;
 
-    INDEX2COORDS(k, shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zIndex);
+    INDEX2COORDS(k, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zIndex);
 
     outputBuf[zIndex] = matrix[j];
   }
@@ -635,9 +635,9 @@ static void luNN_(LaunchContext *context, NDArray *compound, NDArray *permutatio
 
       sd::LongType permIndex1, permIndex2;
       sd::LongType permCoords1[SD_MAX_RANK], permCoords2[SD_MAX_RANK];
-      INDEX2COORDS(i, shape::rank(permutationShape), permutationShape, permCoords1);
-      COORDS2INDEX(shape::rank(permutationShape), shape::shapeOf(permutationShape), permCoords1, permIndex1);
-      INDEX2COORDS(pivotIndex, shape::rank(permutationShape), permutationShape, permCoords2);
+      INDEX2COORDS(i, shape::rank(permutationShape), shape::shapeOf(permutationShape), permCoords1);
+      COORDS2INDEX(shape::rank(permutationShape), shape::stride(permutationShape), permCoords1, permIndex1);
+      INDEX2COORDS(pivotIndex, shape::rank(permutationShape), shape::shapeOf(permutationShape), permCoords2);
       COORDS2INDEX(shape::rank(permutationShape), shape::shapeOf(permutationShape), permCoords2, permIndex2);
 
       math::sd_swap(permutationBuf[permIndex1], permutationBuf[permIndex2]);
@@ -700,8 +700,8 @@ static Status determinant_(LaunchContext *context, NDArray *input, NDArray *outp
     lup_<T, int>(context, &matrix, nullptr, nullptr);
     sd::LongType offset;
     sd::LongType offsetCoords[SD_MAX_RANK];
-    INDEX2COORDS(e, shape::rank(output->shapeInfo()), output->shapeInfo(), offsetCoords);
-    COORDS2INDEX(shape::rank(output->shapeInfo()), shape::shapeOf(output->shapeInfo()), offsetCoords, offset);
+    INDEX2COORDS(e, shape::rank(output->shapeInfo()), shape::shapeOf(output->shapeInfo()), offsetCoords);
+    COORDS2INDEX(shape::rank(output->shapeInfo()), shape::stride(output->shapeInfo()), offsetCoords, offset);
     auto inputBuf = reinterpret_cast<T *>(matrix.specialBuffer());
     auto outputBuf = reinterpret_cast<T *>(output->specialBuffer()) + offset;
     determinantKernel<T><<<launchDims.x, launchDims.y, launchDims.z, *stream>>>(inputBuf, outputBuf, n);

--- a/libnd4j/include/ops/declarable/helpers/cuda/matrixSetDiag.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/matrixSetDiag.cu
@@ -67,18 +67,18 @@ SD_KERNEL static void matrixSetDiagCuda(const void* vx, const LongType* xShapeIn
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < xLen; i += gridDim.x * blockDim.x) {
-    INDEX2COORDS(i, xRank, xShapeInfo, coords);
+    INDEX2COORDS(i, xRank, shape::shapeOf(xShapeInfo), coords);
 
     LongType xOffset, zOffset, yOffset;
-    COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(xRank, shape::stride(xShapeInfo), coords, xOffset);
     if (areSameOffsets) {
       zOffset = xOffset;
     } else {
-      COORDS2INDEX(xRank, shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(xRank, shape::stride(zShapeInfo), coords, zOffset);
     }
     // condition to be on diagonal of innermost matrix
     if (coords[xRank - 2] == coords[xRank - 1]) {
-      COORDS2INDEX(xRank - 1, shape::shapeOf(yShapeInfo), coords, yOffset);
+      COORDS2INDEX(xRank - 1, shape::stride(yShapeInfo), coords, yOffset);
       z[zOffset] = y[yOffset];
     } else {
       z[zOffset] = zeroPad ? static_cast<T>(0) : x[xOffset];

--- a/libnd4j/include/ops/declarable/helpers/cuda/max_pooling.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/max_pooling.cu
@@ -37,8 +37,8 @@ static SD_KERNEL void indicesFiller(void* vz, LongType const* zShapeInfo, LongTy
     for (LongType e = threadIdx.x; e < part; e += blockDim.x) {
       LongType zCoords[SD_MAX_RANK];
       LongType zOffset;
-      INDEX2COORDS(e + b * part, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(e + b * part, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
       z[zOffset] = static_cast<Z>(e);
     }
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/merge.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/merge.cu
@@ -56,8 +56,8 @@ static SD_KERNEL void mergeMaxIndexCudaLauncher(void** inArrs, void** inShapes, 
       LongType xCoords[SD_MAX_RANK];
       LongType xOffset;
 
-      INDEX2COORDS(e, shape::rank(xShape), xShape, xCoords);
-      COORDS2INDEX(shape::rank(xShape), shape::shapeOf(xShape), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(xShape), shape::shapeOf(xShape), xCoords);
+      COORDS2INDEX(shape::rank(xShape), shape::stride(xShape), xCoords, xOffset);
 
       auto val = x[xOffset];
       if (mVal < val) {
@@ -69,8 +69,8 @@ static SD_KERNEL void mergeMaxIndexCudaLauncher(void** inArrs, void** inShapes, 
     LongType outputCoords[SD_MAX_RANK];
     LongType outputOffset;
 
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, outputCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
 
     output[outputOffset] = mIdx;
   }
@@ -128,8 +128,8 @@ static SD_KERNEL void mergeMaxCudaLauncher(void** inArrs, void** inShapes, const
       LongType xCoords[SD_MAX_RANK];
       LongType xOffset;
 
-      INDEX2COORDS(e, shape::rank(xShape), xShape, xCoords);
-      COORDS2INDEX(shape::rank(xShape), shape::shapeOf(xShape), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(xShape), shape::shapeOf(xShape), xCoords);
+      COORDS2INDEX(shape::rank(xShape), shape::stride(xShape), xCoords, xOffset);
 
       auto val = x[xOffset];
       if (mVal < val) {
@@ -140,8 +140,8 @@ static SD_KERNEL void mergeMaxCudaLauncher(void** inArrs, void** inShapes, const
     LongType outputCoords[SD_MAX_RANK];
     LongType outputOffset;
 
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, outputCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
 
     output[outputOffset] = mVal;
   }
@@ -197,8 +197,8 @@ static SD_KERNEL void mergeMaxBpCudaLauncher(void** inArrs, void** inShapes, con
     LongType xOffset, zOffset, gradOffset;
 
     if (!bSameOrderAndEws1) {
-      INDEX2COORDS(e, shape::rank(gradientShape), gradientShape, coords);
-      COORDS2INDEX(shape::rank(gradientShape), shape::shapeOf(gradientShape), coords, gradOffset);
+      INDEX2COORDS(e, shape::rank(gradientShape), shape::shapeOf(gradientShape), coords);
+      COORDS2INDEX(shape::rank(gradientShape), shape::stride(gradientShape), coords, gradOffset);
     } else {
       gradOffset = e;
     }
@@ -208,7 +208,7 @@ static SD_KERNEL void mergeMaxBpCudaLauncher(void** inArrs, void** inShapes, con
 
       if (!bSameOrderAndEws1) {
         auto xShape = reinterpret_cast<LongType*>(inShapes[i]);
-        COORDS2INDEX(shape::rank(xShape), shape::shapeOf(xShape), coords, xOffset);
+        COORDS2INDEX(shape::rank(xShape), shape::stride(xShape), coords, xOffset);
       } else {
         xOffset = e;
       }
@@ -223,7 +223,7 @@ static SD_KERNEL void mergeMaxBpCudaLauncher(void** inArrs, void** inShapes, con
     // outputs have to be pre-nullify
     if (!bSameOrderAndEws1) {
       auto outShape = reinterpret_cast<LongType*>(outShapes[nMaxIndex]);
-      COORDS2INDEX(shape::rank(outShape), shape::shapeOf(outShape), coords, zOffset);
+      COORDS2INDEX(shape::rank(outShape), shape::stride(outShape), coords, zOffset);
     } else {
       zOffset = e;
     }
@@ -312,8 +312,8 @@ static SD_KERNEL void mergeAvgCudaLauncher(void** inArrs, void** inShapes, const
       LongType xCoords[SD_MAX_RANK];
       LongType xOffset;
 
-      INDEX2COORDS(e, shape::rank(xShape), xShape, xCoords);
-      COORDS2INDEX(shape::rank(xShape), shape::shapeOf(xShape), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(xShape), shape::shapeOf(xShape), xCoords);
+      COORDS2INDEX(shape::rank(xShape), shape::stride(xShape), xCoords, xOffset);
 
       sum += x[xOffset];
     }
@@ -321,8 +321,8 @@ static SD_KERNEL void mergeAvgCudaLauncher(void** inArrs, void** inShapes, const
     LongType outputCoords[SD_MAX_RANK];
     LongType outputOffset;
 
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, outputCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
 
     output[outputOffset] = sum / numArrays;
   }
@@ -374,8 +374,8 @@ static SD_KERNEL void mergeAvgBpCudaLauncher(const void* vgradient, const LongTy
   for (LongType e = tid; e < length; e += step) {
     LongType gradOffset;
     if (!bSameOrderAndEws1) {
-      INDEX2COORDS(e, shape::rank(gradientShape), gradientShape, coords);
-      COORDS2INDEX(shape::rank(gradientShape), shape::shapeOf(gradientShape), coords, gradOffset);
+      INDEX2COORDS(e, shape::rank(gradientShape), shape::shapeOf(gradientShape), coords);
+      COORDS2INDEX(shape::rank(gradientShape), shape::stride(gradientShape), coords, gradOffset);
     } else {
       gradOffset = e;
     }
@@ -384,7 +384,7 @@ static SD_KERNEL void mergeAvgBpCudaLauncher(const void* vgradient, const LongTy
       LongType zOffset;
       if (!bSameOrderAndEws1) {
         auto outShape = reinterpret_cast<LongType*>(outShapes[i]);
-        COORDS2INDEX(shape::rank(outShape), shape::shapeOf(outShape), coords, zOffset);
+        COORDS2INDEX(shape::rank(outShape), shape::stride(outShape), coords, zOffset);
       } else {
         zOffset = e;
       }
@@ -464,8 +464,8 @@ static SD_KERNEL void mergeAddCudaLauncher(void** inArrs, void** inShapes, const
       LongType xOffset;
       sd::LongType xCoords[SD_MAX_RANK];
 
-      INDEX2COORDS(e, shape::rank(xShape), xShape, xCoords);
-      COORDS2INDEX(shape::rank(xShape), shape::shapeOf(xShape), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(xShape), shape::shapeOf(xShape), xCoords);
+      COORDS2INDEX(shape::rank(xShape), shape::stride(xShape), xCoords, xOffset);
 
       sum += x[xOffset];
     }
@@ -473,8 +473,8 @@ static SD_KERNEL void mergeAddCudaLauncher(void** inArrs, void** inShapes, const
     LongType outputOffset;
     sd::LongType outputCoords[SD_MAX_RANK];
 
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, outputCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
 
     output[outputOffset] = sum;
   }
@@ -531,8 +531,8 @@ static SD_KERNEL void mergeAddBpCudaLauncher(const void* vgradient, const LongTy
   for (LongType e = tid; e < length; e += step) {
     LongType gradOffset;
     if (!bSameOrderAndEws1) {
-      INDEX2COORDS(e, shape::rank(gradientShape), gradientShape, coords);
-      COORDS2INDEX(shape::rank(gradientShape), shape::shapeOf(gradientShape), coords, gradOffset);
+      INDEX2COORDS(e, shape::rank(gradientShape), shape::shapeOf(gradientShape), coords);
+      COORDS2INDEX(shape::rank(gradientShape), shape::stride(gradientShape), coords, gradOffset);
     } else {
       gradOffset = e;
     }
@@ -541,7 +541,7 @@ static SD_KERNEL void mergeAddBpCudaLauncher(const void* vgradient, const LongTy
       LongType zOffset;
       if (!bSameOrderAndEws1) {
         auto outShape = reinterpret_cast<LongType*>(outShapes[i]);
-        COORDS2INDEX(shape::rank(outShape), shape::shapeOf(outShape), coords, zOffset);
+        COORDS2INDEX(shape::rank(outShape), shape::stride(outShape), coords, zOffset);
       } else {
         zOffset = e;
       }

--- a/libnd4j/include/ops/declarable/helpers/cuda/meshgrid.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/meshgrid.cu
@@ -54,10 +54,10 @@ static SD_DEVICE void assign_(void *vx, LongType *xShapeInfo, void *vz, LongType
   LongType zOffset;
 
   for (int i = threadIdx.x; i < length; i += blockDim.x) {
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = x[xOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/nth_element.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/nth_element.cu
@@ -55,10 +55,10 @@ static SD_KERNEL void fillUpElementKernel(void* outputBuffer, LongType const* ou
     LongType zCoords[SD_MAX_RANK];
     LongType xCoords[SD_MAX_RANK];
 
-    INDEX2COORDS(t, shape::rank(outputShapeInfo), outputShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(outputShapeInfo), shape::shapeOf(outputShapeInfo), zCoords, zOffset);
-    INDEX2COORDS(n, shape::rank(pTadShape), pTadShape, xCoords);
-    COORDS2INDEX(shape::rank(pTadShape), shape::shapeOf(pTadShape), xCoords, xOffset);
+    INDEX2COORDS(t, shape::rank(outputShapeInfo), shape::shapeOf(outputShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(outputShapeInfo), shape::stride(outputShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(n, shape::rank(pTadShape), shape::shapeOf(pTadShape), xCoords);
+    COORDS2INDEX(shape::rank(pTadShape), shape::stride(pTadShape), xCoords, xOffset);
 
     z[zOffset] = tX[xOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/one_hot.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/one_hot.cu
@@ -66,15 +66,15 @@ SD_KERNEL static void onehotCuda(const void *vx, const LongType *xShapeInfo, voi
   const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
 
   for (LongType i = tid; i < zLen; i += totalThreads) {
-    INDEX2COORDS(i, zRank, zShapeInfo, coord);
+    INDEX2COORDS(i, zRank, shape::shapeOf(zShapeInfo), coord);
     sd::LongType zOffset;
-    COORDS2INDEX(zRank, shape::shapeOf(zShapeInfo), coord, zOffset);
+    COORDS2INDEX(zRank, shape::stride(zShapeInfo), coord, zOffset);
     const auto depthCoord = coord[axis];
 
     for (LongType j = axis; j < zRank - 1; ++j) coord[j] = coord[j + 1];
 
     sd::LongType xOffset;
-    COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), coord, xOffset);
+    COORDS2INDEX(xRank, shape::stride(xShapeInfo), coord, xOffset);
     const LongType idx = x[xOffset];
     z[zOffset] = depthCoord == idx ? on : off;
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/percentile.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/percentile.cu
@@ -53,10 +53,10 @@ static SD_KERNEL void percentileKernel(void* vx, const LongType* xTadShapeInfo, 
           for (int tid = threadIdx.x; tid < tadLength; tid += blockDim.x) {
             auto top = 2 * tid + 1;
             if (top < tadLength) {
-              INDEX2COORDS(top - 1, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, t0);
-              INDEX2COORDS(top, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, t1);
+              INDEX2COORDS(top - 1, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, t0);
+              INDEX2COORDS(top, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, t1);
 
               if (x[t0] > x[t1]) {
                 // swap values
@@ -70,10 +70,10 @@ static SD_KERNEL void percentileKernel(void* vx, const LongType* xTadShapeInfo, 
           for (int tid = threadIdx.x; tid < tadLength; tid += blockDim.x) {
             auto top = 2 * tid + 2;
             if (top < tadLength) {
-              INDEX2COORDS(top - 1, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, t0);
-              INDEX2COORDS(top, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, t1);
+              INDEX2COORDS(top - 1, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, t0);
+              INDEX2COORDS(top, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+              COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, t1);
 
               if (x[t0] > x[t1]) {
                 // swap values
@@ -90,10 +90,10 @@ static SD_KERNEL void percentileKernel(void* vx, const LongType* xTadShapeInfo, 
 
     // saving final value
     if (threadIdx.x == 0) {
-      INDEX2COORDS(t, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
-      INDEX2COORDS(position, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, positionOffset);
+      INDEX2COORDS(t, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(position, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, positionOffset);
       z[zOffset] = x[positionOffset];
     }
     __syncthreads();

--- a/libnd4j/include/ops/declarable/helpers/cuda/polyGamma.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/polyGamma.cu
@@ -59,21 +59,21 @@ SD_KERNEL static void polyGammaCuda(const void *vn, const LongType *nShapeInfo, 
   LongType zOffset;
 
   for (int i = tid; i < len; i += totalThreads) {
-    INDEX2COORDS(i, shape::rank(nShapeInfo), nShapeInfo, nCoords);
-    COORDS2INDEX(shape::rank(nShapeInfo), shape::shapeOf(nShapeInfo), nCoords, nOffset);
+    INDEX2COORDS(i, shape::rank(nShapeInfo), shape::shapeOf(nShapeInfo), nCoords);
+    COORDS2INDEX(shape::rank(nShapeInfo), shape::stride(nShapeInfo), nCoords, nOffset);
 
     if (sameOffsetNX) {
       xOffset = nOffset;
     } else {
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     }
 
     if (sameOffsetNZ) {
       zOffset = nOffset;
     } else {
-      INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
     }
 
     const T order = n[nOffset];

--- a/libnd4j/include/ops/declarable/helpers/cuda/prefix.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/prefix.cu
@@ -49,10 +49,10 @@ static void prefix_(scalar::Ops op, const void* vx, LongType const* xShapeInfo, 
 
   if (reverse) {
     for (LongType e = length - 1; e >= 0; --e) {
-      INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       sum = op == scalar::Add ? simdOps::Add<T, T, T>::op(sum, x[xOffset]) : simdOps::Multiply<T, T, T>::op(sum, x[xOffset]);
       if (!exclusive) prevSum = sum;
@@ -62,10 +62,10 @@ static void prefix_(scalar::Ops op, const void* vx, LongType const* xShapeInfo, 
     }
   } else {
     for (LongType e = 0; e < length; e++) {
-      INDEX2COORDS(e, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(e, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
       sum = op == scalar::Add ? simdOps::Add<T, T, T>::op(sum, x[xOffset]) : simdOps::Multiply<T, T, T>::op(sum, x[xOffset]);
       if (!exclusive) prevSum = sum;

--- a/libnd4j/include/ops/declarable/helpers/cuda/print_variable.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/print_variable.cu
@@ -40,8 +40,8 @@ static SD_KERNEL void print_device(const void *special, const LongType *shapeInf
   LongType offset;
 
   for (uint64_t e = 0; e < length; e++) {
-    INDEX2COORDS(e, shape::rank(shapeInfo), shapeInfo, coords);
-    COORDS2INDEX(shape::rank(shapeInfo), shape::shapeOf(shapeInfo), coords, offset);
+    INDEX2COORDS(e, shape::rank(shapeInfo), shape::shapeOf(shapeInfo), coords);
+    COORDS2INDEX(shape::rank(shapeInfo), shape::stride(shapeInfo), coords, offset);
     printf("%f", (float)x[offset]);
 
     if (e < length - 1) printf(", ");

--- a/libnd4j/include/ops/declarable/helpers/cuda/random.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/random.cu
@@ -152,16 +152,16 @@ static SD_KERNEL void fillGammaKernel(T const* uList, LongType uLength, T const*
       LongType bIndex;
       LongType zIndex;
 
-      INDEX2COORDS(e, shape::rank(alphaShape), alphaShape, aCoords);
-      COORDS2INDEX(shape::rank(alphaShape), shape::shapeOf(alphaShape), aCoords, aIndex);
+      INDEX2COORDS(e, shape::rank(alphaShape), shape::shapeOf(alpha), aCoords);
+      COORDS2INDEX(shape::rank(alphaShape), shape::stride(alphaShape), aCoords, aIndex);
       if (betaShape) {
-        INDEX2COORDS(e, shape::rank(betaShape), betaShape, bCoords);
-        COORDS2INDEX(shape::rank(betaShape), shape::shapeOf(betaShape), bCoords, bIndex);
+        INDEX2COORDS(e, shape::rank(betaShape), shape::shapeOf(beta), bCoords);
+        COORDS2INDEX(shape::rank(betaShape), shape::stride(betaShape), bCoords, bIndex);
       } else {
         bIndex = -1LL;
       }
-      INDEX2COORDS(e + pos, shape::rank(outputShape), outputShape, zCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zIndex);
+      INDEX2COORDS(e + pos, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zIndex);
 
       auto betaV = T(beta != nullptr ? beta[bIndex] : T(1.f));
       output[zIndex] = alpha[aIndex] > T(1.f) ? gammaGreat(uList, pos, uLength, alpha[aIndex], betaV)
@@ -262,10 +262,10 @@ static SD_KERNEL void fillPoissonKernel(T* uList, LongType uLength, T* lambda, c
       LongType lIndex;
       LongType zIndex;
 
-      INDEX2COORDS(e, shape::rank(lambdaShape), lambdaShape, lCoords);
-      COORDS2INDEX(shape::rank(lambdaShape), shape::shapeOf(lambdaShape), lCoords, lIndex);
-      INDEX2COORDS(e + pos, shape::rank(outputShape), outputShape, zCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zIndex);
+      INDEX2COORDS(e, shape::rank(lambdaShape), shape::shapeOf(lambdaShape), lCoords);
+      COORDS2INDEX(shape::rank(lambdaShape), shape::stride(lambdaShape), lCoords, lIndex);
+      INDEX2COORDS(e + pos, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zIndex);
 
       while (u > s) {
         x += T(1.);
@@ -331,8 +331,8 @@ static SD_KERNEL void fillUniformKernel(graph::RandomGenerator* devRng, T from, 
     LongType zCoords[SD_MAX_RANK];
     LongType zIndex;
 
-    INDEX2COORDS(i, shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zIndex);
+    INDEX2COORDS(i, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zIndex);
 
     output[zIndex] = devRng->relativeT<T>(i, from, to);
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/reverse.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/reverse.cu
@@ -67,10 +67,10 @@ static SD_KERNEL void reverseTadKernel(const void* vinput, const LongType* input
     LongType fOffset;
     LongType lOffset;
 
-    INDEX2COORDS(idx, shape::rank(inputTadShape), inputTadShape, fCoords);
-    COORDS2INDEX(shape::rank(inputTadShape), shape::shapeOf(inputTadShape), fCoords, fOffset);
-    INDEX2COORDS(numOfElemsToReverse - idx - 1, shape::rank(inputTadShape), inputTadShape, lCoords);
-    COORDS2INDEX(shape::rank(inputTadShape), shape::shapeOf(inputTadShape),lCoords, lOffset);
+    INDEX2COORDS(idx, shape::rank(inputTadShape), shape::shapeOf(inputTadShape), fCoords);
+    COORDS2INDEX(shape::rank(inputTadShape), shape::stride(inputTadShape), fCoords, fOffset);
+    INDEX2COORDS(numOfElemsToReverse - idx - 1, shape::rank(inputTadShape), shape::shapeOf(inputTadShape), lCoords);
+    COORDS2INDEX(shape::rank(inputTadShape), shape::stride(inputTadShape),lCoords, lOffset);
 
     // now we're storing input values
     auto v1 = tadInput[fOffset];
@@ -81,10 +81,10 @@ static SD_KERNEL void reverseTadKernel(const void* vinput, const LongType* input
     LongType zfOffset;
     LongType zlOffset;
 
-    INDEX2COORDS(idx, shape::rank(outputTadShape), outputTadShape, zfCoords);
-    COORDS2INDEX(shape::rank(outputTadShape), shape::shapeOf(outputTadShape), zfCoords, zfOffset);
-    INDEX2COORDS(numOfElemsToReverse - idx - 1, shape::rank(outputTadShape), outputTadShape, zlCoords);
-    COORDS2INDEX(shape::rank(outputTadShape), shape::shapeOf(outputTadShape), zlCoords, zlOffset);
+    INDEX2COORDS(idx, shape::rank(outputTadShape), shape::shapeOf(outputTadShape), zfCoords);
+    COORDS2INDEX(shape::rank(outputTadShape), shape::stride(outputTadShape), zfCoords, zfOffset);
+    INDEX2COORDS(numOfElemsToReverse - idx - 1, shape::rank(outputTadShape), shape::shapeOf(outputTadShape), zlCoords);
+    COORDS2INDEX(shape::rank(outputTadShape), shape::stride(outputTadShape), zlCoords, zlOffset);
 
     // and saving values to output arrays
     tadOutput[zfOffset] = v2;
@@ -102,10 +102,10 @@ static SD_KERNEL void reverseTadKernel(const void* vinput, const LongType* input
       LongType xOffset;
       LongType zOffset;
 
-      INDEX2COORDS(numOfElemsToReverse / 2, shape::rank(inputTadShape), inputTadShape, xCoords);
-      COORDS2INDEX(shape::rank(inputTadShape), shape::shapeOf(inputTadShape), xCoords, xOffset);
-      INDEX2COORDS(numOfElemsToReverse / 2, shape::rank(outputTadShape), outputTadShape, zCoords);
-      COORDS2INDEX(shape::rank(outputTadShape), shape::shapeOf(outputTadShape), zCoords, zOffset);
+      INDEX2COORDS(numOfElemsToReverse / 2, shape::rank(inputTadShape), shape::shapeOf(inputTadShape), xCoords);
+      COORDS2INDEX(shape::rank(inputTadShape), shape::stride(inputTadShape), xCoords, xOffset);
+      INDEX2COORDS(numOfElemsToReverse / 2, shape::rank(outputTadShape), shape::shapeOf(outputTadShape), zCoords);
+      COORDS2INDEX(shape::rank(outputTadShape), shape::stride(outputTadShape), zCoords, zOffset);
 
       tadOutput[zOffset] = tadInput[xOffset];
     }
@@ -138,10 +138,10 @@ static SD_KERNEL void reverseArrayKernel(const void* input, const LongType* inpu
     LongType fOffset;
     LongType lOffset;
 
-    INDEX2COORDS(e, shape::rank(inputShape), inputShape, fCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), fCoords, fOffset);
-    INDEX2COORDS(numOfElemsToReverse - e - 1, shape::rank(inputShape), inputShape, lCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), lCoords, lOffset);
+    INDEX2COORDS(e, shape::rank(inputShape), shape::shapeOf(inputShape), fCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), fCoords, fOffset);
+    INDEX2COORDS(numOfElemsToReverse - e - 1, shape::rank(inputShape), shape::shapeOf(inputShape), lCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), lCoords, lOffset);
 
     auto v1 = inputArr[fOffset];
     auto v2 = inputArr[lOffset];
@@ -151,10 +151,10 @@ static SD_KERNEL void reverseArrayKernel(const void* input, const LongType* inpu
     LongType zfOffset;
     LongType zlOffset;
 
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, zfCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zfCoords, zfOffset);
-    INDEX2COORDS(numOfElemsToReverse - e - 1, shape::rank(outputShape), outputShape, zlCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zlCoords, zlOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(shape::shapeOf(zShapeInfo)outputShape), zfCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zfCoords, zfOffset);
+    INDEX2COORDS(numOfElemsToReverse - e - 1, shape::rank(outputShape), shape::shapeOf(outputShape), zlCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zlCoords, zlOffset);
 
     outputArr[zfOffset] = v2;
     outputArr[zlOffset] = v1;
@@ -166,10 +166,10 @@ static SD_KERNEL void reverseArrayKernel(const void* input, const LongType* inpu
     LongType xOffset;
     LongType zOffset;
 
-    INDEX2COORDS(limit, shape::rank(inputShape), inputShape, xCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
-    INDEX2COORDS(limit, shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zOffset);
+    INDEX2COORDS(limit, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
+    INDEX2COORDS(limit, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zOffset);
 
     outputArr[zOffset] = inputArr[xOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/roll.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/roll.cu
@@ -49,15 +49,15 @@ static void SD_DEVICE rollKernelLinearStage1Dev(const void *vx, const LongType *
   for (LongType i = tid; i < actualShift; i += blockDim.x * gridDim.x) {
     int sourceIndex = fullLength - actualShift + i;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffsetA);
-    INDEX2COORDS(sourceIndex, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffsetB);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffsetA);
+    INDEX2COORDS(sourceIndex, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffsetB);
 
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffsetA);
-    INDEX2COORDS(sourceIndex, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffsetB);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffsetA);
+    INDEX2COORDS(sourceIndex, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffsetB);
 
     auto eA = x[xOffsetA];
     auto eB = x[xOffsetB];
@@ -94,15 +94,15 @@ static void SD_KERNEL rollKernelLinearStage2(const void *vx, const LongType *xSh
       int destinationIndex = fullLength - (count + 1) * actualShift + i;
       int sourceIndex = fullLength - count * actualShift + i;
 
-      INDEX2COORDS(destinationIndex, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffsetA);
-      INDEX2COORDS(sourceIndex, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffsetB);
+      INDEX2COORDS(destinationIndex, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffsetA);
+      INDEX2COORDS(sourceIndex, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffsetB);
 
-      INDEX2COORDS(destinationIndex, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffsetA);
-      INDEX2COORDS(sourceIndex, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffsetB);
+      INDEX2COORDS(destinationIndex, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffsetA);
+      INDEX2COORDS(sourceIndex, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffsetB);
 
       auto eA = x[xOffsetB];
       auto eB = x[xOffsetA];
@@ -137,15 +137,15 @@ static void SD_KERNEL rollKernelLinearStage3(const void *vx, const LongType *xSh
     LongType zOffsetA;
     LongType zOffsetB;
 
-    INDEX2COORDS(remainIdx, shape::rank(xShapeInfo), xShapeInfo, xCoordsA);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoordsA, xOffsetA);
-    INDEX2COORDS(sourceIndex, shape::rank(xShapeInfo), xShapeInfo, xCoordsB);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoordsB, xOffsetB);
+    INDEX2COORDS(remainIdx, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoordsA);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoordsA, xOffsetA);
+    INDEX2COORDS(sourceIndex, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoordsB);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoordsB, xOffsetB);
 
-    INDEX2COORDS(remainIdx, shape::rank(zShapeInfo), zShapeInfo, zCoordsA);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoordsA, zOffsetA);
-    INDEX2COORDS(sourceIndex, shape::rank(zShapeInfo), zShapeInfo, zCoordsB);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoordsB, zOffsetB);
+    INDEX2COORDS(remainIdx, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoordsA);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoordsA, zOffsetA);
+    INDEX2COORDS(sourceIndex, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoordsB);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoordsB, zOffsetB);
 
     auto eA = x[xOffsetA];
     auto eB = x[xOffsetB];
@@ -166,8 +166,8 @@ static void SD_DEVICE swapTadsKernel(void *vx, void *vz, const LongType *zShapeI
     LongType zCoords[SD_MAX_RANK];
     LongType zOffset;
 
-    INDEX2COORDS(e, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     auto eA = x[zOffset];
     auto eB = z[zOffset];

--- a/libnd4j/include/ops/declarable/helpers/cuda/s_t_b.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/s_t_b.cu
@@ -59,16 +59,16 @@ SD_KERNEL static void batchToSpaceCuda(const void* vx, const LongType* xShapeInf
 
   if (i >= zLen) return;
 
-  INDEX2COORDS(i, rank, zShapeInfo, coords);
+  INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), coords);
 
   LongType zOffset;
-  COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+  COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
   coords[1] += cropBottom;
   coords[2] += cropLeft;
 
   LongType xOffset;
-  COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+  COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
 
   z[zOffset] = x[xOffset];
 }
@@ -161,10 +161,10 @@ SD_KERNEL static void batchToSpaceNDCuda(const void* vx, const LongType* xShapeI
   LongType* coords = sharedMem + threadIdx.x * rank;
 
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < zLen; i += gridDim.x * blockDim.x) {
-    INDEX2COORDS(i, rank, zShapeInfo, coords);
+    INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), coords);
 
     LongType zOffset;
-    COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
     // evaluate spatial coordinates for x
     for (LongType j = 1; j <= numOfSpatialDims; ++j) {
@@ -173,7 +173,7 @@ SD_KERNEL static void batchToSpaceNDCuda(const void* vx, const LongType* xShapeI
     }
 
     LongType xOffset;
-    COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
 
     z[zOffset] = x[xOffset];
   }
@@ -297,10 +297,10 @@ SD_KERNEL static void spaceToBatchCuda(const void* vx, const LongType* xShapeInf
 
   if (i >= zLen) return;
 
-  INDEX2COORDS(i, rank, zShapeInfo, coords);
+  INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), coords);
 
   LongType zOffset;
-  COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+  COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
   if (coords[1] >= padBottom && coords[1] < zShapeInfo[2] - padTop && coords[2] >= padLeft &&
       coords[2] < zShapeInfo[3] - padRight) {
@@ -308,7 +308,7 @@ SD_KERNEL static void spaceToBatchCuda(const void* vx, const LongType* xShapeInf
     coords[2] -= padLeft;
 
     LongType xOffset;
-    COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
 
     z[zOffset] = x[xOffset];
   } else
@@ -411,10 +411,10 @@ SD_KERNEL static void spaceToBatchNDCuda(const void* vx, const LongType* xShapeI
   auto coords = sharedMem + threadIdx.x * rank;
 
   for (LongType i = blockDim.x * blockIdx.x + threadIdx.x; i < zLen; i += totalThreads) {
-    INDEX2COORDS(i, rank, zShapeInfo, coords);
+    INDEX2COORDS(i, rank, shape::shapeOf(zShapeInfo), coords);
 
     LongType zOffset;
-    COORDS2INDEX(rank, shape::shapeOf(zShapeInfo), coords, zOffset);
+    COORDS2INDEX(rank, shape::stride(zShapeInfo), coords, zOffset);
 
     bool within = true;
 
@@ -433,7 +433,7 @@ SD_KERNEL static void spaceToBatchNDCuda(const void* vx, const LongType* xShapeI
     }
 
     LongType xOffset;
-    COORDS2INDEX(rank, shape::shapeOf(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
 
     if (within)
       z[zOffset] = x[xOffset];

--- a/libnd4j/include/ops/declarable/helpers/cuda/scatter_simple.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/scatter_simple.cu
@@ -50,19 +50,19 @@ static SD_KERNEL void scatterSimpleKernel(void* vx, const LongType* xTadShape, c
     auto x = reinterpret_cast<X*>(vx) + xTadOffsets[i];
     LongType idxCoords[SD_MAX_RANK];
     LongType idxOffset;
-    INDEX2COORDS(i, shape::rank(iShapeInfo), iShapeInfo, idxCoords);
-    COORDS2INDEX(shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), idxCoords, idxOffset);
+    INDEX2COORDS(i, shape::rank(iShapeInfo), shape::shapeOf(iShapeInfo), idxCoords);
+    COORDS2INDEX(shape::rank(iShapeInfo), shape::stride(iShapeInfo), idxCoords, idxOffset);
     auto idx = indices[idxOffset];
 
     LongType xCoords[SD_MAX_RANK];
     LongType xOffset;
-    INDEX2COORDS(idx, shape::rank(xTadShape), xTadShape, xCoords);
-    COORDS2INDEX(shape::rank(xTadShape), shape::shapeOf(xTadShape), xCoords, xOffset);
+    INDEX2COORDS(idx, shape::rank(xTadShape), shape::shapeOf(xTadShape), xCoords);
+    COORDS2INDEX(shape::rank(xTadShape), shape::stride(xTadShape), xCoords, xOffset);
 
     LongType uCoords[SD_MAX_RANK];
     LongType uOffset;
-    INDEX2COORDS(i, shape::rank(uShapeInfo), uShapeInfo, uCoords);
-    COORDS2INDEX(shape::rank(uShapeInfo), shape::shapeOf(uShapeInfo), uCoords, uOffset);
+    INDEX2COORDS(i, shape::rank(uShapeInfo), shape::shapeOf(uShapeInfo), uCoords);
+    COORDS2INDEX(shape::rank(uShapeInfo), shape::stride(uShapeInfo), uCoords, uOffset);
 
     x[xOffset] = u[uOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/scatter_update.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/scatter_update.cu
@@ -67,10 +67,10 @@ SD_KERNEL static void scatterUpdateCuda(const int opCode, const int numOfInd, vo
       LongType xOffset;
       LongType yOffset;
 
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-      INDEX2COORDS(i, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-      COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(i, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+      COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
 
       switch (opCode) {
         case 0:

--- a/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/segment_sum.cu
@@ -59,16 +59,16 @@ static SD_KERNEL void segmentSumLinearKernel(const void* input, const LongType* 
 
     if (segment < numOfClasses) {
       LongType zCoords[SD_MAX_RANK];
-      INDEX2COORDS(segment, shape::rank(outputShape), outputShape, zCoords);
-      COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zIndex);
+      INDEX2COORDS(segment, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+      COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zIndex);
       if(zIndex >= zLen)
         return;
       start = starts[segment];
       finish = start + lengths[segment];
       LongType xCoords[SD_MAX_RANK];
-      INDEX2COORDS(start, shape::rank(inputShape), inputShape, xCoords);
+      INDEX2COORDS(start, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
       LongType xOffset;
-      COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
+      COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
       z[zIndex] = x[xOffset];
     }
   }
@@ -76,9 +76,9 @@ static SD_KERNEL void segmentSumLinearKernel(const void* input, const LongType* 
 
   for (auto e = start + threadIdx.x + 1; e < finish; e += blockDim.x) {
     LongType xCoords[SD_MAX_RANK];
-    INDEX2COORDS(e, shape::rank(inputShape), inputShape, xCoords);
+    INDEX2COORDS(e, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
     LongType xOffset;
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
     if (xOffset >= xLen) return;
     math::atomics::sd_atomicAdd(&z[zIndex], x[xOffset]);
   }
@@ -105,13 +105,13 @@ static SD_KERNEL void unsortedSegmentSumLinearKernel(const void* input, const Lo
     zLen = shape::length(outputShape);
 
     LongType zCoords[SD_MAX_RANK];
-    INDEX2COORDS(segment, shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zIndex);
+    INDEX2COORDS(segment, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zIndex);
     if (lengths[segment] > 0) {
       LongType xCoords[SD_MAX_RANK];
       LongType xOffset;
-      INDEX2COORDS(starts[segment], shape::rank(inputShape), inputShape, xCoords);
-      COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
+      INDEX2COORDS(starts[segment], shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
+      COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
       z[zIndex] = x[xOffset];
     } else {
       z[zIndex] = 0;
@@ -126,10 +126,10 @@ static SD_KERNEL void unsortedSegmentSumLinearKernel(const void* input, const Lo
       LongType xIndex;
       LongType yIndex;
 
-      INDEX2COORDS(e, shape::rank(inputShape), inputShape, xCoords);
-      COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xIndex);
-      INDEX2COORDS(e, shape::rank(indicesShape), indicesShape, yCoords);
-      COORDS2INDEX(shape::rank(indicesShape), shape::shapeOf(indicesShape), yCoords, yIndex);
+      INDEX2COORDS(e, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
+      COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xIndex);
+      INDEX2COORDS(e, shape::rank(indicesShape), shape::shapeOf(indicesShape), yCoords);
+      COORDS2INDEX(shape::rank(indicesShape), shape::stride(indicesShape), yCoords, yIndex);
 
       if (y[yIndex] == segment && e != starts[segment]) {
         math::atomics::sd_atomicAdd(&z[zIndex], x[xIndex]);
@@ -167,10 +167,10 @@ static SD_KERNEL void segmentSumTadKernel(void* inputBuf, const LongType* inputS
       LongType xIndex;
       LongType zIndex;
 
-      INDEX2COORDS(e, shape::rank(inputTads), inputTads, xCoords);
-      COORDS2INDEX(shape::rank(inputTads), shape::shapeOf(inputTads), xCoords, xIndex);
-      INDEX2COORDS(e, shape::rank(outputTads), outputTads, zCoords);
-      COORDS2INDEX(shape::rank(outputTads), shape::shapeOf(outputTads), zCoords, zIndex);
+      INDEX2COORDS(e, shape::rank(inputTads), shape::shapeOf(inputTads), xCoords);
+      COORDS2INDEX(shape::rank(inputTads), shape::stride(inputTads), xCoords, xIndex);
+      INDEX2COORDS(e, shape::rank(outputTads), shape::shapeOf(outputTads), zCoords);
+      COORDS2INDEX(shape::rank(outputTads), shape::stride(outputTads), zCoords, zIndex);
 
       math::atomics::sd_atomicAdd(&z[zIndex], x[xIndex]);
     }
@@ -313,15 +313,15 @@ static SD_KERNEL void segmentSumBPLinearKernel(const void* inputBuf, const LongT
     LongType yOffset;
     LongType gradOffsetO;
 
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zOffset);
-    INDEX2COORDS(e, shape::rank(inputShape), inputShape, xCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
-    INDEX2COORDS(e, shape::rank(indicesShape), indicesShape, yCoords);
-    COORDS2INDEX(shape::rank(indicesShape), shape::shapeOf(indicesShape), yCoords, yOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(indicesShape), shape::shapeOf(indicesShape), yCoords);
+    COORDS2INDEX(shape::rank(indicesShape), shape::stride(indicesShape), yCoords, yOffset);
     auto classIndex = y[yOffset];
-    INDEX2COORDS(classIndex, shape::rank(epsShape), epsShape, zCoords);
-    COORDS2INDEX(shape::rank(epsShape), shape::shapeOf(epsShape), zCoords, gradOffsetO);
+    INDEX2COORDS(classIndex, shape::rank(epsShape), shape::shapeOf(epsShape), zCoords);
+    COORDS2INDEX(shape::rank(epsShape), shape::stride(epsShape), zCoords, gradOffsetO);
 
     z[zOffset] = gradOut[gradOffsetO];
   }
@@ -356,8 +356,8 @@ static SD_KERNEL void segmentSumBPTadKernel(const void* inputBuf, const LongType
   for (auto i = blockIdx.x; i < yLen; i += gridDim.x) {
     LongType yCoords[SD_MAX_RANK];
     LongType yIndex;
-    INDEX2COORDS(i, shape::rank(indicesShape), indicesShape, yCoords);
-    COORDS2INDEX(shape::rank(indicesShape), shape::shapeOf(indicesShape), yCoords, yIndex);
+    INDEX2COORDS(i, shape::rank(indicesShape), shape::shapeOf(indicesShape), yCoords);
+    COORDS2INDEX(shape::rank(indicesShape), shape::stride(indicesShape), yCoords, yIndex);
     auto segment = y[yIndex];
     auto currentOut = z + outOffsets[i];
     auto outGrad = gradOut + gradOutOffsets[segment];

--- a/libnd4j/include/ops/declarable/helpers/cuda/sequence_mask.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/sequence_mask.cu
@@ -49,11 +49,11 @@ static SD_KERNEL void sequenceMaskKernel(const void* inputBuf, const LongType* i
 
   for (auto i = blockIdx.x; i < maxIndex; i += gridDim.x)
     for (auto k = threadIdx.x; k < inputLen; k += blockDim.x) {
-      INDEX2COORDS(k, shape::rank(inputShape), inputShape, inputCoords);
-      COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords, inputOffset);
+      INDEX2COORDS(k, shape::rank(inputShape), shape::shapeOf(inputShape), inputCoords);
+      COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), inputCoords, inputOffset);
       if (i < input[inputOffset]) {
-        INDEX2COORDS(k * maxIndex + i, shape::rank(outputShape), outputShape, outputCoords);
-        COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords, outputOffset);
+        INDEX2COORDS(k * maxIndex + i, shape::rank(outputShape), shape::shapeOf(outputShape), outputCoords);
+        COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), outputCoords, outputOffset);
         output[outputOffset] = B(true);
       }
     }

--- a/libnd4j/include/ops/declarable/helpers/cuda/split.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/split.cu
@@ -60,17 +60,17 @@ SD_KERNEL static void splitCuda(const void* vx, const LongType* xShapeInfo, void
   LongType coords[SD_MAX_RANK];
 
   for (LongType i = tid; i < xLen; i += totalThreads) {
-    INDEX2COORDS(i, xRank, xShapeInfo, coords);
+    INDEX2COORDS(i, xRank, shape::shapeOf(xShapeInfo), coords);
 
     LongType xOffset;
-    COORDS2INDEX(xRank, shape::shapeOf(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(xRank, shape::stride(xShapeInfo), coords, xOffset);
 
     auto* z = reinterpret_cast<T*>(reinterpret_cast<void**>(pVz)[coords[axis] / zDim]);
 
     coords[axis] %= zDim;
 
     LongType zOffset;
-    COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), coords, zOffset);
+    COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), coords, zOffset);
 
     z[zOffset] = x[xOffset];
   }

--- a/libnd4j/include/ops/declarable/helpers/cuda/sru.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/sru.cu
@@ -155,12 +155,12 @@ SD_KERNEL static void sruBICuda(const void* vx, const LongType* xShapeInfo, cons
 
   if (tid >= len) return;
 
-  INDEX2COORDS(tid, rank - 1, xShapeInfo + 2, coords + 1);  // loop through last two dimensions of x : {bS, 2*K}
+  INDEX2COORDS(tid, rank - 1, shape::shapeOf(xShapeInfo), coords + 1);  // loop through last two dimensions of x : {bS, 2*K}
 
   LongType maskOffst, c0Offset, bFOffset, bROffset;
-  COORDS2INDEX(rank - 1, maskShapeInfo + 1, coords + 1, maskOffst);
-  COORDS2INDEX(rank - 1, c0ShapeInfo + 1, coords + 1, c0Offset);
-  COORDS2INDEX(rank - 1, bShapeInfo + 2, coords + 2, bFOffset);
+  COORDS2INDEX(rank - 1, shape::stride(maskShapeInfo), coords + 1, maskOffst);
+  COORDS2INDEX(rank - 1, shape::stride(c0ShapeInfo), coords + 1, c0Offset);
+  COORDS2INDEX(rank - 1, shape::stride(bShapeInfo), coords + 2, bFOffset);
   bROffset = bFOffset + 2 * K * bShapeInfo[2];  // 2*K*b_stride
 
   const T maskVal = mask ? mask[maskOffst] : static_cast<T>(1);
@@ -176,13 +176,13 @@ SD_KERNEL static void sruBICuda(const void* vx, const LongType* xShapeInfo, cons
     coords[0] = 0;
 
   LongType xOffset, htOffset, ctOffset;
-  COORDS2INDEX(rank, xShapeInfo, coords, xOffset);
-  COORDS2INDEX(rank, htShapeInfo, coords, htOffset);
-  COORDS2INDEX(rank, ctShapeInfo, coords, ctOffset);
+  COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
+  COORDS2INDEX(rank, shape::stride(htShapeInfo), coords, htOffset);
+  COORDS2INDEX(rank, shape::stride(ctShapeInfo), coords, ctOffset);
 
   coords[2] *= 3;
   LongType wiOffset0, wiOffset1, wiOffset2;
-  COORDS2INDEX(rank, wiShapeInfo, coords, wiOffset0);
+  COORDS2INDEX(rank, shape::stride(wiShapeInfo), coords, wiOffset0);
   wiOffset1 = wiOffset0 + wiShapeInfo[rank + 3];  // add last stride
   wiOffset2 = wiOffset1 + wiShapeInfo[rank + 3];  // add last stride
 
@@ -320,14 +320,14 @@ SD_KERNEL static void sruBIBPCuda(const void* vx, const LongType* xShapeInfo, co
 
   if (tid >= len) return;
 
-  INDEX2COORDS(tid, rank - 1, xShapeInfo + 2, coords + 1);  // loop through last two dimensions of x : {bS, 2*K}
+  INDEX2COORDS(tid, rank - 1, shape::shapeOf(xShapeInfo), coords + 1);  // loop through last two dimensions of x : {bS, 2*K}
 
   LongType maskOffst, c0Offset, gradCtOffset, gradC0Offset, bFOffset, bROffset, gradBFOffset, gradBROffset;
-  if (mask) COORDS2INDEX(rank - 1, maskShapeInfo + 1, coords + 1, maskOffst);
-  COORDS2INDEX(rank - 1, c0ShapeInfo + 1, coords + 1, c0Offset);
-  COORDS2INDEX(rank - 1, gradCtShapeInfo + 1, coords + 1, gradCtOffset);
-  COORDS2INDEX(rank - 1, gradC0ShapeInfo + 1, coords + 1, gradC0Offset);
-  COORDS2INDEX(rank - 1, bShapeInfo + 2, coords + 2, bFOffset);
+  if (mask) COORDS2INDEX(rank - 1, shape::stride(maskShapeInfo), coords + 1, maskOffst);
+  COORDS2INDEX(rank - 1, shape::stride(c0ShapeInfo), coords + 1, c0Offset);
+  COORDS2INDEX(rank - 1, shape::stride(gradCtShapeInfo), coords + 1, gradCtOffset);
+  COORDS2INDEX(rank - 1, shape::stride(gradC0ShapeInfo), coords + 1, gradC0Offset);
+  COORDS2INDEX(rank - 1, shape::stride(bShapeInfo), coords + 2, bFOffset);
   bROffset = bFOffset + 2 * K * bShapeInfo[2];  // 2*K*b_stride
   gradBFOffset = coords[1] * gradBShapeInfo[3] / 2 + coords[2] * gradBShapeInfo[4];
   gradBROffset = gradBFOffset + gradBShapeInfo[3];
@@ -340,17 +340,17 @@ SD_KERNEL static void sruBIBPCuda(const void* vx, const LongType* xShapeInfo, co
     coords[0] = time - 1;
 
   LongType xOffset, ctOffset, gradIOffset, gradHtOffset;
-  COORDS2INDEX(rank, xShapeInfo, coords, xOffset);
-  COORDS2INDEX(rank, ctShapeInfo, coords, ctOffset);
-  COORDS2INDEX(rank, gradIShapeInfo, coords, gradIOffset);
-  COORDS2INDEX(rank, gradHtShapeInfo, coords, gradHtOffset);
+  COORDS2INDEX(rank, shape::stride(xShapeInfo), coords, xOffset);
+  COORDS2INDEX(rank, shape::stride(ctShapeInfo), coords, ctOffset);
+  COORDS2INDEX(rank, shape::stride(gradIShapeInfo), coords, gradIOffset);
+  COORDS2INDEX(rank, shape::stride(gradHtShapeInfo), coords, gradHtOffset);
 
   coords[2] *= 3;
   LongType gradWiOffset0, gradWiOffset1, gradWiOffset2, wiOffset0, wiOffset1, wiOffset2;
-  COORDS2INDEX(rank, gradWiShapeInfo, coords, gradWiOffset0);
+  COORDS2INDEX(rank, shape::stride(gradWiShapeInfo), coords, gradWiOffset0);
   gradWiOffset1 = gradWiOffset0 + gradWiShapeInfo[rank + 3];  // add last stride
   gradWiOffset2 = gradWiOffset1 + gradWiShapeInfo[rank + 3];  // add last stride
-  COORDS2INDEX(rank, wiShapeInfo, coords, wiOffset0);
+  COORDS2INDEX(rank, shape::stride(wiShapeInfo), coords, wiOffset0);
   wiOffset1 = wiOffset0 + wiShapeInfo[rank + 3];  // add last stride
   wiOffset2 = wiOffset1 + wiShapeInfo[rank + 3];  // add last stride
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/stack.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/stack.cu
@@ -53,8 +53,8 @@ static SD_KERNEL void stackScalarsCuda(void* pVx, void* vz, const LongType* zSha
     const T* x = reinterpret_cast<const T*>(reinterpret_cast<void**>(pVx)[i]);
     LongType zOffset;
     LongType zCoords[SD_MAX_RANK];
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
     z[zOffset] = *x;
   }
 }
@@ -139,8 +139,8 @@ static SD_KERNEL void unstackScalarsCuda(const void* vx, const LongType* xShapeI
 
   for (LongType i = tid; i < xLen; i += totalThreads) {
     T* z = reinterpret_cast<T*>(reinterpret_cast<void**>(pVz)[i]);
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
     *z = x[xOffset];
   }
 }

--- a/libnd4j/include/ops/declarable/helpers/cuda/top_k.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/top_k.cu
@@ -51,13 +51,13 @@ SD_KERNEL static void inTopKCuda(const void* vx, const LongType* xShapeInfo, con
     xTad = reinterpret_cast<const X*>(vx) + xTadOffsets[blockIdx.x];
     LongType yCoords[SD_MAX_RANK];
     LongType yOffset;
-    INDEX2COORDS(blockIdx.x, shape::rank(yShapeInfo), yShapeInfo, yCoords);
-    COORDS2INDEX(shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords, yOffset);
+    INDEX2COORDS(blockIdx.x, shape::rank(yShapeInfo), shape::shapeOf(yShapeInfo), yCoords);
+    COORDS2INDEX(shape::rank(yShapeInfo), shape::stride(yShapeInfo), yCoords, yOffset);
     idx = y[yOffset];
     LongType xCoords[SD_MAX_RANK];
     LongType xOffset;
-    INDEX2COORDS(idx, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(idx, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, xOffset);
     elemToCompare = xTad[xOffset];
   }
 
@@ -67,8 +67,8 @@ SD_KERNEL static void inTopKCuda(const void* vx, const LongType* xShapeInfo, con
   for (LongType i = threadIdx.x; i < xTadLen; i += blockDim.x) {
     LongType xCoords[SD_MAX_RANK];
     LongType xOffset;
-    INDEX2COORDS(i, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, xOffset);
     if (elemToCompare < xTad[xOffset]) ++sharedMem[threadIdx.x];
   }
 
@@ -83,8 +83,8 @@ SD_KERNEL static void inTopKCuda(const void* vx, const LongType* xShapeInfo, con
   if (threadIdx.x == 0) {
     LongType zCoords[SD_MAX_RANK];
     LongType zOffset;
-    INDEX2COORDS(blockIdx.x, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(blockIdx.x, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
     z[zOffset] = *sharedMem < k;
   }
 }
@@ -144,15 +144,15 @@ static SD_KERNEL void topValuesMover(void const* vx, LongType const* xTadShapeIn
     LongType xOffset;
 
     for (int e = threadIdx.x; e < k; e += blockDim.x) {
-      INDEX2COORDS(e, shape::rank(iTadShapeInfo), iTadShapeInfo, iCoords);
-      COORDS2INDEX(shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), iCoords, iOffset);
+      INDEX2COORDS(e, shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), iCoords);
+      COORDS2INDEX(shape::rank(iTadShapeInfo), shape::stride(iTadShapeInfo), iCoords, iOffset);
       auto idx = i[iOffset];
 
-      INDEX2COORDS(e, shape::rank(zTadShapeInfo), zTadShapeInfo, zCoords);
-      COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords, zOffset);
+      INDEX2COORDS(e, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords);
+      COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zCoords, zOffset);
 
-      INDEX2COORDS(idx, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-      COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, xOffset);
+      INDEX2COORDS(idx, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+      COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, xOffset);
 
       z[zOffset] = x[xOffset];
     }
@@ -191,8 +191,8 @@ static SD_KERNEL void indicesAlongDimension(void const* vx, LongType const* xTad
       for (int e = threadIdx.x; e < tadLength; e++) {
         LongType xCoords[SD_MAX_RANK];
         LongType xOffset;
-        INDEX2COORDS(e, shape::rank(xTadShapeInfo), xTadShapeInfo, xCoords);
-        COORDS2INDEX(shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords, xOffset);
+        INDEX2COORDS(e, shape::rank(xTadShapeInfo), shape::shapeOf(xTadShapeInfo), xCoords);
+        COORDS2INDEX(shape::rank(xTadShapeInfo), shape::stride(xTadShapeInfo), xCoords, xOffset);
         auto value = x[xOffset];
 
         // we'll compare this value to current stored ones
@@ -223,13 +223,13 @@ static SD_KERNEL void indicesAlongDimension(void const* vx, LongType const* xTad
         localMaximum = tempValues[scanWidth - 1];
         LongType zCoords[SD_MAX_RANK];
         LongType zOffset;
-        INDEX2COORDS(p, shape::rank(zTadShapeInfo), zTadShapeInfo, zCoords);
-        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords, zOffset);
+        INDEX2COORDS(p, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zCoords);
+        COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zCoords, zOffset);
         z[zOffset] = tempValues[scanWidth - 1];
         LongType iCoords[SD_MAX_RANK];
         LongType iOffset;
-        INDEX2COORDS(p, shape::rank(iTadShapeInfo), iTadShapeInfo, iCoords);
-        COORDS2INDEX(shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), iCoords, iOffset);
+        INDEX2COORDS(p, shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), iCoords);
+        COORDS2INDEX(shape::rank(iTadShapeInfo), shape::stride(iTadShapeInfo), iCoords, iOffset);
         i[iOffset] = tempIndices[scanWidth - 1];
       }
       __syncthreads();
@@ -245,12 +245,12 @@ static SD_KERNEL void indicesAlongDimension(void const* vx, LongType const* xTad
             if (top < k) {
               LongType t0Coords[SD_MAX_RANK];
               LongType t0Offset;
-              INDEX2COORDS(top - 1, shape::rank(iTadShapeInfo), iTadShapeInfo, t0Coords);
-              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t0Coords, t0Offset);
+              INDEX2COORDS(top - 1, shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t0Coords);
+              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::stride(iTadShapeInfo), t0Coords, t0Offset);
               LongType t1Coords[SD_MAX_RANK];
               LongType t1Offset;
-              INDEX2COORDS(top, shape::rank(iTadShapeInfo), iTadShapeInfo, t1Coords);
-              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t1Coords, t1Offset);
+              INDEX2COORDS(top, shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t1Coords);
+              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::stride(iTadShapeInfo), t1Coords, t1Offset);
 
               if (i[t0Offset] > i[t1Offset]) {
                 // swap indices first
@@ -261,12 +261,12 @@ static SD_KERNEL void indicesAlongDimension(void const* vx, LongType const* xTad
                 // swap values next
                 LongType zT0Coords[SD_MAX_RANK];
                 LongType zT0Offset;
-                INDEX2COORDS(top - 1, shape::rank(zTadShapeInfo), zTadShapeInfo, zT0Coords);
-                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT0Coords, zT0Offset);
+                INDEX2COORDS(top - 1, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT0Coords);
+                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zT0Coords, zT0Offset);
                 LongType zT1Coords[SD_MAX_RANK];
                 LongType zT1Offset;
-                INDEX2COORDS(top, shape::rank(zTadShapeInfo), zTadShapeInfo, zT1Coords);
-                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT1Coords, zT1Offset);
+                INDEX2COORDS(top, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT1Coords);
+                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zT1Coords, zT1Offset);
 
                 X dz0 = z[zT0Offset];
                 z[zT0Offset] = z[zT1Offset];
@@ -280,12 +280,12 @@ static SD_KERNEL void indicesAlongDimension(void const* vx, LongType const* xTad
             if (top < k) {
               LongType t0Coords[SD_MAX_RANK];
               LongType t0Offset;
-              INDEX2COORDS(top - 1, shape::rank(iTadShapeInfo), iTadShapeInfo, t0Coords);
-              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t0Coords, t0Offset);
+              INDEX2COORDS(top - 1, shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t0Coords);
+              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::stride(iTadShapeInfo), t0Coords, t0Offset);
               LongType t1Coords[SD_MAX_RANK];
               LongType t1Offset;
-              INDEX2COORDS(top, shape::rank(iTadShapeInfo), iTadShapeInfo, t1Coords);
-              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t1Coords, t1Offset);
+              INDEX2COORDS(top, shape::rank(iTadShapeInfo), shape::shapeOf(iTadShapeInfo), t1Coords);
+              COORDS2INDEX(shape::rank(iTadShapeInfo), shape::stride(iTadShapeInfo), t1Coords, t1Offset);
 
               if (i[t0Offset] > i[t1Offset]) {
                 // swap indices first
@@ -296,12 +296,12 @@ static SD_KERNEL void indicesAlongDimension(void const* vx, LongType const* xTad
                 // swap values next
                 LongType zT0Coords[SD_MAX_RANK];
                 LongType zT0Offset;
-                INDEX2COORDS(top - 1, shape::rank(zTadShapeInfo), zTadShapeInfo, zT0Coords);
-                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT0Coords, zT0Offset);
+                INDEX2COORDS(top - 1, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT0Coords);
+                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zT0Coords, zT0Offset);
                 LongType zT1Coords[SD_MAX_RANK];
                 LongType zT1Offset;
-                INDEX2COORDS(top, shape::rank(zTadShapeInfo), zTadShapeInfo, zT1Coords);
-                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT1Coords, zT1Offset);
+                INDEX2COORDS(top, shape::rank(zTadShapeInfo), shape::shapeOf(zTadShapeInfo), zT1Coords);
+                COORDS2INDEX(shape::rank(zTadShapeInfo), shape::stride(zTadShapeInfo), zT1Coords, zT1Offset);
 
                 X dz0 = z[zT0Offset];
                 z[zT0Offset] = z[zT1Offset];

--- a/libnd4j/include/ops/declarable/helpers/cuda/triangular_solve.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/triangular_solve.cu
@@ -181,8 +181,8 @@ static SD_KERNEL void upperAdjointKernel(T const* input, T* output, LongType bat
         LongType zPos[] = {r, c};
         LongType xPos[] = {c, r};
         LongType zIndex, xIndex;
-        COORDS2INDEX(2, outputTads + 1, zPos, zIndex);
-        COORDS2INDEX(2, inputTads + 1, xPos, xIndex);
+        COORDS2INDEX(2, shape::stride(outputTads), zPos, zIndex);
+        COORDS2INDEX(2, shape::stride(inputTads), xPos, xIndex);
         outputPart[zIndex] = inputPart[xIndex];
       }
     }
@@ -201,8 +201,8 @@ static SD_KERNEL void lowerAdjointKernel(T const* input, T* output, LongType bat
         LongType zPos[] = {r, c};
         LongType xPos[] = {c, r};
         LongType zIndex, xIndex;
-        COORDS2INDEX(2, outputTads + 1, zPos, zIndex);
-        COORDS2INDEX(2, inputTads + 1, xPos, xIndex);
+        COORDS2INDEX(2, shape::stride(outputTads), zPos, zIndex);
+        COORDS2INDEX(2, shape::stride(inputTads), xPos, xIndex);
         outputPart[zIndex] = inputPart[xIndex];
       }
     }

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaBelief.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaBelief.cu
@@ -84,35 +84,35 @@ SD_KERNEL void adaBeliefUpdaterCuda(const void* vx, const LongType* xShapeInfo, 
     LongType xOffset, zOffset, initMOffset, initUOffset, stMOffset, stUOffset;
 
     INDEX2COORDS(i, shape::rank(xShapeInfo),shape::shapeOf(xShapeInfo), coords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
     if (bXZsame) {
       zOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     if (bXInUSame) {
       initUOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(invShapeInfo), shape::shapeOf(invShapeInfo), coords, initUOffset);
+      COORDS2INDEX(shape::rank(invShapeInfo), shape::stride(invShapeInfo), coords, initUOffset);
     }
 
     if (bXStUSame) {
       stUOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stvShapeInfo), shape::shapeOf(stvShapeInfo), coords, stUOffset);
+      COORDS2INDEX(shape::rank(stvShapeInfo), shape::stride(stvShapeInfo), coords, stUOffset);
     }
 
     if (bXInMSame) {
       initMOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(inmShapeInfo), shape::shapeOf(inmShapeInfo), coords, initMOffset);
+      COORDS2INDEX(shape::rank(inmShapeInfo), shape::stride(inmShapeInfo), coords, initMOffset);
     }
 
     if (bXStMSame) {
       stMOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stmShapeInfo), shape::shapeOf(stmShapeInfo), coords, stMOffset);
+      COORDS2INDEX(shape::rank(stmShapeInfo), shape::stride(stmShapeInfo), coords, stMOffset);
     }
 
     stM[stMOffset] = beta1 * initM[initMOffset] + grad[xOffset] * (1 - beta1);

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaDelta.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaDelta.cu
@@ -76,36 +76,36 @@ SD_KERNEL void adaDeltaUpdaterCuda(const void* vx, const LongType* xShapeInfo, c
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < xLen; i += gridDim.x * blockDim.x) {
     LongType xOffset, zOffset, initMsgOffset, initMsdxOffset, stMsgOffset, stMsdxOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
     if (bXZsame) {
       zOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     if (bXInMsgSame) {
       initMsgOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(inMsgShapeInfo), shape::shapeOf(inMsgShapeInfo), coords, initMsgOffset);
+      COORDS2INDEX(shape::rank(inMsgShapeInfo), shape::stride(inMsgShapeInfo), coords, initMsgOffset);
     }
 
     if (bXStMsgSame) {
       stMsgOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stMsgShapeInfo), shape::shapeOf(stMsgShapeInfo), coords, stMsgOffset);
+      COORDS2INDEX(shape::rank(stMsgShapeInfo), shape::stride(stMsgShapeInfo), coords, stMsgOffset);
     }
 
     if (bXInMsdxSame) {
       initMsdxOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(inMsdxShapeInfo), shape::shapeOf(inMsdxShapeInfo), coords, initMsdxOffset);
+      COORDS2INDEX(shape::rank(inMsdxShapeInfo), shape::stride(inMsdxShapeInfo), coords, initMsdxOffset);
     }
 
     if (bXStMsdxSame) {
       stMsdxOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stMsdxShapeInfo), shape::shapeOf(stMsdxShapeInfo), coords, stMsdxOffset);
+      COORDS2INDEX(shape::rank(stMsdxShapeInfo), shape::stride(stMsdxShapeInfo), coords, stMsdxOffset);
     }
     stMsg[stMsgOffset] = rho * initMsg[initMsgOffset] + grad[xOffset] * grad[xOffset] * rhoT;
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaGrad.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaGrad.cu
@@ -68,24 +68,24 @@ SD_KERNEL void adaGradUpdaterCuda(const void* vx, const LongType* xShapeInfo, co
     LongType xOffset, zOffset, initOffset, stOffset;
 
     if (!bEWS || !bOrdering) {
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
       if (bXZsame) {
         zOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
       }
 
       if (bXInSame) {
         initOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords, initOffset);
+        COORDS2INDEX(shape::rank(inShapeInfo), shape::stride(inShapeInfo), coords, initOffset);
       }
 
       if (bXStSame) {
         stOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(stShapeInfo), shape::shapeOf(stShapeInfo), coords, stOffset);
+        COORDS2INDEX(shape::rank(stShapeInfo), shape::stride(stShapeInfo), coords, stOffset);
       }
     } else {
       xOffset = zOffset = initOffset = stOffset = i;

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaMax.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdaMax.cu
@@ -78,36 +78,36 @@ SD_KERNEL void adaMaxUpdaterCuda(const void* vx, const LongType* xShapeInfo, con
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < xLen; i += gridDim.x * blockDim.x) {
     LongType xOffset, zOffset, initMOffset, initUOffset, stMOffset, stUOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
     if (bXZsame) {
       zOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     if (bXInUSame) {
       initUOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(invShapeInfo), shape::shapeOf(invShapeInfo), coords, initUOffset);
+      COORDS2INDEX(shape::rank(invShapeInfo), shape::stride(invShapeInfo), coords, initUOffset);
     }
 
     if (bXStUSame) {
       stUOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stvShapeInfo), shape::shapeOf(stvShapeInfo), coords, stUOffset);
+      COORDS2INDEX(shape::rank(stvShapeInfo), shape::stride(stvShapeInfo), coords, stUOffset);
     }
 
     if (bXInMSame) {
       initMOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(inmShapeInfo), shape::shapeOf(inmShapeInfo), coords, initMOffset);
+      COORDS2INDEX(shape::rank(inmShapeInfo), shape::stride(inmShapeInfo), coords, initMOffset);
     }
 
     if (bXStMSame) {
       stMOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stmShapeInfo), shape::shapeOf(stmShapeInfo), coords, stMOffset);
+      COORDS2INDEX(shape::rank(stmShapeInfo), shape::stride(stmShapeInfo), coords, stMOffset);
     }
     // m = B_1 * m + (1-B_1)*grad
     stM[stMOffset] = beta1 * initM[initMOffset] + grad[xOffset] * (1 - beta1);

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAdam.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAdam.cu
@@ -84,13 +84,13 @@ SD_KERNEL void adamUpdaterCuda(const void* vx, const LongType* xShapeInfo, const
     LongType xOffset = i, zOffset = i, initMOffset = i, initUOffset = i, stMOffset = i, stUOffset = i;
 
     if (!bEWS || !bOrdering) {
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
-      if (!bXZsame) COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
-      if (!bXInUSame) COORDS2INDEX(shape::rank(invShapeInfo), shape::shapeOf(invShapeInfo), coords, initUOffset);
-      if (!bXStUSame) COORDS2INDEX(shape::rank(stvShapeInfo), shape::shapeOf(stvShapeInfo), coords, stUOffset);
-      if (!bXInMSame) COORDS2INDEX(shape::rank(inmShapeInfo), shape::shapeOf(inmShapeInfo), coords, initMOffset);
-      if (!bXStMSame) COORDS2INDEX(shape::rank(stmShapeInfo), shape::shapeOf(stmShapeInfo), coords, stMOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
+      if (!bXZsame) COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
+      if (!bXInUSame) COORDS2INDEX(shape::rank(invShapeInfo), shape::stride(invShapeInfo), coords, initUOffset);
+      if (!bXStUSame) COORDS2INDEX(shape::rank(stvShapeInfo), shape::stride(stvShapeInfo), coords, stUOffset);
+      if (!bXInMSame) COORDS2INDEX(shape::rank(inmShapeInfo), shape::stride(inmShapeInfo), coords, initMOffset);
+      if (!bXStMSame) COORDS2INDEX(shape::rank(stmShapeInfo), shape::stride(stmShapeInfo), coords, stMOffset);
     }
 
     stM[stMOffset] = beta1 * initM[initMOffset] + grad[xOffset] * (1 - beta1);

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterAmsGrad.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterAmsGrad.cu
@@ -92,48 +92,48 @@ SD_KERNEL void amsGradUpdaterCuda(const void* vx, const LongType* xShapeInfo, co
         stHOffset = i;
 
     if (!bOrdering) {
-      INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-      COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+      INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+      COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
       if (bXZsame) {
         zOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+        COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
       }
 
       if (bXInMSame) {
         initMOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(inmShapeInfo), shape::shapeOf(inmShapeInfo), coords, initMOffset);
+        COORDS2INDEX(shape::rank(inmShapeInfo), shape::stride(inmShapeInfo), coords, initMOffset);
       }
 
       if (bXStMSame) {
         stMOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(stmShapeInfo), shape::shapeOf(stmShapeInfo), coords, stMOffset);
+        COORDS2INDEX(shape::rank(stmShapeInfo), shape::stride(stmShapeInfo), coords, stMOffset);
       }
 
       if (bXInUSame) {
         initVOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(invShapeInfo), shape::shapeOf(invShapeInfo), coords, initVOffset);
+        COORDS2INDEX(shape::rank(invShapeInfo), shape::stride(invShapeInfo), coords, initVOffset);
       }
 
       if (bXStUSame) {
         stVOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(stvShapeInfo), shape::shapeOf(stvShapeInfo), coords, stVOffset);
+        COORDS2INDEX(shape::rank(stvShapeInfo), shape::stride(stvShapeInfo), coords, stVOffset);
       }
 
       if (bXInHSame) {
         initHOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(inhShapeInfo), shape::shapeOf(inhShapeInfo), coords, initHOffset);
+        COORDS2INDEX(shape::rank(inhShapeInfo), shape::stride(inhShapeInfo), coords, initHOffset);
       }
 
       if (bXStHSame) {
         stHOffset = xOffset;
       } else {
-        COORDS2INDEX(shape::rank(sthShapeInfo), shape::shapeOf(sthShapeInfo), coords, stHOffset);
+        COORDS2INDEX(shape::rank(sthShapeInfo), shape::stride(sthShapeInfo), coords, stHOffset);
       }
     }
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterNadam.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterNadam.cu
@@ -78,36 +78,36 @@ SD_KERNEL void nadamUpdaterCuda(const void* vx, const LongType* xShapeInfo, cons
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < xLen; i += gridDim.x * blockDim.x) {
     LongType xOffset, zOffset, initMOffset, initUOffset, stMOffset, stUOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
     if (bXZsame) {
       zOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     if (bXInUSame) {
       initUOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(invShapeInfo), shape::shapeOf(invShapeInfo), coords, initUOffset);
+      COORDS2INDEX(shape::rank(invShapeInfo), shape::stride(invShapeInfo), coords, initUOffset);
     }
 
     if (bXStUSame) {
       stUOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stvShapeInfo), shape::shapeOf(stvShapeInfo), coords, stUOffset);
+      COORDS2INDEX(shape::rank(stvShapeInfo), shape::stride(stvShapeInfo), coords, stUOffset);
     }
 
     if (bXInMSame) {
       initMOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(inmShapeInfo), shape::shapeOf(inmShapeInfo), coords, initMOffset);
+      COORDS2INDEX(shape::rank(inmShapeInfo), shape::stride(inmShapeInfo), coords, initMOffset);
     }
 
     if (bXStMSame) {
       stMOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stmShapeInfo), shape::shapeOf(stmShapeInfo), coords, stMOffset);
+      COORDS2INDEX(shape::rank(stmShapeInfo), shape::stride(stmShapeInfo), coords, stMOffset);
     }
     auto oneMinusBeta1Grad = grad[xOffset] * mbeta1;
 

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterNesterovs.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterNesterovs.cu
@@ -66,24 +66,24 @@ SD_KERNEL void nesterovsUpdaterCuda(const void* vx, const LongType* xShapeInfo, 
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < xLen; i += gridDim.x * blockDim.x) {
     LongType xOffset, zOffset, initOffset, stOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
     if (bXZsame) {
       zOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     if (bXInSame) {
       initOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords, initOffset);
+      COORDS2INDEX(shape::rank(inShapeInfo), shape::stride(inShapeInfo), coords, initOffset);
     }
 
     if (bXStSame) {
       stOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stShapeInfo), shape::shapeOf(stShapeInfo), coords, stOffset);
+      COORDS2INDEX(shape::rank(stShapeInfo), shape::stride(stShapeInfo), coords, stOffset);
     }
     T prevState = momentum * init[initOffset];
     st[stOffset] = prevState - lr * grad[xOffset];

--- a/libnd4j/include/ops/declarable/helpers/cuda/updaterRmsProp.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/updaterRmsProp.cu
@@ -64,24 +64,24 @@ SD_KERNEL void rmsPropUpdaterCuda(const void *vx, const LongType *xShapeInfo, co
   for (LongType i = blockIdx.x * blockDim.x + threadIdx.x; i < xLen; i += gridDim.x * blockDim.x) {
     LongType xOffset, zOffset, initOffset, stOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, coords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, xOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, xOffset);
     if (bXZsame) {
       zOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), coords, zOffset);
+      COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), coords, zOffset);
     }
 
     if (bXInSame) {
       initOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(inShapeInfo), shape::shapeOf(inShapeInfo), coords, initOffset);
+      COORDS2INDEX(shape::rank(inShapeInfo), shape::stride(inShapeInfo), coords, initOffset);
     }
 
     if (bXStSame) {
       stOffset = xOffset;
     } else {
-      COORDS2INDEX(shape::rank(stShapeInfo), shape::shapeOf(stShapeInfo), coords, stOffset);
+      COORDS2INDEX(shape::rank(stShapeInfo), shape::stride(stShapeInfo), coords, stOffset);
     }
     st[stOffset] = init[initOffset] * rmsDecay + x[xOffset] * x[xOffset] * (1 - rmsDecay);
     up[zOffset] = (lr * x[xOffset]) / (math::sd_sqrt<T, T>(st[stOffset]) + epsilon);

--- a/libnd4j/include/ops/declarable/helpers/cuda/weights.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/weights.cu
@@ -40,14 +40,14 @@ static SD_DEVICE void adjustWeightsKernelD(void* inputBuffer, LongType const* in
   LongType yOffset;
 
   for (LongType e = tid; e < inputLength; e += blockDim.x) {
-    INDEX2COORDS(e, shape::rank(inputShape), inputShape, xCoords);
-    COORDS2INDEX(shape::rank(inputShape), shape::shapeOf(inputShape), xCoords, xOffset);
+    INDEX2COORDS(e, shape::rank(inputShape), shape::shapeOf(inputShape), xCoords);
+    COORDS2INDEX(shape::rank(inputShape), shape::stride(inputShape), xCoords, xOffset);
     if (xOffset >= inputLength) return;
     LongType current = *(reinterpret_cast<LongType*>(inputBuffer) + xOffset);
     if (current == val) {
       if (weightsBuffer != nullptr) {
-        INDEX2COORDS(e, shape::rank(weightsShape), weightsShape, yCoords);
-        COORDS2INDEX(shape::rank(weightsShape), shape::shapeOf(weightsShape), yCoords, yOffset);
+        INDEX2COORDS(e, shape::rank(weightsShape), shape::shapeOf(weightsShape), yCoords);
+        COORDS2INDEX(shape::rank(weightsShape), shape::stride(weightsShape), yCoords, yOffset);
         math::atomics::sd_atomicAdd(
             reinterpret_cast<T*>(outputBuffer),
             reinterpret_cast<T*>(weightsBuffer)[yOffset]);
@@ -71,8 +71,8 @@ static SD_KERNEL void adjustWeightsKernel(void* inputBuffer, LongType const* inp
   for (LongType e = blockIdx.x; e < outputLength; e += threadCount) {
     LongType zCoords[SD_MAX_RANK];
     LongType zOffset;
-    INDEX2COORDS(e, shape::rank(outputShape), outputShape, zCoords);
-    COORDS2INDEX(shape::rank(outputShape), shape::shapeOf(outputShape), zCoords, zOffset);
+    INDEX2COORDS(e, shape::rank(outputShape), shape::shapeOf(outputShape), zCoords);
+    COORDS2INDEX(shape::rank(outputShape), shape::stride(outputShape), zCoords, zOffset);
     T* outputBufferZ = reinterpret_cast<T*>(outputBuffer) + zOffset;
     adjustWeightsKernelD<T>(inputBuffer, inputShape, weightsBuffer, weightsShape, (void*)outputBufferZ, inputLength,
                             outputLength, (int)zOffset);

--- a/libnd4j/include/ops/declarable/helpers/cuda/zeta.cu
+++ b/libnd4j/include/ops/declarable/helpers/cuda/zeta.cu
@@ -52,12 +52,12 @@ SD_KERNEL static void zetaCuda(const void *vx, const LongType *xShapeInfo, const
     LongType qOffset;
     LongType zOffset;
 
-    INDEX2COORDS(i, shape::rank(xShapeInfo), xShapeInfo, xCoords);
-    COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords, xOffset);
-    INDEX2COORDS(i, shape::rank(qShapeInfo), qShapeInfo, qCoords);
-    COORDS2INDEX(shape::rank(qShapeInfo), shape::shapeOf(qShapeInfo), qCoords, qOffset);
-    INDEX2COORDS(i, shape::rank(zShapeInfo), zShapeInfo, zCoords);
-    COORDS2INDEX(shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords, zOffset);
+    INDEX2COORDS(i, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), xCoords);
+    COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), xCoords, xOffset);
+    INDEX2COORDS(i, shape::rank(qShapeInfo), shape::shapeOf(qShapeInfo), qCoords);
+    COORDS2INDEX(shape::rank(qShapeInfo), shape::stride(qShapeInfo), qCoords, qOffset);
+    INDEX2COORDS(i, shape::rank(zShapeInfo), shape::shapeOf(zShapeInfo), zCoords);
+    COORDS2INDEX(shape::rank(zShapeInfo), shape::stride(zShapeInfo), zCoords, zOffset);
 
     z[zOffset] = zetaScalar<T>(x[xOffset], q[qOffset]);
   }

--- a/libnd4j/include/ops/impl/specials_single.hpp
+++ b/libnd4j/include/ops/impl/specials_single.hpp
@@ -163,16 +163,15 @@ void SpecialMethods<T>::concatCpuGeneric(const std::vector<NDArray *> &inArrs, N
     return;
   }
 
-  // TODO: optimize the other cases to be NEC friendly as well
   // general case
   auto func = PRAGMA_THREADS_FOR {
     sd::LongType coords[SD_MAX_RANK], temp;
 
     for (sd::LongType i = start; i < stop; i += increment) {
-      INDEX2COORDS(i, shape::rank(output.shapeInfo()), output.shapeInfo(), coords);
+      INDEX2COORDS(i, shape::rank(output.shapeInfo()), shape::shapeOf(output.shapeInfo()), coords);
 
       sd::LongType zOffset;
-      COORDS2INDEX(shape::rank(output.shapeInfo()), shape::shapeOf(output.shapeInfo()), coords, zOffset);
+      COORDS2INDEX(shape::rank(output.shapeInfo()), shape::stride(output.shapeInfo()), coords, zOffset);
 
       sd::LongType inArrIdx = 0;
       sd::LongType xDim = inArrs[inArrIdx]->sizeAt(axis);
@@ -185,7 +184,7 @@ void SpecialMethods<T>::concatCpuGeneric(const std::vector<NDArray *> &inArrs, N
 
       const T *x = inArrs[inArrIdx]->bufferAsT<T>();
       sd::LongType xOffset;
-      COORDS2INDEX(shape::rank(inArrs[inArrIdx]->shapeInfo()), shape::shapeOf(inArrs[inArrIdx]->shapeInfo()), coords,
+      COORDS2INDEX(shape::rank(inArrs[inArrIdx]->shapeInfo()), shape::stride(inArrs[inArrIdx]->shapeInfo()), coords,
                    xOffset);
 
       zBuff[zOffset] = x[xOffset];
@@ -250,9 +249,9 @@ void SpecialMethods<T>::splitCpuGeneric(NDArray& input, const std::vector<NDArra
     sd::LongType coords[SD_MAX_RANK], temp;
 
     for (sd::LongType i = start; i < stop; i += increment) {
-      INDEX2COORDS(i, shape::rank(input.shapeInfo()), input.shapeInfo(), coords);
+      INDEX2COORDS(i, shape::rank(input.shapeInfo()), shape::shapeOf(input.shapeInfo()), coords);
       sd::LongType xOffset;
-      COORDS2INDEX(shape::rank(input.shapeInfo()), shape::shapeOf(input.shapeInfo()), coords, xOffset);
+      COORDS2INDEX(shape::rank(input.shapeInfo()), shape::stride(input.shapeInfo()), coords, xOffset);
 
       sd::LongType outArrIdx = 0;
       temp = coords[axis];
@@ -264,7 +263,7 @@ void SpecialMethods<T>::splitCpuGeneric(NDArray& input, const std::vector<NDArra
 
       T* z = outArrs[outArrIdx]->bufferAsT<T>();
       sd::LongType zOffset;
-      COORDS2INDEX(shape::rank(outArrs[outArrIdx]->shapeInfo()), shape::shapeOf(outArrs[outArrIdx]->shapeInfo()), coords, zOffset);
+      COORDS2INDEX(shape::rank(outArrs[outArrIdx]->shapeInfo()), shape::stride(outArrs[outArrIdx]->shapeInfo()), coords, zOffset);
       z[zOffset] = xBuff[xOffset];
 
       coords[axis] = temp;
@@ -299,9 +298,9 @@ template <typename T>
 sd::LongType SpecialMethods<T>::getPosition(NDArray *input, sd::LongType index) {
   auto xShapeInfo = input->shapeInfo();
   LongType coords[SD_MAX_RANK];
-  INDEX2COORDS(index, shape::rank(xShapeInfo), xShapeInfo, coords);
+  INDEX2COORDS(index, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
   LongType offset;
-  COORDS2INDEX(shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords, offset);
+  COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
   return offset;
 }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -1701,7 +1701,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         logBeforePutIfNeccessary();
         if (rank() > 2)
             throw new IllegalStateException("Cannot use putScalar(int,int,double) on a rank " + rank() + " INDArray");
-        long offset = Shape.getOffsetUnsafe(jvmShapeInfo.javaShapeInformation, row, col);
+        long offset = Shape.getOffsetUnsafe(jvmShapeInfo.javaShapeInformation, row, col) + offset();
         data.put(offset, value);
 
         logPutIfNeccessary();
@@ -4539,7 +4539,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
             if(startingOffset < length() &&  i > 0 && offset >= length() || inIdx >= rank()) {
                 if(startingOffset >= length() &&  offset >= length())
                     return Nd4j.empty(dataType());
-                else if(indexes.length > 1 && outShape[0] > 0 && !(indexes[i] instanceof NewAxis) && !(indexes[i] instanceof NDArrayIndexAll)) {
+                else if(indexes.length > 1 && outShape.length > 0 && outShape[0] > 0 && !(indexes[i] instanceof NewAxis) && !(indexes[i] instanceof NDArrayIndexAll)) {
                     //more indices to process but we've exhausted this list
                     //use the offset we have and process further indices
                     //recursively

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/NDArrayViewSmokeTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/NDArrayViewSmokeTests.java
@@ -1,0 +1,759 @@
+/*
+ *  ******************************************************************************
+ *  *
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Apache License, Version 2.0 which is available at
+ *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *
+ *  *  See the NOTICE file distributed with this work for additional
+ *  *  information regarding copyright ownership.
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations
+ *  * under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  *****************************************************************************
+ */
+
+package org.eclipse.deeplearning4j.nd4j.linalg;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.*;
+
+public class NDArrayViewSmokeTests {
+
+    @Test
+    public void testReshapeAssignmentsSimplified() {
+        // Create an array of shape (4,4)
+        INDArray arr = Nd4j.linspace(1, 16, 16).reshape('c', 4, 4);
+
+        // Create a corresponding Java array
+        double[][] arrJava = new double[4][4];
+
+        // Initialize arrJava with values from arr
+        for (int i = 0; i < 4; i++) {
+            for (int j = 0; j < 4; j++) {
+                arrJava[i][j] = arr.getDouble(i, j);
+            }
+        }
+
+        // Reshape the array to (2,8)
+        INDArray reshaped = arr.reshape('c', 2, 8);
+
+        // Create a Java array corresponding to reshaped
+        double[][] reshapedJava = new double[2][8];
+
+        // Initialize reshapedJava with values from reshaped
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < 8; j++) {
+                reshapedJava[i][j] = reshaped.getDouble(i, j);
+            }
+        }
+
+        // Modify elements in reshaped array
+        reshaped.putScalar(0, 0, 1000); // Corresponds to arr(0,0)
+        reshaped.putScalar(1, 7, 2000); // Corresponds to arr(3,3)
+
+        // Modify reshapedJava
+        reshapedJava[0][0] = 1000;
+        reshapedJava[1][7] = 2000;
+
+        // Update arrJava accordingly
+        arrJava[0][0] = 1000;
+        arrJava[3][3] = 2000;
+
+        // Print reshapedJava after modification
+        System.out.println("reshapedJava after modifications:");
+        for (int i = 0; i < reshapedJava.length; i++) {
+            for (int j = 0; j < reshapedJava[i].length; j++) {
+                System.out.print(reshapedJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Print arrJava after reshaped modifications
+        System.out.println("arrJava after reshaped modifications:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                System.out.print(arrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that arrJava matches arr using getDouble
+        assertEquals(arrJava[0][0], arr.getDouble(0, 0));
+        assertEquals(arrJava[3][3], arr.getDouble(3, 3));
+
+        // Check that arr matches arrJava using NDArrayIndex
+        assertEquals(arrJava[0][0], arr.get(NDArrayIndex.point(0), NDArrayIndex.point(0)).getDouble());
+        assertEquals(arrJava[3][3], arr.get(NDArrayIndex.point(3), NDArrayIndex.point(3)).getDouble());
+
+        // Modify original array
+        arr.putScalar(1, 1, 3000);
+
+        // Update arrJava
+        arrJava[1][1] = 3000;
+
+        // Since arr(1,1) corresponds to linear index 5 in row-major order
+        // In reshaped array (2,8), this linear index maps to (0,5)
+        // Update reshapedJava
+        reshapedJava[0][5] = 3000;
+
+        // Print arrJava after arr modification
+        System.out.println("arrJava after arr modification:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                System.out.print(arrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Print reshapedJava after arr modification
+        System.out.println("reshapedJava after arr modification:");
+        for (int i = 0; i < reshapedJava.length; i++) {
+            for (int j = 0; j < reshapedJava[i].length; j++) {
+                System.out.print(reshapedJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that reshapedJava matches reshaped using getDouble
+        assertEquals(reshapedJava[0][5], reshaped.getDouble(0, 5));
+
+        // Check that reshaped matches reshapedJava using NDArrayIndex
+        assertEquals(reshapedJava[0][5], reshaped.get(NDArrayIndex.point(0), NDArrayIndex.point(5)).getDouble());
+
+        // Check that reshaped view reflects the change
+        assertEquals(3000, reshaped.getDouble(0, 5));
+    }
+
+    @Test
+    public void testPermuteAssignmentsSimplified() {
+        // Create an array of shape (3,3,3)
+        INDArray arr = Nd4j.linspace(1, 27, 27).reshape('c', 3, 3, 3);
+
+        // Create corresponding Java array
+        double[][][] arrJava = new double[3][3][3];
+
+        // Initialize arrJava
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                for (int k = 0; k < 3; k++) {
+                    arrJava[i][j][k] = arr.getDouble(i, j, k);
+                }
+            }
+        }
+
+        // Permute the array to rearrange dimensions
+        INDArray permuted = arr.permute(2, 1, 0);
+
+        // Create Java array for permuted
+        double[][][] permutedJava = new double[3][3][3];
+
+        // Initialize permutedJava
+        for (int a = 0; a < 3; a++) {
+            for (int b = 0; b < 3; b++) {
+                for (int c = 0; c < 3; c++) {
+                    permutedJava[a][b][c] = permuted.getDouble(a, b, c);
+                }
+            }
+        }
+
+        // Modify elements in permuted array
+        permuted.putScalar(0, 0, 0, 1000); // Corresponds to arr(0,0,0)
+        permuted.putScalar(2, 2, 2, 2000); // Corresponds to arr(2,2,2)
+
+        // Modify permutedJava
+        permutedJava[0][0][0] = 1000;
+        permutedJava[2][2][2] = 2000;
+
+        // Update arrJava accordingly
+        arrJava[0][0][0] = 1000;
+        arrJava[2][2][2] = 2000;
+
+        // Print permutedJava after modification
+        System.out.println("permutedJava after modifications:");
+        for (int a = 0; a < permutedJava.length; a++) {
+            for (int b = 0; b < permutedJava[a].length; b++) {
+                for (int c = 0; c < permutedJava[a][b].length; c++) {
+                    System.out.print(permutedJava[a][b][c] + " ");
+                }
+                System.out.print(" | ");
+            }
+            System.out.println();
+        }
+
+        // Print arrJava after permuted modifications
+        System.out.println("arrJava after permuted modifications:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                for (int k = 0; k < arrJava[i][j].length; k++) {
+                    System.out.print(arrJava[i][j][k] + " ");
+                }
+                System.out.print(" | ");
+            }
+            System.out.println();
+        }
+
+        // Check that arrJava matches arr using getDouble
+        assertEquals(arrJava[0][0][0], arr.getDouble(0, 0, 0));
+        assertEquals(arrJava[2][2][2], arr.getDouble(2, 2, 2));
+
+        // Check that arr matches arrJava using NDArrayIndex
+        assertEquals(arrJava[0][0][0], arr.get(NDArrayIndex.point(0), NDArrayIndex.point(0), NDArrayIndex.point(0)).getDouble());
+        assertEquals(arrJava[2][2][2], arr.get(NDArrayIndex.point(2), NDArrayIndex.point(2), NDArrayIndex.point(2)).getDouble());
+
+        // Modify original array
+        arr.putScalar(1, 1, 1, 3000);
+
+        // Update arrJava
+        arrJava[1][1][1] = 3000;
+
+        // Update permutedJava
+        permutedJava[1][1][1] = 3000;
+
+        // Print arrJava after arr modification
+        System.out.println("arrJava after arr modification:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                for (int k = 0; k < arrJava[i][j].length; k++) {
+                    System.out.print(arrJava[i][j][k] + " ");
+                }
+                System.out.print(" | ");
+            }
+            System.out.println();
+        }
+
+        // Print permutedJava after arr modification
+        System.out.println("permutedJava after arr modification:");
+        for (int a = 0; a < permutedJava.length; a++) {
+            for (int b = 0; b < permutedJava[a].length; b++) {
+                for (int c = 0; c < permutedJava[a][b].length; c++) {
+                    System.out.print(permutedJava[a][b][c] + " ");
+                }
+                System.out.print(" | ");
+            }
+            System.out.println();
+        }
+
+        // Check that permutedJava matches permuted using getDouble
+        assertEquals(permutedJava[1][1][1], permuted.getDouble(1, 1, 1));
+
+        // Check that permuted matches permutedJava using NDArrayIndex
+        assertEquals(permutedJava[1][1][1], permuted.get(NDArrayIndex.point(1), NDArrayIndex.point(1), NDArrayIndex.point(1)).getDouble());
+
+        // Check that permuted is updated accordingly
+        assertEquals(3000, permuted.getDouble(1, 1, 1));
+    }
+
+    @Test
+    public void testViewModificationReflectsInOriginal() {
+        // Create an array of shape (3,3)
+        INDArray arr = Nd4j.linspace(1, 9, 9).reshape('c', 3, 3);
+
+        // Create corresponding Java array
+        double[][] arrJava = new double[3][3];
+
+        // Initialize arrJava
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                arrJava[i][j] = arr.getDouble(i, j);
+            }
+        }
+
+        // Create a view by selecting a subarray
+        INDArray view = arr.get(NDArrayIndex.interval(1, 3), NDArrayIndex.interval(1, 3));
+
+        // Create corresponding Java array for view
+        double[][] viewJava = new double[2][2];
+
+        // Initialize viewJava
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < 2; j++) {
+                viewJava[i][j] = view.getDouble(i, j);
+            }
+        }
+
+        // Modify the view
+        view.putScalar(0, 0, 100);
+        view.putScalar(1, 1, 200);
+
+        // Modify viewJava
+        viewJava[0][0] = 100;
+        viewJava[1][1] = 200;
+
+        // Update arrJava accordingly
+        arrJava[1][1] = 100;
+        arrJava[2][2] = 200;
+
+        // Print viewJava after modification
+        System.out.println("viewJava after modifications:");
+        for (int i = 0; i < viewJava.length; i++) {
+            for (int j = 0; j < viewJava[i].length; j++) {
+                System.out.print(viewJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Print arrJava after view modifications
+        System.out.println("arrJava after view modifications:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                System.out.print(arrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that arrJava matches arr using getDouble
+        assertEquals(arrJava[1][1], arr.getDouble(1, 1));
+        assertEquals(arrJava[2][2], arr.getDouble(2, 2));
+
+        // Check that arr matches arrJava using NDArrayIndex
+        assertEquals(arrJava[1][1], arr.get(NDArrayIndex.point(1), NDArrayIndex.point(1)).getDouble());
+        assertEquals(arrJava[2][2], arr.get(NDArrayIndex.point(2), NDArrayIndex.point(2)).getDouble());
+
+        // Modify original array
+        arr.putScalar(0, 0, 300);
+
+        // Update arrJava
+        arrJava[0][0] = 300;
+
+        // Print arrJava after arr modification
+        System.out.println("arrJava after arr modification:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                System.out.print(arrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that view is unaffected at this index
+        // Since arr(0,0) is not part of the view
+        assertEquals(300, arr.getDouble(0, 0));
+        assertEquals(300, arr.get(NDArrayIndex.point(0), NDArrayIndex.point(0)).getDouble());
+
+        // Modify an element in arr that is in the view
+        arr.putScalar(1, 1, 400);
+
+        // Update arrJava
+        arrJava[1][1] = 400;
+
+        // Update viewJava
+        viewJava[0][0] = 400;
+
+        // Print viewJava after arr modification
+        System.out.println("viewJava after arr modification:");
+        for (int i = 0; i < viewJava.length; i++) {
+            for (int j = 0; j < viewJava[i].length; j++) {
+                System.out.print(viewJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that view reflects the change using getDouble
+        assertEquals(400, view.getDouble(0, 0));
+
+        // Check that view matches viewJava using NDArrayIndex
+        assertEquals(viewJava[0][0], view.get(NDArrayIndex.point(0), NDArrayIndex.point(0)).getDouble());
+    }
+
+    @Test
+    public void testSlicingAssignmentsSimplified() {
+        // Create an array of shape (3,3,3)
+        INDArray arr = Nd4j.linspace(1, 27, 27).reshape('c', 3, 3, 3);
+
+        // Create corresponding Java array
+        double[][][] arrJava = new double[3][3][3];
+
+        // Initialize arrJava
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                for (int k = 0; k < 3; k++) {
+                    arrJava[i][j][k] = arr.getDouble(i, j, k);
+                }
+            }
+        }
+
+        // Take a slice along the first dimension
+        INDArray slice = arr.slice(1); // Corresponds to arr(1,:,:)
+
+        // Create corresponding Java array for slice
+        double[][] sliceJava = new double[3][3];
+
+        // Initialize sliceJava
+        for (int j = 0; j < 3; j++) {
+            for (int k = 0; k < 3; k++) {
+                sliceJava[j][k] = slice.getDouble(j, k);
+            }
+        }
+
+        // Modify elements in the slice
+        slice.putScalar(0, 0, 1000); // Corresponds to arr(1,0,0)
+        slice.putScalar(2, 2, 2000); // Corresponds to arr(1,2,2)
+
+        // Modify sliceJava
+        sliceJava[0][0] = 1000;
+        sliceJava[2][2] = 2000;
+
+        // Update arrJava accordingly
+        arrJava[1][0][0] = 1000;
+        arrJava[1][2][2] = 2000;
+
+        // Print sliceJava after modification
+        System.out.println("sliceJava after modifications:");
+        for (int j = 0; j < sliceJava.length; j++) {
+            for (int k = 0; k < sliceJava[j].length; k++) {
+                System.out.print(sliceJava[j][k] + " ");
+            }
+            System.out.println();
+        }
+
+        // Print arrJava after slice modifications
+        System.out.println("arrJava after slice modifications:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                for (int k = 0; k < arrJava[i][j].length; k++) {
+                    System.out.print(arrJava[i][j][k] + " ");
+                }
+                System.out.print(" | ");
+            }
+            System.out.println();
+        }
+
+        // Check that arrJava matches arr using getDouble
+        assertEquals(arrJava[1][0][0], arr.getDouble(1, 0, 0));
+        assertEquals(arrJava[1][2][2], arr.getDouble(1, 2, 2));
+
+        // Check that arr matches arrJava using NDArrayIndex
+        assertEquals(arrJava[1][0][0], arr.get(NDArrayIndex.point(1), NDArrayIndex.point(0), NDArrayIndex.point(0)).getDouble());
+        assertEquals(arrJava[1][2][2], arr.get(NDArrayIndex.point(1), NDArrayIndex.point(2), NDArrayIndex.point(2)).getDouble());
+
+        // Modify original array
+        arr.putScalar(1, 1, 1, 3000);
+
+        // Update arrJava
+        arrJava[1][1][1] = 3000;
+
+        // Update sliceJava
+        sliceJava[1][1] = 3000;
+
+        // Print arrJava after arr modification
+        System.out.println("arrJava after arr modification:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                for (int k = 0; k < arrJava[i][j].length; k++) {
+                    System.out.print(arrJava[i][j][k] + " ");
+                }
+                System.out.print(" | ");
+            }
+            System.out.println();
+        }
+
+        // Print sliceJava after arr modification
+        System.out.println("sliceJava after arr modification:");
+        for (int j = 0; j < sliceJava.length; j++) {
+            for (int k = 0; k < sliceJava[j].length; k++) {
+                System.out.print(sliceJava[j][k] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that sliceJava matches slice using getDouble
+        assertEquals(sliceJava[1][1], slice.getDouble(1, 1));
+
+        // Check that slice matches sliceJava using NDArrayIndex
+        assertEquals(sliceJava[1][1], slice.get(NDArrayIndex.point(1), NDArrayIndex.point(1)).getDouble());
+
+        // Check that slice is updated
+        assertEquals(3000, slice.getDouble(1, 1));
+    }
+
+    @Test
+    public void testAdvancedIndexingAssignmentsSimplified() {
+        // Create an array of shape (5,5)
+        INDArray arr = Nd4j.linspace(1, 25, 25).reshape('c', 5, 5);
+
+        // Create corresponding Java array
+        double[][] arrJava = new double[5][5];
+
+        // Initialize arrJava
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                arrJava[i][j] = arr.getDouble(i, j);
+            }
+        }
+
+        // Use advanced indexing to get a subarray
+        INDArrayIndex[] indices = new INDArrayIndex[]{
+                NDArrayIndex.interval(1, 4),
+                NDArrayIndex.interval(1, 4)
+        };
+        INDArray subArr = arr.get(indices);
+
+        // Create corresponding Java array for subArr
+        double[][] subArrJava = new double[3][3];
+
+        // Initialize subArrJava
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                subArrJava[i][j] = subArr.getDouble(i, j);
+            }
+        }
+
+        // Modify elements in subArr
+        subArr.putScalar(0, 0, 1000); // Corresponds to arr(1,1)
+        subArr.putScalar(2, 2, 2000); // Corresponds to arr(3,3)
+
+        // Modify subArrJava
+        subArrJava[0][0] = 1000;
+        subArrJava[2][2] = 2000;
+
+        // Update arrJava accordingly
+        arrJava[1][1] = 1000;
+        arrJava[3][3] = 2000;
+
+        // Print subArrJava after modification
+        System.out.println("subArrJava after modifications:");
+        for (int i = 0; i < subArrJava.length; i++) {
+            for (int j = 0; j < subArrJava[i].length; j++) {
+                System.out.print(subArrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Print arrJava after subArr modifications
+        System.out.println("arrJava after subArr modifications:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                System.out.print(arrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that arrJava matches arr using getDouble
+        assertEquals(arrJava[1][1], arr.getDouble(1, 1));
+        assertEquals(arrJava[3][3], arr.getDouble(3, 3));
+
+        // Check that arr matches arrJava using NDArrayIndex
+        assertEquals(arrJava[1][1], arr.get(NDArrayIndex.point(1), NDArrayIndex.point(1)).getDouble());
+        assertEquals(arrJava[3][3], arr.get(NDArrayIndex.point(3), NDArrayIndex.point(3)).getDouble());
+
+        // Modify original array
+        arr.putScalar(2, 2, 3000);
+
+        // Update arrJava
+        arrJava[2][2] = 3000;
+
+        // Update subArrJava
+        subArrJava[1][1] = 3000;
+
+        // Print arrJava after arr modification
+        System.out.println("arrJava after arr modification:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                System.out.print(arrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Print subArrJava after arr modification
+        System.out.println("subArrJava after arr modification:");
+        for (int i = 0; i < subArrJava.length; i++) {
+            for (int j = 0; j < subArrJava[i].length; j++) {
+                System.out.print(subArrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that subArrJava matches subArr using getDouble
+        assertEquals(subArrJava[1][1], subArr.getDouble(1, 1));
+
+        // Check that subArr matches subArrJava using NDArrayIndex
+        assertEquals(subArrJava[1][1], subArr.get(NDArrayIndex.point(1), NDArrayIndex.point(1)).getDouble());
+
+        // Check that subArr is updated
+        assertEquals(3000, subArr.getDouble(1, 1));
+    }
+
+    @Test
+    public void testAssignFromView() {
+        // Create an array of shape (4,4)
+        INDArray arr = Nd4j.linspace(1, 16, 16).reshape('c', 4, 4);
+
+        // Create corresponding Java array
+        double[][] arrJava = new double[4][4];
+
+        // Initialize arrJava with values from arr
+        for (int i = 0; i < arr.rows(); i++) {
+            for (int j = 0; j < arr.columns(); j++) {
+                arrJava[i][j] = arr.getDouble(i, j);
+            }
+        }
+
+        // Create a view by selecting a subarray
+        INDArray view = arr.get(NDArrayIndex.interval(1, 3), NDArrayIndex.interval(1, 3));
+
+        // Create corresponding Java array for view
+        double[][] viewJava = new double[view.rows()][view.columns()];
+
+        // Initialize viewJava with values from view
+        for (int i = 0; i < view.rows(); i++) {
+            for (int j = 0; j < view.columns(); j++) {
+                viewJava[i][j] = view.getDouble(i, j);
+            }
+        }
+
+        // Create another array to assign from
+        INDArray toAssign = Nd4j.ones(2, 2).mul(100);
+
+        // Create corresponding Java array for toAssign
+        double[][] toAssignJava = new double[2][2];
+        for (int i = 0; i < toAssign.rows(); i++) {
+            for (int j = 0; j < toAssign.columns(); j++) {
+                toAssignJava[i][j] = toAssign.getDouble(i, j);
+            }
+        }
+
+        // Update viewJava
+        for (int i = 0; i < viewJava.length; i++) {
+            for (int j = 0; j < viewJava[i].length; j++) {
+                viewJava[i][j] = toAssignJava[i][j];
+            }
+        }
+
+        // Since view is a view into arr, update arrJava accordingly
+        for (int i = 0; i < viewJava.length; i++) {
+            for (int j = 0; j < viewJava[i].length; j++) {
+                arrJava[i + 1][j + 1] = viewJava[i][j];
+            }
+        }
+
+
+        // Perform assignment
+        view.assign(toAssign);
+
+
+        // Check that the original array is updated
+        assertEquals(100, arr.getDouble(1, 1));
+        assertEquals(100, arr.getDouble(1, 2));
+        assertEquals(100, arr.getDouble(2, 1));
+        assertEquals(100, arr.getDouble(2, 2));
+
+        // Check that arrJava matches arr using getDouble
+        for (int i = 0; i < arr.rows(); i++) {
+            for (int j = 0; j < arr.columns(); j++) {
+                assertEquals(arrJava[i][j], arr.getDouble(i, j));
+                assertEquals(arrJava[i][j], arr.get(NDArrayIndex.point(i), NDArrayIndex.point(j)).getDouble());
+            }
+        }
+
+        // Print the updated arrJava
+        System.out.println("arrJava after assign from view:");
+        for (int i = 0; i < arrJava.length; i++) {
+            for (int j = 0; j < arrJava[i].length; j++) {
+                System.out.print(arrJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Print the updated viewJava
+        System.out.println("viewJava after assign:");
+        for (int i = 0; i < viewJava.length; i++) {
+            for (int j = 0; j < viewJava[i].length; j++) {
+                System.out.print(viewJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+    }
+
+
+    @Test
+    public void testDupFromDifferentOrders() {
+        // Create arrays in 'c' and 'f' orders
+        INDArray arrC = Nd4j.linspace(1, 9, 9).reshape('c', 3, 3);
+        INDArray arrF = Nd4j.linspace(1, 9, 9).reshape('f', 3, 3);
+
+        // Create corresponding Java arrays
+        double[][] arrCJava = new double[3][3];
+        double[][] arrFJava = new double[3][3];
+
+        // Initialize arrCJava and arrFJava with values from arrC and arrF
+        for (int i = 0; i < arrC.rows(); i++) {
+            for (int j = 0; j < arrC.columns(); j++) {
+                arrCJava[i][j] = arrC.getDouble(i, j);
+                arrFJava[i][j] = arrF.getDouble(i, j);
+            }
+        }
+
+        // Duplicate arrays
+        INDArray dupC = arrC.dup('c');
+        INDArray dupF = arrF.dup('f');
+
+        // Create corresponding Java arrays for duplicates
+        double[][] dupCJava = new double[3][3];
+        double[][] dupFJava = new double[3][3];
+
+        // Initialize dupCJava and dupFJava with values from dupC and dupF
+        for (int i = 0; i < dupC.rows(); i++) {
+            for (int j = 0; j < dupC.columns(); j++) {
+                dupCJava[i][j] = dupC.getDouble(i, j);
+                dupFJava[i][j] = dupF.getDouble(i, j);
+            }
+        }
+
+        // Modify duplicates
+        dupC.putScalar(0, 0, 1000);
+        dupF.putScalar(2, 2, 2000);
+
+        // Update dupCJava and dupFJava
+        dupCJava[0][0] = 1000;
+        dupFJava[2][2] = 2000;
+
+        // Check that originals are unaffected
+        assertEquals(1, arrC.getDouble(0, 0));
+        assertEquals(9, arrF.getDouble(2, 2));
+
+        // Check that arrCJava and arrFJava match arrC and arrF
+        for (int i = 0; i < arrC.rows(); i++) {
+            for (int j = 0; j < arrC.columns(); j++) {
+                assertEquals(arrCJava[i][j], arrC.getDouble(i, j));
+                assertEquals(arrCJava[i][j], arrC.get(NDArrayIndex.point(i), NDArrayIndex.point(j)).getDouble());
+                assertEquals(arrFJava[i][j], arrF.getDouble(i, j));
+                assertEquals(arrFJava[i][j], arrF.get(NDArrayIndex.point(i), NDArrayIndex.point(j)).getDouble());
+            }
+        }
+
+        // Print duplicates
+        System.out.println("dupCJava after modification:");
+        for (int i = 0; i < dupCJava.length; i++) {
+            for (int j = 0; j < dupCJava[i].length; j++) {
+                System.out.print(dupCJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        System.out.println("dupFJava after modification:");
+        for (int i = 0; i < dupFJava.length; i++) {
+            for (int j = 0; j < dupFJava[i].length; j++) {
+                System.out.print(dupFJava[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        // Check that dupCJava and dupFJava match dupC and dupF
+        for (int i = 0; i < dupC.rows(); i++) {
+            for (int j = 0; j < dupC.columns(); j++) {
+                assertEquals(dupCJava[i][j], dupC.getDouble(i, j));
+                assertEquals(dupCJava[i][j], dupC.get(NDArrayIndex.point(i), NDArrayIndex.point(j)).getDouble());
+                assertEquals(dupFJava[i][j], dupF.getDouble(i, j));
+                assertEquals(dupFJava[i][j], dupF.get(NDArrayIndex.point(i), NDArrayIndex.point(j)).getDouble());
+            }
+        }
+    }
+}


### PR DESCRIPTION


## What changes were proposed in this pull request?

fix scalar index when using the indexing api
fix usage of index2coords by migrating shape information to shape::shapeOf
fix usage of coords2index by migrating accidental shapeOf invocations to strides
## How was this patch tested?

new indexing smoke tests to quickly identify issues with views

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
