### PR TITLE
Fixes tadpack to be more granular

### DIFF
--- a/libnd4j/include/array/TadPack.h
+++ b/libnd4j/include/array/TadPack.h
@@ -38,6 +38,8 @@ class SD_LIB_EXPORT TadPack {
   LongType _shapeInfoLength = 0;
   LongType* _dimensions = nullptr;
   LongType _dimensionsLength = 0;
+  size_t _packHash = 0;  // Cache the hash for quick comparison
+
  public:
   explicit TadPack(const ConstantShapeBuffer& shapes,
                    const ConstantOffsetsBuffer& offets, LongType numTads,
@@ -69,6 +71,46 @@ class SD_LIB_EXPORT TadPack {
     return ret;
   }
 
+  void computeHash() {
+    size_t hash = 17;
+
+    // Add dimensions to hash
+    for (LongType i = 0; i < _dimensionsLength; i++) {
+      hash = hash * 31 + static_cast<size_t>(_dimensions[i]);
+    }
+
+    // Add shape info to hash if available
+    LongType* primaryShape = primaryShapeInfo();
+    if (primaryShape) {
+      int rank = shape::rank(primaryShape);
+
+      // Add rank
+      hash = hash * 13 + static_cast<size_t>(rank);
+
+      // Add shape dimensions
+      LongType* shapeValues = shape::shapeOf(primaryShape);
+      for (int i = 0; i < rank; i++) {
+        hash = hash * 17 + static_cast<size_t>(shapeValues[i]);
+      }
+
+      // Add strides
+      LongType* strides = shape::stride(primaryShape);
+      for (int i = 0; i < rank; i++) {
+        hash = hash * 23 + static_cast<size_t>(strides[i]);
+      }
+
+      // Add order and data type
+      hash = hash * 29 + static_cast<size_t>(shape::order(primaryShape));
+      hash = hash * 37 + static_cast<size_t>(ArrayOptions::dataType(primaryShape));
+    }
+
+    // Add number of TADs
+    hash = hash * 41 + static_cast<size_t>(_numTads);
+
+    _packHash = hash;
+  }
+
+
   /**
    * These methods return either primary or special pointers depending on platform binaries were compiled for
    * @return
@@ -77,6 +119,7 @@ class SD_LIB_EXPORT TadPack {
   LongType* platformOffsets();
 
   void print(const char* msg);
+  bool operator==( TadPack& other);
 };
 }  // namespace sd
 

--- a/libnd4j/include/array/impl/TadPack.cpp
+++ b/libnd4j/include/array/impl/TadPack.cpp
@@ -39,6 +39,8 @@ TadPack::TadPack(const ConstantShapeBuffer& shapes,
     }
   }
 
+  computeHash();
+
 }
 
 LongType* TadPack::primaryShapeInfo() {
@@ -94,4 +96,78 @@ void TadPack::print(const char* msg) {
 }
 
 LongType TadPack::shapeInfoLength() { return shape::shapeInfoLength(primaryShapeInfo()); }
+bool TadPack::operator==( TadPack& other)  {
+  // Compare number of TADs
+  if (_numTads != other._numTads)
+    return false;
+
+  // Compare shape information
+  LongType* thisShape = primaryShapeInfo();
+  LongType* otherShape = other.primaryShapeInfo();
+
+  // Check for null shape info
+  if ((thisShape == nullptr) != (otherShape == nullptr))
+    return false;
+
+  if (thisShape != nullptr) {
+    // Compare rank
+    const int thisRank = shape::rank(thisShape);
+    const int otherRank = shape::rank(otherShape);
+    if (thisRank != otherRank)
+      return false;
+
+    // Compare shape order
+    if (shape::order(thisShape) != shape::order(otherShape))
+      return false;
+
+    // Compare data type
+    if (ArrayOptions::dataType(thisShape) != ArrayOptions::dataType(otherShape))
+      return false;
+
+    // Compare shape dimensions
+    for (int i = 0; i < thisRank; i++) {
+      if (shape::shapeOf(thisShape)[i] != shape::shapeOf(otherShape)[i])
+        return false;
+    }
+
+    // Compare shape strides
+    for (int i = 0; i < thisRank; i++) {
+      if (shape::stride(thisShape)[i] != shape::stride(otherShape)[i])
+        return false;
+    }
+  }
+
+  // Compare dimensions array
+  if ((_dimensions == nullptr) != (other._dimensions == nullptr))
+    return false;
+
+  if (_dimensions != nullptr) {
+    if (_dimensionsLength != other._dimensionsLength)
+      return false;
+
+    for (LongType i = 0; i < _dimensionsLength; i++) {
+      if (_dimensions[i] != other._dimensions[i])
+        return false;
+    }
+  }
+
+  // Compare offsets
+  LongType* thisOffsets = primaryOffsets();
+  LongType* otherOffsets = other.primaryOffsets();
+
+  // Check for null offsets
+  if ((thisOffsets == nullptr) != (otherOffsets == nullptr))
+    return false;
+
+  if (thisOffsets != nullptr) {
+    for (LongType i = 0; i < _numTads; i++) {
+      if (thisOffsets[i] != otherOffsets[i])
+        return false;
+    }
+  }
+
+  return true;
+}
+
+
 }  // namespace sd

--- a/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
+++ b/libnd4j/include/legacy/cpu/NativeOpExecutioner.cpp
@@ -130,7 +130,6 @@ void NativeOpExecutioner::execBroadcast(sd::LaunchContext *lc, int opNum, const 
   auto yType = sd::ArrayOptions::dataType(hYShapeInfo);
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
   auto loopKind = sd::LoopKind::deduceKindOfLoopBroadcast(hXShapeInfo, hYShapeInfo, hZShapeInfo);
-
   auto func = PRAGMA_THREADS_FOR {
     BUILD_SINGLE_SELECTOR_THRICE(
         xType, functions::broadcast::Broadcast,

--- a/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
+++ b/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
@@ -658,8 +658,6 @@ const char *getAllCustomOps() { return sd::ops::OpRegistrator::getInstance().get
 OpaqueShapeList *calculateOutputShapes2(sd::Pointer *extraPointers, sd::LongType hash, OpaqueContext *context) {
   try {
     auto op = sd::ops::OpRegistrator::getInstance().getOperation(hash);
-    printf("Obtained op: %s\n", op->getOpName()->c_str());
-    fflush(stdout);
     sd::ShapeList inShapes;
 
     for (size_t e = 0; e < context->width(); e++) {

--- a/libnd4j/include/loops/cpu/broadcasting.hpp
+++ b/libnd4j/include/loops/cpu/broadcasting.hpp
@@ -67,11 +67,303 @@ void Broadcast<X, Y, Z>::exec(const void* vx, const sd::LongType* xShapeInfo,
                               const sd::LongType* xTadShapeInfo, const sd::LongType* xTadOffset,
                               const sd::LongType* zTadShapeInfo, const sd::LongType* zTadOffset,
                               sd::LoopKind::Kind loopKind, sd::LongType start, sd::LongType stop) {
+
   auto x = reinterpret_cast<const X*>(vx);
   auto y = reinterpret_cast<const Y*>(vy);
   auto z = reinterpret_cast<Z*>(vz);
 
-  if (loopKind == sd::LoopKind::BROADCAST_SCALAR_X) {
+  // Get rank information
+  const int xRank = shape::rank(xShapeInfo);
+  const int yRank = shape::rank(yShapeInfo);
+  const int zRank = shape::rank(zShapeInfo);
+  const int xTadRank = xTadShapeInfo ? shape::rank(xTadShapeInfo) : xRank;
+  const int zTadRank = zTadShapeInfo ? shape::rank(zTadShapeInfo) : zRank;
+
+  // Get shape information
+  const sd::LongType* xShape = shape::shapeOf(xShapeInfo);
+  const sd::LongType* yShape = shape::shapeOf(yShapeInfo);
+  const sd::LongType* zShape = shape::shapeOf(zShapeInfo);
+  const sd::LongType* xTadShape = shape::shapeOf(xTadShapeInfo);
+  const sd::LongType* zTadShape = shape::shapeOf(zTadShapeInfo);
+
+  // Get stride information
+  const sd::LongType* xStrides = shape::stride(xShapeInfo);
+  const sd::LongType* yStrides = shape::stride(yShapeInfo);
+  const sd::LongType* zStrides = shape::stride(zShapeInfo);
+  const sd::LongType* xTadStrides = shape::stride(xTadShapeInfo);
+  const sd::LongType* zTadStrides = shape::stride(zTadShapeInfo);
+
+  // Classify array types
+  // For X array or X TAD
+  bool isXScalar = xTadRank == 0 || (xTadRank == 1 && xTadShape[0] == 1);
+  bool isXVector = (xTadRank == 1 && xTadShape[0] > 1) ||
+                   (xTadRank == 2 && (xTadShape[0] == 1 || xTadShape[1] == 1));
+  bool isXRowVector = (xTadRank == 1 && xTadShape[0] > 1) ||
+                      (xTadRank == 2 && xTadShape[0] == 1 && xTadShape[1] > 1);
+  bool isXColumnVector = (xTadRank == 2 && xTadShape[0] > 1 && xTadShape[1] == 1);
+
+  // For Y array
+  bool isYScalar = yRank == 0 || (yRank == 1 && yShape[0] == 1);
+  bool isYVector = (yRank == 1 && yShape[0] > 1) ||
+                   (yRank == 2 && (yShape[0] == 1 || yShape[1] == 1));
+  bool isYRowVector = (yRank == 1 && yShape[0] > 1) ||
+                      (yRank == 2 && yShape[0] == 1 && yShape[1] > 1);
+  bool isYColumnVector = (yRank == 2 && yShape[0] > 1 && yShape[1] == 1);
+
+  // For Z array or Z TAD
+  bool isZScalar = zTadRank == 0 || (zTadRank == 1 && zTadShape[0] == 1);
+  bool isZVector = (zTadRank == 1 && zTadShape[0] > 1) ||
+                   (zTadRank == 2 && (zTadShape[0] == 1 || zTadShape[1] == 1));
+  bool isZRowVector = (zTadRank == 1 && zTadShape[0] > 1) ||
+                      (zTadRank == 2 && zTadShape[0] == 1 && zTadShape[1] > 1);
+  bool isZColumnVector = (zTadRank == 2 && zTadShape[0] > 1 && zTadShape[1] == 1);
+
+  // Handle scalar broadcasting as a special case first
+  if (isYScalar) {
+    // Scalar broadcast - apply same value to every element
+    const Y scalarY = y[0];
+    sd::LongType length = shape::length(xTadShapeInfo ? xTadShapeInfo : xShapeInfo);
+
+    if (xTadShapeInfo && zTadShapeInfo) {
+      // TAD case
+      for (auto i = start; i < stop; i++) {
+        auto oX = x + xTadOffset[i];
+        auto oZ = z + zTadOffset[i];
+
+        // Handle different X and Z shapes
+        if (isXVector && isZVector) {
+          sd::LongType len = shape::length(xTadShapeInfo);
+          PRAGMA_OMP_SIMD
+          for (sd::LongType f = 0; f < len; f++) {
+            sd::LongType xOffset = f * xTadStrides[xTadRank-1];
+            sd::LongType zOffset = f * zTadStrides[zTadRank-1];
+            oZ[zOffset] = OpType::op(oX[xOffset], scalarY);
+          }
+        } else {
+          // General case
+          for (sd::LongType f = 0; f < length; f++) {
+            // Calculate proper offsets for current position
+            sd::LongType xCoord[SD_MAX_RANK], zCoord[SD_MAX_RANK];
+            sd::LongType xOffset, zOffset;
+
+            INDEX2COORDS(f, xTadRank, xTadShape, xCoord);
+            INDEX2COORDS(f, zTadRank, zTadShape, zCoord);
+
+            COORDS2INDEX(xTadRank, xTadStrides, xCoord, xOffset);
+            COORDS2INDEX(zTadRank, zTadStrides, zCoord, zOffset);
+
+            oZ[zOffset] = OpType::op(oX[xOffset], scalarY);
+          }
+        }
+      }
+    } else {
+      // Non-TAD case
+      PRAGMA_OMP_SIMD
+      for (sd::LongType f = 0; f < length; f++)
+        z[f] = OpType::op(x[f], scalarY);
+    }
+  }
+    // Handle 2D broadcasting
+  else if (loopKind == sd::LoopKind::BROADCAST_2D) {
+    // Determine shapes for broadcasting
+    sd::LongType nRows = zTadShape[0];
+    sd::LongType nCols = zTadRank > 1 ? zTadShape[1] : shape::length(zTadShapeInfo);
+
+    // Special vector broadcasting cases
+    if (isYVector && (isXRowVector || isXColumnVector || isXVector)) {
+      // Vector to vector broadcasting
+      if (isYRowVector && (isXRowVector || isXVector)) {
+        // Row vector to row vector
+        for (auto i = start; i < stop; i++) {
+          auto baseX = x + xTadOffset[i];
+          auto baseZ = z + zTadOffset[i];
+
+          sd::LongType xStride = xTadRank > 1 ? xTadStrides[xTadRank - 1] : xTadStrides[0];
+          sd::LongType yStride = yRank == 1 ? yStrides[0] : yStrides[1];
+          sd::LongType zStride = zTadRank ? zTadStrides[zTadRank - 1] : zTadStrides[0];
+
+
+          PRAGMA_OMP_SIMD
+          for (sd::LongType i1 = 0; i1 < nCols; i1++) {
+            auto rX = baseX + i1 * xStride;
+            auto rY = y + i1 * yStride;
+            auto rZ = baseZ + i1 * zStride;
+
+            *rZ = OpType::op(*rX, *rY);
+          }
+        }
+      }
+      else if (isYColumnVector && (isXColumnVector || isXVector)) {
+        // Column vector to column vector
+        // Row vector to row vector
+        for (auto i = start; i < stop; i++) {
+          auto baseX = x + (xTadOffset ? xTadOffset[i] : 0);
+          auto baseZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+          // Calculate correct strides based on shape and rank
+          sd::LongType xStride;
+          if (xTadRank == 1) {
+            xStride = xTadStrides[0];
+          } else { // xTadRank == 2
+            xStride = xTadStrides[0]; // For 2D column vector, use row stride
+          }
+
+          sd::LongType yStride;
+          if (yRank == 1) {
+            yStride = yStrides[0];
+          } else { // yRank == 2
+            yStride = yStrides[0]; // For 2D column vector, use row stride
+          }
+
+          sd::LongType zStride;
+          if (zTadRank == 1) {
+            zStride = zTadStrides[0];
+          } else { // zTadRank == 2
+            zStride = zTadStrides[0]; // For 2D column vector, use row stride
+          }
+
+          // Verify dimensions match
+          sd::LongType xLen = isXColumnVector ? (xTadRank == 2 ? xTadShape[0] : xTadShape[0]) : xTadShape[0];
+          sd::LongType yLen = yRank == 2 ? yShape[0] : yShape[0];
+          printf("xLen: %lld; yLen: %lld nRows %lld,xStride %lld,yStride %lld, zStride %lld\n", xLen, yLen,nRows,xStride,yStride,zStride);
+          PRAGMA_OMP_SIMD
+          for (sd::LongType i1 = 0; i1 < nRows; i1++) {
+            auto rX = baseX + i1 * xStride;
+            auto rY = y + i1 * yStride;
+            auto rZ = baseZ + i1 * zStride;
+
+            *rZ = OpType::op(*rX, *rY);
+          }
+        }
+      }
+      else if (isYColumnVector && isXRowVector) {
+        // Column vector to row vector (outer product)
+        for (auto i = start; i < stop; i++) {
+          auto baseX = x + (xTadOffset ? xTadOffset[i] : 0);
+          auto baseZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+          for (sd::LongType i0 = 0; i0 < nRows; i0++) {
+            auto colValue = y[i0 * yStrides[0]];
+
+            PRAGMA_OMP_SIMD
+            for (sd::LongType i1 = 0; i1 < nCols; i1++) {
+              auto rX = baseX + i1 * xTadStrides[xTadRank-1];
+              auto rZ = baseZ + i0 * zTadStrides[0] + i1 * zTadStrides[1];
+
+              *rZ = OpType::op(*rX, colValue);
+            }
+          }
+        }
+      }
+      else if (isYRowVector && isXColumnVector) {
+        // Row vector to column vector (outer product)
+        for (auto i = start; i < stop; i++) {
+          printf("4 2d tad: %lld\n", i);
+          fflush(stdout);
+          auto baseX = x + (xTadOffset ? xTadOffset[i] : 0);
+          auto baseZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+          for (sd::LongType i0 = 0; i0 < nRows; i0++) {
+            auto xValue = baseX[i0 * xTadStrides[0]];
+
+            PRAGMA_OMP_SIMD
+            for (sd::LongType i1 = 0; i1 < nCols; i1++) {
+              auto rY = y + i1 * (yRank == 1 ? yStrides[0] : yStrides[1]);
+              auto rZ = baseZ + i0 * zTadStrides[0] + i1 * zTadStrides[1];
+
+              *rZ = OpType::op(xValue, *rY);
+            }
+          }
+        }
+      }
+    }
+      // Matrix with vector broadcasting
+    else if ((isXRowVector && isYRowVector) || (isXColumnVector && isYColumnVector)) {
+      // Matching vectors - element-wise operation
+      for (auto i = start; i < stop; i++) {
+        auto baseX = x + (xTadOffset ? xTadOffset[i] : 0);
+        auto baseZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+        sd::LongType vecLength = isXRowVector ? nCols : nRows;
+        sd::LongType xStride = isXRowVector ? xTadStrides[xTadRank-1] : xTadStrides[0];
+        sd::LongType yStride = isYRowVector ? (yRank == 1 ? yStrides[0] : yStrides[1]) : yStrides[0];
+        sd::LongType zStride = isZRowVector ? zTadStrides[zTadRank-1] : zTadStrides[0];
+
+        PRAGMA_OMP_SIMD
+        for (sd::LongType i1 = 0; i1 < vecLength; i1++) {
+          auto rX = baseX + i1 * xStride;
+          auto rY = y + i1 * yStride;
+          auto rZ = baseZ + i1 * zStride;
+
+          *rZ = OpType::op(*rX, *rY);
+        }
+      }
+    }
+      // Matrix with row vector broadcasting
+    else if (isYRowVector && xTadRank == 2 && zTadRank == 2 &&
+             xTadShape[1] == (yRank == 1 ? yShape[0] : yShape[1])) {
+      // Broadcasting row vector (each element applied to a column)
+      for (auto i0 = start; i0 < stop; i0++) {
+        auto baseX = x + (xTadOffset ? xTadOffset[i0] : 0);
+        auto baseZ = z + (zTadOffset ? zTadOffset[i0] : 0);
+
+        for (sd::LongType i1 = 0; i1 < nRows; i1++) {
+          for (sd::LongType i2 = 0; i2 < nCols; i2++) {
+            // Get element from X at current position
+            auto xOffset = i1 * xTadStrides[0] + i2 * xTadStrides[1];
+            // Get element from Y row vector based on column index only
+            auto yOffset = i2 * (yRank == 1 ? yStrides[0] : yStrides[1]);
+            // Get destination element in Z at current position
+            auto zOffset = i1 * zTadStrides[0] + i2 * zTadStrides[1];
+
+            // Apply operation
+            baseZ[zOffset] = OpType::op(baseX[xOffset], y[yOffset]);
+          }
+        }
+      }
+    }
+      // Matrix with column vector broadcasting
+    else if (isYColumnVector) {
+      // Broadcasting column vector (each element applied to a row)
+      for (auto i0 = start; i0 < stop; i0++) {
+        auto baseX = x + (xTadOffset ? xTadOffset[i0] : 0);
+        auto baseZ = z + (zTadOffset ? zTadOffset[i0] : 0);
+
+        for (sd::LongType i1 = 0; i1 < nRows; i1++) {
+          // Get element from column vector based on row index
+          auto rY = y + i1 * yStrides[0];
+
+          PRAGMA_OMP_SIMD
+          for (sd::LongType i2 = 0; i2 < nCols; i2++) {
+            auto rX = baseX + i1 * xTadStrides[0] + i2 * xTadStrides[1];
+            auto rZ = baseZ + i1 * zTadStrides[0] + i2 * zTadStrides[1];
+
+            *rZ = OpType::op(*rX, *rY);
+          }
+        }
+      }
+    }
+      // Standard 2D broadcasting
+    else {
+      for (auto i0 = start; i0 < stop; i0++) {
+        auto baseX = x + (xTadOffset ? xTadOffset[i0] : 0);
+        auto baseZ = z + (zTadOffset ? zTadOffset[i0] : 0);
+
+        for (sd::LongType i1 = 0; i1 < nRows; i1++) {
+          PRAGMA_OMP_SIMD
+          for (sd::LongType i2 = 0; i2 < nCols; i2++) {
+            auto rX = baseX + i1 * xTadStrides[0] + i2 * xTadStrides[1];
+            auto rY = y + i1 * yStrides[0] + i2 * yStrides[1];
+            auto rZ = baseZ + i1 * zTadStrides[0] + i2 * zTadStrides[1];
+
+            *rZ = OpType::op(*rX, *rY);
+          }
+        }
+      }
+    }
+  }
+    // Handle remaining loop kinds
+  else if (loopKind == sd::LoopKind::BROADCAST_SCALAR_X) {
     sd::LongType tadLength = shape::length(xTadShapeInfo);
     for (auto i = start; i < stop; i++) {
       auto oY = y + (i * tadLength);
@@ -95,43 +387,276 @@ void Broadcast<X, Y, Z>::exec(const void* vx, const sd::LongType* xShapeInfo,
         oZ[f] = OpType::op(oX[f], oY);
     }
   }
-  else if (loopKind == sd::LoopKind::BROADCAST_2D) {
-    const sd::LongType nSize1 = shape::sizeAt(zShapeInfo, 1);
-    const sd::LongType* xStrides = shape::stride(xTadShapeInfo);
-    const sd::LongType* yStrides = shape::stride(yShapeInfo);
-    const sd::LongType* zStrides = shape::stride(zTadShapeInfo);
+    // Handle 3D broadcasting (generalized like 2D case)
+  else if (loopKind == sd::LoopKind::BROADCAST_3D) {
+    // Get TAD info
+    const sd::LongType tadRank = xTadShapeInfo ? shape::rank(xTadShapeInfo) : 3;
+    const sd::LongType* tadShape = xTadShapeInfo ? shape::shapeOf(xTadShapeInfo) : xShape;
+    const sd::LongType* tadStride = xTadShapeInfo ? shape::stride(xTadShapeInfo) : xStrides;
+    const sd::LongType tadLength = xTadShapeInfo ? shape::length(xTadShapeInfo) : shape::length(xShapeInfo);
+    if (isYVector) {
+      // Vector broadcasting
+      const sd::LongType yLength = yRank == 1 ? yShape[0] : (yShape[0] == 1 ? yShape[1] : yShape[0]);
+      const sd::LongType yStride = yRank == 1 ? yStrides[0] : (yShape[0] == 1 ? yStrides[1] : yStrides[0]);
 
-    for (auto i0 = start; i0 < stop; i0++) {
-      auto baseX = x + xTadOffset[i0];
-      auto baseZ = z + zTadOffset[i0];
+      // Determine which dimension this vector should be broadcast along
+      // For a 3D TAD, check if vector length matches any dimension
+      if (tadRank == 3) {
+        if (yLength == tadShape[2]) {
+          // Broadcast along last dimension
+          for (auto i = start; i < stop; i++) {
+            auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+            auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
 
-      PRAGMA_OMP_SIMD
-      for (sd::LongType i1 = 0; i1 < nSize1; i1++) {
-        auto rX = baseX + xStrides[1] * i1;
-        auto rY = y + yStrides[1] * i1;
-        auto rZ = baseZ + zStrides[1] * i1;
+            for (sd::LongType j = 0; j < tadLength; j++) {
+              // Calculate TAD coords
+              sd::LongType coords[SD_MAX_RANK];
+              INDEX2COORDS(j, tadRank, tadShape, coords);
 
-        *rZ = OpType::op(*rX, *rY);
+              // Get offsets
+              sd::LongType xOffset, zOffset;
+              COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+              COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
+
+              // Get Y index - use the last dimension (coords[2])
+              sd::LongType yOffset = coords[2] * yStride;
+
+              // Apply operation
+              oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
+            }
+          }
+        }
+        else if (yLength == tadShape[1]) {
+          // Broadcast along middle dimension
+          PRAGMA_OMP_SIMD
+          for (auto i = start; i < stop; i++) {
+            auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+            auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+            for (sd::LongType j = 0; j < tadLength; j++) {
+              // Calculate TAD coords
+              sd::LongType coords[SD_MAX_RANK];
+              INDEX2COORDS(j, tadRank, tadShape, coords);
+
+              // Get offsets
+              sd::LongType xOffset, zOffset;
+              COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+              COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
+
+              // Get Y index - use the middle dimension (coords[1])
+              sd::LongType yOffset = coords[1] * yStride;
+
+              // Apply operation
+              oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
+            }
+          }
+        }
+        else if (yLength == tadShape[0]) {
+          // Broadcast along first dimension
+          PRAGMA_OMP_SIMD
+          for (auto i = start; i < stop; i++) {
+            printf("6 Handling tad: %lld\n", i);
+            fflush(stdout);
+            auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+            auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+            for (sd::LongType j = 0; j < tadLength; j++) {
+              // Calculate TAD coords
+              sd::LongType coords[SD_MAX_RANK];
+              INDEX2COORDS(j, tadRank, tadShape, coords);
+
+              // Get offsets
+              sd::LongType xOffset, zOffset;
+              COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+              COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
+
+              // Get Y index - use the first dimension (coords[0])
+              sd::LongType yOffset = coords[0] * yStride;
+
+              // Apply operation
+              oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
+            }
+          }
+        }
+        else {
+          // Default broadcasting behavior - broadcast along the last dimension
+          PRAGMA_OMP_SIMD
+          for (auto i = start; i < stop; i++) {
+            printf("5 Handling tad: %lld\n", i);
+            fflush(stdout);
+            auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+            auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+            for (sd::LongType j = 0; j < tadLength; j++) {
+              // Calculate TAD coords
+              sd::LongType coords[SD_MAX_RANK];
+              INDEX2COORDS(j, tadRank, tadShape, coords);
+
+              // Get offsets
+              sd::LongType xOffset, zOffset;
+              COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+              COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
+
+              // Get Y index with wrapping/broadcasting
+              sd::LongType yOffset = (coords[2] % yLength) * yStride;
+
+              // Apply operation
+              oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
+            }
+          }
+        }
+      }
+      else {
+        // Handle lower rank TADs (1D or 2D)
+        PRAGMA_OMP_SIMD
+        for (auto i = start; i < stop; i++) {
+          auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+          auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+          for (sd::LongType j = 0; j < tadLength; j++) {
+            // Calculate TAD coords
+            sd::LongType coords[SD_MAX_RANK];
+            INDEX2COORDS(j, tadRank, tadShape, coords);
+
+            // Get offsets
+            sd::LongType xOffset, zOffset;
+            COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+            COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
+
+            // Get Y index - for lower ranks, broadcast along the last available dimension
+            sd::LongType lastCoord = tadRank > 0 ? coords[tadRank - 1] : 0;
+            sd::LongType yOffset = (lastCoord % yLength) * yStride;
+
+            // Apply operation
+            oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
+          }
+        }
       }
     }
-  }
-  else if (loopKind == sd::LoopKind::BROADCAST_3D) {
-    const sd::LongType nSize1 = shape::sizeAt(zShapeInfo, 1);
-    const sd::LongType nSize2 = shape::sizeAt(zShapeInfo, 2);
+    else if (yRank == 2) {
+      // Y is a 2D matrix - determine which dimensions it aligns with
+      for (auto i = start; i < stop; i++) {
+        auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+        auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
+        PRAGMA_OMP_SIMD
+        for (sd::LongType j = 0; j < tadLength; j++) {
+          // Calculate TAD coords
+          sd::LongType coords[SD_MAX_RANK];
+          INDEX2COORDS(j, tadRank, tadShape, coords);
 
-    const sd::LongType* xStrides = shape::stride(xShapeInfo);
-    const sd::LongType* yStrides = shape::stride(yShapeInfo);
-    const sd::LongType* zStrides = shape::stride(zShapeInfo);
+          // Get offsets
+          sd::LongType xOffset, zOffset;
+          COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+          COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
 
-    for (auto i0 = start; i0 < stop; i0++) {
+          // Calculate Y offset based on dimension matching
+          sd::LongType yOffset;
+
+          // Default behavior for different 2D matrix broadcasting patterns
+          if (tadRank == 3) {
+            if (yShape[0] == tadShape[0] && yShape[1] == tadShape[2]) {
+              // Y is aligned with dimensions 0 and 2
+              yOffset = coords[0] * yStrides[0] + coords[2] * yStrides[1];
+            }
+            else if (yShape[0] == tadShape[0] && yShape[1] == tadShape[1]) {
+              // Y is aligned with dimensions 0 and 1
+              yOffset = coords[0] * yStrides[0] + coords[1] * yStrides[1];
+            }
+            else if (yShape[0] == tadShape[1] && yShape[1] == tadShape[2]) {
+              // Y is aligned with dimensions 1 and 2
+              yOffset = coords[1] * yStrides[0] + coords[2] * yStrides[1];
+            }
+            else {
+              // Default: broadcast Y to match the last two dimensions with modulo
+              yOffset = (coords[1] % yShape[0]) * yStrides[0] + (coords[2] % yShape[1]) * yStrides[1];
+            }
+          }
+          else if (tadRank == 2) {
+            // Direct mapping for 2D TAD and 2D Y
+            yOffset = (coords[0] % yShape[0]) * yStrides[0] + (coords[1] % yShape[1]) * yStrides[1];
+          }
+          else {
+            // For 1D TAD, map to the first dimension of Y
+            yOffset = (coords[0] % yShape[0]) * yStrides[0];
+          }
+
+          // Apply operation
+          oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
+        }
+      }
+    }
+    else if (yRank == 3) {
+      // Y is a 3D tensor
       PRAGMA_OMP_SIMD
-      for (sd::LongType i1 = 0; i1 < nSize1; i1++) {
-        for (sd::LongType i2 = 0; i2 < nSize2; i2++) {
-          auto rX = x + (xStrides[0] * i0 + xStrides[1] * i1 + xStrides[2] * i2);
-          auto rY = y + (yStrides[0] * i0 + yStrides[1] * i1 + yStrides[2] * i2);
-          auto rZ = z + (zStrides[0] * i0 + zStrides[1] * i1 + zStrides[2] * i2);
+      for (auto i = start; i < stop; i++) {
+        auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+        auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
 
-          *rZ = OpType::op(*rX, *rY);
+        for (sd::LongType j = 0; j < tadLength; j++) {
+          // Calculate TAD coords
+          sd::LongType coords[SD_MAX_RANK];
+          INDEX2COORDS(j, tadRank, tadShape, coords);
+
+          // Get offsets
+          sd::LongType xOffset, zOffset;
+          COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+          COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
+
+          // Calculate Y offset with modulo for broadcasting if needed
+          sd::LongType yCoords[3] = {0, 0, 0};
+
+          // Map coordinates appropriately based on ranks
+          if (tadRank == 3) {
+            yCoords[0] = coords[0] % yShape[0];
+            yCoords[1] = coords[1] % yShape[1];
+            yCoords[2] = coords[2] % yShape[2];
+          }
+          else if (tadRank == 2) {
+            // Map 2D to last 2 dimensions of 3D
+            yCoords[0] = 0;  // First dimension is broadcasted
+            yCoords[1] = coords[0] % yShape[1];
+            yCoords[2] = coords[1] % yShape[2];
+          }
+          else {
+            // Map 1D to last dimension of 3D
+            yCoords[0] = 0;
+            yCoords[1] = 0;
+            yCoords[2] = coords[0] % yShape[2];
+          }
+
+          sd::LongType yOffset = yCoords[0] * yStrides[0] + yCoords[1] * yStrides[1] + yCoords[2] * yStrides[2];
+
+          // Apply operation
+          oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
+        }
+      }
+    }
+    else {
+      // General case for other ranks of Y
+      for (auto i = start; i < stop; i++) {
+        auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
+        auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
+
+        for (sd::LongType j = 0; j < tadLength; j++) {
+          // Calculate TAD coords
+          sd::LongType coords[SD_MAX_RANK];
+          INDEX2COORDS(j, tadRank, tadShape, coords);
+
+          // Get offsets
+          sd::LongType xOffset, zOffset;
+          COORDS2INDEX(tadRank, tadStride, coords, xOffset);
+          COORDS2INDEX(tadRank, zTadStrides, coords, zOffset);
+
+          // Calculate Y offset based on rank
+          sd::LongType yOffset = 0;
+
+          // Map coordinates to Y based on rank
+          for (int d = 0; d < tadRank && d < yRank; d++) {
+            yOffset += (coords[d] % yShape[d]) * yStrides[d];
+          }
+
+          // Apply operation
+          oZ[zOffset] = OpType::op(oX[xOffset], y[yOffset]);
         }
       }
     }
@@ -141,23 +666,16 @@ void Broadcast<X, Y, Z>::exec(const void* vx, const sd::LongType* xShapeInfo,
     const sd::LongType nSize2 = shape::sizeAt(zShapeInfo, 2);
     const sd::LongType nSize3 = shape::sizeAt(zShapeInfo, 3);
 
-    const sd::LongType* xStrides = shape::stride(xShapeInfo);
-    const sd::LongType* yStrides = shape::stride(yShapeInfo);
-    const sd::LongType* zStrides = shape::stride(zShapeInfo);
-
     for (auto i = start; i < stop; i++) {
       uint64_t i0 = i / nSize1;
       uint64_t i1 = i % nSize1;
 
-      PRAGMA_OMP_SIMD
       for (sd::LongType i2 = 0; i2 < nSize2; i2++) {
+        PRAGMA_OMP_SIMD
         for (sd::LongType i3 = 0; i3 < nSize3; i3++) {
-          auto rX = x + (xStrides[0] * i0 + xStrides[1] * i1 +
-                         xStrides[2] * i2 + xStrides[3] * i3);
-          auto rY = y + (yStrides[0] * i0 + yStrides[1] * i1 +
-                         yStrides[2] * i2 + yStrides[3] * i3);
-          auto rZ = z + (zStrides[0] * i0 + zStrides[1] * i1 +
-                         zStrides[2] * i2 + zStrides[3] * i3);
+          auto rX = x + (xStrides[0] * i0 + xStrides[1] * i1 + xStrides[2] * i2 + xStrides[3] * i3);
+          auto rY = y + (yStrides[0] * i0 + yStrides[1] * i1 + yStrides[2] * i2 + yStrides[3] * i3);
+          auto rZ = z + (zStrides[0] * i0 + zStrides[1] * i1 + zStrides[2] * i2 + zStrides[3] * i3);
 
           *rZ = OpType::op(*rX, *rY);
         }
@@ -170,24 +688,17 @@ void Broadcast<X, Y, Z>::exec(const void* vx, const sd::LongType* xShapeInfo,
     const sd::LongType nSize3 = shape::sizeAt(zShapeInfo, 3);
     const sd::LongType nSize4 = shape::sizeAt(zShapeInfo, 4);
 
-    const sd::LongType* xStrides = shape::stride(xShapeInfo);
-    const sd::LongType* yStrides = shape::stride(yShapeInfo);
-    const sd::LongType* zStrides = shape::stride(zShapeInfo);
-
     for (auto i = start; i < stop; i++) {
       uint32_t i0 = i / nSize1;
       uint32_t i1 = i % nSize1;
 
-      PRAGMA_OMP_SIMD
       for (sd::LongType i2 = 0; i2 < nSize2; i2++) {
         for (sd::LongType i3 = 0; i3 < nSize3; i3++) {
+          PRAGMA_OMP_SIMD
           for (sd::LongType i4 = 0; i4 < nSize4; i4++) {
-            auto rX = x + (xStrides[0] * i0 + xStrides[1] * i1 +
-                           xStrides[2] * i2 + xStrides[3] * i3 + xStrides[4] * i4);
-            auto rY = y + (yStrides[0] * i0 + yStrides[1] * i1 +
-                           yStrides[2] * i2 + yStrides[3] * i3 + yStrides[4] * i4);
-            auto rZ = z + (zStrides[0] * i0 + zStrides[1] * i1 +
-                           zStrides[2] * i2 + zStrides[3] * i3 + zStrides[4] * i4);
+            auto rX = x + (xStrides[0] * i0 + xStrides[1] * i1 + xStrides[2] * i2 + xStrides[3] * i3 + xStrides[4] * i4);
+            auto rY = y + (yStrides[0] * i0 + yStrides[1] * i1 + yStrides[2] * i2 + yStrides[3] * i3 + yStrides[4] * i4);
+            auto rZ = z + (zStrides[0] * i0 + zStrides[1] * i1 + zStrides[2] * i2 + zStrides[3] * i3 + zStrides[4] * i4);
 
             *rZ = OpType::op(*rX, *rY);
           }
@@ -196,18 +707,7 @@ void Broadcast<X, Y, Z>::exec(const void* vx, const sd::LongType* xShapeInfo,
     }
   }
   else {
-    // Default case for other ranks
-    const int xRank = shape::rank(xShapeInfo);
-    const int yRank = shape::rank(yShapeInfo);
-    const int zRank = shape::rank(zShapeInfo);
-
-    const sd::LongType* xShape = shape::shapeOf(xShapeInfo);
-    const sd::LongType* yShape = shape::shapeOf(yShapeInfo);
-    const sd::LongType* zShape = shape::shapeOf(zShapeInfo);
-    const sd::LongType* xStrides = shape::stride(xShapeInfo);
-    const sd::LongType* yStrides = shape::stride(yShapeInfo);
-    const sd::LongType* zStrides = shape::stride(zShapeInfo);
-
+    // Default case for other ranks - general purpose implementation
     sd::LongType xCoords[SD_MAX_RANK];
     sd::LongType yCoords[SD_MAX_RANK];
     sd::LongType zCoords[SD_MAX_RANK];

--- a/libnd4j/include/loops/cpu/broadcasting_bool.hpp
+++ b/libnd4j/include/loops/cpu/broadcasting_bool.hpp
@@ -614,10 +614,6 @@ template <typename OpType>
 void BroadcastBool<X, Z>::exec(const void *vx, const sd::LongType *xShapeInfo, const void *vy,
                                const sd::LongType *yShapeInfo, void *vz, const sd::LongType *zShapeInfo,
                                void *vextraParams) {
-
-
-  printf("BroadcastBool<X, Z>::exec\n");
-  fflush(stdout);
   const X *x = reinterpret_cast<const X *>(vx);
   const X *y = reinterpret_cast<const X *>(vy);
   Z *z = reinterpret_cast<Z *>(vz);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -3066,7 +3066,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     private void applyBroadcastOp(INDArray vector, final char operation) {
         Nd4j.getCompressor().autoDecompress(this);
         int alongDimension = Shape.isRowVectorShape(vector.shape()) ?
-                -1 : -0;
+                -1 : 0;
         switch (operation) {
             case 'a':
                 Nd4j.getExecutioner().exec(new BroadcastAddOp(this, vector, this, alongDimension));

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/BroadcastingOpsSmokeTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/BroadcastingOpsSmokeTests.java
@@ -927,8 +927,10 @@ public class BroadcastingOpsSmokeTests {
         INDArray colVector = Nd4j.create(new double[] {10, 20}).reshape(2, 1);
 
         // Test row vector broadcasting
+
         INDArray rowAddResult = subView.addRowVector(rowVector);
         INDArray rowMulResult = subView.mulRowVector(rowVector);
+
 
         // Test column vector broadcasting
         INDArray colAddResult = subView.addColumnVector(colVector);


### PR DESCRIPTION


## What changes were proposed in this pull request?

When TADPack was ran at a certain scale with multiple threads
collisions happened.
This would only happen when running tests in parallel.

This makes the tad pack and trie more granular to more clearly define what is/isn't equal to avoid clashes.

## How was this patch tested?

Using the broadcasting smoke tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [X ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
