### PR TITLE
PR03: FlatBuffers Schema & Generated Code

### DIFF
--- a/libnd4j/include/graph/scheme/array.fbs
+++ b/libnd4j/include/graph/scheme/array.fbs
@@ -79,6 +79,10 @@ table FlatArray {
     // Fields for external file storage
     externalDataFilename:[string];     // Filename for externally stored data
     isExternal:bool = false;           // Flag indicating if data is stored externally
+
+    // For C++ native reader - offset/length of appended data in SDNB file
+    appendedDataOffset:long;           // Byte offset from start of SDNB file
+    appendedDataLength:long;           // Byte length of appended data
 }
 
 root_type FlatArray;


### PR DESCRIPTION
## Summary

**[PR 03](https://github.com/deeplearning4j/deeplearning4j/pull/10436) of [22 PRs](https://github.com/deeplearning4j/deeplearning4j/pulls?q=is%3Apr+ag_new_release_updates_2)** in the `ag_new_release_updates_2` branch split. Merge after Layer 0 (build system + platform macros).

- **FlatBuffers 25.2.10 vendored:** 27 C++ runtime headers in `libnd4j/include/flatbuffers/` (and mirrored to secondary location); replaces system/downloaded dependency
- **Version enforcement:** Generated C++ headers `static_assert` version 25.2.10; Java classes call `Constants.FLATBUFFERS_25_2_10()` at runtime — mismatches fail fast
- **`array.fbs` schema updates:** Adds `BufferChunk` table (long index + byte[] data) for >2 GB arrays; `FlatArray` gains `bufferChunks`, `totalBufferSize:long`, `externalDataFilename:[string]` (ONNX-style external tensors)
- **New DType entries:** `BFLOAT16 = 17`, `UTF8 = 50`, `UTF16 = 51`, `UTF32 = 52` — matches [PR04](https://github.com/deeplearning4j/deeplearning4j/pull/10437) C++ DataType enum
- **`ModelContainer` schema:** Structured model envelope with `ContainerHeader`, `SectionHeader[]` index (O(1) section seek), `ArraysSection`, `MetadataSection` (key-value provenance), and optional `ShardInfo` for split-file models
- **`CompressionType` enum:** `NONE`, `DEFLATE`, `ZSTD` for future array section compression
- **Generated Java — new `graph` package:** 58 auto-generated classes targeting the `graph` package namespace, covering the full schema
- **Legacy package update:** `org.nd4j.graph.FlatArray` regenerated with 25.2.10 validator and new chunk/external-file accessors

## What Changed

### FlatBuffers Runtime Headers — Primary Location (27 files)
Vendored FlatBuffers 25.2.10 C++ runtime under `libnd4j/include/flatbuffers/`:

- `base.h` — platform detection, FLATBUFFERS_ASSERT, integer types
- `allocator.h` — Allocator interface
- `buffer.h` / `buffer_ref.h` — buffer verification and non-owning references
- `flatbuffer_builder.h` — primary serialization API
- `flexbuffers.h` — schema-less FlexBuffers variant
- `idl.h` — .fbs IDL parser
- `reflection.h` / `reflection_generated.h` — runtime schema introspection
- `verifier.h` — buffer integrity checking before deserialization
- `array.h`, `default_allocator.h`, `detached_buffer.h`, `file_manager.h`, `hash.h`, `minireflect.h`, `registry.h`, `stl_emulation.h`, `string.h`, `struct.h`, `table.h`, `util.h`, `vector.h`, `vector_downward.h` — remaining 25.2.10 runtime components

### FlatBuffers Runtime Headers — Secondary Location (31 files)
`libnd4j/libnd4j/include/flatbuffers/` — duplicate of same headers plus:
- `pch/flatc_pch.h` / `pch/pch.h` — precompiled headers for flatc tool

### FlatBuffers CMake (1 file)
- `libnd4j/include/flatbuffers/CMakeLists.txt` — integrates vendored library into libnd4j CMake

### Schema Updates (1 file)
- `libnd4j/include/graph/scheme/array.fbs` — adds `BufferChunk` table; extends `FlatArray` with chunk/external-file fields; adds `CompressionType`, `SectionType` enums; adds `DType.BFLOAT16 = 17`, `UTF8/16/32 = 50/51/52`

### Generated C++ Headers (4 files)
- `libnd4j/include/graph/generated/array_generated.h` — regenerated; static_asserts version 25.2.10; includes BufferChunk and updated FlatArray
- `libnd4j/include/graph/generated/container_generated.h` — new; `CompressionType`, `SectionType`, `ContainerHeader`, `MetadataEntry`, `MetadataSection`, `ShardInfo`, `SectionHeader`, `ArrayEntry`, `ArraysSection`, `ModelContainer`
- `libnd4j/include/graph/generated/uigraphevents_generated.h` — new; UI event types (UIEvent, UIEventType, UIHistogram, etc.)
- `libnd4j/include/graph/generated/uigraphstatic_generated.h` — new; static UI graph structure (UIGraphStructure, UIVariable, UIOp, etc.)

### Generated Java Code — New Package `graph` (58 files)
Key classes under `libnd4j/include/graph/generated/graph/`:

- `ModelContainer.java` — top-level container with header, sections, metadata, graph, arrays, shardInfo
- `ContainerHeader.java` — format version, magic bytes, creation timestamp
- `SectionHeader.java` — per-section offset and type for indexed file access
- `ArraysSection.java` / `ArrayEntry.java` — dense array section with named entries
- `MetadataSection.java` / `MetadataEntry.java` — key-value model provenance metadata
- `ShardInfo.java` — sharding descriptor for split model files
- `FlatArray.java` — updated FlatArray with chunk and external-file accessors
- `FlatGraph.java`, `FlatNode.java`, `FlatVariable.java`, `FlatConfiguration.java`, `FlatProperties.java` — graph structure bindings
- `FlatInferenceRequest.java`, `FlatDropRequest.java`, `FlatResponse.java`, `FlatResult.java`, `FlatTiming.java` — request/response protocol bindings
- `DType.java`, `ByteOrder.java`, `Direction.java`, `ExecutionMode.java`, `InputType.java`, `LossReduce.java`, `OpClass.java`, `OpType.java`, `OutputMode.java`, `ProfilingMode.java`, `VarType.java` — enum classes
- `UIAddName.java`, `UIEvent.java`, `UIEventSubtype.java`, `UIEventType.java`, `UIGraphStructure.java`, `UIHardwareState.java`, `UIHistogram.java`, `UIHistogramType.java`, `UIInfoType.java`, `UIOp.java`, `UIStaticInfoRecord.java`, `UISummaryStatistics.java`, `UISystemInfo.java`, `UIVariable.java` — UI/visualization schema bindings
- `UpdaterState.java`, `SameDiffSubInstance.java`, `SequenceItem.java`, `SequenceItemRoot.java`, `FrameIteration.java`, `IntPair.java`, `IntTriple.java`, `LongPair.java`, `LongTriple.java` — auxiliary schema types
- `CompressionType.java`, `SectionType.java`, `BufferChunk.java` — container schema enums and chunk type

### Generated Java Code — Legacy Package Update (1 file)
- `libnd4j/include/graph/generated/org/nd4j/graph/FlatArray.java` — regenerated with 25.2.10 validator; adds `bufferChunks`, `totalBufferSize`, `externalDataFilename` accessors

## Dependencies

- **Depends on:** [PR01](https://github.com/deeplearning4j/deeplearning4j/pull/10456) (CMake build system for FlatBuffers vendoring)
- **Required by:** [PR05](https://github.com/deeplearning4j/deeplearning4j/pull/10438), [PR06](https://github.com/deeplearning4j/deeplearning4j/pull/10439), [PR07](https://github.com/deeplearning4j/deeplearning4j/pull/10440) and any PR reading/writing FlatBuffers-serialized graphs or model files

## Merge Order

These 22 PRs must merge in layer order. Each layer depends on the layers above it being merged first. PRs within the same layer are independent and can merge in parallel.

> **This PR:** Merge after Layer 0 (build system + platform macros).

| Layer | PRs |
|---|---|
| **0** (no deps) | [PR01](https://github.com/deeplearning4j/deeplearning4j/pull/10456), [PR02](https://github.com/deeplearning4j/deeplearning4j/pull/10435), [PR20](https://github.com/deeplearning4j/deeplearning4j/pull/10453) |
| **1** (build/infra) | [PR03](https://github.com/deeplearning4j/deeplearning4j/pull/10436), [PR04](https://github.com/deeplearning4j/deeplearning4j/pull/10437) |
| **2** (native core) | [PR05](https://github.com/deeplearning4j/deeplearning4j/pull/10438), [PR06](https://github.com/deeplearning4j/deeplearning4j/pull/10439), [PR07](https://github.com/deeplearning4j/deeplearning4j/pull/10440) |
| **3** (native feat) | [PR08](https://github.com/deeplearning4j/deeplearning4j/pull/10441), [PR09](https://github.com/deeplearning4j/deeplearning4j/pull/10442), [PR10](https://github.com/deeplearning4j/deeplearning4j/pull/10443), [PR11](https://github.com/deeplearning4j/deeplearning4j/pull/10444) |
| **4** (java core) | [PR12](https://github.com/deeplearning4j/deeplearning4j/pull/10445), [PR13](https://github.com/deeplearning4j/deeplearning4j/pull/10446), [PR14](https://github.com/deeplearning4j/deeplearning4j/pull/10447), [PR15](https://github.com/deeplearning4j/deeplearning4j/pull/10448) |
| **5** (java feat) | [PR16](https://github.com/deeplearning4j/deeplearning4j/pull/10449) |
| **6** (import/gen) | [PR17](https://github.com/deeplearning4j/deeplearning4j/pull/10450), [PR18](https://github.com/deeplearning4j/deeplearning4j/pull/10451), [PR19](https://github.com/deeplearning4j/deeplearning4j/pull/10452), [PR21](https://github.com/deeplearning4j/deeplearning4j/pull/10454) |
| **7** (validation) | [PR22](https://github.com/deeplearning4j/deeplearning4j/pull/10455) |



