### PR TITLE
Migrate secrets to EF naming convention

### DIFF
--- a/.github/workflows/build-deploy-android-arm64.yml
+++ b/.github/workflows/build-deploy-android-arm64.yml
@@ -126,8 +126,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           server-id: 'central'
-          server-username: ${{ secrets.SONATYPE_USER_1 }}
-          server-password: ${{ secrets.SONATYPE_USER1_PASS }}
+          server-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
 
         
 
@@ -218,7 +218,7 @@ jobs:
       - name: Build with Maven
         shell: bash
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           CROSS_COMPILER_DIR: ${{ steps.setup-ndk.outputs.ndk-path }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -226,9 +226,9 @@ jobs:
           BUILD_USING_MAVEN: 1
           TARGET_OS: android
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           DEPLOY_TO: central
           PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}

--- a/.github/workflows/build-deploy-android-x86_64.yml
+++ b/.github/workflows/build-deploy-android-x86_64.yml
@@ -133,8 +133,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           server-id: 'central'
-          server-username: ${{ secrets.SONATYPE_USER_1 }}
-          server-password: ${{ secrets.SONATYPE_USER1_PASS }}
+          server-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
         
         
 
@@ -257,11 +257,11 @@ jobs:
       - name: Build with Maven
         shell: bash
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
           SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}

--- a/.github/workflows/build-deploy-cross-platform.yml
+++ b/.github/workflows/build-deploy-cross-platform.yml
@@ -75,8 +75,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           server-id: 'central'
-          server-username: ${{ secrets.SONATYPE_USER_1 }}
-          server-password: ${{ secrets.SONATYPE_USER1_PASS }}
+          server-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
         
         
 
@@ -84,13 +84,13 @@ jobs:
       - name: Build on  linux-x86_64
         shell: bash
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
           SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}

--- a/.github/workflows/build-deploy-linux-arm64.yml
+++ b/.github/workflows/build-deploy-linux-arm64.yml
@@ -150,8 +150,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           server-id: 'central'
-          server-username: ${{ secrets.SONATYPE_USER_1 }}
-          server-password: ${{ secrets.SONATYPE_USER1_PASS }}
+          server-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
 
       - name: Setup path
         shell: bash
@@ -305,14 +305,14 @@ jobs:
       - name: Build with Maven
         shell: bash
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
           DEPLOY_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
           SNAPSHOT_VERSION: ${{ github.event.inputs.snapshotVersion }}

--- a/.github/workflows/build-deploy-linux-cuda-12.3.yml
+++ b/.github/workflows/build-deploy-linux-cuda-12.3.yml
@@ -169,7 +169,7 @@ jobs:
           server-id:  ${{ github.event.inputs.serverId }}
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           cache: 'maven'
 
@@ -239,13 +239,13 @@ jobs:
       - name: Run cuda compilation on linux-x86_64
         shell: bash
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}
           RELEASE_VERSION: ${{ matrix.release_version }}
           SNAPSHOT_VERSION: ${{ matrix.snapshot_version }}

--- a/.github/workflows/build-deploy-linux-cuda-12.6.yml
+++ b/.github/workflows/build-deploy-linux-cuda-12.6.yml
@@ -169,7 +169,7 @@ jobs:
           server-id:  ${{ github.event.inputs.serverId }}
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           cache: 'maven'
 
@@ -197,13 +197,13 @@ jobs:
       - name: Run cuda compilation on linux-x86_64
         shell: bash
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}
           RELEASE_VERSION: ${{ matrix.release_version }}
           SNAPSHOT_VERSION: ${{ matrix.snapshot_version }}

--- a/.github/workflows/build-deploy-linux-x86_64-compat.yml
+++ b/.github/workflows/build-deploy-linux-x86_64-compat.yml
@@ -151,13 +151,13 @@ jobs:
         uses: ./.github/actions/build-centos
         env:
           JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64/
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}
           RELEASE_VERSION: ${{ matrix.release_version }}
           SNAPSHOT_VERSION: ${{ matrix.snapshot_version }}
@@ -188,13 +188,13 @@ jobs:
                            eval "${DEPLOY_COMMAND}"
               fi
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}
           RELEASE_VERSION: ${{ matrix.release_version }}
           SNAPSHOT_VERSION: ${{ matrix.snapshot_version }}

--- a/.github/workflows/build-deploy-linux-x86_64.yml
+++ b/.github/workflows/build-deploy-linux-x86_64.yml
@@ -177,7 +177,7 @@ jobs:
           server-id:  ${{ github.event.inputs.serverId }}
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
         
 
@@ -196,13 +196,13 @@ jobs:
       - name: Build on  linux-x86_64
         shell: bash
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           DEBIAN_FRONTEND: noninteractive
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}
           RELEASE_VERSION: ${{ matrix.release_version }}
           SNAPSHOT_VERSION: ${{ matrix.snapshot_version }}

--- a/.github/workflows/build-deploy-mac-arm64.yml
+++ b/.github/workflows/build-deploy-mac-arm64.yml
@@ -147,8 +147,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           server-id: 'central'
-          server-username: ${{ secrets.SONATYPE_USER_1 }}
-          server-password: ${{ secrets.SONATYPE_USER1_PASS }}
+          server-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
         
         
 

--- a/.github/workflows/build-deploy-mac.yml
+++ b/.github/workflows/build-deploy-mac.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@v1
         env:
-            GPG_PRIVATE_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+            GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
             PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Set up Java for publishing to OSSRH
@@ -153,8 +153,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           server-id: 'central'
-          server-username: ${{ secrets.SONATYPE_USER_1 }}
-          server-password: ${{ secrets.SONATYPE_USER1_PASS }}
+          server-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
         
         
 
@@ -183,10 +183,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}
           RELEASE_VERSION: ${{ matrix.release_version }}
           SNAPSHOT_VERSION: ${{ matrix.snapshot_version }}

--- a/.github/workflows/build-deploy-windows-cuda-12.3.yml
+++ b/.github/workflows/build-deploy-windows-cuda-12.3.yml
@@ -266,8 +266,8 @@ jobs:
       - name: Run cuda build
         shell: cmd
         env:
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERFORM_RELEASE: ${{ github.event.inputs.deployToReleaseStaging }}

--- a/.github/workflows/build-deploy-windows-cuda-12.6.yml
+++ b/.github/workflows/build-deploy-windows-cuda-12.6.yml
@@ -246,17 +246,17 @@ jobs:
           echo "CUDA_PATH=$cudaPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Import GPG Key
-        if: ${{ secrets.SONATYPE_GPG_KEY != '' && secrets.MAVEN_GPG_PASSPHRASE != '' }}
+        if: ${{ secrets.GPG_PRIVATE_KEY != '' && secrets.MAVEN_GPG_PASSPHRASE != '' }}
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg_private_key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Run cuda build
         shell: cmd
         env:
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}

--- a/.github/workflows/build-deploy-windows.yml
+++ b/.github/workflows/build-deploy-windows.yml
@@ -229,7 +229,7 @@ jobs:
           server-id:   ${{ github.event.inputs.serverId }}
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.SONATYPE_GPG_KEY }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
         
 
@@ -280,18 +280,18 @@ jobs:
                    )
               )
         env:
-          MAVEN_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TO: central
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USER_1 }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_USER1_PASS }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.PACKAGES_GPG_PASS }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           PERFORM_RELEASE: ${{ matrix.deploy_to_release_staging }}
           RELEASE_VERSION: ${{ matrix.release_version }}
           SNAPSHOT_VERSION: ${{ matrix.snapshot_version }}
           RELEASE_REPO_ID: ${{ matrix.release_repo_id }}
           GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          GPG_SIGNING_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           MODULES: ${{ matrix.mvn_flags }}
           HELPER: ${{ matrix.helper }}
           EXTENSION: ${{ matrix.extension }}

--- a/.github/workflows/cpu-sanity-check-tests.yaml
+++ b/.github/workflows/cpu-sanity-check-tests.yaml
@@ -323,8 +323,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           server-id: 'central'
-          server-username: ${{ secrets.SONATYPE_USER_1 }}
-          server-password: ${{ secrets.SONATYPE_USER1_PASS }}
+          server-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+          server-password: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
         
 
 


### PR DESCRIPTION
Related to https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5935

## What changes were proposed in this pull request?

Adapt secrets to EF naming convention:
* CENTRAL_SONATYPE_TOKEN_PASSWORD
* CENTRAL_SONATYPE_TOKEN_USERNAME
* GPG_KEY_ID
* GPG_PASSPHRASE
* GPG_PRIVATE_KEY
