### PR TITLE
Array memory management: buffer lifecycle, deallocator fixes

### DIFF
--- a/libnd4j/include/array/ConstantOffsetsBuffer.h
+++ b/libnd4j/include/array/ConstantOffsetsBuffer.h
@@ -34,14 +34,18 @@ namespace sd {
 
 class SD_LIB_EXPORT ConstantOffsetsBuffer {
  private:
+  static constexpr uint32_t MAGIC_VALID = 0xC0FFE575;  // "COFFSETS" - magic number for validity check
+  uint32_t _magic = 0;  // Validity marker to detect use-after-free
   std::shared_ptr<PointerWrapper> _primaryOffsets;
   std::shared_ptr<PointerWrapper> _specialOffsets;
 
  public:
   ConstantOffsetsBuffer(const std::shared_ptr<PointerWrapper> &primary);
   ConstantOffsetsBuffer(const std::shared_ptr<PointerWrapper> &primary, const std::shared_ptr<PointerWrapper> &special);
-  ConstantOffsetsBuffer() = default;
-  ~ConstantOffsetsBuffer() = default;
+  ConstantOffsetsBuffer();  // Default constructor - sets magic number
+  ~ConstantOffsetsBuffer();  // Need custom destructor to clear magic
+
+  inline bool isValid() const { return _magic == MAGIC_VALID; }
 
   LongType *primary();
   LongType *special();

--- a/libnd4j/include/array/InteropDataBuffer.h
+++ b/libnd4j/include/array/InteropDataBuffer.h
@@ -39,15 +39,45 @@ class SD_LIB_EXPORT InteropDataBuffer {
   bool owner;
   DataType _dataType = DataType::UNKNOWN;
  public:
+  size_t _cachedLenInBytes = 0;
+  void* _cachedPrimaryPtr = nullptr;  // Cached for deallocation tracking
+  void* _cachedSpecialPtr = nullptr;  // Cached for deallocation tracking
+  bool _closed = false;
   bool isConstant = false;
 
   InteropDataBuffer(InteropDataBuffer *dataBuffer, uint64_t length);
   InteropDataBuffer(DataBuffer * databuffer);
   InteropDataBuffer(size_t lenInBytes, DataType dtype, bool allocateBoth);
-  ~InteropDataBuffer() {}
+  ~InteropDataBuffer() {
+    // Mark as closed FIRST to prevent any concurrent access
+    _closed = true;
+    // If we own the DataBuffer and it's not constant, clean it up
+    if (owner && !isConstant && _dataBuffer != nullptr) {
+      delete _dataBuffer;
+    }
+    // Always null out the pointer to prevent use-after-free
+    _dataBuffer = nullptr;
+  }
+
 #ifndef __JAVACPP_HACK__
   DataBuffer * getDataBuffer() const;
   DataBuffer * dataBuffer();
+  // In InteropDataBuffer class, add these public methods:
+  // Check if the underlying DataBuffer pointer is still valid
+  // by checking if it's non-null
+  bool hasValidDataBuffer() const { return _dataBuffer != nullptr; }
+
+  // Get the DataBuffer pointer directly without validation
+  DataBuffer* getDataBufferDirect() const { return _dataBuffer; }
+
+  // Mark the DataBuffer as invalid (set to null)
+  void invalidateDataBuffer() { _dataBuffer = nullptr; }
+  bool isOwner() const { return owner; }
+
+  // Safe accessor that doesn't touch other fields
+  DataBuffer* getDataBufferUnsafe() const {
+    return _dataBuffer;
+  }
 #endif
 
   void printDbAllocationTrace();

--- a/libnd4j/include/array/impl/ShapeDescriptor.cpp
+++ b/libnd4j/include/array/impl/ShapeDescriptor.cpp
@@ -68,6 +68,7 @@ LongType *ShapeDescriptor::toShapeInfo() const {
 ShapeDescriptor::~ShapeDescriptor() {
   // no-op
   if(_shape_strides != nullptr && this->ownsShapeStrides) {
+    delete[] _shape_strides;
     _shape_strides = nullptr;
   }
 
@@ -86,10 +87,12 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const Lo
     std::string errorMessage;
     errorMessage += "Invalid ordering from shape buffer";
     errorMessage += std::to_string(order);
+    delete[] _shape_strides;
     THROW_EXCEPTION(errorMessage.c_str());
 
   }
   if(!DataTypeUtils::validDataType(_dataType)) {
+    delete[] _shape_strides;
     THROW_EXCEPTION("Shape descriptor created with invalid data type");
   }
   auto _shape = _shape_strides;
@@ -102,7 +105,16 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const Lo
   fillStrides();
 
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 
 
@@ -112,13 +124,16 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const Lo
                                  const LongType *strides, const LongType rank, LongType extras = -1) {
   if(shape == nullptr)
     THROW_EXCEPTION("ShapeDescriptor constructor: Shape can not be null!");
+  _shape_strides = nullptr;
+  ownsShapeStrides = false;
   if(type  == UNKNOWN)
     THROW_EXCEPTION("Shape descriptor created with invalid data type");
-  _shape_strides = new LongType[2 * rank];
+  ownsShapeStrides = true;
   //note this used to operate directly on the vector buffer
   //it now does manual copies with more checks.
   //this is to handle the 0 length case.
   if(rank < 1) {
+    _shape_strides = new LongType[2 * rank];
     _dataType = type;
     _order = order;
     _rank = rank;
@@ -149,7 +164,16 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const Lo
   }
 
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -183,14 +207,25 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const st
     std::string errorMessage;
     errorMessage += "Invalid ordering from shape buffer";
     errorMessage += std::to_string(_order);
+    delete[] _shape_strides;
     THROW_EXCEPTION(errorMessage.c_str());
 
   }
   if(!DataTypeUtils::validDataType(_dataType)) {
+    delete[] _shape_strides;
     THROW_EXCEPTION("Shape descriptor created with invalid data type");
   }
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -204,7 +239,16 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const st
     THROW_EXCEPTION("Shape descriptor created with invalid data type");
   }
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -218,7 +262,16 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const LongType length)
   }
 
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -255,7 +308,7 @@ ShapeDescriptor::ShapeDescriptor(const LongType *shapeInfo, bool validateDataTyp
     }
   }
 
-
+  _shape_strides = nullptr;
   _order = shape::order(shapeInfo);
   this->ownsShapeStrides = true;
   if(_order != 'c' && _order != 'f') {
@@ -363,7 +416,16 @@ ShapeDescriptor::ShapeDescriptor(const LongType *shapeInfo, bool validateDataTyp
   }
 
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 
 }
@@ -387,7 +449,16 @@ ShapeDescriptor::ShapeDescriptor(const LongType *shapeInfo, const DataType dtype
   }
 
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -398,7 +469,16 @@ ShapeDescriptor::ShapeDescriptor(const LongType *shapeInfo, const LongType *dtyp
   }
 
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -412,7 +492,16 @@ ShapeDescriptor::ShapeDescriptor(const LongType *shapeInfo, const LongType *dtyp
 
 
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -464,8 +553,17 @@ LongType ShapeDescriptor::allocLength() const {
 
 void ShapeDescriptor::collectStoreStackTrace() {
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
   this->storeStackTrace = backward::StackTrace();
+#ifdef __cpp_exceptions
+  try {
+    this->storeStackTrace.load_here(32);
+  } catch (...) {
+    // Stack trace capture failed - storeStackTrace will remain empty (size() == 0)
+  }
+#else
   this->storeStackTrace.load_here(32);
+#endif
 #endif
 }
 
@@ -568,7 +666,16 @@ ShapeDescriptor::ShapeDescriptor(const ShapeDescriptor &other) {
   this->ownsShapeStrides = false;
   _paddedAllocSize = other._paddedAllocSize;
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
 }
 
@@ -582,7 +689,16 @@ ShapeDescriptor::ShapeDescriptor(const DataType type, const char order, const st
   _shape_strides = new LongType [2 * rank2];
   this->ownsShapeStrides = true;
 #if defined(SD_GCC_FUNCTRACE)
+  // - backward-cpp's backtrace() is NOT safe during very early JVM initialization
+#ifdef __cpp_exceptions
+  try {
+    this->st.load_here();
+  } catch (...) {
+    // Stack trace capture failed - st will remain empty (size() == 0)
+  }
+#else
   this->st.load_here();
+#endif
 #endif
   auto _shape = _shape_strides;
   auto _strides = _shape_strides + rank2;


### PR DESCRIPTION
## Summary

This PR fixes critical memory management issues in the array and buffer handling layer of libnd4j.

### Why these changes?
Memory leak analysis revealed several issues:
1. **Buffer leaks** - DataBuffer instances not being properly cleaned up
2. **Double-free crashes** - Incorrect ownership tracking in InteropDataBuffer
3. **Missing deallocators** - Some allocation paths lacked corresponding deallocation
4. **Shape descriptor leaks** - ShapeDescriptor objects accumulating in caches

### What changed?

**DataBuffer.cpp** (+281/-76)
- Added proper reference counting for buffer ownership
- Fixed cleanup logic to prevent double-frees
- Added null checks before deallocation
- Improved logging for debugging memory issues

**InteropDataBuffer.cpp** (+71/-23)
- Fixed ownership semantics - InteropDataBuffer now correctly tracks whether it owns the underlying buffer
- Added `isOwner()` method to check ownership status
- Prevents deallocation of buffers owned by Java layer

**PrimaryPointerDeallocator.cpp** (+13/-1)
- Added safety checks before deallocation
- Improved error handling for invalid pointers

**ShapeDescriptor.cpp** (+118/-2)
- Fixed memory leak in shape descriptor caching
- Added proper cleanup when descriptors are evicted from cache

**TadPack.cpp** (+79/-0)
- Added proper destructor to clean up TAD buffers
- Fixed leak where TAD shape buffers were never freed

## Test plan
- [ ] Run with AddressSanitizer (ASAN) - no memory errors
- [ ] Run with LeakSanitizer (LSAN) - no leaks detected
- [ ] Long-running operations don't show memory growth

🤖 Generated with [Claude Code](https://claude.ai/code)
