### PR TITLE
Clean up cuda build when functrace is enabled

### DIFF
--- a/libnd4j/CMakeLists.txt
+++ b/libnd4j/CMakeLists.txt
@@ -113,8 +113,10 @@ if (SD_CUDA)
         message("Jetson nano cublas library is ${CUDA_cublas_LIBRARY} and CuSolver library ${CUDA_cusolver_LIBRARY}")
     endif()
 
-
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}   -allow-unsupported-compiler --ptxas-options=-v  -Xptxas -O1")
+    if("${SD_PTXAS}" STREQUAL  "ON")
+        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --ptxas-options=-v")
+    endif()
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}   -allow-unsupported-compiler  ")
     if(SD_KEEP_NVCC_OUTPUT)
         set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}  --keep ")
     endif()
@@ -157,13 +159,7 @@ foreach(TEMPLATE_FILE ${CUDA_TEMPLATE_FILES})
 endforeach()
 
 
-# Define a function to generate individual CUDA files for each type combination
-# Find and replace the existing function:
-function(genSingleFunctionCuda TEMPLATE_FILE COMBINATION OUTPUT_DIR)
-    # ...existing implementation...
-endfunction()
 
-# REPLACE WITH THIS IMPLEMENTATION:
 
 function(genSingleFunctionCuda TEMPLATE_FILE COMBINATION OUTPUT_DIR)
     # Split the COMBINATION string into a list
@@ -573,8 +569,8 @@ endif()
 # -fsanitize=leak
 if (SD_ANDROID_BUILD)
     set_property(GLOBAL PROPERTY JOB_POOLS one_job=1 two_jobs=2)
-    set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} -O${SD_OPTIMIZATION_LEVEL} -fPIC -Wno-braced-scalar-init -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else -D_RELEASE=true")
-    set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -O${SD_OPTIMIZATION_LEVEL} -g -fPIC -Wno-braced-scalar-init -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else")
+    set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} -O${SD_OPTIMIZATION_LEVEL} -fPIC -Wno-return-type -Wno-unknown-pragmas -Wno-braced-scalar-init -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else -D_RELEASE=true")
+    set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -O${SD_OPTIMIZATION_LEVEL} -g -fPIC -Wno-return-type -Wno-unknown-pragmas -Wno-braced-scalar-init -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else")
 elseif (APPLE)
     if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64*" OR "${SD_ARCH}" MATCHES "armv8-a")
         set(SD_ARCH armv8-a)
@@ -583,8 +579,8 @@ elseif (APPLE)
     endif()
 
 
-    set(CMAKE_CXX_FLAGS_RELEASE  "-O${SD_OPTIMIZATION_LEVEL} -fPIC -Wno-braced-scalar-init -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else -D__APPLE_OS__=true -D_RELEASE=true")
-    set(CMAKE_CXX_FLAGS_DEBUG  " -O${SD_OPTIMIZATION_LEVEL} -g -fPIC -Wno-braced-scalar-init -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else -D__APPLE_OS__=true")
+    set(CMAKE_CXX_FLAGS_RELEASE  "-O${SD_OPTIMIZATION_LEVEL} -fPIC -Wno-return-type -Wno-braced-scalar-init -Wno-unknown-pragmas -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else -D__APPLE_OS__=true -D_RELEASE=true")
+    set(CMAKE_CXX_FLAGS_DEBUG  " -O${SD_OPTIMIZATION_LEVEL} -g -fPIC -Wno-return-type -Wno-braced-scalar-init -Wno-unknown-pragmas -Wno-delete-non-virtual-dtor -Wno-unused-command-line-argument -Wno-dangling-else -D__APPLE_OS__=true")
 elseif(WIN32)
     set(SD_X86_BUILD true)
     if (SD_CUDA)

--- a/libnd4j/blas/CMakeLists.txt
+++ b/libnd4j/blas/CMakeLists.txt
@@ -200,7 +200,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_SYSTEM_NAME MATCHES "A
         endif()
 
         # Set C++ compiler and flags
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fstack-protector -fstack-protector-all  -Wall -Wextra -Werror -Wno-error=int-in-bool-context -Wno-unused-variable -Wno-error=implicit-fallthrough -Wno-return-type -Wno-unused-parameter -Wno-error=unknown-pragmas -ggdb3 -lpthread -pthread -MT -Bsymbolic -lbfd -rdynamic -lunwind -ldw -ldl -fno-omit-frame-pointer -fno-optimize-sibling-calls -rdynamic -finstrument-functions  -O0 -fPIC")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fstack-protector -fstack-protector-all  -Wall  -Wextra -Werror -Wno-return-type -Wno-error=int-in-bool-context -Wno-unused-variable -Wno-error=implicit-fallthrough -Wno-return-type -Wno-unused-parameter -Wno-error=unknown-pragmas -ggdb3 -lpthread -pthread -MT -Bsymbolic -lbfd -rdynamic -lunwind -ldw -ldl -fno-omit-frame-pointer -fno-optimize-sibling-calls -rdynamic -finstrument-functions  -O0 -fPIC")
         add_compile_definitions(SD_GCC_FUNCTRACE)
     endif()
 endif()
@@ -262,7 +262,7 @@ if(SD_CUDA)
 
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             if(SD_GCC_FUNCTRACE STREQUAL "ON")
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Werror -Wall   -Wno-unused-variable -Wno-unused-parameter  -Wreturn-type -W -ggdb3 -fPIC -DSD_GCC_FUNCTRACE=1 -Bsymbolic -lbfd -rdynamic -lunwind -ldw -ldl -fno-omit-frame-pointer -fno-optimize-sibling-calls -finstrument-functions  -O0")
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Werror -Wall   -Wno-return-type  -Wno-unknown-pragmas  -Wno-unused-variable -Wno-unused-parameter  -Wreturn-type -W -ggdb3 -fPIC -DSD_GCC_FUNCTRACE=1 -Bsymbolic -lbfd -rdynamic -lunwind -ldw -ldl -fno-omit-frame-pointer -fno-optimize-sibling-calls -finstrument-functions  -O0")
                 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-fPIC --device-debug -lineinfo -G")
                 add_compile_definitions(SD_GCC_FUNCTRACE)
             else()
@@ -306,7 +306,7 @@ if(SD_CUDA)
         endif()
 
         # Cap the number of registers to prevent resource exhaustion
-        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --maxrregcount=40 ")
+        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -maxrregcount=128  ")
 
         # Define CUDA Architectures
         string(TOLOWER "${COMPUTE}" COMPUTE_CMP)
@@ -371,6 +371,11 @@ if(SD_CUDA)
         endif()
        include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/TypeMST.cmake)
 
+        # 2. Process the compilation_units templates
+        file(GLOB CUDA_COMPILATION_UNITS ../include/loops/cuda/compilation_units/*.cu.in)
+        foreach(FL_ITEM ${CUDA_COMPILATION_UNITS})
+            genCompilation(${FL_ITEM})
+        endforeach()
 
         # Decide whether to use all combinations or optimized MST combinations
        set(SD_USE_MST_TYPES ON)
@@ -423,7 +428,7 @@ if(SD_CUDA)
         file(GLOB_RECURSE INDEXING_SOURCES ../include/indexing/*.cpp ../include/indexing/*.h)
         file(GLOB_RECURSE LOOPS_SOURCES ../include/loops/impl/*.cpp ../include/loops/*.h ../include/loops/*.chpp)
         file(GLOB_RECURSE LEGACY_SOURCES ../include/legacy/impl/*.cpp ../include/legacy/*.cu ../include/legacy/*.h)
-        file(GLOB_RECURSE LOOPS_SOURCES_CUDA ../include/loops/*.cu)
+        file(GLOB_RECURSE LOOPS_SOURCES_CUDA ../include/loops/*.cu ../include/loops/cuda/**/*.cu)
         file(GLOB_RECURSE COMPILATION_UNITS ../include/loops/cuda/compilation_units/*.cu.in ../include/ops/impl/compilation_units/*.cpp.in)
         file(GLOB_RECURSE COMPILATION_UNITS ../include/loops/cuda/compilation_units/*.cu.in ../include/loops/cuda/comb_compilation_units/*.cu.in  ../include/ops/impl/compilation_units/*.cpp.in)
 
@@ -485,6 +490,8 @@ if(SD_CUDA)
                     ${CUSTOMOPS_ONEDNN_SOURCES}
                     ${CUSTOMOPS_ARMCOMPUTE_SOURCES}
                     ${CUSTOMOPS_GENERIC_SOURCES}
+                    ${LOOPS_SOURCES_CUDA}
+
             )
         else()
             add_library(samediff_obj OBJECT
@@ -509,6 +516,8 @@ if(SD_CUDA)
                     ${CUSTOMOPS_ONEDNN_SOURCES}
                     ${CUSTOMOPS_ARMCOMPUTE_SOURCES}
                     ${CUSTOMOPS_GENERIC_SOURCES}
+                    ${LOOPS_SOURCES_CUDA}
+
             )
         endif()
 

--- a/libnd4j/buildnativeoperations.sh
+++ b/libnd4j/buildnativeoperations.sh
@@ -94,7 +94,7 @@ PRINT_MATH="OFF"
 KEEP_NVCC="OFF"
 PREPROCESS="ON"  # Initialize PREPROCESS variable
 CMAKE_ARGUMENTS=""
-
+PTXAS_INFO="OFF"
 while [[ $# -gt 0 ]]
 do
     key="$1"
@@ -106,6 +106,10 @@ do
                 CMAKE_ARGUMENTS="$CMAKE_ARGUMENTS -DGENERATE_FLATC=ON"
                 shift # past argument
                 ;;
+    -ptxas|--ptxas-info)
+            PTXAS_INFO="$value"
+            shift # past argument
+            ;;
         -ol|--optimization-level)
             OPTIMIZATION_LEVEL="$value"
             shift # past argument
@@ -712,6 +716,7 @@ if [ "$LOG_OUTPUT" == "none" ]; then
         -DPRINT_INDICES="$PRINT_INDICES" \
         -DSD_KEEP_NVCC_OUTPUT="$KEEP_NVCC" \
         -DSD_GCC_FUNCTRACE="$FUNC_TRACE" \
+        -DSD_PTXAS="$PTXAS_INFO" \
         "$BLAS_ARG" \
         "$ARCH_ARG" \
         "$NAME_ARG" \
@@ -739,6 +744,7 @@ else
         -DPRINT_INDICES="$PRINT_INDICES" \
         -DSD_KEEP_NVCC_OUTPUT="$KEEP_NVCC" \
         -DSD_GCC_FUNCTRACE="$FUNC_TRACE" \
+        -DSD_PTXAS="$PTXAS_INFO" \
         "$BLAS_ARG" \
         "$ARCH_ARG" \
         "$NAME_ARG" \
@@ -773,6 +779,7 @@ if [ "$PREPROCESS" == "ON" ]; then
            -DSD_KEEP_NVCC_OUTPUT="$KEEP_NVCC" \
            -DSD_GCC_FUNCTRACE="$FUNC_TRACE" \
             -DSD_PREPROCESS="$PREPROCESS" \
+           -DSD_PTXAS="$PTXAS_INFO" \
            "$BLAS_ARG" \
            "$ARCH_ARG" \
            "$NAME_ARG" \
@@ -804,6 +811,7 @@ if [ "$PREPROCESS" == "ON" ]; then
            "$ARCH_ARG" \
            "$NAME_ARG" \
            "$OP_OUTPUT_FILE_ARG" \
+           -DSD_PTXAS="$PTXAS_INFO" \
            -DSD_SANITIZE="${SANITIZE}" \
            -DSD_CHECK_VECTORIZATION="${CHECK_VECTORIZATION}" \
            "$USE_LTO" \

--- a/libnd4j/include/array/NDArray.h
+++ b/libnd4j/include/array/NDArray.h
@@ -2003,7 +2003,7 @@ void * _bufferWithOffset(LongType offset,DataBuffer *buffer) {
 //note this is meant to be used with primary() (host side/cpu) use specialBuffer() for device side buffers
 void *NDArray::buffer() {
   BUILD_SINGLE_SELECTOR(dataType(), return _bufferWithOffset, (offset(),getDataBuffer()),SD_COMMON_TYPES);
-
+  return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -2639,7 +2639,7 @@ void NDArray::copyDataForAssign(NDArray& thisArray,  NDArray& other, const sd::L
                                           other.buffer(),
                                           otherShapeInfo,
                                           other.specialBuffer(),
-                                          otherShapeInfo,
+                                          other.specialShapeInfo(),
                                           nullptr
         , allowParallelism);
     thisArray.registerSpecialUse({&thisArray}, {&other}); // Registering through the instance

--- a/libnd4j/include/array/TadDescriptor.h
+++ b/libnd4j/include/array/TadDescriptor.h
@@ -28,7 +28,7 @@
 namespace sd {
 class SD_LIB_EXPORT TadDescriptor {
  private:
-  ShapeDescriptor _originalShape;
+  sd::LongType *_originalShape;
 
   std::vector<LongType> _axis;
 
@@ -36,8 +36,6 @@ class SD_LIB_EXPORT TadDescriptor {
 
  public:
   explicit TadDescriptor(const LongType *originalShape, const LongType *dimensions, const LongType length,
-                         const bool keepUnitiesInShape = false);
-  explicit TadDescriptor(const ShapeDescriptor &descriptor, const std::vector<LongType> &dimensions,
                          const bool keepUnitiesInShape = false);
   ~TadDescriptor() = default;
 
@@ -56,8 +54,7 @@ class SD_LIB_EXPORT TadDescriptor {
   bool operator<(const TadDescriptor &other) const;
 
   std::vector<LongType> &axis();
-  ShapeDescriptor &originalShape();
-  ShapeDescriptor const &originalShapeConst() const;
+  LongType *originalShape();
   bool areUnitiesinShape() const;
 };
 }  // namespace sd

--- a/libnd4j/include/array/impl/ExtraArguments.cpp
+++ b/libnd4j/include/array/impl/ExtraArguments.cpp
@@ -79,7 +79,7 @@ void ExtraArguments::convertAndCopy(Pointer pointer, LongType offset) {
 #ifdef __CUDABLAS__
   // TODO: maybe make it asynchronous eventually?
   cudaMemcpy(pointer, target, length * DataTypeUtils::sizeOf(DataTypeUtils::fromT<T>()), cudaMemcpyHostToDevice);
-  delete target;
+  delete[] target;
 #endif
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void ExtraArguments::convertAndCopy,

--- a/libnd4j/include/array/impl/TadDescriptor.cpp
+++ b/libnd4j/include/array/impl/TadDescriptor.cpp
@@ -33,7 +33,6 @@ TadDescriptor::TadDescriptor(const TadDescriptor &other) {
 
 TadDescriptor::TadDescriptor(const LongType *originalShape, const LongType *dimensions, const LongType length,
                              const bool keepUnitiesInShape) {
-  ShapeDescriptor *descriptor = new ShapeDescriptor(originalShape, false);
 
   _axis.resize(length);
   for (LongType e = 0; e < length; e++) {
@@ -42,17 +41,8 @@ TadDescriptor::TadDescriptor(const LongType *originalShape, const LongType *dime
 
   if (length > 1) std::sort(_axis.begin(), _axis.end());
 
-  _originalShape = *descriptor;
+  _originalShape = const_cast<sd::LongType *>(originalShape);
   _unitiesInShape = keepUnitiesInShape;
-}
-
-TadDescriptor::TadDescriptor(const ShapeDescriptor &descriptor, const std::vector<LongType> &dimensions,
-                             const bool keepUnitiesInShape) {
-  _originalShape = descriptor;
-  _axis = dimensions;
-  _unitiesInShape = keepUnitiesInShape;
-
-  if (_axis.size() > 1) std::sort(_axis.begin(), _axis.end());
 }
 
 bool TadDescriptor::operator==(const TadDescriptor &other) const {
@@ -67,9 +57,7 @@ bool TadDescriptor::operator<(const TadDescriptor &other) const {
 
 std::vector<LongType> &TadDescriptor::axis() { return _axis; }
 
-ShapeDescriptor &TadDescriptor::originalShape() { return _originalShape; }
-
-ShapeDescriptor const &TadDescriptor::originalShapeConst() const { return _originalShape; }
+LongType *TadDescriptor::originalShape() { return _originalShape; }
 
 bool TadDescriptor::areUnitiesinShape() const { return _unitiesInShape; }
 }  // namespace sd
@@ -80,13 +68,6 @@ size_t hash<sd::TadDescriptor>::operator()(const sd::TadDescriptor &k) const {
 
   // Start with initial hash from unities flag
   uint64_t hash = ModularHasher::hash_scalar(k.areUnitiesinShape());
-
-  // Combine with original shape hash
-  hash = ModularHasher::combine_hashes({
-      hash,
-      std::hash<sd::ShapeDescriptor>()(k.originalShapeConst())
-  });
-
   // Hash the axis vector
   auto& axes = const_cast<sd::TadDescriptor&>(k).axis();
   if (!axes.empty()) {

--- a/libnd4j/include/execution/impl/Threads.cpp
+++ b/libnd4j/include/execution/impl/Threads.cpp
@@ -146,6 +146,9 @@ Span2 Span2::build(int loop, uint64_t threadID, uint64_t numThreads, int64_t sta
     default:
       THROW_EXCEPTION("");
   }
+
+  return Span2(startX, stopX, incX, 0, 0, incY);
+
 }
 
 int64_t Span::startX() const {

--- a/libnd4j/include/graph/impl/Context.cpp
+++ b/libnd4j/include/graph/impl/Context.cpp
@@ -252,6 +252,8 @@ Variable *Context::variable(std::pair<int, int> &p) {
     errorMessage += "\n";
     THROW_EXCEPTION(errorMessage.c_str());
   }
+
+  return nullptr;
 }
 
 void Context::pushNDArrayToVariableSpace(int nodeId, int index, NDArray *array, bool removable) {
@@ -355,6 +357,8 @@ NDArray *Context::outputArray(int idx) {
   errorMessage += std::to_string(_fastpath_out.size());
 
   THROW_EXCEPTION(errorMessage.c_str());
+
+  return nullptr;
 }
 
 NDArray *Context::array(int idx) {

--- a/libnd4j/include/graph/impl/ContextPrototype.cpp
+++ b/libnd4j/include/graph/impl/ContextPrototype.cpp
@@ -89,6 +89,8 @@ DataType ContextPrototype::dataType(int index) {
   } else {
     return _dArgs.at(index);
   }
+
+  return DataType::UNKNOWN;
 }
 
 void ContextPrototype::setDataType(int index, DataType type) {

--- a/libnd4j/include/graph/impl/Node.cpp
+++ b/libnd4j/include/graph/impl/Node.cpp
@@ -688,6 +688,8 @@ sd::ops::DeclarableOp* sd::graph::Node::buildOpByType(::graph::OpType opType, in
     default:
       THROW_EXCEPTION("Bad opType passed in");
   }
+
+  return nullptr;
 }
 
 bool Node::isDeductable() { return _isDeductable; }

--- a/libnd4j/include/graph/impl/Variable.cpp
+++ b/libnd4j/include/graph/impl/Variable.cpp
@@ -278,6 +278,8 @@ flatbuffers::Offset<::graph::FlatVariable> Variable::asFlatVariable(flatbuffers:
   } else {
     THROW_EXCEPTION("Variable::asFlatVariable isn't possible for NDArrayList");
   }
+
+  return CreateFlatVariable(builder, 0, 0, static_cast<::graph::DType>(0), 0, 0);
 }
 }  // namespace graph
 }  // namespace sd

--- a/libnd4j/include/graph/impl/VariableProxy.cpp
+++ b/libnd4j/include/graph/impl/VariableProxy.cpp
@@ -88,6 +88,7 @@ Variable *VariableProxy::getVariable(int id) {
 
   sd_printf("Unable to get Variable to proxy: [%i]\n", id);
   THROW_EXCEPTION("Bad arguments");
+  return nullptr;
 }
 
 Variable *VariableProxy::getVariable(int id, int idx) {
@@ -97,6 +98,7 @@ Variable *VariableProxy::getVariable(int id, int idx) {
 
   sd_printf("Unable to get Variable to proxy: [%i:%i]\n", id, idx);
   THROW_EXCEPTION("Bad arguments");
+  return nullptr;
 }
 
 Variable *VariableProxy::getVariable(std::pair<int, int> &pair) {
@@ -106,6 +108,7 @@ Variable *VariableProxy::getVariable(std::pair<int, int> &pair) {
 
   sd_printf("Unable to get Variable to proxy: [%i:%i]\n", pair.first, pair.second);
   THROW_EXCEPTION("Bad arguments");
+  return nullptr;
 }
 
 Variable *VariableProxy::getVariable(std::string *symbol) {
@@ -115,6 +118,7 @@ Variable *VariableProxy::getVariable(std::string *symbol) {
 
   sd_printf("Unable to get Variable to proxy: [%s]\n", symbol->c_str());
   THROW_EXCEPTION("Bad arguments");
+  return nullptr;
 }
 
 void VariableProxy::replaceVariable(Variable *variable) {

--- a/libnd4j/include/graph/impl/VariableSpace.cpp
+++ b/libnd4j/include/graph/impl/VariableSpace.cpp
@@ -121,6 +121,7 @@ sd::graph::Variable* sd::graph::VariableSpace::getVariable(std::pair<int, int>& 
   }
   sd_printf("Unknown variable requested: [%i,%i]\n", pair.first, pair.second);
   THROW_EXCEPTION("Unknown variable requested");
+  return nullptr;
 }
 
 bool sd::graph::VariableSpace::hasVariable(int id) { return _variables.count(id) == 1 || _temporary.count(id) == 1; }
@@ -128,7 +129,6 @@ bool sd::graph::VariableSpace::hasVariable(int id) { return _variables.count(id)
 bool sd::graph::VariableSpace::hasVariable(std::pair<int, int>& id) { return _paired.count(id) > 0; }
 
 void sd::graph::VariableSpace::putOutputVariable(Variable* variable) {
-  // putVariable(_auto_counter--, variable);
   putVariable(variable->id(), variable);
 }
 

--- a/libnd4j/include/helpers/CudaLaunchHelper.h
+++ b/libnd4j/include/helpers/CudaLaunchHelper.h
@@ -29,7 +29,6 @@
 namespace sd {
 class SD_LIB_EXPORT CudaLaunchHelper {
  public:
-  static Triple getFlatLaunchParams(sd::LongType length, int SM, int CORES, int SHARED_MEMORY);
   static int getReductionBlocks(sd::LongType xLength, int blockSize = 512);
 };
 }  // namespace sd

--- a/libnd4j/include/helpers/hhSequence.h
+++ b/libnd4j/include/helpers/hhSequence.h
@@ -59,7 +59,7 @@ class HHsequence {
    *  constructor
    */
   HHsequence(NDArray& vectors, NDArray& coeffs, const char type);
-
+  HHsequence() = delete;
   /**
    *  this method mathematically multiplies input matrix on Householder sequence from the left H0*H1*...Hn * matrix
    *

--- a/libnd4j/include/helpers/impl/ConstantTadHelper.cpp
+++ b/libnd4j/include/helpers/impl/ConstantTadHelper.cpp
@@ -58,6 +58,8 @@ TadPack* ConstantTadHelper::tadForDimensions(LongType* originalShape, LongType* 
     errorMessage += e.what();
     THROW_EXCEPTION(errorMessage.c_str());
   }
+
+  return nullptr;
 }
 
 } // namespace sd

--- a/libnd4j/include/helpers/impl/ConstantTadHelper.cpp
+++ b/libnd4j/include/helpers/impl/ConstantTadHelper.cpp
@@ -35,7 +35,7 @@ TadPack* ConstantTadHelper::tadForDimensions(LongType* originalShape, std::vecto
 }
 
 TadPack* ConstantTadHelper::tadForDimensions(TadDescriptor* descriptor) {
-  return tadForDimensions(descriptor->originalShape().toShapeInfo(), descriptor->axis().data(),
+  return tadForDimensions(descriptor->originalShape(), descriptor->axis().data(),
                           descriptor->axis().size());
 }
 
@@ -46,7 +46,7 @@ TadPack* ConstantTadHelper::tadForDimensions(LongType* originalShape, LongType* 
     if (dimLength <= 0) THROW_EXCEPTION("Invalid dimension length");
 
     int rank = shape::rank(originalShape);
-    if (rank <= 0) THROW_EXCEPTION("Invalid shape rank");
+    if (rank < 0) THROW_EXCEPTION("Invalid shape rank");
 
     std::vector<LongType> dims(dimensions, dimensions + dimLength);
 

--- a/libnd4j/include/helpers/impl/CudaLaunchHelper.cpp
+++ b/libnd4j/include/helpers/impl/CudaLaunchHelper.cpp
@@ -23,12 +23,6 @@
 #include <math/templatemath.h>
 
 namespace sd {
-Triple CudaLaunchHelper::getFlatLaunchParams(LongType length, int SM, int CORES, int SHARED_MEMORY) {
-  // TODO: to be implemented
-  Triple triple(1, 2, 3);
-
-  return triple;
-}
 
 int CudaLaunchHelper::getReductionBlocks(LongType xLength, int blockSize) {
   int div = xLength / blockSize;

--- a/libnd4j/include/helpers/impl/OpArgsHolder.cpp
+++ b/libnd4j/include/helpers/impl/OpArgsHolder.cpp
@@ -81,7 +81,7 @@ OpArgsHolder::OpArgsHolder(OpArgsHolder&& other) noexcept
 ////////////////////////////////////////////////////////////////////////
 // assignment operator
 OpArgsHolder& OpArgsHolder::operator=(const OpArgsHolder& other) {
-  THROW_EXCEPTION("OpArgsHolder::OpArgsHolder assignment operator: don't use me !");
+  return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/libnd4j/include/helpers/impl/biDiagonalUp.cpp
+++ b/libnd4j/include/helpers/impl/biDiagonalUp.cpp
@@ -148,6 +148,8 @@ HHsequence BiDiagonalUp::makeHHsequence_(const char type) {
 HHsequence BiDiagonalUp::makeHHsequence(const char type) {
   auto xType = _HHmatrix.dataType();
   BUILD_SINGLE_SELECTOR(xType, return makeHHsequence_, (type);, SD_FLOAT_TYPES);
+  NDArray dummy = NDArray();
+  return HHsequence(dummy, dummy, 'u');
 }
 
 BUILD_SINGLE_TEMPLATE(template void BiDiagonalUp::_evalData, (), SD_FLOAT_TYPES);

--- a/libnd4j/include/legacy/cuda/NativeOpExecutioner.cu
+++ b/libnd4j/include/legacy/cuda/NativeOpExecutioner.cu
@@ -537,7 +537,7 @@ void NativeOpExecutioner::execReduceSame(sd::LaunchContext* lc, int opNum, void 
   dim3 launchDims = getReduceDims(numBlocks);
 
   BUILD_SINGLE_SELECTOR(xType, functions::reduce::ReduceSameFunction,
-                        ::execReduceXD(launchDims, stream, opNum, dX, dXShapeInfo, hXShapeInfo, extraParams,
+                        ::execReduce(launchDims, stream, opNum, dX, dXShapeInfo, hXShapeInfo, extraParams,
                                        reductionPointer, dZ, dZShapeInfo, hZShapeInfo, dimension),
                         SD_COMMON_TYPES);
 }
@@ -575,7 +575,7 @@ void NativeOpExecutioner::execReduceLong(sd::LaunchContext* lc, int opNum, void 
   dim3 launchDims = getReduceDims(numBlocks);
 
   BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceLongFunction,
-                        ::execReduceXD(launchDims, stream, opNum, dX,
+                        ::execReduce(launchDims, stream, opNum, dX,
                                        const_cast<sd::LongType*>(dXShapeInfo),
                                        const_cast<sd::LongType*>(hXShapeInfo), extraParams,
                                        reductionPointer, dZ,
@@ -608,7 +608,7 @@ void NativeOpExecutioner::execReduceBool(sd::LaunchContext* lc, int opNum, void 
   dim3 launchDims = getReduceDims(numBlocks);
 
   BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceBoolFunction,
-                        ::execReduceXD(launchDims, stream, opNum, dX, const_cast<sd::LongType*>(dXShapeInfo),
+                        ::execReduce(launchDims, stream, opNum, dX, const_cast<sd::LongType*>(dXShapeInfo),
                                        const_cast<sd::LongType*>(hXShapeInfo), extraParams,
                                        reductionPointer, dZ,
                                        const_cast<sd::LongType*>(dZShapeInfo), const_cast<sd::LongType*>(hZShapeInfo), dimension),
@@ -644,7 +644,7 @@ void NativeOpExecutioner::execReduceFloat(sd::LaunchContext* lc, int opNum, cons
   dim3 launchDims = getReduceDims(numBlocks);
 
   BUILD_DOUBLE_SELECTOR(xType, zType, functions::reduce::ReduceFloatFunction,
-                        ::execReduceXD(launchDims, stream, opNum, dX, dXShapeInfo, hXShapeInfo, extraParams,
+                        ::execReduce(launchDims, stream, opNum, dX, dXShapeInfo, hXShapeInfo, extraParams,
                                        reductionPointer, dZ, dZShapeInfo, hZShapeInfo, dimension),
                         SD_COMMON_TYPES, SD_FLOAT_TYPES);
 }

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -82,7 +82,7 @@ bool supportedP2P = false;
 
 int minThreads = 32;
 
-__constant__ char deviceConstantMemory[49152];
+__constant__ char deviceConstantMemory[65536];
 
 
 

--- a/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
+++ b/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
@@ -279,6 +279,7 @@ sd::Pointer numpyHeaderForNd4j(sd::Pointer data, sd::Pointer shapeBuffer, sd::Lo
   auto shapeBufferCast = reinterpret_cast<sd::LongType*>(shapeBuffer);
   auto type = sd::ArrayOptions::dataType(shapeBufferCast);
   BUILD_SINGLE_SELECTOR(type, return _numpyHeaderForNd4j, (data, shapeBuffer, wordSize, headerSize), SD_COMMON_TYPES);
+  return nullptr;
 }
 
 /**
@@ -370,6 +371,7 @@ long numpyHeaderLengthWordSize(sd::Pointer shapeBuffer,long wordSize) {
   auto shapeBufferCast = reinterpret_cast<sd::LongType*>(shapeBuffer);
   auto type = sd::ArrayOptions::dataType(shapeBufferCast);
   BUILD_SINGLE_SELECTOR(type, return _numpyHeaderLengthWordSize, (shapeBuffer, wordSize), SD_COMMON_TYPES);
+  return 0;
 
 }
 
@@ -378,6 +380,7 @@ long numpyHeaderLength(OpaqueDataBuffer *opaqueDataBuffer,sd::Pointer shapeBuffe
   auto type = sd::ArrayOptions::dataType(shapeBufferCast);
 
   BUILD_SINGLE_SELECTOR(type, return _numpyHeaderLength, (opaqueDataBuffer, shapeBuffer), SD_COMMON_TYPES);
+  return 0;
 
 }
 
@@ -388,6 +391,7 @@ sd::Pointer numpyFromNd4j(sd::Pointer data, sd::Pointer shapeBuffer, sd::LongTyp
   auto type = sd::ArrayOptions::dataType(shapeBufferCast);
 
   BUILD_SINGLE_SELECTOR(type, return _numpyFromNd4j, (data, shapeBuffer, wordSize), SD_COMMON_TYPES);
+  return nullptr;
 }
 
 
@@ -637,6 +641,8 @@ sd::LongType *mmapFile(sd::Pointer *extraPointers, const char *fileName, sd::Lon
     sd::LaunchContext::defaultContext()->errorReference()->setErrorMessage(e.what());
     THROW_EXCEPTION(e.what());
   }
+
+  return nullptr;
 }
 void munmapFile(sd::Pointer *extraPointers, sd::LongType  *ptrMap, sd::LongType  length) {}
 
@@ -1155,6 +1161,8 @@ int estimateThreshold(sd::Pointer *extraPointers, sd::Pointer hX, sd::LongType c
     sd::LaunchContext::defaultContext()->errorReference()->setErrorMessage(e.what());
     return 0;
   }
+
+  return 0;
 }
 
 
@@ -1387,7 +1395,7 @@ const char* getNpyArrayNameFromMap(void* map, int index, char* nameBuffer) {
       memcpy(nameBuffer, it->first.c_str(), len_of_str);
     }
   }
-  THROW_EXCEPTION("No array at index.");
+  return "";
 }
 
 void* getNpyArrayFromMap(void* map, int index) {
@@ -1402,7 +1410,8 @@ void* getNpyArrayFromMap(void* map, int index) {
       return arr;
     }
   }
-  THROW_EXCEPTION("No array at index.");
+
+ return nullptr;
 }
 
 
@@ -1682,6 +1691,7 @@ sd::TadPack *tadOnlyShapeInfo(OpaqueDataBuffer *hXShapeInfo, sd::LongType *dimen
     THROW_EXCEPTION(e.what());
   }
 
+  return nullptr;
 
 }
 

--- a/libnd4j/include/legacy/impl/cnpy.cpp
+++ b/libnd4j/include/legacy/impl/cnpy.cpp
@@ -106,6 +106,7 @@ char cnpy::mapType() {
     return '?';
 }
 
+
 sd::DataType cnpy::dataTypeFromHeader(char *data) {
   // indices for type & data size
   const int st = 10;
@@ -133,10 +134,14 @@ sd::DataType cnpy::dataTypeFromHeader(char *data) {
           return sd::DataType::INT32;
         case '8':
           return sd::DataType::INT64;
+
         default:
-          THROW_EXCEPTION("Only data sizes of [1, 2, 4, 8] are supported for Integer data types import");
+          return sd::DataType::UNKNOWN;
+
+
       }
     case 'f':
+
       switch (s) {
         case '1':
           return sd::DataType::FLOAT8;
@@ -147,7 +152,7 @@ sd::DataType cnpy::dataTypeFromHeader(char *data) {
         case '8':
           return sd::DataType::DOUBLE;
         default:
-          THROW_EXCEPTION("Only data sizes of [1, 2, 4, 8] are supported for Float data types import");
+          return sd::DataType::UNKNOWN;
       }
     case 'u':
       switch (s) {
@@ -160,13 +165,18 @@ sd::DataType cnpy::dataTypeFromHeader(char *data) {
         case '8':
           return sd::DataType::UINT64;
         default:
-          THROW_EXCEPTION("Only data sizes of [1, 2, 4, 8] are supported for Unsigned data types import");
+          return sd::DataType::UNKNOWN;
+
       }
     case 'c':
-      THROW_EXCEPTION("Import of complex data types isn't supported yet");
+      return sd::DataType::UNKNOWN;
+
     default:
-      THROW_EXCEPTION("Unknown type marker");
+      return sd::DataType::UNKNOWN;
+
   }
+
+  return sd::DataType::UNKNOWN;
 }
 
 template <typename T>
@@ -546,7 +556,7 @@ cnpy::NpyArray cnpy::npzLoad(std::string fname, std::string varname) {
 
   fclose(fp);
   printf("npz_load: Error! Variable name %s not found in %s!\n", varname.c_str(), fname.c_str());
-  THROW_EXCEPTION("Variable wasn't found in file");
+  return NpyArray();
 }
 
 /**

--- a/libnd4j/include/loops/cuda/reduce/reduce_bool.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_bool.cu
@@ -43,7 +43,7 @@ SD_KERNEL void simpleReduce(
     void* z,
     const sd::LongType* zShapeInfo) {
 
-  functions::reduce::ReduceBoolFunction<X, Z>::template transformCudaXD<OpType>(
+  functions::reduce::ReduceBoolFunction<X, Z>::template transformCuda<OpType>(
       x,
       outerXTadShapeInfo,
       innerXTadShapeInfo,
@@ -113,7 +113,7 @@ SD_DEVICE void ReduceBoolFunction<X, Z>::aggregatePartials(
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Z>
 template <typename OpType>
-SD_DEVICE void ReduceBoolFunction<X, Z>::transformCudaXD(
+SD_DEVICE void ReduceBoolFunction<X, Z>::transformCuda(
     const void* vx,
     const sd::LongType* outerXTadShapeInfo,
     const sd::LongType* innerXTadShapeInfo,
@@ -319,7 +319,7 @@ SD_DEVICE void ReduceBoolFunction<X, Z>::execScalarCuda(
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Z>
 template <typename OpType>
-SD_HOST void ReduceBoolFunction<X, Z>::intermediateXD(
+SD_HOST void ReduceBoolFunction<X, Z>::intermediate(
     dim3 launchDims,
     cudaStream_t* stream,
     const void* x,
@@ -346,7 +346,7 @@ SD_HOST void ReduceBoolFunction<X, Z>::intermediateXD(
         *stream);
     if (res != 0) {
       throw sd::cuda_exception::build(
-          "ReduceBoolFunction<X,Z>::intermediateXD: failed to copy temporary scalar", res);
+          "ReduceBoolFunction<X,Z>::intermediate: failed to copy temporary scalar", res);
     }
 
     auto ptr = sd::LaunchContext::defaultContext()->getScalarPointer();
@@ -465,7 +465,7 @@ SD_HOST void ReduceBoolFunction<X, Y>::execReduceScalar(
 
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Y>
-SD_HOST void ReduceBoolFunction<X, Y>::execReduceXD(
+SD_HOST void ReduceBoolFunction<X, Y>::execReduce(
     dim3 launchDims,
     cudaStream_t* stream,
     const int opNum,
@@ -490,7 +490,7 @@ SD_HOST void ReduceBoolFunction<X, Y>::execReduceXD(
         nullptr);
   } else {
     DISPATCH_BY_OPNUM_TT(
-        intermediateXD,
+        intermediate,
         PARAMS(
             launchDims, stream, x, dXShapeInfo, hXShapeInfo, extraParams,
             vreductionBuffer, z, dZShapeInfo, hZShapeInfo, dims),

--- a/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
+++ b/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
@@ -44,7 +44,7 @@ SD_KERNEL void simpleReduce(
     void* z,
     const sd::LongType* zShapeInfo) {
 
-  functions::reduce::ReduceFloatFunction<X,Z>::template transformCudaXD<OpType>(
+  functions::reduce::ReduceFloatFunction<X,Z>::template transformCuda<OpType>(
       x,
       outerXTadShapeInfo,
       innerXTadShapeInfo,
@@ -118,7 +118,7 @@ SD_DEVICE void ReduceFloatFunction<X,Z>::aggregatePartials(
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Z>
 template <typename OpType>
-SD_DEVICE void ReduceFloatFunction<X,Z>::transformCudaXD(
+SD_DEVICE void ReduceFloatFunction<X,Z>::transformCuda(
     const void* vx,
     const sd::LongType* outerXTadShapeInfo,
     const sd::LongType* innerXTadShapeInfo,
@@ -329,7 +329,7 @@ SD_DEVICE void ReduceFloatFunction<X, Z>::execScalarCuda(
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Z>
 template<typename OpType>
-SD_HOST void ReduceFloatFunction<X,Z>::intermediateXD(
+SD_HOST void ReduceFloatFunction<X,Z>::intermediate(
     dim3 launchDims,
     cudaStream_t* stream,
     const void* x,
@@ -355,7 +355,7 @@ SD_HOST void ReduceFloatFunction<X,Z>::intermediateXD(
         *stream);
     if (res != 0) {
       throw sd::cuda_exception::build(
-          "ReduceFloatFunction<X,Z>::intermediateXD: failed to copy temporary scalar", res);
+          "ReduceFloatFunction<X,Z>::intermediate: failed to copy temporary scalar", res);
     }
 
     auto ptr = sd::LaunchContext::defaultContext()->getScalarPointer();
@@ -465,7 +465,7 @@ SD_HOST void ReduceFloatFunction<X,Y>::execReduceScalar(
 
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Y>
-SD_HOST void ReduceFloatFunction<X,Y>::execReduceXD(
+SD_HOST void ReduceFloatFunction<X,Y>::execReduce(
     dim3 launchDims,
     cudaStream_t* stream,
     const int opNum,
@@ -486,13 +486,13 @@ SD_HOST void ReduceFloatFunction<X,Y>::execReduceXD(
         nullptr, 0, vreductionBuffer, nullptr);
   } else {
     DISPATCH_BY_OPNUM_TT(
-        intermediateXD,
+        intermediate,
         PARAMS(
             launchDims, stream, x, dXShapeInfo, hXShapeInfo, extraParams, vreductionBuffer, z, dZShapeInfo,
             hZShapeInfo, dims),
         OPS_A(REDUCE_FLOAT_OPS));
   }
-  sd::DebugHelper::checkErrorCode(stream, "ReduceFloatFunction execReduceXD(...) failed");
+  sd::DebugHelper::checkErrorCode(stream, "ReduceFloatFunction execReduce(...) failed");
 }
 
 }  // namespace reduce

--- a/libnd4j/include/loops/cuda/reduce/reduce_long.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_long.cu
@@ -42,7 +42,7 @@ SD_KERNEL void simpleReduce(
     void* z,
     const sd::LongType* zShapeInfo) {
 
-  functions::reduce::ReduceLongFunction<X, Z>::template transformCudaXD<OpType>(
+  functions::reduce::ReduceLongFunction<X, Z>::template transformCuda<OpType>(
       x,
       outerXTadShapeInfo,
       innerXTadShapeInfo,
@@ -137,7 +137,7 @@ SD_DEVICE void ReduceLongFunction<X, Z>::aggregatePartials(
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Z>
 template <typename OpType>
-SD_DEVICE void ReduceLongFunction<X, Z>::transformCudaXD(
+SD_DEVICE void ReduceLongFunction<X, Z>::transformCuda(
     const void* vx,
     const sd::LongType* outerXTadShapeInfo,
     const sd::LongType* innerXTadShapeInfo,
@@ -339,7 +339,7 @@ SD_DEVICE void ReduceLongFunction<X, Z>::execScalarCuda(
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Z>
 template <typename OpType>
-SD_HOST void ReduceLongFunction<X, Z>::intermediateXD(
+SD_HOST void ReduceLongFunction<X, Z>::intermediate(
     dim3 launchDims,
     cudaStream_t* stream,
     const void* x,
@@ -366,7 +366,7 @@ SD_HOST void ReduceLongFunction<X, Z>::intermediateXD(
         *stream);
     if (res != 0) {
       throw sd::cuda_exception::build(
-          "ReduceLongFunction<X,Z>::intermediateXD: failed to copy temporary scalar", res);
+          "ReduceLongFunction<X,Z>::intermediate: failed to copy temporary scalar", res);
     }
 
     auto ptr = sd::LaunchContext::defaultContext()->getScalarPointer();
@@ -394,7 +394,7 @@ SD_HOST void ReduceLongFunction<X, Z>::intermediateXD(
             z,
             dZShapeInfo);
   }
-  sd::DebugHelper::checkErrorCode(stream, "ReduceLongFunction intermediateXD(...) failed");
+  sd::DebugHelper::checkErrorCode(stream, "ReduceLongFunction intermediate(...) failed");
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -472,7 +472,7 @@ SD_HOST void ReduceLongFunction<X, Y>::execReduceScalar(
 
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Y>
-SD_HOST void ReduceLongFunction<X, Y>::execReduceXD(dim3 launchDims, cudaStream_t *stream, int opNum, const void *vx,
+SD_HOST void ReduceLongFunction<X, Y>::execReduce(dim3 launchDims, cudaStream_t *stream, int opNum, const void *vx,
                                                     sd::LongType *dXShapeInfo,  sd::LongType *hXShapeInfo, void *extraParams,
                                                     void *vreductionBuffer, void *vz,  sd::LongType *dZShapeInfo,
                                                     sd::LongType *hZShapeInfo,  sd::LongType *dims) {
@@ -486,7 +486,7 @@ SD_HOST void ReduceLongFunction<X, Y>::execReduceXD(dim3 launchDims, cudaStream_
         nullptr, 0, vreductionBuffer, nullptr);
   } else {
     DISPATCH_BY_OPNUM_TT(
-        intermediateXD,
+        intermediate,
         PARAMS(launchDims, stream, vx, dXShapeInfo, hXShapeInfo,
                extraParams, vreductionBuffer, vz, dZShapeInfo, hZShapeInfo, dims),
         OPS_A(REDUCE_LONG_OPS));

--- a/libnd4j/include/loops/cuda/reduce/reduce_same.cu
+++ b/libnd4j/include/loops/cuda/reduce/reduce_same.cu
@@ -42,7 +42,7 @@ SD_KERNEL void simpleReduce(
     void* z,
     const sd::LongType* zShapeInfo) {
 
-  functions::reduce::ReduceSameFunction<X>::template transformCudaXD<OpType>(
+  functions::reduce::ReduceSameFunction<X>::template transformCuda<OpType>(
       x,
       outerXTadShapeInfo,
       innerXTadShapeInfo,
@@ -107,7 +107,7 @@ SD_DEVICE void ReduceSameFunction<X>::aggregatePartials(
 ////////////////////////////////////////////////////////////////////////
 template <typename X>
 template <typename OpType>
-SD_DEVICE void ReduceSameFunction<X>::transformCudaXD(
+SD_DEVICE void ReduceSameFunction<X>::transformCuda(
     const void* vx,
     const sd::LongType* outerXTadShapeInfo,
     const sd::LongType* innerXTadShapeInfo,
@@ -329,7 +329,7 @@ SD_DEVICE void ReduceSameFunction<X>::execScalarCuda(
 ////////////////////////////////////////////////////////////////////////
 template <typename X>
 template <typename OpType>
-SD_HOST void ReduceSameFunction<X>::intermediateXD(
+SD_HOST void ReduceSameFunction<X>::intermediate(
     dim3 launchDims,
     cudaStream_t* stream,
     const void* x,
@@ -356,7 +356,7 @@ SD_HOST void ReduceSameFunction<X>::intermediateXD(
         *stream);
     if (res != 0) {
       throw sd::cuda_exception::build(
-          "ReduceSameFunction<X>::intermediateXD: failed to copy temporary scalar", res);
+          "ReduceSameFunction<X>::intermediate: failed to copy temporary scalar", res);
     }
 
     auto ptr = sd::LaunchContext::defaultContext()->getScalarPointer();
@@ -393,7 +393,7 @@ SD_HOST void ReduceSameFunction<X>::intermediateXD(
         vreductionBuffer,
         z,
         dZShapeInfo);
-    sd::DebugHelper::checkErrorCode(stream, "ReduceSameFunction intermediateXD(...) failed");
+    sd::DebugHelper::checkErrorCode(stream, "ReduceSameFunction intermediate(...) failed");
   }
 }
 
@@ -472,7 +472,7 @@ SD_HOST void ReduceSameFunction<X>::execReduceScalar(
 
 ////////////////////////////////////////////////////////////////////////
 template <typename X>
-SD_HOST void ReduceSameFunction<X>::execReduceXD(
+SD_HOST void ReduceSameFunction<X>::execReduce(
     dim3 launchDims,
     cudaStream_t* stream,
     const int opNum,
@@ -495,7 +495,7 @@ SD_HOST void ReduceSameFunction<X>::execReduceXD(
         nullptr, 0, vreductionBuffer, nullptr);
   } else {
     DISPATCH_BY_OPNUM_T(
-        intermediateXD,
+        intermediate,
         PARAMS(
             launchDims, stream, x, dXShapeInfo, hXShapeInfo, extraParams, vreductionBuffer, z, dZShapeInfo,
             hZShapeInfo, dims),

--- a/libnd4j/include/loops/cuda/scalar_bool.cu
+++ b/libnd4j/include/loops/cuda/scalar_bool.cu
@@ -239,7 +239,6 @@ __device__ void ScalarBoolTransform<X,Z>::transformCuda(
  }
 }
 
-// omitted code for transformCuda with EWS etc, for brevity
 
 ////////////////////////////////////////////////////////////////////////
 template <typename X, typename Z>

--- a/libnd4j/include/loops/reduce_bool.h
+++ b/libnd4j/include/loops/reduce_bool.h
@@ -54,7 +54,7 @@ class SD_LIB_HIDDEN ReduceBoolFunction {
                                        const sd::LongType *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_DEVICE void transformCudaXD(const void *vx, const sd::LongType *outerXTadShapeInfo,
+  static SD_DEVICE void transformCuda(const void *vx, const sd::LongType *outerXTadShapeInfo,
                                         const sd::LongType *innerXTadShapeInfo, void *extraParams,
                                         void *vreductionBuffer, void *vz, const sd::LongType *zShapeInfo);
 
@@ -67,7 +67,7 @@ class SD_LIB_HIDDEN ReduceBoolFunction {
                                          void *reductionBuffer, const sd::LongType *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_HOST void intermediateXD(dim3 launchDims, cudaStream_t *stream, const void *vx,
+  static SD_HOST void intermediate(dim3 launchDims, cudaStream_t *stream, const void *vx,
                                      sd::LongType *dXShapeInfo, sd::LongType *hXShapeInfo,
                                      void *extraParams, void *vreductionBuffer, void *vz,
                                      sd::LongType *dZShapeInfo, sd::LongType *hZShapeInfo, sd::LongType *dims);
@@ -79,7 +79,7 @@ class SD_LIB_HIDDEN ReduceBoolFunction {
                                        sd::LongType dimensionLength,
                                        void *reductionBuffer, const sd::LongType *tadOnlyShapeInfo);
 
-  static SD_HOST void execReduceXD(dim3 launchDims, cudaStream_t *stream, const int opNum, const void *vx,
+  static SD_HOST void execReduce(dim3 launchDims, cudaStream_t *stream, const int opNum, const void *vx,
                                    sd::LongType *dXShapeInfo, sd::LongType *hXShapeInfo, void *extraParams,
                                    void *vreductionBuffer, void *vz, sd::LongType *dZShapeInfo,
                                    sd::LongType *hZShapeInfo, sd::LongType *dims);

--- a/libnd4j/include/loops/reduce_float.h
+++ b/libnd4j/include/loops/reduce_float.h
@@ -53,7 +53,7 @@ class ReduceFloatFunction {
                                        const sd::LongType *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_DEVICE void transformCudaXD(const void *vx, const sd::LongType *outerXTadShapeInfo,
+  static SD_DEVICE void transformCuda(const void *vx, const sd::LongType *outerXTadShapeInfo,
                                         const sd::LongType *innerXTadShapeInfo, void *extraParams,
                                         void *vreductionBuffer, void *vz, const sd::LongType *zShapeInfo);
 
@@ -66,7 +66,7 @@ class ReduceFloatFunction {
                                          void *reductionBuffer, const sd::LongType *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_HOST void intermediateXD(dim3 launchDims, cudaStream_t *stream, const void *vx,
+  static SD_HOST void intermediate(dim3 launchDims, cudaStream_t *stream, const void *vx,
                                      const sd::LongType *dXShapeInfo, const sd::LongType *hXShapeInfo,
                                      void *extraParams, void *vreductionBuffer, void *vz,
                                      const sd::LongType *dZShapeInfo, const sd::LongType *hZShapeInfo,
@@ -79,7 +79,7 @@ class ReduceFloatFunction {
                                        sd::LongType dimensionLength,
                                        void *reductionBuffer, const sd::LongType *tadOnlyShapeInfo);
 
-  static SD_HOST void execReduceXD(dim3 launchDims, cudaStream_t *stream, int opNum, const void *vx,
+  static SD_HOST void execReduce(dim3 launchDims, cudaStream_t *stream, int opNum, const void *vx,
                                    const sd::LongType *dXShapeInfo, const sd::LongType *hXShapeInfo, void *extraParams,
                                    void *vreductionBuffer, void *vz, const sd::LongType *dZShapeInfo,
                                    const sd::LongType *hZShapeInfo, const sd::LongType *dims);

--- a/libnd4j/include/loops/reduce_long.h
+++ b/libnd4j/include/loops/reduce_long.h
@@ -55,7 +55,7 @@ class SD_LIB_HIDDEN ReduceLongFunction {
                                        const sd::LongType *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_DEVICE void transformCudaXD(const void *vx, const sd::LongType *outerXTadShapeInfo,
+  static SD_DEVICE void transformCuda(const void *vx, const sd::LongType *outerXTadShapeInfo,
                                         const sd::LongType *innerXTadShapeInfo, void *extraParams,
                                         void *vreductionBuffer, void *vz, const sd::LongType *zShapeInfo);
 
@@ -68,7 +68,7 @@ class SD_LIB_HIDDEN ReduceLongFunction {
                                          void *reductionBuffer, const sd::LongType *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_HOST void intermediateXD(dim3 launchDims, cudaStream_t *stream, const void *vx,
+  static SD_HOST void intermediate(dim3 launchDims, cudaStream_t *stream, const void *vx,
                                       sd::LongType *dXShapeInfo,  sd::LongType *hXShapeInfo,
                                      void *extraParams, void *vreductionBuffer, void *vz,
                                       sd::LongType *dZShapeInfo,  sd::LongType *hZShapeInfo,
@@ -81,7 +81,7 @@ class SD_LIB_HIDDEN ReduceLongFunction {
                                        sd::LongType dimensionLength,
                                        void *reductionBuffer,  sd::LongType *tadOnlyShapeInfo);
 
-  static SD_HOST void execReduceXD(dim3 launchDims, cudaStream_t *stream, int opNum, const void *vx,
+  static SD_HOST void execReduce(dim3 launchDims, cudaStream_t *stream, int opNum, const void *vx,
                                     sd::LongType *dXShapeInfo,  sd::LongType *hXShapeInfo, void *extraParams,
                                    void *vreductionBuffer, void *vz,  sd::LongType *dZShapeInfo,
                                     sd::LongType *hZShapeInfo,  sd::LongType *dims);

--- a/libnd4j/include/loops/reduce_same.h
+++ b/libnd4j/include/loops/reduce_same.h
@@ -60,7 +60,7 @@ class SD_LIB_HIDDEN ReduceSameFunction {
                                              void *reductionBuffer, sd::LongType const *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_DEVICE void transformCudaXD(const void *vx, const sd::LongType *outerXTadShapeInfo,
+  static SD_DEVICE void transformCuda(const void *vx, const sd::LongType *outerXTadShapeInfo,
                                         const sd::LongType *innerXTadShapeInfo, void *extraParams,
                                         void *reductionBuffer, void *vz, const sd::LongType *zShapeInfo);
 
@@ -73,7 +73,7 @@ class SD_LIB_HIDDEN ReduceSameFunction {
                                          void *reductionBuffer, sd::LongType const *tadOnlyShapeInfo);
 
   template <typename OpType>
-  static SD_HOST void intermediateXD(dim3 launchDims, cudaStream_t *stream, const void *vx,
+  static SD_HOST void intermediate(dim3 launchDims, cudaStream_t *stream, const void *vx,
                                      const sd::LongType *dXShapeInfo, const sd::LongType *hXShapeInfo,
                                      void *extraParams, void *reductionBuffer, void *vz,
                                      const sd::LongType *dZShapeInfo, const sd::LongType *hZShapeInfo,
@@ -86,7 +86,7 @@ class SD_LIB_HIDDEN ReduceSameFunction {
                                        sd::LongType dimensionLength,
                                        void *reductionBuffer, sd::LongType const *tadOnlyShapeInfo);
 
-  static SD_HOST void execReduceXD(dim3 launchDims, cudaStream_t *stream, const int opNum, const void *vx,
+  static SD_HOST void execReduce(dim3 launchDims, cudaStream_t *stream, const int opNum, const void *vx,
                                    const sd::LongType *dXShapeInfo, const sd::LongType *hXShapeInfo, void *extraParams,
                                    void *reductionBuffer, void *vz, const sd::LongType *dZShapeInfo,
                                    const sd::LongType *hZShapeInfo, const long long int *dims);

--- a/libnd4j/include/ops/declarable/generic/shape/reshape_no_copy.cpp
+++ b/libnd4j/include/ops/declarable/generic/shape/reshape_no_copy.cpp
@@ -112,7 +112,9 @@ DECLARE_SHAPE_FN(reshape_no_copy) {
     }
   }
 
-  return SHAPELIST(CONSTANT(newShapeInfo));
+
+  auto newShape2 = ConstantShapeHelper::getInstance().createFromExisting(newShapeInfo);
+  return SHAPELIST(CONSTANT(newShape2));
 }
 
 DECLARE_TYPES(reshape_no_copy) {

--- a/libnd4j/include/ops/declarable/helpers/convolutions.h
+++ b/libnd4j/include/ops/declarable/helpers/convolutions.h
@@ -93,6 +93,8 @@ class SD_LIB_HIDDEN ConvolutionUtils {
     } else {
       THROW_EXCEPTION("Unsupported weight format");
     }
+
+    return 0;
   }
 
   static inline LongType sizeOfOutChannels(const LongType *shapeInfo,LongType weightsFormat) {

--- a/libnd4j/include/ops/declarable/helpers/impl/choose.cpp
+++ b/libnd4j/include/ops/declarable/helpers/impl/choose.cpp
@@ -112,10 +112,11 @@ NDArray* processCondition(LaunchContext* context, int mode, NDArray* arg, NDArra
   if (numResult != nullptr) numResult->syncToDevice();
 
   compScalar.syncToDevice();
+  return nullptr;
 }
 BUILD_SINGLE_TEMPLATE(template NDArray* processCondition_,
                       (int mode, sd::NDArray* arg, sd::NDArray* comp, sd::NDArray* output, sd::NDArray* numResult,
-                       sd::NDArray& compScalar),
+                          sd::NDArray& compScalar),
                       SD_FLOAT_TYPES);
 
 template <typename T>

--- a/libnd4j/include/ops/declarable/helpers/impl/listdiff.cpp
+++ b/libnd4j/include/ops/declarable/helpers/impl/listdiff.cpp
@@ -53,6 +53,7 @@ sd::LongType listDiffCount(sd::LaunchContext* context, NDArray* values, NDArray*
   BUILD_SINGLE_SELECTOR(xType, return listDiffCount_, (values, keep), SD_COMMON_TYPES);
 
   NDArray::registerPrimaryUse({}, {values, keep});
+  return 0;
 }
 
 BUILD_SINGLE_TEMPLATE(template sd::LongType listDiffCount_, (NDArray * values, NDArray* keep);, SD_COMMON_TYPES);
@@ -110,7 +111,7 @@ sd::Status listDiffFunctor(sd::LaunchContext* context, NDArray* values, NDArray*
   } else if (DataTypeUtils::isZ(xType)) {
     BUILD_SINGLE_SELECTOR(xType, result = listDiffFunctor_, (values, keep, output1, output2), SD_INTEGER_TYPES);
   } else {
-    THROW_EXCEPTION("ListDiff: Only integer and floating point data types are supported");
+   return sd::Status::KERNEL_FAILURE;
   }
 
   NDArray::registerPrimaryUse({output1, output2}, {values, keep});

--- a/libnd4j/include/ops/declarable/helpers/impl/unique.cpp
+++ b/libnd4j/include/ops/declarable/helpers/impl/unique.cpp
@@ -49,6 +49,7 @@ static LongType uniqueCount_(NDArray* input) {
 
 LongType uniqueCount(LaunchContext* context, NDArray* input) {
   BUILD_SINGLE_SELECTOR(input->dataType(), return uniqueCount_, (input), SD_COMMON_TYPES);
+  return 0;
 }
 
 BUILD_SINGLE_TEMPLATE(template sd::LongType uniqueCount_, (NDArray * input), SD_COMMON_TYPES);
@@ -102,6 +103,9 @@ Status uniqueFunctor(LaunchContext* context, NDArray* input, NDArray* values, ND
   indices->syncToDevice();
 
   if (counts != nullptr) counts->syncToDevice();
+
+
+  return sd::Status::KERNEL_FAILURE;
 }
 
 BUILD_SINGLE_TEMPLATE(template sd::Status uniqueFunctor_,

--- a/libnd4j/include/ops/declarable/impl/BooleanOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/BooleanOp.cpp
@@ -59,6 +59,8 @@ bool BooleanOp::verify(Context &block) {
     sd_printf("Got error %i during [%s] evaluation: ", (int)status, this->getOpDescriptor()->getOpName()->c_str());
     THROW_EXCEPTION("Internal error");
   }
+
+  return false;
 }
 
 bool BooleanOp::prepareOutputs(Context &ctx) {

--- a/libnd4j/include/ops/declarable/impl/LegacyRandomOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/LegacyRandomOp.cpp
@@ -290,6 +290,7 @@ Status LegacyRandomOp::validateAndExecute_(Context& block) {
 Status LegacyRandomOp::validateAndExecute(Context& block) {
   auto z = OUTPUT_VARIABLE(0);
   BUILD_SINGLE_SELECTOR(z->dataType(), return validateAndExecute_, (block), SD_FLOAT_TYPES);
+  return sd::Status::KERNEL_FAILURE;
 }
 
 /**
@@ -313,6 +314,8 @@ ShapeList* LegacyRandomOp::calculateOutputShape(ShapeList* inputShape, Context& 
     return SHAPELIST(ConstantShapeHelper::getInstance().createShapeInfo(dtype, 'c', zShapeVector));
   } else
     THROW_EXCEPTION("LegacyRandomOp: Unknown input data type!");
+
+  return nullptr;
 }
 
 Status LegacyRandomOp::execute(Context* block) { return DeclarableOp::execute(block); }

--- a/libnd4j/pom.xml
+++ b/libnd4j/pom.xml
@@ -60,6 +60,8 @@
         <libnd4j.operations></libnd4j.operations>
         <libnd4j.datatypes></libnd4j.datatypes>
         <libnd4j.sanitize>OFF</libnd4j.sanitize>
+        <!-- Used during cuda compilation. Shows information about ptxas assembly for debugging cuda.-->
+        <libnd4j.ptxas>OFF</libnd4j.ptxas>
         <!-- NOTE WHEN SETTING THIS VALUE. THREAD AND ADDRESS CAN NOT BE USED TOGETHER. THAT IS WHY THIS OPTION EXISTS.
          FOR THREADS USE: thread,undefined,float-divide-by-zero,float-cast-overflow
          FOR ADDRESS USE: address,float-divide-by-zero,float-cast-overflow

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/cache/BasicConstantHandler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/cache/BasicConstantHandler.java
@@ -23,11 +23,6 @@ package org.nd4j.linalg.cache;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 
 public abstract class BasicConstantHandler implements ConstantHandler {
-    @Override
-    public long moveToConstantSpace(DataBuffer dataBuffer) {
-        // no-op
-        return 0L;
-    }
 
     @Override
     public DataBuffer relocateConstantSpace(DataBuffer dataBuffer) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/cache/ConstantHandler.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/cache/ConstantHandler.java
@@ -26,18 +26,6 @@ import org.nd4j.linalg.api.buffer.DataType;
 public interface ConstantHandler {
 
     /**
-     * If specific hardware supports dedicated constant memory,
-     * this method forces DataBuffer passed in to be moved
-     * to that constant memory.
-     *
-     * PLEASE NOTE: This method implementation is hardware-dependant.
-     *
-     * @param dataBuffer
-     * @return
-     */
-    long moveToConstantSpace(DataBuffer dataBuffer);
-
-    /**
      *
      * PLEASE NOTE: This method implementation is hardware-dependant.
      * PLEASE NOTE: This method does NOT allow concurrent use of any array

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/pom.xml
@@ -125,6 +125,7 @@
                                 <exclude>*.so</exclude>
                                 <exclude>META-INF/native-image/${javacpp.platform}${javacpp.platform.extension}/</exclude>
                             </excludes>
+
                         </configuration>
                     </execution>
                     <execution>
@@ -331,8 +332,8 @@
                                 <linkPath>${libnd4jhome}/blasbuild/cuda/blas</linkPath>
                             </linkPaths>
                             <compilerOptions>
-                                <compilerOption>${javacpp.compiler.options}</compilerOption>
                                 <compilerOption>-std=c++17</compilerOption>
+                                <compilerOption>-Wl,--no-undefined</compilerOption>
                             </compilerOptions>
                         </configuration>
                         <executions>
@@ -346,8 +347,7 @@
                                     <skip>${javacpp.parser.skip}</skip>
                                     <deleteJniFiles>false</deleteJniFiles>
                                     <outputDirectory>${project.build.sourceDirectory}</outputDirectory>
-                                    <classOrPackageName>org.nd4j.presets.cuda.Nd4jCudaPresets
-                                    </classOrPackageName>
+                                    <classOrPackageName>org.nd4j.presets.cuda.Nd4jCudaPresets</classOrPackageName>
                                 </configuration>
                             </execution>
                             <execution>
@@ -477,7 +477,10 @@
                                 <compilerOption>-fno-optimize-sibling-calls</compilerOption>
                                 <compilerOption>-g</compilerOption>
                                 <compilerOption>-fPIC</compilerOption>
+                                <compilerOption>-std=c++17</compilerOption>
+
                             </compilerOptions>
+
                         </configuration>
                         <executions>
                             <execution>
@@ -489,10 +492,9 @@
                                 <configuration>
                                     <skip>${javacpp.parser.skip}</skip>
                                     <outputDirectory>${project.build.sourceDirectory}</outputDirectory>
-                                    <classOrPackageName>org.nd4j.presets.cuda.Nd4jCudaPresets
-                                        <deleteJniFiles>false</deleteJniFiles>
+                                    <classOrPackageName>org.nd4j.presets.cuda.Nd4jCudaPresets</classOrPackageName>
+                                    <deleteJniFiles>false</deleteJniFiles>
 
-                                    </classOrPackageName>
                                 </configuration>
                             </execution>
                             <execution>

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/Allocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/Allocator.java
@@ -180,7 +180,5 @@ public interface Allocator {
 
     DataBuffer getConstantBuffer(double[] array);
 
-    DataBuffer moveToConstant(DataBuffer dataBuffer);
-
     MemoryHandler getMemoryHandler();
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/impl/AtomicAllocator.java
@@ -38,9 +38,7 @@ import org.nd4j.jita.handler.MemoryHandler;
 import org.nd4j.jita.handler.impl.CudaZeroHandler;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
-import org.nd4j.linalg.api.memory.enums.MemoryKind;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.cache.ConstantHandler;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.jcublas.buffer.BaseCudaDataBuffer;
 import org.nd4j.linalg.jcublas.context.CudaContext;
@@ -131,9 +129,6 @@ public class AtomicAllocator implements Allocator {
 
     }
 
-    protected Map<Long, AllocationPoint> allocationsMap(){
-        return allocationsMap;
-    }
 
     public void applyConfiguration() {
         CudaEnvironment.getInstance().notifyConfigurationApplied();
@@ -657,9 +652,4 @@ public class AtomicAllocator implements Allocator {
         return Nd4j.getConstantHandler().getConstantBuffer(array, DataType.DOUBLE);
     }
 
-    @Override
-    public DataBuffer moveToConstant(DataBuffer dataBuffer) {
-        Nd4j.getConstantHandler().moveToConstantSpace(dataBuffer);
-        return dataBuffer;
-    }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/tad/DeviceTADManager.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/tad/DeviceTADManager.java
@@ -21,6 +21,7 @@
 package org.nd4j.jita.allocator.tad;
 
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.nd4j.common.primitives.Pair;
 import org.nd4j.jita.allocator.impl.AtomicAllocator;
 import org.nd4j.linalg.api.buffer.DataBuffer;
@@ -40,15 +41,10 @@ import java.util.concurrent.Semaphore;
  */
 @Slf4j
 public class DeviceTADManager extends BasicTADManager {
-    protected List<Map<TadDescriptor, Pair<DataBuffer, DataBuffer>>> tadCache = new ArrayList<>();
-    private Semaphore lock = new Semaphore(1);
+
 
     public DeviceTADManager() {
-        int numDevices = Nd4j.getAffinityManager().getNumberOfDevices();
 
-        for (int i = 0; i < numDevices; i++) {
-            tadCache.add(i, new ConcurrentHashMap<>());
-        }
     }
 
     /**
@@ -57,79 +53,20 @@ public class DeviceTADManager extends BasicTADManager {
     @Override
     public void purgeBuffers() {
         log.info("Purging TAD buffers...");
-
-        tadCache = new ArrayList<>();
-
-        int numDevices = Nd4j.getAffinityManager().getNumberOfDevices();
-
-        for (int i = 0; i < numDevices; i++) {
-            log.info("Resetting device: [{}]", i);
-            tadCache.add(i, new ConcurrentHashMap<TadDescriptor, Pair<DataBuffer, DataBuffer>>());
-        }
-
         super.purgeBuffers();
     }
 
     @Override
     public Pair<DataBuffer, DataBuffer> getTADOnlyShapeInfo(INDArray array, long... dimension) {
-        /*
-            so, we check, if we have things cached.
-            If we don't - we just create new TAD shape, and push it to constant memory
-        */
         if (dimension != null && dimension.length > 1)
             Arrays.sort(dimension);
 
-        Integer deviceId = AtomicAllocator.getInstance().getDeviceId();
+        if (dimension == null)
+            dimension = new long[] {Integer.MAX_VALUE};
+
+        val pack = Nd4j.getExecutioner().tadShapeInfoAndOffsets(array, dimension);
 
 
-        //extract the dimensions and shape buffer for comparison
-        TadDescriptor descriptor = new TadDescriptor(array, dimension);
-
-        if (!tadCache.get(deviceId).containsKey(descriptor)) {
-            log.trace("Creating new TAD...");
-            //create the TAD with the shape information and corresponding offsets
-            //note that we use native code to get access to the shape information.
-            Pair<DataBuffer, DataBuffer> buffers = super.getTADOnlyShapeInfo(array, dimension);
-            /**
-             * Store the buffers in constant memory.
-             * The main implementation of this is cuda right now.
-             *
-             * Explanation from: http://cuda-programming.blogspot.jp/2013/01/what-is-constant-memory-in-cuda.html
-             * The CUDA language makes available another kind of memory known as constant memory. As the opName may indicate, we use constant memory for data that will not change over the course of a kernel execution.
-            
-             Why Constant Memory?
-            
-             NVIDIA hardware provides 64KB of constant memory that
-             it treats differently than it treats standard global memory. In some situations,
-             using constant memory rather than global memory will reduce the required memory bandwidth.
-            
-             NOTE HERE FOR US: We use 48kb of it using these methods.
-            
-             Note also that we use the {@link AtomicAllocator} which is the cuda memory manager
-             for moving the current host space data buffer to constant memory.
-            
-             We do this for device access to shape information.
-             */
-            //if (buffers.getFirst() != array.shapeInfoDataBuffer())
-                //AtomicAllocator.getInstance().moveToConstant(buffers.getFirst());
-            /**
-             * @see {@link org.nd4j.jita.constant.ProtectedCudaConstantHandler}
-             */
-            //if (buffers.getSecond() != null)
-           //     AtomicAllocator.getInstance().moveToConstant(buffers.getSecond());
-
-            // so, at this point we have buffer valid on host side.
-            // And we just need to replace DevicePointer with constant pointer
-            tadCache.get(deviceId).put(descriptor, buffers);
-
-            bytes.addAndGet((buffers.getFirst().length() * 4));
-
-            if (buffers.getSecond() != null)
-                bytes.addAndGet(buffers.getSecond().length() * 8);
-
-            log.trace("Using TAD from cache...");
-        }
-
-        return tadCache.get(deviceId).get(descriptor);
+        return new Pair<>(pack.getTadShapeInfo(), pack.getTadOffsets());
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/constant/CudaConstantHandler.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/constant/CudaConstantHandler.java
@@ -42,11 +42,6 @@ public class CudaConstantHandler extends BasicConstantHandler {
     }
 
     @Override
-    public long moveToConstantSpace(DataBuffer dataBuffer) {
-        return wrappedHandler.moveToConstantSpace(dataBuffer);
-    }
-
-    @Override
     public DataBuffer getConstantBuffer(int[] array, DataType type) {
         return wrappedHandler.getConstantBuffer(array, type);
     }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/flow/impl/SynchronousFlowController.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/flow/impl/SynchronousFlowController.java
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
  * @author raver119@gmail.com
  */
 public class SynchronousFlowController implements FlowController {
-    private static Logger log = LoggerFactory.getLogger(SynchronousFlowController.class);
     private volatile Allocator allocator;
     protected NativeOps nativeOps = NativeOpsHolder.getInstance().getDeviceNativeOps();
     protected Configuration configuration = CudaEnvironment.getInstance().getConfiguration();
@@ -177,20 +176,6 @@ public class SynchronousFlowController implements FlowController {
 
     @Override
     public void registerAction(CudaContext context, AllocationPoint result, AllocationPoint... operands) {
-        // this method is irrelevant now, everything happens in C++ now
-        /*
-        eventsProvider.storeEvent(result.getLastWriteEvent());
-        result.setLastWriteEvent(eventsProvider.getEvent());
-        result.getLastWriteEvent().register(context.getOldStream());
-
-
-        for (AllocationPoint operand : operands) {
-            eventsProvider.storeEvent(operand.getLastReadEvent());
-            operand.setLastReadEvent(eventsProvider.getEvent());
-            operand.getLastReadEvent().register(context.getOldStream());
-        }
-        //   context.syncOldStream();
-        */
     }
 
     @Override
@@ -254,9 +239,6 @@ public class SynchronousFlowController implements FlowController {
             if (pointShape.getAllocationStatus() == AllocationStatus.HOST) {
                 val oShape = array.shapeInfoDataBuffer();
                 val nShape = Nd4j.getConstantHandler().relocateConstantSpace(oShape);
-
-                if (nShape == oShape)
-                    Nd4j.getConstantHandler().moveToConstantSpace(nShape);
                 ((JCublasNDArray) array).setShapeInfoDataBuffer(nShape);
             }
         }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -161,7 +161,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         super(pointer, indexer, length);
 
         // allocating interop buffer
-        this.ptrDataBuffer = OpaqueDataBuffer.allocateDataBuffer(length, type, false);
+        this.ptrDataBuffer = OpaqueDataBuffer.allocateDataBuffer(length, type, true);
         // passing existing pointer to native holder
         this.ptrDataBuffer.setPrimaryBuffer(pointer, length);
 
@@ -361,7 +361,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         this.elementSize =  (byte) elementSize;
 
         // we allocate native DataBuffer AND it will contain our device pointer
-        ptrDataBuffer = OpaqueDataBuffer.allocateDataBuffer(length, type, false);
+        ptrDataBuffer = OpaqueDataBuffer.allocateDataBuffer(length, type, true);
         this.allocationPoint = new AllocationPoint(ptrDataBuffer, length * type.width());
 
         if (initialize) {
@@ -1531,7 +1531,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         type = currentType;
 
         if (ptrDataBuffer == null) {
-            ptrDataBuffer = OpaqueDataBuffer.allocateDataBuffer(length(), type, false);
+            ptrDataBuffer = OpaqueDataBuffer.allocateDataBuffer(length(), type, true);
             this.deallocationId = Nd4j.getDeallocatorService().pickObject(this);
         }
 

--- a/platform-tests/bin/java
+++ b/platform-tests/bin/java
@@ -23,7 +23,8 @@
 set -exo pipefail
 java_call="java "
 script_dir=$( cd -- "$( dirname -- "${bash_source[0]}" )" &> /dev/null && pwd )
-
+echo "RUNNING WITH CUSTOM JVM"
+echo "TEST RUNNER PREFIX: $test_runner_prefix"
 #source "${script_dir}/env.sh"
 # find libjvm.so
 if [[ -n $libjvm_so ]]; then
@@ -41,7 +42,7 @@ if [[ -z $libjvm_path ]]; then
 fi
 
 # if test_runner_prefix is not empty and contains "valgrind"
-if [[ -n $test_runner_prefix && $test_runner_prefix =~ "valgrind" ]]; then
+if [[ -n $TEST_RUNNER_PREFIX && TEST_RUNNER_PREFIX =~ "valgrind" ]]; then
     # create a file to store the suppression information
     suppression_file="valgrind_suppressions.supp"
 
@@ -67,31 +68,27 @@ eof
     echo "valgrind suppression file has been generated."
 
     # check if "--suppressions" already exists in test_runner_prefix
-    if [[ $test_runner_prefix != *"--suppressions"* ]]; then
-        test_runner_prefix="$test_runner_prefix   --suppressions=$suppression_file --track-origins=yes --keep-stacktraces=alloc-and-free --error-limit=no"
+    if [[ $TEST_RUNNER_PREFIX != *"--suppressions"* ]]; then
+        $TEST_RUNNER_PREFIX="$TEST_RUNNER_PREFIX   --suppressions=$suppression_file --track-origins=yes --keep-stacktraces=alloc-and-free --error-limit=no"
     fi
 
-    java_call="${java_call} -djava.compiler=none"
+    java_call="${java_call} -Djava.compiler=none"
 fi
 # if test_runner_prefix is not empty and contains "compute-sanitizer"
-if [[ -n $test_runner_prefix && $test_runner_prefix =~ "compute-sanitizer" ]]; then
+if [[ -n $TEST_RUNNER_PREFIX && $TEST_RUNNER_PREFIX =~ "compute-sanitizer" ]]; then
+    TEST_RUNNER_PREFIX="${TEST_RUNNER_PREFIX} --tool=memcheck"
     # set default options for compute-sanitizer if none are specified
-    if [[ $test_runner_prefix == *"compute-sanitizer"* && $test_runner_prefix != *"--tool"* ]]; then
-        # add default options for comprehensive memory checking
-        test_runner_prefix="$test_runner_prefix --tool=memcheck --leak-check=full --report-api-errors=all"
-    fi
-
     # add jvm option to disable jit compilation to help with debugging
-    java_call="${java_call} -djava.compiler=none"
+    java_call="${java_call}  -Djava.compiler=none"
 
     echo "running with cuda compute-sanitizer"
 fi
 export CUDA_VISIBLE_DEVICES=1
 # print the final command
-echo "$test_runner_prefix $java_call $@"
-$test_runner_prefix $java_call "$@"
+echo "$TEST_RUNNER_PREFIX $java_call $@"
+$TEST_RUNNER_PREFIX $java_call "$@"
 
 # if test_runner_prefix is not empty and contains "valgrind", remove the suppression file
-if [[ -n $test_runner_prefix && $test_runner_prefix =~ "valgrind" ]]; then
+if [[ -n $TEST_RUNNER_PREFIX && $TEST_RUNNER_PREFIX =~ "valgrind" ]]; then
     rm -f $suppression_file
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor method renaming: remove the xd suffix on some cuda functions.
Add back reduce folder when compiling cuda build.
Add std c++ 17 to functrace cuda preset for new c++ 17 standard.
Fixes cuda cache usage to properly use the underlying c++ cache instead.

## How was this patch tested?

Ran builds while trying to work on crash fixes.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [ X] Relevant tests for your changes are passing.
