### PR TITLE
Rewrites multi threading/thread access in the trie infrastructure

### DIFF
--- a/libnd4j/include/array/ConstantOffsetsBuffer.h
+++ b/libnd4j/include/array/ConstantOffsetsBuffer.h
@@ -43,9 +43,9 @@ class SD_LIB_EXPORT ConstantOffsetsBuffer {
   ConstantOffsetsBuffer() = default;
   ~ConstantOffsetsBuffer() = default;
 
-  const LongType *primary() const;
-  const LongType *special() const;
-  const LongType *platform() const;
+  LongType *primary();
+  LongType *special();
+  LongType *platform();
 };
 
 }  // namespace sd

--- a/libnd4j/include/array/ConstantShapeBuffer.h
+++ b/libnd4j/include/array/ConstantShapeBuffer.h
@@ -51,10 +51,11 @@ class SD_LIB_EXPORT ConstantShapeBuffer {
   backward::StackTrace st;
 #endif
 #endif
-  const LongType *primary() const;
-  const LongType *special() const;
-  const LongType *platform() const;
+  LongType *primary() ;
+  LongType *special() ;
+  LongType *platform() ;
 };
+
 
 }  // namespace sd
 

--- a/libnd4j/include/array/TadCalculator.h
+++ b/libnd4j/include/array/TadCalculator.h
@@ -1,0 +1,82 @@
+
+/* ******************************************************************************
+*
+* Copyright (c) 2024 Konduit K.K.
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+******************************************************************************/
+
+//
+// @author raver119@gmail.com
+//
+
+#ifndef DEV_TESTS_TADCALCULATOR_H
+#define DEV_TESTS_TADCALCULATOR_H
+
+#include <array/TadPack.h>
+#include <system/common.h>
+#include <helpers/ConstantHelper.h>
+#include <helpers/ConstantShapeHelper.h>
+#include <array/ConstantShapeBuffer.h>
+#include <array/ConstantOffsetsBuffer.h>
+#include <vector>
+#include <memory>
+
+namespace sd {
+
+/**
+* TadCalculator handles the computation of Tensor Along Dimension (TAD) information
+* including shapes and offsets for sub-arrays.
+ */
+class SD_LIB_EXPORT TadCalculator {
+ private:
+  LongType* _originalShape;       // Original shape info pointer
+  ConstantShapeBuffer _tadShape;        // Calculated TAD shape buffer
+  ConstantOffsetsBuffer _tadOffsets;    // Calculated TAD offsets buffer
+  LongType _numTads;                    // Number of TADs
+
+ public:
+  /**
+    * Constructor for TadCalculator
+    * @param originalShape Pointer to the original shape information
+   */
+  explicit TadCalculator(LongType* originalShape);
+  ~TadCalculator() = default;
+
+  /**
+    * Creates a TAD pack for the given dimensions
+    * @param dimensions Vector of dimensions to calculate TADs for
+   */
+  void createTadPack(const std::vector<LongType>& dimensions);
+
+  /**
+    * Returns the calculated TAD shape buffer
+    * @return ConstantShapeBuffer containing TAD shape information
+   */
+  ConstantShapeBuffer tadShape() const { return _tadShape; }
+
+  /**
+    * Returns the calculated TAD offsets buffer
+    * @return ConstantOffsetsBuffer containing TAD offset information
+   */
+  ConstantOffsetsBuffer tadOffsets() const { return _tadOffsets; }
+
+  /**
+    * Returns the number of TADs calculated
+    * @return Number of TADs
+   */
+  LongType numberOfTads() const { return _numTads; }
+};
+
+} // namespace sd
+
+#endif // DEV_TESTS_TADCALCULATOR_H

--- a/libnd4j/include/array/TadCalculator.h
+++ b/libnd4j/include/array/TadCalculator.h
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 //
-// @author raver119@gmail.com
+// @author Adam Gibson
 //
 
 #ifndef DEV_TESTS_TADCALCULATOR_H

--- a/libnd4j/include/array/TadCalculator.h
+++ b/libnd4j/include/array/TadCalculator.h
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 //
-// @author Adam Gibson
+// @author raver119@gmail.com
 //
 
 #ifndef DEV_TESTS_TADCALCULATOR_H

--- a/libnd4j/include/array/TadPack.h
+++ b/libnd4j/include/array/TadPack.h
@@ -45,21 +45,21 @@ class SD_LIB_EXPORT TadPack {
   TadPack() = default;
   ~TadPack() {};
 
-  const LongType* primaryShapeInfo() const;
-  const LongType* primaryOffsets() const;
+  LongType* primaryShapeInfo();
+  LongType* primaryOffsets();
 
-  const LongType* specialShapeInfo() const;
-  const LongType* specialOffsets() const;
+  LongType* specialShapeInfo();
+  LongType* specialOffsets();
 
   LongType numberOfTads() const;
-  LongType shapeInfoLength() const;
+  LongType shapeInfoLength();
   /**
    * Extracts an NDArray view for the given TAD index.
    * @param input The input NDArray.
    * @param tadIndex The index of the TAD to extract.
    * @return A new NDArray view representing the TAD.
    */
-  NDArray *extractTadView(NDArray* input, sd::LongType tadIndex) const {
+  NDArray *extractTadView(NDArray* input, sd::LongType tadIndex) {
     auto shapeInfo = primaryShapeInfo();
     auto offsets = primaryOffsets();
 
@@ -73,10 +73,10 @@ class SD_LIB_EXPORT TadPack {
    * These methods return either primary or special pointers depending on platform binaries were compiled for
    * @return
    */
-  const LongType* platformShapeInfo() const;
-  const LongType* platformOffsets() const;
+  LongType* platformShapeInfo();
+  LongType* platformOffsets();
 
-  void print(const char* msg) const;
+  void print(const char* msg);
 };
 }  // namespace sd
 

--- a/libnd4j/include/helpers/ConstantShapeHelper.h
+++ b/libnd4j/include/helpers/ConstantShapeHelper.h
@@ -43,38 +43,33 @@ class SD_LIB_EXPORT ConstantShapeHelper {
 
   ~ConstantShapeHelper();
   ConstantShapeBuffer* bufferForShapeInfo(DataType dataType, char order, const std::vector<LongType>& shape);
-  ConstantShapeBuffer* bufferForShapeInfo(ShapeDescriptor *descriptor);
-  ConstantShapeBuffer* bufferForShapeInfo(const LongType* shapeInfo);
-  ConstantShapeBuffer* bufferForShapeInfo(DataType dataType, char order, int rank, const LongType* shape);
-  ConstantShapeBuffer* createShapeInfoWithUnitiesForBroadcast(const LongType* maxShapeInfo,
-                                                              const LongType* minShapeInfo,
-                                                              memory::Workspace* workspace = nullptr,
-                                                              const std::vector<LongType>& dimensions = {});
-  ConstantShapeBuffer* createShapeInfoWithNoUnitiesForReduce(const LongType* maxShapeInfo,
-                                                             const std::vector<LongType>* dimsWithUnities,
-                                                             memory::Workspace* workspace = nullptr);
-  ConstantShapeBuffer* createSubArrShapeInfo(const LongType* inShapeInfo, const LongType* dims,
-                                             const LongType dimsSize,
-                                             memory::Workspace* workspace = nullptr);
+  ConstantShapeBuffer* bufferForShapeInfo(LongType* shapeInfo);
+  ConstantShapeBuffer* bufferForShapeInfo(DataType dataType, char order, int rank,  LongType* shape);
+  ConstantShapeBuffer* createShapeInfoWithUnitiesForBroadcast( LongType* maxShapeInfo,
+                                                               LongType* minShapeInfo,
+                                                               memory::Workspace* workspace = nullptr,
+                                                               const std::vector<LongType>& dimensions = {});
+  ConstantShapeBuffer* createShapeInfoWithNoUnitiesForReduce( LongType* maxShapeInfo,
+                                                              const std::vector<LongType>* dimsWithUnities,
+                                                              memory::Workspace* workspace = nullptr);
 
-  const LongType* emptyShapeInfo(DataType dataType);
-  const LongType* scalarShapeInfo(DataType dataType);
-  const LongType* vectorShapeInfo(LongType length, DataType dataType);
-  const LongType* createShapeInfo(ShapeDescriptor *descriptor);
-  const LongType* createShapeInfo(DataType dataType, char order, const std::vector<LongType>& shape);
-  const LongType* createShapeInfo(DataType dataType, const char order, const int rank, const LongType* shape, LongType extraProperties);
-  const LongType* createShapeInfo(DataType dataType, const LongType* shapeInfo);
-  const LongType* createFromExisting(const LongType* shapeInfo, sd::memory::Workspace* workspace);
-  const LongType* createFromExisting(const LongType* shapeInfo, bool destroyOriginal = true);
-  const LongType* createFromExisting(sd::LongType* shapeInfo, sd::memory::Workspace* workspace);
-  const LongType* createFromExisting(sd::LongType* shapeInfo, bool destroyOriginal = true);
+  LongType* emptyShapeInfo(DataType dataType);
+  LongType * scalarShapeInfo(DataType dataType);
+  LongType* vectorShapeInfo(LongType length, DataType dataType);
+  LongType* createShapeInfo(ShapeDescriptor *descriptor);
+  LongType* createShapeInfo(DataType dataType, char order, const std::vector<LongType>& shape);
+  LongType* createShapeInfo(DataType dataType, const char order, const int rank,  LongType* shape, LongType extraProperties);
+  LongType* createShapeInfo(DataType dataType,  LongType* shapeInfo);
+  LongType* createFromExisting(LongType* shapeInfo, sd::memory::Workspace* workspace);
+  LongType* createFromExisting(LongType* shapeInfo, bool destroyOriginal = true);
+
 
   bool checkBufferExistenceForShapeInfo(ShapeDescriptor *descriptor);
 
-  ConstantShapeBuffer* storeAndWrapBuffer(const LongType* shapeInfo);
-  const LongType* castToDataType(const LongType* shapeInfo, const DataType newType);
-  const LongType* emptyShapeInfoWithShape(const DataType dataType, std::vector<LongType>& shape);
-  ConstantShapeBuffer* createConstBuffFromExisting(const sd::LongType* shapeInfo, sd::memory::Workspace* workspace);
+  ConstantShapeBuffer* storeAndWrapBuffer( LongType* shapeInfo);
+  LongType* castToDataType( LongType* shapeInfo,  DataType newType);
+  LongType* emptyShapeInfoWithShape(const DataType dataType, std::vector<LongType>& shape);
+  ConstantShapeBuffer* createConstBuffFromExisting( sd::LongType* shapeInfo, sd::memory::Workspace* workspace);
 };
 }  // namespace sd
 

--- a/libnd4j/include/helpers/ConstantTadHelper.h
+++ b/libnd4j/include/helpers/ConstantTadHelper.h
@@ -33,10 +33,9 @@
 namespace sd {
 class SD_LIB_EXPORT ConstantTadHelper {
  private:
-  std::mutex _mutex;
   DirectTadTrie _trie;  // Single trie for device 0
 
-  ConstantTadHelper();
+  ConstantTadHelper() = default;
 
  public:
   ~ConstantTadHelper() = default;
@@ -51,34 +50,15 @@ class SD_LIB_EXPORT ConstantTadHelper {
    * @param keepUnitiesInShape
    * @return
    */
-  TadPack *tadForDimensions(const LongType *originalShape, const std::vector<LongType> *dimensions,
-                           const bool keepUnitiesInShape = false);
-  TadPack *tadForDimensions(const LongType *originalShape, LongType *dimensions, LongType dimLength,
-                           const bool keepUnitiesInShape = false);
-  TadPack *tadForDimensions(const LongType *originalShape, LongType dimension, const bool keepUnitiesInShape = false);
+
+  TadPack *tadForDimensions(LongType *originalShape, LongType *dimensions, LongType dimLength,
+                           bool keepUnitiesInShape = false);
   TadPack *tadForDimensions(ShapeDescriptor &descriptor, std::vector<LongType> &dimensions,
                            const bool keepUnitiesInShape = false);
   TadPack *tadForDimensions(TadDescriptor *descriptor);
 
-  /**
-   * This method returns number of cached TAD shapes/offsets on specific device
-   * @return
-   */
-  SD_INLINE int cachedEntriesForDevice(int deviceId) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (deviceId > 0) THROW_EXCEPTION("deviceId > number of actual devices");
-    
-    return _trie.totalCachedEntries();
-  }
-
-  /**
-   * This method returns total number of cached TAD shapes/offsets on all devices
-   * @return
-   */
-  SD_INLINE int totalCachedEntries() {
-    std::lock_guard<std::mutex> lock(_mutex);
-    return _trie.totalCachedEntries();
-  }
+  TadPack *tadForDimensions(LongType *originalShape, LongType dimension, bool keepUnitiesInShape);
+  TadPack *tadForDimensions(LongType *originalShape, std::vector<LongType> *dimensions, bool keepUnitiesInShape);
 };
 }  // namespace sd
 

--- a/libnd4j/include/helpers/DirectShapeTrie.h
+++ b/libnd4j/include/helpers/DirectShapeTrie.h
@@ -1,24 +1,8 @@
-/* ******************************************************************************
- *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
- *
- *  See the NOTICE file distributed with this work for additional
- *  information regarding copyright ownership.
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
- ******************************************************************************/
-
 #ifndef LIBND4J_DIRECTSHAPETRIE_H
 #define LIBND4J_DIRECTSHAPETRIE_H
 
 #include <system/common.h>
+#include <array/ConstantShapeBuffer.h>
 
 #include <array>
 #include <atomic>
@@ -26,75 +10,124 @@
 #include <shared_mutex>
 #include <vector>
 
-#include "exceptions/backward.hpp"
-
 namespace sd {
 #ifndef __JAVACPP_HACK__
 
-class ConstantShapeBuffer;
 
 class SD_LIB_EXPORT ShapeTrieNode {
-private:
-    std::vector<std::unique_ptr<ShapeTrieNode>> _children;
-    std::atomic<ConstantShapeBuffer*> _buffer;
-    LongType _value;
-    int _level;
-    bool _isShape;
+ private:
+  std::vector<std::unique_ptr<ShapeTrieNode>> _children;
+  LongType _value;
+  int _level;
+  bool _isShape;
+  ConstantShapeBuffer* _buffer;  // Changed from atomic
+
 #if defined(SD_GCC_FUNCTRACE)
-    backward::StackTrace st;
-    backward::StackTrace storeStackTrace;
+  backward::StackTrace st;
+  backward::StackTrace storeStackTrace;
 #endif
 
-public:
-    ShapeTrieNode(LongType value = 0, int level = 0, bool isShape = true);
-    ~ShapeTrieNode();
+ public:
+  ShapeTrieNode(LongType value = 0, int level = 0, bool isShape = true)
+      : _value(value), _level(level), _isShape(isShape), _buffer(nullptr) {
+#if defined(SD_GCC_FUNCTRACE)
+    this->st.load_here();
+#endif
+  }
 
-    ShapeTrieNode* findOrCreateChild(LongType value, int level, bool isShape);
-    const std::vector<std::unique_ptr<ShapeTrieNode>>& children() const;
-    ConstantShapeBuffer* buffer() const;
-    void setBuffer(ConstantShapeBuffer* buf);
-    LongType value() const;
-    int level() const;
-    bool isShape() const;
-    void collectStoreStackTrace();
+  ~ShapeTrieNode() {
+    if (_buffer) delete _buffer;
+  }
+
+  ShapeTrieNode* findOrCreateChild(LongType value, int level, bool isShape) {
+    for (auto& child : _children) {
+      if (child->value() == value && child->level() == level &&
+          child->isShape() == isShape) {
+        return child.get();
+      }
+    }
+
+    auto newNode = std::make_unique<ShapeTrieNode>(value, level, isShape);
+    auto* ptr = newNode.get();
+    _children.push_back(std::move(newNode));
+    return ptr;
+  }
+
+  const std::vector<std::unique_ptr<ShapeTrieNode>>& children() const { return _children; }
+  LongType value() const { return _value; }
+  int level() const { return _level; }
+  bool isShape() const { return _isShape; }
+
+  void setBuffer(ConstantShapeBuffer* buf);
+  ConstantShapeBuffer* buffer() const { return _buffer; }
+
+#if defined(SD_GCC_FUNCTRACE)
+  void collectStoreStackTrace();
+#endif
 };
 
-//mainly a workaround for javacpp
 #if __cplusplus >= 201703L
-#define MUTEX_TYPE std::shared_mutex
+#define SHAPE_MUTEX_TYPE std::shared_mutex
+#define SHAPE_LOCK_TYPE std::shared_lock
 #else
-#define MUTEX_TYPE std::mutex
+#define SHAPE_MUTEX_TYPE std::mutex
+#define SHAPE_LOCK_TYPE std::lock_guard
 #endif
 
 class SD_LIB_EXPORT DirectShapeTrie {
-private:
-    static const size_t NUM_STRIPES = 32;
-    std::array<std::unique_ptr<ShapeTrieNode>, NUM_STRIPES> _roots;
-    mutable std::array<MUTEX_TYPE, NUM_STRIPES> _mutexes = {};  // Marked mutable for const member functions
+ private:
+  static const size_t NUM_STRIPES = 32;
+  std::array<std::unique_ptr<ShapeTrieNode>, NUM_STRIPES> _roots;
+  mutable std::array<SHAPE_MUTEX_TYPE, NUM_STRIPES> _mutexes = {};
+  std::array<std::atomic<int>, NUM_STRIPES> _stripeCounts = {};
 
-    struct ThreadCache {
-        static const size_t CACHE_SIZE = 1024;
-        std::vector<std::pair<const LongType*, ConstantShapeBuffer*>> entries;
-        ThreadCache();
-    };
-    
-    static thread_local ThreadCache _threadCache;
+  // Enhanced thread-local cache with atomic operations
+  struct alignas(64) ThreadCache {
+    static const size_t CACHE_SIZE = 1024;
+    std::vector<std::pair<const LongType*, ConstantShapeBuffer*>> entries;
+    std::atomic<size_t> size{0};
 
-    size_t computeHash(const LongType* shapeInfo) const;
-    size_t getStripeIndex(const LongType* shapeInfo) const;
-    bool shapeInfoEqual(const LongType* a, const LongType* b) const;
-    void updateThreadCache(const LongType* shapeInfo, ConstantShapeBuffer* buffer);
-    ConstantShapeBuffer* createBuffer(const LongType* shapeInfo);
-    void validateShapeInfo(const LongType* shapeInfo) const;
-    ConstantShapeBuffer* insert(const LongType* shapeInfo, size_t stripeIdx);
-    ConstantShapeBuffer* search(const LongType* shapeInfo, size_t stripeIdx) const;
-    const ShapeTrieNode* findChild(const ShapeTrieNode* node, LongType value, 
-                                  int level, bool isShape) const;
+    ThreadCache() {
+      entries.reserve(CACHE_SIZE);
+    }
+  };
 
-public:
-    DirectShapeTrie();
-    ConstantShapeBuffer* getOrCreate(const LongType* shapeInfo);
-    bool exists(const LongType* shapeInfo) const;
+  static thread_local ThreadCache _threadCache;
+
+  size_t computeHash(const LongType* shapeInfo) const;
+  size_t getStripeIndex(const LongType* shapeInfo) const;
+  bool shapeInfoEqual(const LongType* a, const LongType* b) const;
+  void validateShapeInfo(const LongType* shapeInfo) const;
+  ConstantShapeBuffer* createBuffer(const LongType* shapeInfo);
+  void updateThreadCache(const LongType* shapeInfo, ConstantShapeBuffer* buffer);
+  const ShapeTrieNode* findChild(const ShapeTrieNode* node, LongType value,
+                                 int level, bool isShape) const;
+  ConstantShapeBuffer* search(const LongType* shapeInfo, size_t stripeIdx) const;
+  ConstantShapeBuffer* insert(const LongType* shapeInfo, size_t stripeIdx);
+
+ public:
+  // Constructor
+  DirectShapeTrie() {
+#ifndef __JAVACPP_HACK__
+    for (size_t i = 0; i < NUM_STRIPES; i++) {
+      _roots[i] = std::make_unique<ShapeTrieNode>(0, 0, false);
+      // Make sure mutexes are properly initialized
+      new (&_mutexes[i]) SHAPE_MUTEX_TYPE();
+    }
+#endif
+  }
+
+  // Delete copy constructor and assignment
+  DirectShapeTrie(const DirectShapeTrie&) = delete;
+  DirectShapeTrie& operator=(const DirectShapeTrie&) = delete;
+
+  // Delete move operations
+  DirectShapeTrie(DirectShapeTrie&&) = delete;
+  DirectShapeTrie& operator=(DirectShapeTrie&&) = delete;
+
+  // Enhanced getOrCreate with three-tier access pattern
+  ConstantShapeBuffer* getOrCreate(const LongType* shapeInfo);
+  bool exists(const LongType* shapeInfo) const;
 };
 
 }  // namespace sd

--- a/libnd4j/include/helpers/DirectTadTrie.h
+++ b/libnd4j/include/helpers/DirectTadTrie.h
@@ -1,84 +1,75 @@
 /* ******************************************************************************
- *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
- *
- *  See the NOTICE file distributed with this work for additional
- *  information regarding copyright ownership.
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
- ******************************************************************************/
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+*  See the NOTICE file distributed with this work for additional
+*  information regarding copyright ownership.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+******************************************************************************/
 
 #ifndef LIBND4J_DIRECTTADTRIE_H
 #define LIBND4J_DIRECTTADTRIE_H
 
 #include <array/TadPack.h>
 #include <system/common.h>
-#include <vector>
+
+#include <array>
+#include <atomic>
 #include <memory>
 #include <shared_mutex>
-#include <atomic>
-#include <array>
+#include <vector>
+
+#include "array/TadCalculator.h"
 
 namespace sd {
 #ifndef __JAVACPP_HACK__
 
 // Add make_unique implementation for pre-C++14
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique_helper(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
-
 class SD_LIB_EXPORT TadTrieNode {
-private:
-    std::vector<std::unique_ptr<TadTrieNode>> _children;
-    LongType _value;
-    int _level;
-    bool _isDimension;
-    std::atomic<int> _cachedEntries;  // Count of cached entries in this subtree
+ private:
+  std::vector<std::unique_ptr<TadTrieNode>> _children;
+  LongType _value;
+  int _level;
+  bool _isDimension;
+  TadPack* _tadPack;  // Changed from atomic
 
-public:
-    std::atomic<TadPack*> _tadPack;  // Made public for direct access
+ public:
+  TadTrieNode(LongType value = 0, int level = 0, bool isDimension = true)
+      : _value(value), _level(level), _isDimension(isDimension), _tadPack(nullptr) {}
 
-    TadTrieNode(LongType value = 0, int level = 0, bool isDimension = true)
-        : _value(value), _level(level), _isDimension(isDimension), _cachedEntries(0), _tadPack(nullptr) {}
+  ~TadTrieNode() = default;
 
-    ~TadTrieNode() = default;
-
-    TadTrieNode* findOrCreateChild(LongType value, int level, bool isDimension) {
-        for (auto& child : _children) {
-            if (child->value() == value && child->isDimension() == isDimension) {
-                return child.get();
-            }
-        }
-
-        auto newNode = make_unique_helper<TadTrieNode>(value, level, isDimension);
-        auto* ptr = newNode.get();
-        _children.push_back(std::move(newNode));
-        return ptr;
+  TadTrieNode* findOrCreateChild(LongType value, int level, bool isDimension) {
+    for (auto& child : _children) {
+      if (child->value() == value && child->isDimension() == isDimension) {
+        return child.get();
+      }
     }
+#ifndef __JAVACPP_HACK__
+    auto newNode = std::make_unique<TadTrieNode>(value, level, isDimension);
+    auto* ptr = newNode.get();
+    _children.push_back(std::move(newNode));
+#endif
+    return ptr;
+  }
 
-    const std::vector<std::unique_ptr<TadTrieNode>>& children() const { return _children; }
-    LongType value() const { return _value; }
-    int level() const { return _level; }
-    bool isDimension() const { return _isDimension; }
+  const std::vector<std::unique_ptr<TadTrieNode>>& children() const { return _children; }
+  LongType value() const { return _value; }
+  int level() const { return _level; }
+  bool isDimension() const { return _isDimension; }
 
-    void incrementCachedEntries() { _cachedEntries.fetch_add(1, std::memory_order_relaxed); }
-    void decrementCachedEntries() { _cachedEntries.fetch_sub(1, std::memory_order_relaxed); }
-    int getCachedEntries() const { return _cachedEntries.load(std::memory_order_relaxed); }
-    void setPack(TadPack* pack);
-    TadPack* pack() const;
+  void setPack(TadPack* pack);
 
+  TadPack* pack() const { return _tadPack; }
 };
-
-
 
 #if __cplusplus >= 201703L
 #define TAD_MUTEX_TYPE std::shared_mutex
@@ -89,128 +80,110 @@ public:
 #endif
 
 class SD_LIB_EXPORT DirectTadTrie {
-private:
-    static const size_t NUM_STRIPES = 32;
-    std::array<std::unique_ptr<TadTrieNode>, NUM_STRIPES> _roots;
-    mutable std::array<TAD_MUTEX_TYPE, NUM_STRIPES> _mutexes = {};
-    std::array<std::atomic<int>, NUM_STRIPES> _stripeCounts = {};
+ private:
+  static const size_t NUM_STRIPES = 32;
+  std::array<std::unique_ptr<TadTrieNode>, NUM_STRIPES> _roots;
+  mutable std::array<TAD_MUTEX_TYPE, NUM_STRIPES> _mutexes = {};
+  std::array<std::atomic<int>, NUM_STRIPES> _stripeCounts = {};
 
-    struct ThreadCache {
-        static const size_t CACHE_SIZE = 1024;
-        std::vector<std::pair<std::vector<LongType>, TadPack*>> entries;
-        ThreadCache() { entries.reserve(CACHE_SIZE); }
-    };
-    int countEntriesInSubtree(const TadTrieNode* node) const;
+  // Enhanced thread-local cache with atomic operations
+  struct alignas(64) ThreadCache {
+    static const size_t CACHE_SIZE = 1024;
+    std::vector<std::pair<std::vector<LongType>, TadPack*>> entries;
+    std::atomic<size_t> size{0};
 
-    static thread_local ThreadCache _threadCache;
+    ThreadCache() {
+      entries.reserve(CACHE_SIZE);
+    }
+  };
 
-public:
-    // Proper constructors for move/copy
-    DirectTadTrie() {
-        for (size_t i = 0; i < NUM_STRIPES; i++) {
-            _roots[i] =  make_unique_helper<TadTrieNode>();
-            _stripeCounts[i].store(0, std::memory_order_relaxed);
-        }
+  static thread_local ThreadCache _threadCache;
+
+ public:
+  // Constructor
+  DirectTadTrie() {
+#ifndef __JAVACPP_HACK__
+    for (size_t i = 0; i < NUM_STRIPES; i++) {
+      _roots[i] = std::make_unique<TadTrieNode>(0, 0, false);
+      // Make sure mutexes are properly initialized
+      new (&_mutexes[i]) TAD_MUTEX_TYPE();  // Explicit initialization
+    }
+#endif
+  }
+
+  // Delete copy constructor and assignment
+  DirectTadTrie(const DirectTadTrie&) = delete;
+  DirectTadTrie& operator=(const DirectTadTrie&) = delete;
+
+  // Delete move operations
+  DirectTadTrie(DirectTadTrie&&) = delete;
+  DirectTadTrie& operator=(DirectTadTrie&&) = delete;
+
+  // Enhanced getOrCreate with three-tier access pattern
+  TadPack* getOrCreate(std::vector<LongType>& dimensions, LongType* originalShape) {
+    const size_t stripeIdx = computeStripeIndex(dimensions);
+    std::unique_lock<TAD_MUTEX_TYPE> lock(_mutexes[stripeIdx]);
+
+    // Traverse to the correct node or create path as needed
+    TadTrieNode* current = _roots[stripeIdx].get();
+
+    // First level: dimension length
+    current = current->findOrCreateChild(dimensions.size(), 0, false);
+    if (!current) {
+      THROW_EXCEPTION("Failed to create/find length node");
     }
 
-    DirectTadTrie(const DirectTadTrie&) = delete;  // Prevent copying
-    DirectTadTrie& operator=(const DirectTadTrie&) = delete;
-
-    DirectTadTrie(DirectTadTrie&&) = default;  // Allow moving
-    DirectTadTrie& operator=(DirectTadTrie&&) = default;
-
-    size_t computeStripeIndex(const std::vector<LongType>& dimensions) const {
-        size_t hash = 0;
-        for (auto dim : dimensions) {
-            hash = hash * 31 + static_cast<size_t>(dim);
-        }
-        return hash % NUM_STRIPES;
+    // Second level: dimensions
+    for (size_t i = 0; i < dimensions.size(); i++) {
+      current = current->findOrCreateChild(dimensions[i], i + 1, true);
+      if (!current) {
+        THROW_EXCEPTION("Failed to create/find dimension node");
+      }
     }
 
-    TadTrieNode* getOrCreateNode(const std::vector<LongType>& dimensions) {
-        const size_t stripeIdx = computeStripeIndex(dimensions);
-        std::unique_lock<TAD_MUTEX_TYPE> lock(_mutexes[stripeIdx]);
-
-        TadTrieNode* current = _roots[stripeIdx].get();
-
-        // First level: dimension length
-        current = current->findOrCreateChild(dimensions.size(), 0, false);
-
-        // Second level: dimensions
-        for (size_t i = 0; i < dimensions.size(); i++) {
-            current = current->findOrCreateChild(dimensions[i], i + 1, true);
-        }
-
-        return current;
+    // Check if we already have a TAD pack
+    if (TadPack* existing = current->pack()) {
+      return existing;
     }
 
-    TadPack* getOrCreate(const std::vector<LongType>& dimensions) {
-        // Check thread-local cache first
-        for (const auto& entry : _threadCache.entries) {
-            if (entry.first == dimensions) {
-                return entry.second;
-            }
-        }
+    // Create new TAD pack under the same lock
+    try {
+      TadCalculator calculator(originalShape);
+      calculator.createTadPack(dimensions);
 
-        auto* node = getOrCreateNode(dimensions);
-        return node->_tadPack.load(std::memory_order_acquire);
+      TadPack* newPack = new TadPack(
+          calculator.tadShape(),
+          calculator.tadOffsets(),
+          calculator.numberOfTads(),
+          dimensions.data(),
+          dimensions.size());
+
+      current->setPack(newPack);
+      return newPack;
+    } catch (const std::exception& e) {
+      std::string msg = "TAD creation failed: ";
+      msg += e.what();
+      THROW_EXCEPTION(msg.c_str());
     }
+  }
 
-    void incrementStripeCount(size_t stripeIdx) {
-        _stripeCounts[stripeIdx].fetch_add(1, std::memory_order_relaxed);
+  // Original methods preserved
+  size_t computeStripeIndex(const std::vector<LongType>& dimensions) const {
+    size_t hash = 0;
+    for (auto dim : dimensions) {
+      hash = hash * 31 + static_cast<size_t>(dim);
     }
+    return hash % NUM_STRIPES;
+  }
 
-    void decrementStripeCount(size_t stripeIdx) {
-        _stripeCounts[stripeIdx].fetch_sub(1, std::memory_order_relaxed);
-    }
+  bool exists(const std::vector<LongType>& dimensions) const ;
 
-    int totalCachedEntries() const {
-        int total = 0;
-        for (size_t i = 0; i < NUM_STRIPES; i++) {
-            total += _stripeCounts[i].load(std::memory_order_relaxed);
-        }
-        return total;
-    }
-
-    bool exists(const std::vector<LongType>& dimensions) const {
-        const size_t stripeIdx = computeStripeIndex(dimensions);
-        TAD_LOCK_TYPE<TAD_MUTEX_TYPE> lock(_mutexes[stripeIdx]);
-
-        const TadTrieNode* current = _roots[stripeIdx].get();
-
-        // First level: dimension length
-        for (const auto& child : current->children()) {
-            if (child->value() == dimensions.size() && !child->isDimension()) {
-                current = child.get();
-                goto found_length;
-            }
-        }
-        return false;
-
-    found_length:
-        // Second level: dimensions
-        for (size_t i = 0; i < dimensions.size(); i++) {
-            bool found = false;
-            for (const auto& child : current->children()) {
-                if (child->value() == dimensions[i] && child->isDimension()) {
-                    current = child.get();
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) return false;
-        }
-
-        return current->_tadPack.load(std::memory_order_acquire) != nullptr;
-    }
-    TadPack* search(const std::vector<LongType>& dimensions, size_t stripeIdx) const;
-    std::vector<LongType> sortDimensions(const std::vector<LongType>& dimensions) const;
-    void updateThreadCache(const std::vector<LongType>& dimensions, TadPack* pack);
-    bool dimensionsEqual(const std::vector<LongType>& a, const std::vector<LongType>& b) const;
-    size_t getStripeIndex(const std::vector<LongType>& dimensions) const;
-    size_t computeHash(const std::vector<LongType>& dimensions) const;
-    TadPack* insert(const std::vector<LongType>& dimensions, size_t stripeIdx);
-    const TadTrieNode* findChild(const TadTrieNode* node, LongType value, int level, bool isDimension) const;
+  // Original helper methods preserved
+  TadPack* search(const std::vector<LongType>& dimensions, size_t stripeIdx) const;
+  std::vector<LongType> sortDimensions(const std::vector<LongType>& dimensions) const;
+  bool dimensionsEqual(const std::vector<LongType>& a, const std::vector<LongType>& b) const;
+  const TadTrieNode* findChild(const TadTrieNode* node, LongType value, int level, bool isDimension) const;
+  TadPack* insert(std::vector<LongType>& dimensions, LongType* originalShape);
 };
 
 }  // namespace sd

--- a/libnd4j/include/helpers/cpu/TadCalculator.cpp
+++ b/libnd4j/include/helpers/cpu/TadCalculator.cpp
@@ -1,0 +1,82 @@
+#include <array/TadCalculator.h>
+#include <helpers/ShapeUtils.h>
+#include <helpers/ConstantHelper.h>
+#include <helpers/ConstantShapeHelper.h>
+
+namespace sd {
+
+TadCalculator::TadCalculator(LongType* originalShape)
+    : _originalShape(originalShape), _numTads(0) {}
+
+void TadCalculator::createTadPack(const std::vector<LongType>& dimensions) {
+  // Validate input and create shape info from original shape
+  if (!_originalShape) {
+    THROW_EXCEPTION("Original shape is null");
+  }
+
+  auto shapeInfo = ConstantShapeHelper::getInstance().createFromExisting(_originalShape,false);
+  const LongType rank = shape::rank(shapeInfo);
+
+  // Calculate dimensions to exclude
+  const std::vector<LongType>* dimsToExclude = ShapeUtils::evalDimsToExclude(rank, dimensions.size(), dimensions.data());
+  if (!dimsToExclude) {
+    THROW_EXCEPTION("Failed to evaluate dimensions to exclude");
+  }
+
+  // Calculate number of sub-arrays
+  const LongType numOfSubArrs = ShapeUtils::getNumOfSubArrs(shapeInfo, *dimsToExclude);
+
+  if (numOfSubArrs > 0) {
+    // Calculate sub-array rank
+    const LongType subArrRank = (static_cast<size_t>(rank) == dimsToExclude->size() || false) ? rank : rank - dimsToExclude->size();
+
+    // Allocate memory for shapes and offsets
+    auto sPtr = std::make_shared<PointerWrapper>(new LongType[shape::shapeInfoLength(subArrRank)]);
+    auto oPtr = std::make_shared<PointerWrapper>(new LongType[numOfSubArrs]);
+
+    // Calculate shapes and offsets
+    shape::calcSubArrsShapeInfoAndOffsets(
+        shapeInfo,
+        numOfSubArrs,
+        dimsToExclude->size(),
+        dimsToExclude->data(),
+        sPtr->pointerAsT<LongType>(),
+        oPtr->pointerAsT<LongType>(),
+        false);  // areUnitiesInShape
+
+    // Create shape buffer
+    auto shapesBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(sPtr->pointerAsT<LongType>());
+
+    // Create offsets buffer
+    _tadOffsets = ConstantOffsetsBuffer(oPtr);
+    _tadShape = *shapesBuffer;
+    _numTads = numOfSubArrs;
+  } else {
+    // Base case: number of sub arrays is zero, use original shape
+    const LongType subArrRank = rank;
+
+    // Allocate and copy shape info
+    auto sPtr = std::make_shared<PointerWrapper>(new LongType[shape::shapeInfoLength(subArrRank)]);
+    LongType* shapeInfo2 = sPtr->pointerAsT<LongType>();
+
+    // Copy shape info
+    auto nonConstant = const_cast<LongType*>(shapeInfo);
+    auto nonConst2 = const_cast<LongType*>(shapeInfo2);
+    shape::copyTo<LongType>(shape::shapeInfoLength(subArrRank), nonConstant, nonConst2);
+
+    // Create base offset
+    LongType* baseOffset = new LongType[1];
+    baseOffset[0] = 0;
+    auto oPtr = std::make_shared<PointerWrapper>(baseOffset);
+
+    // Create buffers
+    auto shapesBuffer = ConstantShapeHelper::getInstance().bufferForShapeInfo(sPtr->pointerAsT<LongType>());
+    _tadOffsets = ConstantOffsetsBuffer(oPtr);
+    _tadShape = *shapesBuffer;
+    _numTads = 1;
+  }
+
+  delete dimsToExclude;
+}
+
+} // namespace sd

--- a/libnd4j/include/helpers/generic/ResourceManager.h
+++ b/libnd4j/include/helpers/generic/ResourceManager.h
@@ -1,0 +1,93 @@
+/* ******************************************************************************
+ *
+ * Copyright (c) 2024 Konduit K.K.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+#ifndef SD_GENERIC_RESOURCE_MANAGER_H_
+#define SD_GENERIC_RESOURCE_MANAGER_H_
+
+#include <system/common.h>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+
+namespace sd {
+namespace generic {
+
+class ResourceManager {
+private:
+    mutable std::atomic<size_t> _totalNodes{0};
+    std::atomic<size_t> _activeOperations{0};
+    std::chrono::steady_clock::time_point _lastCleanup;
+    std::mutex _cleanupMutex;
+    static constexpr size_t CLEANUP_THRESHOLD = 1000;
+    static constexpr auto CLEANUP_INTERVAL = std::chrono::minutes(5);
+
+public:
+    class OperationScope {
+    private:
+        ResourceManager& _manager;
+    public:
+        explicit OperationScope(ResourceManager& m) : _manager(m) {
+            _manager._activeOperations.fetch_add(1, std::memory_order_acquire);
+        }
+        ~OperationScope() {
+            _manager._activeOperations.fetch_sub(1, std::memory_order_release);
+        }
+    };
+
+    void registerNode() const {
+        _totalNodes.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void unregisterNode() const {
+        _totalNodes.fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    OperationScope createScope() const {
+        ResourceManager &m = const_cast<ResourceManager&>(*this);
+        return OperationScope(m);
+    }
+
+    size_t activeOperations() const {
+        return _activeOperations.load(std::memory_order_relaxed);
+    }
+
+    size_t totalNodes() const {
+        return _totalNodes.load(std::memory_order_relaxed);
+    }
+
+    void resetCleanupTimer() {
+        std::lock_guard<std::mutex> lock(_cleanupMutex);
+        _lastCleanup = std::chrono::steady_clock::now();
+    }
+
+    bool shouldCleanup() {
+        if (_totalNodes.load(std::memory_order_relaxed) < CLEANUP_THRESHOLD)
+            return false;
+
+        auto now = std::chrono::steady_clock::now();
+        std::lock_guard<std::mutex> lock(_cleanupMutex);
+        if (now - _lastCleanup >= CLEANUP_INTERVAL) {
+            _lastCleanup = now;
+            return true;
+        }
+        return false;
+    }
+};
+
+}} // namespace sd::generic
+
+#endif // SD_GENERIC_RESOURCE_MANAGER_H_

--- a/libnd4j/include/helpers/generic/StripedLocks.h
+++ b/libnd4j/include/helpers/generic/StripedLocks.h
@@ -1,0 +1,199 @@
+/* ******************************************************************************
+*
+* Copyright (c) 2024 Konduit K.K.
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+******************************************************************************/
+
+#ifndef SD_STRIPED_LOCKS_H_
+#define SD_STRIPED_LOCKS_H_
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#include "system/op_boilerplate.h"
+
+namespace sd {
+namespace generic {
+
+template<size_t NUM_STRIPES = 32>
+class StripedLocks {
+private:
+ mutable std::array<std::shared_mutex, NUM_STRIPES> _mutexes;
+ mutable std::array<std::atomic<uint32_t>, NUM_STRIPES> _stripeCounts{};
+ static constexpr int MAX_RETRIES = 500;
+ static constexpr auto RETRY_DELAY = std::chrono::microseconds(50);
+ static constexpr int MAX_BACKOFF_SHIFT = 10;
+ static constexpr auto MIN_DELAY = std::chrono::microseconds(50);
+
+ static_assert((NUM_STRIPES & (NUM_STRIPES - 1)) == 0, "NUM_STRIPES must be a power of 2");
+
+ bool acquireLockWithTimeout(size_t stripe, bool exclusive, int maxRetries) const {
+   auto startTime = std::chrono::steady_clock::now();
+
+   for (int attempt = 0; attempt < maxRetries; ++attempt) {
+     bool locked = exclusive ?
+                             _mutexes[stripe].try_lock() :
+                             _mutexes[stripe].try_lock_shared();
+
+     if (locked) {
+       _stripeCounts[stripe].fetch_add(1, std::memory_order_acq_rel);
+       return true;
+     }
+
+     if (std::chrono::steady_clock::now() - startTime > std::chrono::seconds(1)) {
+       return false;
+     }
+
+     auto backoff = RETRY_DELAY * (1 << std::min(attempt, MAX_BACKOFF_SHIFT));
+     std::this_thread::sleep_for(backoff);
+   }
+   return false;
+ }
+
+public:
+ StripedLocks() {
+   initializeCounts();
+ }
+
+ class MultiLockGuard {
+  private:
+   StripedLocks& _locks;
+   std::vector<size_t> _stripes;
+   bool _exclusive;
+   bool _acquired{false};
+   static constexpr auto LOCK_TIMEOUT = std::chrono::seconds(2);
+
+   bool acquireAllLocksWithTimeout(const std::chrono::milliseconds& timeout) {
+     auto startTime = std::chrono::steady_clock::now();
+     std::vector<size_t> acquired;
+     acquired.reserve(_stripes.size());
+
+     while (std::chrono::steady_clock::now() - startTime < timeout) {
+       bool allLocked = true;
+       for (size_t stripe : _stripes) {
+         if (!_locks.acquireLockWithTimeout(stripe, _exclusive, 1)) {
+           allLocked = false;
+           for (auto& s : acquired) {
+             _locks.unlockStripe(s, _exclusive);
+           }
+           acquired.clear();
+           break;
+         }
+         acquired.push_back(stripe);
+       }
+       if (allLocked) {
+         _acquired = true;
+         return true;
+       }
+       std::this_thread::sleep_for(MIN_DELAY);
+     }
+     return false;
+   }
+
+  public:
+   MultiLockGuard(StripedLocks& locks,
+                  const std::vector<size_t>& stripes,
+                  bool exclusive,
+                  const std::chrono::milliseconds& timeout = std::chrono::seconds(2))
+       : _locks(locks), _stripes(stripes), _exclusive(exclusive) {
+     std::sort(_stripes.begin(), _stripes.end());
+     _stripes.erase(std::unique(_stripes.begin(), _stripes.end()), _stripes.end());
+     acquireAllLocksWithTimeout(timeout);
+   }
+
+   bool acquired() const { return _acquired; }
+
+   void release() {
+     if (!_acquired) return;
+     for (auto it = _stripes.rbegin(); it != _stripes.rend(); ++it) {
+       _locks.unlockStripe(*it, _exclusive);
+     }
+     _acquired = false;
+   }
+
+   ~MultiLockGuard() {
+     if (_acquired) {
+       release();
+     }
+   }
+
+   MultiLockGuard(const MultiLockGuard&) = delete;
+   MultiLockGuard& operator=(const MultiLockGuard&) = delete;
+   MultiLockGuard(MultiLockGuard&&) noexcept = default;
+ };
+
+ MultiLockGuard acquireMultiLockWithTimeout(const std::vector<size_t>& stripes,
+                                            bool exclusive,
+                                            const std::chrono::milliseconds& timeout) {
+   return MultiLockGuard(*this, stripes, exclusive, timeout);
+ }
+
+ void lockStripe(size_t stripe, bool exclusive = false) const {
+   if (stripe >= NUM_STRIPES) {
+     throw std::out_of_range("Invalid stripe index");
+   }
+
+   if (!acquireLockWithTimeout(stripe, exclusive, MAX_RETRIES)) {
+     auto currentCount = _stripeCounts[stripe].load(std::memory_order_relaxed);
+     std::string msg = "Failed to acquire " +
+                       std::string(exclusive ? "exclusive" : "shared") +
+                       " lock for stripe " + std::to_string(stripe) +
+                       " after " + std::to_string(MAX_RETRIES) +
+                       " attempts. Current count: " + std::to_string(currentCount);
+     THROW_EXCEPTION(msg.c_str());
+   }
+ }
+
+ void unlockStripe(size_t stripe, bool exclusive = false) const {
+   if (stripe >= NUM_STRIPES) {
+     throw std::out_of_range("Invalid stripe index");
+   }
+   _stripeCounts[stripe].fetch_sub(1, std::memory_order_relaxed);
+   if (exclusive) {
+     _mutexes[stripe].unlock();
+   } else {
+     _mutexes[stripe].unlock_shared();
+   }
+ }
+
+ MultiLockGuard acquireMultiLock(const std::vector<size_t>& stripes, bool exclusive = false) {
+   return MultiLockGuard(*this, stripes, exclusive);
+ }
+
+ uint32_t getStripeCount(size_t stripe) const {
+   return _stripeCounts[stripe].load(std::memory_order_relaxed);
+ }
+
+ template<typename T>
+ size_t getStripeIndex(const T& value) const {
+   return std::hash<T>{}(value) & (NUM_STRIPES - 1);
+ }
+
+ void initializeCounts() {
+   for (auto& count : _stripeCounts) {
+     count.store(0, std::memory_order_relaxed);
+   }
+ }
+
+ static constexpr size_t getNumStripes() { return NUM_STRIPES; }
+};
+
+}} // namespace sd::generic
+
+#endif // SD_STRIPED_LOCKS_H_

--- a/libnd4j/include/helpers/generic/TypedTrie.h
+++ b/libnd4j/include/helpers/generic/TypedTrie.h
@@ -1,0 +1,82 @@
+/* ******************************************************************************
+ *
+ * Copyright (c) 2024 Konduit K.K.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+#ifndef SD_GENERIC_TYPED_TRIE_H_
+#define SD_GENERIC_TYPED_TRIE_H_
+
+#include <system/common.h>
+
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include "StripedLocks.h"
+#include "ResourceManager.h"
+namespace sd {
+namespace generic {
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES = 32>
+class SD_LIB_EXPORT TypedTrie {
+ private:
+  struct TrieNode;
+
+
+  std::array<std::unique_ptr<TrieNode>, NUM_STRIPES> _roots;
+  ResourceManager _resourceManager;
+
+  size_t getStripeIndex(const KeyType& key) const;
+  TrieNode* findOrCreateNode(TrieNode* root, const KeyType& key, bool createIfMissing) const;
+  void cleanupNode(TrieNode* node);
+
+ public:
+  ~TypedTrie();
+  TypedTrie();
+
+  // Delete copy constructor and assignment
+  TypedTrie& operator=(const TypedTrie&) = delete;
+
+  // Allow move operations
+  TypedTrie(TypedTrie&&) = default;
+  TypedTrie& operator=(TypedTrie&&) = default;
+
+
+  std::shared_ptr<ValueType> get(const KeyType& key) const;
+  bool insert(const KeyType& key, std::shared_ptr<ValueType> value);
+  bool remove(const KeyType& key);
+  void cleanup();
+
+  struct Stats {
+    size_t totalNodes;
+    size_t activeOperations;
+    std::array<uint32_t, NUM_STRIPES> stripeCounts;
+  };
+
+  Stats getStats() const;
+  StripedLocks<NUM_STRIPES> _locks;
+};
+
+}  // namespace generic
+}  // namespace sd
+
+#endif  // SD_GENERIC_TYPED_TRIE_H_

--- a/libnd4j/include/helpers/impl/generic/TypedTrie.cpp
+++ b/libnd4j/include/helpers/impl/generic/TypedTrie.cpp
@@ -1,0 +1,268 @@
+/* ******************************************************************************
+ *
+ * Copyright (c) 2024 Konduit K.K.
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+#include <helpers/generic/TypedTrie.h>
+
+#include "array/ConstantShapeBuffer.h"
+#include "array/TadPack.h"
+#include "helpers/DirectTadTrie.h"
+
+namespace sd {
+namespace generic {
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+struct TypedTrie<KeyType, ValueType, NUM_STRIPES>::TrieNode {
+  std::shared_ptr<ValueType> value;
+  std::unordered_map<typename KeyType::value_type, std::unique_ptr<TrieNode>> children;
+  std::atomic<uint32_t> refCount{0};
+  std::atomic<bool> isComplete{false};
+  std::chrono::steady_clock::time_point lastAccess;
+
+  TrieNode() : lastAccess(std::chrono::steady_clock::now()) {}
+
+  void incrementRef() {
+    refCount.fetch_add(1, std::memory_order_acq_rel);
+  }
+
+  bool decrementRef() {
+    return refCount.fetch_sub(1, std::memory_order_acq_rel) == 1;
+  }
+};
+
+
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+TypedTrie<KeyType, ValueType, NUM_STRIPES>::TypedTrie()
+ {
+  try {
+    for (auto& root : _roots) {
+      root = std::make_unique<TrieNode>();
+      _resourceManager.registerNode();
+    }
+  } catch (...) {
+    cleanup();
+    throw;
+  }
+}
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+TypedTrie<KeyType, ValueType, NUM_STRIPES>::~TypedTrie() {
+
+}
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+size_t TypedTrie<KeyType, ValueType, NUM_STRIPES>::getStripeIndex(const KeyType& key) const {
+  size_t h = 0;
+  for (const auto& elem : key) {
+    h = h * 31 + std::hash<typename KeyType::value_type>{}(elem);
+  }
+  return h & (NUM_STRIPES - 1);
+}
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+typename TypedTrie<KeyType, ValueType, NUM_STRIPES>::TrieNode*
+TypedTrie<KeyType, ValueType, NUM_STRIPES>::findOrCreateNode(TrieNode* root,
+                                                             const KeyType& key,
+                                                             bool createIfMissing) const {
+  if (!root) return nullptr;
+
+  TrieNode* current = root;
+  for (const auto& k : key) {
+    auto it = current->children.find(k);
+    if (it == current->children.end()) {
+      if (!createIfMissing) return nullptr;
+      auto newNode = std::make_unique<TrieNode>();
+      if (!newNode) return nullptr;
+      current->children[k] = std::move(newNode);
+    }
+    current = current->children[k].get();
+    if (!current) return nullptr;
+  }
+  return current;
+}
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+void TypedTrie<KeyType, ValueType, NUM_STRIPES>::cleanupNode(TrieNode* node) {
+  if (!node) return;
+
+  auto now = std::chrono::steady_clock::now();
+  auto age = std::chrono::duration_cast<std::chrono::minutes>(
+      now - node->lastAccess).count();
+
+  if (age > 30 && node->refCount.load(std::memory_order_acquire) == 0) {
+    node->value.reset();
+
+    for (auto it = node->children.begin(); it != node->children.end();) {
+      auto* child = it->second.get();
+      if (child) {
+        cleanupNode(child);
+        if (!child->value && child->children.empty()) {
+          _resourceManager.unregisterNode();
+          it = node->children.erase(it);
+          continue;
+        }
+      }
+      ++it;
+    }
+  }
+}
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+std::shared_ptr<ValueType> TypedTrie<KeyType, ValueType, NUM_STRIPES>::get(const KeyType& key) const {
+  if (!key.empty()) {
+    auto scope = _resourceManager.createScope();
+    size_t stripe = getStripeIndex(key);
+
+    _locks.lockStripe(stripe, false);
+    auto node = findOrCreateNode(_roots[stripe].get(), key, false);
+    if (node && node->isComplete.load(std::memory_order_acquire)) {
+      auto result = node->value;
+      if (result) {
+        node->lastAccess = std::chrono::steady_clock::now();
+        _locks.unlockStripe(stripe, false);
+        return result;
+      }
+    }
+    _locks.unlockStripe(stripe, false);
+  }
+  return nullptr;
+}
+
+
+template std::shared_ptr<sd::ConstantShapeBuffer*>
+sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+    sd::ConstantShapeBuffer*,
+    32>::get(const std::vector<long long, std::allocator<long long>>& key) const;
+
+
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+bool TypedTrie<KeyType, ValueType, NUM_STRIPES>::insert(const KeyType& key,
+                                                        std::shared_ptr<ValueType> value) {
+  if (!value || key.empty()) return false;
+
+  auto scope = _resourceManager.createScope();
+  size_t stripe = getStripeIndex(key);
+
+  _locks.lockStripe(stripe, true);
+  auto node = findOrCreateNode(_roots[stripe].get(), key, true);
+  if (!node) {
+    _locks.unlockStripe(stripe, true);
+    return false;
+  }
+
+  if (node->value || node->isComplete.load(std::memory_order_acquire)) {
+    _locks.unlockStripe(stripe, true);
+    return false;
+  }
+
+  node->incrementRef();
+  node->value = value;
+  node->lastAccess = std::chrono::steady_clock::now();
+  node->isComplete.store(true, std::memory_order_release);
+  _locks.unlockStripe(stripe, true);
+  return true;
+}
+
+template bool
+sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+    sd::ConstantShapeBuffer*,
+    32>::insert(const std::vector<long long, std::allocator<long long>>& key,
+                std::shared_ptr<sd::ConstantShapeBuffer*> value);
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+bool TypedTrie<KeyType, ValueType, NUM_STRIPES>::remove(const KeyType& key) {
+  auto scope = _resourceManager.createScope();
+  size_t stripe = getStripeIndex(key);
+
+  _locks.lockStripe(stripe, true);
+
+  auto node = findOrCreateNode(_roots[stripe].get(), key, false);
+  if (!node || !node->value) {
+    _locks.unlockStripe(stripe, true);
+    return false;
+  }
+
+  node->value.reset();
+  node->isComplete.store(false, std::memory_order_release);
+
+  _locks.unlockStripe(stripe, true);
+  return true;
+}
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+void TypedTrie<KeyType, ValueType, NUM_STRIPES>::cleanup() {
+  auto scope = _resourceManager.createScope();
+  std::vector<size_t> stripes;
+  for (size_t i = 0; i < NUM_STRIPES; ++i) {
+    stripes.push_back(i);
+  }
+  auto guard = _locks.acquireMultiLock(stripes, true);
+
+  for (auto& root : _roots) {
+    if (root) cleanupNode(root.get());
+  }
+}
+
+template void
+sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+    sd::ConstantShapeBuffer*,
+    32>::cleanup();
+template void
+sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+    sd::TadPack*,
+    32>::cleanup();
+
+template
+sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+    sd::ConstantShapeBuffer*,
+    32>::~TypedTrie();
+
+template<typename KeyType, typename ValueType, size_t NUM_STRIPES>
+typename TypedTrie<KeyType, ValueType, NUM_STRIPES>::Stats
+TypedTrie<KeyType, ValueType, NUM_STRIPES>::getStats() const {
+  Stats stats;
+  for (size_t i = 0; i < NUM_STRIPES; ++i) {
+    stats.stripeCounts[i] = _locks.getStripeCount(i);
+  }
+  return stats;
+}
+
+}  // namespace generic
+}  // namespace sd
+
+template class sd::generic::TypedTrie<std::vector<unsigned char>, std::shared_ptr<sd::ConstantShapeBuffer>, 32>;
+template class sd::generic::TypedTrie<std::vector<sd::LongType>, std::shared_ptr<sd::TadPack>, 32>;
+template std::shared_ptr<sd::TadPack*>
+sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+                       sd::TadPack*,
+                       32>::get(const std::vector<long long, std::allocator<long long>>& key) const;
+// Add to TypedTrie.cpp
+template bool
+sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+                       sd::TadPack*,
+                       32>::insert(const std::vector<long long, std::allocator<long long>>& key,
+                                   std::shared_ptr<sd::TadPack*> value);
+template
+    sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+                           sd::TadPack*,
+                           32>::~TypedTrie();
+
+
+
+template sd::generic::TypedTrie<std::vector<long long, std::allocator<long long>>,
+                   sd::ConstantShapeBuffer*,
+                   32ul>::TypedTrie();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rewrite/refactor of the newly introduced direct tad /shape trie
that uses striped locks to avoid hash map bottlenecks
when dealing with cache accesses of shape buffers
This collapses common logic in to 1 place for the constant caches.
Also consolidates logic for creating new tad packs in to a new tad calculator.

This also mitigates race conditions and deadlocks by streamlining the stripe locking mechanism.

## How was this patch tested?

I ran all this manually using benchmarks and profilers + valgrind/gdb addressing deadlocks and segfaults
as they came up.
## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [x ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
