### PR TITLE
Fixes reshape relates segfaults, convert more tad pack related functions to use normal pointers to avoid java related deallocation isssues

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java
@@ -36,6 +36,7 @@ import org.nd4j.common.primitives.Pair;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
@@ -194,7 +195,7 @@ public class SubsamplingLayer extends AbstractLayer<org.deeplearning4j.nn.conf.l
                         layerConf().getCnn2dDataFormat() == CNN2DFormat.NCHW ? 0 : 1);  //0: NCHW, 1=NHWC
 
         DynamicCustomOp build = b.build();
-        long[] shape = build.calculateOutputShape().get(0).getShape();
+        long[] shape = Shape.shape(build.calculateOutputShape().get(0).asLong());
 
         INDArray output = workspaceMgr.createUninitialized(ArrayType.ACTIVATIONS, input.dataType(), shape, 'c');
         build.addOutputArgument(output);

--- a/libnd4j/include/array/ArrayOptions.h
+++ b/libnd4j/include/array/ArrayOptions.h
@@ -137,10 +137,9 @@ class SD_LIB_EXPORT ArrayOptions {
   static SD_HOST void validateSingleDataType(LongType property);
   static SD_HOST void setPropertyBit(LongType *shapeInfo, LongType property);
   static SD_HOST void setPropertyBits(LongType *shapeInfo, std::initializer_list<LongType> properties);
-
-  static SD_HOST bool isSparseArray(LongType *shapeInfo);
+  static SD_HOST sd::LongType numDataTypesSet(sd::LongType property);
   static SD_HOST bool isUnsigned(LongType *shapeInfo);
-
+  static SD_HOST bool isSparseArray(sd::LongType *shapeInfo);
   static SD_HOST DataType dataType(const LongType *shapeInfo);
 
   static SD_HOST SpaceType spaceType(LongType *shapeInfo);

--- a/libnd4j/include/array/ArrayOptions.hXX
+++ b/libnd4j/include/array/ArrayOptions.hXX
@@ -248,7 +248,6 @@ SD_HOST bool ArrayOptions::isUnsigned(sd::LongType *shapeInfo) {
 long long int numDataTypesSet(sd::LongType property);
 long long int numDataTypesSet(sd::LongType property);
 SD_HOST sd::DataType ArrayOptions::dataTypeValue(sd::LongType property) {
-  validateSingleDataType(property);
   const sd::LongType dataTypeFlags[] = DATA_TYPE_FLAGS;
   const sd::DataType dataTypes[] = DATA_TYPES;
   const size_t numTypes = sizeof(dataTypeFlags) / sizeof(sd::LongType);

--- a/libnd4j/include/array/ArrayOptions.hXX
+++ b/libnd4j/include/array/ArrayOptions.hXX
@@ -245,6 +245,8 @@ SD_HOST bool ArrayOptions::isUnsigned(sd::LongType *shapeInfo) {
     sd::DataType::UTF32 \
 }
 
+long long int numDataTypesSet(sd::LongType property);
+long long int numDataTypesSet(sd::LongType property);
 SD_HOST sd::DataType ArrayOptions::dataTypeValue(sd::LongType property) {
   validateSingleDataType(property);
   const sd::LongType dataTypeFlags[] = DATA_TYPE_FLAGS;
@@ -272,6 +274,8 @@ SD_HOST sd::DataType ArrayOptions::dataTypeValue(sd::LongType property) {
 
   return sd::DataType::UNKNOWN;
 }
+
+
 
 SD_HOST void validateFlags(sd::LongType property, const sd::LongType flags[], size_t numFlags) {
   LongType flagIndices[numFlags];
@@ -311,19 +315,28 @@ SD_HOST void ArrayOptions::validateSingleDataType(sd::LongType property) {
 }
 
 
+SD_HOST sd::LongType ArrayOptions::numDataTypesSet(sd::LongType property) {
+  const sd::LongType dataTypeFlags[] = DATA_TYPE_FLAGS;
+  const size_t numDataTypeFlags = sizeof(dataTypeFlags) / sizeof(sd::LongType);
 
+  LongType flagIndices[numDataTypeFlags];
+  sd::LongType numFlagsSet = 0;
+  for (size_t i = 0; i < numDataTypeFlags; ++i) {
+    if (hasPropertyBitSetForFlags(property, dataTypeFlags[i])) {
+      flagIndices[i] = 1;
+      numFlagsSet++;
+    } else {
+      flagIndices[i] = 0;
+    }
+  }
+
+  return numFlagsSet;
+}
 
 SD_HOST sd::DataType ArrayOptions::dataType(const sd::LongType *shapeInfo) {
   if(shapeInfo == nullptr)
     THROW_EXCEPTION("ArrayOptions::dataType(..) shapeInfo can not be null!");
-/*#if defined(SD_GCC_FUNCTRACE)
-  Printer p;
-  StackTrace st;
-  st.load_here();
-  FILE *fp = fopen("stacktrace-.txt", "a+");
-  p.print(st,fp);
-  fclose(fp);
-#endif*/
+
   auto extra = ArrayOptions::extra(shapeInfo);
   return ArrayOptions::dataTypeValue(extra);
 }

--- a/libnd4j/include/array/ConstantShapeBuffer.h
+++ b/libnd4j/include/array/ConstantShapeBuffer.h
@@ -38,14 +38,15 @@ namespace sd {
 
 class SD_LIB_EXPORT ConstantShapeBuffer {
  private:
-  std::shared_ptr<PointerWrapper> _primaryShapeInfo;
-  std::shared_ptr<PointerWrapper> _specialShapeInfo;
+  PointerWrapper* _primaryShapeInfo;
+  PointerWrapper*  _specialShapeInfo;
 
 
  public:
-  ConstantShapeBuffer(const std::shared_ptr<PointerWrapper> &primary);
-  ConstantShapeBuffer(const std::shared_ptr<PointerWrapper> &primary, const std::shared_ptr<PointerWrapper> &special);
-  ConstantShapeBuffer() = default;
+  ConstantShapeBuffer( PointerWrapper* primary);
+  ConstantShapeBuffer( PointerWrapper* primary, PointerWrapper* special);
+  ConstantShapeBuffer();
+  ~ConstantShapeBuffer();
 #ifndef  __JAVACPP_HACK__
 #if defined(SD_GCC_FUNCTRACE)
   backward::StackTrace st;

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -1815,9 +1815,6 @@ void NDArray::assign(NDArray other, bool allowParallelism) {
 
   NDArray::copyDataForAssign(*this, other, modifiedOtherShapeInfo, allowParallelism);
 
-  if (modifiedOtherShapeInfo != other.shapeInfo()) {
-    RELEASE(const_cast<sd::LongType*>(modifiedOtherShapeInfo), getContext()->getWorkspace());
-  }
 }
 //////////////////////////////////////////////////////////////////////////
 
@@ -1947,7 +1944,7 @@ void NDArray::templatedSet(void *buffer, LongType offset, void *value) {
   auto t = reinterpret_cast<T *>(buffer);
   const auto y = *(reinterpret_cast<const Y *>(value));
   if(t == nullptr) {
-   THROW_EXCEPTION("NDArray::templatedSet: first buffer is nullptr");
+    THROW_EXCEPTION("NDArray::templatedSet: first buffer is nullptr");
   }
 
   t[offset] = y;
@@ -2659,14 +2656,34 @@ void NDArray::copyDataForAssign(NDArray& thisArray,  NDArray& other, const sd::L
 // Adjusts shape for assignment without modifying the original array
 const sd::LongType* NDArray::modifyShapeForAssign( NDArray& thisArray,  NDArray& other) {
   if (!shape::shapeEquals(thisArray.shapeInfo(), other.shapeInfo())) {
-    std::vector<sd::LongType> thisShape = thisArray.getShapeAsVector();
-    return reshapeShapeInfo(other, other.ordering(), thisShape);
+    std::vector<sd::LongType> *thisShape = new std::vector<sd::LongType>(thisArray.getShapeAsVector());
+    auto ret = reshapeShapeInfo(other, other.ordering(), *thisShape);
+    delete thisShape;
+    return ret;
   }
   return other.shapeInfo();
 }
 
 // Reshape logic modularized into a static helper function
 sd::LongType* NDArray::reshapeShapeInfo( NDArray& array, char order, const std::vector<sd::LongType>& newShape) {
+  //nothing to do for scalar shape info
+  if(array.isScalar()) {
+    //no need for strides with scalar just set shape
+    sd::LongType  *ret = new sd::LongType[newShape.size()];
+    ret[0] = newShape.size();
+    for (size_t i = 0; i < newShape.size(); i++) {
+      ret[i + 1] = newShape[i];
+    }
+
+    shape::setOrder(ret, 'c');
+    ArrayOptions::setExtra(ret, ArrayOptions::defaultFlag());
+    ArrayOptions::setDataType(ret, array.dataType());
+    auto ret2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(ret);
+    delete[] ret;
+    return ret2->primary();
+  }
+
+
   if (order != 'c' && order != 'f') {
     std::string errorMessage = "reshapeShapeInfo: unknown order, must be 'c' or 'f', received: ";
     errorMessage += order;
@@ -2704,20 +2721,19 @@ sd::LongType* NDArray::reshapeShapeInfo( NDArray& array, char order, const std::
     THROW_EXCEPTION("reshapeShapeInfo: bad length of new shape!");
   }
 
-  sd::LongType* shapeInfoNew = nullptr;
-  ALLOCATE(shapeInfoNew, array.getContext()->getWorkspace(),
-           shape::shapeInfoLength(shape_vector.size()), sd::LongType);
+
+  sd::LongType* shapeInfoNew =  new sd::LongType[shape::shapeInfoLength(shape_vector.size())];
   shapeInfoNew[0] = static_cast<sd::LongType>(shape_vector.size());
   bool canReshape = ops::helpers::reshapeNoAlloc(array.shapeInfo(), shape_vector, order, shapeInfoNew);
-  ArrayOptions::setDataType(shapeInfoNew, ArrayOptions::dataType(array.shapeInfo()));
-  shape::setOrder(shapeInfoNew, order);
-
   if (!canReshape) {
     shape::calcStrides(shapeInfoNew, order);
+    shape::setOrder(shapeInfoNew, order);
+
   }
 
   auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfoNew)->primary();
-  return const_cast<sd::LongType*>(ret);
+  delete[] shapeInfoNew;
+  return ret;
 }
 
 NDArray& NDArray::reshape(const char order, std::vector<sd::LongType>& shape, bool copyToNewBuff) & {
@@ -3682,7 +3698,7 @@ void *NDArray::operator new(size_t i) {
 ////////////////////////////////////////////////////////////////////////
 void NDArray::operator delete(void *p) {
   if (!sd::memory::MemoryRegistrator::getInstance().hasWorkspaceAttached()) {
-      free(p);
+    //free(p);
   }
 }
 
@@ -4005,7 +4021,7 @@ NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCor
   NDArray result(newShape, true, getContext());
 
   this->varianceAlongDimension(op, result, biasCorrected, copy);
-  delete copy;
+  //delete copy;
   return result;
 }
 
@@ -4014,7 +4030,7 @@ NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCor
                                         const std::initializer_list<LongType> *dimensions)  {
   std::vector<sd::LongType> *copy = new std::vector<sd::LongType>(*dimensions);
   auto ret = varianceAlongDimension(op, biasCorrected, copy);
-  delete copy;
+ // delete copy;
   return ret;
 }
 
@@ -4023,7 +4039,7 @@ void NDArray::varianceAlongDimension(sd::variance::Ops op, NDArray &target, cons
                                      const std::initializer_list<LongType> *dimensions)  {
   std::vector<sd::LongType> *copy = new std::vector<sd::LongType>(*dimensions);
   varianceAlongDimension(op, target, biasCorrected, copy);
-  delete copy;
+  //delete copy;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -4955,7 +4971,7 @@ void NDArray::reduceAlongDimension(sd::reduce::SameOps op, NDArray *target, cons
 
   NDArray::registerSpecialUse({target}, {this});
 
-  delete copy;
+  //delete copy;
 
 }
 
@@ -5043,7 +5059,7 @@ void NDArray::reduceAlongDimension(sd::reduce::BoolOps op, NDArray *target, cons
     NativeOpExecutioner::execReduceBool(getContext(), op, buffer(), shapeInfo(), specialBuffer(), specialShapeInfo(),
                                         nullptr, target->buffer(), zShapeInfoH, target->specialBuffer(), zShapeInfoD,
                                         dims->data(), dims->size());
-     delete dims;
+    delete dims;
   }
   synchronize("NDArray::reduceAlongDimension LongOps");
 
@@ -5196,9 +5212,9 @@ NDArray::p(const sd::LongType i, const T value) {  // Note: value not NDArray re
     THROW_EXCEPTION(errorMessage.c_str());
   }
   if(isScalar()) {
-        // Direct value assignment, no need for scalar.isS() check
-        templatedSet<T, T>(buffer(), 0, dataType(), (void*)&value);
-        return;
+    // Direct value assignment, no need for scalar.isS() check
+    templatedSet<T, T>(buffer(), 0, dataType(), (void*)&value);
+    return;
   }
 
   sd::LongType coords[1] = {i};

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -3730,7 +3730,7 @@ void *NDArray::operator new(size_t i) {
 ////////////////////////////////////////////////////////////////////////
 void NDArray::operator delete(void *p) {
   if (!sd::memory::MemoryRegistrator::getInstance().hasWorkspaceAttached()) {
-    //free(p);
+    free(p);
   }
 }
 
@@ -4053,7 +4053,7 @@ NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCor
   NDArray result(newShape, true, getContext());
 
   this->varianceAlongDimension(op, result, biasCorrected, copy);
-  //delete copy;
+  delete copy;
   return result;
 }
 
@@ -4062,7 +4062,7 @@ NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCor
                                         const std::initializer_list<LongType> *dimensions)  {
   std::vector<sd::LongType> *copy = new std::vector<sd::LongType>(*dimensions);
   auto ret = varianceAlongDimension(op, biasCorrected, copy);
-  // delete copy;
+  delete copy;
   return ret;
 }
 
@@ -4071,7 +4071,7 @@ void NDArray::varianceAlongDimension(sd::variance::Ops op, NDArray &target, cons
                                      const std::initializer_list<LongType> *dimensions)  {
   std::vector<sd::LongType> *copy = new std::vector<sd::LongType>(*dimensions);
   varianceAlongDimension(op, target, biasCorrected, copy);
-  //delete copy;
+  delete copy;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -5003,7 +5003,7 @@ void NDArray::reduceAlongDimension(sd::reduce::SameOps op, NDArray *target, cons
 
   NDArray::registerSpecialUse({target}, {this});
 
-  //delete copy;
+  delete copy;
 
 }
 

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -98,7 +98,20 @@ std::u32string NDArray::e(sd::LongType i)  {
 }
 
 LongType NDArray::getOffset(const LongType i) {
+  if (!isScalar() && i >= lengthOf()) {
+    std::string errorMessage;
+    errorMessage += "Requested index is out of range: [";
+    errorMessage += StringUtils::valueToString<sd::LongType>(i);
+    errorMessage += "] vs ";
+    errorMessage += StringUtils::valueToString<sd::LongType>(lengthOf());
+    errorMessage += " on array with shape ";
+    errorMessage += ShapeUtils::shapeAsString(shapeInfo());
+    THROW_EXCEPTION(errorMessage.c_str());
+  }
+
+
   return _offset + i;
+
 }
 
 template <>
@@ -1810,11 +1823,8 @@ bool NDArray::isBroadcastableTo(NDArray &other)  {
 // This method assigns values of given NDArray to this one
 void NDArray::assign(NDArray other, bool allowParallelism) {
   NDArray::validateAssign(*this, other);
-
   const sd::LongType* modifiedOtherShapeInfo = NDArray::modifyShapeForAssign(*this, other);
-
   NDArray::copyDataForAssign(*this, other, modifiedOtherShapeInfo, allowParallelism);
-
 }
 //////////////////////////////////////////////////////////////////////////
 
@@ -2665,30 +2675,43 @@ const sd::LongType* NDArray::modifyShapeForAssign( NDArray& thisArray,  NDArray&
 }
 
 // Reshape logic modularized into a static helper function
-sd::LongType* NDArray::reshapeShapeInfo( NDArray& array, char order, const std::vector<sd::LongType>& newShape) {
+// Reshape logic modularized into a static helper function
+sd::LongType* NDArray::reshapeShapeInfo(NDArray& array, char order, const std::vector<sd::LongType>& newShape) {
   //nothing to do for scalar shape info
   if(array.isScalar()) {
     //no need for strides with scalar just set shape
-    sd::LongType  *ret = new sd::LongType[newShape.size()];
+    sd::LongType *ret = new sd::LongType[shape::shapeInfoLength(newShape.size())];
+    // Initialize memory to prevent garbage values
+    memset(ret, 0, sizeof(sd::LongType) * shape::shapeInfoLength(newShape.size()));
+
     ret[0] = newShape.size();
     for (size_t i = 0; i < newShape.size(); i++) {
       ret[i + 1] = newShape[i];
     }
 
+
     shape::setOrder(ret, 'c');
     ArrayOptions::setExtra(ret, ArrayOptions::defaultFlag());
     ArrayOptions::setDataType(ret, array.dataType());
+
     auto ret2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(ret);
-    delete[] ret;
+
+
+    // Important: Check ownership - if bufferForShapeInfo copies the data, we need to free ret
+    // Otherwise we have a memory leak
+    delete[] ret;  // Remove this if bufferForShapeInfo takes ownership
+
+
+
     return ret2->primary();
   }
-
 
   if (order != 'c' && order != 'f') {
     std::string errorMessage = "reshapeShapeInfo: unknown order, must be 'c' or 'f', received: ";
     errorMessage += order;
     THROW_EXCEPTION(errorMessage.c_str());
   }
+
 
   std::vector<sd::LongType> shape_vector;
   int numberNegativesOnes = 0;
@@ -2712,6 +2735,7 @@ sd::LongType* NDArray::reshapeShapeInfo( NDArray& array, char order, const std::
     }
   }
 
+
   sd::LongType arrLength = 1;
   for (const auto& dim : shape_vector) {
     arrLength *= dim;
@@ -2722,18 +2746,35 @@ sd::LongType* NDArray::reshapeShapeInfo( NDArray& array, char order, const std::
   }
 
 
-  sd::LongType* shapeInfoNew =  new sd::LongType[shape::shapeInfoLength(shape_vector.size())];
+  size_t shapeInfoLength = shape::shapeInfoLength(shape_vector.size());
+
+
+  sd::LongType* shapeInfoNew = new sd::LongType[shapeInfoLength];
+
+  // Initialize to prevent garbage values
+  memset(shapeInfoNew, 0, sizeof(sd::LongType) * shapeInfoLength);
+
   shapeInfoNew[0] = static_cast<sd::LongType>(shape_vector.size());
+
   bool canReshape = ops::helpers::reshapeNoAlloc(array.shapeInfo(), shape_vector, order, shapeInfoNew);
+
   if (!canReshape) {
     shape::calcStrides(shapeInfoNew, order);
     shape::setOrder(shapeInfoNew, order);
-
   }
 
-  auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfoNew)->primary();
+  // Additional validation before passing to buffer
+  if (shapeInfoNew == nullptr) {
+    THROW_EXCEPTION("reshapeShapeInfo: shapeInfoNew is null after initialization!");
+  }
+
+
+  auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(shapeInfoNew);
+
   delete[] shapeInfoNew;
-  return ret;
+
+
+  return ret->primary();
 }
 
 NDArray& NDArray::reshape(const char order, std::vector<sd::LongType>& shape, bool copyToNewBuff) & {
@@ -2742,11 +2783,9 @@ NDArray& NDArray::reshape(const char order, std::vector<sd::LongType>& shape, bo
   if (copyToNewBuff) {
     NDArray* ret = new NDArray(newShapeInfo, true, getContext(), false);
     this->applyTransform(transform::Assign, ret, nullptr);
-    RELEASE(const_cast<sd::LongType*>(newShapeInfo), getContext()->getWorkspace());
     return *ret;
   } else {
     NDArray* ret = new NDArray(getDataBuffer(), const_cast<sd::LongType*>(newShapeInfo), getContext(), offset());
-    RELEASE(const_cast<sd::LongType*>(newShapeInfo), getContext()->getWorkspace());
     return *ret;
   }
 }
@@ -4030,7 +4069,7 @@ NDArray NDArray::varianceAlongDimension(sd::variance::Ops op, const bool biasCor
                                         const std::initializer_list<LongType> *dimensions)  {
   std::vector<sd::LongType> *copy = new std::vector<sd::LongType>(*dimensions);
   auto ret = varianceAlongDimension(op, biasCorrected, copy);
- // delete copy;
+  // delete copy;
   return ret;
 }
 
@@ -5135,9 +5174,9 @@ template SD_LIB_EXPORT void NDArray::p(const sd::LongType i, const sd::LongType 
 
 ////////////////////////////////////////////////////////////////////////
 void NDArray::p(const sd::LongType i, NDArray *scalar) {
-  if (!scalar->isScalar())
+  if (scalar->lengthOf() > 1) {
     THROW_EXCEPTION("NDArray::p method: input array must be scalar!");
-
+  }
   if (i >= _length) {
     std::string errorMessage;
     errorMessage += "NDArray::p(i, NDArray_scalar): input index is out of array length !";

--- a/libnd4j/include/array/NDArray.hXX
+++ b/libnd4j/include/array/NDArray.hXX
@@ -2695,14 +2695,7 @@ sd::LongType* NDArray::reshapeShapeInfo(NDArray& array, char order, const std::v
     ArrayOptions::setDataType(ret, array.dataType());
 
     auto ret2 = ConstantShapeHelper::getInstance().bufferForShapeInfo(ret);
-
-
-    // Important: Check ownership - if bufferForShapeInfo copies the data, we need to free ret
-    // Otherwise we have a memory leak
-    delete[] ret;  // Remove this if bufferForShapeInfo takes ownership
-
-
-
+    delete[] ret;
     return ret2->primary();
   }
 

--- a/libnd4j/include/array/TadCalculator.h
+++ b/libnd4j/include/array/TadCalculator.h
@@ -75,6 +75,7 @@ class SD_LIB_EXPORT TadCalculator {
     * @return Number of TADs
    */
   LongType numberOfTads() const { return _numTads; }
+  virtual ~TadCalculator();
 };
 
 } // namespace sd

--- a/libnd4j/include/array/TadCalculator.h
+++ b/libnd4j/include/array/TadCalculator.h
@@ -40,8 +40,8 @@ namespace sd {
 class SD_LIB_EXPORT TadCalculator {
  private:
   LongType* _originalShape;       // Original shape info pointer
-  ConstantShapeBuffer _tadShape;        // Calculated TAD shape buffer
-  ConstantOffsetsBuffer _tadOffsets;    // Calculated TAD offsets buffer
+  ConstantShapeBuffer *_tadShape;        // Calculated TAD shape buffer
+  ConstantOffsetsBuffer *_tadOffsets;    // Calculated TAD offsets buffer
   LongType _numTads;                    // Number of TADs
 
  public:
@@ -50,7 +50,7 @@ class SD_LIB_EXPORT TadCalculator {
     * @param originalShape Pointer to the original shape information
    */
   explicit TadCalculator(LongType* originalShape);
-  ~TadCalculator() = default;
+  ~TadCalculator();
 
   /**
     * Creates a TAD pack for the given dimensions
@@ -62,13 +62,13 @@ class SD_LIB_EXPORT TadCalculator {
     * Returns the calculated TAD shape buffer
     * @return ConstantShapeBuffer containing TAD shape information
    */
-  ConstantShapeBuffer tadShape() const { return _tadShape; }
+  ConstantShapeBuffer *tadShape() const { return _tadShape; }
 
   /**
     * Returns the calculated TAD offsets buffer
     * @return ConstantOffsetsBuffer containing TAD offset information
    */
-  ConstantOffsetsBuffer tadOffsets() const { return _tadOffsets; }
+  ConstantOffsetsBuffer *tadOffsets() const { return _tadOffsets; }
 
   /**
     * Returns the number of TADs calculated

--- a/libnd4j/include/array/TadPack.h
+++ b/libnd4j/include/array/TadPack.h
@@ -28,12 +28,12 @@
 #include <system/common.h>
 
 #include <array/NDArray.h>
-
+#ifndef __JAVACPP_HACK__
 namespace sd {
 class SD_LIB_EXPORT TadPack {
  private:
-  ConstantShapeBuffer _tadShape;
-  ConstantOffsetsBuffer _tadOffsets;
+  ConstantShapeBuffer *_tadShape;
+  ConstantOffsetsBuffer *_tadOffsets;
   LongType _numTads = 0;
   LongType _shapeInfoLength = 0;
   LongType* _dimensions = nullptr;
@@ -41,8 +41,8 @@ class SD_LIB_EXPORT TadPack {
   size_t _packHash = 0;  // Cache the hash for quick comparison
 
  public:
-  explicit TadPack(const ConstantShapeBuffer& shapes,
-                   const ConstantOffsetsBuffer& offets, LongType numTads,
+  explicit TadPack( ConstantShapeBuffer *shapes,
+                    ConstantOffsetsBuffer *offets, LongType numTads,
                    LongType* dimensions = nullptr, LongType dimLength = 0);
   TadPack() = default;
   ~TadPack() {};
@@ -124,3 +124,4 @@ class SD_LIB_EXPORT TadPack {
 }  // namespace sd
 
 #endif  // DEV_TESTS_TADPACK_H
+#endif

--- a/libnd4j/include/array/cuda/CudaPointerDeallocator.cu
+++ b/libnd4j/include/array/cuda/CudaPointerDeallocator.cu
@@ -36,7 +36,7 @@ void CudaPointerDeallocator::release(void *ptr) {
     // Only free if it's a regular device pointer
     // cudaMemoryTypeDevice is for regular allocations we can free
     if (attributes.type == cudaMemoryTypeDevice) {
-      cudaFree(ptr);
+      //cudaFree(ptr);
     }
     // Don't free other types (like constant memory)
   } else {

--- a/libnd4j/include/array/cuda/CudaPointerDeallocator.cu
+++ b/libnd4j/include/array/cuda/CudaPointerDeallocator.cu
@@ -36,7 +36,7 @@ void CudaPointerDeallocator::release(void *ptr) {
     // Only free if it's a regular device pointer
     // cudaMemoryTypeDevice is for regular allocations we can free
     if (attributes.type == cudaMemoryTypeDevice) {
-      //cudaFree(ptr);
+      cudaFree(ptr);
     }
     // Don't free other types (like constant memory)
   } else {

--- a/libnd4j/include/array/cuda/DataBuffer.cu
+++ b/libnd4j/include/array/cuda/DataBuffer.cu
@@ -310,7 +310,7 @@ void DataBuffer::syncToSpecial(const bool forceSync) {
 void DataBuffer::deleteSpecial() {
   if (_isOwnerSpecial && _specialBuffer != nullptr && getLenInBytes() != 0) {
     auto p = reinterpret_cast<int8_t*>(_specialBuffer);
-    // RELEASE_SPECIAL(p, _workspace);
+    RELEASE_SPECIAL(p, _workspace);
     _specialBuffer = nullptr;
     _isOwnerSpecial = false;
 

--- a/libnd4j/include/array/cuda/DataBuffer.cu
+++ b/libnd4j/include/array/cuda/DataBuffer.cu
@@ -186,6 +186,21 @@ void DataBuffer::showCounters(const char* msg1, const char* msg2) {
 }
 ////////////////////////////////////////////////////////////////////////
 void DataBuffer::allocateSpecial() {
+  if (_specialBuffer != nullptr) {
+    return;
+  }
+
+  if (_lenInBytes == 0) {
+    std::string errorMessage;
+    errorMessage += "DataBuffer::allocateSpecial: ";
+    errorMessage += "Special buffer is already allocated";
+    errorMessage += " or length is 0";
+    errorMessage += "Length is: ";
+    errorMessage += std::to_string(getLenInBytes());
+    errorMessage += "Special buffer is nullptr : ";
+    errorMessage += std::to_string(_specialBuffer == nullptr);
+    THROW_EXCEPTION(errorMessage.c_str());
+  }
 #if defined(SD_GCC_FUNCTRACE)
   if(Environment::getInstance().isFuncTracePrintAllocate()) {
     allocationStackTraceSpecial = new StackTrace();
@@ -198,10 +213,20 @@ void DataBuffer::allocateSpecial() {
     auto deviceId = AffinityManager::currentDeviceId();
 
     if (_workspace == nullptr) {
-      if (!memory::MemoryCounter::getInstance().validate(getLenInBytes()))
-        throw allocation_exception::build("Requested amount exceeds device limits",
-                                          memory::MemoryCounter::getInstance().deviceLimit(deviceId),
-                                              getLenInBytes());
+      if (!memory::MemoryCounter::getInstance().validate(getLenInBytes())) {
+        std::string errorMessage;
+        errorMessage += "DataBuffer::allocateSpecial: ";
+        errorMessage += "Requested amount exceeds device limits";
+        errorMessage += "DeviceId: ";
+        errorMessage += std::to_string(deviceId);
+        errorMessage += "Device limit: ";
+        errorMessage += std::to_string(memory::MemoryCounter::getInstance().deviceLimit(deviceId));
+        errorMessage += "Requested amount: ";
+        errorMessage += std::to_string(getLenInBytes());
+        errorMessage += "Special buffer is nullptr : ";
+        errorMessage += std::to_string(_specialBuffer == nullptr);
+        THROW_EXCEPTION(errorMessage.c_str());
+      }
     }
 
     ALLOCATE_SPECIAL(_specialBuffer, _workspace, getLenInBytes(), int8_t);
@@ -234,10 +259,25 @@ void DataBuffer::syncToPrimary(const LaunchContext* context, const bool forceSyn
   allocatePrimary();
 
   auto res = cudaStreamSynchronize(*context->getCudaStream());
-  if (res != 0) throw cuda_exception::build("DataBuffer::syncToPrimary failed to to some previous kernel failre", res);
+  if (res != 0)  {
+    std::string errorMessage;
+    errorMessage += "DataBuffer::syncToPrimary: cudaStreamSynchronize failed: ";
+    errorMessage += std::to_string(getLenInBytes());
+    errorMessage += cudaGetErrorString(res);
+    errorMessage += "Special buffer is nullptr : ";
+    THROW_EXCEPTION(errorMessage.c_str());
+  }
 
   res = cudaMemcpy(_primaryBuffer, _specialBuffer, getLenInBytes(), cudaMemcpyDeviceToHost);
-  if (res != 0) throw cuda_exception::build("DataBuffer::syncToPrimary cudaMemcpy failed", res);
+  if (res != 0) {
+        std::string errorMessage;
+        errorMessage += "DataBuffer::syncToPrimary: cudaMemcpy failed: ";
+        errorMessage += std::to_string(getLenInBytes());
+        errorMessage += cudaGetErrorString(res);
+        errorMessage += "Special buffer is nullptr : ";
+        errorMessage += std::to_string(_specialBuffer == nullptr);
+        THROW_EXCEPTION(errorMessage.c_str());
+  }
 
   readPrimary();
 }
@@ -254,7 +294,14 @@ void DataBuffer::syncToSpecial(const bool forceSync) {
   allocateSpecial();
 
   auto res = cudaMemcpy(_specialBuffer, _primaryBuffer, getLenInBytes(), cudaMemcpyHostToDevice);
-  if (res != 0) throw cuda_exception::build("DataBuffer::syncToSpecial cudaMemcpy failed", res);
+  if (res != 0) {
+    std::string errorMessage;
+    errorMessage += "Failed to copy dataBuffer::syncToSpecial: ";
+    errorMessage += std::to_string(getLenInBytes());
+    errorMessage += cudaGetErrorString(res);
+    THROW_EXCEPTION(errorMessage.c_str());
+
+  }
 
   readSpecial();
 }
@@ -263,7 +310,7 @@ void DataBuffer::syncToSpecial(const bool forceSync) {
 void DataBuffer::deleteSpecial() {
   if (_isOwnerSpecial && _specialBuffer != nullptr && getLenInBytes() != 0) {
     auto p = reinterpret_cast<int8_t*>(_specialBuffer);
-   // RELEASE_SPECIAL(p, _workspace);
+    // RELEASE_SPECIAL(p, _workspace);
     _specialBuffer = nullptr;
     _isOwnerSpecial = false;
 

--- a/libnd4j/include/array/cuda/DataBuffer.cu
+++ b/libnd4j/include/array/cuda/DataBuffer.cu
@@ -263,7 +263,7 @@ void DataBuffer::syncToSpecial(const bool forceSync) {
 void DataBuffer::deleteSpecial() {
   if (_isOwnerSpecial && _specialBuffer != nullptr && getLenInBytes() != 0) {
     auto p = reinterpret_cast<int8_t*>(_specialBuffer);
-    RELEASE_SPECIAL(p, _workspace);
+   // RELEASE_SPECIAL(p, _workspace);
     _specialBuffer = nullptr;
     _isOwnerSpecial = false;
 

--- a/libnd4j/include/array/impl/ConstantShapeBuffer.cpp
+++ b/libnd4j/include/array/impl/ConstantShapeBuffer.cpp
@@ -24,17 +24,30 @@
 #include <array/ConstantShapeBuffer.h>
 
 namespace sd {
-ConstantShapeBuffer::ConstantShapeBuffer(const std::shared_ptr<PointerWrapper> &primary)
-    : ConstantShapeBuffer(primary, std::shared_ptr<PointerWrapper>(nullptr)) {
+ConstantShapeBuffer::ConstantShapeBuffer( PointerWrapper* primary)
+    : ConstantShapeBuffer(primary, nullptr) {
 #if defined(SD_GCC_FUNCTRACE)
   st = backward::StackTrace();
   st.load_here(32);
 #endif
 
 }
+ConstantShapeBuffer::ConstantShapeBuffer() {
+  _primaryShapeInfo = nullptr;
+  _specialShapeInfo = nullptr;
+}
+ConstantShapeBuffer::~ConstantShapeBuffer() {
+  if(_primaryShapeInfo != nullptr)
+    delete _primaryShapeInfo;
+  _primaryShapeInfo = nullptr;
 
-ConstantShapeBuffer::ConstantShapeBuffer(const std::shared_ptr<PointerWrapper> &primary,
-                                         const std::shared_ptr<PointerWrapper> &special) {
+  if(_specialShapeInfo != nullptr)
+    delete _specialShapeInfo;
+  _specialShapeInfo = nullptr;
+}
+
+ConstantShapeBuffer::ConstantShapeBuffer( PointerWrapper* primary,
+                                          PointerWrapper* special) {
   _primaryShapeInfo = primary;
   _specialShapeInfo = special;
 #if defined(SD_GCC_FUNCTRACE)
@@ -44,14 +57,22 @@ ConstantShapeBuffer::ConstantShapeBuffer(const std::shared_ptr<PointerWrapper> &
 }
 
 LongType *ConstantShapeBuffer::primary()  {
-  return reinterpret_cast<LongType *>(_primaryShapeInfo->pointer());
+  if(_primaryShapeInfo != nullptr) {
+    return reinterpret_cast<LongType *>(_primaryShapeInfo->pointer());
+  }
+
+  return nullptr;
 }
 
- LongType *ConstantShapeBuffer::special()  {
-  return reinterpret_cast<LongType *>(_specialShapeInfo->pointer());
+LongType *ConstantShapeBuffer::special()  {
+  if(_specialShapeInfo != nullptr) {
+    return reinterpret_cast<LongType *>(_specialShapeInfo->pointer());
+  }
+
+  return nullptr;
 }
 
- LongType *ConstantShapeBuffer::platform()  {
+LongType *ConstantShapeBuffer::platform()  {
 #ifdef __CUDABLAS__
   return special();
 #else

--- a/libnd4j/include/array/impl/ConstantShapeBuffer.cpp
+++ b/libnd4j/include/array/impl/ConstantShapeBuffer.cpp
@@ -48,7 +48,7 @@ LongType *ConstantShapeBuffer::primary()  {
 }
 
  LongType *ConstantShapeBuffer::special()  {
-  return _specialShapeInfo ? reinterpret_cast<LongType *>(_specialShapeInfo->pointer()) : nullptr;
+  return reinterpret_cast<LongType *>(_specialShapeInfo->pointer());
 }
 
  LongType *ConstantShapeBuffer::platform()  {

--- a/libnd4j/include/array/impl/ExtraArguments.cpp
+++ b/libnd4j/include/array/impl/ExtraArguments.cpp
@@ -51,7 +51,7 @@ ExtraArguments::ExtraArguments() {
 ExtraArguments::~ExtraArguments() {
   for (auto p : _pointers) {
 #ifdef __CUDABLAS__
-   // cudaFree(p);
+    cudaFree(p);
 #else  // CPU branch
     delete reinterpret_cast<int8_t *>(p);
 #endif
@@ -77,9 +77,8 @@ void ExtraArguments::convertAndCopy(Pointer pointer, LongType offset) {
   }
 
 #ifdef __CUDABLAS__
-  // TODO: maybe make it asynchronous eventually?
   cudaMemcpy(pointer, target, length * DataTypeUtils::sizeOf(DataTypeUtils::fromT<T>()), cudaMemcpyHostToDevice);
-  //delete[] target;
+  delete[] target;
 #endif
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void ExtraArguments::convertAndCopy,

--- a/libnd4j/include/array/impl/ExtraArguments.cpp
+++ b/libnd4j/include/array/impl/ExtraArguments.cpp
@@ -51,7 +51,7 @@ ExtraArguments::ExtraArguments() {
 ExtraArguments::~ExtraArguments() {
   for (auto p : _pointers) {
 #ifdef __CUDABLAS__
-    cudaFree(p);
+   // cudaFree(p);
 #else  // CPU branch
     delete reinterpret_cast<int8_t *>(p);
 #endif
@@ -79,7 +79,7 @@ void ExtraArguments::convertAndCopy(Pointer pointer, LongType offset) {
 #ifdef __CUDABLAS__
   // TODO: maybe make it asynchronous eventually?
   cudaMemcpy(pointer, target, length * DataTypeUtils::sizeOf(DataTypeUtils::fromT<T>()), cudaMemcpyHostToDevice);
-  delete[] target;
+  //delete[] target;
 #endif
 }
 BUILD_SINGLE_TEMPLATE(template SD_LIB_EXPORT void ExtraArguments::convertAndCopy,

--- a/libnd4j/include/array/impl/PointerWrapper.cpp
+++ b/libnd4j/include/array/impl/PointerWrapper.cpp
@@ -30,7 +30,7 @@ PointerWrapper::PointerWrapper(void *ptr, const std::shared_ptr<PointerDeallocat
 }
 
 PointerWrapper::~PointerWrapper() {
- // if (_deallocator.get() != nullptr) _deallocator->release(_pointer);
+  if (_deallocator.get() != nullptr) _deallocator->release(_pointer);
 }
 
 void *PointerWrapper::pointer() const { return _pointer; }

--- a/libnd4j/include/array/impl/ResultSet.cpp
+++ b/libnd4j/include/array/impl/ResultSet.cpp
@@ -112,7 +112,7 @@ void ResultSet::delContent() {
       auto buffer = v->dataBuffer();
       deleted.push_back(buffer);
       if (!v->isView() && v->shapeInfo() != nullptr) {
-        delete v;
+      //  delete v;
       }
     }
   }

--- a/libnd4j/include/array/impl/ResultSet.cpp
+++ b/libnd4j/include/array/impl/ResultSet.cpp
@@ -112,7 +112,7 @@ void ResultSet::delContent() {
       auto buffer = v->dataBuffer();
       deleted.push_back(buffer);
       if (!v->isView() && v->shapeInfo() != nullptr) {
-      //  delete v;
+        delete v;
       }
     }
   }

--- a/libnd4j/include/array/impl/TadPack.cpp
+++ b/libnd4j/include/array/impl/TadPack.cpp
@@ -25,8 +25,8 @@
 #include <system/Environment.h>
 
 namespace sd {
-TadPack::TadPack(const ConstantShapeBuffer& shapes,
-                 const ConstantOffsetsBuffer& offets, LongType numTads,
+TadPack::TadPack( ConstantShapeBuffer *shapes,
+                  ConstantOffsetsBuffer *offets, LongType numTads,
                  LongType* dimensions, LongType dimLength)
     : _tadShape(shapes),
       _tadOffsets(offets) {
@@ -44,18 +44,18 @@ TadPack::TadPack(const ConstantShapeBuffer& shapes,
 }
 
 LongType* TadPack::primaryShapeInfo() {
-  if(_tadShape.primary() == nullptr)
+  if(_tadShape->primary() == nullptr)
     THROW_EXCEPTION("TadPack::primaryShapeInfo: primary shape info is nullptr!");
-  return _tadShape.primary();
+  return _tadShape->primary();
 }
 
 LongType* TadPack::primaryOffsets() {
-  return _tadOffsets.primary();
+  return _tadOffsets->primary();
 }
 
-LongType* TadPack::specialShapeInfo() { return _tadShape.special(); }
+LongType* TadPack::specialShapeInfo() { return _tadShape->special(); }
 
-LongType* TadPack::specialOffsets() { return _tadOffsets.special(); }
+LongType* TadPack::specialOffsets() { return _tadOffsets->special(); }
 
 LongType TadPack::numberOfTads() const { return _numTads; }
 
@@ -73,7 +73,7 @@ void TadPack::print(const char* msg) {
   printf("%s: ", msg);
   printf("Offsets:\n");
   for (int e = 0; e < _numTads; e++) {
-    printf("%lld, ", _tadOffsets.primary()[e]);
+    printf("%lld, ", _tadOffsets->primary()[e]);
   }
   printf("\n");
 
@@ -88,7 +88,7 @@ void TadPack::print(const char* msg) {
   }
 
   printf("tad pack shape info:");
-  shape::printShapeInfo(_tadShape.primary());
+  shape::printShapeInfo(_tadShape->primary());
   printf("\n");
   printf("number of tads: %lld\n", _numTads);
   printf("shape info length: %lld\n", _shapeInfoLength);

--- a/libnd4j/include/helpers/DirectShapeTrie.h
+++ b/libnd4j/include/helpers/DirectShapeTrie.h
@@ -147,7 +147,14 @@ class SD_LIB_EXPORT DirectShapeTrie {
     }
 
     // Clean up all root nodes
-    delete _roots;
+    if (_roots != nullptr) {
+      for (size_t i = 0; i < NUM_STRIPES; i++) {
+        if ((*_roots)[i] != nullptr) {
+          delete (*_roots)[i];
+        }
+      }
+      delete _roots;
+    }
   }
 
   // Delete move operations

--- a/libnd4j/include/helpers/DirectShapeTrie.h
+++ b/libnd4j/include/helpers/DirectShapeTrie.h
@@ -1,3 +1,20 @@
+/* ******************************************************************************
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+*  See the NOTICE file distributed with this work for additional
+*  information regarding copyright ownership.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+******************************************************************************/
+
 #ifndef DIRECTSHAPETRIE_H
 #define DIRECTSHAPETRIE_H
 
@@ -24,57 +41,55 @@ class SD_LIB_EXPORT ShapeTrieNode {
   LongType _value;
   int _level;
   bool _isShape;
-  ConstantShapeBuffer* _buffer;  // Now accessed atomically
+  ConstantShapeBuffer* _buffer = nullptr;  // Now accessed atomically
   int _shapeHash;   // Store a hash of the shape for validation
-  
+
 #if defined(SD_GCC_FUNCTRACE)
   backward::StackTrace storeStackTrace;
 #endif
 
  public:
-  ShapeTrieNode(LongType value = 0, int level = 0, bool isShape = true, int shapeHash = 0)
-      : _value(value), _level(level), _isShape(isShape), _buffer(nullptr), _shapeHash(shapeHash) {}
+  ShapeTrieNode(LongType value = 0, int level = 0, bool isShape = true, sd::LongType shapeHash = 0)
+      : _value(value), _level(level), _isShape(isShape), _shapeHash(shapeHash) {
+  }
 
-  ~ShapeTrieNode() = default;
+  ~ShapeTrieNode() {
+    // Delete children
+    for (auto* child : _children) {
+      delete child;
+    }
+    _children.clear();
 
-  ShapeTrieNode* findOrCreateChild(LongType value, int level, bool isShape, int shapeHash = 0) {
-    // Reserve space upfront to avoid reallocation during pushback
-    if (level == 0) {  // This is where it's crashing based on the stack trace
-      printf("findOrCreateChild: value=%lld, level=%d, isShape=%d, shapeHash=%d, size=%zu, capacity=%zu\n",
-             (long long)value, level, isShape, shapeHash, _children.size(), _children.capacity());
+    // Delete buffer if it exists
+    if (_buffer != nullptr) {
+      delete _buffer;
+      _buffer = nullptr;
+    }
+  }
+
+
+  // Replace the current findOrCreateChild with this more defensive version
+  ShapeTrieNode* findOrCreateChild(LongType value, int level, bool isShape, int shapeHash) {
+    // First search for existing child
+    for (auto* child : _children) {
+      if (child != nullptr &&
+          child->value() == value &&
+          child->level() == level &&
+          child->isShape() == isShape &&
+          (shapeHash == 0 || child->shapeHash() == shapeHash)) {
+        return child;
+      }
     }
 
-    // Existing reserve code - add safety check
-    if (_children.size() == _children.capacity()) {
-      if (_children.size() > 1000) {
-        printf("WARNING: Extremely large children array in findOrCreateChild: %zu\n", _children.size());
-      }
-
-      try {
-        _children.reserve(_children.size() + 10);
-      } catch (const std::exception& e) {
-        printf("ERROR in reserve: %s\n", e.what());
-        // Continue anyway - it will throw its own exception if allocation fails
-      }
+    // Create new node with standard allocation
+    try {
+      auto* newNode = new ShapeTrieNode(value, level, isShape, shapeHash);
+      // Add to children using standard vector operations
+      _children.push_back(newNode);
+      return newNode;
+    } catch (const std::exception& e) {
+      return nullptr;
     }
-
-
-    printf("findOrCreateChild: passed children reserve\n");
-    fflush(stdout);
-
-    for (auto& child : _children) {
-      if(child != nullptr) {
-        if (child->value() == value && child->level() == level && child->isShape() == isShape &&
-            (shapeHash == 0 || child->shapeHash() == shapeHash)) {
-          return child;
-        }
-      }
-
-    }
-
-    auto newNode = new ShapeTrieNode(value, level, isShape, shapeHash);
-    _children.push_back(newNode);
-    return newNode;
   }
 
   const std::vector<ShapeTrieNode*>& children() const { return _children; }
@@ -94,16 +109,23 @@ class SD_LIB_EXPORT ShapeTrieNode {
 class SD_LIB_EXPORT DirectShapeTrie {
  private:
   static const size_t NUM_STRIPES = 256; // Increased from 32 to reduce collisions
-  std::array<ShapeTrieNode*, NUM_STRIPES> _roots;
-  mutable std::array<SHAPE_MUTEX_TYPE, NUM_STRIPES> _mutexes = {};
+  std::array<ShapeTrieNode*, NUM_STRIPES> *_roots;
+  std::array<SHAPE_MUTEX_TYPE*, NUM_STRIPES> *_mutexes = nullptr;
+
+  // Helper method to create a fallback buffer when trie insertion fails
+  // Always returns a valid shape buffer or throws an exception
+  ConstantShapeBuffer* createFallbackBuffer(const LongType* shapeInfo, int rank);
 
  public:
   // Constructor
   DirectShapeTrie() {
+    _roots = new std::array<ShapeTrieNode*, NUM_STRIPES>();
+    _mutexes = new std::array<SHAPE_MUTEX_TYPE*, NUM_STRIPES>();
+
     for (size_t i = 0; i < NUM_STRIPES; i++) {
-      _roots[i] = new ShapeTrieNode(0, 0, false);
-      // Make sure mutexes are properly initialized
-      new (&_mutexes[i]) SHAPE_MUTEX_TYPE();  // Explicit initialization
+      (*_roots)[i] = new ShapeTrieNode(0, 0, false);
+      // Allocate mutexes on the heap
+      (*_mutexes)[i] = new SHAPE_MUTEX_TYPE();
     }
 
     ShapeBufferPlatformHelper::initialize();
@@ -113,11 +135,27 @@ class SD_LIB_EXPORT DirectShapeTrie {
   DirectShapeTrie(const DirectShapeTrie&) = delete;
   DirectShapeTrie& operator=(const DirectShapeTrie&) = delete;
 
+  ~DirectShapeTrie() {
+    // Clean up all mutexes
+    if (_mutexes != nullptr) {
+      for (size_t i = 0; i < NUM_STRIPES; i++) {
+        if ((*_mutexes)[i] != nullptr) {
+          delete (*_mutexes)[i];
+        }
+      }
+      delete _mutexes;
+    }
+
+    // Clean up all root nodes
+    delete _roots;
+  }
+
   // Delete move operations
   DirectShapeTrie(DirectShapeTrie&&) = delete;
   DirectShapeTrie& operator=(DirectShapeTrie&&) = delete;
 
   // Improved thread-safe getOrCreate
+  // Always returns a valid shape buffer or throws an exception
   ConstantShapeBuffer* getOrCreate(const LongType* shapeInfo);
 
   // Check if a shape info already exists in the trie
@@ -131,7 +169,7 @@ class SD_LIB_EXPORT DirectShapeTrie {
   ConstantShapeBuffer* search(const LongType* shapeInfo, size_t stripeIdx) const;
   ConstantShapeBuffer* insert(const LongType* shapeInfo, size_t stripeIdx);
   const ShapeTrieNode* findChild(const ShapeTrieNode* node, LongType value, int level, bool isShape, int shapeHash = 0) const;
-  
+
   // Calculate a unique shape signature for additional validation
   int calculateShapeSignature(const LongType* shapeInfo) const;
 };

--- a/libnd4j/include/helpers/cpu/CpuShapeBufferCreator.cpp
+++ b/libnd4j/include/helpers/cpu/CpuShapeBufferCreator.cpp
@@ -33,7 +33,7 @@ ConstantShapeBuffer* CpuShapeBufferCreator::create(const LongType* shapeInfo, in
         [] (PointerDeallocator* ptr) { delete ptr; }
     );
     
-    auto hPtr = std::make_shared<PointerWrapper>(shapeCopy, deallocator);
+    auto hPtr = new PointerWrapper(shapeCopy, deallocator);
     auto buffer = new ConstantShapeBuffer(hPtr);
     
     return buffer;

--- a/libnd4j/include/helpers/cuda/ConstantHelper.cu
+++ b/libnd4j/include/helpers/cuda/ConstantHelper.cu
@@ -78,11 +78,11 @@ ConstantHelper::ConstantHelper() {
 }
 
 ConstantHelper::~ConstantHelper() {
-/*  for (const auto &v : _cache) {
+  for (const auto &v : _cache) {
     for (const auto &c : v) {
       delete c.second;
     }
-  }*/
+  }
 }
 
 ConstantHelper &ConstantHelper::getInstance() {

--- a/libnd4j/include/helpers/cuda/ConstantHelper.cu
+++ b/libnd4j/include/helpers/cuda/ConstantHelper.cu
@@ -78,11 +78,11 @@ ConstantHelper::ConstantHelper() {
 }
 
 ConstantHelper::~ConstantHelper() {
-  for (const auto &v : _cache) {
+/*  for (const auto &v : _cache) {
     for (const auto &c : v) {
       delete c.second;
     }
-  }
+  }*/
 }
 
 ConstantHelper &ConstantHelper::getInstance() {
@@ -108,41 +108,22 @@ void *ConstantHelper::replicatePointer(void *src, size_t numBytes, memory::Works
     constantOffset = _deviceOffsets[deviceId];
   }
 
-  if (constantOffset + numBytes >= CONSTANT_LIMIT) {
-    int8_t *ptr = nullptr;
-    ALLOCATE_SPECIAL(ptr, workspace, numBytes, int8_t);
-    auto res = cudaMemcpy(ptr, src, numBytes, cudaMemcpyHostToDevice);
-    if (res != 0) {
-      std::string errorMessage = "cudaMemcpy failed with error code " + std::to_string(res);
-      auto lastError = cudaGetLastError(); // get last error
-      if (lastError != cudaSuccess) {
-        errorMessage += "; last error: " + std::string(cudaGetErrorString(lastError));
-      }
-
-      THROW_EXCEPTION(errorMessage.c_str());
-    }
-    return ptr;
-  } else {
-    auto originalBytes = numBytes;
-    auto rem = numBytes % 8;
-    if (rem != 0) numBytes += 8 - rem;
-
-    _deviceOffsets[deviceId] += numBytes;
-
-    auto res = cudaMemcpyToSymbol(deviceConstantMemory, const_cast<const void *>(src), originalBytes, constantOffset,
-                                  cudaMemcpyHostToDevice);
-    if (res != 0) {
-      std::string errorMessage = "cudaMemcpyToSymbol failed with error code " + std::to_string(res);
-      auto lastError = cudaGetLastError(); // get last error
-      if (lastError != cudaSuccess) {
-        errorMessage += "; last error: " + std::string(cudaGetErrorString(lastError));
-      }
-
-      THROW_EXCEPTION(errorMessage.c_str());
+  int8_t *ptr = nullptr;
+  ALLOCATE_SPECIAL(ptr, workspace, numBytes, int8_t);
+  auto res = cudaMemcpy(ptr, src, numBytes, cudaMemcpyHostToDevice);
+  if (res != 0) {
+    std::string errorMessage = "cudaMemcpy failed with error code " + std::to_string(res);
+    auto lastError = cudaGetLastError(); // get last error
+    if (lastError != cudaSuccess) {
+      errorMessage += "; last error: " + std::string(cudaGetErrorString(lastError));
     }
 
-    return reinterpret_cast<int8_t *>(constantPtr) + constantOffset;
+    THROW_EXCEPTION(errorMessage.c_str());
+
   }
+
+  constantPtr = ptr;
+  return reinterpret_cast<int8_t *>(constantPtr) + constantOffset;
 }
 
 ConstantDataBuffer *ConstantHelper::constantBuffer(const ConstantDescriptor &descriptor, DataType dataType) {
@@ -168,7 +149,7 @@ ConstantDataBuffer *ConstantHelper::constantBuffer(const ConstantDescriptor &des
     result = holder->getConstantDataBuffer(dataType);
   } else {
     auto numBytes = descriptor.length() * DataTypeUtils::sizeOf(dataType);
-    auto cbuff = std::make_shared<PointerWrapper>(new int8_t[numBytes], std::make_shared<PrimaryPointerDeallocator>());
+    auto cbuff = std::make_shared<PointerWrapper>(new int8_t[numBytes], std::make_shared<PointerDeallocator>());
     _counters[deviceId] += numBytes;
 
     // create buffer with this dtype
@@ -189,9 +170,9 @@ ConstantDataBuffer *ConstantHelper::constantBuffer(const ConstantDescriptor &des
     auto dbuff = std::make_shared<PointerWrapper>(
         replicatePointer(cbuff->pointer(), descriptor.length() * DataTypeUtils::sizeOf(dataType)));
 
-    ConstantDataBuffer dataBuffer(cbuff, dbuff, descriptor.length(), dataType);
+    ConstantDataBuffer *dataBuffer = new ConstantDataBuffer(cbuff, dbuff, descriptor.length(), dataType);
 
-    holder->addBuffer(dataBuffer, dataType);
+    holder->addBuffer(*dataBuffer, dataType);
     result = holder->getConstantDataBuffer(dataType);
   }
 

--- a/libnd4j/include/helpers/cuda/CudaShapeBufferCreator.cu
+++ b/libnd4j/include/helpers/cuda/CudaShapeBufferCreator.cu
@@ -36,14 +36,14 @@ ConstantShapeBuffer* CudaShapeBufferCreator::create(const LongType* shapeInfo, i
     auto deallocator = std::shared_ptr<CudaPointerDeallocator>(
         new CudaPointerDeallocator(),
         [] (CudaPointerDeallocator* ptr) {
-        //  delete ptr;
+          delete ptr;
         }
     );
     
-    auto hPtr = std::make_shared<PointerWrapper>(shapeCopy, deallocator);
+    auto hPtr = new PointerWrapper(shapeCopy, deallocator);
     
     // Create device pointer for CUDA
-    auto dPtr = std::make_shared<PointerWrapper>(
+    auto dPtr =new PointerWrapper(
         ConstantHelper::getInstance().replicatePointer(shapeCopy,
                                                    shapeInfoLength * sizeof(LongType)),
         std::make_shared<CudaPointerDeallocator>());

--- a/libnd4j/include/helpers/cuda/TadCalculator.cu
+++ b/libnd4j/include/helpers/cuda/TadCalculator.cu
@@ -77,12 +77,11 @@ void TadCalculator::createTadPack(const std::vector<LongType>& dimensions) {
         ConstantHelper::getInstance().replicatePointer(oPtr->pointer(), numOfSubArrs * sizeof(LongType)),
         std::make_shared<CudaPointerDeallocator>());
     
-    _tadOffsets = ConstantOffsetsBuffer(oPtr, offDPtr);
-    _tadShape = *shapesBuffer;
+    _tadOffsets = new ConstantOffsetsBuffer(oPtr, offDPtr);
+    _tadShape = shapesBuffer;
     _numTads = numOfSubArrs;
     
-    // Clean up the original shape buffer since we've created a copy
-    delete shapesBuffer;
+
   } else {
     // Base case: number of sub arrays is zero, use original shape
     const LongType subArrRank = rank;
@@ -105,12 +104,10 @@ void TadCalculator::createTadPack(const std::vector<LongType>& dimensions) {
         ConstantHelper::getInstance().replicatePointer(oPtr->pointer(), 1 * sizeof(LongType)),
         std::make_shared<CudaPointerDeallocator>());
     
-    _tadOffsets = ConstantOffsetsBuffer(oPtr, offDPtr);
-    _tadShape = *shapesBuffer;
+    _tadOffsets = new ConstantOffsetsBuffer(oPtr, offDPtr);
+    _tadShape = shapesBuffer;
     _numTads = 1;
-    
-    // Clean up the original shape buffer since we've created a copy
-    delete shapesBuffer;
+
   }
 
   delete dimsToExclude;

--- a/libnd4j/include/helpers/cuda/TadCalculator.cu
+++ b/libnd4j/include/helpers/cuda/TadCalculator.cu
@@ -32,6 +32,18 @@ namespace sd {
 TadCalculator::TadCalculator(LongType* originalShape)
     : _originalShape(originalShape), _numTads(0) {}
 
+TadCalculator::~TadCalculator() {
+  if (_tadOffsets) {
+    delete _tadOffsets;
+    _tadOffsets = nullptr;
+  }
+  if (_tadShape) {
+    delete _tadShape;
+    _tadShape = nullptr;
+  }
+}
+
+
 void TadCalculator::createTadPack(const std::vector<LongType>& dimensions) {
   // Validate input and create shape info from original shape
   if (!_originalShape) {

--- a/libnd4j/include/helpers/impl/ConstantShapeHelper.cpp
+++ b/libnd4j/include/helpers/impl/ConstantShapeHelper.cpp
@@ -28,6 +28,7 @@
 namespace sd {
 
 ConstantShapeHelper::~ConstantShapeHelper() {
+
 }
 
 ConstantShapeHelper::ConstantShapeHelper() {
@@ -44,8 +45,15 @@ ConstantShapeBuffer* ConstantShapeHelper::createConstBuffFromExisting(sd::LongTy
 }
 
 ConstantShapeBuffer* ConstantShapeHelper::bufferForShapeInfo(LongType* shapeInfo) {
+ if(shapeInfo == nullptr) {
+   THROW_EXCEPTION("shapeInfo is nullptr");
+ }
+ if(shape::rank(shapeInfo) < 0 || shape::rank(shapeInfo) > SD_MAX_RANK) {
+   THROW_EXCEPTION("shapeInfo is not a valid rank.");
+ }
+
  auto buffer = _shapeTrie.getOrCreate(shapeInfo);
- if (!buffer || !buffer->primary()) {
+ if (buffer == nullptr || buffer->primary() == nullptr) {
    THROW_EXCEPTION("Failed to get/create shape buffer");
  }
  return buffer;

--- a/libnd4j/include/helpers/impl/ConstantTadHelper.cpp
+++ b/libnd4j/include/helpers/impl/ConstantTadHelper.cpp
@@ -40,26 +40,17 @@ TadPack* ConstantTadHelper::tadForDimensions(TadDescriptor* descriptor) {
 }
 
 TadPack* ConstantTadHelper::tadForDimensions(LongType* originalShape, LongType* dimensions, LongType dimLength) {
-  try {
     if (!originalShape) THROW_EXCEPTION("Original shape is null");
     if (!dimensions) THROW_EXCEPTION("Dimensions array is null");
     if (dimLength <= 0) THROW_EXCEPTION("Invalid dimension length");
 
-    int rank = shape::rank(originalShape);
+    sd::LongType rank = shape::rank(originalShape);
     if (rank < 0) THROW_EXCEPTION("Invalid shape rank");
 
     std::vector<LongType> dims(dimensions, dimensions + dimLength);
 
     // Single attempt pattern - no double locking
     return _trie.getOrCreate(dims, originalShape);
-
-  } catch (const std::exception& e) {
-    std::string errorMessage = "TAD creation failed: ";
-    errorMessage += e.what();
-    THROW_EXCEPTION(errorMessage.c_str());
-  }
-
-  return nullptr;
 }
 
 } // namespace sd

--- a/libnd4j/include/helpers/impl/DirectShapeTrie.cpp
+++ b/libnd4j/include/helpers/impl/DirectShapeTrie.cpp
@@ -31,7 +31,7 @@ void ShapeTrieNode::setBuffer(ConstantShapeBuffer* buf) {
     if (buf != _buffer) {
       if (shape::equalsSoft(buf->primary(), _buffer->primary())) {
         // The shapes match, safe to delete the duplicate
-       // delete buf;
+        // delete buf;
       } else {
         // The shapes don't match - this is an error condition!
         // We should log this and NOT delete the buffer as it may be used elsewhere
@@ -44,321 +44,329 @@ void ShapeTrieNode::setBuffer(ConstantShapeBuffer* buf) {
 
 #if defined(SD_GCC_FUNCTRACE)
 void ShapeTrieNode::collectStoreStackTrace() {
-    this->storeStackTrace = backward::StackTrace();
-    this->storeStackTrace.load_here(32);
+  this->storeStackTrace = backward::StackTrace();
+  this->storeStackTrace.load_here(32);
 }
 #endif
 
 size_t DirectShapeTrie::computeHash(const LongType* shapeInfo) const {
-    size_t hash = 17; // Prime number starting point
-    const int rank = shape::rank(shapeInfo);
+  size_t hash = 17; // Prime number starting point
+  const int rank = shape::rank(shapeInfo);
 
-    // Add rank first with high weight
-    hash = hash * 31 + rank * 19;
+  // Add rank first with high weight
+  hash = hash * 31 + rank * 19;
 
-    // Add shape elements to hash with position-dependent multipliers
-    const LongType* shape = shape::shapeOf(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        hash = hash * 13 + static_cast<size_t>(shape[i]) * (7 + i);
-    }
+  // Add shape elements to hash with position-dependent multipliers
+  const LongType* shape = shape::shapeOf(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    hash = hash * 13 + static_cast<size_t>(shape[i]) * (7 + i);
+  }
 
-    // Add stride elements to hash with position-dependent multipliers
-    const LongType* strides = shape::stride(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        hash = hash * 19 + static_cast<size_t>(strides[i]) * (11 + i);
-    }
+  // Add stride elements to hash with position-dependent multipliers
+  const LongType* strides = shape::stride(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    hash = hash * 19 + static_cast<size_t>(strides[i]) * (11 + i);
+  }
 
-    // Add data type and order with higher weights
-    hash = hash * 23 + static_cast<size_t>(ArrayOptions::dataType(shapeInfo)) * 29;
-    hash = hash * 37 + static_cast<size_t>(shape::order(shapeInfo)) * 41;
+  // Add data type and order with higher weights
+  hash = hash * 23 + static_cast<size_t>(ArrayOptions::dataType(shapeInfo)) * 29;
+  hash = hash * 37 + static_cast<size_t>(shape::order(shapeInfo)) * 41;
 
-    // Add total element count
-    hash = hash * 43 + shape::length(shapeInfo);
+  // Add total element count
+  hash = hash * 43 + shape::length(shapeInfo);
 
-    return hash;
+  return hash;
 }
 
 int DirectShapeTrie::calculateShapeSignature(const LongType* shapeInfo) const {
-    int signature = 17;
-    const int rank = shape::rank(shapeInfo);
+  int signature = 17;
+  const int rank = shape::rank(shapeInfo);
 
-    // Incorporate rank with weight
-    signature = signature * 31 + rank * 13;
+  // Incorporate rank with weight
+  signature = signature * 31 + rank * 13;
 
-    // Incorporate shape dimensions with position weights
-    const LongType* shapeValues = shape::shapeOf(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        signature = signature * 13 + static_cast<int>(shapeValues[i]) * (7 + i);
-    }
+  // Incorporate shape dimensions with position weights
+  const LongType* shapeValues = shape::shapeOf(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    signature = signature * 13 + static_cast<int>(shapeValues[i]) * (7 + i);
+  }
 
-    // Incorporate data type and order
-    signature = signature * 7 + static_cast<int>(ArrayOptions::dataType(shapeInfo)) * 11;
-    signature = signature * 17 + static_cast<int>(shape::order(shapeInfo)) * 19;
+  // Incorporate data type and order
+  signature = signature * 7 + static_cast<int>(ArrayOptions::dataType(shapeInfo)) * 11;
+  signature = signature * 17 + static_cast<int>(shape::order(shapeInfo)) * 19;
 
-    // Include element count
-    signature = signature * 23 + static_cast<int>(shape::length(shapeInfo) % 10000);
-    
-    return signature;
+  // Include element count
+  signature = signature * 23 + static_cast<int>(shape::length(shapeInfo) % 10000);
+
+  return signature;
 }
 
 size_t DirectShapeTrie::getStripeIndex(const LongType* shapeInfo) const {
-    return computeHash(shapeInfo) % NUM_STRIPES;
+  return computeHash(shapeInfo) % NUM_STRIPES;
 }
 
 bool DirectShapeTrie::shapeInfoEqual(const LongType* a, const LongType* b) const {
-    if (a == b) return true;
-    if (a == nullptr || b == nullptr) return false;
+  if (a == b) return true;
+  if (a == nullptr || b == nullptr) return false;
 
-    const int rankA = shape::rank(a);
-    if (rankA != shape::rank(b)) return false;
+  const int rankA = shape::rank(a);
+  if (rankA != shape::rank(b)) return false;
 
-    const int len = shape::shapeInfoLength(rankA);
-    return std::memcmp(a, b, len * sizeof(LongType)) == 0;
+  const int len = shape::shapeInfoLength(rankA);
+  return std::memcmp(a, b, len * sizeof(LongType)) == 0;
 }
 
 void DirectShapeTrie::validateShapeInfo(const LongType* shapeInfo) const {
-    if (shapeInfo == nullptr) {
-        THROW_EXCEPTION("Shape info cannot be null");
-    }
+  if (shapeInfo == nullptr) {
+    THROW_EXCEPTION("Shape info cannot be null");
+  }
 
-    const int rank = shape::rank(shapeInfo);
-    if (rank < 0 || rank > SD_MAX_RANK) {
-        std::string errorMessage = "Invalid rank: " + std::to_string(rank) +
+  const int rank = shape::rank(shapeInfo);
+  if (rank < 0 || rank > SD_MAX_RANK) {
+    std::string errorMessage = "Invalid rank: " + std::to_string(rank) +
                                ". Valid range is 0 to " + std::to_string(SD_MAX_RANK);
-        THROW_EXCEPTION(errorMessage.c_str());
-    }
+    THROW_EXCEPTION(errorMessage.c_str());
+  }
 
-    if (rank == 0) {
-        const int len = shape::shapeInfoLength(rank);
-        bool allZero = true;
-        for (int i = 0; i < len; i++) {
-            if (shapeInfo[i] != 0) {
-                allZero = false;
-                break;
-            }
-        }
-        if (allZero) {
-            THROW_EXCEPTION("Found shape buffer with all zero values. Values likely unset.");
-        }
+  if (rank == 0) {
+    const int len = shape::shapeInfoLength(rank);
+    bool allZero = true;
+    for (int i = 0; i < len; i++) {
+      if (shapeInfo[i] != 0) {
+        allZero = false;
+        break;
+      }
     }
+    if (allZero) {
+      THROW_EXCEPTION("Found shape buffer with all zero values. Values likely unset.");
+    }
+  }
 
-    if (ArrayOptions::dataType(shapeInfo) == UNKNOWN) {
-        THROW_EXCEPTION("Shape info created with invalid data type");
-    }
+  if (ArrayOptions::dataType(shapeInfo) == UNKNOWN) {
+    THROW_EXCEPTION("Shape info created with invalid data type");
+  }
 
-    char order = shape::order(shapeInfo);
-    if (order != 'c' && order != 'f') {
-        std::string errorMessage = "Invalid ordering in shape buffer: ";
-        errorMessage += order;
-        THROW_EXCEPTION(errorMessage.c_str());
-    }
+  char order = shape::order(shapeInfo);
+  if (order != 'c' && order != 'f') {
+    std::string errorMessage = "Invalid ordering in shape buffer: ";
+    errorMessage += order;
+    THROW_EXCEPTION(errorMessage.c_str());
+  }
 }
 
 const ShapeTrieNode* DirectShapeTrie::findChild(const ShapeTrieNode* node, LongType value,
-                                              int level, bool isShape, int shapeHash) const {
-    if (!node) return nullptr;
+                                                int level, bool isShape, int shapeHash) const {
+  if (!node) return nullptr;
 
-    for (const auto& child : node->children()) {
-        if (child->value() == value &&
-            child->level() == level &&
-            child->isShape() == isShape &&
-            (shapeHash == 0 || child->shapeHash() == shapeHash)) {
-            return child.get();
-        }
+  for (const auto& child : node->children()) {
+    if (child->value() == value &&
+        child->level() == level &&
+        child->isShape() == isShape &&
+        (shapeHash == 0 || child->shapeHash() == shapeHash)) {
+      return child;
     }
-    return nullptr;
+  }
+  return nullptr;
 }
 
 ConstantShapeBuffer* DirectShapeTrie::search(const LongType* shapeInfo, size_t stripeIdx) const {
-    // No locks here - caller handles locking
-    const ShapeTrieNode* current = _roots[stripeIdx].get();
-    const int rank = shape::rank(shapeInfo);
-    const int shapeSignature = calculateShapeSignature(shapeInfo);
+  // No locks here - caller handles locking
+  const ShapeTrieNode* current = _roots[stripeIdx];
+  const int rank = shape::rank(shapeInfo);
+  const int shapeSignature = calculateShapeSignature(shapeInfo);
 
-    // Check rank
-    current = findChild(current, rank, 0, true, shapeSignature);
+  // Check rank
+  current = findChild(current, rank, 0, true, shapeSignature);
+  if (!current) return nullptr;
+
+  // Check datatype
+  current = findChild(current, ArrayOptions::dataType(shapeInfo), 1, true, shapeSignature);
+  if (!current) return nullptr;
+
+  // Check order
+  current = findChild(current, shape::order(shapeInfo), 2, true, shapeSignature);
+  if (!current) return nullptr;
+
+  // Check shape values
+  const LongType* shapeValues = shape::shapeOf(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    current = findChild(current, shapeValues[i], 3 + i, true, shapeSignature);
     if (!current) return nullptr;
+  }
 
-    // Check datatype
-    current = findChild(current, ArrayOptions::dataType(shapeInfo), 1, true, shapeSignature);
+  // Check stride values
+  const LongType* strides = shape::stride(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    current = findChild(current, strides[i], 3 + rank + i, false, shapeSignature);
     if (!current) return nullptr;
+  }
 
-    // Check order
-    current = findChild(current, shape::order(shapeInfo), 2, true, shapeSignature);
-    if (!current) return nullptr;
-
-    // Check shape values
-    const LongType* shapeValues = shape::shapeOf(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        current = findChild(current, shapeValues[i], 3 + i, true, shapeSignature);
-        if (!current) return nullptr;
-    }
-
-    // Check stride values
-    const LongType* strides = shape::stride(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        current = findChild(current, strides[i], 3 + rank + i, false, shapeSignature);
-        if (!current) return nullptr;
-    }
-
-    return current ? current->buffer() : nullptr;
+  return current ? current->buffer() : nullptr;
 }
 
 // Updated getOrCreate method with improved thread safety
 ConstantShapeBuffer* DirectShapeTrie::getOrCreate(const LongType* shapeInfo) {
-    validateShapeInfo(shapeInfo);
-    size_t stripeIdx = getStripeIndex(shapeInfo);
-    int shapeSignature = calculateShapeSignature(shapeInfo);
+  validateShapeInfo(shapeInfo);
+  DataType inputType = ArrayOptions::dataType(shapeInfo);
+  printf("DirectShapeTrie::getOrCreate input type: %d\n", (int)inputType);
 
-    // First try a read-only lookup without obtaining a write lock
-    {
-        std::shared_lock<SHAPE_MUTEX_TYPE> readLock(_mutexes[stripeIdx]);
-        ConstantShapeBuffer* existing = search(shapeInfo, stripeIdx);
-        if (existing != nullptr) {
-            // Verify that the shapes match exactly
-            if (shapeInfoEqual(existing->primary(), shapeInfo)) {
-                return existing;
-            }
-        }
-    }
-    
-    // If not found or not matching, grab exclusive lock and try again
-    std::unique_lock<SHAPE_MUTEX_TYPE> writeLock(_mutexes[stripeIdx]);
-    
-    // Check again under the write lock
+  size_t stripeIdx = getStripeIndex(shapeInfo);
+  int shapeSignature = calculateShapeSignature(shapeInfo);
+
+  // First try a read-only lookup without obtaining a write lock
+  {
+    std::shared_lock<SHAPE_MUTEX_TYPE> readLock(_mutexes[stripeIdx]);
     ConstantShapeBuffer* existing = search(shapeInfo, stripeIdx);
     if (existing != nullptr) {
-        // Double-check the shape match
-        if (shapeInfoEqual(existing->primary(), shapeInfo)) {
-            return existing;
-        }
+      // Verify that the shapes match exactly
+      if (shapeInfoEqual(existing->primary(), shapeInfo)) {
+        return existing;
+      }
     }
-    
-    // Not found or not matching, need to create a new shape buffer
-    ShapeTrieNode* current = _roots[stripeIdx].get();
-    const int rank = shape::rank(shapeInfo);
-    
-    // Insert rank with signature
-    current = current->findOrCreateChild(rank, 0, true, shapeSignature);
-    if (!current) {
-        THROW_EXCEPTION("Failed to create rank node");
-    }
-    
-    // Insert datatype with signature
-    current = current->findOrCreateChild(ArrayOptions::dataType(shapeInfo), 1, true, shapeSignature);
-    if (!current) {
-        THROW_EXCEPTION("Failed to create datatype node");
-    }
-    
-    // Insert order with signature
-    current = current->findOrCreateChild(shape::order(shapeInfo), 2, true, shapeSignature);
-    if (!current) {
-        THROW_EXCEPTION("Failed to create order node");
-    }
-    
-    // Insert shape values with signature
-    const LongType* shapeValues = shape::shapeOf(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        current = current->findOrCreateChild(shapeValues[i], 3 + i, true, shapeSignature);
-        if (!current) {
-            THROW_EXCEPTION("Failed to create shape value node");
-        }
-    }
-    
-    // Insert stride values with signature
-    const LongType* strides = shape::stride(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        current = current->findOrCreateChild(strides[i], 3 + rank + i, false, shapeSignature);
-        if (!current) {
-            THROW_EXCEPTION("Failed to create stride value node");
-        }
-    }
-    
-    // Check if another thread has already created the buffer
-    if (ConstantShapeBuffer* nodeExisting = current->buffer()) {
-        if (shapeInfoEqual(nodeExisting->primary(), shapeInfo)) {
-            return nodeExisting;
-        }
-    }
+  }
 
-    
-    // Create the shape buffer
-    try {
-        ConstantShapeBuffer* buffer = ShapeBufferCreatorHelper::getCurrentCreator().create(shapeInfo, rank);
-        current->setBuffer(buffer);
-        return buffer;
-    } catch (const std::exception& e) {
-        std::string msg = "Shape buffer creation failed: ";
-        msg += e.what();
-        THROW_EXCEPTION(msg.c_str());
-    }
+  // If not found or not matching, grab exclusive lock and try again
+  std::unique_lock<SHAPE_MUTEX_TYPE> writeLock(_mutexes[stripeIdx]);
 
-    return nullptr;
+  // Check again under the write lock
+  ConstantShapeBuffer* existing = search(shapeInfo, stripeIdx);
+  if (existing != nullptr) {
+    // Double-check the shape match
+    if (shapeInfoEqual(existing->primary(), shapeInfo)) {
+      return existing;
+    }
+  }
+
+  // Not found or not matching, need to create a new shape buffer
+  ShapeTrieNode* current = _roots[stripeIdx];
+  const int rank = shape::rank(shapeInfo);
+
+  // Insert rank with signature
+  current = current->findOrCreateChild(rank, 0, true, shapeSignature);
+  if (rank < 0 || rank > SD_MAX_RANK) {
+    printf("ERROR: Invalid rank %lld in DirectShapeTrie::getOrCreate\n", (long long)rank);
+    THROW_EXCEPTION("Invalid rank in shape trie");
+  }
+
+  if (!current) {
+    THROW_EXCEPTION("Failed to create rank node");
+  }
+
+  // Insert datatype with signature
+  current = current->findOrCreateChild(ArrayOptions::dataType(shapeInfo), 1, true, shapeSignature);
+  if (!current) {
+    THROW_EXCEPTION("Failed to create datatype node");
+  }
+
+  // Insert order with signature
+  current = current->findOrCreateChild(shape::order(shapeInfo), 2, true, shapeSignature);
+  if (!current) {
+    THROW_EXCEPTION("Failed to create order node");
+  }
+
+  // Insert shape values with signature
+  const LongType* shapeValues = shape::shapeOf(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    current = current->findOrCreateChild(shapeValues[i], 3 + i, true, shapeSignature);
+    if (!current) {
+      THROW_EXCEPTION("Failed to create shape value node");
+    }
+  }
+
+  // Insert stride values with signature
+  const LongType* strides = shape::stride(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    current = current->findOrCreateChild(strides[i], 3 + rank + i, false, shapeSignature);
+    if (!current) {
+      THROW_EXCEPTION("Failed to create stride value node");
+    }
+  }
+
+  // Check if another thread has already created the buffer
+  if (ConstantShapeBuffer* nodeExisting = current->buffer()) {
+    if (shapeInfoEqual(nodeExisting->primary(), shapeInfo)) {
+      return nodeExisting;
+    }
+  }
+
+
+  // Create the shape buffer
+  ConstantShapeBuffer* buffer = ShapeBufferCreatorHelper::getCurrentCreator().create(shapeInfo, rank);
+  DataType resultType = ArrayOptions::dataType(buffer->primary());
+  if (inputType != resultType) {
+    printf("ERROR: Data type changed from %d to %d in DirectShapeTrie::getOrCreate\n",
+           (int)inputType, (int)resultType);
+  }
+
+  current->setBuffer(buffer);
+  return buffer;
+
+  return nullptr;
 }
 
 bool DirectShapeTrie::exists(const LongType* shapeInfo) const {
-    validateShapeInfo(shapeInfo);
-    size_t stripeIdx = getStripeIndex(shapeInfo);
-    int shapeSignature = calculateShapeSignature(shapeInfo);
+  validateShapeInfo(shapeInfo);
+  size_t stripeIdx = getStripeIndex(shapeInfo);
+  int shapeSignature = calculateShapeSignature(shapeInfo);
 
-    std::shared_lock<SHAPE_MUTEX_TYPE> lock(_mutexes[stripeIdx]);
-    ConstantShapeBuffer* found = search(shapeInfo, stripeIdx);
-    return found != nullptr && shapeInfoEqual(found->primary(), shapeInfo);
+  std::shared_lock<SHAPE_MUTEX_TYPE> lock(_mutexes[stripeIdx]);
+  ConstantShapeBuffer* found = search(shapeInfo, stripeIdx);
+  return found != nullptr && shapeInfoEqual(found->primary(), shapeInfo);
 }
 
 // Original insert method kept for compatibility, but getOrCreate should be used instead
 ConstantShapeBuffer* DirectShapeTrie::insert(const LongType* shapeInfo, size_t stripeIdx) {
-    ShapeTrieNode* current = _roots[stripeIdx].get();
-    const int rank = shape::rank(shapeInfo);
-    const int shapeSignature = calculateShapeSignature(shapeInfo);
+  ShapeTrieNode* current = _roots[stripeIdx];
+  const int rank = shape::rank(shapeInfo);
+  const int shapeSignature = calculateShapeSignature(shapeInfo);
 
-    // Insert rank
-    current = current->findOrCreateChild(rank, 0, true, shapeSignature);
+  // Insert rank
+  current = current->findOrCreateChild(rank, 0, true, shapeSignature);
+  if (!current) return nullptr;
+
+  // Insert datatype
+  current = current->findOrCreateChild(ArrayOptions::dataType(shapeInfo), 1, true, shapeSignature);
+  if (!current) return nullptr;
+
+  // Insert order
+  current = current->findOrCreateChild(shape::order(shapeInfo), 2, true, shapeSignature);
+  if (!current) return nullptr;
+
+  // Insert shape values
+  const LongType* shape = shape::shapeOf(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    current = current->findOrCreateChild(shape[i], 3 + i, true, shapeSignature);
     if (!current) return nullptr;
+  }
 
-    // Insert datatype
-    current = current->findOrCreateChild(ArrayOptions::dataType(shapeInfo), 1, true, shapeSignature);
+  // Insert stride values
+  const LongType* strides = shape::stride(shapeInfo);
+  for (int i = 0; i < rank; i++) {
+    current = current->findOrCreateChild(strides[i], 3 + rank + i, false, shapeSignature);
     if (!current) return nullptr;
+  }
 
-    // Insert order
-    current = current->findOrCreateChild(shape::order(shapeInfo), 2, true, shapeSignature);
-    if (!current) return nullptr;
+  if (!current->buffer()) {
+    try {
+      const int shapeInfoLength = shape::shapeInfoLength(rank);
+      LongType* shapeCopy = new LongType[shapeInfoLength];
+      std::memcpy(shapeCopy, shapeInfo, shapeInfoLength * sizeof(LongType));
 
-    // Insert shape values
-    const LongType* shape = shape::shapeOf(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        current = current->findOrCreateChild(shape[i], 3 + i, true, shapeSignature);
-        if (!current) return nullptr;
+      auto deallocator = std::shared_ptr<PrimaryPointerDeallocator>(new PrimaryPointerDeallocator(),
+                                                                    [] (PrimaryPointerDeallocator* ptr) { delete ptr; });
+      auto hPtr = std::make_shared<PointerWrapper>(shapeCopy, deallocator);
+      auto buffer = new ConstantShapeBuffer(hPtr);
+
+      current->setBuffer(buffer);
+      return buffer;
+    } catch (const std::exception& e) {
+      std::string msg = "Shape buffer creation failed: ";
+      msg += e.what();
+      THROW_EXCEPTION(msg.c_str());
     }
+  }
 
-    // Insert stride values
-    const LongType* strides = shape::stride(shapeInfo);
-    for (int i = 0; i < rank; i++) {
-        current = current->findOrCreateChild(strides[i], 3 + rank + i, false, shapeSignature);
-        if (!current) return nullptr;
-    }
-
-    if (!current->buffer()) {
-        try {
-            const int shapeInfoLength = shape::shapeInfoLength(rank);
-            LongType* shapeCopy = new LongType[shapeInfoLength];
-            std::memcpy(shapeCopy, shapeInfo, shapeInfoLength * sizeof(LongType));
-
-            auto deallocator = std::shared_ptr<PrimaryPointerDeallocator>(new PrimaryPointerDeallocator(),
-                                                                        [] (PrimaryPointerDeallocator* ptr) { delete ptr; });
-            auto hPtr = std::make_shared<PointerWrapper>(shapeCopy, deallocator);
-            auto buffer = new ConstantShapeBuffer(hPtr);
-
-            current->setBuffer(buffer);
-            return buffer;
-        } catch (const std::exception& e) {
-            std::string msg = "Shape buffer creation failed: ";
-            msg += e.what();
-            THROW_EXCEPTION(msg.c_str());
-        }
-    }
-
-    return current->buffer();
+  return current->buffer();
 }
 
 }  // namespace sd

--- a/libnd4j/include/helpers/impl/DirectTadTrie.cpp
+++ b/libnd4j/include/helpers/impl/DirectTadTrie.cpp
@@ -52,9 +52,9 @@ TadPack* DirectTadTrie::enhancedSearch(const std::vector<LongType>& dimensions, 
 
   // Compare with expected strides and shape
   // Create a temporary calculator to check what the strides should be
-  TadCalculator tempCalc(originalShape);
-  tempCalc.createTadPack(dimensions);
-  LongType* expectedShapeInfo = tempCalc.tadShape().primary();
+  TadCalculator *tempCalc = new TadCalculator(originalShape);
+  tempCalc->createTadPack(dimensions);
+  LongType* expectedShapeInfo = tempCalc->tadShape()->primary();
   LongType* expectedStrides = shape::stride(expectedShapeInfo);
 
   // Check if strides are compatible
@@ -215,14 +215,14 @@ TadPack* DirectTadTrie::insert(std::vector<LongType>& dimensions, LongType* orig
   // Create the TadPack only if it doesn't exist yet
   if (!current->pack()) {
     try {
-      TadCalculator calculator(originalShape);
-      calculator.createTadPack(dimensions);
+      TadCalculator *calculator = new TadCalculator(originalShape);
+      calculator->createTadPack(dimensions);
 
       // Create a new TadPack with full dimension information
       TadPack* newPack = new TadPack(
-          calculator.tadShape(),
-          calculator.tadOffsets(),
-          calculator.numberOfTads(),
+          calculator->tadShape(),
+          calculator->tadOffsets(),
+          calculator->numberOfTads(),
           dimensions.data(),
           dimensions.size());
 

--- a/libnd4j/include/helpers/impl/ShapeBuilders.cpp
+++ b/libnd4j/include/helpers/impl/ShapeBuilders.cpp
@@ -59,6 +59,13 @@ LongType* ShapeBuilders::createScalarShapeInfo(const DataType dataType, memory::
   newShape[3] = ArrayOptions::setDataTypeValue(ArrayOptions::defaultFlag(), dataType);
   newShape[4] = 1;
   newShape[5] = 99;
+
+
+  DataType actualType = ArrayOptions::dataType(newShape);
+  if (actualType != dataType) {
+    printf("ERROR: Data type mismatch in scalarShapeInfo - requested %d but got %d\n",
+           DataTypeUtils::asInt(dataType), DataTypeUtils::asInt(actualType));
+  }
   return newShape;
 }
 LongType* ShapeBuilders::createVectorShapeInfo(const DataType dataType, const LongType length,
@@ -219,9 +226,7 @@ LongType* ShapeBuilders::createShapeInfo(const DataType dataType, const char ord
 ////////////////////////////////////////////////////////////////////////////////
 LongType* ShapeBuilders::copyShapeInfo(const LongType* inShapeInfo, const bool copyStrides,
                                        memory::Workspace* workspace) {
-  LongType* outShapeInfo = nullptr;
-  ALLOCATE(outShapeInfo, workspace, shape::shapeInfoLength(inShapeInfo), sd::LongType);
-
+  LongType* outShapeInfo = new LongType[shape::shapeInfoLength(shape::rank(inShapeInfo))];
   memcpy(outShapeInfo, inShapeInfo, shape::shapeInfoByteLength(inShapeInfo));
 
   if (!copyStrides) shape::updateStrides(outShapeInfo, shape::order(outShapeInfo), false);

--- a/libnd4j/include/helpers/impl/ShapeUtils.cpp
+++ b/libnd4j/include/helpers/impl/ShapeUtils.cpp
@@ -204,30 +204,37 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
                                           const bool keepDims,
                                           const bool supportOldShapes,
                                           memory::Workspace* workspace) {
-  if (ArrayOptions::arrayType(shapeInfo) == EMPTY)
+  if (ArrayOptions::arrayType(shapeInfo) == EMPTY) {
+    printf("EMPTY case: Data type of ret: %d\n", ArrayOptions::dataType(shapeInfo));
     return evalReduceShapeInfoEmpty(order, dimsToExclude, shapeInfo, dataType, keepDims, workspace);
-
+  }
   LongType* newShapeInfo = nullptr;
 
   LongType rank = shape::rank(const_cast<LongType*>(shapeInfo));
 
   if (dimsToExclude->size() == 0) {  // return scalar or array with len=1 in this case
     if (keepDims && rank > 1) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(rank), sd::LongType);
+      newShapeInfo = new LongType[shape::shapeInfoLength(rank)];
       newShapeInfo[0] = rank;
       for (LongType i = 0; i < rank; ++i) newShapeInfo[i + 1] = 1;
       updateStridesAndType(newShapeInfo, shapeInfo, order);
       ArrayOptions::setDataType(newShapeInfo, dataType);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+      printf("1 Data type of ret: %d\n", ArrayOptions::dataType(ret));
+      fflush(stdout);
       return ret;
     } else if (supportOldShapes) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
+      newShapeInfo = new LongType[shape::shapeInfoLength(2)];
       shape::shapeOldScalar(dataType, newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+      printf("2 Data type of ret: %d\n", ArrayOptions::dataType(ret));
+      fflush(stdout);
       return ret;
     } else {
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+      printf("3 Data type of ret: %d\n", ArrayOptions::dataType(ret));
+      fflush(stdout);
       return ret;
     }
   }
@@ -237,7 +244,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
   LongType dimSize = dimsToExclude->size();
 
   if (keepDims) {
-    ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(rank), sd::LongType);
+    newShapeInfo = new LongType[shape::shapeInfoLength(rank)];
     newShapeInfo[0] = rank;
 
     for (LongType i = 0; i < rank; ++i) {
@@ -249,6 +256,8 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
     }
     updateStridesAndType(newShapeInfo, shapeInfo, order);
     auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+    printf("4 Data type of ret: %d\n", ArrayOptions::dataType(ret));
+    fflush(stdout);
     return ret;
   }
 
@@ -258,21 +267,23 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
        dimsToExclude->at(0) == INT_MAX)) {  // check whether given dimension is meant for the whole dimension
 
     if (supportOldShapes) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
+      newShapeInfo = new LongType[shape::shapeInfoLength(2)];
       shape::shapeOldScalar(ArrayOptions::dataType(shapeInfo), newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      RELEASE(newShapeInfo, workspace);
+      printf("6 Data type of ret: %d\n", ArrayOptions::dataType(ret));
+      fflush(stdout);
       return ret;
     } else {
 
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(ArrayOptions::dataType(shapeInfo), workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      RELEASE(newShapeInfo, workspace);
+      printf("5 Data type of ret: %d\n", ArrayOptions::dataType(ret));
+      fflush(stdout);
       return ret;
     }
   }
 
-  ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(newRank), sd::LongType);
+  newShapeInfo = new LongType[shape::shapeInfoLength(newRank)];
   newShapeInfo[0] = newRank;  // set rank
   LongType j = 1;
   for (LongType i = 0; i < rank; ++i)
@@ -283,8 +294,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
   // ensure whether vector has proper shape for old shape type
   if (newRank == 1 && supportOldShapes) {
     LongType oldValue = newShapeInfo[1];
-    RELEASE(newShapeInfo, workspace);
-    ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);  // set newRank = 2
+    newShapeInfo = new LongType[shape::shapeInfoLength(2)];
     newShapeInfo[0] = 2;
     if (dimsToExclude->at(0) == 0) {
       newShapeInfo[1] = 1;
@@ -298,6 +308,8 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
   updateStridesAndType(newShapeInfo, shapeInfo, order);
 
   auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+  printf("7 Data type of ret: %d\n", ArrayOptions::dataType(ret));
+  fflush(stdout);
   return ret;
 }
 
@@ -418,7 +430,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
 
   if (dimsToExclude->size() == 0) {  // return scalar or array with len=1 in this case
     if (keepDims && rank > 1) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(rank), sd::LongType);
+      newShapeInfo = new sd::LongType[shape::shapeInfoLength(rank)];
       newShapeInfo[0] = rank;
       for (LongType i = 0; i < rank; ++i) newShapeInfo[i + 1] = 1;
       updateStridesAndType(newShapeInfo, shapeInfo, order);
@@ -426,7 +438,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
       return ret;
     } else if (supportOldShapes) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
+      newShapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, workspace);
       shape::shapeOldScalar(dataType, newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
       return ret;
@@ -442,7 +454,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
   LongType dimSize = dimsToExclude->size();
 
   if (keepDims) {
-    ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(rank), sd::LongType);
+    newShapeInfo = new sd::LongType[shape::shapeInfoLength(rank)];
     newShapeInfo[0] = rank;
 
     for (LongType i = 0; i < rank; ++i) {
@@ -463,21 +475,19 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
        dimsToExclude->at(0) == INT_MAX)) {  // check whether given dimension is meant for the whole dimension
 
     if (supportOldShapes) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
+      newShapeInfo = new sd::LongType[shape::shapeInfoLength(2)];
       shape::shapeOldScalar(ArrayOptions::dataType(shapeInfo), newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      RELEASE(newShapeInfo, workspace);
       return ret;
     } else {
 
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(ArrayOptions::dataType(shapeInfo), workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      RELEASE(newShapeInfo, workspace);
       return ret;
     }
   }
 
-  ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(newRank), sd::LongType);
+  newShapeInfo = new sd::LongType[shape::shapeInfoLength(newRank)];
   newShapeInfo[0] = newRank;  // set rank
   LongType j = 1;
   for (LongType i = 0; i < rank; ++i)
@@ -488,8 +498,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
   // ensure whether vector has proper shape for old shape type
   if (newRank == 1 && supportOldShapes) {
     LongType oldValue = newShapeInfo[1];
-    RELEASE(newShapeInfo, workspace);
-    ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);  // set newRank = 2
+    newShapeInfo = new sd::LongType[shape::shapeInfoLength(2)];
     newShapeInfo[0] = 2;
     if (dimsToExclude->at(0) == 0) {
       newShapeInfo[1] = 1;

--- a/libnd4j/include/helpers/impl/ShapeUtils.cpp
+++ b/libnd4j/include/helpers/impl/ShapeUtils.cpp
@@ -205,7 +205,6 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
                                           const bool supportOldShapes,
                                           memory::Workspace* workspace) {
   if (ArrayOptions::arrayType(shapeInfo) == EMPTY) {
-    printf("EMPTY case: Data type of ret: %d\n", ArrayOptions::dataType(shapeInfo));
     return evalReduceShapeInfoEmpty(order, dimsToExclude, shapeInfo, dataType, keepDims, workspace);
   }
   LongType* newShapeInfo = nullptr;
@@ -220,21 +219,15 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
       updateStridesAndType(newShapeInfo, shapeInfo, order);
       ArrayOptions::setDataType(newShapeInfo, dataType);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      printf("1 Data type of ret: %d\n", ArrayOptions::dataType(ret));
-      fflush(stdout);
       return ret;
     } else if (supportOldShapes) {
       newShapeInfo = new LongType[shape::shapeInfoLength(2)];
       shape::shapeOldScalar(dataType, newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      printf("2 Data type of ret: %d\n", ArrayOptions::dataType(ret));
-      fflush(stdout);
       return ret;
     } else {
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      printf("3 Data type of ret: %d\n", ArrayOptions::dataType(ret));
-      fflush(stdout);
       return ret;
     }
   }
@@ -256,8 +249,6 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
     }
     updateStridesAndType(newShapeInfo, shapeInfo, order);
     auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-    printf("4 Data type of ret: %d\n", ArrayOptions::dataType(ret));
-    fflush(stdout);
     return ret;
   }
 
@@ -270,15 +261,11 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
       newShapeInfo = new LongType[shape::shapeInfoLength(2)];
       shape::shapeOldScalar(ArrayOptions::dataType(shapeInfo), newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      printf("6 Data type of ret: %d\n", ArrayOptions::dataType(ret));
-      fflush(stdout);
       return ret;
     } else {
 
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(ArrayOptions::dataType(shapeInfo), workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      printf("5 Data type of ret: %d\n", ArrayOptions::dataType(ret));
-      fflush(stdout);
       return ret;
     }
   }
@@ -308,8 +295,6 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
   updateStridesAndType(newShapeInfo, shapeInfo, order);
 
   auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-  printf("7 Data type of ret: %d\n", ArrayOptions::dataType(ret));
-  fflush(stdout);
   return ret;
 }
 
@@ -327,31 +312,33 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
 
   if (dimsToExclude->size() == 0) {  // return scalar or array with len=1 in this case
     if (keepDims && rank > 1) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(rank), sd::LongType);
+      newShapeInfo = new sd::LongType[shape::shapeInfoLength(rank)];
       newShapeInfo[0] = rank;
       for (LongType i = 0; i < rank; ++i) newShapeInfo[i + 1] = 1;
       updateStridesAndType(newShapeInfo, shapeInfo, order);
       ArrayOptions::setDataType(newShapeInfo, dataType);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+      delete[] newShapeInfo;
       return ret;
     } else if (supportOldShapes) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
+      newShapeInfo = new sd::LongType[shape::shapeInfoLength(2)];
       shape::shapeOldScalar(dataType, newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+      delete[] newShapeInfo;
       return ret;
     } else {
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(dataType, workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+      delete[] newShapeInfo;
       return ret;
     }
   }
 
   shape::checkDimensions(rank, dimsToExclude);
-
   LongType dimSize = dimsToExclude->size();
 
   if (keepDims) {
-    ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(rank), sd::LongType);
+    newShapeInfo = new sd::LongType[shape::shapeInfoLength(rank)];
     newShapeInfo[0] = rank;
 
     for (LongType i = 0; i < rank; ++i) {
@@ -363,6 +350,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
     }
     updateStridesAndType(newShapeInfo, shapeInfo, order);
     auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+    delete[] newShapeInfo;
     return ret;
   }
 
@@ -372,21 +360,22 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
        dimsToExclude->at(0) == INT_MAX)) {  // check whether given dimension is meant for the whole dimension
 
     if (supportOldShapes) {
-      ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);
+      newShapeInfo = new sd::LongType[shape::shapeInfoLength(2)];
       shape::shapeOldScalar(ArrayOptions::dataType(shapeInfo), newShapeInfo, 'c');
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      RELEASE(newShapeInfo, workspace);
+      delete[] newShapeInfo;
+
       return ret;
     } else {
-
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(ArrayOptions::dataType(shapeInfo), workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
-      RELEASE(newShapeInfo, workspace);
+      delete[] newShapeInfo;
+
       return ret;
     }
   }
 
-  ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(newRank), sd::LongType);
+  newShapeInfo = new sd::LongType[shape::shapeInfoLength(newRank)];
   newShapeInfo[0] = newRank;  // set rank
   LongType j = 1;
   for (LongType i = 0; i < rank; ++i)
@@ -397,7 +386,9 @@ LongType* ShapeUtils::evalReduceShapeInfo(const char order, std::vector<LongType
   // ensure whether vector has proper shape for old shape type
   if (newRank == 1 && supportOldShapes) {
     LongType oldValue = newShapeInfo[1];
+    delete[] newShapeInfo;
     RELEASE(newShapeInfo, workspace);
+    newShapeInfo = new sd::LongType[shape::shapeInfoLength(2)];
     ALLOCATE(newShapeInfo, workspace, shape::shapeInfoLength(2), sd::LongType);  // set newRank = 2
     newShapeInfo[0] = 2;
     if (dimsToExclude->at(0) == 0) {
@@ -466,6 +457,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
     }
     updateStridesAndType(newShapeInfo, shapeInfo, order);
     auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+    delete[] newShapeInfo;
     return ret;
   }
 
@@ -483,6 +475,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
 
       newShapeInfo = ShapeBuilders::createScalarShapeInfo(ArrayOptions::dataType(shapeInfo), workspace);
       auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+      delete[] newShapeInfo;
       return ret;
     }
   }
@@ -512,6 +505,7 @@ LongType* ShapeUtils::evalReduceShapeInfo(char order, std::vector<LongType>* dim
   updateStridesAndType(newShapeInfo, shapeInfo, order);
 
   auto ret = ConstantShapeHelper::getInstance().bufferForShapeInfo(newShapeInfo)->primary();
+  delete[] newShapeInfo;
   return ret;
 }
 

--- a/libnd4j/include/helpers/impl/reshapeNoCopy.cpp
+++ b/libnd4j/include/helpers/impl/reshapeNoCopy.cpp
@@ -122,9 +122,11 @@ bool reshapeNoAlloc(const sd::LongType* inShape,
 
   shape::setShape(outShape, const_cast<sd::LongType*>(newShape.data()));
   shape::setStride(outShape, newStrides.data());
+  if(ArrayOptions::numDataTypesSet(ArrayOptions::extra(outShape)) < 1) {
+    ArrayOptions::setDataType(outShape, ArrayOptions::dataType(inShape));
+  }
+
   shape::setOrder(outShape, order);
-  ArrayOptions::resetFlags(outShape);
-  ArrayOptions::setDataType(outShape, ArrayOptions::dataType(inShape));
 
   return true;
 }

--- a/libnd4j/include/helpers/logger.h
+++ b/libnd4j/include/helpers/logger.h
@@ -80,8 +80,6 @@ SD_INLINE void _printHostBuffer(void* bufferVoid, sd::DataType dataType, sd::Lon
   T *buffer = reinterpret_cast<T *>(bufferVoid);
   // Validate offset
   if (offset < 0 || offset >= length) {
-    printf("Invalid offset: %lld. Must be between 0 and %lld.\n", offset, length - 1);
-    fflush(stdout);
     return;
   }
 

--- a/libnd4j/include/legacy/cuda/NativeOpExecutioner.cu
+++ b/libnd4j/include/legacy/cuda/NativeOpExecutioner.cu
@@ -1304,7 +1304,6 @@ void NativeOpExecutioner::execScalar(sd::LaunchContext* lc, int opNum, void cons
   auto xType = sd::ArrayOptions::dataType(hXShapeInfo);
   auto yType = sd::ArrayOptions::dataType(hScalarShapeInfo);
   auto zType = sd::ArrayOptions::dataType(hZShapeInfo);
-
   if (sd::DataTypeUtils::isS(xType) || sd::DataTypeUtils::isS(yType) || sd::DataTypeUtils::isS(zType)) {
     THROW_EXCEPTION(
         "NativeOpExecutioner::execScalar:: unable to execute on strings. Please write logic higher level in each op "

--- a/libnd4j/include/legacy/cuda/NativeOps.cu
+++ b/libnd4j/include/legacy/cuda/NativeOps.cu
@@ -1149,11 +1149,11 @@ sd::Pointer mallocDevice(sd::LongType memorySize, int deviceId, int flags) {
  * @param pointer pointer that'll be freed
  */
 int freeHost(sd::Pointer pointer) {
-  auto res = cudaFreeHost(reinterpret_cast<void *>(pointer));
+/*  auto res = cudaFreeHost(reinterpret_cast<void *>(pointer));
   if (res != 0) {
     sd::LaunchContext::defaultContext()->errorReference()->setErrorCode(res);
     sd::LaunchContext::defaultContext()->errorReference()->setErrorMessage("cudaFreeHost failed");
-  }
+  }*/
 
   return 1L;
 }

--- a/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
+++ b/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
@@ -1759,7 +1759,7 @@ sd::Pointer dbSpecialBuffer(OpaqueDataBuffer *dataBuffer) {
 void deleteDataBuffer(OpaqueDataBuffer *dataBuffer) {
   if(dataBuffer == nullptr)
     THROW_EXCEPTION("dbPrimaryBuffer: dataBuffer is null");
-  //delete dataBuffer;
+  delete dataBuffer;
 }
 
 void dbSetPrimaryBuffer(OpaqueDataBuffer *dataBuffer, sd::Pointer primaryBuffer, sd::LongType numBytes) {

--- a/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
+++ b/libnd4j/include/legacy/impl/NativeOpsHelpers.cpp
@@ -567,16 +567,11 @@ int dataTypeFromNpyHeader(void *header) { return (int)cnpy::dataTypeFromHeader(r
 OpaqueConstantShapeBuffer shapeBufferEx(int rank, sd::LongType *shape, sd::LongType *strides, sd::DataType dtype,
                                         char order,
                                         sd::LongType ews, sd::LongType extras) {
-  try {
 
     auto desc = sd::ShapeBuilders::createShapeInfo(dtype, order,rank, shape, strides,nullptr, extras);
     auto buffer = sd::ConstantShapeHelper::getInstance().bufferForShapeInfo(desc);
     return buffer;
-  } catch (std::exception &e) {
-    sd::LaunchContext::defaultContext()->errorReference()->setErrorCode(1);
-    sd::LaunchContext::defaultContext()->errorReference()->setErrorMessage(e.what());
-    return nullptr;
-  }
+
 }
 
 void inspectArray(sd::Pointer *extraPointers, sd::Pointer buffer, sd::LongType *shapeInfo, sd::Pointer specialBuffer,
@@ -588,7 +583,10 @@ void inspectArray(sd::Pointer *extraPointers, sd::Pointer buffer, sd::LongType *
   } catch (std::exception &e) {
     sd::LaunchContext::defaultContext()->errorReference()->setErrorCode(1);
     sd::LaunchContext::defaultContext()->errorReference()->setErrorMessage(e.what());
+    THROW_EXCEPTION(e.what());
   }
+
+
 }
 
 
@@ -606,8 +604,11 @@ OpaqueConstantShapeBuffer cacheAndStoreShapeBuffer(sd::LongType *shapeInfo) {
   } catch (std::exception &e) {
     sd::LaunchContext::defaultContext()->errorReference()->setErrorCode(1);
     sd::LaunchContext::defaultContext()->errorReference()->setErrorMessage(e.what());
-    return nullptr;
+    THROW_EXCEPTION(e.what());
+
   }
+
+  return nullptr;
 }
 
 sd::LongType *mmapFile(sd::Pointer *extraPointers, const char *fileName, sd::LongType length) {
@@ -1749,7 +1750,7 @@ sd::Pointer dbSpecialBuffer(OpaqueDataBuffer *dataBuffer) {
 void deleteDataBuffer(OpaqueDataBuffer *dataBuffer) {
   if(dataBuffer == nullptr)
     THROW_EXCEPTION("dbPrimaryBuffer: dataBuffer is null");
-  delete dataBuffer;
+  //delete dataBuffer;
 }
 
 void dbSetPrimaryBuffer(OpaqueDataBuffer *dataBuffer, sd::Pointer primaryBuffer, sd::LongType numBytes) {

--- a/libnd4j/include/loops/cpu/broadcasting.hpp
+++ b/libnd4j/include/loops/cpu/broadcasting.hpp
@@ -455,8 +455,6 @@ void Broadcast<X, Y, Z>::exec(const void* vx, const sd::LongType* xShapeInfo,
           // Broadcast along first dimension
           PRAGMA_OMP_SIMD
           for (auto i = start; i < stop; i++) {
-            printf("6 Handling tad: %lld\n", i);
-            fflush(stdout);
             auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
             auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
 
@@ -482,8 +480,6 @@ void Broadcast<X, Y, Z>::exec(const void* vx, const sd::LongType* xShapeInfo,
           // Default broadcasting behavior - broadcast along the last dimension
           PRAGMA_OMP_SIMD
           for (auto i = start; i < stop; i++) {
-            printf("5 Handling tad: %lld\n", i);
-            fflush(stdout);
             auto oX = x + (xTadOffset ? xTadOffset[i] : 0);
             auto oZ = z + (zTadOffset ? zTadOffset[i] : 0);
 

--- a/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
+++ b/libnd4j/include/loops/cuda/reduce/reduce_float.chpp
@@ -264,10 +264,13 @@ SD_DEVICE void ReduceFloatFunction<X, Z>::execScalarCuda(
     INDEX2COORDS(i, xRank, xShapePtr, xCoords);
     COORDS2INDEX(xRank, xStridePtr, xCoords, xOffset);
 
-    sPartials[threadIdx.x] = OpType::update(
-        sPartials[threadIdx.x],
-        OpType::op(x[xOffset], extraParams),
-        extraParams);
+    if(xOffset < length) {
+      sPartials[threadIdx.x] = OpType::update(
+          sPartials[threadIdx.x],
+          OpType::op(x[xOffset], extraParams),
+          extraParams);
+    }
+
   }
   __syncthreads();
 

--- a/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
+++ b/libnd4j/include/ops/declarable/generic/datatypes/cast.cpp
@@ -51,9 +51,7 @@ DECLARE_SHAPE_FN(cast) {
   auto inShape = inputShape->at(0);
   if(!block.getDArguments()->empty()) {
     DataType newType = block.dataType(0);
-    DataType secondComp = block.getDArguments()->at(0);
     auto desc = new ShapeDescriptor(inShape, newType, true);
-   printf("cast new data type: %s", DataTypeUtils::asString(desc->dataType()).c_str());
     auto newShapeInfo = ConstantShapeHelper::getInstance().createShapeInfo(desc);
     auto compDataType = ArrayOptions::dataType(newShapeInfo);
     if(compDataType != newType) {

--- a/libnd4j/include/ops/declarable/generic/reduce/argmax.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/argmax.cpp
@@ -61,6 +61,8 @@ CUSTOM_OP_IMPL(argmax, 1, 1, false, 0, -2) {
 DECLARE_SHAPE_FN(argmax) {
   auto firstInputShape = inputShape->at(0);
   if(shape::isScalar(firstInputShape)) {
+    printf("first argmax scalar calculate output shape\n");
+    fflush(stdout);
     return SHAPELIST(ConstantShapeHelper::getInstance().scalarShapeInfo(DataType::INT64));
   }
   std::vector<LongType> dims;
@@ -89,10 +91,17 @@ DECLARE_SHAPE_FN(argmax) {
 
   // special case - output is scalar
   if (dims.empty() || (dims.size() == 1 && dims.at(0) == DataTypeUtils::max<int>())) {
-    return SHAPELIST(ConstantShapeHelper::getInstance().scalarShapeInfo(dtype));
+    printf("argmax scalar\n");
+    fflush(stdout);
+    auto ret = ConstantShapeHelper::getInstance().scalarShapeInfo(dtype);
+    printf("Datatype of scalar: %i\n", DataTypeUtils::asInt(ArrayOptions::dataType(ret)));
+    fflush(stdout);
+    return SHAPELIST(ret);
   }
 
   auto ret = ShapeUtils::evalReduceShapeInfo('c', &dims, firstInputShape, dtype, keepDims, false, block.getWorkspace());
+  printf("Datatype of non scalar: %i\n", DataTypeUtils::asInt(ArrayOptions::dataType(ret)));
+  fflush(stdout);
   return SHAPELIST(ret);
 }
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/reduce/argmax.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/argmax.cpp
@@ -61,8 +61,6 @@ CUSTOM_OP_IMPL(argmax, 1, 1, false, 0, -2) {
 DECLARE_SHAPE_FN(argmax) {
   auto firstInputShape = inputShape->at(0);
   if(shape::isScalar(firstInputShape)) {
-    printf("first argmax scalar calculate output shape\n");
-    fflush(stdout);
     return SHAPELIST(ConstantShapeHelper::getInstance().scalarShapeInfo(DataType::INT64));
   }
   std::vector<LongType> dims;
@@ -91,17 +89,11 @@ DECLARE_SHAPE_FN(argmax) {
 
   // special case - output is scalar
   if (dims.empty() || (dims.size() == 1 && dims.at(0) == DataTypeUtils::max<int>())) {
-    printf("argmax scalar\n");
-    fflush(stdout);
     auto ret = ConstantShapeHelper::getInstance().scalarShapeInfo(dtype);
-    printf("Datatype of scalar: %i\n", DataTypeUtils::asInt(ArrayOptions::dataType(ret)));
-    fflush(stdout);
     return SHAPELIST(ret);
   }
 
   auto ret = ShapeUtils::evalReduceShapeInfo('c', &dims, firstInputShape, dtype, keepDims, false, block.getWorkspace());
-  printf("Datatype of non scalar: %i\n", DataTypeUtils::asInt(ArrayOptions::dataType(ret)));
-  fflush(stdout);
   return SHAPELIST(ret);
 }
 }  // namespace ops

--- a/libnd4j/include/ops/declarable/generic/reduce/reduceMean.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduceMean.cpp
@@ -96,9 +96,7 @@ DECLARE_TYPES(reduce_mean) {
 CUSTOM_OP_IMPL(reduce_mean_bp, -2, 1, false, 0, 0) {
   auto input = INPUT_VARIABLE(0);
   auto gradO = INPUT_VARIABLE(1);
-
   auto gradI = OUTPUT_VARIABLE(0);
-
   auto dimensions = *block.getIArguments();
   if (block.width() > 2) {
     auto axesVector = INPUT_VARIABLE(2);
@@ -110,7 +108,6 @@ CUSTOM_OP_IMPL(reduce_mean_bp, -2, 1, false, 0, 0) {
     keepDims = B_ARG(0);
   else if (block.getTArguments()->size())
     keepDims = (bool)T_ARG(0);
-
   REQUIRE_TRUE(
       dimensions.size() <= static_cast<size_t>(input->rankOf()), 0,
       "REDUCE_MEAN_BP OP: the number of dimensions to reduce along must be <= input array rank, but got %i instead",
@@ -124,12 +121,14 @@ CUSTOM_OP_IMPL(reduce_mean_bp, -2, 1, false, 0, 0) {
         input->rankOf(), input->rankOf(), item);
     dimLength *= input->sizeAt(item);
   }
+
   if (gradO->isScalar()) {
     if (dimensions.size() > 0) {
       gradI->assign(gradO->e(0) / (static_cast<double>(dimLength)));
     } else {
       gradI->assign(gradO->e(0) / (static_cast<double>(input->lengthOf())));
     }
+
   } else {
     auto val = (static_cast<double>(gradO->lengthOf() < 1 ? 1.0 : gradO->lengthOf()) )
                / (static_cast<double>(input->lengthOf() < 1 ? 1.0 : input->lengthOf()));
@@ -148,6 +147,7 @@ CUSTOM_OP_IMPL(reduce_mean_bp, -2, 1, false, 0, 0) {
       gradI->applyTrueBroadcast(sd::BroadcastOpsTuple::Multiply(), gradO, gradI);
     }
   }
+
 
   return sd::Status::OK;
 }

--- a/libnd4j/include/ops/declarable/generic/reduce/reduce_sum.cpp
+++ b/libnd4j/include/ops/declarable/generic/reduce/reduce_sum.cpp
@@ -155,10 +155,8 @@ DECLARE_SHAPE_FN(reduce_sum_bp) {
         "REDUCE_SUM_BP OP: the input dimension to reduce along must be in range [-%i, %i), but got %i instead !",
         inputShape->at(0)[0], inputShape->at(0)[0], item);
 
-  sd::LongType* outShapeInfo;
-  COPY_SHAPE(inputShape->at(0), outShapeInfo);
 
-  return SHAPELIST(CONSTANT(outShapeInfo));
+  return SHAPELIST(CONSTANT(inputShape->at(0)));
 }
 
 DECLARE_TYPES(reduce_sum_bp) {

--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -83,9 +83,9 @@ DeclarableOp::DeclarableOp(int numInputs, int numOutputs, const char *opName, bo
 }
 
 DeclarableOp::~DeclarableOp() {
-  if (_descriptor != nullptr) delete _descriptor;
+  //if (_descriptor != nullptr) delete _descriptor;
 
-  if (_scalar != nullptr) delete _scalar;
+ // if (_scalar != nullptr) delete _scalar;
 }
 
 OpDescriptor *DeclarableOp::getOpDescriptor() { return _descriptor; }
@@ -335,7 +335,7 @@ int sd::ops::DeclarableOp::prepareOutputs(Context &ctx) {
             auto aShape = ShapeUtils::shapeAsString(shape);
             auto eShapeInfoString = ShapeUtils::shapeInfoAsString(out);
             auto aShapeInfoString = ShapeUtils::shapeInfoAsString(shape);
-            delete outSha;
+           // delete outSha;
 
             sd_printf(
                 "OP PREPARE OUTPUTS: Op name: %s Failed to set output for op context. Expected vs provided shapes mismatch %s vs %s at index %i with expected shape info %s and output "
@@ -376,7 +376,7 @@ int sd::ops::DeclarableOp::prepareOutputs(Context &ctx) {
             auto eShapeInfoString = ShapeUtils::shapeInfoAsString(out);
             auto aShapeInfoString = ShapeUtils::shapeInfoAsString(array->shapeInfo());
             if (eShapeInfoString != aShapeInfoString) {
-              delete outSha;
+              //delete outSha;
 
               sd_printf(
                   "OP PREPARE OUTPUTS: OP name: %s Expected vs provided shapes mismatch %s vs %s at index %i with expected shape info %s and output "
@@ -392,7 +392,7 @@ int sd::ops::DeclarableOp::prepareOutputs(Context &ctx) {
 
     if (!canUseFastPath) ctx.forbidFastPath(true);
 
-    delete outSha;
+    //delete outSha;
 
     // saving arrayTime
     if (Environment::getInstance().isProfiling() && node != nullptr) {
@@ -431,7 +431,7 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, sd::LongType *shape) 
     var->setNDArray(new NDArray(buffer, shapeInfo, block.launchContext()));
   } else if (var->getNDArray()->lengthOf() != len) {
     // if length not match - lets reallocate array
-    delete var->getNDArray();
+   // delete var->getNDArray();
     auto shapeInfo = ConstantShapeHelper::getInstance().bufferForShapeInfo(__shape)->primary();
     DataBuffer * buffer =
         new DataBuffer(len * sizeof(int8_t), ArrayOptions::dataType(shapeInfo), workspace);
@@ -468,7 +468,7 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, std::initializer_list
     var->setNDArray(new NDArray(order, shape2, block.dataType(), block.launchContext()));
   } else if (var->getNDArray()->lengthOf() != len) {
     // if length not match - lets reallocate array
-    delete var->getNDArray();
+    //delete var->getNDArray();
     var->setNDArray(new NDArray(order, shape2, block.dataType(), block.launchContext()));
   }
 
@@ -801,7 +801,7 @@ void DeclarableOp::overwriteResult(Context &block, int outputIdx, NDArray *array
       sd_debug("calling get variable\n", 0);
       auto var = varSpace->getVariable(block.getNodeId(), outputIdx);
       sd_debug("after calling get variable", 0);
-      if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
+     // if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
 
       var->setNDArray(array);
       var->markRemovable(true);
@@ -819,7 +819,7 @@ void DeclarableOp::overwriteResult(Context &block, int outputIdx, NDArray *array
   auto varSpace = block.getVariableSpace();
   if (varSpace->hasVariable(block.getNodeId(), outputIdx)) {
     auto var = varSpace->getVariable(block.getNodeId(), outputIdx);
-    if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
+  //  if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
 
     var->setNDArray(array);
     var->markRemovable(true);

--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -392,7 +392,7 @@ int sd::ops::DeclarableOp::prepareOutputs(Context &ctx) {
 
     if (!canUseFastPath) ctx.forbidFastPath(true);
 
-    //delete outSha;
+    delete outSha;
 
     // saving arrayTime
     if (Environment::getInstance().isProfiling() && node != nullptr) {
@@ -431,7 +431,7 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, sd::LongType *shape) 
     var->setNDArray(new NDArray(buffer, shapeInfo, block.launchContext()));
   } else if (var->getNDArray()->lengthOf() != len) {
     // if length not match - lets reallocate array
-   // delete var->getNDArray();
+    delete var->getNDArray();
     auto shapeInfo = ConstantShapeHelper::getInstance().bufferForShapeInfo(__shape)->primary();
     DataBuffer * buffer =
         new DataBuffer(len * sizeof(int8_t), ArrayOptions::dataType(shapeInfo), workspace);
@@ -468,7 +468,7 @@ bool sd::ops::DeclarableOp::allocateResult(Context &block, std::initializer_list
     var->setNDArray(new NDArray(order, shape2, block.dataType(), block.launchContext()));
   } else if (var->getNDArray()->lengthOf() != len) {
     // if length not match - lets reallocate array
-    //delete var->getNDArray();
+    delete var->getNDArray();
     var->setNDArray(new NDArray(order, shape2, block.dataType(), block.launchContext()));
   }
 
@@ -801,7 +801,7 @@ void DeclarableOp::overwriteResult(Context &block, int outputIdx, NDArray *array
       sd_debug("calling get variable\n", 0);
       auto var = varSpace->getVariable(block.getNodeId(), outputIdx);
       sd_debug("after calling get variable", 0);
-     // if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
+      if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
 
       var->setNDArray(array);
       var->markRemovable(true);
@@ -819,7 +819,7 @@ void DeclarableOp::overwriteResult(Context &block, int outputIdx, NDArray *array
   auto varSpace = block.getVariableSpace();
   if (varSpace->hasVariable(block.getNodeId(), outputIdx)) {
     auto var = varSpace->getVariable(block.getNodeId(), outputIdx);
-  //  if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
+    if (var->getNDArray() != nullptr && var->isRemovable()) delete var->getNDArray();
 
     var->setNDArray(array);
     var->markRemovable(true);

--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -83,9 +83,9 @@ DeclarableOp::DeclarableOp(int numInputs, int numOutputs, const char *opName, bo
 }
 
 DeclarableOp::~DeclarableOp() {
-  //if (_descriptor != nullptr) delete _descriptor;
+  if (_descriptor != nullptr) delete _descriptor;
 
- // if (_scalar != nullptr) delete _scalar;
+  if (_scalar != nullptr) delete _scalar;
 }
 
 OpDescriptor *DeclarableOp::getOpDescriptor() { return _descriptor; }
@@ -335,7 +335,7 @@ int sd::ops::DeclarableOp::prepareOutputs(Context &ctx) {
             auto aShape = ShapeUtils::shapeAsString(shape);
             auto eShapeInfoString = ShapeUtils::shapeInfoAsString(out);
             auto aShapeInfoString = ShapeUtils::shapeInfoAsString(shape);
-           // delete outSha;
+            delete outSha;
 
             sd_printf(
                 "OP PREPARE OUTPUTS: Op name: %s Failed to set output for op context. Expected vs provided shapes mismatch %s vs %s at index %i with expected shape info %s and output "

--- a/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
+++ b/libnd4j/include/ops/declarable/impl/DeclarableOp.cpp
@@ -376,7 +376,7 @@ int sd::ops::DeclarableOp::prepareOutputs(Context &ctx) {
             auto eShapeInfoString = ShapeUtils::shapeInfoAsString(out);
             auto aShapeInfoString = ShapeUtils::shapeInfoAsString(array->shapeInfo());
             if (eShapeInfoString != aShapeInfoString) {
-              //delete outSha;
+              delete outSha;
 
               sd_printf(
                   "OP PREPARE OUTPUTS: OP name: %s Expected vs provided shapes mismatch %s vs %s at index %i with expected shape info %s and output "

--- a/libnd4j/include/system/op_boilerplate.h
+++ b/libnd4j/include/system/op_boilerplate.h
@@ -2620,26 +2620,23 @@
 
 #else
 
-// we intentionally add 8 tail bytes here to avoid problems with atomic operations
-#define ALLOCATE_SPECIAL(VARIABLE, WORKSPACE, LENGTH, TT)                                                              \
-  if (WORKSPACE == nullptr) {                                                                                          \
-    cudaError_t prevError = cudaGetLastError();                                                                        \
-    auto erc_##VARIABLE = cudaMalloc(reinterpret_cast<void**>(&VARIABLE), LENGTH * sizeof(TT) + 8);                    \
-    cudaError_t newError = cudaGetLastError();                                                                         \
-    if (erc_##VARIABLE != 0 || newError != cudaSuccess) {                                                              \
-      const char* prevErrorString = cudaGetErrorString(prevError);                                                     \
-      const char* newErrorString = cudaGetErrorString(newError);                                                       \
-      std::string errorMessage = "[DEVICE] allocation failed. Previous error: " + std::string(prevErrorString) +      \
-                                 ", New error: " + std::string(newErrorString);                                       \
-      THROW_EXCEPTION(errorMessage.c_str());                                                           \
-    } else {                                                                                                           \
-      sd::memory::MemoryTracker::getInstance().countIn(sd::memory::MemoryType::DEVICE, VARIABLE, LENGTH * sizeof(TT)); \
-    };                                                                                                                 \
-  } else {                                                                                                             \
-    VARIABLE =                                                                                                         \
-        reinterpret_cast<TT*>(WORKSPACE->allocateBytes(sd::memory::MemoryType::DEVICE, LENGTH * sizeof(TT) + 8));      \
-  }
 
+// we intentionally add 8 tail bytes here to avoid problems with atomic operations
+#define ALLOCATE_SPECIAL(VARIABLE, WORKSPACE, LENGTH, TT)                                                             \
+  if (WORKSPACE == nullptr) {                                                                                         \
+                                                                                          \
+    /* Calculate allocation size */                                                                                   \
+    size_t allocSize = LENGTH * sizeof(TT);                                                                       \
+                                                                                                                      \
+    /* Allocation with proper error handling */                                                                       \
+    checkCudaErrors(cudaMalloc(reinterpret_cast<void**>(&VARIABLE), allocSize));                          \
+    sd::memory::MemoryTracker::getInstance().countIn(sd::memory::MemoryType::DEVICE, VARIABLE, allocSize);          \
+                                                                                                              \
+  } else {                                                                                                            \
+    /* Using workspace allocator */                                                                                   \
+    size_t allocSize = LENGTH * sizeof(TT) + 8;                                                                       \
+    VARIABLE = reinterpret_cast<TT*>(WORKSPACE->allocateBytes(sd::memory::MemoryType::DEVICE, allocSize));            \
+  }
 #define RELEASE_SPECIAL(VARIABLE, WORKSPACE)                                         \
   if (VARIABLE != nullptr) {                                                         \
     if (WORKSPACE == nullptr) {                                                      \

--- a/libnd4j/include/system/op_boilerplate.h
+++ b/libnd4j/include/system/op_boilerplate.h
@@ -2621,7 +2621,6 @@
 #else
 
 // we intentionally add 8 tail bytes here to avoid problems with atomic operations
-// we intentionally add 8 tail bytes here to avoid problems with atomic operations
 #define ALLOCATE_SPECIAL(VARIABLE, WORKSPACE, LENGTH, TT)                                                              \
   if (WORKSPACE == nullptr) {                                                                                          \
     cudaError_t prevError = cudaGetLastError();                                                                        \

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/functions/DifferentialFunction.java
@@ -31,11 +31,11 @@ import org.nd4j.common.util.StackTraceUtils;
 import org.nd4j.imports.converters.DifferentialFunctionClassHolder;
 import org.nd4j.imports.descriptors.properties.AttributeAdapter;
 import org.nd4j.imports.descriptors.properties.PropertyMapping;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.Op;
 import org.nd4j.linalg.api.ops.OpContext;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.shade.jackson.annotation.JsonIgnore;
@@ -901,13 +901,14 @@ public abstract class DifferentialFunction {
 
     /**
      * Calculate the output shape for this op
+     *
      * @return List of output shape descriptors
      */
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         throw new ND4JIllegalStateException("Op type of " + getClass().getName() + "did not override calculateOutputShape() method leaked out for [" + this.opName() + "]");
     }
 
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc){
+    public List<DataBuffer> calculateOutputShape(OpContext oc){
         throw new ND4JIllegalStateException("Op type of " + getClass().getName() + " did not override calculateOutputShape(OpContext) method leaked out for [" + this.opName() + "]");
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -1405,7 +1405,7 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                     //Always allocate new output array, rely on memory manager for efficient memory management and array reuse etc
                     boolean isOutput = allReqVariables.contains(outNames[i]);
                     reqShape = Nd4j.createBuffer(asJava);
-                    INDArray out = mmgr.allocateFromDescriptor(isOutput, reqShape);
+                    INDArray out = mmgr.allocateFromDescriptor(false, reqShape);
                     if(Shape.isEmpty(asJava) && !out.isEmpty()) {
                         throw new IllegalStateException("Output shape was empty, but created array was not.");
                     }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/InferenceSession.java
@@ -37,6 +37,7 @@ import org.nd4j.common.base.Preconditions;
 import org.nd4j.common.primitives.Pair;
 import org.nd4j.common.util.ArrayUtil;
 import org.nd4j.imports.VariableUtils;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.memory.MemoryWorkspace;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -1018,8 +1019,8 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
 
             Concat c = new Concat(0, l.stream().filter(input -> input != null).collect(Collectors.toList())
                     .toArray(new INDArray[0]));
-            List<LongShapeDescriptor> shape = c.calculateOutputShape();
-            INDArray out = mmgr.allocate(false, shape.get(0));
+            List<DataBuffer> shape = c.calculateOutputShape();
+            INDArray out = mmgr.allocateFromDescriptor(false, shape.get(0));
             c.setOutputArgument(0, out);
             Nd4j.exec(c);
             return ExecutionResult.createFrom(tArr.getVariable(),out);
@@ -1063,8 +1064,8 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
 
                 Stack s = new Stack(newList.stream().filter(input -> input != null).collect(Collectors.toList())
                         .toArray(new INDArray[0]), null, 0);
-                List<LongShapeDescriptor> shape = s.calculateOutputShape();
-                INDArray out = mmgr.allocate(false, shape.get(0));
+                List<DataBuffer> shape = s.calculateOutputShape();
+                INDArray out = mmgr.allocateFromDescriptor(false, shape.get(0));
                 s.setOutputArgument(0, out);
                 Nd4j.exec(s);
                 return ExecutionResult.createFrom(tArr.getVariable(),out);
@@ -1385,26 +1386,27 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                 oc.setOutputArray(0, oc.getInputArray(0));
 
             } else {
-                List<LongShapeDescriptor> outShape = customOp.calculateOutputShape(oc);
+                List<DataBuffer> outShape = customOp.calculateOutputShape(oc);
                 Preconditions.checkState(outShape != null && outShape.size() > 0, "Failed to calculate output shapes for op %s (%s) - no shapes were returned by calculateOutputShape()", customOp.opName(), customOp.getOwnName());
                 String[] outNames = df.outputVariablesNames();
                 Preconditions.checkState(outNames.length == outShape.size(), "Error in operation shape calculation for op \"%s\": Got %s op output shapes for an operation" +
                         " with %s outputs (number of shapes and outputs must be equal)", df.opName(), outShape.size(), outNames.length);
                 for (int i = 0; i < outShape.size(); i++) {
-                    LongShapeDescriptor reqShape = outShape.get(i);
-
+                    DataBuffer reqShape = outShape.get(i);
+                    long[] asJava = reqShape.asLong();;
                     //Issue: many ops have multiple valid output datatypes, and output shape calc can't at present know which: https://github.com/eclipse/deeplearning4j/issues/6872
                     //As a workaround, we'll use the output variable datatype instead.
                     DataType dt = sameDiff.getVariable(outNames[i]).dataType();
                     DataType currDT = reqShape.dataType();
                     if (dt != currDT) {
-                        reqShape = reqShape.asDataType(dt);
+                        Shape.setExtras(asJava,Shape.extras(asJava));
                     }
 
                     //Always allocate new output array, rely on memory manager for efficient memory management and array reuse etc
                     boolean isOutput = allReqVariables.contains(outNames[i]);
-                    INDArray out = mmgr.allocate(isOutput, reqShape);
-                    if(reqShape.isEmpty() && !out.isEmpty()) {
+                    reqShape = Nd4j.createBuffer(asJava);
+                    INDArray out = mmgr.allocateFromDescriptor(isOutput, reqShape);
+                    if(Shape.isEmpty(asJava) && !out.isEmpty()) {
                         throw new IllegalStateException("Output shape was empty, but created array was not.");
                     }
 
@@ -1463,10 +1465,10 @@ public class InferenceSession extends AbstractSession<INDArray, Pair<SameDiffOp,
                 INDArray z = mmgr.allocate(false, oc.getInputArray(0).dataType(), oc.getInputArray(0).shape());
                 oc.setOutputArray(0, z);
             } else {
-                List<LongShapeDescriptor> outputShape = ((BaseOp) op).calculateOutputShape(oc);
+                List<DataBuffer> outputShape = ((BaseOp) op).calculateOutputShape(oc);
                 Preconditions.checkState(outputShape != null && outputShape.size() == 1, "Could not calculate output shape for op: %s", op.getClass());
-                LongShapeDescriptor lsd = outputShape.get(0);
-                INDArray z = mmgr.allocate(isOutput, lsd);
+                DataBuffer lsd = outputShape.get(0);
+                INDArray z = mmgr.allocateFromDescriptor(isOutput, lsd);
                 oc.setOutputArray(0, z);
             }
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/SessionMemMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/SessionMemMgr.java
@@ -20,6 +20,7 @@
 
 package org.nd4j.autodiff.samediff.internal;
 
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -69,4 +70,5 @@ public interface SessionMemMgr extends Closeable {
      */
     void close();
 
+    INDArray allocateFromDescriptor(boolean detached, DataBuffer dataBuffer);
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/NoOpMemoryMgr.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/samediff/internal/memory/NoOpMemoryMgr.java
@@ -22,6 +22,7 @@ package org.nd4j.autodiff.samediff.internal.memory;
 
 import lombok.NonNull;
 import org.nd4j.autodiff.samediff.internal.SessionMemMgr;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -47,6 +48,11 @@ public class NoOpMemoryMgr extends AbstractMemoryMgr implements SessionMemMgr {
     @Override
     public void close() {
         //No-op
+    }
+
+    @Override
+    public INDArray allocateFromDescriptor(boolean detached, DataBuffer dataBuffer) {
+       return Nd4j.createFromDescriptor(dataBuffer);
     }
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/validation/OpValidation.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/autodiff/validation/OpValidation.java
@@ -21,6 +21,7 @@
 package org.nd4j.autodiff.validation;
 
 import org.nd4j.common.config.ND4JClassLoading;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ops.custom.*;
 import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMax;
 import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMin;
@@ -383,7 +384,7 @@ public class OpValidation {
         collectCoverageInformation(testCase);
 
         //Check shape function:
-        List<LongShapeDescriptor> outShapes;
+        List<DataBuffer> outShapes;
         try {
             outShapes = Nd4j.getExecutioner().calculateOutputShape(testCase.op());
         } catch (Throwable t) {
@@ -401,7 +402,12 @@ public class OpValidation {
             if(!Objects.equals(exp.dataType(), act.dataType())) {
                 return "Shape function check failed for output " + i + ": expected shape " + exp + ", actual shape " + act;
             }
-            if(!Arrays.equals(act.getShape(), exp.getShape())){
+            long[] shapeInfo = act.asLong();
+            long[] actShape = new long[(int) shapeInfo[0]];
+            for(int j = 1; j < shapeInfo.length; j++) {
+                actShape[j - 1] = shapeInfo[j];
+            }
+            if(!Arrays.equals(actShape, exp.getShape())) {
                 return "Shape function check failed for output " + i + ": expected shape " + exp + ", actual shape " + act;
             }
         }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -6022,7 +6022,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     @Override
     public boolean isEmpty() {
-        return data() == null  || data.length() < 1|| Shape.isEmpty(jvmShapeInfo.javaShapeInformation);
+        return Shape.isEmpty(jvmShapeInfo.javaShapeInformation);
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseNDArray.java
@@ -136,7 +136,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .build();
 
 
-        Pair<DataBuffer, long[]> shapeInformation = getShapeInfoProvider().createShapeInformation(longShapeDescriptor);
+        Pair<DataBuffer, long[]> shapeInformation = getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo());
         setShapeInformation(shapeInformation);
 
         this.offset = offset;
@@ -161,7 +161,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
 
     // this field holds jvm copy of shapeInfo
     protected transient JvmShapeInfo jvmShapeInfo;
-    private DataBuffer shapeInfoDataBuffer;
+    protected DataBuffer shapeInfoDataBuffer;
 
 
     private static final AtomicLong arrayCounter = new AtomicLong(0);
@@ -269,7 +269,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .build();
 
 
-        Pair<DataBuffer, long[]> shapeInformation = getShapeInfoProvider().createShapeInformation(longShapeDescriptor);
+        Pair<DataBuffer, long[]> shapeInformation = getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo());
         setShapeInformation(shapeInformation);
         init(shape, stride);
         logCreationFromConstructor();
@@ -279,6 +279,9 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     public BaseNDArray(DataType dataType, long[] shape, long[] strides, MemoryWorkspace currentWorkspace) {
         this(Nd4j.createBuffer(dataType, ArrayUtil.prodLong(shape), false, currentWorkspace), shape, strides, 0, Nd4j.order());
     }
+
+
+
 
 
     public BaseNDArray(LongShapeDescriptor descriptor) {
@@ -296,7 +299,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
         this.data = buffer;
         if (buffer.length() >= Integer.MAX_VALUE)
             throw new IllegalArgumentException("Length of buffer can not be >= Integer.MAX_VALUE");
-        Pair<DataBuffer, long[]> shapeInformation = getShapeInfoProvider().createShapeInformation(longShapeDescriptor);
+        Pair<DataBuffer, long[]> shapeInformation = getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo());
         setShapeInformation(shapeInformation);
         init(longShapeDescriptor.getShape(),longShapeDescriptor.getStride());
         this.offset = longShapeDescriptor.getOffset();
@@ -322,7 +325,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .ews(1)
                 .build();
 
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         init(shape, stride);
     }
 
@@ -363,7 +366,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .offset(offset)
                 .build();
 
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         init(shape, stride);
         logCreationFromConstructor();
     }
@@ -426,7 +429,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 ))
                 .build();
 
-        setShapeInformation(getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         init(shape, stride);
         this.offset = offset;
         logCreationFromConstructor();
@@ -573,7 +576,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                     .build();
 
 
-            setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+            setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
 
             logCreationFromConstructor();
         } catch (Exception e) {
@@ -641,7 +644,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .ews(Shape.elementWiseStride(shape, stride, ordering == 'f'))
                 .extras(ArrayOptionsHelper.composeTypicalChecks(Nd4j.dataType()))
                 .build();
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         init(shape, stride);
         logCreationFromConstructor();
 
@@ -659,7 +662,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .ews(Shape.elementWiseStride(shape, stride, ordering == 'f'))
                 .extras(ArrayOptionsHelper.composeTypicalChecks(Nd4j.dataType()))
                 .build();
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         init(shape, stride);
         logCreationFromConstructor();
 
@@ -736,7 +739,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                         false
                 ))
                 .build();
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         init(shape, stride);
 
         if (slices.get(0).isScalar()) {
@@ -791,7 +794,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .build();
 
         this.offset = offset;
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         if (data != null && data.length > 0) {
 
             val perfD = PerformanceTracker.getInstance().helperStartTransaction();
@@ -829,7 +832,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 ))
                 .build();
 
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         if (data != null && data.length > 0) {
             this.data = Nd4j.createTypedBuffer(data, DataType.FLOAT);
             if (offset >= data.length)
@@ -860,7 +863,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                         false
                 ))
                 .build();
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         if (data != null && data.length > 0) {
             this.data = Nd4j.createBuffer(data);
             if (offset >= data.length)
@@ -898,7 +901,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                         false
                 ))
                 .build();
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(longShapeDescriptor.toShapeInfo()));
         init(shape, stride);
         logCreationFromConstructor();
 
@@ -1408,7 +1411,7 @@ public abstract class BaseNDArray implements INDArray, Iterable {
     @Override
     public void setOrder(char order) {
         LongShapeDescriptor descriptor = LongShapeDescriptor.fromShape(shape(), stride(), elementWiseStride(), order, this.dataType(), isEmpty());
-        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(descriptor));
+        setShapeInformation(Nd4j.getShapeInfoProvider().createShapeInformation(descriptor.toShapeInfo()));
     }
 
     @Override
@@ -4005,8 +4008,8 @@ public abstract class BaseNDArray implements INDArray, Iterable {
                 .build();
         op.addIArgument(dimension); //Native op: last iarg is dimension
 
-        LongShapeDescriptor l = op.calculateOutputShape().get(0);
-        INDArray out = Nd4j.create(l);
+        DataBuffer l = op.calculateOutputShape().get(0);
+        INDArray out = Nd4j.createFromDescriptor(l);
         op.addOutputArgument(out);
         Nd4j.exec(op);
         return out;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/BaseShapeInfoProvider.java
@@ -36,9 +36,8 @@ public abstract class BaseShapeInfoProvider implements ShapeInfoProvider {
     protected AtomicLong bytes = new AtomicLong(0);
 
     @Override
-    public Pair<DataBuffer, long[]> createShapeInformation(LongShapeDescriptor descriptor) {
-        return Pair.of(Shape
-                .createShapeInformation(descriptor), descriptor.toShapeInfo());
+    public Pair<DataBuffer, long[]> createShapeInformation(long[] shapeInfo) {
+        return Pair.of(Nd4j.createBuffer(shapeInfo),shapeInfo);
     }
 
     /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/ShapeInfoProvider.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ndarray/ShapeInfoProvider.java
@@ -28,7 +28,6 @@ import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 public interface ShapeInfoProvider {
 
 
-    Pair<DataBuffer,long[]> createShapeInformation(LongShapeDescriptor descriptor);
     /**
      * This method creates long shapeInformation buffer, based on shape being passed in
      * @param shape
@@ -64,5 +63,7 @@ public interface ShapeInfoProvider {
      * @return
      */
     long getCachedBytes();
+
+    Pair<DataBuffer,long[]> createShapeInformation(long[] shapeInfo);
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseBroadcastBoolOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseBroadcastBoolOp.java
@@ -28,11 +28,13 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.util.SameDiffUtils;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Broadcast;
+import org.nd4j.linalg.factory.Nd4j;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
 import org.tensorflow.framework.NodeDef;
@@ -148,14 +150,14 @@ public abstract class BaseBroadcastBoolOp extends BaseOp implements BroadcastOp 
      *
      * @return
      */
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         if(x == null || y == null)
             return Collections.emptyList();
 
         long[] shapeX = x.shape();
         long[] shapeY = y.shape();
 
-        return Collections.singletonList(LongShapeDescriptor.fromShape(Shape.broadcastOutputShape(shapeX, shapeY), DataType.BOOL));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(Shape.broadcastOutputShape(shapeX, shapeY), DataType.BOOL).toShapeInfo()));
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseBroadcastOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseBroadcastOp.java
@@ -28,11 +28,12 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.util.SameDiffUtils;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
-import org.nd4j.linalg.factory.Broadcast;
+import org.nd4j.linalg.factory.Nd4j;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
 import org.tensorflow.framework.NodeDef;
@@ -147,15 +148,17 @@ public abstract class BaseBroadcastOp extends BaseOp implements BroadcastOp {
      *
      * @return
      */
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         if(x == null || y == null)
             return Collections.emptyList();
 
         long[] shapeX = x.shape();
         long[] shapeY = y.shape();
 
-        return Collections.singletonList(LongShapeDescriptor.fromShape(Shape.broadcastOutputShape(shapeX, shapeY),
-                Shape.pickPairwiseDataType(x.dataType(), y.dataType())));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor
+                .fromShape(Shape.broadcastOutputShape(shapeX, shapeY),
+                Shape.pickPairwiseDataType(x.dataType(), y.dataType()))
+                .toShapeInfo()));
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseIndexAccumulation.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseIndexAccumulation.java
@@ -26,10 +26,12 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.util.SameDiffUtils;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collections;
 import java.util.List;
@@ -97,19 +99,19 @@ public abstract class BaseIndexAccumulation extends BaseOp implements IndexAccum
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
         if(x == null)
             return Collections.emptyList();
 
 
         long[] reducedShape = Shape.getReducedShape(x.shape(), dimensions, keepDims);
-        return Collections.singletonList(LongShapeDescriptor.fromShape(reducedShape, DataType.INT64));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(reducedShape, DataType.INT64).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceBoolOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceBoolOp.java
@@ -23,10 +23,12 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collections;
 import java.util.List;
@@ -137,23 +139,23 @@ public abstract class BaseReduceBoolOp extends BaseReduceOp implements ReduceBoo
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
         if(x == null)
             return Collections.emptyList();
 
         //Calculate reduction shape. Note that reduction on scalar - returns a scalar
         long[] reducedShape = x.rank() == 0 ? x.shape() : Shape.getReducedShape(x.shape(),dimensions, isKeepDims());
-        return Collections.singletonList(LongShapeDescriptor.fromShape(reducedShape, DataType.BOOL));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(reducedShape, DataType.BOOL).toShapeInfo()));
     }
 
     @Override
-    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes){
+    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes) {
         //All reduce bool: always bool output type. 2nd input is axis arg
         Preconditions.checkState(dataTypes != null && (dataTypes.size() == 1 || dataTypes.size() == 2),
                 "Expected 1 or input datatype for %s, got input %s", getClass(), dataTypes);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceFloatOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceFloatOp.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -141,12 +142,12 @@ public abstract class BaseReduceFloatOp extends BaseReduceOp implements ReduceFl
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
 
         if(x == null)
@@ -157,7 +158,7 @@ public abstract class BaseReduceFloatOp extends BaseReduceOp implements ReduceFl
         DataType retType = arg().dataType();
         if(!retType.isFPType())
             retType = Nd4j.defaultFloatingPointType();
-        return Collections.singletonList(LongShapeDescriptor.fromShape(reducedShape, retType));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(reducedShape, retType).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceLongOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceLongOp.java
@@ -23,10 +23,12 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collections;
 import java.util.List;
@@ -132,19 +134,19 @@ public abstract class BaseReduceLongOp extends BaseReduceOp implements ReduceLon
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
         if(x == null)
             return Collections.emptyList();
 
         //Calculate reduction shape. Note that reduction on scalar - returns a scalar
         long[] reducedShape = x.rank() == 0 ? x.shape() : Shape.getReducedShape(x.shape(),dimensions, isKeepDims());
-        return Collections.singletonList(LongShapeDescriptor.fromShape(reducedShape, DataType.LONG));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(reducedShape, DataType.LONG).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceOp.java
@@ -28,8 +28,8 @@ import onnx.Onnx;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.util.SameDiffUtils;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.common.util.ArrayUtil;
 import org.tensorflow.framework.AttrValue;
@@ -240,7 +240,7 @@ public abstract class BaseReduceOp extends BaseOp implements ReduceOp {
     }
 
 
-    public abstract List<LongShapeDescriptor> calculateOutputShape();
+    public abstract List<DataBuffer> calculateOutputShape();
 
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceSameOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseReduceSameOp.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -145,12 +146,12 @@ public abstract class BaseReduceSameOp extends BaseReduceOp implements ReduceSam
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
 
         if(x == null)
@@ -159,7 +160,7 @@ public abstract class BaseReduceSameOp extends BaseReduceOp implements ReduceSam
         //Calculate reduction shape. Note that reduction on scalar - returns a scalar
         long[] reducedShape =  Shape.getReducedShape(x.shape(),dimensions, isKeepDims());
         DataType rt = oc != null ? resultType(oc) : resultType();
-        return Collections.singletonList(LongShapeDescriptor.fromShape(reducedShape, rt));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(reducedShape, rt).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseScalarBoolOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseScalarBoolOp.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.util.SameDiffUtils;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -97,19 +98,19 @@ public abstract class BaseScalarBoolOp extends BaseOp implements ScalarOp {
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
         if(x == null)
             return Collections.emptyList();
         LongShapeDescriptor desc = x.isEmpty() ? LongShapeDescriptor.emptyWithShape(x.shape(),x.dataType()) :
                 LongShapeDescriptor.fromShape(x.shape(), DataType.BOOL);
         //Calculate reduction shape. Note that reduction on scalar - returns a scalar
-        return Collections.singletonList(desc);
+        return Collections.singletonList(Nd4j.createBuffer(desc.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseScalarOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseScalarOp.java
@@ -27,6 +27,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.util.SameDiffUtils;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -111,15 +112,15 @@ public abstract class BaseScalarOp extends BaseOp implements ScalarOp {
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
 
-        val ret = new ArrayList<LongShapeDescriptor>(1);
+        val ret = new ArrayList<DataBuffer>(1);
 
         long[] s;
         if(x != null) {
@@ -133,7 +134,7 @@ public abstract class BaseScalarOp extends BaseOp implements ScalarOp {
 
         LongShapeDescriptor desc = x.isEmpty() ? LongShapeDescriptor.fromShape(x.shape(),Shape.pickPairwiseDataType(aT, sT)) :
                 LongShapeDescriptor.fromShape(s, Shape.pickPairwiseDataType(aT, sT));
-        ret.add(desc);
+        ret.add(Nd4j.createBuffer(desc.toShapeInfo()));
         return ret;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformAnyOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformAnyOp.java
@@ -23,9 +23,11 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collections;
 import java.util.List;
@@ -103,10 +105,10 @@ public abstract class BaseTransformAnyOp extends BaseTransformOp implements Tran
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         if(x == null)
             return Collections.emptyList();
-        return Collections.singletonList(LongShapeDescriptor.fromShape(x.shape(), x.dataType()));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(x.shape(), x.dataType()).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformBoolOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformBoolOp.java
@@ -23,9 +23,11 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collections;
 import java.util.List;
@@ -113,12 +115,12 @@ public abstract class BaseTransformBoolOp extends BaseTransformOp implements Tra
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
         if(x == null)
             return Collections.emptyList();
@@ -126,11 +128,11 @@ public abstract class BaseTransformBoolOp extends BaseTransformOp implements Tra
         LongShapeDescriptor desc = x.isEmpty() ? LongShapeDescriptor.emptyWithShape(x.shape(),DataType.BOOL) :
                 LongShapeDescriptor.fromShape(x.shape(), DataType.BOOL);
         //Calculate reduction shape. Note that reduction on scalar - returns a scalar
-        return Collections.singletonList(desc);
+        return Collections.singletonList(Nd4j.createBuffer(desc.toShapeInfo()));
     }
 
     @Override
-    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes){
+    public List<DataType> calculateOutputDataTypes(List<DataType> dataTypes) {
         //All bool tranform ops: always bool output type
         SDVariable[] args = args();
         Preconditions.checkState(dataTypes != null && dataTypes.size() == args.length, "Expected exactly %s input datatype(s) for %s, got input %s", args.length, getClass(), dataTypes);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformFloatOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformFloatOp.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -101,22 +102,22 @@ public abstract class BaseTransformFloatOp extends BaseTransformOp implements Tr
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
         if(x == null)
             return Collections.emptyList();
         if(x.isEmpty()) {
-            List<LongShapeDescriptor> ret = new ArrayList<>();
+            List<DataBuffer> ret = new ArrayList<>();
             LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.emptyWithShape(x.shape(),x.dataType());
-            ret.add(longShapeDescriptor);
+            ret.add(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
             return ret;
         }
-        return Collections.singletonList(LongShapeDescriptor.fromShape(x.shape(), x.isR() ? x.dataType() : Nd4j.defaultFloatingPointType()));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(x.shape(), x.isR() ? x.dataType() : Nd4j.defaultFloatingPointType()).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformOp.java
@@ -24,9 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.util.SameDiffUtils;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
-import org.nd4j.linalg.util.LinAlgExceptions;
 
 import java.util.List;
 
@@ -136,7 +135,7 @@ public abstract class BaseTransformOp extends BaseOp implements TransformOp {
         super(x);
     }
 
-    public abstract List<LongShapeDescriptor> calculateOutputShape();
+    public abstract List<DataBuffer> calculateOutputShape();
 
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformSameOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformSameOp.java
@@ -23,9 +23,11 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -117,20 +119,20 @@ public abstract class BaseTransformSameOp extends BaseTransformOp implements Tra
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
         if(x == null)
             return Collections.emptyList();
         if(x.isEmpty()) {
             LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.emptyWithShape(x.shape(),x.dataType());
-            return Collections.singletonList(longShapeDescriptor);
+            return Collections.singletonList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
         }
-        return Collections.singletonList(LongShapeDescriptor.fromShape(x.shape(), x.dataType()));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(x.shape(), x.dataType()).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformStrictOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/BaseTransformStrictOp.java
@@ -23,9 +23,11 @@ package org.nd4j.linalg.api.ops;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collections;
 import java.util.List;
@@ -108,17 +110,17 @@ public abstract class BaseTransformStrictOp extends BaseTransformOp implements T
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         if(x == null)
             return Collections.emptyList();
-        return Collections.singletonList(LongShapeDescriptor.fromShape(x.shape(), x.dataType()));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(x.shape(), x.dataType()).toShapeInfo()));
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         if(oc.getInputArray(0) == null)
             return Collections.emptyList();
-        return Collections.singletonList(LongShapeDescriptor.fromShape(oc.getInputArray(0).shape(), oc.getInputArray(0).dataType()));
+        return Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(oc.getInputArray(0).shape(), oc.getInputArray(0).dataType()).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/CustomOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/CustomOp.java
@@ -21,7 +21,7 @@
 package org.nd4j.linalg.api.ops;
 
 import lombok.val;
-import org.jetbrains.annotations.NotNull;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
@@ -129,15 +129,17 @@ public interface CustomOp  {
 
  /**
   * Calculate the output shape for this op
+  *
   * @return Output array shapes
   */
- List<LongShapeDescriptor> calculateOutputShape();
+ List<DataBuffer> calculateOutputShape();
 
  /**
   * Calculate the output shape for this op
+  *
   * @return Output array shapes
   */
- List<LongShapeDescriptor> calculateOutputShape(OpContext opContext);
+ List<DataBuffer> calculateOutputShape(OpContext opContext);
 
  /**
   * Get the custom op descriptor if one is available.
@@ -207,8 +209,8 @@ public interface CustomOp  {
     if (list.isEmpty())
      throw new ND4JIllegalStateException("Op name " + opName() + " failed to calculate output shape and data types.");
 
-    for (LongShapeDescriptor shape : list) {
-     INDArray newOut = Nd4j.create(shape, false);
+    for (DataBuffer shape : list) {
+     INDArray newOut = Nd4j.createFromDescriptor(shape);
      addOutputArgument(newOut);
     }
     shapeOverride = true;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/NoOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/NoOp.java
@@ -23,9 +23,9 @@ package org.nd4j.linalg.api.ops;
 import onnx.Onnx;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.factory.Nd4j;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
@@ -96,19 +96,19 @@ public class NoOp extends DynamicCustomOp {
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         if(inputArguments != null && !inputArguments.isEmpty()){
-            return Collections.singletonList(inputArguments.get(0).shapeDescriptor());
+            return Collections.singletonList(inputArguments.get(0).shapeInfoDataBuffer());
         }
-        return Collections.singletonList(Nd4j.empty(DataType.BOOL).shapeDescriptor());
+        return Collections.singletonList(Nd4j.empty(DataType.BOOL).shapeInfoDataBuffer());
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc){
+    public List<DataBuffer> calculateOutputShape(OpContext oc){
         if(oc.getInputArrays() != null && !oc.getInputArrays().isEmpty()){
-            return Collections.singletonList(oc.getInputArray(0).shapeDescriptor());
+            return Collections.singletonList(oc.getInputArray(0).shapeInfoDataBuffer());
         }
-        return Collections.singletonList(Nd4j.empty(DataType.BOOL).shapeDescriptor());
+        return Collections.singletonList(Nd4j.empty(DataType.BOOL).shapeInfoDataBuffer());
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/UserDefinedCustomOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/UserDefinedCustomOp.java
@@ -21,11 +21,10 @@ package org.nd4j.linalg.api.ops;
 
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
@@ -155,10 +154,10 @@ public abstract class UserDefinedCustomOp extends DynamicCustomOp {
     @Override
     public abstract boolean isInplaceCall();
     @Override
-    public abstract List<LongShapeDescriptor> calculateOutputShape();
+    public abstract List<DataBuffer> calculateOutputShape();
 
     @Override
-    public abstract List<LongShapeDescriptor> calculateOutputShape(OpContext oc);
+    public abstract List<DataBuffer> calculateOutputShape(OpContext oc);
     @Override
     public abstract  List<SDVariable> doDiff(List<SDVariable> f1);
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/compat/CompatSparseToDense.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/compat/CompatSparseToDense.java
@@ -23,11 +23,13 @@ package org.nd4j.linalg.api.ops.compat;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
 import java.util.List;
@@ -60,8 +62,8 @@ public class CompatSparseToDense extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
-        return Arrays.asList(LongShapeDescriptor.fromShape(oc.getInputArrays().get(1).toLongVector(),oc.getInputArrays().get(0).dataType()));
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
+        return Arrays.asList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(oc.getInputArrays().get(1).toLongVector(),oc.getInputArrays().get(0).dataType()).toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Invoke.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/custom/Invoke.java
@@ -29,9 +29,7 @@ import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.samediff.VariableType;
 import org.nd4j.autodiff.samediff.config.ExecutionResult;
 import org.nd4j.autodiff.samediff.config.SDValue;
-import org.nd4j.autodiff.samediff.config.SDValueType;
-import org.nd4j.autodiff.samediff.internal.AbstractSession;
-import org.nd4j.autodiff.samediff.internal.InferenceSession;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
@@ -282,21 +280,21 @@ public class Invoke extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return Collections.emptyList();
     }
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         /**
          * TODO: Figure out how to invoke calculate output shape
          * for a graph. This may involve adding a new function
          * to a samediff graph that just calls compute shape for everything.
          */
-        List<LongShapeDescriptor> ret = new ArrayList<>();
+        List<DataBuffer> ret = new ArrayList<>();
         for(int i = 0; i < getNumOutputs(); i++) {
-            ret.add(LongShapeDescriptor.fromShape(new int[]{1},DataType.DOUBLE));
+            ret.add(Nd4j.createBuffer(LongShapeDescriptor.fromShape(new int[]{1},DataType.DOUBLE).toShapeInfo()));
         }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
@@ -1132,7 +1132,8 @@ public abstract class DefaultOpExecutioner implements OpExecutioner {
 
     protected DataBuffer getShapeFromPointer(CustomOp op,OpContext ctx,LongPointer ptr) {
         val rank = (int) ptr.get(0);
-        return Nd4j.createBuffer(ptr,Shape.shapeInfoLength(rank),DataType.INT64);
+        int len = Shape.shapeInfoLength(rank);
+        return Nd4j.createBuffer(ptr.capacity(len),Shape.shapeInfoLength(rank),DataType.INT64);
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/DefaultOpExecutioner.java
@@ -44,7 +44,6 @@ import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.api.shape.TadPack;
-import org.nd4j.linalg.api.shape.options.ArrayOptionsHelper;
 import org.nd4j.linalg.cache.TADManager;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
@@ -892,11 +891,11 @@ public abstract class DefaultOpExecutioner implements OpExecutioner {
 
 
     @Override
-    public INDArray[] allocateOutputArrays(CustomOp op){
-        List<LongShapeDescriptor> shapes = calculateOutputShape(op);
+    public INDArray[] allocateOutputArrays(CustomOp op) {
+        List<DataBuffer> shapes = calculateOutputShape(op);
         INDArray[] out = new INDArray[shapes.size()];
         for(int i = 0; i < shapes.size(); i++) {
-            out[i] = Nd4j.create(shapes.get(i));
+            out[i] = Nd4j.createFromDescriptor(shapes.get(i));
         }
         return out;
     }
@@ -1075,7 +1074,7 @@ public abstract class DefaultOpExecutioner implements OpExecutioner {
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(@NonNull CustomOp op) {
+    public List<DataBuffer> calculateOutputShape(@NonNull CustomOp op) {
         try(OpContext ctx = buildContext()) {
             op.setupOpContextFromCustomOp(ctx);
             return calculateOutputShape(op, ctx);
@@ -1085,9 +1084,9 @@ public abstract class DefaultOpExecutioner implements OpExecutioner {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(@NonNull CustomOp op, OpContext opContext) {
+    public List<DataBuffer> calculateOutputShape(@NonNull CustomOp op, OpContext opContext) {
         val hash = op.opHash();
-        val result = new ArrayList<LongShapeDescriptor>();
+        val result = new ArrayList<DataBuffer>();
 
         OpaqueShapeList ptrptr;
         ptrptr = Nd4j.getNativeOps().calculateOutputShapes2(null, hash, opContext.contextPointer());
@@ -1131,42 +1130,9 @@ public abstract class DefaultOpExecutioner implements OpExecutioner {
         return result;
     }
 
-    protected LongShapeDescriptor getShapeFromPointer(CustomOp op,OpContext ctx,LongPointer ptr) {
+    protected DataBuffer getShapeFromPointer(CustomOp op,OpContext ctx,LongPointer ptr) {
         val rank = (int) ptr.get(0);
-
-        val shape = new long[rank * 2 + 4];
-        for (int i = 0; i < shape.length; i++) {
-            shape[i] = ptr.get(i);
-        }
-
-        LongShapeDescriptor ret = LongShapeDescriptor.builder()
-                .shape(Shape.shape(shape))
-                .stride(Shape.stride(shape))
-                .order(Shape.order(shape))
-                .ews(Shape.elementWiseStride(shape))
-                .extras(Shape.extras(shape))
-                .offset(offsetForDescriptor(op,ctx,Shape.extras(shape)))
-                .build();
-        return ret;
-    }
-
-    private static long offsetForDescriptor(CustomOp op,OpContext ctx,long flags) {
-       for(int i = 0; i < ArrayOptionsHelper.ARRAY_COPY_OFFSET_INDEXES.length; i++) {
-           if(ArrayOptionsHelper.hasBitSet(flags,ArrayOptionsHelper.ARRAY_COPY_OFFSET_INDEXES[i])) {
-               return offsetAtIndex(op,ctx,i);
-           }
-       }
-
-        return 0;
-
-    }
-
-    private static long offsetAtIndex(CustomOp op, OpContext ctx,int idx) {
-        if(ctx != null) {
-            return ctx.getInputArray(idx).offset();
-        } else {
-            return op.getInputArgument(idx).offset();
-        }
+        return Nd4j.createBuffer(ptr,Shape.shapeInfoLength(rank),DataType.INT64);
     }
 
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/executioner/OpExecutioner.java
@@ -20,17 +20,14 @@
 
 package org.nd4j.linalg.api.ops.executioner;
 
-import lombok.NonNull;
 import org.bytedeco.javacpp.Pointer;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ndarray.INDArrayStatistics;
 import org.nd4j.linalg.api.ops.*;
-import org.nd4j.linalg.api.ops.impl.scatter.ScatterUpdate;
 import org.nd4j.linalg.api.ops.impl.summarystats.Variance;
 import org.nd4j.linalg.api.rng.Random;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.TadPack;
 import org.nd4j.linalg.cache.TADManager;
 import org.nd4j.linalg.factory.Environment;
@@ -313,9 +310,9 @@ public interface OpExecutioner {
      */
     INDArray[] exec(CustomOp op, OpContext context);
 
-    List<LongShapeDescriptor> calculateOutputShape(CustomOp op);
+    List<DataBuffer> calculateOutputShape(CustomOp op);
 
-    List<LongShapeDescriptor> calculateOutputShape(CustomOp op, OpContext opContext);
+    List<DataBuffer> calculateOutputShape(CustomOp op, OpContext opContext);
 
     /**
      * Equivalent to calli

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/controlflow/compat/BaseCompatOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/controlflow/compat/BaseCompatOp.java
@@ -29,9 +29,9 @@ import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.NoOpNameFoundException;
 import org.nd4j.imports.descriptors.properties.AttributeAdapter;
 import org.nd4j.imports.descriptors.properties.PropertyMapping;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.factory.Nd4j;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
@@ -164,7 +164,7 @@ public abstract class BaseCompatOp extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         throw new UnsupportedOperationException("calculateOutputShape() is not supported for control flow ops.");
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/ExternalErrorsFunction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/layers/ExternalErrorsFunction.java
@@ -26,6 +26,7 @@ import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.samediff.VariableType;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
@@ -42,7 +43,7 @@ import java.util.*;
 public class ExternalErrorsFunction extends DynamicCustomOp {
     public static final String OP_NAME = "ExternalErrorsFn";
 
-    private static final List<LongShapeDescriptor> OUT_SHAPE = Collections.singletonList(LongShapeDescriptor.fromShape(new long[0], Nd4j.dataType()));
+    private static final List<DataBuffer> OUT_SHAPE = Collections.singletonList(Nd4j.createBuffer(LongShapeDescriptor.fromShape(new long[0], Nd4j.dataType()).toShapeInfo()));
 
     private Map<String,INDArray> gradients;
     private Map<String,SDVariable> gradVariables;
@@ -203,12 +204,12 @@ public class ExternalErrorsFunction extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(){
+    public List<DataBuffer> calculateOutputShape(){
         return OUT_SHAPE;
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc){
+    public List<DataBuffer> calculateOutputShape(OpContext oc){
         return OUT_SHAPE;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/custom/BaseDynamicCustomIndexReduction.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/reduce/custom/BaseDynamicCustomIndexReduction.java
@@ -22,9 +22,9 @@ package org.nd4j.linalg.api.ops.impl.reduce.custom;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -155,7 +155,7 @@ public abstract class BaseDynamicCustomIndexReduction extends BaseDynamicCustomR
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
@@ -169,7 +169,7 @@ public abstract class BaseDynamicCustomIndexReduction extends BaseDynamicCustomR
                 "Expected 1 or input datatype for %s, got input %s", getClass(), dataTypes);
         Preconditions.checkState(dataTypes.size() == 1 || dataTypes.get(1).isIntType(), "When executing reductions" +
                 "with 2 inputs, second input (axis) must be an integer datatype for %s, got %s", getClass(), dataTypes);
-        return Collections.singletonList(DataType.LONG);
+        return Collections.singletonList(DataType.INT64);
     }
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Eye.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/Eye.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.api.ops.impl.shape;
 import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
@@ -131,11 +132,8 @@ public class Eye extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(){
-        List<LongShapeDescriptor> l = super.calculateOutputShape();
-        if(dataType != null && l != null && l.size() > 0){
-            l.set(0, l.get(0).asDataType(dataType));
-        }
+    public List<DataBuffer> calculateOutputShape() {
+        List<DataBuffer> l = super.calculateOutputShape();
         return l;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/ReshapeNoCopy.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/ReshapeNoCopy.java
@@ -22,6 +22,7 @@ package org.nd4j.linalg.api.ops.impl.shape;
 import lombok.val;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
@@ -101,13 +102,13 @@ public class ReshapeNoCopy extends DynamicCustomOp {
                 if (list.isEmpty())
                     throw new ND4JIllegalStateException("Op name " + opName() + " failed to calculate output shape and data types.");
 
-                LongShapeDescriptor needsCopyShape = list.get(0);
-                if(ArrayOptionsHelper.arrayNeedsCopy(needsCopyShape.getExtras())) {
-                    INDArray newOut = Nd4j.create(needsCopyShape, false);
+                DataBuffer needsCopyShape = list.get(0);
+                if(ArrayOptionsHelper.arrayNeedsCopy(needsCopyShape.asLong())) {
+                    INDArray newOut = Nd4j.createFromDescriptor(needsCopyShape);
                     addOutputArgument(newOut);
                 } else {
 
-                    INDArray newOut = Nd4j.create(inputArguments.get(0).data(),needsCopyShape);
+                    INDArray newOut = Nd4j.createFromDescriptor(inputArguments.get(0).data(),needsCopyShape);
                     addOutputArgument(newOut);
                 }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/tensorops/BaseTensorOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/shape/tensorops/BaseTensorOp.java
@@ -20,13 +20,12 @@
 
 package org.nd4j.linalg.api.ops.impl.shape.tensorops;
 
-import lombok.val;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.Op;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.factory.Nd4j;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
@@ -73,7 +72,7 @@ public abstract class BaseTensorOp extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         throw new UnsupportedOperationException("calculateOutputShape() is not supported for tensor ops.");
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/summarystats/StandardDeviation.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/summarystats/StandardDeviation.java
@@ -24,12 +24,14 @@ import lombok.val;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.reduce.bp.StandardDeviationBp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -349,7 +351,7 @@ public class StandardDeviation extends Variance {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         if(args().length < 1) {
             throw new ND4JIllegalStateException("Unable to compute input shape. No arguments found.");
         }
@@ -360,9 +362,9 @@ public class StandardDeviation extends Variance {
         }
         long[] inputShape = (argShape == null || Shape.isPlaceholderShape(argShape) ? x().shape() : argShape);
 
-        val ret = new ArrayList<LongShapeDescriptor>(1);
+        val ret = new ArrayList<DataBuffer>(1);
         val reducedShape = Shape.getReducedShape(inputShape,dimensions, isKeepDims());
-        ret.add(LongShapeDescriptor.fromShape(reducedShape, resultType()));
+        ret.add(Nd4j.createBuffer(LongShapeDescriptor.fromShape(reducedShape, resultType()).toShapeInfo()));
         return ret;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/summarystats/Variance.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/summarystats/Variance.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseReduceOp;
@@ -449,12 +450,12 @@ public class Variance extends BaseReduceOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray x = oc != null ? oc.getInputArray(0) : x();
 
         if(oc == null && args().length < 1) {
@@ -467,9 +468,9 @@ public class Variance extends BaseReduceOp {
         }
         long[] inputShape = (argShape == null || Shape.isPlaceholderShape(argShape) ? x.shape() : argShape);
 
-        val ret = new ArrayList<LongShapeDescriptor>(1);
+        val ret = new ArrayList<DataBuffer>(1);
         val reducedShape = Shape.getReducedShape(inputShape,dimensions, isKeepDims());
-        ret.add(LongShapeDescriptor.fromShape(reducedShape, resultType()));
+        ret.add(Nd4j.createBuffer(LongShapeDescriptor.fromShape(reducedShape, resultType()).toShapeInfo()));
         return ret;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/MaxOut.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/MaxOut.java
@@ -24,6 +24,7 @@ import lombok.val;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseTransformOp;
@@ -122,8 +123,8 @@ public class MaxOut extends BaseTransformOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
-        val ret = new ArrayList<LongShapeDescriptor>(1);
+    public List<DataBuffer> calculateOutputShape() {
+        val ret = new ArrayList<DataBuffer>(1);
         if(arg() == null)
             throw new ND4JIllegalStateException("No arg found for op!");
 
@@ -131,7 +132,7 @@ public class MaxOut extends BaseTransformOp {
         if(arr == null)
             return Collections.emptyList();
 
-        ret.add(LongShapeDescriptor.fromShape(arr.shape(), Nd4j.defaultFloatingPointType()));
+        ret.add(Nd4j.createBuffer(LongShapeDescriptor.fromShape(arr.shape(), Nd4j.defaultFloatingPointType()).toShapeInfo()));
         return ret;
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/gradient/GradientBackwardsMarker.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/impl/transforms/gradient/GradientBackwardsMarker.java
@@ -23,9 +23,9 @@ package org.nd4j.linalg.api.ops.impl.transforms.gradient;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 
 import java.util.Collections;
 import java.util.List;
@@ -79,7 +79,7 @@ public class GradientBackwardsMarker extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         throw new UnsupportedOperationException("calculateOutputShape() is not supported for control flow ops.");
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/BaseRandomOp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/BaseRandomOp.java
@@ -24,14 +24,11 @@ import lombok.NoArgsConstructor;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BaseOp;
-import org.nd4j.linalg.api.ops.DynamicCustomOp;
-import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.RandomOp;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
-import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Collections;
@@ -72,7 +69,7 @@ public abstract class BaseRandomOp extends BaseOp implements RandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         return calculateOutputShape(null);
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/AlphaDropOut.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/AlphaDropOut.java
@@ -23,10 +23,12 @@ package org.nd4j.linalg.api.ops.random.impl;
 import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.random.BaseRandomOp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
 import java.util.List;
@@ -76,14 +78,14 @@ public class AlphaDropOut extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BernoulliDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BernoulliDistribution.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
@@ -112,14 +113,14 @@ public class BernoulliDistribution extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
     @Override
     public List<SDVariable> doDiff(List<SDVariable> f1) {

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistribution.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
@@ -125,14 +126,14 @@ public class BinomialDistribution extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override
@@ -141,7 +142,7 @@ public class BinomialDistribution extends BaseRandomOp {
     }
 
     @Override
-    public void setZ(INDArray z){
+    public void setZ(INDArray z) {
         //We want all 3 args set to z for this op
         this.x = z;
         this.y = z;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistributionEx.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/BinomialDistributionEx.java
@@ -24,10 +24,12 @@ import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.random.BaseRandomOp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
 import java.util.List;
@@ -112,13 +114,13 @@ public class BinomialDistributionEx extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/Choice.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/Choice.java
@@ -24,10 +24,12 @@ import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.random.BaseRandomOp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
 import java.util.List;
@@ -70,14 +72,14 @@ public class Choice extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/CustomDropOut.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/CustomDropOut.java
@@ -22,11 +22,11 @@ package org.nd4j.linalg.api.ops.random.impl;
 
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.OpContext;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -98,9 +98,9 @@ public class CustomDropOut extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray input = oc.getInputArray(0);
-        return Arrays.asList(input.shapeDescriptor(),input.shapeDescriptor());
+        return Arrays.asList(input.shapeInfoDataBuffer());
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/DropOut.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/DropOut.java
@@ -24,10 +24,10 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.random.BaseRandomOp;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
@@ -97,9 +97,9 @@ public class DropOut extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray input = oc.getInputArray(0);
-        return Arrays.asList(input.shapeDescriptor());
+        return Arrays.asList(input.shapeInfoDataBuffer());
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/DropOutBp.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/DropOutBp.java
@@ -21,15 +21,13 @@
 package org.nd4j.linalg.api.ops.random.impl;
 
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
 import org.nd4j.linalg.api.ops.OpContext;
-import org.nd4j.linalg.api.ops.random.BaseRandomOp;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -69,9 +67,9 @@ public class DropOutBp extends DynamicCustomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         INDArray input = oc.getInputArray(0);
-        return Arrays.asList(input.shapeDescriptor());
+        return Arrays.asList(input.shapeInfoDataBuffer());
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/DropOutInverted.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/DropOutInverted.java
@@ -24,10 +24,12 @@ import lombok.NonNull;
 import onnx.Onnx;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.random.BaseRandomOp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 import org.tensorflow.framework.AttrValue;
 import org.tensorflow.framework.GraphDef;
 import org.tensorflow.framework.NodeDef;
@@ -90,14 +92,14 @@ public class DropOutInverted extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/GaussianDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/GaussianDistribution.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
@@ -135,14 +136,14 @@ public class GaussianDistribution extends BaseRandomOp {
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/Linspace.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/Linspace.java
@@ -24,6 +24,7 @@ import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
@@ -131,14 +132,14 @@ public class Linspace extends BaseRandomOp {
 
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/LogNormalDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/LogNormalDistribution.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
@@ -131,14 +132,14 @@ public class LogNormalDistribution extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/ProbablisticMerge.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/ProbablisticMerge.java
@@ -23,10 +23,12 @@ package org.nd4j.linalg.api.ops.random.impl;
 import lombok.NonNull;
 import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.random.BaseRandomOp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
 import java.util.List;
@@ -70,14 +72,14 @@ public class ProbablisticMerge extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/TruncatedNormalDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/TruncatedNormalDistribution.java
@@ -25,6 +25,7 @@ import org.nd4j.autodiff.samediff.SDVariable;
 import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.common.base.Preconditions;
 import org.nd4j.imports.NoOpNameFoundException;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
@@ -140,14 +141,14 @@ public class TruncatedNormalDistribution extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/UniformDistribution.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/ops/random/impl/UniformDistribution.java
@@ -31,7 +31,6 @@ import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.OpContext;
 import org.nd4j.linalg.api.ops.random.BaseRandomOp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
-import org.nd4j.linalg.api.shape.options.ArrayOptionsHelper;
 import org.nd4j.linalg.factory.Nd4j;
 
 import java.util.Arrays;
@@ -114,14 +113,14 @@ public class UniformDistribution extends BaseRandomOp {
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape(OpContext oc) {
+    public List<DataBuffer> calculateOutputShape(OpContext oc) {
         return calculateOutputShape();
     }
 
     @Override
-    public List<LongShapeDescriptor> calculateOutputShape() {
+    public List<DataBuffer> calculateOutputShape() {
         LongShapeDescriptor longShapeDescriptor = LongShapeDescriptor.fromShape(shape,dataType);
-        return Arrays.asList(longShapeDescriptor);
+        return Arrays.asList(Nd4j.createBuffer(longShapeDescriptor.toShapeInfo()));
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/LongShapeDescriptor.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/api/shape/LongShapeDescriptor.java
@@ -208,7 +208,6 @@ public class LongShapeDescriptor {
             ret[i + 1 + rank()] = stride[i];
         }
 
-        Shape.setElementWiseStride(ret, (int) ews);
         Shape.setOrder(ret, order);
         Shape.setExtras(ret, extras);
         return ret;

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/BaseNDArrayFactory.java
@@ -341,7 +341,7 @@ public abstract class BaseNDArrayFactory implements NDArrayFactory {
     @Override
     public INDArray arange(double begin, double end, double step) {
         DynamicCustomOp op = new Range(begin, end, step, DataType.FLOAT);
-        List<LongShapeDescriptor> shape = op.calculateOutputShape();
+        List<DataBuffer> shape = op.calculateOutputShape();
         INDArray out = Nd4j.create(shape.get(0));
         op.setOutputArgument(0, out);
         Nd4j.exec(op);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/NDArrayFactory.java
@@ -1480,6 +1480,8 @@ public interface NDArrayFactory {
      */
     INDArray createFromNpyPointer(Pointer pointer);
 
+    INDArray createFromDescriptor(DataBuffer shapeInformation);
+
 
     /**
      * Create from an in memory numpy header.
@@ -1572,4 +1574,6 @@ public interface NDArrayFactory {
     INDArray create(Collection<String> strings, long[] shape, char order);
 
     INDArray createUninitialized(DataType dataType, long[] shape, long[] strides, char ordering, MemoryWorkspace currentWorkspace);
+
+    INDArray create(DataBuffer dataBuffer, DataBuffer descriptor);
 }

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/ops/transforms/Transforms.java
@@ -23,6 +23,7 @@ package org.nd4j.linalg.ops.transforms;
 import lombok.NonNull;
 import lombok.val;
 import org.nd4j.common.base.Preconditions;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.CustomOp;
@@ -124,7 +125,7 @@ public class Transforms {
 
     public static INDArray cross(INDArray x, INDArray y) {
         Cross c = new Cross(x, y, null);
-        List<LongShapeDescriptor> shape = c.calculateOutputShape();
+        List<DataBuffer> shape = c.calculateOutputShape();
         INDArray out = Nd4j.create(shape.get(0));
         c.addOutputArgument(out);
         Nd4j.getExecutioner().exec(c);

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueDataBuffer.java
@@ -68,7 +68,7 @@ public class OpaqueDataBuffer extends Pointer {
     }
 
     public static OpaqueDataBuffer externalizedDataBuffer(long numElements, @NonNull DataType dataType, Pointer primary, Pointer special) {
-        OpaqueDataBuffer ret =Nd4j.getNativeOps().dbCreateExternalDataBuffer(numElements, dataType.toInt(), primary, special);
+        OpaqueDataBuffer ret =Nd4j.getNativeOps().dbCreateExternalDataBuffer(numElements, dataType.toInt(), primary, special).retainReference();
         if(NativeOpsHolder.getInstance().getDeviceNativeOps().isFuncTrace())
             ret.captureTrace();
         return ret;
@@ -89,7 +89,7 @@ public class OpaqueDataBuffer extends Pointer {
         for (int t = 0; t < MAX_TRIES; t++) {
             try {
                 // try to allocate data buffer
-                buffer = Nd4j.getNativeOps().allocateDataBuffer(numElements, dataType.toInt(), allocateBoth);
+                buffer = Nd4j.getNativeOps().allocateDataBuffer(numElements, dataType.toInt(), allocateBoth).retainReference();
                 //when  using func trace we want to print allocation traces when deallocation is called. this is used to debug
                 //potential race condition and crashes. c++ prints the equivalent stack trace when func trace is enabled.
                 //This allows us to check where a deallocated buffer that caused an issue was allocated.
@@ -168,7 +168,7 @@ public class OpaqueDataBuffer extends Pointer {
 
         for (int t = 0; t < MAX_TRIES; t++) {
             try {
-                buffer =Nd4j.getNativeOps().dbCreateView(this, bytesLength);
+                buffer =Nd4j.getNativeOps().dbCreateView(this, bytesLength).retainReference();
                 if(NativeOpsHolder.getInstance().getDeviceNativeOps().isFuncTrace())
                     buffer.captureTrace();
                 // check error code

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/nativeblas/OpaqueNDArray.java
@@ -63,7 +63,7 @@ public class OpaqueNDArray extends Pointer {
             OpaqueDataBuffer buffer,
             OpaqueDataBuffer specialBuffer,
             long offset) {
-        return Nd4j.getNativeOps().create(shapeInfo, buffer, specialBuffer, offset);
+        return Nd4j.getNativeOps().create(shapeInfo, buffer, specialBuffer, offset).retainReference();
     }
 
     /**
@@ -121,7 +121,7 @@ public class OpaqueNDArray extends Pointer {
      * @return A Pointer to the buffer.
      */
     public static Pointer getOpaqueNDArrayBuffer(OpaqueNDArray array) {
-        return Nd4j.getNativeOps().getOpaqueNDArrayBuffer(array);
+        return Nd4j.getNativeOps().getOpaqueNDArrayBuffer(array).retainReference();
     }
 
     /**
@@ -132,7 +132,7 @@ public class OpaqueNDArray extends Pointer {
      * @return A Pointer to the special buffer.
      */
     public static Pointer getOpaqueNDArraySpecialBuffer(OpaqueNDArray array) {
-        return Nd4j.getNativeOps().getOpaqueNDArraySpecialBuffer(array);
+        return Nd4j.getNativeOps().getOpaqueNDArraySpecialBuffer(array).retainReference();
     }
 
     /**

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-native-api/src/main/java/org/nd4j/nativeblas/BaseNativeNDArrayFactory.java
@@ -733,4 +733,5 @@ public abstract class BaseNativeNDArrayFactory extends BaseNDArrayFactory {
 
     }
 
+    public abstract INDArray createFromDescriptor(DataBuffer shapeInformation);
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cpu-backend-common/src/main/java/org/nd4j/linalg/cpu/nativecpu/ops/NativeOpExecutioner.java
@@ -947,6 +947,15 @@ public class NativeOpExecutioner extends DefaultOpExecutioner {
         return customOps;
     }
 
+    @Override
+    public INDArray createFromDescriptor(DataBuffer shapeInformation) {
+        NDArray ndArray = new NDArray();
+        ndArray.setShapeInfoDataBuffer(shapeInformation);
+        DataType dt = Shape.dataType(ndArray.shapeInfoJava());
+        DataBuffer buff = Nd4j.createBuffer(dt,ndArray.length(),false);
+        ndArray.setData(buff);
+        return ndArray;
+    }
 
 
 

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/tad/DeviceTADManager.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/jita/allocator/tad/DeviceTADManager.java
@@ -65,8 +65,8 @@ public class DeviceTADManager extends BasicTADManager {
             dimension = new long[] {Integer.MAX_VALUE};
 
         val pack = Nd4j.getExecutioner().tadShapeInfoAndOffsets(array, dimension);
-
-
-        return new Pair<>(pack.getTadShapeInfo(), pack.getTadOffsets());
+        DataBuffer tadShapeInfo = pack.getTadShapeInfo();
+        DataBuffer offsets = pack.getTadOffsets();
+        return new Pair<>(tadShapeInfo, offsets);
     }
 }

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArray.java
@@ -67,6 +67,8 @@ public class JCublasNDArray extends BaseNDArray {
 
 
     public JCublasNDArray(DataBuffer buffer, CudaLongDataBuffer shapeInfo, long[] javaShapeInfo) {
+        this.data = buffer;
+        setShapeInfoDataBuffer(shapeInfo);
         this.jvmShapeInfo = new JvmShapeInfo(javaShapeInfo);
     }
 
@@ -430,6 +432,10 @@ public class JCublasNDArray extends BaseNDArray {
         super(longShapeDescriptor);
     }
 
+    public JCublasNDArray(DataType dataType, long[] shape, long[] strides, int i, char ordering, MemoryWorkspace currentWorkspace) {
+        super(dataType,shape,strides,currentWorkspace);
+    }
+
     @Override
     public INDArray dup() {
         if (this.isCompressed() && this.ordering() == Nd4j.order().charValue()) {
@@ -480,6 +486,7 @@ public class JCublasNDArray extends BaseNDArray {
      */
     public void setShapeInfoDataBuffer(DataBuffer buffer) {
         this.jvmShapeInfo = new JvmShapeInfo(buffer.asLong());
+        this.shapeInfoDataBuffer = buffer;
     }
 
     private Object writeReplace() throws java.io.ObjectStreamException {

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/JCublasNDArrayFactory.java
@@ -192,6 +192,18 @@ public class JCublasNDArrayFactory extends BaseNativeNDArrayFactory {
         return new JCublasNDArray(data, shape, ordering);
     }
 
+
+
+    @Override
+    public INDArray createFromDescriptor(DataBuffer shapeInformation) {
+        JCublasNDArray jCublasNDArray = new JCublasNDArray();
+        jCublasNDArray.setShapeInfoDataBuffer(shapeInformation);
+        DataType dt = Shape.dataType(jCublasNDArray.shapeInfoJava());
+        DataBuffer buff = Nd4j.createBuffer(dt,jCublasNDArray.length(),false);
+        jCublasNDArray.setData(buff);
+        return jCublasNDArray;
+    }
+
     @Override
     public INDArray create(LongShapeDescriptor longShapeDescriptor) {
         return new JCublasNDArray(longShapeDescriptor);
@@ -201,13 +213,21 @@ public class JCublasNDArrayFactory extends BaseNativeNDArrayFactory {
     public INDArray create(Collection<String> strings, long[] shape, char order) {
         val pairShape = Nd4j.getShapeInfoProvider().createShapeInformation(shape, order, DataType.UTF8);
         val buffer = new CudaUtf8Buffer(strings);
-        val list = new ArrayList<>(strings);
         return Nd4j.createArrayFromShapeBuffer(buffer, pairShape);
     }
 
     @Override
     public INDArray createUninitialized(DataType dataType, long[] shape, long[] strides, char ordering, MemoryWorkspace currentWorkspace) {
-        return null;
+        return new JCublasNDArray(dataType,shape,strides,0,ordering,currentWorkspace);
+    }
+
+    @Override
+    public INDArray create(DataBuffer dataBuffer, DataBuffer descriptor) {
+        JCublasNDArray jCublasNDArray = new JCublasNDArray();
+        jCublasNDArray.setShapeInfoDataBuffer(descriptor);
+        DataType dt = Shape.dataType(jCublasNDArray.shapeInfoJava());
+        jCublasNDArray.setData(dataBuffer);
+        return jCublasNDArray;
     }
 
     @Override

--- a/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/nd4j-cuda/src/main/java/org/nd4j/linalg/jcublas/buffer/BaseCudaDataBuffer.java
@@ -373,7 +373,6 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
 
         // let deallocator pick up this object
         this.deallocationId = Nd4j.getDeallocatorService().pickObject(this);
-        lazyAllocateHostPointer();
     }
 
     protected void initPointers(long length, int elementSize, boolean initialize, @NonNull MemoryWorkspace workspace) {
@@ -416,6 +415,7 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         workspaceGenerationId = workspace.getGenerationId();
         this.attached = true;
         this.parentWorkspace = workspace;
+        initHostPointerAndIndexer();
     }
 
     /**
@@ -546,7 +546,6 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         if (released.get())
             throw new IllegalStateException("You can't use DataBuffer once it was released");
 
-        // FIXME: very bad thing,
         lazyAllocateHostPointer();
 
         return super.pointer();
@@ -1519,7 +1518,6 @@ public abstract class BaseCudaDataBuffer extends BaseDataBuffer implements JCuda
         this.allocationPoint.tickHostWrite();
     }
 
-    // Rest of the existing code remains unchanged...
 
     /**
      * Initialize pointer and indexer based on the current data type

--- a/platform-tests/bin/java
+++ b/platform-tests/bin/java
@@ -76,7 +76,7 @@ eof
 fi
 # if test_runner_prefix is not empty and contains "compute-sanitizer"
 if [[ -n $TEST_RUNNER_PREFIX && $TEST_RUNNER_PREFIX =~ "compute-sanitizer" ]]; then
-    TEST_RUNNER_PREFIX="${TEST_RUNNER_PREFIX} --tool=memcheck"
+    TEST_RUNNER_PREFIX="${TEST_RUNNER_PREFIX} --tool=memcheck --report-api-errors all  --show-backtrace yes --print-limit 1000 "
     # set default options for compute-sanitizer if none are specified
     # add jvm option to disable jit compilation to help with debugging
     java_call="${java_call}  -Djava.compiler=none"

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TestCustomOps.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/frameworkimport/tensorflow/TestCustomOps.java
@@ -27,6 +27,7 @@ import org.nd4j.linalg.BaseNd4jTestWithBackends;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 
@@ -57,7 +58,7 @@ public class TestCustomOps extends BaseNd4jTestWithBackends {
 
         val outShape = Nd4j.getExecutioner().calculateOutputShape(op);
         assertEquals(1, outShape.size());
-        assertArrayEquals(new long[]{1, 29, 29, 264}, outShape.get(0).getShape());
+        assertArrayEquals(new long[]{1, 29, 29, 264}, Shape.shape(outShape.get(0).asLong()));
 
         Nd4j.getExecutioner().exec(op); //Crash here
     }

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestLayerOpValidation.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestLayerOpValidation.java
@@ -49,6 +49,7 @@ import org.nd4j.linalg.api.ops.impl.layers.recurrent.outputs.LSTMLayerOutputs;
 import org.nd4j.linalg.api.ops.impl.layers.recurrent.weights.LSTMLayerWeights;
 import org.nd4j.linalg.api.ops.impl.transforms.custom.LayerNorm;
 import org.nd4j.linalg.api.ops.impl.transforms.custom.Standardize;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.ops.transforms.Transforms;
@@ -413,7 +414,7 @@ public class TestLayerOpValidation extends BaseOpValidation {
         long[] exp = new long[]{1, outH, outW, 3};    //NHWC
 
         assertEquals(1, outSizes.size());
-        assertArrayEquals(exp, outSizes.get(0).getShape());
+        assertArrayEquals(exp, Shape.shape(outSizes.get(0).asLong()));
 
         INDArray grad = Nd4j.create(exp);
 
@@ -424,9 +425,8 @@ public class TestLayerOpValidation extends BaseOpValidation {
         val outSizesBP = Nd4j.getExecutioner().calculateOutputShape(avg2dDeriv);
         assertEquals(1, outSizesBP.size());
 
-        assertArrayEquals(inSize, outSizesBP.get(0).getShape());
+        assertArrayEquals(inSize, Shape.shape(outSizesBP.get(0).asLong()));
     }
-
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
@@ -453,7 +453,7 @@ public class TestLayerOpValidation extends BaseOpValidation {
         long[] exp = new long[]{1, outH, outW, 3};    //NHWC
 
         assertEquals(1, outSizes.size());
-        assertArrayEquals(exp, outSizes.get(0).getShape());
+        assertArrayEquals(exp, Shape.shape(outSizes.get(0).asLong()));
 
         INDArray grad = Nd4j.create(exp);
 
@@ -462,11 +462,10 @@ public class TestLayerOpValidation extends BaseOpValidation {
 
         val outSizesBP = Nd4j.getExecutioner().calculateOutputShape(avg2dDeriv);
         assertEquals(1, outSizesBP.size());
-        assertArrayEquals(inSize, outSizesBP.get(0).getShape());
+        assertArrayEquals(inSize, Shape.shape(outSizesBP.get(0).asLong()));
 
         Nd4j.getExecutioner().execAndReturn(avg2dDeriv);
     }
-
 
     private static int[] ncdhwToNdhwc(int[] in) {
         return new int[]{in[0], in[2], in[3], in[4], in[1]};

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestMiscOpValidation.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/opvalidation/TestMiscOpValidation.java
@@ -40,6 +40,7 @@ import org.nd4j.common.base.Preconditions;
 import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.enums.PartitionMode;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.CustomOp;
@@ -70,6 +71,7 @@ import org.nd4j.linalg.api.ops.impl.transforms.custom.Fill;
 import org.nd4j.linalg.api.ops.impl.transforms.pairwise.arithmetic.FloorDivOp;
 import org.nd4j.linalg.api.ops.impl.transforms.pairwise.arithmetic.FloorModOp;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
@@ -928,7 +930,7 @@ public class TestMiscOpValidation extends BaseOpValidation {
                 .build());
 
         val outShapes = Nd4j.getExecutioner().calculateOutputShape(m);
-        assertArrayEquals(new long[]{4,3}, outShapes.get(0).getShape());
+        assertArrayEquals(new long[]{4,3}, Shape.shape(outShapes.get(0).asLong()));
         Nd4j.getExecutioner().exec(m);
 
         //Another case: ([3,4]*[2,4]T)T = [2,3]     -   tA=false, tB=true, tR=true
@@ -942,11 +944,9 @@ public class TestMiscOpValidation extends BaseOpValidation {
                 .build());
 
         val outShapes2 = Nd4j.getExecutioner().calculateOutputShape(m);
-        assertArrayEquals(new long[]{2,3}, outShapes2.get(0).getShape());
+        assertArrayEquals(new long[]{2,3}, Shape.shape(outShapes2.get(0).asLong()));
         Nd4j.getExecutioner().exec(m);
-
     }
-
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testFillOp(){
@@ -1397,7 +1397,7 @@ public class TestMiscOpValidation extends BaseOpValidation {
 
         assertEquals(1, shapes.size());
 
-        assertArrayEquals(new long[]{2}, shapes.get(0).getShape());
+        assertArrayEquals(new long[]{2}, Shape.shape(shapes.get(0).asLong()));
     }
 
     @ParameterizedTest
@@ -1456,13 +1456,12 @@ public class TestMiscOpValidation extends BaseOpValidation {
         val outShape = Nd4j.getExecutioner().calculateOutputShape(op);
 
         assertEquals(1, outShape.size());
-        assertArrayEquals(new long[]{5}, outShape.get(0).getShape());
+        assertArrayEquals(new long[]{5}, Shape.shape(outShape.get(0).asLong()));
     }
-
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
-    public void testZerosOnesLike(){
+    public void testZerosOnesLike() {
         Nd4j.getRandom().setSeed(12345);
 
         List<int[]> shapes = Arrays.asList(new int[0], new int[]{3}, new int[]{3,4}, new int[]{3,4,5});
@@ -1667,10 +1666,10 @@ public class TestMiscOpValidation extends BaseOpValidation {
                 .addIntegerArguments(0, 1)      //Transpose arr2 only
                 .build();
 
-        List<LongShapeDescriptor> shapes = op.calculateOutputShape();
+        List<DataBuffer> shapes = op.calculateOutputShape();
         assertEquals(1, shapes.size());
         long[] shape = new long[]{32,12,128,128};
-        assertArrayEquals(shape, shapes.get(0).getShape());
+        assertArrayEquals(shape, Shape.shape(shapes.get(0).asLong()));
 
         INDArray out = Nd4j.create(FLOAT, shape);
 
@@ -1702,10 +1701,10 @@ public class TestMiscOpValidation extends BaseOpValidation {
                 .addIntegerArguments(0, 1)      //Transpose arr2 only
                 .build();
 
-        List<LongShapeDescriptor> shapes = op.calculateOutputShape();
+        List<DataBuffer> shapes = op.calculateOutputShape();
         assertEquals(1, shapes.size());
         long[] shape = new long[]{32,12,128,128};
-        assertArrayEquals(shape, shapes.get(0).getShape());
+        assertArrayEquals(shape, Shape.shape(shapes.get(0).asLong()));
 
         INDArray out = Nd4j.create(FLOAT, shape);
 
@@ -1726,8 +1725,8 @@ public class TestMiscOpValidation extends BaseOpValidation {
                 .addIntegerArguments(0) //reverse = false
                 .build();
 
-        List<LongShapeDescriptor> shapeList = op.calculateOutputShape();
-        long[] shape = shapeList.get(0).getShape();
+        List<DataBuffer> shapeList = op.calculateOutputShape();
+        long[] shape = Shape.shape(shapeList.get(0).asLong());
         long[] expShape = new long[0];
         assertArrayEquals(expShape, shape);
 
@@ -1738,6 +1737,7 @@ public class TestMiscOpValidation extends BaseOpValidation {
         System.out.println(out);
         assertEquals(0.0, out.getDouble(0), 1e-5);
     }
+
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
@@ -1754,8 +1754,8 @@ public class TestMiscOpValidation extends BaseOpValidation {
                 .addIntegerArguments(axes[1])
                 .build();
 
-        List<LongShapeDescriptor> l = op.calculateOutputShape();
-        assertArrayEquals(new long[]{2,2}, l.get(0).getShape());         //Returning [1,2,2]
+        List<DataBuffer> l = op.calculateOutputShape();
+        assertArrayEquals(new long[]{2,2}, Shape.shape(l.get(0).asLong()));         //Returning [1,2,2]
     }
 
     @ParameterizedTest
@@ -1769,7 +1769,7 @@ public class TestMiscOpValidation extends BaseOpValidation {
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
-    public void testStopGradient(){
+    public void testStopGradient() {
 
         SameDiff sd = SameDiff.create();
         SDVariable w = sd.var("w", Nd4j.rand(DataType.DOUBLE, 3, 4));
@@ -1781,8 +1781,6 @@ public class TestMiscOpValidation extends BaseOpValidation {
         INDArray vArr = gm.get(v.name());
         INDArray wArr = gm.get(w.name());
 
-//        System.out.println(vArr);
-//        System.out.println(wArr);
 
         assertEquals(Nd4j.zeros(DataType.DOUBLE, 3, 4), wArr);
     }

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/FailingSameDiffTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/FailingSameDiffTests.java
@@ -32,6 +32,7 @@ import org.nd4j.linalg.BaseNd4jTestWithBackends;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.ops.transforms.Transforms;
@@ -57,12 +58,11 @@ public class FailingSameDiffTests extends BaseNd4jTestWithBackends {
     public void testEyeShape(Nd4jBackend backend) {
         val dco = DynamicCustomOp.builder("eye")
                 .addIntegerArguments(3,3)
-                //.addIntegerArguments(-99,3,3) //Also fails
                 .build();
 
         val list = Nd4j.getExecutioner().calculateOutputShape(dco);
         assertEquals(1, list.size());   //Fails here - empty list
-        assertArrayEquals(new long[]{3,3}, list.get(0).getShape());
+        assertArrayEquals(new long[]{3,3}, Shape.shape(list.get(0).asLong()));
     }
 
     @ParameterizedTest

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/autodiff/samediff/SameDiffTests.java
@@ -83,6 +83,7 @@ import org.nd4j.linalg.api.ops.impl.transforms.custom.Max;
 import org.nd4j.linalg.api.ops.impl.transforms.custom.Min;
 import org.nd4j.linalg.api.ops.random.impl.BernoulliDistribution;
 import org.nd4j.linalg.api.shape.LongShapeDescriptor;
+import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.checkutil.NDArrayCreationUtil;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.MultiDataSet;
@@ -2246,7 +2247,7 @@ public class SameDiffTests extends BaseNd4jTestWithBackends {
 
         assertEquals(1, shapes.size());
 
-        assertArrayEquals(expShape, shapes.get(0).getShape());
+        assertArrayEquals(expShape, Shape.shape(shapes.get(0).asLong()));
     }
 
 

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/Nd4jTestsC.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/Nd4jTestsC.java
@@ -6364,7 +6364,7 @@ public class Nd4jTestsC extends BaseNd4jTestWithBackends {
                 .build();
 
         val shape = Nd4j.getExecutioner().calculateOutputShape(op).get(0);
-        assertArrayEquals(new long[]{}, shape.getShape());
+        assertArrayEquals(new long[]{}, Shape.shape(shape.asLong()));
 
         Nd4j.getExecutioner().exec(op);
 
@@ -6386,13 +6386,12 @@ public class Nd4jTestsC extends BaseNd4jTestWithBackends {
                 .build();
 
         val shape = Nd4j.getExecutioner().calculateOutputShape(op).get(0);
-        assertArrayEquals(new long[]{}, shape.getShape());
+        assertArrayEquals(new long[]{}, Shape.shape(shape.asLong()));
 
         Nd4j.getExecutioner().exec(op);
 
         assertEquals(exp, output);
     }
-
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testVectorSqueeze(Nd4jBackend backend) {
@@ -6406,7 +6405,7 @@ public class Nd4jTestsC extends BaseNd4jTestWithBackends {
                 .build();
 
         val shape = Nd4j.getExecutioner().calculateOutputShape(op).get(0);
-        assertArrayEquals(new long[]{6}, shape.getShape());
+        assertArrayEquals(new long[]{6}, Shape.shape(shape.asLong()));
 
         Nd4j.getExecutioner().exec(op);
 
@@ -6442,14 +6441,13 @@ public class Nd4jTestsC extends BaseNd4jTestWithBackends {
                 .build();
 
         val shape = Nd4j.getExecutioner().calculateOutputShape(op).get(0);
-        assertArrayEquals(exp.shape(), shape.getShape());
+        assertArrayEquals(exp.shape(), Shape.shape(shape.asLong()));
 
         Nd4j.getExecutioner().exec(op);
 
         assertArrayEquals(exp.shape(), output.shape());
         assertEquals(exp, output);
     }
-
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
@@ -8414,13 +8412,11 @@ public class Nd4jTestsC extends BaseNd4jTestWithBackends {
         c.addOutputArgument(out);
         Nd4j.getExecutioner().exec(c);
 
-        List<LongShapeDescriptor> l = c.calculateOutputShape();
+        List<DataBuffer> l = c.calculateOutputShape();
 
-//        System.out.println(Arrays.toString(l.get(0).getShape()));
 
         //from [4,4,3] to [2,4,6] then crop to [2,4,5]
     }
-
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testToFromByteArray() throws IOException {

--- a/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/custom/CustomOpsTests.java
+++ b/platform-tests/src/test/java/org/eclipse/deeplearning4j/nd4j/linalg/custom/CustomOpsTests.java
@@ -23,8 +23,6 @@ package org.eclipse.deeplearning4j.nd4j.linalg.custom;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.nd4j.autodiff.samediff.SDVariable;
@@ -32,49 +30,20 @@ import org.nd4j.autodiff.samediff.SameDiff;
 import org.nd4j.autodiff.validation.OpValidation;
 import org.nd4j.autodiff.validation.TestCase;
 import org.nd4j.common.tests.tags.NativeTag;
-import org.nd4j.common.tests.tags.TagNames;
 import org.nd4j.linalg.BaseNd4jTestWithBackends;
 import org.nd4j.linalg.api.blas.params.MMulTranspose;
+import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.buffer.DataType;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.CustomOp;
 import org.nd4j.linalg.api.ops.DynamicCustomOp;
-import org.nd4j.linalg.api.ops.custom.AdjustContrast;
-import org.nd4j.linalg.api.ops.custom.AdjustHue;
-import org.nd4j.linalg.api.ops.custom.AdjustSaturation;
-import org.nd4j.linalg.api.ops.custom.BetaInc;
-import org.nd4j.linalg.api.ops.custom.BitCast;
-import org.nd4j.linalg.api.ops.custom.DivideNoNan;
-import org.nd4j.linalg.api.ops.custom.DrawBoundingBoxes;
-import org.nd4j.linalg.api.ops.custom.FakeQuantWithMinMaxVarsPerChannel;
-import org.nd4j.linalg.api.ops.custom.Flatten;
-import org.nd4j.linalg.api.ops.custom.FusedBatchNorm;
-import org.nd4j.linalg.api.ops.custom.HsvToRgb;
-import org.nd4j.linalg.api.ops.custom.KnnMinDistance;
-import org.nd4j.linalg.api.ops.custom.Lgamma;
-import org.nd4j.linalg.api.ops.custom.LinearSolve;
-import org.nd4j.linalg.api.ops.custom.Logdet;
-import org.nd4j.linalg.api.ops.custom.Lstsq;
-import org.nd4j.linalg.api.ops.custom.Lu;
-import org.nd4j.linalg.api.ops.custom.MatrixBandPart;
-import org.nd4j.linalg.api.ops.custom.Polygamma;
-import org.nd4j.linalg.api.ops.custom.RandomCrop;
-import org.nd4j.linalg.api.ops.custom.RgbToGrayscale;
-import org.nd4j.linalg.api.ops.custom.RgbToHsv;
-import org.nd4j.linalg.api.ops.custom.RgbToYiq;
-import org.nd4j.linalg.api.ops.custom.RgbToYuv;
-import org.nd4j.linalg.api.ops.custom.Roll;
-import org.nd4j.linalg.api.ops.custom.ToggleBits;
-import org.nd4j.linalg.api.ops.custom.TriangularSolve;
-import org.nd4j.linalg.api.ops.custom.YiqToRgb;
-import org.nd4j.linalg.api.ops.custom.YuvToRgb;
+import org.nd4j.linalg.api.ops.custom.*;
 import org.nd4j.linalg.api.ops.executioner.OpExecutioner;
 import org.nd4j.linalg.api.ops.executioner.OpStatus;
 import org.nd4j.linalg.api.ops.impl.controlflow.Where;
 import org.nd4j.linalg.api.ops.impl.image.NonMaxSuppression;
 import org.nd4j.linalg.api.ops.impl.image.ResizeArea;
 import org.nd4j.linalg.api.ops.impl.image.ResizeBilinear;
-import org.nd4j.linalg.api.ops.impl.reduce.MmulBp;
 import org.nd4j.linalg.api.ops.impl.shape.Create;
 import org.nd4j.linalg.api.ops.impl.shape.Linspace;
 import org.nd4j.linalg.api.ops.impl.shape.OnesLike;
@@ -86,14 +55,12 @@ import org.nd4j.linalg.api.ops.impl.transforms.pairwise.arithmetic.AddOp;
 import org.nd4j.linalg.api.ops.impl.transforms.pairwise.arithmetic.ModOp;
 import org.nd4j.linalg.api.ops.random.compat.RandomStandardNormal;
 import org.nd4j.linalg.api.ops.random.impl.DropOut;
-import org.nd4j.linalg.api.shape.LongShapeDescriptor;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.exception.ND4JIllegalStateException;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.factory.Nd4jBackend;
 import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.nd4j.linalg.indexing.conditions.Conditions;
-import org.nd4j.nativeblas.NativeOpsHolder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -459,7 +426,7 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
         val shapes = Nd4j.getExecutioner().calculateOutputShape(op);
 
         assertEquals(1, shapes.size());
-        assertArrayEquals(new long[]{5, 2}, shapes.get(0).getShape());
+        assertArrayEquals(new long[]{5, 2}, Shape.shape(shapes.get(0).asLong()));
     }
 
 
@@ -656,14 +623,13 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
                         0)  //Shrink axis mask
                 .build();
 
-        List<LongShapeDescriptor> l = op.calculateOutputShape();
+        List<DataBuffer> l = op.calculateOutputShape();
         assertEquals(1, l.size());
         assertEquals(DataType.DOUBLE, l.get(0).dataType());
-        assertTrue(l.get(0).isEmpty()); //Should be empty array, is rank 0 scalar
+        assertTrue(Shape.isEmpty(l.get(0).asLong())); //Should be empty array, is rank 0 scalar
 
         Nd4j.exec(op);  //Execution is OK
     }
-
 
 
 
@@ -967,21 +933,19 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
         DynamicCustomOp op = DynamicCustomOp.builder("adjust_contrast_v2")
                 .addInputs(Nd4j.create(DataType.FLOAT, 256, 256,3), Nd4j.scalar(0.5f))
                 .build();
-        List<LongShapeDescriptor> lsd = op.calculateOutputShape();
+        List<DataBuffer> lsd = op.calculateOutputShape();
         assertEquals(1, lsd.size());
-        assertArrayEquals(new long[]{256, 256, 3}, lsd.get(0).getShape());
+        assertArrayEquals(new long[]{256, 256, 3}, Shape.shape(lsd.get(0).asLong()));
     }
-
-
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testBitCastShape(Nd4jBackend backend) {
         INDArray out = Nd4j.createUninitialized(1,10);
         BitCast op = new BitCast(Nd4j.zeros(1,10), DataType.FLOAT.toInt(), out);
-        List<LongShapeDescriptor> lsd = op.calculateOutputShape();
+        List<DataBuffer> lsd = op.calculateOutputShape();
         assertEquals(1, lsd.size());
-        assertArrayEquals(new long[]{1,10,2}, lsd.get(0).getShape());
+        assertArrayEquals(new long[]{1,10,2}, Shape.shape(lsd.get(0).asLong()));
     }
 
 
@@ -1219,9 +1183,9 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
                 .addFloatingPointArguments(-1.0, 1.0, 0.01)
                 .build();
 
-        List<LongShapeDescriptor> lsd = op.calculateOutputShape();
+        List<DataBuffer> lsd = op.calculateOutputShape();
         //System.out.println("Calculated output shape: " + Arrays.toString(lsd.get(0).getShape()));
-        op.setOutputArgument(0, Nd4j.create(lsd.get(0)));
+        op.setOutputArgument(0, Nd4j.createFromDescriptor(lsd.get(0)));
 
         Nd4j.exec(op);
     }
@@ -1232,22 +1196,20 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
     public void testBitCastShape_1(Nd4jBackend backend) {
         val out = Nd4j.createUninitialized(1,10);
         BitCast op = new BitCast(Nd4j.zeros(DataType.FLOAT,1,10), DataType.INT.toInt(), out);
-        List<LongShapeDescriptor> lsd = op.calculateOutputShape();
+        List<DataBuffer> lsd = op.calculateOutputShape();
         assertEquals(1, lsd.size());
-        assertArrayEquals(new long[]{1,10}, lsd.get(0).getShape());
+        assertArrayEquals(new long[]{1,10}, Shape.shape(lsd.get(0).asLong()));
     }
-
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
     public void testBitCastShape_2(Nd4jBackend backend) {
         val out = Nd4j.createUninitialized(1,10);
         BitCast op = new BitCast(Nd4j.zeros(DataType.DOUBLE,1,10), DataType.INT.toInt(), out);
-        List<LongShapeDescriptor> lsd = op.calculateOutputShape();
+        List<DataBuffer> lsd = op.calculateOutputShape();
         assertEquals(1, lsd.size());
-        assertArrayEquals(new long[]{1,10, 2}, lsd.get(0).getShape());
+        assertArrayEquals(new long[]{1,10, 2}, Shape.shape(lsd.get(0).asLong()));
     }
-
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")
@@ -1434,7 +1396,7 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
                 0.7271f,0.1804f,0.5056f,0.8925f,
                 0.5461f,0.9234f,0.0856f,0.7938f}).reshape(3,4);
         MatrixBandPart op = new MatrixBandPart(input,1,-1);
-        List<LongShapeDescriptor> lsd = op.calculateOutputShape();
+        List<DataBuffer> lsd = op.calculateOutputShape();
         assertEquals(1, lsd.size());
     }
 
@@ -1522,12 +1484,10 @@ public class CustomOpsTests extends BaseNd4jTestWithBackends {
 
         AdjustHue op = new AdjustHue(image, 0.2f);
         INDArray[] res = Nd4j.exec(op);
-//        System.out.println(res[0]);
-        List<LongShapeDescriptor> lsd = op.calculateOutputShape();
+        List<DataBuffer> lsd = op.calculateOutputShape();
         assertEquals(1, lsd.size());
-        assertArrayEquals(new long[]{8, 8, 3}, lsd.get(0).getShape());
+        assertArrayEquals(new long[]{8, 8, 3}, Shape.shape(lsd.get(0).asLong()));
     }
-
 
     @ParameterizedTest
     @MethodSource("org.nd4j.linalg.BaseNd4jTestWithBackends#configs")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Note: most files are not logical changes. Just API changes for tad pack related functionality making them pointers. This is to avoid smart pointer and stack based deallocation.

This also fixes a very subtle segfault that I found while running the samediff training tests.
All run now without crashing and 1 failure left with testGradients.
This PR is mainly focused on cleaning up the reshape for assign that works around
calling reshape in certain places without calling the op.



## How was this patch tested?

Mainly ran SameDiffTrainingTest.

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.konduit.ai/multi-project/how-to-guides/contribute/eclipse-contributors) page for details
- [ X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X ] Created tests for any significant new code additions.
- [X ] Relevant tests for your changes are passing.
