### PR TITLE
Continuation of compiler warnings/minimizing undefined behavior

### DIFF
--- a/libnd4j/include/array/cpu/NDArray.cpp
+++ b/libnd4j/include/array/cpu/NDArray.cpp
@@ -108,7 +108,7 @@ void NDArray::fillAsTriangular(const float val, int lower, int upper, NDArray& t
       auto lCompare = includeEdges ? row <= (col - lower) : row < (col - lower);
       auto uCompare = includeEdges ? row >= (col - upper) : row > (col - upper);
 
-      if (direction == 'u' && lCompare || direction == 'l' && uCompare) {
+      if ((direction == 'u' && lCompare) || (direction == 'l' && uCompare)) {
         z[zOffset] = value;
       } else {
         z[zOffset] = x[xOffset];
@@ -157,7 +157,7 @@ void NDArray::setIdentity() {
 
   float v = 1.0f;
 
-  for (int i = 0; i < minDim; ++i) templatedSet<float>(buffer(), i * offset, this->dataType(), &v);
+  for (int i = 0; i < minDim; ++i) templatedSet<float,float>(buffer(), i * offset, this->dataType(), &v);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/helpers/Loops.h
+++ b/libnd4j/include/helpers/Loops.h
@@ -805,7 +805,6 @@ SD_LIB_HIDDEN void reduceExec54(const X* x, const LongType* xShapeInfo, Z* z, co
 #if defined(PRINT_INDICES)
                 shape::printShapeInfo(xShapeInfo);
                 shape::printShapeInfo(zShapeInfo);
-                printf("Index i0,i1,i2,i3,i4 is %lld,%lld,%lld,%lld,%lld offset %lld reduceExec54\n", i0,i1,i2,i3,i4,i4);
 #endif
                 s = OpType::update(s, OpType::op(x3[i4], extraParams), extraParams);
               }
@@ -814,7 +813,6 @@ SD_LIB_HIDDEN void reduceExec54(const X* x, const LongType* xShapeInfo, Z* z, co
 #if defined(PRINT_INDICES)
                 shape::printShapeInfo(xShapeInfo);
                 shape::printShapeInfo(zShapeInfo);
-                printf("Index i0,i1,i2,i3,i4 is %lld,%lld,%lld,%lld,%lld offset %lld reduceExec54\n", i0,i1,i2,i3,i4,i4 * xStrd4);
 #endif
                 s = OpType::update(s, OpType::op(x3[i4 * xStrd4], extraParams), extraParams);
               }
@@ -975,20 +973,6 @@ SD_LIB_HIDDEN void TransformLoops<X, Z, E>::loopTransform(const X* x,
           COORDS2INDEX(xRank, xStride, xCoords, xOffset);
           COORDS2INDEX(zRank, zStride, zCoords, zOffset);
 
-#if defined(PRINT_INDICES)
-          shape::printShapeInfo(xShapeInfo);
-          shape::printShapeInfo(zShapeInfo);
-          printf("Index is %lld x offset is %lld z offset is %lld loop kind: default TransformLoops<X, Z, E>::loopTransform\n", i, xOffset, zOffset);
-          for (int e = 0; e < shape::rank(xShapeInfo); e++) {
-            printf("xCoords[%i]: %lld\n", e, xCoords[e]);
-          }
-
-          for (int e = 0; e < shape::rank(zShapeInfo); e++) {
-            printf("zCoords[%i]: %lld\n", e, xCoords[e]);
-          }
-
-          fflush(stdout);
-#endif
 
           auto opResult = OpType::op(x[xOffset], extraParams);
           z[zOffset] = static_cast<Z>(opResult);
@@ -1011,20 +995,6 @@ SD_LIB_HIDDEN void TransformLoops<X, Z, E>::loopTransform(const X* x,
           COORDS2INDEX(xRank, xStride, xCoords, xOffset);
           COORDS2INDEX(zRank, zStride, zCoords, zOffset);
 
-#if defined(PRINT_INDICES)
-          shape::printShapeInfo(xShapeInfo);
-          shape::printShapeInfo(zShapeInfo);
-          printf("Index is %lld x offset is %lld z offset is %lld loop kind: default TransformLoops<X, Z, E>::loopTransform\n", i, xOffset, zOffset);
-          for (int e = 0; e < shape::rank(xShapeInfo); e++) {
-            printf("xCoords[%i]: %lld\n", e, xCoords[e]);
-          }
-
-          for (int e = 0; e < shape::rank(zShapeInfo); e++) {
-            printf("zCoords[%i]: %lld\n", e, zCoords[e]);
-          }
-
-          fflush(stdout);
-#endif
 
           auto opResult = OpType::op(x[xOffset], extraParams);
           z[zOffset] = static_cast<Z>(opResult);
@@ -1055,19 +1025,19 @@ void Reduction3Loops<X, Z>::loopReduce3(const X* x, const LongType* xShapeInfo, 
   std::vector<LongType> zeroOffsets;
 
   if (xLen == yLen) {
-    tadPackX = ConstantTadHelper::getInstance().tadForDimensions(xShapeInfo, dims, dimsLen);
-    tadPackY = ConstantTadHelper::getInstance().tadForDimensions(yShapeInfo, dims, dimsLen);
+    tadPackX = ConstantTadHelper::getInstance().tadForDimensions(const_cast<sd::LongType*>(xShapeInfo), dims, dimsLen);
+    tadPackY = ConstantTadHelper::getInstance().tadForDimensions(const_cast<sd::LongType*>(yShapeInfo), dims, dimsLen);
     xTadShapeInfo = tadPackX->primaryShapeInfo();
     yTadShapeInfo = tadPackY->primaryShapeInfo();
     xTadOffsets = tadPackX->primaryOffsets();
     yTadOffsets = tadPackY->primaryOffsets();
   } else if (yLen > xLen) {
-    tadPackY = ConstantTadHelper::getInstance().tadForDimensions(yShapeInfo, dims, dimsLen);
+    tadPackY = ConstantTadHelper::getInstance().tadForDimensions(const_cast<sd::LongType*>(yShapeInfo), dims, dimsLen);
     xTadShapeInfo = xShapeInfo;
     yTadShapeInfo = tadPackY->primaryShapeInfo();
     yTadOffsets = tadPackY->primaryOffsets();
   } else {
-    tadPackX = ConstantTadHelper::getInstance().tadForDimensions(xShapeInfo, dims, dimsLen);
+    tadPackX = ConstantTadHelper::getInstance().tadForDimensions(const_cast<sd::LongType*>(xShapeInfo), dims, dimsLen);
     yTadShapeInfo = yShapeInfo;
     xTadShapeInfo = tadPackX->primaryShapeInfo();
     xTadOffsets = tadPackX->primaryOffsets();
@@ -1110,8 +1080,7 @@ void Reduction3Loops<X, Z>::loopReduce3(const X* x, const LongType* xShapeInfo, 
     sd::LongType yTadRank = shape::rank(yTadShapeInfo);
     sd::LongType *xTadShape = shape::shapeOf(xTadShapeInfo);
     sd::LongType *yTadShape = shape::shapeOf(yTadShapeInfo);
-    sd::LongType *xTadStride = shape::stride(xTadShapeInfo);
-    sd::LongType *yTadStride = shape::stride(yTadShapeInfo);
+
     for (LongType j = 0; j < tadLen; ++j) {
       LongType coords[SD_MAX_RANK];
       LongType  yCoords[SD_MAX_RANK];
@@ -1124,7 +1093,6 @@ void Reduction3Loops<X, Z>::loopReduce3(const X* x, const LongType* xShapeInfo, 
 #if defined(PRINT_INDICES)
       shape::printShapeInfo(xTadShapeInfo);
       shape::printShapeInfo(yTadShapeInfo);
-      printf("Index is %lld offset is %lld loop kind: default Reduction3Loops<X, Z>::loopReduce3\n", i,j);
 #endif
       s = OpType::update(s, OpType::op(xTad[xTadOffset], yTad[yTadOffset], extraParams), extraParams);
     }

--- a/libnd4j/include/helpers/cpu/MmulHelper.cpp
+++ b/libnd4j/include/helpers/cpu/MmulHelper.cpp
@@ -237,7 +237,7 @@ NDArray* MmulHelper::mmulMxM( NDArray* A,  NDArray* B, NDArray* C, const double 
   const bool typeDouble = hasGemm && ABC && aType == DataType::DOUBLE;
   const bool typeFloat = hasGemm && ABC && aType == DataType::FLOAT32;
 
-  if (!typeFloat && !typeDouble || !Environment::getInstance().isEnableBlas()) {
+  if ((!typeFloat && !typeDouble) || !Environment::getInstance().isEnableBlas()) {
     BUILD_SINGLE_SELECTOR_THRICE(aType, usualGemm, (A, B, C, 0, 1, 0, 1, 0, 1, alpha, beta), SD_NUMERIC_TYPES);
   } else {
     std::vector<NDArray*> toDelete;
@@ -353,7 +353,7 @@ NDArray* MmulHelper::mmulMxV( NDArray* A, NDArray* X, sd::NDArray* Y, const doub
   const bool typeDouble = hasGemv && AXY && aType == DataType::DOUBLE;
   const bool typeFloat = hasGemv && AXY && aType == DataType::FLOAT32;
 
-  if (!typeDouble && !typeFloat || !Environment::getInstance().isEnableBlas()) {
+  if ((!typeDouble && !typeFloat) || !Environment::getInstance().isEnableBlas()) {
     BUILD_SINGLE_SELECTOR_THRICE(aType, usualGemv, (A, X, Y, incx, incy, 0, alpha, beta), SD_NUMERIC_TYPES);
   } else {
     NDArray* pA(const_cast<NDArray*>(A));

--- a/libnd4j/include/legacy/impl/NativeOpExecutionerHelpers.cpp
+++ b/libnd4j/include/legacy/impl/NativeOpExecutionerHelpers.cpp
@@ -21,51 +21,17 @@
 //
 #include <legacy/NativeOpExecutioner.h>
 
-inline static void execSort(sd::NDArray *x, bool descending) {
+void NativeOpExecutioner::execSort(sd::NDArray *x, bool descending) {
   auto xType = x->dataType();
-
-  BUILD_SINGLE_SELECTOR(xType, sd::SpecialMethods, ::sortGeneric(x, descending), SD_COMMON_TYPES);
+  BUILD_SINGLE_SELECTOR(xType, sd::SpecialMethods, ::sortGeneric(x, descending), SD_NUMERIC_TYPES);
 }
 
-static void execSort(sd::NDArray *x, sd::LongType *dimension,  sd::LongType dimensionLength,
+ void NativeOpExecutioner::execSort(sd::NDArray *x, sd::LongType *dimension,  sd::LongType dimensionLength,
                      bool descending) {
   auto xType = x->dataType();
 
   BUILD_SINGLE_SELECTOR(
       xType, sd::SpecialMethods,
       ::sortTadGeneric(x, dimension, dimensionLength, descending),
-      SD_COMMON_TYPES);
-}
-
-inline static void execSortCooIndices(sd::LongType *indices, void *x, sd::LongType length,
-                                      const sd::LongType *xShapeInfo) {
-  auto xType = sd::ArrayOptions::dataType(xShapeInfo);
-  int rank = shape::rank(xShapeInfo);
-
-  BUILD_SINGLE_SELECTOR(xType, sd::sparse::SparseUtils, ::sortCooIndicesGeneric(indices, x, length, rank),
-                        SD_COMMON_TYPES);
-}
-
-inline static void execRavelMultiIndex(sd::LongType *indices, sd::LongType *flatIndices, sd::LongType length,
-                                       sd::LongType *shapeInfo, int mode) {
-  sd::sparse::IndexUtils::ravelMultiIndex(indices, flatIndices, length, shapeInfo, mode);
-}
-
-inline static void execUnravelIndex(sd::LongType *indices, sd::LongType *flatIndices, sd::LongType length,
-                                    sd::LongType *shapeInfo) {
-  sd::sparse::IndexUtils::unravelIndex(indices, flatIndices, length, shapeInfo);
-}
-
-inline static sd::LongType encodeBitmap(sd::NDArray *x, sd::LongType N, long long int *dz,
-                                        float threshold) {
-  auto xType = x->dataType();
-
-  BUILD_SINGLE_SELECTOR(xType, return sd::SpecialMethods, ::encodeBitmapGeneric(x, N, dz, threshold),
-                        SD_FLOAT_TYPES);
-}
-
-inline static void decodeBitmap(sd::NDArray *dx, sd::LongType N, sd::NDArray *z) {
-  auto zType = z->dataType();
-
-  BUILD_SINGLE_SELECTOR(zType, sd::SpecialMethods, ::decodeBitmapGeneric(dx,z,N), SD_FLOAT_TYPES);
+      SD_NUMERIC_TYPES);
 }

--- a/libnd4j/include/loops/cpu/pairwise_int.cpp
+++ b/libnd4j/include/loops/cpu/pairwise_int.cpp
@@ -30,31 +30,7 @@ using namespace simdOps;
 namespace functions {
 namespace pairwise_transforms {
 
-template <typename X>
-void PairWiseIntTransform<X>::exec(const int opNum, const void *x, sd::LongType xEws, const void *y, sd::LongType yEws,
-                                   void *z, sd::LongType zEws, void *extraParams, sd::LongType n, const uint64_t start,
-                                   const uint64_t stop) {
-  DISPATCH_BY_OPNUM_T(exec, PARAMS(x, xEws, y, yEws, z, zEws, extraParams, n, start, stop), PAIRWISE_INT_OPS);
-};
 
-template <typename X>
-template <typename OpType>
-void PairWiseIntTransform<X>::exec(const void *vx, sd::LongType xEws, const void *vy, sd::LongType yEws, void *vz,
-                                   sd::LongType zEws, void *vextraParams, const sd::LongType n, const uint64_t start,
-                                   const uint64_t stop) {
-  auto x = reinterpret_cast<const X *>(vx);
-  auto y = reinterpret_cast<const X *>(vy);
-  auto z = reinterpret_cast<X *>(vz);
-  auto extraParams = reinterpret_cast<X *>(vextraParams);
-
-  if (xEws == 1 && yEws == 1 && zEws == 1) {
-    PRAGMA_OMP_SIMD
-    for (auto i = start; i < stop; i++) z[i] = OpType::op(x[i], y[i], extraParams);
-  } else {
-    PRAGMA_OMP_SIMD
-    for (auto i = start; i < stop; i++) z[i * zEws] = OpType::op(x[i * xEws], y[i * yEws], extraParams);
-  }
-}
 
 template <typename X>
 void PairWiseIntTransform<X>::exec(const int opNum, const void *x, const sd::LongType *xShapeInfo, const void *y,

--- a/libnd4j/include/loops/type_conversions.h
+++ b/libnd4j/include/loops/type_conversions.h
@@ -103,15 +103,8 @@ template <typename T>
 SD_HOST void encoderKernelP3Generic(dim3 &launchDims, cudaStream_t *stream, void *dx, int *offsets, LongType N,
                                     void *dz);
 
-template <typename T>
-SD_HOST void decoderKernelGeneric(dim3 &launchDims, cudaStream_t *stream, const void *dx, LongType N, void *dz);
 
-template <typename T>
-SD_HOST void cudaEncodeBitmapGeneric(dim3 &launchDims, cudaStream_t *stream, void *vdx, LongType N, int *dz,
-                                     int *scalar, int *reductionBuffer, float threshold);
 
-template <typename T>
-SD_HOST void cudaDecodeBitmapGeneric(dim3 &launchDims, cudaStream_t *stream, const void *dx, LongType N, void *vdz);
 
 SD_KERNEL void uniformAdd(int *g_data, int *uniforms, int n, int blockOffset, int baseIndex);
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/lup.cpp
@@ -365,7 +365,8 @@ static sd::Status determinant_(LaunchContext* context, NDArray* input, NDArray* 
 
   for (sd::LongType e = 0; e < output->lengthOf(); e++) {
     for (sd::LongType k = e * n2, row = 0; k < (e + 1) * n2; ++k, ++row) matrix.p(row, input->e<T>(k));
-    output->p(e, lup_<T, sd::LongType>(context, &matrix, (NDArray*)nullptr, (NDArray*)nullptr));
+    auto ret = lup_<T, sd::LongType>(context, &matrix, (NDArray*)nullptr, (NDArray*)nullptr);
+    output->p(e, ret);
   }
 
   return sd::Status::OK;
@@ -557,7 +558,6 @@ sd::Status cholesky_(LaunchContext* context, NDArray* input, NDArray* output, bo
     for (sd::LongType k = e * n2, l = 0; k < (e + 1) * n2; k++) {
       matrix->p(l++, input->e<T>(k));
     }
-    float zero = 0.f;
     // if (e) // from the second loop need to zero matrix
     lowerMatrix->assign(zero);
 
@@ -594,7 +594,7 @@ sd::Status logdetFunctor_(LaunchContext* context, NDArray* input, NDArray* outpu
   ResultSet matrices = tempOutput.allTensorsAlongDimension({input->rankOf() - 2, input->rankOf() - 1});
 
   for (sd::LongType e = 0; e < totalCount; e++) {
-    for (size_t i = 0; i < n; ++i)
+    for (sd::LongType i = 0; i < n; ++i)
       output->r<T>(e) += sd::math::sd_log<T, T>(sd::math::sd_pow<T, T, T>(matrices.at(e)->t<T>(i, i), T(2)));
   }
   return sd::Status::OK;

--- a/libnd4j/include/ops/declarable/helpers/cpu/pad.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/pad.cpp
@@ -51,7 +51,7 @@ static void copy_core_rank(const T* x, T* coreZ, const sd::LongType* xShapes, co
       offset = sd::inc_coords<constRank - 1>(cst, offset);
     }
   } else {
-    for (auto k = 0; k < loop_count; k++) {
+    for (size_t k = 0; k < loop_count; k++) {
       auto xPtr = &(x[offset.first]);
       auto zPtr = &(coreZ[offset.second]);
       for (int i = 0; i < inputLastSize; i++) {

--- a/libnd4j/include/ops/declarable/helpers/cpu/scatter.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/scatter.cpp
@@ -170,7 +170,8 @@ void scatterForLoss(sd::LaunchContext* context, NDArray& indices, NDArray& updat
     auto func = PRAGMA_THREADS_FOR {
       for (auto i = start; i < stop; i++) {
         auto subArr = updates(i, *dimsToExclude);
-        output.p(i, subArr.e(indices.e<sd::LongType>(i)));
+        auto curr = indices.e<sd::LongType>(i);
+        output.p(i, curr);
       }
     };
 
@@ -182,7 +183,8 @@ void scatterForLoss(sd::LaunchContext* context, NDArray& indices, NDArray& updat
       for (auto i = start; i < stop; i++) {
         auto subArr = updates(i, *dimsToExclude);
         auto ind = indices.e<sd::LongType>(i);
-        subArr.p(ind, subArr.e(ind) - 1.);
+        auto curr = subArr.e<sd::LongType>(ind) - 1.;
+        subArr.p(ind,curr);
       }
     };
 

--- a/libnd4j/include/ops/declarable/helpers/cpu/tile.cpp
+++ b/libnd4j/include/ops/declarable/helpers/cpu/tile.cpp
@@ -28,6 +28,7 @@ namespace sd {
 namespace ops {
 namespace helpers {
 
+
 //////////////////////////////////////////////////////////////////////////
 template <typename T>
 static void tileBP_(NDArray& gradO /*input*/, NDArray& gradI /*output*/, const std::vector<sd::LongType> reps) {
@@ -37,7 +38,7 @@ static void tileBP_(NDArray& gradO /*input*/, NDArray& gradI /*output*/, const s
   const sd::LongType gradOLen = gradO.lengthOf();  // gradOLen >= gradILen
 
   // initial zeroing of gradI content
-  memset(gradIBuff, 0, gradILen * sizeof(T));
+  sd::ops::safe_zero(gradIBuff, static_cast<size_t>(gradILen));
 
   LongType gradOCoords[SD_MAX_RANK];
   LongType gradICoords[SD_MAX_RANK];

--- a/libnd4j/include/ops/impl/specials_single.hpp
+++ b/libnd4j/include/ops/impl/specials_single.hpp
@@ -144,7 +144,7 @@ void SpecialMethods<T>::concatCpuGeneric(const std::vector<NDArray *> &inArrs, N
       auto outPtr = &(z[start * totalCopySize]);
       auto numOfInArrs = inputArgs.size();
       for (int i = start; i < stop; i++) {
-        for (int j = 0; j < numOfInArrs; j++) {
+        for (size_t j = 0; j < numOfInArrs; j++) {
           auto inputCopySize = inputArgs[j].size;
           const T *inputBasePtr = inputArgs[j].ptr;
           auto inputPtr = &(inputBasePtr[i * inputCopySize]);
@@ -242,7 +242,7 @@ void SpecialMethods<T>::splitCpuGeneric(NDArray& input, const std::vector<NDArra
     T* x = const_cast<T*>(xBuff);
     for (sd::LongType i = 0; i < numSplits; ++i) {
       const auto memAmountToCopy = outArrs[i]->lengthOf();
-      memcpy(outArrs[i]->bufferAsT<T>(), x, memAmountToCopy * sizeofT);
+      ops::safe_copy(x, static_cast<const T*>(outArrs[i]->buffer()), static_cast<size_t>(memAmountToCopy));
       x += memAmountToCopy;
     }
     return;
@@ -294,42 +294,127 @@ void SpecialMethods<T>::splitCpuGeneric(NDArray& input, const std::vector<NDArra
   samediff::Threads::parallel_for(func, 0, input.lengthOf());
 }
 
-/**
- * This kernel accumulates X arrays, and stores result into Z
- *
- * @tparam T
- * @param x
- * @param z
- * @param n
- * @param length
- */
-
-/**
- * This kernel averages X input arrays, and stores result to Z
- *
- * @tparam T
- * @param x
- * @param z
- * @param n
- * @param length
- * @param propagate
- */
-
-template <typename T>
-sd::LongType SpecialMethods<T>::getPosition(NDArray *input, sd::LongType index) {
-  auto xShapeInfo = input->shapeInfo();
-  LongType coords[SD_MAX_RANK];
-  INDEX2COORDS(index, shape::rank(xShapeInfo), shape::shapeOf(xShapeInfo), coords);
-  LongType offset;
-  COORDS2INDEX(shape::rank(xShapeInfo), shape::stride(xShapeInfo), coords, offset);
-  return offset;
-}
-
 template <typename T>
 void SpecialMethods<T>::sortGeneric(NDArray *input, bool descending) {
   auto x = input->bufferAsT<T>();
   auto xShapeInfo = input->shapeInfo();
   quickSort_parallel(input, Environment::getInstance().maxMasterThreads(), descending);
+}
+
+template <typename T>
+void SpecialMethods<T>::quickSort_parallel_internal(NDArray *x, int left, int right, int cutoff, bool descending) {
+  if (right - left <= cutoff) {
+    // Use insertion sort for small arrays
+    auto xBuff = x->bufferAsT<T>();
+    for (int i = left + 1; i <= right; i++) {
+      T key = xBuff[i];
+      int j = i - 1;
+      if (descending) {
+        while (j >= left && xBuff[j] < key) {
+          xBuff[j + 1] = xBuff[j];
+          j--;
+        }
+      } else {
+        while (j >= left && xBuff[j] > key) {
+          xBuff[j + 1] = xBuff[j];
+          j--;
+        }
+      }
+      xBuff[j + 1] = key;
+    }
+    return;
+  }
+
+  // Choose pivot as median of three
+  auto xBuff = x->bufferAsT<T>();
+  int mid = (left + right) / 2;
+  if (descending) {
+    if (xBuff[right] > xBuff[left]) std::swap(xBuff[right], xBuff[left]);
+    if (xBuff[mid] > xBuff[left]) std::swap(xBuff[mid], xBuff[left]);
+    if (xBuff[right] > xBuff[mid]) std::swap(xBuff[right], xBuff[mid]);
+  } else {
+    if (xBuff[right] < xBuff[left]) std::swap(xBuff[right], xBuff[left]);
+    if (xBuff[mid] < xBuff[left]) std::swap(xBuff[mid], xBuff[left]);
+    if (xBuff[right] < xBuff[mid]) std::swap(xBuff[right], xBuff[mid]);
+  }
+
+  // Partition
+  T pivot = xBuff[mid];
+  int i = left;
+  int j = right;
+
+  while (i <= j) {
+    if (descending) {
+      while (xBuff[i] > pivot) i++;
+      while (xBuff[j] < pivot) j--;
+    } else {
+      while (xBuff[i] < pivot) i++;
+      while (xBuff[j] > pivot) j--;
+    }
+
+    if (i <= j) {
+      std::swap(xBuff[i], xBuff[j]);
+      i++;
+      j--;
+    }
+  }
+
+  // Recursively sort sub-arrays
+  if (left < j) quickSort_parallel_internal(x, left, j, cutoff, descending);
+  if (i < right) quickSort_parallel_internal(x, i, right, cutoff, descending);
+}
+
+template <typename T>
+void SpecialMethods<T>::quickSort_parallel(NDArray *x, int numThreads, bool descending) {
+  const int CUTOFF = 32;  // Threshold for switching to insertion sort
+  auto length = x->lengthOf();
+
+  if (length <= 1) return;
+
+  // For very small arrays, just use the internal sort
+  if (length <= CUTOFF || numThreads <= 1) {
+    quickSort_parallel_internal(x, 0, length - 1, CUTOFF, descending);
+    return;
+  }
+
+  // For larger arrays, partition into segments and sort in parallel
+  int segmentSize = length / numThreads;
+  auto func = PRAGMA_THREADS_FOR {
+    int threadLeft = start * segmentSize;
+    int threadRight = (start == numThreads - 1) ? length - 1 : (start + 1) * segmentSize - 1;
+    quickSort_parallel_internal(x, threadLeft, threadRight, CUTOFF, descending);
+  };
+
+  samediff::Threads::parallel_for(func, 0, numThreads);
+
+  // Merge sorted segments if we used multiple threads
+  if (numThreads > 1) {
+    auto xBuff = x->bufferAsT<T>();
+    std::vector<T> temp(length);
+    for (int size = segmentSize; size < length; size *= 2) {
+      for (int left = 0; left < length; left += 2 * size) {
+        int mid = std::min(left + size, (int)length);
+        int right = std::min(left + 2 * size, (int)length);
+        int i = left, j = mid, k = left;
+
+        // Merge two segments
+        while (i < mid && j < right) {
+          if (descending) {
+            temp[k++] = (xBuff[i] >= xBuff[j]) ? xBuff[i++] : xBuff[j++];
+          } else {
+            temp[k++] = (xBuff[i] <= xBuff[j]) ? xBuff[i++] : xBuff[j++];
+          }
+        }
+        while (i < mid) temp[k++] = xBuff[i++];
+        while (j < right) temp[k++] = xBuff[j++];
+
+        // Copy back
+        for (i = left; i < right; i++) {
+          xBuff[i] = temp[i];
+        }
+      }
+    }
+  }
 }
 
 template <typename T>
@@ -340,7 +425,8 @@ void SpecialMethods<T>::sortTadGeneric(NDArray *input, sd::LongType *dimension, 
   int numTads = xLength / xTadLength;
 
   const std::vector<sd::LongType> dimVector(dimension, dimension + dimensionLength);
-  auto pack = sd::ConstantTadHelper::getInstance().tadForDimensions(input->shapeInfo(), &dimVector,false);
+  auto pack = sd::ConstantTadHelper::getInstance().tadForDimensions(const_cast<sd::LongType *>(input->shapeInfo()),
+                                                                    const_cast<sd::LongType *>(dimVector.data()),false);
 
   auto func = PRAGMA_THREADS_FOR {
     for (auto r = start; r < stop; r++) {
@@ -350,93 +436,6 @@ void SpecialMethods<T>::sortTadGeneric(NDArray *input, sd::LongType *dimension, 
     }
   };
   samediff::Threads::parallel_tad(func, 0, numTads);
-}
-
-template <typename T>
-void SpecialMethods<T>::decodeBitmapGeneric(NDArray *input, NDArray *output,sd::LongType N) {
-  auto dz = output->bufferAsT<T>();
-  auto x = input->bufferAsT<int>();
-  sd::LongType lim = N / 16 + 5;
-
-  FloatBits2 fb;
-  fb.i_ = x[2];
-  float threshold = fb.f_;
-
-  auto pPos = -1;
-
-  auto func = PRAGMA_THREADS_FOR {
-    for (auto e = start; e < stop; e++) {
-      const auto v = x[e];
-      for (int bitId = 0; bitId < 16; bitId++) {
-        bool hasBit = (v & 1 << (bitId)) != 0;
-        bool hasSign = (v & 1 << (bitId + 16)) != 0;
-        auto cPos = (e - 4) * 16 + bitId;
-
-        if (hasBit) {
-          if (hasSign)
-            dz[cPos] -= static_cast<T>(threshold);
-          else
-            dz[cPos] += static_cast<T>(threshold);
-        } else if (hasSign) {
-          dz[cPos] -= static_cast<T>(threshold / 2);
-        }
-
-        pPos = cPos;
-      }
-    }
-  };
-
-  samediff::Threads::parallel_for(func, 4, lim);
-}
-
-template <typename T>
-sd::LongType SpecialMethods<T>::encodeBitmapGeneric(NDArray *input, sd::LongType N,
-                                                    LongType *dz,float threshold) {
-  auto dx = input->bufferAsT<T>();
-  const T two(2.0f);
-  const T zero(0.0f);
-  const T t(threshold);
-  const T thalf = t / two;
-
-  sd::LongType retVal = 0L;
-
-  PRAGMA_OMP_PARALLEL_FOR_REDUCTION(+ : retVal)
-  for (auto x = 0; x < N; x += 16) {
-    int byte = 0;
-    int byteId = x / 16 + 4;
-
-    for (int f = 0; f < 16; f++) {
-      auto e = x + f;
-
-      if (e >= N) continue;
-
-      T val = dx[e];
-      T abs = sd::math::sd_abs<T, T>(val);
-
-      int bitId = e % 16;
-
-      if (abs >= t) {
-        byte |= 1 << (bitId);
-        retVal++;
-
-        if (val < zero) {
-          byte |= 1 << (bitId + 16);
-          dx[e] += t;
-        } else {
-          dx[e] -= t;
-        }
-      } else if (abs >= thalf && val < zero) {
-        byte |= 1 << (bitId + 16);
-        dx[e] += thalf;
-
-        retVal++;
-      }
-    }
-
-    dz[byteId] = byte;
-  }
-
-  return retVal;
 }
 
 }  // namespace sd


### PR DESCRIPTION
api compatibility removing booleans from constant tad helper Adds missing class prefixes to some methods due to linker errors Handles some l/rvalue compilation errors when migrating to references only for arguments Fixes some compiler warnings around if statement condiitons

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ X] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
